### PR TITLE
Coverage: Fix PHPUnit warnings

### DIFF
--- a/projects/packages/forms/changelog/fix-phpunit_covers_warnings
+++ b/projects/packages/forms/changelog/fix-phpunit_covers_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHPUnit coverage warnings.

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form-plugin.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form-plugin.php
@@ -12,13 +12,12 @@ use WorDBless\BaseTestCase;
 /**
  * Test class for Contact_Form_Plugin
  *
- * @covers Automattic\Jetpack\Forms\Contact_Form\Contact_Form_Plugin
+ * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
  */
 class WP_Test_Contact_Form_Plugin extends BaseTestCase {
 	/**
 	 * Test that ::revert_that_print works correctly
 	 *
-	 * @covers Automattic\Jetpack\Forms\Contact_Form\Contact_Form_Plugin::revert_that_print
 	 * @dataProvider arrayReversals
 	 */
 	public function testStaticPrintReversal( $array, $decode_html ) {

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form-plugin.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form-plugin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Unit Tests for Automattic\Jetpack\Forms\Contact_Form\Contact_Form_Plugin.
+ * Unit Tests for Contact_Form_Plugin.
  *
  * @package automattic/jetpack-forms
  */
@@ -12,7 +12,7 @@ use WorDBless\BaseTestCase;
 /**
  * Test class for Contact_Form_Plugin
  *
- * @covers Contact_Form_Plugin
+ * @covers Automattic\Jetpack\Forms\Contact_Form\Contact_Form_Plugin
  */
 class WP_Test_Contact_Form_Plugin extends BaseTestCase {
 	/**

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form-plugin.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form-plugin.php
@@ -18,6 +18,7 @@ class WP_Test_Contact_Form_Plugin extends BaseTestCase {
 	/**
 	 * Test that ::revert_that_print works correctly
 	 *
+	 * @covers Automattic\Jetpack\Forms\Contact_Form\Contact_Form_Plugin::revert_that_print
 	 * @dataProvider arrayReversals
 	 */
 	public function testStaticPrintReversal( $array, $decode_html ) {

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form-plugin.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form-plugin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Unit Tests for Automattic\Jetpack\Forms\Contact_Form.
+ * Unit Tests for Automattic\Jetpack\Forms\Contact_Form\Contact_Form_Plugin.
  *
  * @package automattic/jetpack-forms
  */
@@ -10,7 +10,7 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 use WorDBless\BaseTestCase;
 
 /**
- * Test class for Contact_Form
+ * Test class for Contact_Form_Plugin
  *
  * @covers Contact_Form_Plugin
  */

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -577,7 +577,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	 * Tests that 'grunion_delete_old_spam()' deletes an old post that is marked as spam.
 	 *
 	 * @author tonykova
-	 * @covers Util::grunion_delete_old_spam
+	 * @covers \Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam
 	 */
 	public function test_grunion_delete_old_spam_deletes_an_old_post_marked_as_spam() {
 		// grunion_Delete_old_spam performs direct DB queries which cannot be tested outside of a working WP install.
@@ -599,7 +599,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	 * Tests that 'grunion_delete_old_spam' does not delete a new post that is marked as spam.
 	 *
 	 * @author tonykova
-	 * @covers Util::grunion_delete_old_spam
+	 * @covers \Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam
 	 */
 	public function test_grunion_delete_old_spam_does_not_delete_a_new_post_marked_as_spam() {
 		$post_id = wp_insert_post(

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -15,7 +15,7 @@ use WorDBless\Posts;
 /**
  * Test class for Contact_Form
  *
- * @covers Automattic\Jetpack\Forms\Contact_Form\Contact_Form
+ * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form
  */
 class WP_Test_Contact_Form extends BaseTestCase {
 

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -599,7 +599,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	 * Tests that 'grunion_delete_old_spam' does not delete a new post that is marked as spam.
 	 *
 	 * @author tonykova
-	 * @covers ::grunion_delete_old_spam
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form::grunion_delete_old_spam
 	 */
 	public function test_grunion_delete_old_spam_does_not_delete_a_new_post_marked_as_spam() {
 		$post_id = wp_insert_post(
@@ -619,7 +619,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	 * Tests that token is left intact when there is not matching field.
 	 *
 	 * @author tonykova
-	 * @covers Contact_Form_Plugin
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 */
 	public function test_token_left_intact_when_no_matching_field() {
 		$plugin       = Contact_Form_Plugin::init();
@@ -635,7 +635,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	 * Tests that token is replaced with an empty string when there is not value in field.
 	 *
 	 * @author tonykova
-	 * @covers Contact_Form_Plugin
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 */
 	public function test_replaced_with_empty_string_when_no_value_in_field() {
 		$plugin       = Contact_Form_Plugin::init();
@@ -651,7 +651,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	 * Tests that token in curly brackets is replaced with the value when the name has whitespace.
 	 *
 	 * @author tonykova
-	 * @covers Contact_Form_Plugin
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 */
 	public function test_token_can_replace_entire_subject_with_token_field_whose_name_has_whitespace() {
 		$plugin       = Contact_Form_Plugin::init();
@@ -667,7 +667,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	 * Tests that token with curly brackets is replaced with value.
 	 *
 	 * @author tonykova
-	 * @covers Contact_Form_Plugin
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 */
 	public function test_token_with_curly_brackets_can_be_replaced() {
 		$plugin       = Contact_Form_Plugin::init();
@@ -715,7 +715,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	/**
 	 * Tests shortcode with commas and brackets.
 	 *
-	 * @covers Contact_Form_Field
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_array_values_with_commas_and_brackets() {
 		$shortcode = "[contact-field type='radio' options='\"foo\",bar&#044; baz,&#091;b&#092;rackets&#093;' label='fun &#093;&#091; times'/]";
@@ -726,7 +726,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	/**
 	 * Tests Gutenblock input with commas and brackets.
 	 *
-	 * @covers Contact_Form_Field
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_array_values_with_commas_and_brackets_from_gutenblock() {
 		$attr = array(
@@ -741,7 +741,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	/**
 	 * Test for text field_renders
 	 *
-	 * @covers Contact_Form_Field
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_text_field_renders_as_expected() {
 		$attributes = array(
@@ -760,7 +760,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	/**
 	 * Test for email field_renders
 	 *
-	 * @covers Contact_Form_Field
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_email_field_renders_as_expected() {
 		$attributes = array(
@@ -779,7 +779,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	/**
 	 * Test for url field_renders
 	 *
-	 * @covers Contact_Form_Field
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_url_field_renders_as_expected() {
 		$attributes = array(
@@ -798,7 +798,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	/**
 	 * Test for telephone field_renders
 	 *
-	 * @covers Contact_Form_Field
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_telephone_field_renders_as_expected() {
 		$attributes = array(
@@ -817,7 +817,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	/**
 	 * Test for date field_renders
 	 *
-	 * @covers Contact_Form_Field
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_date_field_renders_as_expected() {
 		$attributes = array(
@@ -837,7 +837,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	/**
 	 * Test for textarea field_renders
 	 *
-	 * @covers Contact_Form_Field
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_textarea_field_renders_as_expected() {
 		$attributes = array(
@@ -856,7 +856,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	/**
 	 * Test for checkbox field_renders
 	 *
-	 * @covers Contact_Form_Field
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_checkbox_field_renders_as_expected() {
 		$attributes = array(
@@ -875,7 +875,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	/**
 	 * Multiple fields
 	 *
-	 * @covers Contact_Form_Field
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_checkbox_multiple_field_renders_as_expected() {
 		$attributes = array(
@@ -895,7 +895,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	/**
 	 * Test for radio field_renders
 	 *
-	 * @covers Contact_Form_Field
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_radio_field_renders_as_expected() {
 		$attributes = array(
@@ -915,7 +915,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	/**
 	 * Test for select field_renders
 	 *
-	 * @covers Contact_Form_Field
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_select_field_renders_as_expected() {
 		$attributes = array(
@@ -1208,7 +1208,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	/**
 	 * Test get_export_data_for_posts with fully vaid data input.
 	 *
-	 * @covers Contact_Form_Plugin
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_get_export_data_for_posts_fully_valid_data() {
@@ -1328,7 +1328,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	/**
 	 * Test get_export_data_for_posts with single invalid entry for post meta
 	 *
-	 * @covers Contact_Form_Plugin
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_get_export_data_for_posts_invalid_single_entry_meta() {
@@ -1433,7 +1433,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	/**
 	 * Test get_export_data_for_posts with invalid all entries for post meta
 	 *
-	 * @covers Contact_Form_Plugin
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_get_export_data_for_posts_invalid_all_entries_meta() {
@@ -1523,7 +1523,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	/**
 	 * Test get_export_data_for_posts with single invalid entry for parsed fields.
 	 *
-	 * @covers Contact_Form_Plugin
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_get_export_data_for_posts_single_invalid_entry_for_parse_fields() {
@@ -1636,7 +1636,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	/**
 	 * Test get_export_data_for_posts with all entries for parsed fields invalid.
 	 *
-	 * @covers Contact_Form_Plugin
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_get_export_data_for_posts_all_entries_for_parse_fields_invalid() {
@@ -1679,7 +1679,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	/**
 	 * Test map_parsed_field_contents_of_post_to_field_names
 	 *
-	 * @covers Contact_Form_Plugin
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_map_parsed_field_contents_of_post_to_field_names() {

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -599,7 +599,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	 * Tests that 'grunion_delete_old_spam' does not delete a new post that is marked as spam.
 	 *
 	 * @author tonykova
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form::grunion_delete_old_spam
+	 * @covers Util::grunion_delete_old_spam
 	 */
 	public function test_grunion_delete_old_spam_does_not_delete_a_new_post_marked_as_spam() {
 		$post_id = wp_insert_post(

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -15,7 +15,7 @@ use WorDBless\Posts;
 /**
  * Test class for Contact_Form
  *
- * @covers Contact_Form
+ * @covers Automattic\Jetpack\Forms\Contact_Form\Contact_Form
  */
 class WP_Test_Contact_Form extends BaseTestCase {
 

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -580,7 +580,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	 * @covers Util::grunion_delete_old_spam
 	 */
 	public function test_grunion_delete_old_spam_deletes_an_old_post_marked_as_spam() {
-		// grunion_Delete_old_spam performs direct DB queries which cannot be tested outisde of a working WP install.
+		// grunion_Delete_old_spam performs direct DB queries which cannot be tested outside of a working WP install.
 		$this->markTestSkipped();
 		// @phan-suppress-next-line PhanPluginUnreachableCode
 		$post_id = wp_insert_post(

--- a/projects/packages/image-cdn/changelog/fix-phpunit_covers_warnings
+++ b/projects/packages/image-cdn/changelog/fix-phpunit_covers_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHPUnit coverage warnings.

--- a/projects/packages/image-cdn/tests/php/test_class.image_cdn.php
+++ b/projects/packages/image-cdn/tests/php/test_class.image_cdn.php
@@ -194,7 +194,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests that Image_CDN creates a singleton.
 	 *
 	 * @author scotchfield
-	 * @covers Image_CDN::instance
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::instance
 	 * @since 3.2
 	 */
 	public function test_image_cdn_instance_singleton() {
@@ -413,7 +413,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	/**
 	 * Tests Photon will parse the dimensions from a filename that contains query parameters.
 	 *
-	 * @covers Image_CDN::parse_dimensions_from_filename
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::parse_dimensions_from_filename
 	 */
 	public function test_image_cdn_parse_dimensions_from_filename_with_query_parameters() {
 		$image_url = 'http://' . WP_TESTS_DOMAIN . '/no-dimensions-here-148x148.jpg?foo=bar&baz=qux';

--- a/projects/packages/image-cdn/tests/php/test_class.image_cdn.php
+++ b/projects/packages/image-cdn/tests/php/test_class.image_cdn.php
@@ -183,7 +183,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests that Image CDN creates an Image CDN instance.
 	 *
 	 * @author scotchfield
-	 * @covers Image_CDN::instance
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::instance
 	 * @since 3.2
 	 */
 	public function test_image_cdn_instance() {
@@ -207,7 +207,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Image CDN's HTML parsing when there is nothing to parse.
 	 *
 	 * @author scotchfield
-	 * @covers Image_CDN::parse_images_from_html
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::parse_images_from_html
 	 * @since 3.2
 	 */
 	public function test_image_cdn_parse_images_from_html_empty() {
@@ -238,7 +238,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon's HTML parsing.
 	 *
 	 * @author scotchfield
-	 * @covers Image_CDN::parse_images_from_html
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::parse_images_from_html
 	 * @since 3.2
 	 */
 	public function test_image_cdn_parse_images_from_html_a_tags_without_images() {
@@ -251,7 +251,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon's HTML parsing.
 	 *
 	 * @author biskobe
-	 * @covers Image_CDN::filter_the_content
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_the_content
 	 * @since 3.2
 	 */
 	public function test_image_cdn_parse_images_from_html_a_tags_with_hash_in_href() {
@@ -272,7 +272,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon's HTML parsing.
 	 *
 	 * @author scotchfield
-	 * @covers Image_CDN::parse_images_from_html
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::parse_images_from_html
 	 * @since 3.2
 	 */
 	public function test_image_cdn_parse_images_from_html_empty_a_tag() {
@@ -285,7 +285,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon's HTML parsing.
 	 *
 	 * @author scotchfield
-	 * @covers Image_CDN::parse_images_from_html
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::parse_images_from_html
 	 * @since 3.2
 	 */
 	public function test_image_cdn_parse_images_from_html_extra_attributes() {
@@ -298,7 +298,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon's HTML parsing.
 	 *
 	 * @author scotchfield
-	 * @covers Image_CDN::parse_images_from_html
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::parse_images_from_html
 	 * @since 3.2
 	 */
 	public function test_image_cdn_parse_images_from_html_minimum_multiple_with_links() {
@@ -311,7 +311,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon's HTML parsing.
 	 *
 	 * @author scotchfield
-	 * @covers Image_CDN::parse_images_from_html
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::parse_images_from_html
 	 * @since 3.2
 	 */
 	public function test_image_cdn_parse_images_from_html_minimum_multiple() {
@@ -324,7 +324,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon's HTML parsing.
 	 *
 	 * @author scotchfield
-	 * @covers Image_CDN::parse_images_from_html
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::parse_images_from_html
 	 * @since 3.2
 	 */
 	public function test_image_cdn_parse_images_from_html_minimum() {
@@ -337,7 +337,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests that Photon will parse a multiline html snippet.
 	 *
 	 * @author scotchfield
-	 * @covers Image_CDN::parse_images_from_html
+	 * @coverAutomattic\Jetpack\Image_CDN\Image_CDN::parse_images_from_html
 	 * @since 3.2
 	 */
 	public function test_image_cdn_parse_images_from_html_multiline() {
@@ -350,7 +350,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon's parse of the src attribute.
 	 *
 	 * @author ccprog
-	 * @covers Image_CDN::parse_images_from_html
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::parse_images_from_html
 	 */
 	public function test_image_cdn_parse_images_from_html_src_attribute() {
 		list( $sample_html, $expected ) = $this->get_image_cdn_sample_content( 'src-attribute.html' );
@@ -362,7 +362,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon will parse the dimensions from a filename when there is no value.
 	 *
 	 * @author scotchfield
-	 * @covers Image_CDN::parse_dimensions_from_filename
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::parse_dimensions_from_filename
 	 * @since 3.2
 	 */
 	public function test_image_cdn_parse_dimensions_from_filename_no_dimensions() {
@@ -375,7 +375,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon will parse the dimensions from a filename for an invalid value.
 	 *
 	 * @author scotchfield
-	 * @covers Image_CDN::parse_dimensions_from_filename
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::parse_dimensions_from_filename
 	 * @since 3.2
 	 */
 	public function test_image_cdn_parse_dimensions_from_filename_no_dimensions_letter() {
@@ -388,7 +388,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon will parse the dimensions from a filename for an invalid value.
 	 *
 	 * @author scotchfield
-	 * @covers Image_CDN::parse_dimensions_from_filename
+	 * @coverAutomattic\Jetpack\Image_CDN\Image_CDN::parse_dimensions_from_filename
 	 * @since 3.2
 	 */
 	public function test_image_cdn_parse_dimensions_from_filename_invalid_dimensions() {
@@ -401,7 +401,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon will parse the dimensions from a filename for a small value.
 	 *
 	 * @author scotchfield
-	 * @covers Image_CDN::parse_dimensions_from_filename
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::parse_dimensions_from_filename
 	 * @since 3.2
 	 */
 	public function test_image_cdn_parse_dimensions_from_filename_valid_dimensions() {
@@ -425,7 +425,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon will parse the dimensions from a filename for a large value.
 	 *
 	 * @author scotchfield
-	 * @covers Image_CDN::parse_dimensions_from_filename
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::parse_dimensions_from_filename
 	 * @since 3.2
 	 */
 	public function test_image_cdn_parse_dimensions_from_filename_valid_large_dimensions() {
@@ -438,7 +438,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon image_downsize filter will return accurate size for a full-size image.
 	 *
 	 * @author kraftbj
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.8.2
 	 */
 	public function test_image_cdn_return_full_size_dimensions() {
@@ -458,7 +458,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon image_downsize filter will return accurate size for a known size.
 	 *
 	 * @author kraftbj
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.8.2
 	 */
 	public function test_image_cdn_return_large_size_dimensions() {
@@ -481,7 +481,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon image_downsize filter will return accurate size for a known size.
 	 *
 	 * @author emilyatmobtown
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 */
 	public function test_image_cdn_return_medium_large_size_dimensions() {
 		global $content_width;
@@ -503,7 +503,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon image_downsize filter will return accurate size for a known size.
 	 *
 	 * @author kraftbj
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.8.2
 	 */
 	public function test_image_cdn_return_jetpack_soft_defined_size_dimensions() {
@@ -526,7 +526,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon image_downsize filter will return accurate size for a known size.
 	 *
 	 * @author kraftbj
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.8.2
 	 */
 	public function test_image_cdn_return_jetpack_soft_undefined_size_dimensions() {
@@ -549,7 +549,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon image_downsize filter will return accurate size for an known size.
 	 *
 	 * @author kraftbj
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.8.2
 	 */
 	public function test_image_cdn_return_jetpack_soft_undefined_zero_size_dimensions() {
@@ -572,7 +572,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon image_downsize filter will return accurate size for a known size.
 	 *
 	 * @author kraftbj
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.8.2
 	 */
 	public function test_image_cdn_return_jetpack_hard_defined_size_dimensions() {
@@ -595,7 +595,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon image_downsize filter will return accurate size for an unknown-when-uploading size.
 	 *
 	 * @author kraftbj
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.8.2
 	 */
 	public function test_image_cdn_return_jetpack_hard_undefined_size_dimensions() {
@@ -618,7 +618,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon image_downsize filter will return accurate size for a known size.
 	 *
 	 * @author kraftbj
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.8.2
 	 */
 	public function test_image_cdn_return_jetpack_hard_undefined_zero_size_dimensions() {
@@ -641,7 +641,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon image_downsize filter will return accurate size for an unknown-when-uploading size.
 	 *
 	 * @author kraftbj
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.8.2
 	 */
 	public function test_image_cdn_return_jetpack_soft_defined_after_upload_size_dimensions() {
@@ -665,7 +665,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon image_downsize filter will return accurate size for an unknown-when-uploading size.
 	 *
 	 * @author kraftbj
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.8.2
 	 */
 	public function test_image_cdn_return_jetpack_soft_undefined_after_upload_size_dimensions() {
@@ -689,7 +689,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon image_downsize filter will return accurate size for an unknown-when-uploading size.
 	 *
 	 * @author kraftbj
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.8.2
 	 */
 	public function test_image_cdn_return_jetpack_soft_undefined_zero_after_upload_size_dimensions() {
@@ -713,7 +713,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon image_downsize filter will return accurate size for an unknown-when-uploading size.
 	 *
 	 * @author kraftbj
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.8.2
 	 */
 	public function test_image_cdn_return_jetpack_hard_defined_after_upload_size_dimensions() {
@@ -737,7 +737,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon image_downsize filter will return accurate size for an unknown-when-uploading size.
 	 *
 	 * @author kraftbj
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.8.2
 	 */
 	public function test_image_cdn_return_jetpack_hard_undefined_after_upload_size_dimensions() {
@@ -761,7 +761,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon image_downsize filter will return accurate size for an unknown-when-uploading size.
 	 *
 	 * @author kraftbj
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.8.2
 	 */
 	public function test_image_cdn_return_jetpack_hard_undefined_zero_after_upload_size_dimensions() {
@@ -785,7 +785,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon image_downsize will return a custom-size image.
 	 *
 	 * @author kraftbj
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.8.2
 	 */
 	public function test_image_cdn_return_custom_size_array_dimensions() {
@@ -807,7 +807,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	/**
 	 * Tests Photon image_downsize will return a cropped image for custom size if the custom size matches a registered size.
 	 *
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 0.4.3
 	 */
 	public function test_image_cdn_return_custom_size_array_uses_registered_crop() {
@@ -826,7 +826,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	/**
 	 * Tests Photon image_downsize will return a cropped image for custom size if the custom size matches a registered size.
 	 *
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 0.4.3
 	 */
 	public function test_image_cdn_return_false_for_image_with_null_size() {
@@ -841,7 +841,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests that Photon will not return an image larger than the original via image_downsize.
 	 *
 	 * @author kraftbj
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.9.0
 	 */
 	public function test_image_cdn_return_custom_size_array_dimensions_larger_than_original() {
@@ -864,7 +864,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests image_downsize filter for a defined size with no meta.
 	 *
 	 * @author dereksmart
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.9.0
 	 */
 	public function test_image_cdn_return_jetpack_soft_defined_size_dimensions_no_meta() {
@@ -887,7 +887,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests image_downsize filter for a soft crop for an existing oversized image size.
 	 *
 	 * @author kraftbj
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.9.0
 	 */
 	public function test_image_cdn_return_jetpack_soft_oversized() {
@@ -911,7 +911,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests image_downsize filter for a soft crop for an undefined size.
 	 *
 	 * @author dereksmart
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.9.0
 	 */
 	public function test_image_cdn_return_jetpack_soft_undefined_size_dimensions_no_meta() {
@@ -934,7 +934,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests image_downsize filter for a soft crop after upload.
 	 *
 	 * @author kraftbj
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.9.0
 	 */
 	public function test_image_cdn_return_jetpack_soft_oversized_after_upload() {
@@ -958,7 +958,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon's image_downsize on a known image size.
 	 *
 	 * @author dereksmart
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.9.0
 	 */
 	public function test_image_cdn_return_jetpack_hard_defined_size_dimensions_no_meta() {
@@ -981,7 +981,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon's image_downsize filter with an undefined size.
 	 *
 	 * @author dereksmart
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.9.0
 	 */
 	public function test_image_cdn_return_jetpack_hard_undefined_size_dimensions_no_meta() {
@@ -1004,7 +1004,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests image_downsize filter when there is no meta information available.
 	 *
 	 * @author dereksmart
-	 * @covers Image_CDN::filter_image_downsize
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_image_downsize
 	 * @since 3.9.0
 	 */
 	public function test_image_cdn_return_custom_size_array_dimensions_no_meta() {
@@ -1027,7 +1027,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon's filtering of the_content when both height/width are known.
 	 *
 	 * @author ebinnion
-	 * @covers Image_CDN::filter_the_content
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_the_content
 	 * @since 5.6.0
 	 */
 	public function test_image_cdn_filter_the_content_does_not_remove_width_height_when_both_known() {
@@ -1048,7 +1048,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Test Photon's filtering of the_content when either width/height is not known.
 	 *
 	 * @author ebinnion
-	 * @covers Image_CDN::filter_the_content
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_the_content
 	 * @since 5.6.0
 	 */
 	public function test_image_cdn_filter_the_content_does_not_have_width_height_when_at_least_one_not_known() {
@@ -1065,7 +1065,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests Photon's filtering of the_content with filtered args.
 	 *
 	 * @author ebinnion
-	 * @covers Image_CDN::filter_the_content
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_the_content
 	 * @dataProvider photon_attributes_when_filtered_data_provider
 	 * @since 5.6.0
 	 *
@@ -1101,7 +1101,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Checks that Photon ignores data-width and data-height attributes when parsing the attributes.
 	 *
 	 * @author mmtr
-	 * @covers Image_CDN::filter_the_content
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_the_content
 	 * @since 8.0.0
 	 */
 	public function test_image_cdn_filter_the_content_ignores_data_width_and_data_height_attributes() {
@@ -1118,7 +1118,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Checks that Photon parses correctly the width and height attributes when they are not preceded by a space.
 	 *
 	 * @author mmtr
-	 * @covers Image_CDN::filter_the_content
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_the_content
 	 * @since 8.0.0
 	 */
 	public function test_image_cdn_filter_the_content_parses_width_height_when_no_spaces_between_attributes() {
@@ -1202,7 +1202,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	/**
 	 * Tests that Photon ignores percentage dimensions. It should fall back to e.g. a "size-foo" class.
 	 *
-	 * @covers Image_CDN::filter_the_content
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_the_content
 	 */
 	public function test_image_cdn_filter_the_content_percentage_width_and_height() {
 		$sample_html      = '<img src="http://example.com/test.png" class="test size-large" width="45%" height="55%" />';
@@ -1223,7 +1223,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	/**
 	 * Tests that Photon ignores empty dimensions. It should fall back to e.g. a "size-foo" class.
 	 *
-	 * @covers Image_CDN::filter_the_content
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_the_content
 	 */
 	public function test_image_cdn_filter_the_content_empty_width_and_height() {
 		$sample_html      = '<img src="http://example.com/test.png" class="test size-large" width="" height="" />';
@@ -1244,7 +1244,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	/**
 	 * Tests that Photon ignores bogus dimensions. It should fall back to e.g. a "size-foo" class.
 	 *
-	 * @covers Image_CDN::filter_the_content
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_the_content
 	 */
 	public function test_image_cdn_filter_the_content_bogus_width_and_height() {
 		$sample_html      = '<img src="http://example.com/test.png" class="test size-large" width="1vh" height="1vh" />';
@@ -1266,7 +1266,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests that Photon will filter for an AMP response.
 	 *
 	 * @author westonruter
-	 * @covers Image_CDN::filter_the_content
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_the_content
 	 * @dataProvider photon_attributes_when_amp_response
 	 * @since 7.6.0
 	 *
@@ -1309,7 +1309,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests that Photon will filter for AMP stories.
 	 *
 	 * @author westonruter
-	 * @covers Image_CDN::filter_the_content
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::filter_the_content
 	 * @covers Jetpack_AMP_Support::filter_image_cdn_post_image_args_for_stories
 	 * @since 7.6.0
 	 * @todo Move to Jetpack
@@ -1463,7 +1463,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 
 	 * @author kraftbj
 	 * @requires PHPUnit 7.5
-	 * @covers Image_CDN::should_rest_image_cdn_image_downsize_insert_attachment
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::should_rest_image_cdn_image_downsize_insert_attachment
 	 * @group rest-api
 	 */
 	public function test_image_cdn_cdn_in_rest_response_with_created_item() {
@@ -1499,7 +1499,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 *
 	 * @author ebinnion
 	 * @requires PHPUnit 7.5
-	 * @covers Image_CDN::should_rest_image_cdn_image_downsize_insert_attachment
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::should_rest_image_cdn_image_downsize_insert_attachment
 	 * @group rest-api
 	 */
 	public function test_image_cdn_in_rest_response_external_media() {
@@ -1561,7 +1561,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	/**
 	 * Tests that Photon will not strip the dimensions from an external URL.
 	 *
-	 * @covers Image_CDN::strip_image_dimensions_maybe
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::strip_image_dimensions_maybe
 	 */
 	public function test_image_cdn_strip_image_dimensions_maybe_ignores_external_files() {
 		$ext_domain = 'https://some.domain/wp-content/uploads/2019/1/test-image-300x300.jpg';
@@ -1572,7 +1572,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	/**
 	 * Tests Photon stripping the image dimensions from filename.
 	 *
-	 * @covers Image_CDN::strip_image_dimensions_maybe
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::strip_image_dimensions_maybe
 	 */
 	public function test_image_cdn_strip_image_dimensions_maybe_strips_resized_string() {
 		$orig_filename = 'test-image-large.png';
@@ -1602,7 +1602,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * @param bool   $expected If is valid Photon-able URL.
 	 *
 	 * @author kraftbj
-	 * @covers       Image_CDN::validate_image_url
+	 * @covers       Automattic\Jetpack\Image_CDN\Image_CDN::validate_image_url
 	 * @dataProvider get_test_image_cdn_validate_image_url_file_types_data_provider
 	 * @since 10.0.0
 	 */

--- a/projects/packages/image-cdn/tests/php/test_class.image_cdn.php
+++ b/projects/packages/image-cdn/tests/php/test_class.image_cdn.php
@@ -1463,7 +1463,6 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 
 	 * @author kraftbj
 	 * @requires PHPUnit 7.5
-	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::should_rest_image_cdn_image_downsize_insert_attachment
 	 * @group rest-api
 	 */
 	public function test_image_cdn_cdn_in_rest_response_with_created_item() {
@@ -1499,7 +1498,6 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 *
 	 * @author ebinnion
 	 * @requires PHPUnit 7.5
-	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::should_rest_image_cdn_image_downsize_insert_attachment
 	 * @group rest-api
 	 */
 	public function test_image_cdn_in_rest_response_external_media() {

--- a/projects/packages/image-cdn/tests/php/test_class.image_cdn.php
+++ b/projects/packages/image-cdn/tests/php/test_class.image_cdn.php
@@ -337,7 +337,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	 * Tests that Photon will parse a multiline html snippet.
 	 *
 	 * @author scotchfield
-	 * @coverAutomattic\Jetpack\Image_CDN\Image_CDN::parse_images_from_html
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN::parse_images_from_html
 	 * @since 3.2
 	 */
 	public function test_image_cdn_parse_images_from_html_multiline() {

--- a/projects/packages/image-cdn/tests/php/test_class.image_cdn_core.php
+++ b/projects/packages/image-cdn/tests/php/test_class.image_cdn_core.php
@@ -31,7 +31,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author kraftbj
-	 * @covers ::Image_CDN_Core::cdn_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since 3.9.2
 	 */
 	public function test_photonizing_https_image_adds_ssl_query_arg() {
@@ -42,7 +42,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author kraftbj
-	 * @covers ::Image_CDN_Core::cdn_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since  3.9.2
 	 */
 	public function test_photonizing_http_image_no_ssl_query_arg() {
@@ -53,7 +53,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author donncha
-	 * @covers ::Image_CDN_Core::cdn_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since 0.2.3
 	 */
 	public function test_photon_url_with_query_parameters() {
@@ -71,7 +71,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_no_filter
 	 */
@@ -86,7 +86,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_no_filter
 	 */
@@ -101,7 +101,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_no_filter
 	 */
@@ -113,7 +113,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_no_filter
 	 */
@@ -125,7 +125,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_no_filter
 	 */
@@ -137,7 +137,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_filter_http
 	 */
@@ -150,7 +150,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_filter_http
 	 */
@@ -163,7 +163,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_filter_http
 	 */
@@ -176,7 +176,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_filter_http
 	 */
@@ -189,7 +189,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_filter_http
 	 */
@@ -202,7 +202,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_filter_network_path
 	 */
@@ -215,7 +215,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_filter_network_path
 	 */
@@ -228,7 +228,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_filter_network_path
 	 */
@@ -241,7 +241,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_filter_network_path
 	 */
@@ -254,7 +254,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_filter_network_path
 	 */
@@ -266,7 +266,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 	}
 
 	/**
-	 * @covers ::Image_CDN_Core::is_cdn_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::is_cdn_url
 	 * @since  0.5.0
 	 * @group  jetpack_photon_filter_network_path
 	 */
@@ -284,7 +284,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 	}
 
 	/**
-	 * @covers ::Image_CDN_Core::cdn_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since  0.5.1
 	 * @group  jetpack_photon_filter_url_encoding
 	 */
@@ -297,7 +297,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url_scheme
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url_scheme
 	 * @since  4.5.0
 	 * @group  Image_CDN_Core::cdn_url_scheme
 	 */
@@ -309,7 +309,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url_scheme
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url_scheme
 	 * @since  4.5.0
 	 * @group  Image_CDN_Core::cdn_url_scheme
 	 */
@@ -321,7 +321,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url_scheme
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url_scheme
 	 * @since  4.5.0
 	 * @group  Image_CDN_Core::cdn_url_scheme
 	 */
@@ -333,7 +333,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url_scheme
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url_scheme
 	 * @since  4.5.0
 	 * @group  Image_CDN_Core::cdn_url_scheme
 	 */
@@ -345,7 +345,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url_scheme
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url_scheme
 	 * @since  4.5.0
 	 * @group  Image_CDN_Core::cdn_url_scheme
 	 */
@@ -357,7 +357,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url_scheme
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url_scheme
 	 * @since  4.5.0
 	 * @group  Image_CDN_Core::cdn_url_scheme
 	 */
@@ -369,7 +369,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::cdn_url_scheme
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url_scheme
 	 * @since  4.5.0
 	 * @group  Image_CDN_Core::cdn_url_scheme
 	 */
@@ -383,7 +383,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 	 * Testing the filter allowing to skip Photon for specific domains.
 	 *
 	 * @author aduth
-	 * @covers ::Image_CDN_Core::banned_domains
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::banned_domains
 	 * @since  5.0.0
 	 * @group  Image_CDN_Core::banned_domains
 	 * @dataProvider get_photon_domains

--- a/projects/packages/image-cdn/tests/php/test_class.image_cdn_core.php
+++ b/projects/packages/image-cdn/tests/php/test_class.image_cdn_core.php
@@ -399,7 +399,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 	 * Tests that Photon will rely on native resizing for WordPress.com images.
 	 *
 	 * @author aforcier
-	 * @covers ::jetpack_photon_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since  9.5.0
 	 */
 	public function test_photonizing_wordpress_url() {
@@ -414,7 +414,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 	 * Tests that Photon will rely on native resizing for VideoPress poster images.
 	 *
 	 * @author aforcier
-	 * @covers ::jetpack_photon_url
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
 	 * @since  9.5.0
 	 */
 	public function test_photonizing_videopress_url() {

--- a/projects/packages/ip/changelog/fix-phpunit_covers_warnings
+++ b/projects/packages/ip/changelog/fix-phpunit_covers_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHPUnit coverage warnings.

--- a/projects/packages/ip/tests/php/test-utils.php
+++ b/projects/packages/ip/tests/php/test-utils.php
@@ -36,8 +36,8 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * Test `get_ip`.
 	 *
-	 * @covers ::get_ip
-	 * @covers ::clean_ip
+	 * @covers Automattic\Jetpack\IP\Utils::get_ip
+	 * @covers Automattic\Jetpack\IP\Utils::clean_ip
 	 * @dataProvider provide_get_ip
 	 * @param string|false $expect Expected output.
 	 * @param array        $server Data for `$_SERVER`.
@@ -250,7 +250,7 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * Test `ip_is_private`.
 	 *
-	 * @covers ::ip_is_private
+	 * @covers Automattic\Jetpack\IP\Utils::ip_is_private
 	 */
 	public function test_ip_is_private() {
 		$public_ips = array(
@@ -277,7 +277,7 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * Test `convert_ip_address`.
 	 *
-	 * @covers ::convert_ip_address
+	 * @covers Automattic\Jetpack\IP\Utils::convert_ip_address
 	 */
 	public function test_convert_ip_address() {
 		$converted_ip_address = Utils::convert_ip_address( '1.2.3.4' );
@@ -287,7 +287,7 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * Test `ip_address_is_in_range`.
 	 *
-	 * @covers ::ip_address_is_in_range
+	 * @covers Automattic\Jetpack\IP\Utils::ip_address_is_in_range
 	 */
 	public function test_ip_address_is_in_range() {
 		// IPv4 - Hyphenated ranges
@@ -390,7 +390,7 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	 * Test `get_ip_addresses_from_string`.
 	 * Covers IPv4 and IPv6 addresses, including ranges, concatenated with various delimiters.
 	 *
-	 * @covers ::get_ip_addresses_from_string
+	 * @covers Automattic\Jetpack\IP\Utils::get_ip_addresses_from_string
 	 */
 	public function test_get_ip_addresses_from_string() {
 		$ip_string =
@@ -432,7 +432,7 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * Test `validate_ip_range`.
 	 *
-	 * @covers ::validate_ip_range
+	 * @covers Automattic\Jetpack\IP\Utils::validate_ip_range
 	 */
 	public function test_validate_ip_range() {
 		// Valid ranges - IPv4.
@@ -477,7 +477,7 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * Test `validate_cidr`.
 	 *
-	 * @covers ::validate_cidr
+	 * @covers Automattic\Jetpack\IP\Utils::validate_cidr
 	 */
 	public function test_validate_cidr() {
 		// Valid IPv4 CIDR notations
@@ -545,7 +545,7 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * Test `parse_cidr`.
 	 *
-	 * @covers ::parse_cidr
+	 * @covers Automattic\Jetpack\IP\Utils::parse_cidr
 	 */
 	public function test_parse_cidr() {
 		// Valid IPv4 CIDR notation
@@ -568,7 +568,7 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * Test `get_ip_version`.
 	 *
-	 * @covers ::get_ip_version
+	 * @covers Automattic\Jetpack\IP\Utils::get_ip_version
 	 */
 	public function test_get_ip_version() {
 		// Valid IPv4 address
@@ -584,7 +584,7 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * Test `validate_netmask`.
 	 *
-	 * @covers ::validate_netmask
+	 * @covers Automattic\Jetpack\IP\Utils::validate_netmask
 	 */
 	public function test_validate_netmask() {
 		// Valid netmask for IPv4
@@ -610,7 +610,7 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * Test `ip_in_ipv4_cidr`.
 	 *
-	 * @covers ::ip_in_ipv4_cidr
+	 * @covers Automattic\Jetpack\IP\Utils::ip_in_ipv4_cidr
 	 */
 	public function test_ip_in_ipv4_cidr() {
 		// IP within CIDR range
@@ -635,7 +635,7 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * Test `ip_in_ipv6_cidr`.
 	 *
-	 * @covers ::ip_in_ipv6_cidr
+	 * @covers Automattic\Jetpack\IP\Utils::ip_in_ipv6_cidr
 	 */
 	public function test_ip_in_ipv6_cidr() {
 		// IP within CIDR range
@@ -660,7 +660,7 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * Test `ip_in_cidr`.
 	 *
-	 * @covers ::ip_in_cidr
+	 * @covers Automattic\Jetpack\IP\Utils::ip_in_cidr
 	 */
 	public function test_ip_in_cidr() {
 		// IPv4 - Valid cases

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-phpunit_covers_warnings
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-phpunit_covers_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHPUnit coverage warnings.

--- a/projects/packages/jetpack-mu-wpcom/tests/php/common/wpcom-enqueue-dynamic-script/class-wpcom-enqueue-dynamic-script-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/common/wpcom-enqueue-dynamic-script/class-wpcom-enqueue-dynamic-script-test.php
@@ -8,7 +8,7 @@
 /**
  * Class for WPCOM_Enqueue_Dynamic_Script_Test.
  *
- * @covers WPCOM_Enqueue_Dynamic_Script.
+ * @covers WPCOM_Enqueue_Dynamic_Script
  */
 class WPCOM_Enqueue_Dynamic_Script_Test extends \WorDBless\BaseTestCase {
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-block-editor/class-jetpack-wpcom-block-editor-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-block-editor/class-jetpack-wpcom-block-editor-test.php
@@ -11,7 +11,7 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom\WPCOM_Block_Editor\Jetpack_WPCOM_Block_E
 /**
  * Class Jetpack_WPCOM_Block_Editor.
  *
- * @covers Jetpack_WPCOM_Block_Editor
+ * @covers Automattic\Jetpack\Jetpack_Mu_Wpcom\WPCOM_Block_Editor\Jetpack_WPCOM_Block_Editor
  */
 class Jetpack_WPCOM_Block_Editor_Test extends \WorDBless\BaseTestCase {
 	/**

--- a/projects/packages/masterbar/changelog/fix-phpunit_covers_warnings
+++ b/projects/packages/masterbar/changelog/fix-phpunit_covers_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHPUnit coverage warnings.

--- a/projects/packages/masterbar/tests/php/test-class-atomic-additional-css-manager.php
+++ b/projects/packages/masterbar/tests/php/test-class-atomic-additional-css-manager.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Test_WPORG_Additional_Css_Manager class.
+ * Test_Atomic_Additional_CSS_Manager class.
  *
  * @package automattic/jetpack-masterbar
  */
@@ -16,7 +16,7 @@ require_once ABSPATH . WPINC . '/class-wp-customize-control.php';
 require_once ABSPATH . WPINC . '/class-wp-customize-section.php';
 
 /**
- * @covers Test_WPORG_Additional_Css_Manager
+ * @covers Automattic\Jetpack\Masterbar\Atomic_Additional_CSS_Manager
  */
 class Test_Atomic_Additional_CSS_Manager extends TestCase {
 	/**

--- a/projects/packages/masterbar/tests/php/test-class-css-customizer-nudge.php
+++ b/projects/packages/masterbar/tests/php/test-class-css-customizer-nudge.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Test WPCOM_CSS_Customizer_Nudge.
+ * Test CSS_Customizer_Nudge.
  *
  * @package automattic/jetpack-masterbar
  */
@@ -15,7 +15,7 @@ require_once ABSPATH . WPINC . '/class-wp-customize-control.php';
 require_once dirname( __DIR__, 2 ) . '/src/nudges/bootstrap.php';
 
 /**
- * @covers Automattic\Jetpack\Masterbar\WPCOM_CSS_Customizer_Nudge
+ * @covers Automattic\Jetpack\Masterbar\CSS_Customizer_Nudge
  */
 class Test_CSS_Customizer_Nudge extends TestCase {
 	/**

--- a/projects/packages/masterbar/tests/php/test-class-dashboard-switcher-tracking.php
+++ b/projects/packages/masterbar/tests/php/test-class-dashboard-switcher-tracking.php
@@ -15,7 +15,7 @@ use WorDBless\Users as WorDBless_Users;
 /**
  * Class Test_Dashboard_Switcher_Tracking
  *
- * @covers Dashboard_Switcher_Tracking
+ * @covers Automattic\Jetpack\Masterbar\Dashboard_Switcher_Tracking
  */
 class Test_Dashboard_Switcher_Tracking extends TestCase {
 	/**

--- a/projects/packages/masterbar/tests/php/test-class-wpcom-admin-menu.php
+++ b/projects/packages/masterbar/tests/php/test-class-wpcom-admin-menu.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/data/admin-menu.php';
 /**
  * Class Test_WPcom_Admin_Menu.
  *
- * @covers Automattic\Jetpack\Dashboard_Customizations\WPcom_Admin_Menu
+ * @covers Automattic\Jetpack\Masterbar\WPcom_Admin_Menu
  */
 class Test_WPcom_Admin_Menu extends TestCase {
 

--- a/projects/plugins/crm/changelog/fix-phpunit_covers_warnings
+++ b/projects/plugins/crm/changelog/fix-phpunit_covers_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHPUnit coverage warnings.

--- a/projects/plugins/crm/tests/php/automation/class-automation-engine-test.php
+++ b/projects/plugins/crm/tests/php/automation/class-automation-engine-test.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/tools/class-automation-faker.php';
 /**
  * Test Automation Engine
  *
- * @covers Automattic\Jetpack\CRM\Automation
+ * @covers Automattic\Jetpack\CRM\Automation\Automation_Engine
  */
 class Automation_Engine_Test extends JPCRM_Base_Test_Case {
 

--- a/projects/plugins/crm/tests/php/automation/class-automation-workflow-test.php
+++ b/projects/plugins/crm/tests/php/automation/class-automation-workflow-test.php
@@ -22,7 +22,7 @@ require_once __DIR__ . '/tools/class-automation-faker.php';
  *
  * @since 6.2.0
  *
- * @covers Automattic\Jetpack\CRM\Automation
+ * @covers Automattic\Jetpack\CRM\Automation\Automation_Workflow
  */
 class Automation_Workflow_Test extends JPCRM_Base_Test_Case {
 

--- a/projects/plugins/crm/tests/php/automation/class-workflow-repository-test.php
+++ b/projects/plugins/crm/tests/php/automation/class-workflow-repository-test.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/tools/class-automation-faker.php';
 /**
  * Test Automation Engine
  *
- * @covers Automattic\Jetpack\CRM\Automation
+ * @covers Automattic\Jetpack\CRM\Automation\Workflow_Repository
  */
 class Workflow_Repository_Test extends JPCRM_Base_Integration_Test_Case {
 

--- a/projects/plugins/crm/tests/php/automation/class-workflow-repository-test.php
+++ b/projects/plugins/crm/tests/php/automation/class-workflow-repository-test.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/tools/class-automation-faker.php';
 /**
  * Test Automation Engine
  *
- * @covers Automattic\Jetpack\CRM\Automation\Workflow_Repository
+ * @covers Automattic\Jetpack\CRM\Automation\Workflow\Workflow_Repository
  */
 class Workflow_Repository_Test extends JPCRM_Base_Integration_Test_Case {
 

--- a/projects/plugins/crm/tests/php/automation/companies/class-company-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/companies/class-company-trigger-test.php
@@ -16,7 +16,10 @@ require_once __DIR__ . '../../tools/class-automation-faker.php';
 /**
  * Test Automation Workflow functionalities
  *
- * @covers Automattic\Jetpack\CRM\Automation
+ * @covers Automattic\Jetpack\CRM\Automation\Company_Updated
+ * @covers Automattic\Jetpack\CRM\Automation\Company_Created
+ * @covers Automattic\Jetpack\CRM\Automation\Company_Deleted
+ * @covers Automattic\Jetpack\CRM\Automation\Company_Status_Updated
  */
 class Company_Trigger_Test extends JPCRM_Base_Test_Case {
 

--- a/projects/plugins/crm/tests/php/automation/companies/class-company-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/companies/class-company-trigger-test.php
@@ -16,10 +16,10 @@ require_once __DIR__ . '../../tools/class-automation-faker.php';
 /**
  * Test Automation Workflow functionalities
  *
- * @covers Automattic\Jetpack\CRM\Automation\Company_Updated
- * @covers Automattic\Jetpack\CRM\Automation\Company_Created
- * @covers Automattic\Jetpack\CRM\Automation\Company_Deleted
- * @covers Automattic\Jetpack\CRM\Automation\Company_Status_Updated
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Company_Updated
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Company_Created
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Company_Deleted
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Company_Status_Updated
  */
 class Company_Trigger_Test extends JPCRM_Base_Test_Case {
 

--- a/projects/plugins/crm/tests/php/automation/contacts/class-contact-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/class-contact-trigger-test.php
@@ -18,12 +18,12 @@ require_once __DIR__ . '../../tools/class-automation-faker.php';
 /**
  * Test Automation Workflow functionalities
  *
- * @covers Automattic\Jetpack\CRM\Automation\Contact_Before_Deleted
- * @covers Automattic\Jetpack\CRM\Automation\Contact_Created
- * @covers Automattic\Jetpack\CRM\Automation\Contact_Deleted
- * @covers Automattic\Jetpack\CRM\Automation\Contact_Email_Updated
- * @covers Automattic\Jetpack\CRM\Automation\Contact_Status_Updated
- * @covers Automattic\Jetpack\CRM\Automation\Contact_Updated
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Contact_Before_Deleted
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Contact_Created
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Contact_Deleted
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Contact_Email_Updated
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Contact_Status_Updated
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Contact_Updated
  */
 class Contact_Trigger_Test extends JPCRM_Base_Test_Case {
 

--- a/projects/plugins/crm/tests/php/automation/contacts/class-contact-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/class-contact-trigger-test.php
@@ -18,7 +18,12 @@ require_once __DIR__ . '../../tools/class-automation-faker.php';
 /**
  * Test Automation Workflow functionalities
  *
- * @covers Automattic\Jetpack\CRM\Automation
+ * @covers Automattic\Jetpack\CRM\Automation\Contact_Before_Deleted
+ * @covers Automattic\Jetpack\CRM\Automation\Contact_Created
+ * @covers Automattic\Jetpack\CRM\Automation\Contact_Deleted
+ * @covers Automattic\Jetpack\CRM\Automation\Contact_Email_Updated
+ * @covers Automattic\Jetpack\CRM\Automation\Contact_Status_Updated
+ * @covers Automattic\Jetpack\CRM\Automation\Contact_Updated
  */
 class Contact_Trigger_Test extends JPCRM_Base_Test_Case {
 

--- a/projects/plugins/crm/tests/php/automation/invoices/actions/class-set-invoice-status-test.php
+++ b/projects/plugins/crm/tests/php/automation/invoices/actions/class-set-invoice-status-test.php
@@ -11,7 +11,7 @@ use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_Test_Case;
 /**
  * Test Automation Workflow functionalities
  *
- * @covers Automattic\Jetpack\CRM\Automation\Actions\Set_Invoice_Status_Test
+ * @covers Automattic\Jetpack\CRM\Automation\Actions\Set_Invoice_Status
  */
 class Set_Invoice_Status_Test extends JPCRM_Base_Integration_Test_Case {
 

--- a/projects/plugins/crm/tests/php/automation/invoices/class-invoice-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/invoices/class-invoice-trigger-test.php
@@ -16,10 +16,10 @@ require_once __DIR__ . '../../tools/class-automation-faker.php';
 /**
  * Test Automation Workflow functionalities
  *
- * @covers Automattic\Jetpack\CRM\Automation\Invoice_Created
- * @covers Automattic\Jetpack\CRM\Automation\Invoice_Deleted
- * @covers Automattic\Jetpack\CRM\Automation\Invoice_Status_Updated
- * @covers Automattic\Jetpack\CRM\Automation\Invoice_Updated
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Invoice_Created
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Invoice_Deleted
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Invoice_Status_Updated
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Invoice_Updated
  */
 class Invoice_Trigger_Test extends JPCRM_Base_Test_Case {
 

--- a/projects/plugins/crm/tests/php/automation/invoices/class-invoice-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/invoices/class-invoice-trigger-test.php
@@ -16,7 +16,10 @@ require_once __DIR__ . '../../tools/class-automation-faker.php';
 /**
  * Test Automation Workflow functionalities
  *
- * @covers Automattic\Jetpack\CRM\Automation
+ * @covers Automattic\Jetpack\CRM\Automation\Invoice_Created
+ * @covers Automattic\Jetpack\CRM\Automation\Invoice_Deleted
+ * @covers Automattic\Jetpack\CRM\Automation\Invoice_Status_Updated
+ * @covers Automattic\Jetpack\CRM\Automation\Invoice_Updated
  */
 class Invoice_Trigger_Test extends JPCRM_Base_Test_Case {
 

--- a/projects/plugins/crm/tests/php/automation/quotes/class-quote-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/quotes/class-quote-trigger-test.php
@@ -17,7 +17,11 @@ require_once __DIR__ . '../../tools/class-automation-faker.php';
 /**
  * Test Automation's quote triggers
  *
- * @covers Automattic\Jetpack\CRM\Automation
+ * @covers Automattic\Jetpack\CRM\Automation\Quote_Accepted
+ * @covers Automattic\Jetpack\CRM\Automation\Quote_Created
+ * @covers Automattic\Jetpack\CRM\Automation\Quote_Deleted
+ * @covers Automattic\Jetpack\CRM\Automation\Quote_Status_Updated
+ * @covers Automattic\Jetpack\CRM\Automation\Quote_Updated
  */
 class Quote_Trigger_Test extends JPCRM_Base_Test_Case {
 

--- a/projects/plugins/crm/tests/php/automation/quotes/class-quote-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/quotes/class-quote-trigger-test.php
@@ -17,11 +17,11 @@ require_once __DIR__ . '../../tools/class-automation-faker.php';
 /**
  * Test Automation's quote triggers
  *
- * @covers Automattic\Jetpack\CRM\Automation\Quote_Accepted
- * @covers Automattic\Jetpack\CRM\Automation\Quote_Created
- * @covers Automattic\Jetpack\CRM\Automation\Quote_Deleted
- * @covers Automattic\Jetpack\CRM\Automation\Quote_Status_Updated
- * @covers Automattic\Jetpack\CRM\Automation\Quote_Updated
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Quote_Accepted
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Quote_Created
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Quote_Deleted
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Quote_Status_Updated
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Quote_Updated
  */
 class Quote_Trigger_Test extends JPCRM_Base_Test_Case {
 

--- a/projects/plugins/crm/tests/php/automation/transactions/actions/class-set-transaction-status-test.php
+++ b/projects/plugins/crm/tests/php/automation/transactions/actions/class-set-transaction-status-test.php
@@ -11,7 +11,7 @@ use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_Test_Case;
 /**
  * Test Automation Workflow functionalities
  *
- * @covers Automattic\Jetpack\CRM\Automation\Actions\Set_Transaction_Status_Test
+ * @covers Automattic\Jetpack\CRM\Automation\Actions\Set_Transaction_Status
  */
 class Set_Transaction_Status_Test extends JPCRM_Base_Integration_Test_Case {
 

--- a/projects/plugins/crm/tests/php/automation/transactions/class-transaction-condition-test.php
+++ b/projects/plugins/crm/tests/php/automation/transactions/class-transaction-condition-test.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '../../tools/class-automation-faker.php';
 /**
  * Test Automation Transaction Condition functionalities
  *
- * @covers Automattic\Jetpack\CRM\Automation
+ * @covers Automattic\Jetpack\CRM\Automation\Transaction_Field
  */
 class Transaction_Condition_Test extends JPCRM_Base_Test_Case {
 

--- a/projects/plugins/crm/tests/php/automation/transactions/class-transaction-condition-test.php
+++ b/projects/plugins/crm/tests/php/automation/transactions/class-transaction-condition-test.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '../../tools/class-automation-faker.php';
 /**
  * Test Automation Transaction Condition functionalities
  *
- * @covers Automattic\Jetpack\CRM\Automation\Transaction_Field
+ * @covers Automattic\Jetpack\CRM\Automation\Conditions\Transaction_Field
  */
 class Transaction_Condition_Test extends JPCRM_Base_Test_Case {
 

--- a/projects/plugins/crm/tests/php/automation/wordpress/class-wp-user-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/wordpress/class-wp-user-trigger-test.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '../../tools/class-automation-faker.php';
 /**
  * Test Automation Workflow functionalities
  *
- * @covers Automattic\Jetpack\CRM\Automation\WP_User_Created
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\WP_User_Created
  */
 class WP_User_Trigger_Test extends JPCRM_Base_Integration_Test_Case {
 

--- a/projects/plugins/crm/tests/php/automation/wordpress/class-wp-user-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/wordpress/class-wp-user-trigger-test.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '../../tools/class-automation-faker.php';
 /**
  * Test Automation Workflow functionalities
  *
- * @covers Automattic\Jetpack\CRM\Automation
+ * @covers Automattic\Jetpack\CRM\Automation\WP_User_Created
  */
 class WP_User_Trigger_Test extends JPCRM_Base_Integration_Test_Case {
 

--- a/projects/plugins/crm/tests/php/entities/class-company-entity-test.php
+++ b/projects/plugins/crm/tests/php/entities/class-company-entity-test.php
@@ -9,7 +9,7 @@ use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_Test_Case;
 /**
  * Test Event Manager system.
  *
- * @covers Automattic\Jetpack\CRM\Entities
+ * @covers Automattic\Jetpack\CRM\Entities\Company
  */
 class Company_Entity_Test extends JPCRM_Base_Integration_Test_Case {
 

--- a/projects/plugins/crm/tests/php/entities/class-contact-entity-test.php
+++ b/projects/plugins/crm/tests/php/entities/class-contact-entity-test.php
@@ -9,7 +9,7 @@ use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_Test_Case;
 /**
  * Test Event Manager system.
  *
- * @covers Automattic\Jetpack\CRM\Entities
+ * @covers Automattic\Jetpack\CRM\Entities\Contact
  */
 class Contact_Entity_Test extends JPCRM_Base_Integration_Test_Case {
 

--- a/projects/plugins/crm/tests/php/entities/class-invoice-entity-test.php
+++ b/projects/plugins/crm/tests/php/entities/class-invoice-entity-test.php
@@ -9,7 +9,7 @@ use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_Test_Case;
 /**
  * Test Event Manager system.
  *
- * @covers Automattic\Jetpack\CRM\Entities
+ * @covers Automattic\Jetpack\CRM\Entities\Invoice
  */
 class Invoice_Entity_Test extends JPCRM_Base_Integration_Test_Case {
 

--- a/projects/plugins/crm/tests/php/entities/class-quote-entity-test.php
+++ b/projects/plugins/crm/tests/php/entities/class-quote-entity-test.php
@@ -9,7 +9,7 @@ use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_Test_Case;
 /**
  * Test Event Manager system.
  *
- * @covers Automattic\Jetpack\CRM\Entities
+ * @covers Automattic\Jetpack\CRM\Entities\Quote
  */
 class Quote_Entity_Test extends JPCRM_Base_Integration_Test_Case {
 

--- a/projects/plugins/crm/tests/php/entities/class-task-entity-test.php
+++ b/projects/plugins/crm/tests/php/entities/class-task-entity-test.php
@@ -9,7 +9,7 @@ use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_Test_Case;
 /**
  * Test Event Manager system.
  *
- * @covers Automattic\Jetpack\CRM\Entities
+ * @covers Automattic\Jetpack\CRM\Entities\Task
  */
 class Task_Entity_Test extends JPCRM_Base_Integration_Test_Case {
 

--- a/projects/plugins/crm/tests/php/entities/class-transaction-entity-test.php
+++ b/projects/plugins/crm/tests/php/entities/class-transaction-entity-test.php
@@ -9,7 +9,7 @@ use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_Test_Case;
 /**
  * Test Event Manager system.
  *
- * @covers Automattic\Jetpack\CRM\Entities
+ * @covers Automattic\Jetpack\CRM\Entities\Transaction
  */
 class Transaction_Entity_Test extends JPCRM_Base_Integration_Test_Case {
 

--- a/projects/plugins/crm/tests/php/event-manager/class-event-manager-test.php
+++ b/projects/plugins/crm/tests/php/event-manager/class-event-manager-test.php
@@ -19,7 +19,9 @@ require_once __DIR__ . '/../automation/tools/class-automation-faker.php';
 /**
  * Test Event Manager system.
  *
- * @covers Automattic\Jetpack\CRM\Event_Manager
+ * @covers Automattic\Jetpack\CRM\Event_Manager\Contact_Event
+ * @covers Automattic\Jetpack\CRM\Event_Manager\Invoice_Event
+ * @covers Automattic\Jetpack\CRM\Event_Manager\Transaction_Event
  */
 class Event_Manager_Test extends JPCRM_Base_Test_Case {
 

--- a/projects/plugins/jetpack/changelog/fix-phpunit_covers_warnings
+++ b/projects/plugins/jetpack/changelog/fix-phpunit_covers_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix PHPUnit coverage warnings.

--- a/projects/plugins/jetpack/tests/php/modules/publicize/test_class.publicize.php
+++ b/projects/plugins/jetpack/tests/php/modules/publicize/test_class.publicize.php
@@ -21,7 +21,7 @@ if ( ! function_exists( 'publicize_init' ) ) {
 
 /**
  * @group publicize
- * @covers Jetpack_Publicize
+ * @covers Automattic\Jetpack\Publicize\Publicize
  */
 class WP_Test_Publicize extends WP_UnitTestCase {
 

--- a/projects/plugins/jetpack/tests/php/modules/videopress/test_class.videopress-player.php
+++ b/projects/plugins/jetpack/tests/php/modules/videopress/test_class.videopress-player.php
@@ -42,7 +42,7 @@ class WP_Test_VideoPress_Player extends WP_UnitTestCase {
 	 * Tests the output of html5_dynamic_next().
 	 *
 	 * @dataProvider get_html_test_data
-	 * @covers VideoPress_Player::test_output_html5_dynamic_next()
+	 * @covers VideoPress_Player
 	 *
 	 * @param array  $options The player options.
 	 * @param string $expected The expected generated content.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Enabling code coverage resulted in about 320 `@cover` annotation warnings from PHPUnit. This PR fixes those.

The warnings were of these varieties:
* Missing namespace in annotation (most warnings were due to this)
* References to just the namespace instead of the actual class or function (CRM had lots of these)
* Typos (e.g. a leading `::` on a class name or a full stop at the end of the line)
* Outdated or non-existent function name referenced (e.g. `jetpack_photon_url` and `should_rest_image_cdn_image_downsize_insert_attachment`) 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Download the raw logs, e.g. from here:
    https://github.com/Automattic/jetpack/actions/runs/11617472093/job/32352785310?pr=39989
2. Verify there are no remaining problem entries, e.g. like this:
    `grep -B1 -i '@covers' ~/Downloads/job-logs.txt `