### PR TITLE
Boost: Better handling for slashes for cornerstone pages

### DIFF
--- a/projects/plugins/boost/app/data-sync/Cornerstone_Pages_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Cornerstone_Pages_Entry.php
@@ -40,7 +40,7 @@ class Cornerstone_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 
 	private function sanitize_value( $value ) {
 		if ( is_array( $value ) ) {
-			$value = array_values( array_unique( array_filter( array_map( array( $this, 'transform_to_relative' ), $value ) ) ) );
+			$value = array_values( array_unique( array_map( array( $this, 'transform_to_relative' ), $value ) ) );
 		} else {
 			$value = array();
 		}
@@ -57,8 +57,10 @@ class Cornerstone_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 		}
 
 		// Ensure the URL starts with a slash.
-		$url = ltrim( $url, '/' );
-		$url = '/' . $url;
+		if ( $url !== '' ) {
+			$url = ltrim( $url, '/' );
+			$url = '/' . $url;
+		}
 
 		return $url;
 	}

--- a/projects/plugins/boost/app/data-sync/Cornerstone_Pages_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Cornerstone_Pages_Entry.php
@@ -32,6 +32,8 @@ class Cornerstone_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 			return;
 		}
 
+		$value = array_map( 'untrailingslashit', $value );
+
 		$updated = update_option( $this->option_key, $value );
 		if ( $updated ) {
 			( new Environment_Change_Detector() )->handle_cornerstone_pages_list_update();

--- a/projects/plugins/boost/app/lib/Cornerstone_Pages.php
+++ b/projects/plugins/boost/app/lib/Cornerstone_Pages.php
@@ -104,7 +104,16 @@ class Cornerstone_Pages implements Has_Setup {
 	}
 
 	public function get_pages() {
-		return jetpack_boost_ds_get( 'cornerstone_pages_list' );
+		$pages = jetpack_boost_ds_get( 'cornerstone_pages_list' );
+
+		$permalink_structure = get_option( 'permalink_structure' );
+
+		// If permalink structure ends with slash, add trailing slashes
+		if ( $permalink_structure && substr( $permalink_structure, -1 ) === '/' ) {
+			$pages = array_map( 'trailingslashit', $pages );
+		}
+
+		return $pages;
 	}
 
 	public function get_properties() {

--- a/projects/plugins/boost/app/lib/Cornerstone_Pages.php
+++ b/projects/plugins/boost/app/lib/Cornerstone_Pages.php
@@ -37,14 +37,14 @@ class Cornerstone_Pages implements Has_Setup {
 
 	private function default_pages() {
 		if ( $this->get_max_pages() === static::FREE_MAX_PAGES ) {
-			return array( '/' );
+			return array( '' );
 		}
 
 		$max_pages               = $this->get_max_pages();
 		$yoast_cornerstone_pages = $this->get_yoast_cornerstone_pages();
 		$woocommerce_pages       = $this->get_woocommerce_pages();
 
-		$homepage = array( '/' );
+		$homepage = array( '' );
 
 		$urls = array_unique( array_merge( $homepage, $woocommerce_pages, $yoast_cornerstone_pages ) );
 

--- a/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Cornerstone_Provider.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Cornerstone_Provider.php
@@ -58,7 +58,7 @@ class Cornerstone_Provider extends Provider {
 			return home_url( $wp->request );
 		}
 
-		return add_query_arg( $wp->query_vars, home_url( '/' ) );
+		return add_query_arg( $wp->query_vars, home_url() );
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/update-boost-cornerstone-pages-slashes
+++ b/projects/plugins/boost/changelog/update-boost-cornerstone-pages-slashes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Don't store trailing slashes for foundation pages.
+
+


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/40005

## Proposed changes:

* Allow an empty string to be stored in the db. This will be for the home-page;
* Home-page always has a trailing slash. This remains unchanged as browsers handle it;
* Remove any trailing slashes when storing list of urls;
* Add trailing slashes if necessary, based on the permalink structure.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Setup Boost;
- Add some URLs to the list;
- Try various combinations of URLs with and without slashes;
- Change the permalink structure to not have a trailing slash and see that that's properly reflected in the UI.