### PR TITLE
coverage: Add missing files/dirs to phpunit configs

### DIFF
--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -188,6 +188,6 @@ if [[ "$WITH_WPCOMSH" == true ]]; then
 fi
 
 # Catch anything that doesn't use the WP_TESTS_CONFIG_FILE_PATH env variable.
-echo '<?php die( "Use the WP_TESTS_CONFIG_FILE_PATH environment variable to locate a customized config." );' > "/tmp/wordpress-$WP_BRANCH/wp-tests-config.php"
+echo '<?php throw new \Exception( "Use the WP_TESTS_CONFIG_FILE_PATH environment variable to locate a customized config." );' > "/tmp/wordpress-$WP_BRANCH/wp-tests-config.php"
 
 exit $EXIT

--- a/projects/packages/classic-theme-helper/changelog/add-phpunit-coverage-configs
+++ b/projects/packages/classic-theme-helper/changelog/add-phpunit-coverage-configs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Add missing files/dirs to phpunit coverage config.
+
+

--- a/projects/packages/classic-theme-helper/phpunit.xml.dist
+++ b/projects/packages/classic-theme-helper/phpunit.xml.dist
@@ -8,6 +8,7 @@
 		<whitelist processUncoveredFilesFromWhitelist="false">
 			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
 			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<directory suffix=".php">_inc</directory>
 			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>

--- a/projects/packages/phpcs-filter/changelog/add-phpunit-coverage-configs
+++ b/projects/packages/phpcs-filter/changelog/add-phpunit-coverage-configs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Add missing files/dirs to phpunit coverage config.
+
+

--- a/projects/packages/phpcs-filter/phpunit.xml.dist
+++ b/projects/packages/phpcs-filter/phpunit.xml.dist
@@ -8,6 +8,7 @@
 		<whitelist processUncoveredFilesFromWhitelist="false">
 			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
 			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<file>stdin-bootstrap.php</file>
 			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>

--- a/projects/packages/scheduled-updates/changelog/add-phpunit-coverage-configs
+++ b/projects/packages/scheduled-updates/changelog/add-phpunit-coverage-configs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Add missing files/dirs to phpunit coverage config.
+
+

--- a/projects/packages/scheduled-updates/phpunit.xml.dist
+++ b/projects/packages/scheduled-updates/phpunit.xml.dist
@@ -9,4 +9,11 @@
 			<directory suffix="-test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="false">
+			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
+			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<directory suffix=".php">src</directory>
+		</whitelist>
+	</filter>
 </phpunit>

--- a/projects/packages/search/changelog/add-phpunit-coverage-configs
+++ b/projects/packages/search/changelog/add-phpunit-coverage-configs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Add missing files/dirs to phpunit coverage config.
+
+

--- a/projects/packages/search/phpunit.xml.dist
+++ b/projects/packages/search/phpunit.xml.dist
@@ -2,6 +2,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage>
     <include>
+      <directory suffix=".php">compatibility</directory>
       <directory suffix=".php">src</directory>
     </include>
   </coverage>

--- a/projects/plugins/boost/changelog/add-phpunit-coverage-configs
+++ b/projects/plugins/boost/changelog/add-phpunit-coverage-configs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Add missing files/dirs to phpunit coverage config.
+
+

--- a/projects/plugins/boost/phpunit.xml.dist
+++ b/projects/plugins/boost/phpunit.xml.dist
@@ -17,6 +17,10 @@
 
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
+			<file>index.php</file>
+			<file>jetpack-boost.php</file>
+			<file>serve-minified-content.php</file>
+			<file>wp-js-data-sync.php</file>
 			<directory suffix=".php">app</directory>
 			<directory suffix=".php">compatibility</directory>
 		</whitelist>

--- a/projects/plugins/crm/changelog/add-phpunit-coverage-configs
+++ b/projects/plugins/crm/changelog/add-phpunit-coverage-configs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Add missing files/dirs to phpunit coverage config.
+
+

--- a/projects/plugins/crm/phpunit.xml.dist
+++ b/projects/plugins/crm/phpunit.xml.dist
@@ -7,6 +7,7 @@
       <directory suffix=".php">api</directory>
       <directory suffix=".php">includes</directory>
       <directory suffix=".php">modules</directory>
+      <directory suffix=".php">public</directory>
       <directory suffix=".php">src</directory>
     </include>
   </coverage>

--- a/projects/plugins/crm/phpunit.xml.dist
+++ b/projects/plugins/crm/phpunit.xml.dist
@@ -3,6 +3,7 @@
   <coverage processUncoveredFiles="false">
     <include>
       <file>ZeroBSCRM.php</file>
