### PR TITLE
Deprecation notices: Ensure the Deprecate class is loaded after translations

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-deprecate-class-loading-order
+++ b/projects/plugins/jetpack/changelog/fix-deprecate-class-loading-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Actions: Ensure Deprecations class loads after translations to prevent errors

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -750,8 +750,7 @@ class Jetpack {
 
 		// Add 5-star
 		add_filter( 'plugin_row_meta', array( $this, 'add_5_star_review_link' ), 10, 2 );
-
-		Deprecate::instance();
+		add_action( 'init', array( Deprecate::class, 'instance' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

* This PR helps prevent the following error from displaying in logs (only present on trunk at the moment, and with WordPress 6.7 active as well): `Exception: _load_textdomain_just_in_time doing it wrong for jetpack in /var/www/html/wp-includes/l10n.php:1358`. This would have begun once [this PR](https://github.com/Automattic/jetpack/pull/39567) was merged, as the PR changed a demo notice example to be un-commented, hence triggering the translations.
* It ensures the `Deprecate` class initialization is hooked into `init`, which runs after `load_textdomain`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:


Note - you may need to set a non-English (United States) language for your site (and install the corresponding translations, which is done via `/wp-admin/update-core.php` - I found I had to navigate through the site a bit before coming back to the core updates page when translations would now be available - updating translations seems to be needed rather than just confirming they are up to date.). 

On self-hosted:

To replicate the issue:

* On a free site, connected to WordPress.com,  install the WordPress Beta Tester plugin
* Go to Tools > Beta Testing, and set the plugin to use Beta/RC Only (as we're now in the RC stage of the 6.7 release - nightly will give you 6.8)
* Go to Dashboard > Updates, and update to the most recent version of WP.
* You likely will need to update translations at this stage.
* Load any admin page, and in your error log you should see the notice `Exception: _load_textdomain_just_in_time doing it wrong for jetpack in /var/www/html/wp-includes/l10n.php:1358`

To test the fix:

* Apply this PR
* Edit the `$this->notices` array in `jetpack/src/class-deprecate.php` to change `show` to `true`. Open up a Jetpack dashboard page - you should see a deprecation notice. This confirms the change doesn't affect the functionality here.
* There should be none of the above mentioned errors in logs.


