### PR TITLE
Boost: Prioritize cornerstone provider while serving critical CSS

### DIFF
--- a/projects/plugins/boost/app/lib/critical-css/source-providers/Source_Providers.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/Source_Providers.php
@@ -38,12 +38,12 @@ class Source_Providers {
 	 * @var Provider[]
 	 */
 	protected $providers = array(
+		Cornerstone_Provider::class,
 		Post_ID_Provider::class,
 		WP_Core_Provider::class,
 		Singular_Post_Provider::class,
 		Archive_Provider::class,
 		Taxonomy_Provider::class,
-		Cornerstone_Provider::class,
 	);
 
 	public function get_providers() {

--- a/projects/plugins/boost/app/lib/critical-css/source-providers/Source_Providers.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/Source_Providers.php
@@ -110,6 +110,10 @@ class Source_Providers {
 		return $this->request_cached_css;
 	}
 
+	public function get_current_critical_css_key() {
+		return $this->current_critical_css_key;
+	}
+
 	/**
 	 * Get providers sources.
 	 *

--- a/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Cornerstone_Provider.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Cornerstone_Provider.php
@@ -77,6 +77,15 @@ class Cornerstone_Provider extends Provider {
 	 * @inheritdoc
 	 */
 	public static function get_hash_for_url( $url ) {
+		// Remove the home_url from the beginning of the URL.
+		$home_url = home_url();
+		if ( stripos( $url, $home_url ) === 0 ) {
+			$url = substr( $url, strlen( $home_url ) );
+		}
+		if ( $url === '' ) {
+			$url = '/';
+		}
+
 		$hash = hash( 'md5', $url );
 
 		return substr( $hash, 0, 8 );

--- a/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Cornerstone_Provider.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Cornerstone_Provider.php
@@ -82,9 +82,6 @@ class Cornerstone_Provider extends Provider {
 		if ( stripos( $url, $home_url ) === 0 ) {
 			$url = substr( $url, strlen( $home_url ) );
 		}
-		if ( $url === '' ) {
-			$url = '/';
-		}
 
 		$hash = hash( 'md5', $url );
 

--- a/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
@@ -117,6 +117,10 @@ class Cloud_CSS implements Pluggable, Has_Always_Available_Endpoints, Changes_Pa
 			return;
 		}
 
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG === true ) {
+			$critical_css = "/* Critical CSS Key: {$this->paths->get_current_critical_css_key()} */\n" . $critical_css;
+		}
+
 		$display = new Display_Critical_CSS( $critical_css );
 		add_action( 'wp_head', array( $display, 'display_critical_css' ), 0 );
 		add_filter( 'style_loader_tag', array( $display, 'asynchronize_stylesheets' ), 10, 4 );

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/Critical_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/Critical_CSS.php
@@ -94,6 +94,10 @@ class Critical_CSS implements Pluggable, Changes_Page_Output, Optimization {
 			return;
 		}
 
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG === true ) {
+			$critical_css = "/* Critical CSS Key: {$this->paths->get_current_critical_css_key()} */\n" . $critical_css;
+		}
+
 		$display = new Display_Critical_CSS( $critical_css );
 		add_action( 'wp_head', array( $display, 'display_critical_css' ), 0 );
 		add_filter( 'style_loader_tag', array( $display, 'asynchronize_stylesheets' ), 10, 4 );

--- a/projects/plugins/boost/changelog/fix-ccss-cornerstone-provider-priority
+++ b/projects/plugins/boost/changelog/fix-ccss-cornerstone-provider-priority
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Change to an unreleased feature
+
+


### PR DESCRIPTION
## Proposed changes:
* When a page is serving critical CSS, it looks up critical CSS on providers based on a specified priority. Previously cornerstone provider was positioned as the last item. So, if the page matched with any other provider group before cornerstone, it wouldn't serve the page specific critical CSS, and instead use the group. This is fixed in this PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
None