### PR TITLE
wpcom-block-editor-nux: Support getting the canvas mode from the query string after GB 19.6

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2268,6 +2268,9 @@ importers:
       '@wordpress/private-apis':
         specifier: ^1.8.1
         version: 1.9.0
+      '@wordpress/router':
+        specifier: ^1.8.11
+        version: 1.9.0(react@18.3.1)
       '@wordpress/url':
         specifier: 4.9.0
         version: 4.9.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-use-location-for-canvas-mode
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-use-location-for-canvas-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+wpcom-block-editor: Support getting the canvas mode from the query string after GB 19.6

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -70,6 +70,7 @@
 		"@wordpress/icons": "10.9.0",
 		"@wordpress/plugins": "7.9.0",
 		"@wordpress/private-apis": "^1.8.1",
+		"@wordpress/router": "^1.8.11",
 		"@wordpress/url": "4.9.0",
 		"clsx": "2.1.1",
 		"debug": "4.3.4",

--- a/projects/packages/jetpack-mu-wpcom/src/common/hooks/index.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/common/hooks/index.ts
@@ -1,0 +1,2 @@
+export { default as useCanvasMode } from './use-canvas-mode';
+export { default as useLocation } from './use-location';

--- a/projects/packages/jetpack-mu-wpcom/src/common/hooks/use-canvas-mode.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/common/hooks/use-canvas-mode.ts
@@ -1,0 +1,20 @@
+import { useSelect } from '@wordpress/data';
+import useLocation from './use-location';
+
+const useCanvasMode = () => {
+	const location = useLocation();
+
+	return useSelect(
+		select => {
+			// The canvas mode is limited to the site editor.
+			if ( ! select( 'core/edit-site' ) ) {
+				return null;
+			}
+
+			return new URLSearchParams( location?.search ).get( 'canvas' ) || 'view';
+		},
+		[ location?.search ]
+	);
+};
+
+export default useCanvasMode;

--- a/projects/packages/jetpack-mu-wpcom/src/common/hooks/use-location.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/common/hooks/use-location.ts
@@ -1,0 +1,15 @@
+import * as router from '@wordpress/router';
+import { getUnlock } from '../utils';
+
+const unlock = getUnlock();
+
+const routerPrivateApis = router?.privateApis;
+
+let useLocation: () => Location | null = () => null;
+
+// The routerPrivateApis may be unavailable.
+if ( unlock && routerPrivateApis && unlock( routerPrivateApis ) ) {
+	useLocation = unlock( routerPrivateApis ).useLocation;
+}
+
+export default useLocation;

