### PR TITLE
Fix race condition when loading theme compatibility files.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-theme-compatibility
+++ b/projects/plugins/jetpack/changelog/fix-theme-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Themes: Fix race condition when loading theme compatibility files.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -867,7 +867,7 @@ class Jetpack {
 	 * @action plugins_loaded
 	 */
 	public function late_initialization() {
-		add_action( 'after_setup_theme', array( 'Jetpack', 'load_modules' ), 1 );
+		add_action( 'after_setup_theme', array( 'Jetpack', 'load_modules' ), -2 );
 		My_Jetpack_Initializer::init();
 
 		// Initialize Boost Speed Score

--- a/projects/plugins/jetpack/modules/theme-tools.php
+++ b/projects/plugins/jetpack/modules/theme-tools.php
@@ -60,7 +60,7 @@ function jetpack_load_theme_compat() {
 		_jetpack_require_compat_file( get_template(), $compat_files );
 	}
 }
-add_action( 'after_setup_theme', 'jetpack_load_theme_compat' );
+add_action( 'after_setup_theme', 'jetpack_load_theme_compat', -1 );
 
 /**
  * Requires a file once, if the passed key exists in the files array.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow up on #39968 and #39992 which led to some race-conditions when loading the theme compatibility module.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* By reverting to the original priority from #39992 and updating the priority in `class.jetpack.php` the correct order should be maintained without causing errors on WP.com.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* This needs to be tested against an atomic site.
* Activate the `twentyfourteen` theme and verify there are no fatal errors.
* Activate the `twentytwenty` theme and go to a post page. Ensure that "related posts" section underneath the post content isn't squashed to the left.

