### PR TITLE
E2E: Remove invalid character from artifact name

### DIFF
--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -67,7 +67,7 @@ const projects = [
 		buildGroup: 'jetpack-boost',
 	},
 	{
-		project: 'Jetpack Boost - Concatenate JS/CSS',
+		project: 'Jetpack Boost - Concatenate JS and CSS',
 		path: 'projects/plugins/boost/tests/e2e',
 		testArgs: [ 'specs/concatenate', '--retries=1' ],
 		targets: [ 'plugins/boost' ],


### PR DESCRIPTION
## Proposed changes:

- Fixes failed artifact uploads for Boost's Concatenate JS/CSS E2E test.

![image](https://github.com/user-attachments/assets/e425fedc-5935-47d1-a85c-c10b245585e7)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- ~Make sure the e2e summary for the [Concatenate JS and CSS e2e test](https://github.com/Automattic/jetpack/actions/runs/11686360404) doesn't fail when uploading artifact.~
- Not sure how this can be tested as there are no Boost changes.