### PR TITLE
Full sync config modules order dictates order of execution

### DIFF
--- a/projects/packages/sync/.phan/baseline.php
+++ b/projects/packages/sync/.phan/baseline.php
@@ -9,8 +9,8 @@
  */
 return [
     // # Issue statistics:
+    // PhanTypeMismatchReturnProbablyReal : 40+ occurrences
     // PhanTypeMismatchArgument : 35+ occurrences
-    // PhanTypeMismatchReturnProbablyReal : 35+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 30+ occurrences
     // PhanTypeMismatchReturn : 20+ occurrences
     // PhanUndeclaredProperty : 20+ occurrences
@@ -19,6 +19,7 @@ return [
     // PhanPluginSimplifyExpressionBool : 9 occurrences
     // PhanPossiblyUndeclaredVariable : 8 occurrences
     // PhanPluginDuplicateSwitchCaseLooseEquality : 6 occurrences
+    // PhanUndeclaredTypeReturnType : 6 occurrences
     // PhanNonClassMethodCall : 5 occurrences
     // PhanRedundantCondition : 4 occurrences
     // PhanTypeExpectedObjectPropAccess : 4 occurrences
@@ -81,6 +82,8 @@ return [
         'src/modules/class-woocommerce-hpos-orders.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'src/modules/class-woocommerce.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'src/replicastore/class-table-checksum.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchPropertyProbablyReal'],
+        'src/sync-queue/class-queue-storage-options.php' => ['PhanUndeclaredTypeReturnType'],
+        'src/sync-queue/class-queue-storage-table.php' => ['PhanUndeclaredTypeReturnType'],
         'tests/php/test-actions.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/test-dedicated-sender.php' => ['PhanDeprecatedFunction', 'PhanUndeclaredProperty'],
         'tests/php/test-rest-endpoints.php' => ['PhanNoopNew', 'PhanTypeMismatchReturn'],

--- a/projects/packages/sync/.phan/baseline.php
+++ b/projects/packages/sync/.phan/baseline.php
@@ -82,8 +82,6 @@ return [
         'src/modules/class-woocommerce-hpos-orders.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'src/modules/class-woocommerce.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'src/replicastore/class-table-checksum.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchPropertyProbablyReal'],
-        'src/sync-queue/class-queue-storage-options.php' => ['PhanUndeclaredTypeReturnType'],
-        'src/sync-queue/class-queue-storage-table.php' => ['PhanUndeclaredTypeReturnType'],
         'tests/php/test-actions.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/test-dedicated-sender.php' => ['PhanDeprecatedFunction', 'PhanUndeclaredProperty'],
         'tests/php/test-rest-endpoints.php' => ['PhanNoopNew', 'PhanTypeMismatchReturn'],

--- a/projects/packages/sync/changelog/update-full-sync-config-modules-order-dictates-order-of-execution
+++ b/projects/packages/sync/changelog/update-full-sync-config-modules-order-dictates-order-of-execution
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Sync: Modules in Full Sync are now sent in the order the config is set.

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -1295,16 +1295,16 @@ class Defaults {
 	 * @var array list of module names.
 	 */
 	public static $default_full_sync_config = array(
-		'comments'           => 1,
 		'constants'          => 1,
 		'functions'          => 1,
 		'options'            => 1,
-		'posts'              => 1,
-		'term_relationships' => 1,
 		'terms'              => 1,
 		'themes'             => 1,
-		'updates'            => 1,
 		'users'              => 1,
+		'posts'              => 1,
+		'comments'           => 1,
+		'updates'            => 1,
+		'term_relationships' => 1,
 	);
 
 	/**

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -425,7 +425,12 @@ class Full_Sync_Immediately extends Module {
 				true === $status['progress'][ $module_name ]['finished'] ) {
 					continue;
 			}
-			$remaining_modules[] = $module;
+			// Ensure that 'constants', 'options', and 'callables' are sent first.
+			if ( in_array( $module_name, array( 'network_options', 'options', 'functions', 'constants' ), true ) ) {
+				array_unshift( $remaining_modules, $module );
+			} else {
+				$remaining_modules[] = $module;
+			}
 		}
 		return $remaining_modules;
 	}

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -414,33 +414,20 @@ class Full_Sync_Immediately extends Module {
 	 * @return array
 	 */
 	public function get_remaining_modules_to_send() {
-		$status = $this->get_status();
-
-		return array_filter(
-			Modules::get_modules(),
-			/**
-			 * Select configured and not finished modules.
-			 *
-			 * @param Module $module
-			 * @return bool
-			 */
-			function ( $module ) use ( $status ) {
-				// Skip module if not configured for this sync or module is done.
-				if ( ! isset( $status['config'][ $module->name() ] ) ) {
-					return false;
-				}
-				if ( ! $status['config'][ $module->name() ] ) {
-					return false;
-				}
-				if ( isset( $status['progress'][ $module->name() ]['finished'] ) ) {
-					if ( true === $status['progress'][ $module->name() ]['finished'] ) {
-						return false;
-					}
-				}
-
-				return true;
+		$status            = $this->get_status();
+		$remaining_modules = array();
+		foreach ( $status['config'] as $module_name => $module_config ) {
+			$module = Modules::get_module( $module_name );
+			if ( ! $module ) {
+				continue;
 			}
-		);
+			if ( isset( $status['progress'][ $module_name ]['finished'] ) &&
+				true === $status['progress'][ $module_name ]['finished'] ) {
+					continue;
+			}
+			$remaining_modules[] = $module;
+		}
+		return $remaining_modules;
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -416,7 +416,7 @@ class Full_Sync_Immediately extends Module {
 	public function get_remaining_modules_to_send() {
 		$status            = $this->get_status();
 		$remaining_modules = array();
-		foreach ( $status['config'] as $module_name => $module_config ) {
+		foreach ( array_keys( $status['config'] ) as $module_name ) {
 			$module = Modules::get_module( $module_name );
 			if ( ! $module ) {
 				continue;

--- a/projects/plugins/jetpack/changelog/update-full-sync-config-modules-order-dictates-order-of-execution
+++ b/projects/plugins/jetpack/changelog/update-full-sync-config-modules-order-dictates-order-of-execution
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Sync: Added test for Full Sync sending modules in the order config is set

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
@@ -318,9 +318,9 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals(
 			array(
 				'object_id'        => Modules\Term_Relationships::MAX_INT,
-				$previous_interval_end,
 				'term_taxonomy_id' => Modules\Term_Relationships::MAX_INT,
-			)
+			),
+			$previous_interval_end
 		);
 	}
 
@@ -949,11 +949,11 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals(
 			array(
 				'started'  => false,
-				$full_sync_status,
 				'finished' => false,
 				'progress' => array(),
 				'config'   => array(),
-			)
+			),
+			$full_sync_status
 		);
 	}
 

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
@@ -67,13 +67,13 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 
 	public function test_sync_health_in_sync_on_full_sync_end() {
 		Health::update_status( Health::STATUS_OUT_OF_SYNC );
-		$this->assertEquals( Health::get_status(), Health::STATUS_OUT_OF_SYNC );
+		$this->assertEquals( Health::STATUS_OUT_OF_SYNC, Health::get_status() );
 		$post = self::factory()->post->create();
 		self::factory()->comment->create_post_comments( $post, 11 );
 
 		$this->full_sync->start();
 		$this->sender->do_full_sync();
-		$this->assertEquals( Health::get_status(), Health::STATUS_IN_SYNC );
+		$this->assertEquals( Health::STATUS_IN_SYNC, Health::get_status() );
 	}
 
 	/** This only applies to the test replicastore - in production we overlay data. */
@@ -178,7 +178,7 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 
 		$post_on_server = $this->server_replica_storage->get_post( $post->ID );
 		$this->assertEquals( '[foo]', $post_on_server->post_content );
-		$this->assertEquals( trim( $post_on_server->post_content_filtered ), 'bar' );
+		$this->assertEquals( 'bar', trim( $post_on_server->post_content_filtered ) );
 	}
 
 	public function foo_shortcode() {
@@ -316,9 +316,9 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 		$previous_interval_end = $event->args['previous_end'];
 
 		$this->assertEquals(
-			$previous_interval_end,
 			array(
 				'object_id'        => Modules\Term_Relationships::MAX_INT,
+				$previous_interval_end,
 				'term_taxonomy_id' => Modules\Term_Relationships::MAX_INT,
 			)
 		);
@@ -554,7 +554,7 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_full_sync();
 
 		$synced_options_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_options' );
-		$this->assertEquals( count( $synced_options_event->args ), 2, 'Size of synced options not as expected' );
+		$this->assertCount( 2, $synced_options_event->args, 'Size of synced options not as expected' );
 		$this->assertEquals( 'foo', $synced_options_event->args['my_option'] );
 		$this->assertEquals( 'bar', $synced_options_event->args['my_prefix_value'] );
 
@@ -947,9 +947,9 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 		$full_sync_status = $this->full_sync->get_status();
 
 		$this->assertEquals(
-			$full_sync_status,
 			array(
 				'started'  => false,
+				$full_sync_status,
 				'finished' => false,
 				'progress' => array(),
 				'config'   => array(),
@@ -1318,5 +1318,37 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 
 		$start_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_start' );
 		$this->assertTrue( ! empty( $start_event ) );
+	}
+
+	public function test_full_sync_sends_actions_sorted_by_config() {
+		$post_id = self::factory()->post->create();
+		self::factory()->comment->create_post_comments( $post_id );
+
+		$this->full_sync->start(
+			array(
+				'posts'     => true,
+				'users'     => true,
+				'constants' => true,
+				'comments'  => true,
+				'terms'     => true,
+			)
+		);
+		$this->sender->do_full_sync();
+
+		$this->full_sync->continue_sending();
+		$this->sender->do_full_sync();
+
+		$events                       = $this->server_event_storage->get_all_events();
+		$expected_events_action_names = array(
+			'jetpack_full_sync_start',
+			'jetpack_full_sync_posts',
+			'jetpack_full_sync_users',
+			'jetpack_full_sync_constants',
+			'jetpack_full_sync_comments',
+			'jetpack_full_sync_terms',
+			'jetpack_full_sync_end',
+		);
+		$actual_events_action_names   = wp_list_pluck( $events, 'action' );
+		$this->assertEquals( $expected_events_action_names, $actual_events_action_names );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
@@ -1320,6 +1320,32 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( ! empty( $start_event ) );
 	}
 
+	public function test_full_sync_sends_actions_sorted_by_config_constants_always_first() {
+		$post_id = self::factory()->post->create();
+		self::factory()->comment->create_post_comments( $post_id );
+
+		$this->full_sync->start(
+			array(
+				'terms' => true,
+				'users' => true,
+			)
+		);
+		$this->sender->do_full_sync();
+
+		$this->full_sync->continue_sending();
+		$this->sender->do_full_sync();
+
+		$events                       = $this->server_event_storage->get_all_events();
+		$expected_events_action_names = array(
+			'jetpack_full_sync_start',
+			'jetpack_full_sync_terms',
+			'jetpack_full_sync_users',
+			'jetpack_full_sync_end',
+		);
+		$actual_events_action_names   = wp_list_pluck( $events, 'action' );
+		$this->assertEquals( $expected_events_action_names, $actual_events_action_names );
+	}
+
 	public function test_full_sync_sends_actions_sorted_by_config() {
 		$post_id = self::factory()->post->create();
 		self::factory()->comment->create_post_comments( $post_id );
@@ -1341,9 +1367,9 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 		$events                       = $this->server_event_storage->get_all_events();
 		$expected_events_action_names = array(
 			'jetpack_full_sync_start',
+			'jetpack_full_sync_constants',
 			'jetpack_full_sync_posts',
 			'jetpack_full_sync_users',
-			'jetpack_full_sync_constants',
 			'jetpack_full_sync_comments',
 			'jetpack_full_sync_terms',
 			'jetpack_full_sync_end',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/vulcan/issues/583

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When retrieving the remaining modules, the logic was using the order of `Modules::get_modules()`now we will be using the config passed to Full Sync that can be easily updated with [jetpack_full_sync_config](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/modules/class-full-sync-immediately.php#L90) filter.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pfKYZu-1BX-p2
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. --o>

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

For a Jetpack connected site, 

- Add the filter in 36309-pb/ (with Code Snippets for example).
In trunk:
- Run a Full Sync of everything through Debugger
- Check in the jetpack-audit* logs that the order **is not** the one specified in the filter.
With this branch:

In trunk:
- Run a Full Sync of everything through Debugger
- Check in the jetpack-audit* logs that the order **is** the one specified in the filter with constants going first.