--- a/projects/packages/jetpack-mu-wpcom/src/common/utils.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/common/utils.ts
@@ -1,0 +1,21 @@
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+export const getUnlock = () => {
+	/**
+	 * Sometimes Gutenberg doesn't allow you to re-register the module and throws an error.
+	 * FIXME: The new version allow it by default, but we might need to ensure that all the site has the new version.
+	 * @see https://github.com/Automattic/wp-calypso/pull/79663
+	 */
+	let unlock: ( object: any ) => any | undefined; // eslint-disable-line @typescript-eslint/no-explicit-any
+	try {
+		unlock = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+			'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+			'@wordpress/edit-site'
+		).unlock;
+		return unlock;
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Error: Unable to get the unlock api. Reason: %s', error );
+		return undefined;
+	}
+};

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -4,8 +4,8 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 import { registerPlugin } from '@wordpress/plugins';
-import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { getQueryArg } from '@wordpress/url';
+import { useCanvasMode } from '../../../common/hooks';
 import {
 	HasSeenSellerCelebrationModalProvider,
 	HasSeenVideoCelebrationModalProvider,
@@ -23,22 +23,6 @@ import WpcomNux from './welcome-modal/wpcom-nux';
 import LaunchWpcomWelcomeTour from './welcome-tour/tour-launch';
 
 /**
- * Sometimes Gutenberg doesn't allow you to re-register the module and throws an error.
- * FIXME: The new version allow it by default, but we might need to ensure that all the site has the new version.
- * @see https://github.com/Automattic/wp-calypso/pull/79663
- */
-let unlock;
-try {
-	unlock = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
-		'@wordpress/edit-site'
-	).unlock;
-} catch ( error ) {
-	// eslint-disable-next-line no-console
-	console.error( 'Error: Unable to get the unlock api. Reason: %s', error );
-}
-
-/**
  * The WelcomeTour component
  */
 function WelcomeTour() {
@@ -46,31 +30,23 @@ function WelcomeTour() {
 		getQueryArg( window.location.href, 'showDraftPostModal' )
 	);
 
-	const {
-		show,
-		isLoaded,
-		variant,
-		isManuallyOpened,
-		isNewPageLayoutModalOpen,
-		siteEditorCanvasMode,
-	} = useSelect( select => {
-		const welcomeGuideStoreSelect = select( 'automattic/wpcom-welcome-guide' );
-		const starterPageLayoutsStoreSelect = select( 'automattic/starter-page-layouts' );
-		let canvasMode;
-		if ( unlock && select( 'core/edit-site' ) ) {
-			canvasMode =
-				select( 'core/edit-site' ) && unlock( select( 'core/edit-site' ) ).getCanvasMode();
-		}
+	const { show, isLoaded, variant, isManuallyOpened, isNewPageLayoutModalOpen } = useSelect(
+		select => {
+			const welcomeGuideStoreSelect = select( 'automattic/wpcom-welcome-guide' );
+			const starterPageLayoutsStoreSelect = select( 'automattic/starter-page-layouts' );
 
-		return {
-			show: welcomeGuideStoreSelect.isWelcomeGuideShown(),
-			isLoaded: welcomeGuideStoreSelect.isWelcomeGuideStatusLoaded(),
-			variant: welcomeGuideStoreSelect.getWelcomeGuideVariant(),
-			isManuallyOpened: welcomeGuideStoreSelect.isWelcomeGuideManuallyOpened(),
-			isNewPageLayoutModalOpen: starterPageLayoutsStoreSelect?.isOpen(), // Handle the case where SPT is not initalized.
-			siteEditorCanvasMode: canvasMode,
-		};
-	}, [] );
+			return {
+				show: welcomeGuideStoreSelect.isWelcomeGuideShown(),
+				isLoaded: welcomeGuideStoreSelect.isWelcomeGuideStatusLoaded(),
+				variant: welcomeGuideStoreSelect.getWelcomeGuideVariant(),
+				isManuallyOpened: welcomeGuideStoreSelect.isWelcomeGuideManuallyOpened(),
+				isNewPageLayoutModalOpen: starterPageLayoutsStoreSelect?.isOpen(), // Handle the case where SPT is not initalized.
+			};
+		},
+		[]
+	);
+
+	const siteEditorCanvasMode = useCanvasMode();
 
 	const setOpenState = useDispatch( 'automattic/starter-page-layouts' )?.setOpenState;
 

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-use-location-for-canvas-mode
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-use-location-for-canvas-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+wpcom-block-editor: Support getting the canvas mode from the query string after GB 19.6

--- a/projects/plugins/wpcomsh/changelog/fix-use-location-for-canvas-mode
+++ b/projects/plugins/wpcomsh/changelog/fix-use-location-for-canvas-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+wpcom-block-editor: Support getting the canvas mode from the query string after GB 19.6


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/39997

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Support getting the canvas mode from the query string after GB 19.6

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your site
* Go to your site, which has Welcome Tour open by default in the Editor. If not, go to the Editor to turn it on first
* Go to the Site Editor
* Make sure the Welcome Tour is NOT visible on the "view" mode
* Enter the "edit" mode by clicking the content on the right side
* Make sure the Welcome Tour is visible
* Go to the Post Editor
* Make sure the Welcome Tour is visible as well

