### PR TITLE
Boost: Fix fatal error when fetching pages during `init`

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -197,6 +197,10 @@ const List: React.FC< ListProps > = ( { items, setItems, maxItems, description }
 			.map( line => line.trim() )
 			.filter( line => line.trim() !== '' );
 
+		if ( lines.length === 0 ) {
+			throw new Error( __( 'You must add at least one URL.', 'jetpack-boost' ) );
+		}
+
 		// Check if the number of items exceeds maxItems
 		if ( lines.length > maxItems ) {
 			const message = sprintf(

--- a/projects/plugins/boost/app/lib/Cornerstone_Pages.php
+++ b/projects/plugins/boost/app/lib/Cornerstone_Pages.php
@@ -12,13 +12,22 @@ class Cornerstone_Pages implements Has_Setup {
 	const FREE_MAX_PAGES    = 1;
 
 	public function setup() {
+		$this->register_ds_stores();
+
 		add_filter( 'jetpack_boost_critical_css_providers', array( $this, 'remove_ccss_front_page_provider' ), 10, 2 );
 		add_filter( 'display_post_states', array( $this, 'add_display_post_states' ), 10, 2 );
-		add_action( 'init', array( $this, 'register_ds_stores' ), 0 );
+		add_action( 'init', array( $this, 'set_default_pages' ), 0 );
 	}
 
-	public function register_ds_stores() {
-		$schema = Schema::as_array( Schema::as_string() )->fallback( $this->default_pages() );
+	public function set_default_pages() {
+		$pages = jetpack_boost_ds_get( 'cornerstone_pages_list' );
+		if ( empty( $pages ) ) {
+			jetpack_boost_ds_set( 'cornerstone_pages_list', $this->default_pages() );
+		}
+	}
+
+	private function register_ds_stores() {
+		$schema = Schema::as_array( Schema::as_string() )->fallback( array() );
 		jetpack_boost_register_option( 'cornerstone_pages_list', $schema, new Cornerstone_Pages_Entry( 'cornerstone_pages_list' ) );
 		jetpack_boost_register_readonly_option( 'cornerstone_pages_properties', array( $this, 'get_properties' ) );
 	}
@@ -105,10 +114,6 @@ class Cornerstone_Pages implements Has_Setup {
 
 	public function get_pages() {
 		$pages = jetpack_boost_ds_get( 'cornerstone_pages_list' );
-		// This is in case the DS store is not initialized yet.
-		if ( empty( $pages ) ) {
-			$pages = $this->default_pages();
-		}
 
 		$permalink_structure = get_option( 'permalink_structure' );
 

--- a/projects/plugins/boost/app/lib/Cornerstone_Pages.php
+++ b/projects/plugins/boost/app/lib/Cornerstone_Pages.php
@@ -14,7 +14,7 @@ class Cornerstone_Pages implements Has_Setup {
 	public function setup() {
 		add_filter( 'jetpack_boost_critical_css_providers', array( $this, 'remove_ccss_front_page_provider' ), 10, 2 );
 		add_filter( 'display_post_states', array( $this, 'add_display_post_states' ), 10, 2 );
-		add_action( 'init', array( $this, 'register_ds_stores' ) );
+		add_action( 'init', array( $this, 'register_ds_stores' ), 0 );
 	}
 
 	public function register_ds_stores() {

--- a/projects/plugins/boost/app/lib/Cornerstone_Pages.php
+++ b/projects/plugins/boost/app/lib/Cornerstone_Pages.php
@@ -105,6 +105,10 @@ class Cornerstone_Pages implements Has_Setup {
 
 	public function get_pages() {
 		$pages = jetpack_boost_ds_get( 'cornerstone_pages_list' );
+		// This is in case the DS store is not initialized yet.
+		if ( empty( $pages ) ) {
+			$pages = $this->default_pages();
+		}
 
 		$permalink_structure = get_option( 'permalink_structure' );
 

--- a/projects/plugins/boost/changelog/fix-boost-cornerstone-pages-fatal
+++ b/projects/plugins/boost/changelog/fix-boost-cornerstone-pages-fatal
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix for an unreleased feature.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1730996767561429-slack-CDLH4C1UZ

## Proposed changes:

- Update Cornerstone Pages DS store initialization to happen a bit earlier;
- Add error state if the Cornerstone Pages UI list is empty;
- Update how default value for Cornerstone Pages is handled.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1730996767561429-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Setup Boost (free) with CRM;
- There should be no fatal error;
- Add the URL of an existing page to the cornerstone pages UI and save;
- Update the page and make sure the notice indicating that a page from the cornerstone pages list got updated, is showing.