### PR TITLE
AI Assistant: Add feature flag for list to table transform

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-list-transform-flag
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-list-transform-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Add feature flag for list to table transform

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -197,3 +197,17 @@ add_action(
 		}
 	}
 );
+
+/**
+ * Register the `ai-list-to-table-transform` extension.
+ */
+add_action(
+	'jetpack_register_gutenberg_extensions',
+	function () {
+		if ( apply_filters( 'jetpack_ai_enabled', true ) &&
+			apply_filters( 'list_to_table_transform_enabled', false )
+		) {
+			\Jetpack_Gutenberg::set_extension_available( 'ai-list-to-table-transform' );
+		}
+	}
+);

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -78,7 +78,8 @@
 		"recipe",
 		"v6-video-frame-poster",
 		"videopress/video-chapters",
-		"ai-assistant-backend-prompts"
+		"ai-assistant-backend-prompts",
+		"ai-list-to-table-transform"
 	],
 	"experimental": [],
 	"no-post-editor": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #40074 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `ai-list-to-table-transform` beta flag
* Enable only if `list_to_table_transform_enabled` filter is true

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:

* Check out this branch and make sure you have the snippets plugin installed
* Make sure `JETPACK_BLOCKS_VARIATION` is set to `production`
* Edit/create a post and in the console paste`Jetpack_Editor_Initial_State.available_blocks['ai-list-to-table-transform']`
* It should return `undefined`
* In an enabled snippet set `JETPACK_BLOCKS_VARIATION` to `beta`: `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );`
* Reload. `Jetpack_Editor_Initial_State.available_blocks['ai-list-to-table-transform']` should now return:
  * `{available: false, unavailable_reason: 'missing_module', details: Array(0)}`
* Now `add_filter( 'list_to_table_transform_enabled', '__return_true' );` to your snippet
* Reload. `Jetpack_Editor_Initial_State.available_blocks['ai-list-to-table-transform']` should now return:
  * `{available: true}`
