### PR TITLE
Stats: Fix flaky test

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-odyssey-flaky-test
+++ b/projects/packages/stats-admin/changelog/fix-odyssey-flaky-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed flaky tests

--- a/projects/packages/stats-admin/tests/php/test-odyssey-assets.php
+++ b/projects/packages/stats-admin/tests/php/test-odyssey-assets.php
@@ -23,7 +23,7 @@ class Test_Odyssey_Assets extends Stats_Test_Case {
 	 */
 	public function test_get_cdn_asset_cache_buster_remote_error() {
 		add_filter( 'pre_http_request', array( $this, 'break_cdn_cache_buster_request' ), 15, 3 );
-		$this->assertGreaterThanOrEqual( time(), floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ) );
+		$this->assertEqualsWithDelta( time(), floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ), 2 );
 		remove_filter( 'pre_http_request', array( $this, 'break_cdn_cache_buster_request' ), 15 );
 	}
 
@@ -76,7 +76,7 @@ class Test_Odyssey_Assets extends Stats_Test_Case {
 			),
 			false
 		);
-		$this->assertGreaterThanOrEqual( time(), floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ) );
+		$this->assertEqualsWithDelta( time(), floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ), 2 );
 		remove_filter( 'pre_http_request', array( $this, 'break_cdn_cache_buster_request' ), 15 );
 	}
 
@@ -85,7 +85,7 @@ class Test_Odyssey_Assets extends Stats_Test_Case {
 	 */
 	public function test_get_cdn_asset_cache_buster_force_refresh_expired() {
 		$_GET['force_refresh'] = 1;
-		$this->assertGreaterThanOrEqual( time(), floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ) );
+		$this->assertEqualsWithDelta( time(), floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ), 2 );
 	}
 
 	/**

--- a/projects/packages/stats-admin/tests/php/test-odyssey-assets.php
+++ b/projects/packages/stats-admin/tests/php/test-odyssey-assets.php
@@ -23,7 +23,7 @@ class Test_Odyssey_Assets extends Stats_Test_Case {
 	 */
 	public function test_get_cdn_asset_cache_buster_remote_error() {
 		add_filter( 'pre_http_request', array( $this, 'break_cdn_cache_buster_request' ), 15, 3 );
-		$this->assertEquals( time(), floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ) );
+		$this->assertGreaterThanOrEqual( time(), floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ) );
 		remove_filter( 'pre_http_request', array( $this, 'break_cdn_cache_buster_request' ), 15 );
 	}
 
@@ -76,7 +76,7 @@ class Test_Odyssey_Assets extends Stats_Test_Case {
 			),
 			false
 		);
-		$this->assertEquals( time(), floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ) );
+		$this->assertGreaterThanOrEqual( time(), floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ) );
 		remove_filter( 'pre_http_request', array( $this, 'break_cdn_cache_buster_request' ), 15 );
 	}
 
@@ -85,7 +85,7 @@ class Test_Odyssey_Assets extends Stats_Test_Case {
 	 */
 	public function test_get_cdn_asset_cache_buster_force_refresh_expired() {
 		$_GET['force_refresh'] = 1;
-		$this->assertEquals( time(), floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ) );
+		$this->assertGreaterThanOrEqual( time(), floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ) );
 	}
 
 	/**

--- a/projects/packages/stats-admin/tests/php/test-odyssey-assets.php
+++ b/projects/packages/stats-admin/tests/php/test-odyssey-assets.php
@@ -23,7 +23,7 @@ class Test_Odyssey_Assets extends Stats_Test_Case {
 	 */
 	public function test_get_cdn_asset_cache_buster_remote_error() {
 		add_filter( 'pre_http_request', array( $this, 'break_cdn_cache_buster_request' ), 15, 3 );
-		$this->assertEqualsWithDelta( time(), floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ), 2 );
+		$this->assertLessThanOrEqual( 2, time() - floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ) );
 		remove_filter( 'pre_http_request', array( $this, 'break_cdn_cache_buster_request' ), 15 );
 	}
 
@@ -76,7 +76,7 @@ class Test_Odyssey_Assets extends Stats_Test_Case {
 			),
 			false
 		);
-		$this->assertEqualsWithDelta( time(), floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ), 2 );
+		$this->assertLessThanOrEqual( 2, time() - floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ) );
 		remove_filter( 'pre_http_request', array( $this, 'break_cdn_cache_buster_request' ), 15 );
 	}
 
@@ -85,7 +85,7 @@ class Test_Odyssey_Assets extends Stats_Test_Case {
 	 */
 	public function test_get_cdn_asset_cache_buster_force_refresh_expired() {
 		$_GET['force_refresh'] = 1;
-		$this->assertEqualsWithDelta( time(), floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ), 2 );
+		$this->assertLessThanOrEqual( 2, time() - floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes p1730809388759599-slack-C034JEXD1RD

## Proposed changes:

* Use `assertEqualsWithDelta` instead

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

Ensure all tests pass