### PR TITLE
Boost: Clarify cornerstone pages upgrade text for free users

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/lib/stores/cornerstone-pages.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/lib/stores/cornerstone-pages.ts
@@ -25,6 +25,8 @@ export function useCornerstonePages(): [
 
 const CornerstonePagesProperties = z.object( {
 	max_pages: z.number(),
+	max_pages_free: z.number(),
+	max_pages_premium: z.number(),
 } );
 type CornerstonePagesProperties = z.infer< typeof CornerstonePagesProperties >;
 

--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/lib/stores/cornerstone-pages.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/lib/stores/cornerstone-pages.ts
@@ -25,7 +25,6 @@ export function useCornerstonePages(): [
 
 const CornerstonePagesProperties = z.object( {
 	max_pages: z.number(),
-	max_pages_free: z.number(),
 	max_pages_premium: z.number(),
 } );
 type CornerstonePagesProperties = z.infer< typeof CornerstonePagesProperties >;

--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -72,9 +72,13 @@ const Meta = () => {
 								<br />
 								<b>
 									{ createInterpolateElement(
-										__(
-											'Free users can add only one cornerstone page. <link>Upgrade to add more</link>.',
-											'jetpack-boost'
+										sprintf(
+											/* translators: %d is the number of cornerstone pages. */
+											__(
+												'Premium users can add up to %d cornerstone pages. <link>Upgrade now</link>.',
+												'jetpack-boost'
+											),
+											cornerstonePagesProperties.max_pages_premium
 										),
 										{
 											link: (

--- a/projects/plugins/boost/app/lib/Cornerstone_Pages.php
+++ b/projects/plugins/boost/app/lib/Cornerstone_Pages.php
@@ -119,7 +119,6 @@ class Cornerstone_Pages implements Has_Setup {
 	public function get_properties() {
 		return array(
 			'max_pages'         => $this->get_max_pages(),
-			'max_pages_free'    => static::FREE_MAX_PAGES,
 			'max_pages_premium' => static::PREMIUM_MAX_PAGES,
 		);
 	}

--- a/projects/plugins/boost/app/lib/Cornerstone_Pages.php
+++ b/projects/plugins/boost/app/lib/Cornerstone_Pages.php
@@ -118,7 +118,9 @@ class Cornerstone_Pages implements Has_Setup {
 
 	public function get_properties() {
 		return array(
-			'max_pages' => $this->get_max_pages(),
+			'max_pages'         => $this->get_max_pages(),
+			'max_pages_free'    => static::FREE_MAX_PAGES,
+			'max_pages_premium' => static::PREMIUM_MAX_PAGES,
 		);
 	}
 

--- a/projects/plugins/boost/changelog/update-boost-cornerstone-pages-clarify-upgrade-text
+++ b/projects/plugins/boost/changelog/update-boost-cornerstone-pages-clarify-upgrade-text
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update for unreleased feature.
+
+


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/40026.

## Proposed changes:

* Change upgrade text for free users in Cornerstone Pages UI.

![CleanShot 2024-11-04 at 11 50 44](https://github.com/user-attachments/assets/a9df57e9-908a-4f19-a5c6-fab8a541769a)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?


no
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup Boost free;
* Make sure text under Cornerstone Pages UI is the same as the one in the screenshot above.