### PR TITLE
Boost: Add endpoint that lists cornerstone pages

### DIFF
--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -37,6 +37,7 @@ use Automattic\Jetpack_Boost\Modules\Modules_Setup;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache_Setup;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress\Boost_Cache_Settings;
+use Automattic\Jetpack_Boost\REST_API\Endpoints\List_Cornerstone_Pages;
 use Automattic\Jetpack_Boost\REST_API\Endpoints\List_Site_Urls;
 use Automattic\Jetpack_Boost\REST_API\Endpoints\List_Source_Providers;
 use Automattic\Jetpack_Boost\REST_API\REST_API;
@@ -194,6 +195,8 @@ class Jetpack_Boost {
 	public function init_admin( $modules_setup ) {
 		REST_API::register( List_Site_Urls::class );
 		REST_API::register( List_Source_Providers::class );
+		REST_API::register( List_Cornerstone_Pages::class );
+
 		$this->connection->ensure_connection();
 		( new Admin() )->init( $modules_setup );
 	}

--- a/projects/plugins/boost/app/rest-api/endpoints/List_Cornerstone_Pages.php
+++ b/projects/plugins/boost/app/rest-api/endpoints/List_Cornerstone_Pages.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Create a new request for cornerstone pages.
+ *
+ * Handler for GET '/list-cornerstone-pages'.
+ */
+
+namespace Automattic\Jetpack_Boost\REST_API\Endpoints;
+
+use Automattic\Jetpack_Boost\Lib\Cornerstone_Pages;
+use Automattic\Jetpack_Boost\REST_API\Contracts\Endpoint;
+use Automattic\Jetpack_Boost\REST_API\Permissions\Signed_With_Blog_Token;
+
+class List_Cornerstone_Pages implements Endpoint {
+
+	public function request_methods() {
+		return \WP_REST_Server::READABLE;
+	}
+
+	public function response( $_request ) {
+		$cornerstone_pages = new Cornerstone_Pages();
+		return rest_ensure_response( $cornerstone_pages->get_pages() );
+	}
+
+	public function permissions() {
+		return array(
+			new Signed_With_Blog_Token(),
+		);
+	}
+
+	public function name() {
+		return '/list-cornerstone-pages';
+	}
+}

--- a/projects/plugins/boost/changelog/add-cornerstone-pages-endpoint
+++ b/projects/plugins/boost/changelog/add-cornerstone-pages-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Change for an unreleased feature
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/boost-cloud#634

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a protected endpoint that wpcom can access the cornerstone endpoints of a site.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
![image](https://github.com/user-attachments/assets/0c0804ef-eee2-4ae5-8fef-24f1f1c90402)
