### PR TITLE
Google Analytics: only display for WoA sites on My Plan page

### DIFF
--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
@@ -10,7 +10,7 @@ import { get, includes } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { showBackups } from 'state/initial-state';
+import { showBackups, isWoASite } from 'state/initial-state';
 import {
 	isModuleActivated as _isModuleActivated,
 	activateModule,
@@ -522,56 +522,44 @@ class MyPlanBody extends React.Component {
 							</div>
 						) }
 
-						{ isPlanPremiumOrBetter &&
-							'inactive' !== this.props.getModuleOverride( 'google-analytics' ) && (
-								<div className="jp-landing__plan-features-card">
-									<div className="jp-landing__plan-features-img">
-										<img
-											src={ imagePath + 'plans/jetpack.svg' }
-											className="jp-landing__plan-features-icon"
-											alt={ __(
-												'Charts depicting an evolution in traffic and engagement',
-												'jetpack'
-											) }
-										/>
-									</div>
-									<div className="jp-landing__plan-features-text">
-										<h3 className="jp-landing__plan-features-title">
-											{ __( 'Google Analytics', 'jetpack' ) }
-										</h3>
-										<p>
-											{ __(
-												'Complement WordPress.com’s stats with Google’s in-depth look at your visitors and traffic patterns.',
-												'jetpack'
-											) }
-										</p>
-										{ this.props.isModuleActivated( 'google-analytics' ) ? (
-											<Button
-												onClick={ this.handleButtonClickForTracking( 'configure_ga' ) }
-												compact
-												rna
-											>
-												<ExternalLink
-													href={ getRedirectUrl( 'calypso-marketing-traffic', {
-														site: this.props.blogID ?? this.props.siteRawUrl,
-													} ) }
-												>
-													{ __( 'Configure Google Analytics', 'jetpack' ) }
-												</ExternalLink>
-											</Button>
-										) : (
-											<Button
-												onClick={ this.activateGoogleAnalytics }
-												disabled={ this.props.isActivatingModule( 'google-analytics' ) }
-												compact
-												rna
-											>
-												{ __( 'Activate Google Analytics', 'jetpack' ) }
-											</Button>
+						{ isPlanPremiumOrBetter && this.props.isWoASite && (
+							<div className="jp-landing__plan-features-card">
+								<div className="jp-landing__plan-features-img">
+									<img
+										src={ imagePath + 'plans/jetpack.svg' }
+										className="jp-landing__plan-features-icon"
+										alt={ __(
+											'Charts depicting an evolution in traffic and engagement',
+											'jetpack'
 										) }
-									</div>
+									/>
 								</div>
-							) }
+								<div className="jp-landing__plan-features-text">
+									<h3 className="jp-landing__plan-features-title">
+										{ __( 'Google Analytics', 'jetpack' ) }
+									</h3>
+									<p>
+										{ __(
+											'Complement WordPress.com’s stats with Google’s in-depth look at your visitors and traffic patterns.',
+											'jetpack'
+										) }
+									</p>
+									<Button
+										onClick={ this.handleButtonClickForTracking( 'configure_ga' ) }
+										compact
+										rna
+									>
+										<ExternalLink
+											href={ getRedirectUrl( 'calypso-marketing-traffic', {
+												site: this.props.blogID ?? this.props.siteRawUrl,
+											} ) }
+										>
+											{ __( 'Configure Google Analytics', 'jetpack' ) }
+										</ExternalLink>
+									</Button>
+								</div>
+							</div>
+						) }
 
 						{ isPlanPremiumOrBetter &&
 							'inactive' !== this.props.getModuleOverride( 'publicize' ) && (
@@ -897,6 +885,7 @@ export default connect(
 			showBackups: showBackups( state ),
 			getFeatureState: feature => getSetting( state, feature ),
 			isActivatingFeature: feature => isUpdatingSetting( state, feature ),
+			isWoASite: isWoASite( state ),
 		};
 	},
 	dispatch => {

--- a/projects/plugins/jetpack/changelog/update-google-analytics-my-plan
+++ b/projects/plugins/jetpack/changelog/update-google-analytics-my-plan
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update "My Plan" page to only show Google Analytics for WoA sites.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #40039

## Proposed changes:
* Make "My Plan" Google Analytics card only show up on WoA.
* Remove the "Activate" button from the card, make the card always lead to Calypso for GA configuration.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1730741711536659-slack-C0299DMPG

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. On a WoA site, go to "Jetpack -> Dashboard -> My Plan", find the "Google Analytics" card, confirm the "Configure" button leads you to Calypso's "Marketing -> Traffic" settings.
2. On a Self-Hosted site, go to "Jetpack -> Dashboard -> My Plan", confirm the "Google Analytics" card does not show up.