### PR TITLE
Help Center: extend support interaction API

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-help-center-api
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-help-center-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Help Center: extend support interaction API

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-support-interactions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-support-interactions.php
@@ -219,4 +219,34 @@ class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
 
 		return rest_ensure_response( $response );
 	}
+
+	/**
+	 * Update support interaction status.
+	 *
+	 * @param \WP_REST_Request $request    The request sent to the API.
+	 */
+	public function update_support_interaction_status( \WP_REST_Request $request ) {
+		$support_interaction_id = isset( $request['support_interaction_id'] ) ? (int) $request['support_interaction_id'] : null;
+
+		$data = array(
+			'status' => $request['status'],
+		);
+
+		$body = Client::wpcom_json_api_request_as_user(
+			"/support-interactions/$support_interaction_id/status",
+			'2',
+			array(
+				'method' => 'PUT',
+				'body'   => $data,
+			)
+		);
+
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
+
+		return rest_ensure_response( $response );
+	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-support-interactions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-support-interactions.php
@@ -13,9 +13,6 @@ use Automattic\Jetpack\Connection\Client;
  * Class WP_REST_Help_Center_Support_Interactions.
  */
 class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
-	const STATUS_OPEN     = 'open';
-	const STATUS_RESOLVED = 'resolved';
-
 	/**
 	 * WP_REST_Help_Center_Support_Interactions constructor.
 	 */
@@ -40,8 +37,8 @@ class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
 						'type'     => 'string',
 						'required' => false,
 						'enum'     => array(
-							self::STATUS_OPEN,
-							self::STATUS_RESOLVED,
+							'open',
+							'resolved',
 						),
 					),
 					'page'     => array(
@@ -131,8 +128,8 @@ class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
 						'type'     => 'string',
 						'required' => true,
 						'enum'     => array(
-							self::STATUS_OPEN,
-							self::STATUS_RESOLVED,
+							'open',
+							'resolved',
 						),
 					),
 				),

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-support-interactions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-support-interactions.php
@@ -13,6 +13,9 @@ use Automattic\Jetpack\Connection\Client;
  * Class WP_REST_Help_Center_Support_Interactions.
  */
 class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
+	const STATUS_OPEN     = 'open';
+	const STATUS_RESOLVED = 'resolved';
+
 	/**
 	 * WP_REST_Help_Center_Support_Interactions constructor.
 	 */
@@ -32,6 +35,29 @@ class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_support_interactions' ),
 				'permission_callback' => 'is_user_logged_in',
+				'args'                => array(
+					'status'   => array(
+						'type'     => 'string',
+						'required' => false,
+						'enum'     => array(
+							self::STATUS_OPEN,
+							self::STATUS_RESOLVED,
+						),
+					),
+					'page'     => array(
+						'type'     => 'integer',
+						'required' => false,
+						'default'  => 1,
+						'minimum'  => 1,
+					),
+					'per_page' => array(
+						'type'     => 'integer',
+						'required' => false,
+						'default'  => 10,
+						'minimum'  => 1,
+						'maximum'  => 100,
+					),
+				),
 			)
 		);
 
@@ -54,7 +80,7 @@ class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
 				'permission_callback' => 'is_user_logged_in',
 				'args'                => array(
 					'event_external_id' => array(
-						'type'     => 'int',
+						'type'     => 'string',
 						'required' => true,
 					),
 					'event_source'      => array(
@@ -78,7 +104,7 @@ class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
 				'permission_callback' => 'is_user_logged_in',
 				'args'                => array(
 					'event_external_id' => array(
-						'type'     => 'int',
+						'type'     => 'string',
 						'required' => true,
 					),
 					'event_source'      => array(
@@ -88,6 +114,26 @@ class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
 					'event_metadata'    => array(
 						'type'     => 'string',
 						'required' => false,
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<support_interaction_id>[a-zA-Z0-9-]+)/status',
+			array(
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'update_support_interaction_status' ),
+				'permission_callback' => 'is_user_logged_in',
+				'args'                => array(
+					'status' => array(
+						'type'     => 'string',
+						'required' => true,
+						'enum'     => array(
+							self::STATUS_OPEN,
+							self::STATUS_RESOLVED,
+						),
 					),
 				),
 			)

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-support-interactions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-support-interactions.php
@@ -228,18 +228,9 @@ class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
 	public function update_support_interaction_status( \WP_REST_Request $request ) {
 		$support_interaction_id = isset( $request['support_interaction_id'] ) ? (int) $request['support_interaction_id'] : null;
 
-		$data = array(
-			'status' => $request['status'],
-		);
+		$status = $request['status'];
 
-		$body = Client::wpcom_json_api_request_as_user(
-			"/support-interactions/$support_interaction_id/status",
-			'2',
-			array(
-				'method' => 'PUT',
-				'body'   => $data,
-			)
-		);
+		$body = Client::wpcom_json_api_request_as_user( "/support-interactions/$support_interaction_id/status?status={$status}" );
 
 		if ( is_wp_error( $body ) ) {
 			return $body;


### PR DESCRIPTION
## Proposed changes:

* Extend Support Interaction API to match WPCOM version.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
na

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test the Help Center with new flag
* Everything should work properly