+      <directory suffix=".php">admin</directory>
       <directory suffix=".php">api</directory>
       <directory suffix=".php">includes</directory>
       <directory suffix=".php">modules</directory>

--- a/projects/plugins/inspect/changelog/add-phpunit-coverage-configs
+++ b/projects/plugins/inspect/changelog/add-phpunit-coverage-configs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Add missing files/dirs to phpunit coverage config.
+
+

--- a/projects/plugins/inspect/phpunit.xml.dist
+++ b/projects/plugins/inspect/phpunit.xml.dist
@@ -8,6 +8,9 @@
 		<whitelist processUncoveredFilesFromWhitelist="false">
 			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
 			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<file>functions.php</file>
+			<file>options.php</file>
+			<directory suffix=".php">app</directory>
 			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>

--- a/projects/plugins/inspect/phpunit.xml.dist
+++ b/projects/plugins/inspect/phpunit.xml.dist
@@ -11,6 +11,7 @@
 			<file>functions.php</file>
 			<file>options.php</file>
 			<directory suffix=".php">app</directory>
+			<directory suffix=".php">packages</directory>
 			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>

--- a/projects/plugins/jetpack/changelog/add-phpunit-coverage-configs
+++ b/projects/plugins/jetpack/changelog/add-phpunit-coverage-configs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Add missing files/dirs to phpunit coverage config.
+
+

--- a/projects/plugins/jetpack/phpunit.xml.dist
+++ b/projects/plugins/jetpack/phpunit.xml.dist
@@ -115,7 +115,45 @@
 	</groups>
 	<filter>
 		<whitelist>
