### PR TITLE
Social | Fix infinite reload of jetpack settings page

### DIFF
--- a/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
@@ -1,5 +1,9 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { ConnectionManagement, features } from '@automattic/jetpack-publicize-components';
+import {
+	ConnectionManagement,
+	features,
+	getSocialScriptData,
+} from '@automattic/jetpack-publicize-components';
 import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
@@ -27,7 +31,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 		componentDidUpdate() {
 			const isActive = this.props.getOptionValue( 'publicize' );
 			// Reload the page if Publicize is enabled.
-			if ( isActive && ! window.Initial_State.socialInitialState.is_publicize_enabled ) {
+			if ( isActive && ! getSocialScriptData().is_publicize_enabled ) {
 				window.location.reload();
 			}
 		}

--- a/projects/plugins/jetpack/changelog/fix-social-infinite-reload-of-jetpack-settings-page
+++ b/projects/plugins/jetpack/changelog/fix-social-infinite-reload-of-jetpack-settings-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fixed the inifite reload issue on Jetpack Sharing settings

--- a/projects/plugins/social/changelog/fix-social-infinite-reload-of-jetpack-settings-page
+++ b/projects/plugins/social/changelog/fix-social-infinite-reload-of-jetpack-settings-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed the inifite reload issue on Jetpack Sharing settings

--- a/projects/plugins/social/src/js/components/social-module-toggle/index.tsx
+++ b/projects/plugins/social/src/js/components/social-module-toggle/index.tsx
@@ -48,7 +48,7 @@ const SocialModuleToggle: React.FC = () => {
 		await updateSocialPluginSettings( newOption );
 
 		// If the module was enabled, we need to refresh the connection list
-		if ( newOption.publicize_active && ! window.jetpackSocialInitialState.is_publicize_enabled ) {
+		if ( newOption.publicize_active && ! getSocialScriptData().is_publicize_enabled ) {
 			window.location.reload();
 		}
 	}, [ isModuleEnabled, updateSocialPluginSettings ] );


### PR DESCRIPTION
Fix the issue of Jetpack settings page infinite reload when site only connection

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Read `is_publicize_enabled` flag from the new initial state which is always consistent regardless of whether the site is connected or not.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Enable Publicize in Jetpack setttings > Sharing tab
- Confirm that the page reloads after enabling the module
- Confirm the same on Social settings page
- Now remove the Jetpack connection
- Connect the site again (without user connection)
- Goto `wp-admin/admin.php?page=jetpack#/settings`
- Confirm that there is no infinite reload

