### PR TITLE
Tools: Add run ID to `send_tracks_event` script

### DIFF
--- a/tools/includes/send_tracks_event.sh
+++ b/tools/includes/send_tracks_event.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# Generate UUID
+function get_uuid {
+	if command -v uuidgen &>/dev/null; then
+		uuidgen
+	else
+		# Fallback
+		cat /proc/sys/kernel/random/uuid
+	fi
+}
+
 # Sends a tracks event.
 # - 1: Event name
 # - 2: An optional JSON-formatted payload of extra tracks params, e.g. `{"a":1, "b":2}`
@@ -8,6 +18,8 @@ function send_tracks_event {
 	if [[ -z "$1" ]]; then
 		return
 	fi
+
+	[[ -z "$RUN_ID" ]] && RUN_ID=$(get_uuid)
 
 	local TRACKS_URL TRACKS_RESPONSE USER_AGENT PAYLOAD
 	TRACKS_URL='https://public-api.wordpress.com/rest/v1.1/tracks/record?http_envelope=1'
@@ -18,7 +30,7 @@ function send_tracks_event {
 	)
 
 	# Add event name to payload.
-	PAYLOAD=$(jq -r --arg eventName "$1" '.events = [{_en: $eventName}]' <<< "$PAYLOAD")
+	PAYLOAD=$(jq -r --arg eventName "$1" --arg RUN_ID "$RUN_ID" '.events = [{_en: $eventName, run_id: $RUN_ID}]' <<< "$PAYLOAD")
 
 	# Add extra params to payload if provided.
 	if [[ -n "$2" ]]; then

--- a/tools/includes/send_tracks_event.sh
+++ b/tools/includes/send_tracks_event.sh
@@ -19,8 +19,6 @@ function send_tracks_event {
 		return
 	fi
 
-	[[ -z "$RUN_ID" ]] && RUN_ID=$(get_uuid)
-
 	local TRACKS_URL TRACKS_RESPONSE USER_AGENT PAYLOAD
 	TRACKS_URL='https://public-api.wordpress.com/rest/v1.1/tracks/record?http_envelope=1'
 	USER_AGENT='jetpack-monorepo-cli'
@@ -30,7 +28,7 @@ function send_tracks_event {
 	)
 
 	# Add event name to payload.
-	PAYLOAD=$(jq -r --arg eventName "$1" --arg RUN_ID "$RUN_ID" '.events = [{_en: $eventName, run_id: $RUN_ID}]' <<< "$PAYLOAD")
+	PAYLOAD=$(jq -r --arg eventName "$1" --arg RUN_ID "$JP_SEND_TRACKS_RUN_ID" '.events = [{_en: $eventName, run_id: $RUN_ID}]' <<< "$PAYLOAD")
 
 	# Add extra params to payload if provided.
 	if [[ -n "$2" ]]; then
@@ -54,3 +52,7 @@ function send_tracks_event {
 		echo "Failed Tracks call: $TRACKS_RESPONSE"
 	fi
 }
+
+
+[[ -z "$JP_SEND_TRACKS_RUN_ID" ]] && JP_SEND_TRACKS_RUN_ID=$(get_uuid)
+export JP_SEND_TRACKS_RUN_ID

--- a/tools/release-plugin.sh
+++ b/tools/release-plugin.sh
@@ -139,7 +139,6 @@ done
 proceed_p "" "Proceed releasing above projects?" Y
 
 # Sending tracking event
-TRACKING_DATA="{}"
 RELEASED_PLUGINS="{}"
 for PLUGIN in "${!PROJECTS[@]}"; do
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This adds a run ID to each Tracks event, allowing us to group and analyze plugin release runs (e.g. run times, failure data) like we do elsewhere.

If available, we run `uuidgen` to generate a run ID. Otherwise we fall back to `cat /proc/sys/kernel/random/uuid`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

🤷