### PR TITLE
Repo Gardening: update conditions when AI Labeling is triggered

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-ai-labeling-conditions
+++ b/projects/github-actions/repo-gardening/changelog/update-ai-labeling-conditions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Labeling: update conditions when labeling is triggered.

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/ai-labeling.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/ai-labeling.js
@@ -99,9 +99,8 @@ Example response format:
  *
  * When an issue is first opened, parse its contents, send them to OpenAI,
  * and add labels if any matching labels can be found.
- * During testing, we'll run it for any issues, not just opened,
- * but only on issues with the "[Experiment] Automated labeling" label.
- * In that situation, we'll add a label to note that the issue was processed.
+ * During testing, we'll only run it for issues that are not labeled as "[Type] Task".
+ * When we auto-label, we'll add a label to note that the issue was processed.
  *
  * @param {WebhookPayloadIssue} payload - Issue event payload.
  * @param {GitHub}              octokit - Initialized Octokit REST client.
@@ -121,8 +120,8 @@ async function aiLabeling( payload, octokit ) {
 	}
 
 	if (
-		issueLabels.includes( '[Experiment] Automated labeling' ) &&
-		! issueLabels.includes( '[Experiment] AI labels added' )
+		! issueLabels.includes( '[Experiment] AI labels added' ) &&
+		! issueLabels.includes( '[Type] Task' )
 	) {
 		debug(
 			`triage-issues > auto-label: Fetching labels suggested by OpenAI for issue #${ number }`

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
@@ -97,10 +97,10 @@ async function triageIssues( payload, octokit ) {
 				await sendSlackMessage( message, qualityChannel, payload, slackMessageFormat );
 			}
 		}
-	}
 
-	// Use OpenAI to automatically add labels to issues.
-	await aiLabeling( payload, octokit );
+		// Use OpenAI to automatically add labels to issues.
+		await aiLabeling( payload, octokit );
+	}
 
 	// Triage the issue to a Project board if necessary and possible.
 	await updateBoard( payload, octokit, isBugIssue, priorityLabels );


### PR DESCRIPTION
## Proposed changes:

As discussed in pdqkMK-1lq-p2#comment-1657, we now want to trigger AI Labeling more often. It will now be triggered for all newly opened (or reopened) issues, as long as the issue is not labeled "[Type] Task".

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* pdqkMK-1lq-p2#comment-1657

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This is better tested in a fork. Here is an example from a fork:
https://github.com/jeherve/jetpack/issues/171


