### PR TITLE
Social | Fix dataviews styles imported in share status being added globally

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-dataviews-styles-being-added-globally
+++ b/projects/js-packages/publicize-components/changelog/fix-social-dataviews-styles-being-added-globally
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed dataviews styles imported in share status being added globally

--- a/projects/js-packages/publicize-components/src/components/share-status/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/share-status/styles.module.scss
@@ -1,5 +1,3 @@
-@import '@wordpress/dataviews/build-style/style.css';
-
 .trigger-wrapper {
 	margin-top: 1rem;
 	padding-block: 1rem;
@@ -65,6 +63,16 @@
 }
 
 .dataview-wrapper {
+	/**
+	 * We have to use scoped import to avoid styles being added globally.
+	 * By importing the styles here, all the styles from dataviews package will be scoped to this component.
+	 * @see https://github.com/Automattic/jetpack/issues/39981
+	 */
+	// Use :global scope to avoid CSS encapsulation
+	:global {
+		// Use import without ".css" extension to avoid it being rendered as URL
+		@import '@wordpress/dataviews/build-style/style';
+	}
 
 	// Hide the table actions
 	:global(.dataviews__view-actions) {

--- a/projects/plugins/jetpack/changelog/fix-social-dataviews-styles-being-added-globally
+++ b/projects/plugins/jetpack/changelog/fix-social-dataviews-styles-being-added-globally
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed dataviews styles imported in share status being added globally

--- a/projects/plugins/social/changelog/fix-social-dataviews-styles-being-added-globally
+++ b/projects/plugins/social/changelog/fix-social-dataviews-styles-being-added-globally
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed dataviews styles imported in share status being added globally


### PR DESCRIPTION
After #39230, we import dataviews styles for share status reporting in Social UIs, which results in dataviews styles being applied globally and if the dataviews styles are being updated which are immediately reflected if you use Gutenberg plugin, there will be styling conflicts.

This PR fixes that issue by scoping the import to our component that we need dataviews styling for.

Fixes #39981

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Scope the dataviews styles to the local component

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to post editor
* Share the post to a few social networks
* Open share status reporting
* Verify that the styles are same as before
* Follow the steps given in #39981
* Verify that the issue is fixed.

