### PR TITLE
Global Styles on Personal: Update Site Editor Modal and Notice

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-global-styles-on-personal-editor-modal
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-global-styles-on-personal-editor-modal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+The notice and modal shown on the editor now displays the plan name and upgrade URL based on the GS gated plan type'

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -174,13 +174,22 @@ function wpcom_global_styles_enqueue_block_editor_assets() {
 	if ( class_exists( 'WPCom_Languages' ) ) {
 		$learn_more_about_styles_post_id = WPCom_Languages::localize_url( $learn_more_about_styles_post_id );
 	}
+
+	// @TODO Remove this once the global styles are available for all users on the Personal Plan.
+	$upgrade_url = "$calypso_domain/plans/$site_slug?plan=value_bundle&feature=style-customization";
+	$plan_name   = Plans::get_plan( 'value_bundle' )->product_name_short;
+	if ( class_exists( 'WPCOM_Feature_Flags' ) && WPCOM_Feature_Flags::is_enabled( WPCOM_Feature_Flags::GLOBAL_STYLES_ON_PERSONAL_PLAN ) ) {
+		$plan_name   = Plans::get_plan( 'personal-bundle' )->product_name_short;
+		$upgrade_url = "$calypso_domain/plans/$site_slug?plan=personal-bundle&feature=style-customization";
+	}
+
 	wp_localize_script(
 		'wpcom-global-styles-editor',
 		'wpcomGlobalStyles',
 		array(
-			'upgradeUrl'                 => "$calypso_domain/plans/$site_slug?plan=value_bundle&feature=style-customization",
+			'upgradeUrl'                 => $upgrade_url,
 			'wpcomBlogId'                => wpcom_global_styles_get_wpcom_current_blog_id(),
-			'planName'                   => Plans::get_plan( 'value_bundle' )->product_name_short,
+			'planName'                   => $plan_name,
 			'modalImage'                 => plugins_url( 'image.svg', __FILE__ ),
 			'learnMoreAboutStylesUrl'    => $learn_more_about_styles_support_url,
 			'learnMoreAboutStylesPostId' => $learn_more_about_styles_post_id,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes:
- https://github.com/Automattic/dotcom-forge/issues/9520

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We now set the plan and upgrade URL based on the feature flag instead of it being hardcoded to the Premium plan.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Apply the code to your sandbox.
* Create or use a sandboxed free site.
* Go to the site editor and pick a style variation
* You should see the upgrade modal, it should display `Personal` as plan and when proceeding it should do so with the personal plan.
* You should also see a notice on the editor, this notice should also have correct wording and checkout page.
* Check there are no regressions on Atomic.


![Screenshot 2024-11-07 at 17 37 00](https://github.com/user-attachments/assets/3f3d1952-772c-4c24-8001-705d288e49b8)

![Screenshot 2024-11-07 at 17 40 16](https://github.com/user-attachments/assets/a87227b3-cbca-4476-a21f-d246140bade0)
