### PR TITLE
Boost: Check for cornerstone feature specifically

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -23,7 +23,7 @@ const Meta = () => {
 	const cornerstonePagesProperties = useCornerstonePagesProperties();
 	const [ { refetch: refetchRegenerationReason } ] = useRegenerationReason();
 	const premiumFeatures = usePremiumFeatures();
-	const isPremium = premiumFeatures.includes( 'support' );
+	const isPremium = premiumFeatures.includes( 'cornerstone-10-pages' );
 	const navigate = useNavigate();
 	const regenerateAction = useRegenerateCriticalCssAction();
 

--- a/projects/plugins/boost/app/lib/Cornerstone_Pages.php
+++ b/projects/plugins/boost/app/lib/Cornerstone_Pages.php
@@ -137,6 +137,6 @@ class Cornerstone_Pages implements Has_Setup {
 	}
 
 	private function get_max_pages() {
-		return Premium_Features::has_any() ? static::PREMIUM_MAX_PAGES : static::FREE_MAX_PAGES;
+		return Premium_Features::has_feature( Premium_Features::CORNERSTONE_TEN_PAGES ) ? static::PREMIUM_MAX_PAGES : static::FREE_MAX_PAGES;
 	}
 }

--- a/projects/plugins/boost/app/lib/Premium_Features.php
+++ b/projects/plugins/boost/app/lib/Premium_Features.php
@@ -7,13 +7,14 @@ use Automattic\Jetpack\Boost_Core\Lib\Transient;
 
 class Premium_Features {
 
-	const CLOUD_CSS           = 'cloud-critical-css';
-	const IMAGE_SIZE_ANALYSIS = 'image-size-analysis';
-	const PERFORMANCE_HISTORY = 'performance-history';
-	const IMAGE_CDN_LIAR      = 'image-cdn-liar';
-	const IMAGE_CDN_QUALITY   = 'image-cdn-quality';
-	const PRIORITY_SUPPORT    = 'support';
-	const PAGE_CACHE          = 'page-cache';
+	const CLOUD_CSS             = 'cloud-critical-css';
+	const IMAGE_SIZE_ANALYSIS   = 'image-size-analysis';
+	const PERFORMANCE_HISTORY   = 'performance-history';
+	const IMAGE_CDN_LIAR        = 'image-cdn-liar';
+	const IMAGE_CDN_QUALITY     = 'image-cdn-quality';
+	const PRIORITY_SUPPORT      = 'support';
+	const PAGE_CACHE            = 'page-cache';
+	const CORNERSTONE_TEN_PAGES = 'cornerstone-10-pages';
 
 	const TRANSIENT_KEY = 'premium_features';
 
@@ -35,6 +36,7 @@ class Premium_Features {
 			self::IMAGE_CDN_QUALITY,
 			self::PERFORMANCE_HISTORY,
 			self::PRIORITY_SUPPORT,
+			self::CORNERSTONE_TEN_PAGES,
 		);
 
 		if ( ! is_array( $available_features ) ) {

--- a/projects/plugins/boost/changelog/update-cornerstone-premium-check
+++ b/projects/plugins/boost/changelog/update-cornerstone-premium-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Change to an unreleased feature
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/boost-cloud/issues/635

## Proposed changes:
* Check for cornerstone pages specifically

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
* Try `add_filter( 'jetpack_boost_has_feature_cornerstone-10-pages', '__return_false' );`
* Cornerstone pages should allow only 1 feature regardless of premium/free.
* Try `add_filter( 'jetpack_boost_has_feature_cornerstone-10-pages', '__return_true' );`
* Cornerstone pages should allow only 10 feature regardless of premium/free.

