### PR TITLE
Boost: Cornerstone pages UI adjustments

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/cornerstone-pages.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/cornerstone-pages.tsx
@@ -3,15 +3,19 @@ import Meta from './meta/meta';
 import SettingsItem from '$features/ui/settings-item/settings-item';
 import Pill from '$features/ui/pill/pill';
 import Upgraded from '$features/ui/upgraded/upgraded';
+import { usePremiumFeatures } from '$lib/stores/premium-features';
 
 const CornerstonePages = () => {
+	const premiumFeatures = usePremiumFeatures();
+	const isPremium = premiumFeatures.includes( 'cornerstone-10-pages' );
+
 	return (
 		<SettingsItem
 			title={
 				<>
 					{ __( 'Cornerstone Pages', 'jetpack-boost' ) }
 					<Pill text={ __( 'Experimental', 'jetpack-boost' ) } />
-					<Upgraded />
+					{ isPremium && <Upgraded /> }
 				</>
 			}
 			description={

--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -39,7 +39,9 @@ const Meta = () => {
 
 		setCornerstonePages( newItems, () => {
 			refetchRegenerationReason();
-			regenerateAction.mutate();
+			if ( isPremium ) {
+				regenerateAction.mutate();
+			}
 		} );
 	};
 

--- a/projects/plugins/boost/app/data-sync/Cornerstone_Pages_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Cornerstone_Pages_Entry.php
@@ -28,17 +28,11 @@ class Cornerstone_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 	public function set( $value ) {
 		$value = $this->sanitize_value( $value );
 
-		if ( empty( $value ) || count( $value ) === 1 && $value[0] === '' ) {
-			delete_option( $this->option_key );
-			$this->list_updated();
-			return;
-		}
-
 		$value = array_map( 'untrailingslashit', $value );
 
 		$updated = update_option( $this->option_key, $value );
 		if ( $updated ) {
-			$this->list_updated();
+			( new Environment_Change_Detector() )->handle_cornerstone_pages_list_update();
 		}
 	}
 
@@ -71,9 +65,5 @@ class Cornerstone_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 
 	private function transform_to_absolute( $url ) {
 		return home_url( $url );
-	}
-
-	private function list_updated() {
-		( new Environment_Change_Detector() )->handle_cornerstone_pages_list_update();
 	}
 }

--- a/projects/plugins/boost/app/data-sync/Cornerstone_Pages_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Cornerstone_Pages_Entry.php
@@ -4,6 +4,7 @@ namespace Automattic\Jetpack_Boost\Data_Sync;
 
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Get;
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Set;
+use Automattic\Jetpack_Boost\Lib\Cornerstone_Pages;
 use Automattic\Jetpack_Boost\Lib\Environment_Change_Detector;
 
 class Cornerstone_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
@@ -29,8 +30,7 @@ class Cornerstone_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 		$value = $this->sanitize_value( $value );
 
 		if ( empty( $value ) || count( $value ) === 1 && $value[0] === '' ) {
-			delete_option( $this->option_key );
-			return;
+			$value = ( new Cornerstone_Pages() )->default_pages();
 		}
 
 		$value = array_map( 'untrailingslashit', $value );

--- a/projects/plugins/boost/app/data-sync/Cornerstone_Pages_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Cornerstone_Pages_Entry.php
@@ -4,7 +4,6 @@ namespace Automattic\Jetpack_Boost\Data_Sync;
 
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Get;
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Set;
-use Automattic\Jetpack_Boost\Lib\Cornerstone_Pages;
 use Automattic\Jetpack_Boost\Lib\Environment_Change_Detector;
 
 class Cornerstone_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
@@ -30,14 +29,16 @@ class Cornerstone_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 		$value = $this->sanitize_value( $value );
 
 		if ( empty( $value ) || count( $value ) === 1 && $value[0] === '' ) {
-			$value = ( new Cornerstone_Pages() )->default_pages();
+			delete_option( $this->option_key );
+			$this->list_updated();
+			return;
 		}
 
 		$value = array_map( 'untrailingslashit', $value );
 
 		$updated = update_option( $this->option_key, $value );
 		if ( $updated ) {
-			( new Environment_Change_Detector() )->handle_cornerstone_pages_list_update();
+			$this->list_updated();
 		}
 	}
 
@@ -70,5 +71,9 @@ class Cornerstone_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 
 	private function transform_to_absolute( $url ) {
 		return home_url( $url );
+	}
+
+	private function list_updated() {
+		( new Environment_Change_Detector() )->handle_cornerstone_pages_list_update();
 	}
 }

--- a/projects/plugins/boost/app/lib/Cornerstone_Pages.php
+++ b/projects/plugins/boost/app/lib/Cornerstone_Pages.php
@@ -35,7 +35,7 @@ class Cornerstone_Pages implements Has_Setup {
 		return $filtered_providers;
 	}
 
-	public function default_pages() {
+	private function default_pages() {
 		if ( $this->get_max_pages() === static::FREE_MAX_PAGES ) {
 			return array( '' );
 		}

--- a/projects/plugins/boost/app/lib/Cornerstone_Pages.php
+++ b/projects/plugins/boost/app/lib/Cornerstone_Pages.php
@@ -35,7 +35,7 @@ class Cornerstone_Pages implements Has_Setup {
 		return $filtered_providers;
 	}
 
-	private function default_pages() {
+	public function default_pages() {
 		if ( $this->get_max_pages() === static::FREE_MAX_PAGES ) {
 			return array( '' );
 		}

--- a/projects/plugins/boost/changelog/update-boost-cornerstone-pages-adjustments
+++ b/projects/plugins/boost/changelog/update-boost-cornerstone-pages-adjustments
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Change to unreleased feature.
+
+


### PR DESCRIPTION
Fixes #40035, fixes #40036.

## Proposed changes:

* Fix automatically regenerating Critical CSS for free users;
* Fix "cornerstone pages list updated" notice not showing for free users;
* Fix cornerstone pages always showing "upgraded" showing for free users.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pc9hqz-3cA-p2

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Setup Boost free;
- Make sure the "Upgraded" badge doesn't show up next to the "Cornerstone Pages" section title;
- Update the cornerstone pages list and make sure there's a notice under critical css reflecting that;
- After updating the list, critical css shouldn't automatically start generating.