-			<file>./*.php</file>
+			<!-- Can't just <directory>.</directory> because PHPUnit is dumb about scanning before applying any exclusions, and can't glob in <file>. Sigh. -->
+			<file>class.frame-nonce-preview.php</file>
+			<file>class.jetpack-admin.php</file>
+			<file>class.jetpack-affiliate.php</file>
+			<file>class.jetpack-autoupdate.php</file>
+			<file>class.jetpack-bbpress-json-api.compat.php</file>
+			<file>class.jetpack-client-server.php</file>
+			<file>class.jetpack-cli.php</file>
+			<file>class-jetpack-connection-status.php</file>
+			<file>class-jetpack-gallery-settings.php</file>
+			<file>class.jetpack-gutenberg.php</file>
+			<file>class.jetpack-heartbeat.php</file>
+			<file>class.jetpack-modules-list-table.php</file>
+			<file>class.jetpack-network.php</file>
+			<file>class.jetpack-network-sites-list-table.php</file>
+			<file>class.jetpack.php</file>
+			<file>class.jetpack-plan.php</file>
+			<file>class.jetpack-post-images.php</file>
+			<file>class-jetpack-pre-connection-jitms.php</file>
+			<file>class-jetpack-stats-dashboard-widget.php</file>
+			<file>class.jetpack-twitter-cards.php</file>
+			<file>class.jetpack-user-agent.php</file>
+			<file>class-jetpack-xmlrpc-methods.php</file>
+			<file>class.json-api-endpoints.php</file>
+			<file>class.json-api.php</file>
+			<file>class.photon.php</file>
+			<file>enhanced-open-graph.php</file>
+			<file>functions.compat.php</file>
+			<file>functions.cookies.php</file>
+			<file>functions.global.php</file>
+			<file>functions.is-mobile.php</file>
+			<file>functions.opengraph.php</file>
+			<file>functions.photon.php</file>
+			<file>jetpack.php</file>
+			<file>json-api-config.php</file>
+			<file>json-endpoints.php</file>
+			<file>load-jetpack.php</file>
+			<file>locales.php</file>
+			<file>uninstall.php</file>
 			<directory suffix=".php">3rd-party</directory>
 			<directory suffix=".php">extensions</directory>
 			<directory suffix=".php">_inc</directory>
@@ -123,6 +161,7 @@
 			<directory suffix=".php">modules</directory>
 			<directory suffix=".php">sal</directory>
 			<directory suffix=".php">src</directory>
+			<directory suffix=".php">views</directory>
 		</whitelist>
 	</filter>
 	<listeners>

--- a/projects/plugins/super-cache/changelog/add-phpunit-coverage-configs
+++ b/projects/plugins/super-cache/changelog/add-phpunit-coverage-configs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Add missing files/dirs to phpunit coverage config.
+
+

--- a/projects/plugins/super-cache/phpunit.xml.dist
+++ b/projects/plugins/super-cache/phpunit.xml.dist
@@ -8,6 +8,18 @@
 		<whitelist processUncoveredFilesFromWhitelist="false">
 			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
 			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<!-- Can't just <directory>.</directory> because PHPUnit is dumb about scanning before applying any exclusions, and can't glob in <file>. Sigh. -->
+			<file>advanced-cache.php</file>
+			<file>ossdl-cdn.php</file>
+			<file>wp-cache-base.php</file>
+			<file>wp-cache-config-sample.php</file>
+			<file>wp-cache-phase1.php</file>
+			<file>wp-cache-phase2.php</file>
+			<file>wp-cache.php</file>
+			<directory suffix=".php">inc</directory>
+			<directory suffix=".php">partials</directory>
+			<directory suffix=".php">plugins</directory>
+			<directory suffix=".php">rest</directory>
 			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>

--- a/projects/plugins/wpcomsh/changelog/add-phpunit-coverage-configs
+++ b/projects/plugins/wpcomsh/changelog/add-phpunit-coverage-configs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Add missing files/dirs to phpunit coverage config.
+
+

--- a/projects/plugins/wpcomsh/phpunit.xml.dist
+++ b/projects/plugins/wpcomsh/phpunit.xml.dist
@@ -25,4 +25,49 @@
 		<ini name="display_errors" value="On" />
 		<ini name="display_startup_errors" value="On" />
 	</php>
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="false">
+			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
+			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<!-- Can't just <directory>.</directory> because PHPUnit is dumb about scanning before applying any exclusions, and can't glob in <file>. Sigh. -->
+			<file>class-atomic-persistent-data.php</file>
+			<file>class-jetpack-plugin-compatibility.php</file>
+			<file>class-wpcomsh-cli-commands.php</file>
+			<file>class-wpcomsh-log.php</file>
+			<file>constants.php</file>
+			<file>functions.php</file>
+			<file>i18n.php</file>
+			<file>plugin-hotfixes.php</file>
+			<file>support-session.php</file>
+			<file>woa.php</file>
+			<file>wpcomsh-loader.php</file>
+			<file>wpcomsh.php</file>
+			<directory suffix=".php">custom-colors</directory>
+			<directory suffix=".php">customizer-fixes</directory>
+			<directory suffix=".php">endpoints</directory>
+			<directory suffix=".php">feature-plugins</directory>
+			<directory suffix=".php">footer-credit</directory>
+			<directory suffix=".php">frontend-notices</directory>
+			<directory suffix=".php">imports</directory>
+			<directory suffix=".php">jetpack-require-connection-owner</directory>
+			<directory suffix=".php">jetpack-token-error-header</directory>
+			<directory suffix=".php">jetpack-token-resilience</directory>
+			<directory suffix=".php">lib</directory>
+			<directory suffix=".php">logo-tool</directory>
+			<directory suffix=".php">mailpoet</directory>
+			<directory suffix=".php">notices</directory>
+			<directory suffix=".php">performance-profiler</directory>
+			<directory suffix=".php">privacy</directory>
+			<directory suffix=".php">private-site</directory>
+			<directory suffix=".php">safeguard</directory>
+			<directory suffix=".php">share-post</directory>
+			<directory suffix=".php">storage</directory>
+			<directory suffix=".php">storefront</directory>
+			<directory suffix=".php">widgets</directory>
+			<directory suffix=".php">wpcom-features</directory>
+			<directory suffix=".php">wpcom-marketplace</directory>
+			<directory suffix=".php">wpcom-migration-helpers</directory>
+			<directory suffix=".php">wpcom-themes</directory>
+		</whitelist>
+	</filter>
 </phpunit>

--- a/projects/plugins/wpcomsh/tests/bootstrap.php
+++ b/projects/plugins/wpcomsh/tests/bootstrap.php
@@ -53,5 +53,11 @@ function _manually_load_plugin() {
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
+// Override WP_TESTS_CONFIG_FILE_PATH via environment.
+// Important for monorepo CI, if you don't do this then different test runs might collide!
+if ( false !== getenv( 'WP_TESTS_CONFIG_FILE_PATH' ) ) {
+	define( 'WP_TESTS_CONFIG_FILE_PATH', getenv( 'WP_TESTS_CONFIG_FILE_PATH' ) );
+}
+
 // Start up the WP testing environment.
 require_once $_tests_dir . '/includes/bootstrap.php';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Ideally everything would be under `src/`, but that's not the case for a bunch of our packages and plugins.

Also annoying is that PHPUnit doesn't allow globs in `<file>`, so we have to list any root-level files individually.

There are still some root-level files not touched here that might be, e.g. `actions.php` files in a few packages or most plugins' entry point files. Not sure if those should be included or not.
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the coverage data, see if these are covered now? Kind of hard to do though.
