### PR TITLE
CRM: Use Jetpack autoloader instead of default composer autoloader

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-use_jetpack_autoloader
+++ b/projects/plugins/crm/changelog/fix-crm-use_jetpack_autoloader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Code: Ensure we use Jetpack Autoloader throughout the codebase.

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -3042,14 +3042,6 @@ final class ZeroBSCRM {
 	}
 
 				/**
-				 * Autoload vendor libraries
-				 */
-	public function autoload_libraries() {
-
-		require_once ZEROBSCRM_PATH . 'vendor/autoload.php';
-	}
-
-				/**
 				 * Autoload files from a directory which match a regex filter
 				 */
 	public function autoload_from_directory( string $directory, string $regex_filter ) {

--- a/projects/plugins/crm/includes/ZeroBSCRM.Mail.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Mail.php
@@ -1344,15 +1344,11 @@ function jpcrm_mail_delivery_send_via_gmail_oauth( $args ){
         ); foreach ($default_args as $argK => $argV){ $$argK = $argV; if (is_array($args) && isset($args[$argK])) {  if (is_array($args[$argK])){ $newData = $$argK; if (!is_array($newData)) $newData = array(); foreach ($args[$argK] as $subK => $subV){ $newData[$subK] = $subV; }$$argK = $newData;} else { $$argK = $args[$argK]; } } }
         // ============ / LOAD ARGS =============
 
-    // declare debug string (to return if $return_debug)
+		// declare debug string (to return if $return_debug)
 		$debug_string = '';
 
-		// Let's make sure we've loaded the Google API library:
-    // https://developers.google.com/gmail/api/quickstart/php
-		$zbs->autoload_libraries();
-
-    // Load OAuth
-    $zbs->load_oauth_handler();           
+		// Load OAuth
+		$zbs->load_oauth_handler();
 
     // got a usable connection profile?
 		if ( $zbs->oauth->connection_status( 'google_mail' ) ){

--- a/projects/plugins/crm/includes/class-oauth-handler.php
+++ b/projects/plugins/crm/includes/class-oauth-handler.php
@@ -1092,13 +1092,7 @@ class Oauth_Handler {
 		// retrieve config
 		$provider_config = $this->get_provider_config( $provider_key );
 
-   		if ( is_array( $provider_config ) && !empty( $provider_config['token'] ) ){
-
-			global $zbs;
-
-			// Let's make sure we've loaded the Google API library:
-			// https://developers.google.com/gmail/api/quickstart/php
-			$zbs->autoload_libraries();
+		if ( is_array( $provider_config ) && ! empty( $provider_config['token'] ) ) {
 
 			//modified from: https://developers.google.com/people/quickstart/php  since we will always be getting 'offline' access so does not need to re-ask user
 			$client = new \Google_Client();

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -453,16 +453,6 @@ class Woo_Sync {
 
 	}
 
-
-	/**
-	 * Include WooCommerce REST API (well, in fact, autoload /vendor)
-	 */
-	public function include_woocommerce_rest_api(){
-
-		require_once ZEROBSCRM_PATH .  'vendor/autoload.php';
-
-	}
-
 	/**
 	 * Adds items to listview filter using `jpcrm_listview_filters` hook.
 	 *
@@ -2121,9 +2111,6 @@ class Woo_Sync {
 
 		// got creds?
 		if ( !empty( $key ) && !empty( $secret ) && !empty( $domain ) ){
-
-			// include the rest API files
-			$this->include_woocommerce_rest_api();
 
 			return new Client(
 				$domain, 

--- a/projects/plugins/crm/tests/php/bootstrap.php
+++ b/projects/plugins/crm/tests/php/bootstrap.php
@@ -63,7 +63,7 @@ EOF
 // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 echo "Using test root $test_root\n";
 
-if ( ! is_readable( $_plugin_root . '/vendor/autoload.php' ) ) {
+if ( ! is_readable( $_plugin_root . '/vendor/autoload_packages.php' ) ) {
 	echo 'The plugin is not ready for testing.' . PHP_EOL;
 	echo PHP_EOL;
 	echo 'Composer dependencies must be installed.' . PHP_EOL;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR removes calls to the default composer autoloader in deference to the already-used Jetpack autoloader.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In #28364, the Jetpack autoloader was added near the very beginning of the plugin flow. As such, it's available to virtually the entire plugin code.

However, both autoloaders should not be used simultaneously (see p1730113419775779-slack-CDLH4C1UZ), as it could result in incorrect package versions being used. In this case, it was unlikely to cause an issue as we don't lean on the autoloader extensively, but best to fix it anyway.

Mostly this meant removing now-unneeded code, along with changes to satisfy the linter.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The best way to test is to check scenarios where the autoloading was happening.

1. Verify WooSync still runs.
2. Verify OAuth still loads up a Google page when clicking "Connect".
3. Verify `composer tests` passes.