### PR TITLE
Subscriptions Block: Remove submitButtonText setting

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-block-remove-buton-label-textarea
+++ b/projects/plugins/jetpack/changelog/update-subscribe-block-remove-buton-label-textarea
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: remove block setting in order to align with core
+
+

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
@@ -27,7 +27,6 @@ import {
 	DEFAULT_SPACING_VALUE,
 	DEFAULT_FONTSIZE_VALUE,
 	DEFAULT_SUBSCRIBE_PLACEHOLDER,
-	DEFAULT_SUBMIT_BUTTON_LABEL,
 	DEFAULT_SUCCESS_MESSAGE,
 } from './constants';
 
@@ -55,7 +54,6 @@ export default function SubscriptionControls( {
 	textColor,
 	buttonWidth,
 	subscribePlaceholder = DEFAULT_SUBSCRIBE_PLACEHOLDER,
-	submitButtonText = DEFAULT_SUBMIT_BUTTON_LABEL,
 	successMessage = DEFAULT_SUCCESS_MESSAGE,
 } ) {
 	const { isPublicizeEnabled } = usePublicizeConfig();
@@ -290,13 +288,6 @@ export default function SubscriptionControls( {
 					label={ __( 'Input placeholder text', 'jetpack' ) }
 					help={ __( 'Edit the placeholder text of the email address input.', 'jetpack' ) }
 					onChange={ placeholder => setAttributes( { subscribePlaceholder: placeholder } ) }
-				/>
-				<TextareaControl
-					__nextHasNoMarginBottom={ true }
-					value={ submitButtonText }
-					label={ __( 'Submit button label', 'jetpack' ) }
-					help={ __( 'Edit the label of the button a user clicks to subscribe.', 'jetpack' ) }
-					onChange={ text => setAttributes( { submitButtonText: text } ) }
 				/>
 				{ ! isSimpleSite() && (
 					<TextareaControl


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/40072

## Proposed changes:

Core button's text can’t be changed from the block settings. I propose we align with core by removing the Submit Button Label setting from the Subscriptions block. It is not working properly in Firefox, see: https://github.com/Automattic/jetpack/issues/40072

<!--- Explain what functional changes your PR includes -->
* Before
<img width="256" alt="Screenshot 2024-11-08 at 10 24 28 AM" src="https://github.com/user-attachments/assets/a04de4f5-8049-4fdc-bf90-f0a4178202c1">

* After
<img width="282" alt="Screenshot 2024-11-08 at 10 22 37 AM" src="https://github.com/user-attachments/assets/d9a906cc-8096-4d26-9114-7e2e981a3739">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

