### PR TITLE
Theme Tools: ensure theme-compat files are loaded

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-loading-theme-compat-files
+++ b/projects/plugins/jetpack/changelog/fix-loading-theme-compat-files
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Theme Tools: ensure theme-compat files are still loaded when a compatible theme is used.

--- a/projects/plugins/jetpack/modules/theme-tools.php
+++ b/projects/plugins/jetpack/modules/theme-tools.php
@@ -60,7 +60,7 @@ function jetpack_load_theme_compat() {
 		_jetpack_require_compat_file( get_template(), $compat_files );
 	}
 }
-add_action( 'after_setup_theme', 'jetpack_load_theme_compat', -1 );
+add_action( 'after_setup_theme', 'jetpack_load_theme_compat' );
 
 /**
  * Requires a file once, if the passed key exists in the files array.


### PR DESCRIPTION
Fixes #39968

## Proposed changes:

Since we changed when modules are loaded, it caused jetpack_load_theme_compat to be hooked too early.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

1. Install and activate the Twenty Twenty theme on your site.
2. View the frontend and check your browser dev tools
    * You should see the `twentytwenty.css` file being enqueued on the page.
