### PR TITLE
Fix slideshow inside flexbox elements

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-slideshow-inside-flexbox-elements
+++ b/projects/plugins/jetpack/changelog/fix-slideshow-inside-flexbox-elements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix Slideshow block width when used inside a Row block

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
@@ -2,6 +2,7 @@
 @import '../../shared/styles/jetpack-variables.scss';
 
 .wp-block-jetpack-slideshow {
+	min-width: 0;
 	margin-bottom: $jetpack-block-margin-bottom;
 	position: relative;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #25101

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* It fixes a bug with the slideshow width when used inside flexbox elements, like the Row block.
* We implemented the solution suggested by @dsas in https://github.com/Automattic/jetpack/issues/25101#issuecomment-2427679844, which seems the best solution here.

> Unsure how to usefully make that happen from within this block 🤔 recurse upwards through the parents before setting a min-width:0 if it is set to min-width:auto. Seems risky.
> https://github.com/Automattic/jetpack/issues/25101#issuecomment-2427679844

@dsas, not sure if I understand what you mean that would be risky here. Could you clarify more, please?

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

It fixes a bug in the Slideshow block.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a Row block to a post.
* Add a Slideshow block inside the Row block.
* Add a few images to the Slideshow.
* Visit the post in the frontend and make sure the Slideshow works properly.
* Test the multiple Slideshow blocks inside a Row and inside Columns, and make sure it also works properly in the different scenarios.