### PR TITLE
Adds /stats endpoints to whitelist for Blaze

### DIFF
--- a/projects/packages/blaze/changelog/jamesgil23-whitelist-dsp-stats
+++ b/projects/packages/blaze/changelog/jamesgil23-whitelist-dsp-stats
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adds /stats endpoints to the whitelist

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -166,10 +166,20 @@ class Dashboard_REST_Controller {
 		// WordAds DSP API Site Stats routes
 		register_rest_route(
 			static::$namespace,
-			sprintf( '/sites/%1$d/wordads/dsp/api/(?P<api_version>v[0-9]+\.?[0-9]*)/sites/%1$d/stats(?P<sub_path>[a-zA-Z0-9-_\/]*)(\?.*)?', $site_id ),
+			sprintf( '/sites/%d/wordads/dsp/api/(?P<api_version>v[0-9]+\.?[0-9]*)/stats(?P<sub_path>[a-zA-Z0-9-_\/]*)(\?.*)?', $site_id ),
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_dsp_site_stats' ),
+				'callback'            => array( $this, 'get_dsp_stats' ),
+				'permission_callback' => array( $this, 'can_user_view_dsp_callback' ),
+			)
+		);
+
+		register_rest_route(
+			static::$namespace,
+			sprintf( '/sites/%d/wordads/dsp/api/(?P<api_version>v[0-9]+\.?[0-9]*)/stats(?P<sub_path>[a-zA-Z0-9-_\/]*)', $site_id ),
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'edit_dsp_stats' ),
 				'permission_callback' => array( $this, 'can_user_view_dsp_callback' ),
 			)
 		);
@@ -568,19 +578,27 @@ class Dashboard_REST_Controller {
 	}
 
 	/**
-	 * Redirect GET requests to WordAds DSP Site Stats endpoint for the site.
+	 * Redirect GET requests to WordAds DSP Stats endpoint for the site.
 	 *
 	 * @param WP_REST_Request $req The request object.
 	 *
 	 * @return array|WP_Error
 	 */
-	public function get_dsp_site_stats( $req ) {
-		$site_id = $this->get_site_id();
-		if ( is_wp_error( $site_id ) ) {
-			return array();
-		}
+	public function get_dsp_stats( $req ) {
+		$version = $req->get_param( 'api_version' ) ?? 'v1';
+		return $this->get_dsp_generic( "{$version}/stats", $req );
+	}
 
-		return $this->get_dsp_generic( sprintf( 'v1/sites/%d/stats', $site_id ), $req );
+	/**
+	 * Redirect POST requests to WordAds DSP Stats endpoint for the site.
+	 *
+	 * @param WP_REST_Request $req The request object.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function edit_dsp_stats( $req ) {
+		$version = $req->get_param( 'api_version' ) ?? 'v1';
+		return $this->get_dsp_generic( "{$version}/stats", $req );
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -166,7 +166,7 @@ class Dashboard_REST_Controller {
 		// WordAds DSP API Site Stats routes
 		register_rest_route(
 			static::$namespace,
-			sprintf( '/sites/%1$d/wordads/dsp/api/v1.1/sites/%1$d/stats(?P<sub_path>[a-zA-Z0-9-_\/]*)(\?.*)?', $site_id ),
+			sprintf( '/sites/%1$d/wordads/dsp/api/(?P<api_version>v[0-9]+\.?[0-9]*)/sites/%1$d/stats(?P<sub_path>[a-zA-Z0-9-_\/]*)(\?.*)?', $site_id ),
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_dsp_site_stats' ),

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -163,6 +163,17 @@ class Dashboard_REST_Controller {
 			)
 		);
 
+		// WordAds DSP API Site Stats routes
+		register_rest_route(
+			static::$namespace,
+			sprintf( '/sites/%1$d/wordads/dsp/api/v1.1/sites/%1$d/stats(?P<sub_path>[a-zA-Z0-9-_\/]*)(\?.*)?', $site_id ),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_dsp_site_stats' ),
+				'permission_callback' => array( $this, 'can_user_view_dsp_callback' ),
+			)
+		);
+
 		// WordAds DSP API Search routes
 		register_rest_route(
 			static::$namespace,
@@ -554,6 +565,22 @@ class Dashboard_REST_Controller {
 		}
 
 		return $this->get_dsp_generic( sprintf( 'v1/sites/%d/campaigns', $site_id ), $req );
+	}
+
+	/**
+	 * Redirect GET requests to WordAds DSP Site Stats endpoint for the site.
+	 *
+	 * @param WP_REST_Request $req The request object.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function get_dsp_site_stats( $req ) {
+		$site_id = $this->get_site_id();
+		if ( is_wp_error( $site_id ) ) {
+			return array();
+		}
+
+		return $this->get_dsp_generic( sprintf( 'v1/sites/%d/stats', $site_id ), $req );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

This adds a whitelist for some new routes added to the WordPress Blaze apps.

These routes will support some new stat charts we're adding to the user's dashboard.

## Does this pull request change what data or activity we track or use?
No


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:

A code review should be adequate here.

Here is a DSP PR that adds the new endpoint 
2756-ghe-Tumblr/a8c-dsp

