### PR TITLE
Boost: Always save the default cornerstone pages

### DIFF
--- a/projects/plugins/boost/app/data-sync/Cornerstone_Pages_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Cornerstone_Pages_Entry.php
@@ -14,11 +14,12 @@ class Cornerstone_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 		$this->option_key = 'jetpack_boost_ds_' . $option_key;
 	}
 
-	public function get( $fallback_value = false ) {
-		if ( $fallback_value !== false ) {
-			$urls = get_option( $this->option_key, $fallback_value );
-		} else {
-			$urls = get_option( $this->option_key );
+	public function get( $fallback_value = array() ) {
+		$urls = get_option( $this->option_key, array() );
+
+		if ( empty( $urls ) && ! empty( $fallback_value ) ) {
+			$urls = $fallback_value;
+			$this->set( $urls );
 		}
 
 		return array_map( array( $this, 'transform_to_absolute' ), $urls );

--- a/projects/plugins/boost/app/lib/Cornerstone_Pages.php
+++ b/projects/plugins/boost/app/lib/Cornerstone_Pages.php
@@ -18,7 +18,7 @@ class Cornerstone_Pages implements Has_Setup {
 	}
 
 	public function register_ds_stores() {
-		$schema = Schema::as_array( Schema::as_string() )->fallback( self::default_pages() );
+		$schema = Schema::as_array( Schema::as_string() )->fallback( $this->default_pages() );
 		jetpack_boost_register_option( 'cornerstone_pages_list', $schema, new Cornerstone_Pages_Entry( 'cornerstone_pages_list' ) );
 		jetpack_boost_register_readonly_option( 'cornerstone_pages_properties', array( $this, 'get_properties' ) );
 	}

--- a/projects/plugins/boost/changelog/update-cornerstone-pages-default-value
+++ b/projects/plugins/boost/changelog/update-cornerstone-pages-default-value
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Change to an unreleased feature
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #40001

## Proposed changes:
* Save the default cornerstone pages value

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
* Check the `jetpack_boost_ds_cornerstone_pages_list` value in database
* Delete it
* Reload Boost settings page
* Make sure the value is repopulated.

