### PR TITLE
Boost: Add tracks events for cornerstone pages

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -25,6 +25,13 @@ const Meta = () => {
 	const isPremium = premiumFeatures.includes( 'support' );
 	const navigate = useNavigate();
 
+	const toggleExpanded = ( newValue: boolean ) => {
+		recordBoostEvent( 'cornerstone_pages_show_options_toggle', {
+			status: newValue ? 'open' : 'close',
+		} );
+		setIsExpanded( newValue );
+	};
+
 	const updateCornerstonePages = ( newValue: string ) => {
 		const newItems = newValue.split( '\n' ).map( line => line.trim() );
 
@@ -137,7 +144,7 @@ const Meta = () => {
 						weight="regular"
 						iconSize={ 16 }
 						icon={ isExpanded ? <ChevronUp /> : <ChevronDown /> }
-						onClick={ () => setIsExpanded( ! isExpanded ) }
+						onClick={ () => toggleExpanded( ! isExpanded ) }
 					>
 						{ __( 'Show Options', 'jetpack-boost' ) }
 					</Button>
@@ -223,6 +230,9 @@ const List: React.FC< ListProps > = ( { items, setItems, maxItems, description }
 
 	function save() {
 		setItems( inputValue );
+		recordBoostEvent( 'cornerstone_pages_save', {
+			list_length: inputValue.split( '\n' ).length,
+		} );
 	}
 
 	return (

--- a/projects/plugins/boost/changelog/add-cornerstone-tracks
+++ b/projects/plugins/boost/changelog/add-cornerstone-tracks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Added tracks to an unreleased feature
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #40004

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added a tracks event to track when "Show Options" is toggled
* Added a tracks event to track when the list is saved

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
Maybe

## Testing instructions:
* `jetpack_boost_cornerstone_pages_save` and `jetpack_boost_cornerstone_pages_show_options_toggle` events should trigger.

