### PR TITLE
Protect Status: Provide unified threats list

### DIFF
--- a/projects/packages/protect-models/changelog/update-protect-status-format
+++ b/projects/packages/protect-models/changelog/update-protect-status-format
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added threats property to protect status.

--- a/projects/packages/protect-models/src/class-extension-model.php
+++ b/projects/packages/protect-models/src/class-extension-model.php
@@ -36,6 +36,8 @@ class Extension_Model {
 	/**
 	 * A collection of threats related to this version of the extension.
 	 *
+	 * @deprecated $$next-version$$ This property is deprecated. Use Threat_Model::$extension instead.
+	 *
 	 * @var array<Threat_Model>
 	 */
 	public $threats = array();
@@ -81,10 +83,13 @@ class Extension_Model {
 	/**
 	 * Set Threats
 	 *
+	 * @deprecated $$next-version$$ This method is deprecated. Use Threat_Model::$extension instead.
+	 *
 	 * @param array<Threat_Model|array|object> $threats An array of threat data to add to the extension.
 	 */
 	public function set_threats( $threats ) {
 		if ( ! is_array( $threats ) ) {
+			// @phan-suppress-next-line PhanDeprecatedProperty -- Maintaining backwards compatibility.
 			$this->threats = array();
 			return;
 		}
@@ -105,6 +110,7 @@ class Extension_Model {
 			$threats
 		);
 
+		// @phan-suppress-next-line PhanDeprecatedProperty -- Maintaining backwards compatibility.
 		$this->threats = $threats;
 	}
 }

--- a/projects/packages/protect-models/src/class-history-model.php
+++ b/projects/packages/protect-models/src/class-history-model.php
@@ -19,67 +19,13 @@ class History_Model {
 	public $last_checked;
 
 	/**
-	 * The number of threats.
+	 * Threats.
 	 *
-	 * @var int
-	 */
-	public $num_threats;
-
-	/**
-	 * The number of core threats.
+	 * @since $$next-version$$
 	 *
-	 * @var int
+	 * @var array<Threat_Model>
 	 */
-	public $num_core_threats;
-
-	/**
-	 * The number of plugin threats.
-	 *
-	 * @var int
-	 */
-	public $num_plugins_threats;
-
-	/**
-	 * The number of theme threats.
-	 *
-	 * @var int
-	 */
-	public $num_themes_threats;
-
-	/**
-	 * WordPress core.
-	 *
-	 * @var array<Extension_Model>
-	 */
-	public $core = array();
-
-	/**
-	 * Status themes.
-	 *
-	 * @var array<Extension_Model>
-	 */
-	public $themes = array();
-
-	/**
-	 * Status plugins.
-	 *
-	 * @var array<Extension_Model>
-	 */
-	public $plugins = array();
-
-	/**
-	 * File threats.
-	 *
-	 * @var array<Extension_Model>
-	 */
-	public $files = array();
-
-	/**
-	 * Database threats.
-	 *
-	 * @var array<Extension_Model>
-	 */
-	public $database = array();
+	public $threats = array();
 
 	/**
 	 * Whether there was an error loading the history.
@@ -101,6 +47,87 @@ class History_Model {
 	 * @var string
 	 */
 	public $error_message;
+
+	/**
+	 * The number of threats.
+	 *
+	 * @deprecated $$next-version$$ This property is deprecated. Count History_Model::$threats instead.
+	 *
+	 * @var int
+	 */
+	public $num_threats;
+
+	/**
+	 * The number of core threats.
+	 *
+	 * @deprecated $$next-version$$ This property is deprecated. Filter and count History_Model::$threats instead.
+	 *
+	 * @var int
+	 */
+	public $num_core_threats;
+
+	/**
+	 * The number of plugin threats.
+	 *
+	 * @deprecated $$next-version$$ This property is deprecated. Filter and count History_Model::$threats instead.
+	 *
+	 * @var int
+	 */
+	public $num_plugins_threats;
+
+	/**
+	 * The number of theme threats.
+	 *
+	 * @deprecated $$next-version$$ This property is deprecated. Filter and count History_Model::$threats instead.
+	 *
+	 * @var int
+	 */
+	public $num_themes_threats;
+
+	/**
+	 * WordPress core.
+	 *
+	 * @deprecated $$next-version$$ This property is deprecated. Use History_Model::$threats instead.
+	 *
+	 * @var array<Extension_Model>
+	 */
+	public $core = array();
+
+	/**
+	 * Status themes.
+	 *
+	 * @deprecated $$next-version$$ This property is deprecated. Filter and use History_Model::$threats instead.
+	 *
+	 * @var array<Extension_Model>
+	 */
+	public $themes = array();
+
+	/**
+	 * Status plugins.
+	 *
+	 * @deprecated $$next-version$$ This property is deprecated. Filter and use History_Model::$threats instead.
+	 *
+	 * @var array<Extension_Model>
+	 */
+	public $plugins = array();
+
+	/**
+	 * File threats.
+	 *
+	 * @deprecated $$next-version$$ This property is deprecated. Filter and use History_Model::$threats instead.
+	 *
+	 * @var array<Extension_Model>
+	 */
+	public $files = array();
+
+	/**
+	 * Database threats.
+	 *
+	 * @deprecated $$next-version$$ This property is deprecated. Filter and use History_Model::$threats instead.
+	 *
+	 * @var array<Extension_Model>
+	 */
+	public $database = array();
 
 	/**
 	 * Status constructor.

--- a/projects/packages/protect-models/src/class-status-model.php
+++ b/projects/packages/protect-models/src/class-status-model.php
@@ -26,27 +26,6 @@ class Status_Model {
 	public $last_checked;
 
 	/**
-	 * The number of threats.
-	 *
-	 * @var int
-	 */
-	public $num_threats;
-
-	/**
-	 * The number of plugin threats.
-	 *
-	 * @var int
-	 */
-	public $num_plugins_threats;
-
-	/**
-	 * The number of theme threats.
-	 *
-	 * @var int
-	 */
-	public $num_themes_threats;
-
-	/**
 	 * The current report status.
 	 *
 	 * @var string in_progress|scheduled|idle|scanning|provisioning|unavailable
@@ -54,46 +33,20 @@ class Status_Model {
 	public $status;
 
 	/**
+	 * The current reported security threats.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var array<Threat_Model>
+	 */
+	public $threats = array();
+
+	/**
 	 * List of fixable threat IDs.
 	 *
 	 * @var string[]
 	 */
 	public $fixable_threat_ids = array();
-
-	/**
-	 * WordPress core status.
-	 *
-	 * @var object
-	 */
-	public $core;
-
-	/**
-	 * Status themes.
-	 *
-	 * @var array<Extension_Model>
-	 */
-	public $themes = array();
-
-	/**
-	 * Status plugins.
-	 *
-	 * @var array<Extension_Model>
-	 */
-	public $plugins = array();
-
-	/**
-	 * File threats.
-	 *
-	 * @var array<Extension_Model>
-	 */
-	public $files = array();
-
-	/**
-	 * Database threats.
-	 *
-	 * @var array<Extension_Model>
-	 */
-	public $database = array();
 
 	/**
 	 * Whether the site includes items that have not been checked.
@@ -131,12 +84,85 @@ class Status_Model {
 	public $error_message;
 
 	/**
+	 * The number of threats.
+	 *
+	 * @deprecated $$next-version$$ This property is deprecated. Count Status_Model::$threats instead.
+	 *
+	 * @var int
+	 */
+	public $num_threats;
+
+	/**
+	 * The number of plugin threats.
+	 *
+	 * @deprecated $$next-version$$ This property is deprecated. Filter and count Status_Model::$threats instead.
+	 *
+	 * @var int
+	 */
+	public $num_plugins_threats;
+
+	/**
+	 * The number of theme threats.
+	 *
+	 * @deprecated $$next-version$$ This property is deprecated. Filter and count Status_Model::$threats instead.
+	 *
+	 * @var int
+	 */
+	public $num_themes_threats;
+
+	/**
+	 * WordPress core status.
+	 *
+	 * @deprecated $$next-version$$ This property is deprecated. Filter and use Status_Model::$threats instead.
+	 *
+	 * @var object
+	 */
+	public $core;
+
+	/**
+	 * Status themes.
+	 *
+	 * @deprecated $$next-version$$ This property is deprecated. Filter and use Status_Model::$threats instead.
+	 *
+	 * @var array<Extension_Model>
+	 */
+	public $themes = array();
+
+	/**
+	 * Status plugins.
+	 *
+	 * @deprecated $$next-version$$ This property is deprecated. Filter and use Status_Model::$threats instead.
+	 *
+	 * @var array<Extension_Model>
+	 */
+	public $plugins = array();
+
+	/**
+	 * File threats.
+	 *
+	 * @deprecated $$next-version$$ This property is deprecated. Filter and use Status_Model::$threats instead.
+	 *
+	 * @var array<Extension_Model>
+	 */
+	public $files = array();
+
+	/**
+	 * Database threats.
+	 *
+	 * @deprecated $$next-version$$ This property is deprecated. Filter and use Status_Model::$threats instead.
+	 *
+	 * @var array<Extension_Model>
+	 */
+	public $database = array();
+
+	/**
 	 * Status constructor.
 	 *
 	 * @param array $status The status data to load into the class instance.
 	 */
 	public function __construct( $status = array() ) {
 		// set status defaults
+		// @phan-suppress-next-line PhanDeprecatedProperty -- Maintaining backwards compatibility.
 		$this->core = new \stdClass();
 
 		foreach ( $status as $property => $value ) {

--- a/projects/packages/protect-models/src/class-threat-model.php
+++ b/projects/packages/protect-models/src/class-threat-model.php
@@ -97,11 +97,27 @@ class Threat_Model {
 	public $context;
 
 	/**
+	 * The database table of the threat.
+	 *
+	 * @var null|string
+	 */
+	public $table;
+
+	/**
 	 * The source URL of the threat.
 	 *
 	 * @var null|string
 	 */
 	public $source;
+
+	/**
+	 * The threat's extension information.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var null|Extension_Model
+	 */
+	public $extension;
 
 	/**
 	 * Threat Constructor
@@ -114,6 +130,10 @@ class Threat_Model {
 		}
 
 		foreach ( $threat as $property => $value ) {
+			if ( 'extension' === $property && ! empty( $value ) ) {
+				$this->extension = new Extension_Model( $value );
+				continue;
+			}
 			if ( property_exists( $this, $property ) ) {
 				$this->$property = $value;
 			}

--- a/projects/packages/protect-models/tests/php/test-extension-model.php
+++ b/projects/packages/protect-models/tests/php/test-extension-model.php
@@ -28,6 +28,8 @@ class Test_Extension_Model extends BaseTestCase {
 
 	/**
 	 * Tests for extension model's __construct() method.
+	 *
+	 * @phan-suppress PhanDeprecatedProperty -- Maintaining backwards compatibility.
 	 */
 	public function test_extension_model_construct() {
 		$test_data = array(

--- a/projects/packages/protect-models/tests/php/test-threat-model.php
+++ b/projects/packages/protect-models/tests/php/test-threat-model.php
@@ -15,34 +15,63 @@ class Test_Threat_Model extends BaseTestCase {
 	 * Tests for threat model's __construct() method.
 	 */
 	public function test_threat_model_construct() {
+		// Initialize multiple instances of Extension_Threat to test varying initial params
 		$test_data = array(
-			'id'             => 'abc-123-abc-123',
-			'signature'      => 'Test.Threat',
-			'title'          => 'Test Threat',
-			'description'    => 'This is a test threat.',
-			'first_detected' => '2022-01-01T00:00:00.000Z',
-			'fixed_in'       => '1.0.1',
-			'severity'       => 4,
-			'fixable'        => (object) array(
-				'fixer'            => 'update',
-				'target'           => '1.0.1',
-				'extension_status' => 'active',
+			array(
+				'id'          => 'test-threat-1',
+				'signature'   => 'Test.Threat',
+				'title'       => 'Test Threat 1',
+				'description' => 'This is a test threat.',
+				'extension'   => array(
+					'slug'    => 'test-extension-1',
+					'name'    => 'Test Extension 1',
+					'version' => '1.0.0',
+					'type'    => 'plugin',
+				),
 			),
-			'status'         => 'current',
-			'filename'       => '/srv/htdocs/wp-content/uploads/threat.jpg.php',
-			'context'        => (object) array(),
+			array(
+				'id'          => 'test-threat-2',
+				'signature'   => 'Test.Threat',
+				'title'       => 'Test Threat 2',
+				'description' => 'This is a test threat.',
+				'extension'   => array(
+					'slug'    => 'test-extension-2',
+					'name'    => 'Test Extension 2',
+					'version' => '1.0.0',
+					'type'    => 'theme',
+				),
+			),
+			array(
+				'id'          => 'test-threat-3',
+				'signature'   => 'Test.Threat',
+				'title'       => 'Test Threat 3',
+				'description' => 'This is a test threat.',
+			),
 		);
 
-		// Initialize multiple instances of Threat_Model to test varying initial params
-		$test_threats = array(
-			new Threat_Model( $test_data ),
-			new Threat_Model( (object) $test_data ),
+		$test_threats = array_map(
+			function ( $threat_data ) {
+				return new Threat_Model( $threat_data );
+			},
+			$test_data
 		);
 
-		foreach ( $test_threats as $threat ) {
+		foreach ( $test_threats as $loop_index => $threat ) {
+			// Validate the threat data is normalized into model classes
+			$this->assertSame( 'Automattic\Jetpack\Protect_Models\Threat_Model', get_class( $threat ) );
+			if ( isset( $threat->extension ) ) {
+				$this->assertSame( 'Automattic\Jetpack\Protect_Models\Extension_Model', get_class( $threat->extension ) );
+			}
+
 			// Validate the threat data is set properly
-			foreach ( $test_data as $key => $value ) {
-				$this->assertSame( $value, $threat->{ $key } );
+			foreach ( $test_data[ $loop_index ] as $key => $value ) {
+				if ( 'extension' === $key ) {
+					foreach ( $value as $extension_key => $extension_value ) {
+						$this->assertSame( $extension_value, $threat->extension->$extension_key );
+					}
+					continue;
+				}
+				$this->assertSame( $value, $threat->$key );
 			}
 		}
 	}

--- a/projects/packages/protect-status/changelog/update-protect-status-format
+++ b/projects/packages/protect-status/changelog/update-protect-status-format
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added threats property to protect status.

--- a/projects/packages/protect-status/src/class-protect-status.php
+++ b/projects/packages/protect-status/src/class-protect-status.php
@@ -2,6 +2,8 @@
 /**
  * Class to handle the Protect Status of Jetpack Protect
  *
+ * @phan-suppress PhanDeprecatedProperty -- Maintaining backwards compatibility.
+ *
  * @package automattic/jetpack-protect-status
  */
 
@@ -128,6 +130,8 @@ class Protect_Status extends Status {
 	/**
 	 * Normalize data from the Protect Report data source.
 	 *
+	 * @phan-suppress PhanDeprecatedProperty -- Maintaining backwards compatibility.
+	 *
 	 * @param object $report_data Data from the Protect Report.
 	 * @return Status_Model
 	 */
@@ -155,21 +159,26 @@ class Protect_Status extends Status {
 		// normalize WordPress core report data and map into Status_Model
 		$status->core = self::normalize_core_information( isset( $report_data->core ) ? $report_data->core : new \stdClass() );
 
-		// check if any installed items (themes, plugins, or core) have not been checked in the report
+		// loop through all items to merge threats and check if there are any unchecked items
 		$all_items                   = array_merge( $status->plugins, $status->themes, array( $status->core ) );
-		$unchecked_items             = array_filter(
-			$all_items,
-			function ( $item ) {
-				return ! isset( $item->checked ) || ! $item->checked;
+		$status->has_unchecked_items = false;
+		foreach ( $all_items as $item ) {
+			if ( $item->threats ) {
+				$status->threats = array_merge( $status->threats, $item->threats );
 			}
-		);
-		$status->has_unchecked_items = ! empty( $unchecked_items );
+			if ( ! isset( $item->checked ) || ! $item->checked ) {
+				$status->has_unchecked_items = true;
+			}
+		}
 
 		return $status;
 	}
 
 	/**
 	 * Merges the list of installed extensions with the list of extensions that were checked for known vulnerabilities and return a normalized list to be used in the UI
+	 *
+	 * @phan-suppress PhanDeprecatedProperty -- Maintaining backwards compatibility.
+	 * @phan-suppress PhanDeprecatedFunction -- Maintaining backwards compatibility.
 	 *
 	 * @param array  $installed The list of installed extensions, where each attribute key is the extension slug.
 	 * @param object $checked   The list of checked extensions.
@@ -178,6 +187,7 @@ class Protect_Status extends Status {
 	 */
 	protected static function merge_installed_and_checked_lists( $installed, $checked, $append ) {
 		$new_list = array();
+
 		foreach ( array_keys( $installed ) as $slug ) {
 
 			$checked = (object) $checked;
@@ -225,6 +235,8 @@ class Protect_Status extends Status {
 
 	/**
 	 * Check if the WordPress version that was checked matches the current installed version.
+	 *
+	 * @phan-suppress PhanDeprecatedFunction -- Maintaining backwards compatibility.
 	 *
 	 * @param object $core_check The object returned by Protect wpcom endpoint.
 	 * @return object The object representing the current status of core checks.

--- a/projects/packages/protect-status/src/class-scan-status.php
+++ b/projects/packages/protect-status/src/class-scan-status.php
@@ -2,6 +2,8 @@
 /**
  * Class to handle the Scan Status of Jetpack Protect
  *
+ * @phan-suppress PhanDeprecatedFunction -- Maintaining backwards compatibility.
+ *
  * @package automattic/jetpack-protect-status
  */
 
@@ -135,6 +137,8 @@ class Scan_Status extends Status {
 	 * Normalize API Data
 	 * Formats the payload from the Scan API into an instance of Status_Model.
 	 *
+	 * @phan-suppress PhanDeprecatedProperty -- Maintaining backwards compatibility.
+	 *
 	 * @param object $scan_data The data returned by the scan API.
 	 *
 	 * @return Status_Model
@@ -189,7 +193,7 @@ class Scan_Status extends Status {
 							);
 						}
 
-						$status->plugins[ $threat->extension->slug ]->threats[] = new Threat_Model(
+						$threat_model = new Threat_Model(
 							array(
 								'id'                  => isset( $threat->id ) ? $threat->id : null,
 								'signature'           => isset( $threat->signature ) ? $threat->signature : null,
@@ -209,6 +213,10 @@ class Scan_Status extends Status {
 								'source'              => isset( $threat->source ) ? $threat->source : null,
 							)
 						);
+
+						$status->plugins[ $threat->extension->slug ]->threats[] = $threat_model;
+						$status->threats[]                                      = $threat_model;
+
 						++$status->num_threats;
 						++$status->num_plugins_threats;
 						continue;
@@ -229,7 +237,7 @@ class Scan_Status extends Status {
 							);
 						}
 
-						$status->themes[ $threat->extension->slug ]->threats[] = new Threat_Model(
+						$threat_model = new Threat_Model(
 							array(
 								'id'                  => isset( $threat->id ) ? $threat->id : null,
 								'signature'           => isset( $threat->signature ) ? $threat->signature : null,
@@ -249,6 +257,10 @@ class Scan_Status extends Status {
 								'source'              => isset( $threat->source ) ? $threat->source : null,
 							)
 						);
+
+						$status->themes[ $threat->extension->slug ]->threats[] = $threat_model;
+						$status->threats[]                                     = $threat_model;
+
 						++$status->num_threats;
 						++$status->num_themes_threats;
 						continue;
@@ -260,7 +272,7 @@ class Scan_Status extends Status {
 						continue;
 					}
 
-					$status->core->threats[] = new Threat_Model(
+					$threat_model = new Threat_Model(
 						array(
 							'id'             => $threat->id,
 							'signature'      => $threat->signature,
@@ -270,19 +282,27 @@ class Scan_Status extends Status {
 							'severity'       => $threat->severity,
 						)
 					);
+
+					$status->core->threats[] = $threat_model;
+					$status->threats[]       = $threat_model;
+
 					++$status->num_threats;
 
 					continue;
 				}
 
 				if ( ! empty( $threat->filename ) ) {
-					$status->files[] = new Threat_Model( $threat );
+					$threat_model      = new Threat_Model( $threat );
+					$status->files[]   = $threat_model;
+					$status->threats[] = $threat_model;
 					++$status->num_threats;
 					continue;
 				}
 
 				if ( ! empty( $threat->table ) ) {
-					$status->database[] = new Threat_Model( $threat );
+					$threat_model       = new Threat_Model( $threat );
+					$status->database[] = $threat_model;
+					$status->threats[]  = $threat_model;
 					++$status->num_threats;
 					continue;
 				}
@@ -308,9 +328,13 @@ class Scan_Status extends Status {
 	/**
 	 * Merges the list of installed extensions with the list of extensions that were checked for known vulnerabilities and return a normalized list to be used in the UI
 	 *
+	 * @phan-suppress PhanDeprecatedProperty -- Maintaining backwards compatibility.
+	 * @phan-suppress PhanDeprecatedFunction -- Maintaining backwards compatibility.
+	 *
 	 * @param array  $installed The list of installed extensions, where each attribute key is the extension slug.
 	 * @param object $checked   The list of checked extensions.
 	 * @param array  $append    Additional data to append to each result in the list.
+	 *
 	 * @return array Normalized list of extensions.
 	 */
 	protected static function merge_installed_and_checked_lists( $installed, $checked, $append ) {

--- a/projects/packages/protect-status/src/class-status.php
+++ b/projects/packages/protect-status/src/class-status.php
@@ -163,7 +163,7 @@ class Status {
 	 */
 	public static function get_total_threats() {
 		$status = static::get_status();
-		return isset( $status->num_threats ) && is_int( $status->num_threats ) ? $status->num_threats : 0;
+		return count( $status->threats );
 	}
 
 	/**
@@ -172,17 +172,14 @@ class Status {
 	 * @return array
 	 */
 	public static function get_all_threats() {
-		return array_merge(
-			self::get_wordpress_threats(),
-			self::get_themes_threats(),
-			self::get_plugins_threats(),
-			self::get_files_threats(),
-			self::get_database_threats()
-		);
+		$status = static::get_status();
+		return $status->threats;
 	}
 
 	/**
 	 * Get threats found for WordPress core
+	 *
+	 * @deprecated $$next-version$$
 	 *
 	 * @return array
 	 */
@@ -193,6 +190,8 @@ class Status {
 	/**
 	 * Get threats found for themes
 	 *
+	 * @deprecated $$next-version$$
+	 *
 	 * @return array
 	 */
 	public static function get_themes_threats() {
@@ -201,6 +200,8 @@ class Status {
 
 	/**
 	 * Get threats found for plugins
+	 *
+	 * @deprecated $$next-version$$
 	 *
 	 * @return array
 	 */
@@ -211,6 +212,8 @@ class Status {
 	/**
 	 * Get threats found for files
 	 *
+	 * @deprecated $$next-version$$
+	 *
 	 * @return array
 	 */
 	public static function get_files_threats() {
@@ -219,6 +222,8 @@ class Status {
 
 	/**
 	 * Get threats found for plugins
+	 *
+	 * @deprecated $$next-version$$
 	 *
 	 * @return array
 	 */
@@ -236,27 +241,40 @@ class Status {
 	public static function get_threats( $type ) {
 		$status = static::get_status();
 
-		if ( 'core' === $type ) {
-			return isset( $status->$type ) && ! empty( $status->$type->threats ) ? $status->$type->threats : array();
-		}
-
-		if ( 'files' === $type || 'database' === $type ) {
-			return isset( $status->$type ) && ! empty( $status->$type ) ? $status->$type : array();
-		}
-
-		$threats = array();
-		if ( isset( $status->$type ) ) {
-			foreach ( (array) $status->$type as $item ) {
-				if ( ! empty( $item->threats ) ) {
-					$threats = array_merge( $threats, $item->threats );
+		if ( in_array( $type, array( 'plugin', 'theme', 'core' ), true ) ) {
+			return array_filter(
+				$status->threats,
+				function ( $threat ) use ( $type ) {
+					return isset( $threat->extension ) && $type === $threat->extension->type;
 				}
-			}
+			);
 		}
-		return $threats;
+
+		if ( 'files' === $type ) {
+			return array_filter(
+				$status->threats,
+				function ( $threat ) {
+					return ! empty( $threat->filename );
+				}
+			);
+		}
+
+		if ( 'database' === $type ) {
+			return array_filter(
+				$status->threats,
+				function ( $threat ) {
+					return ! empty( $threat->table );
+				}
+			);
+		}
+
+		return $status->threats;
 	}
 
 	/**
 	 * Check if the WordPress version that was checked matches the current installed version.
+	 *
+	 * @phan-suppress PhanDeprecatedFunction -- Maintaining backwards compatibility.
 	 *
 	 * @param object $core_check The object returned by Protect wpcom endpoint.
 	 * @return object The object representing the current status of core checks.
@@ -285,6 +303,8 @@ class Status {
 
 	/**
 	 * Sort By Threats
+	 *
+	 * @deprecated $$next-version$$
 	 *
 	 * @param array<object> $threats Array of threats to sort.
 	 *

--- a/projects/packages/protect-status/tests/php/test-scan-status.php
+++ b/projects/packages/protect-status/tests/php/test-scan-status.php
@@ -134,6 +134,54 @@ class Test_Scan_Status extends BaseTestCase {
 				'num_plugins_threats' => 1,
 				'num_themes_threats'  => 0,
 				'status'              => 'idle',
+				'threats'             => array(
+					new Threat_Model(
+						array(
+							'id'             => 71626681,
+							'signature'      => 'EICAR_AV_Test_Critical',
+							'description'    => 'This is the standard EICAR antivirus test code, and not a real infection. If your site contains this code when you don\'t expect it to, contact Jetpack support for some help.',
+							'first_detected' => '2022-07-27T17 => 49 => 35.000Z',
+							'severity'       => 5,
+							'fixer'          => null,
+							'status'         => 'current',
+							'filename'       => '/var/www/html/wp-content/uploads/jptt_eicar.php',
+							'context'        => (object) array(
+								'15'    => 'echo <<',
+								'17'    => 'HTML;',
+								'marks' => new \stdClass(),
+							),
+						)
+					),
+					new Threat_Model(
+						array(
+							'id'             => '71625245',
+							'signature'      => 'Vulnerable.WP.Extension',
+							'description'    => 'The plugin WooCommerce (version 3.0.0) has a known vulnerability. ',
+							'first_detected' => '2022-07-27T17:22:16.000Z',
+							'severity'       => 3,
+							'fixable'        => null,
+							'status'         => 'current',
+							'source'         => 'https://wpvulndb.com/vulnerabilities/10220',
+						)
+					),
+					new Threat_Model(
+						array(
+							'id'             => 69353714,
+							'signature'      => 'Core.File.Modification',
+							'description'    => 'Core WordPress files are not normally changed. If you did not make these changes you should review the code.',
+							'first_detected' => '2022-06-23T18:42:29.000Z',
+							'severity'       => 4,
+							'status'         => 'current',
+							'fixable'        => (object) array(
+								'fixer'           => 'replace',
+								'file'            => '/var/www/html/wp-admin/index.php',
+								'extensionStatus' => '',
+							),
+							'filename'       => '/var/www/html/wp-admin/index.php',
+							'diff'           => "--- /tmp/wordpress/6.0-en_US/wordpress/wp-admin/index.php\t2021-11-03 03:16:57.000000000 +0000\n+++ /tmp/6299071296/core-file-23271BW6i4wLCe3T7\t2022-06-23 18:42:29.087377846 +0000\n@@ -209,3 +209,4 @@\n wp_print_community_events_templates();\n \n require_once ABSPATH . 'wp-admin/admin-footer.php';\n+if ( true === false ) exit();\n\\ No newline at end of file\n",
+						)
+					),
+				),
 				'fixable_threat_ids'  => array( '69353714' ),
 				'plugins'             => array(
 					new Extension_Model(
@@ -373,18 +421,6 @@ class Test_Scan_Status extends BaseTestCase {
 		$expected = array(
 			new Threat_Model(
 				array(
-					'id'             => '71625245',
-					'signature'      => 'Vulnerable.WP.Extension',
-					'description'    => 'The plugin WooCommerce (version 3.0.0) has a known vulnerability. ',
-					'first_detected' => '2022-07-27T17:22:16.000Z',
-					'severity'       => 3,
-					'fixable'        => null,
-					'status'         => 'current',
-					'source'         => 'https://wpvulndb.com/vulnerabilities/10220',
-				)
-			),
-			new Threat_Model(
-				array(
 					'id'             => 71626681,
 					'signature'      => 'EICAR_AV_Test_Critical',
 					'description'    => 'This is the standard EICAR antivirus test code, and not a real infection. If your site contains this code when you don\'t expect it to, contact Jetpack support for some help.',
@@ -398,6 +434,18 @@ class Test_Scan_Status extends BaseTestCase {
 						'17'    => 'HTML;',
 						'marks' => new \stdClass(),
 					),
+				)
+			),
+			new Threat_Model(
+				array(
+					'id'             => '71625245',
+					'signature'      => 'Vulnerable.WP.Extension',
+					'description'    => 'The plugin WooCommerce (version 3.0.0) has a known vulnerability. ',
+					'first_detected' => '2022-07-27T17:22:16.000Z',
+					'severity'       => 3,
+					'fixable'        => null,
+					'status'         => 'current',
+					'source'         => 'https://wpvulndb.com/vulnerabilities/10220',
 				)
 			),
 			new Threat_Model(

--- a/projects/packages/protect-status/tests/php/test-status.php
+++ b/projects/packages/protect-status/tests/php/test-status.php
@@ -225,6 +225,11 @@ class Test_Status extends BaseTestCase {
 				'num_themes_threats'  => 1,
 				'num_plugins_threats' => 1,
 				'has_unchecked_items' => false,
+				'threats'             => array(
+					$this->get_sample_threat(),
+					$this->get_sample_threat(),
+					$this->get_sample_threat(),
+				),
 			)
 		);
 	}
@@ -361,8 +366,12 @@ class Test_Status extends BaseTestCase {
 		$this->mock_connection();
 
 		add_filter( 'pre_http_request', array( $this, 'return_sample_response' ) );
+		add_filter( 'all_plugins', array( $this, 'return_sample_plugins' ) );
+		add_filter( 'jetpack_sync_get_themes_callable', array( $this, 'return_sample_themes' ) );
 		$status = Protect_Status::get_total_threats();
 		remove_filter( 'pre_http_request', array( $this, 'return_sample_response' ) );
+		remove_filter( 'all_plugins', array( $this, 'return_sample_plugins' ) );
+		remove_filter( 'jetpack_sync_get_themes_callable', array( $this, 'return_sample_themes' ) );
 
 		$this->assertSame( 3, $status );
 	}

--- a/projects/plugins/protect/changelog/update-protect-status-format
+++ b/projects/plugins/protect/changelog/update-protect-status-format
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added phan ignore doc blocks for use of deprecated properties.

--- a/projects/plugins/protect/src/class-scan-history.php
+++ b/projects/plugins/protect/src/class-scan-history.php
@@ -207,6 +207,8 @@ class Scan_History {
 	 * Normalize API Data
 	 * Formats the payload from the Scan API into an instance of History_Model.
 	 *
+	 * @phan-suppress PhanDeprecatedProperty -- Maintaining backwards compatibility.
+	 *
 	 * @param object $scan_data The data returned by the scan API.
 	 * @return History_Model
 	 */
@@ -249,6 +251,8 @@ class Scan_History {
 
 	/**
 	 * Handles threats for extensions such as plugins or themes.
+	 *
+	 * @phan-suppress PhanDeprecatedProperty -- Maintaining backwards compatibility.
 	 *
 	 * @param object $threat The threat object.
 	 * @param object $history The history object.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a `threats: Threat[]` property to the Protect Status.
* Deprecates properties such as `plugins`, `themes`, `core`, and `files` - the threats provided by these properties can now be accessed from the single `threats` property.
* Deprecates additional computed properties such as `num_threats`, `num_plugin_threats`, etc – these values can be computed by consumers using the `threats` property.
* **Only uses `@deprecated` PHPDoc blocks, does not include use of core `_deprecated_*_()` functions, to prevent PHP warnings from being triggered by an intentional deprecation process** (is this ridiculous? my intention is to avoid support tickets from users with `WP_DEBUG` enabled)
* Updates tests.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1730827086851209-slack-C029WFNV69M

peb6dq-31T-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Proof changes, ensure tests are passing.
* While viewing the Protect admin screen, check the contents of `window.jetpackProtectInitialState` to validate the presence of the new `threats` property.
* Test for regression:
  * Jetpack Protect: Test scanning and viewing threat results on both a free and paid plan.
  * My Jetpack: Test viewing the Protect product card in inactive/active states.