### PR TITLE
Add cornerstone feature to the list of premium features

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-wpcom-cornerstone-feature
+++ b/projects/plugins/wpcomsh/changelog/add-wpcom-cornerstone-feature
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+WordPress.com plan features: Added cornerstone 10 pages feature

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -340,6 +340,7 @@ class WPCOM_Features {
 	public const CDN                               = 'cdn';
 	public const CLASSIC_SEARCH                    = 'search';
 	public const CLOUD_CRITICAL_CSS                = 'cloud-critical-css';
+	public const CORNERSTONE_TEN_PAGES             = 'cornerstone-10-pages';
 	public const CLOUDFLARE_ANALYTICS              = 'cloudflare-analytics';
 	public const CLOUDFLARE_CDN                    = 'cloudflare-cdn';
 	public const CONCIERGE                         = 'concierge';
@@ -578,6 +579,10 @@ class WPCOM_Features {
 			self::WP_P2_PLUS_MONTHLY,
 		),
 		self::CLOUD_CRITICAL_CSS                => array(
+			self::JETPACK_BOOST_PLANS,
+			self::JETPACK_COMPLETE_PLANS,
+		),
+		self::CORNERSTONE_TEN_PAGES             => array(
 			self::JETPACK_BOOST_PLANS,
 			self::JETPACK_COMPLETE_PLANS,
 		),


### PR DESCRIPTION
First part of https://github.com/Automattic/boost-cloud/issues/635.

## Proposed changes:
* Add `CORNERSTONE_TEN_PAGES` to the list of Boost premium features

Patch: D165350-code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
None