### PR TITLE
Boost: Regenerate cloud css on cornerstone page list update

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -15,6 +15,7 @@ import getSupportLink from '$lib/utils/get-support-link';
 import { useRegenerationReason } from '$features/critical-css/lib/stores/suggest-regenerate';
 import { usePremiumFeatures } from '$lib/stores/premium-features';
 import { useNavigate } from 'react-router-dom';
+import { useRegenerateCriticalCssAction } from '$features/critical-css/lib/stores/critical-css-state';
 
 const Meta = () => {
 	const [ isExpanded, setIsExpanded ] = useState( false );
@@ -24,12 +25,14 @@ const Meta = () => {
 	const premiumFeatures = usePremiumFeatures();
 	const isPremium = premiumFeatures.includes( 'support' );
 	const navigate = useNavigate();
+	const regenerateAction = useRegenerateCriticalCssAction();
 
 	const updateCornerstonePages = ( newValue: string ) => {
 		const newItems = newValue.split( '\n' ).map( line => line.trim() );
 
 		setCornerstonePages( newItems, () => {
 			refetchRegenerationReason();
+			regenerateAction.mutate();
 		} );
 	};
 

--- a/projects/plugins/boost/changelog/update-boost-regen-cloud-css-on-cornerstone-list-update
+++ b/projects/plugins/boost/changelog/update-boost-regen-cloud-css-on-cornerstone-list-update
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Regenerate critical css when updating foundation pages list.
+
+


### PR DESCRIPTION
Fixes #40002

## Proposed changes:

* Dispatch a request to regenerate Cloud/Critical CSS when the cornerstone pages list is updated

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Setup Boost;
- Edit the "Cornerstone pages" list;
- The critical/cloud css should start regenerating.