### PR TITLE
Boost: Allow loading default pages for cornerstone pages UI

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/lib/stores/cornerstone-pages.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/lib/stores/cornerstone-pages.ts
@@ -26,6 +26,7 @@ export function useCornerstonePages(): [
 const CornerstonePagesProperties = z.object( {
 	max_pages: z.number(),
 	max_pages_premium: z.number(),
+	default_pages: z.array( z.string() ),
 } );
 type CornerstonePagesProperties = z.infer< typeof CornerstonePagesProperties >;
 

--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -53,6 +53,7 @@ const Meta = () => {
 				items={ cornerstonePages.join( '\n' ) }
 				setItems={ updateCornerstonePages }
 				maxItems={ cornerstonePagesProperties.max_pages }
+				defaultValue={ cornerstonePagesProperties.default_pages.join( '\n' ) }
 				description={
 					<>
 						{ createInterpolateElement(
@@ -169,9 +170,16 @@ type ListProps = {
 	setItems: ( newValue: string ) => void;
 	maxItems: number;
 	description: React.ReactNode | null;
+	defaultValue?: string;
 };
 
-const List: React.FC< ListProps > = ( { items, setItems, maxItems, description } ) => {
+const List: React.FC< ListProps > = ( {
+	items,
+	setItems,
+	maxItems,
+	description,
+	defaultValue,
+} ) => {
 	const [ inputValue, setInputValue ] = useState( items );
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const [ inputInvalid, setInputInvalid ] = useState( false );
@@ -248,6 +256,10 @@ const List: React.FC< ListProps > = ( { items, setItems, maxItems, description }
 		} );
 	}
 
+	function loadDefaultValue() {
+		setInputValue( defaultValue || '' );
+	}
+
 	return (
 		<div
 			className={ clsx( styles.section, {
@@ -268,6 +280,13 @@ const List: React.FC< ListProps > = ( { items, setItems, maxItems, description }
 				className={ styles.button }
 			>
 				{ __( 'Save', 'jetpack-boost' ) }
+			</Button>
+			<Button
+				disabled={ inputValue === defaultValue }
+				onClick={ loadDefaultValue }
+				className={ styles.button }
+			>
+				{ __( 'Load Default', 'jetpack-boost' ) }
 			</Button>
 		</div>
 	);

--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -285,6 +285,7 @@ const List: React.FC< ListProps > = ( {
 				disabled={ inputValue === defaultValue }
 				onClick={ loadDefaultValue }
 				className={ styles.button }
+				variant="link"
 			>
 				{ __( 'Load Default', 'jetpack-boost' ) }
 			</Button>

--- a/projects/plugins/boost/app/lib/Cornerstone_Pages.php
+++ b/projects/plugins/boost/app/lib/Cornerstone_Pages.php
@@ -129,6 +129,7 @@ class Cornerstone_Pages implements Has_Setup {
 		return array(
 			'max_pages'         => $this->get_max_pages(),
 			'max_pages_premium' => static::PREMIUM_MAX_PAGES,
+			'default_pages'     => array_map( 'home_url', $this->default_pages() ),
 		);
 	}
 

--- a/projects/plugins/boost/changelog/update-boost-load-default-cornerstone-pages
+++ b/projects/plugins/boost/changelog/update-boost-load-default-cornerstone-pages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Change to an unreleased feature.
+
+


### PR DESCRIPTION
## Proposed changes:

- Add button that loads default pages for Cornerstone Pages UI.

![CleanShot 2024-11-08 at 15 17 41](https://github.com/user-attachments/assets/19c6c0f0-a8ec-4d22-8883-b3aa75827d51)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Setup Boost;
- Make sure the "Load Default" button in the Cornerstone Pages UI works as expected.