### PR TITLE
Jetpack AI: add featured image styles support

### DIFF
--- a/projects/js-packages/ai-client/changelog/add-jetpack-ai-featured-image-styles
+++ b/projects/js-packages/ai-client/changelog/add-jetpack-ai-featured-image-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Client: add effect on AiModalInputPrompt to update/set prompt on prop update

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
@@ -97,6 +97,14 @@ export const AiModalPromptInput = ( {
 		}
 	}, [ prompt ] );
 
+	// fix for contenteditable divs not being able to be cleared by the user
+	// as per default browser behavior
+	const onKeyUp = () => {
+		if ( inputRef.current?.textContent === '' ) {
+			inputRef.current.innerHTML = '';
+		}
+	};
+
 	return (
 		<div className="jetpack-ai-logo-generator__prompt-query">
 			<div
@@ -110,6 +118,7 @@ export const AiModalPromptInput = ( {
 				onInput={ onPromptInput }
 				onPaste={ onPromptPaste }
 				onKeyDown={ onKeyDown }
+				onKeyUp={ onKeyUp }
 				data-placeholder={ placeholder }
 			></div>
 			<Button

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
@@ -87,6 +87,13 @@ export const AiModalPromptInput = ( {
 		event.stopPropagation();
 	};
 
+	useEffect( () => {
+		// Update prompt text node when prop changes
+		if ( inputRef.current && inputRef.current.textContent !== prompt ) {
+			inputRef.current.textContent = prompt;
+		}
+	}, [ prompt ] );
+
 	return (
 		<div className="jetpack-ai-logo-generator__prompt-query">
 			<div

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
@@ -45,6 +45,7 @@ export const AiModalPromptInput = ( {
 	generateHandler = () => {},
 	placeholder = '',
 	buttonLabel = '',
+	minPromptLength = null,
 }: {
 	prompt: string;
 	setPrompt: Dispatch< SetStateAction< string > >;
@@ -52,9 +53,11 @@ export const AiModalPromptInput = ( {
 	generateHandler: () => void;
 	placeholder?: string;
 	buttonLabel?: string;
+	minPromptLength?: number;
 } ) => {
 	const inputRef = useRef< HTMLDivElement | null >( null );
-	const hasPrompt = prompt?.length >= MINIMUM_PROMPT_LENGTH;
+	const hasPrompt =
+		prompt?.length >= ( minPromptLength === null ? MINIMUM_PROMPT_LENGTH : minPromptLength );
 
 	const onPromptInput = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		setPrompt( event.target.textContent || '' );

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-featured-image-styles
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-featured-image-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI: add styles support for featured image AI modal

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.tsx
@@ -31,7 +31,6 @@ export default function AiImageModal( {
 	title,
 	cost,
 	open,
-	placement,
 	images,
 	currentIndex = 0,
 	onClose = null,
@@ -53,6 +52,8 @@ export default function AiImageModal( {
 	instructionsPlaceholder = null,
 	imageStyles = [],
 	onGuessStyle = null,
+	initialPrompt = '',
+	initialStyle = null,
 }: {
 	title: string;
 	cost: number;
@@ -81,10 +82,12 @@ export default function AiImageModal( {
 	instructionsPlaceholder: string;
 	imageStyles?: Array< ImageStyleObject >;
 	onGuessStyle?: ( userPrompt: string ) => Promise< ImageStyle >;
+	initialPrompt?: string;
+	initialStyle?: ImageStyle;
 } ) {
 	const { tracks } = useAnalytics();
 	const { recordEvent: recordTracksEvent } = tracks;
-	const [ userPrompt, setUserPrompt ] = useState( '' );
+	const [ userPrompt, setUserPrompt ] = useState( initialPrompt );
 	const triggeredAutoGeneration = useRef( false );
 	const [ showStyleSelector, setShowStyleSelector ] = useState( false );
 	const [ style, setStyle ] = useState< ImageStyle >( null );
@@ -136,10 +139,10 @@ export default function AiImageModal( {
 		if ( autoStart && open ) {
 			if ( ! triggeredAutoGeneration.current ) {
 				triggeredAutoGeneration.current = true;
-				autoStartAction?.( { userPrompt } );
+				autoStartAction?.( {} );
 			}
 		}
-	}, [ placement, handleGenerate, autoStart, autoStartAction, userPrompt, open ] );
+	}, [ autoStart, autoStartAction, open ] );
 
 	// initialize styles dropdown
 	useEffect( () => {
@@ -155,9 +158,11 @@ export default function AiImageModal( {
 				].filter( v => v ) // simplest way to get rid of empty values
 			);
 			setShowStyleSelector( true );
-			setStyle( IMAGE_STYLE_NONE );
+			setStyle( initialStyle || IMAGE_STYLE_NONE );
 		}
-	}, [ imageStyles ] );
+	}, [ imageStyles, initialStyle ] );
+
+	useEffect( () => setUserPrompt( initialPrompt ), [ initialPrompt ] );
 
 	return (
 		<>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.tsx
@@ -55,6 +55,7 @@ export default function AiImageModal( {
 	initialPrompt = '',
 	initialStyle = null,
 	minPromptLength = null,
+	postContent = null,
 }: {
 	title: string;
 	cost: number;
@@ -191,7 +192,7 @@ export default function AiImageModal( {
 						<AiModalPromptInput
 							prompt={ userPrompt }
 							setPrompt={ setUserPrompt }
-							disabled={ instructionsDisabled }
+							disabled={ instructionsDisabled || ! postContent }
 							generateHandler={ hasError ? handleTryAgain : handleGenerate }
 							placeholder={ instructionsPlaceholder }
 							buttonLabel={ hasError ? tryAgainLabel : generateLabel }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.tsx
@@ -98,7 +98,7 @@ export default function AiImageModal( {
 	}, [ onTryAgain, userPrompt, style ] );
 
 	const handleGenerate = useCallback( async () => {
-		if ( style === IMAGE_STYLE_AUTO ) {
+		if ( style === IMAGE_STYLE_AUTO && onGuessStyle ) {
 			recordTracksEvent( 'jetpack_ai_general_image_guess_style', {
 				context: 'block-editor',
 				tool: 'image',

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.tsx
@@ -54,6 +54,7 @@ export default function AiImageModal( {
 	onGuessStyle = null,
 	initialPrompt = '',
 	initialStyle = null,
+	minPromptLength = null,
 }: {
 	title: string;
 	cost: number;
@@ -84,6 +85,7 @@ export default function AiImageModal( {
 	onGuessStyle?: ( userPrompt: string ) => Promise< ImageStyle >;
 	initialPrompt?: string;
 	initialStyle?: ImageStyle;
+	minPromptLength?: number;
 } ) {
 	const { tracks } = useAnalytics();
 	const { recordEvent: recordTracksEvent } = tracks;
@@ -193,6 +195,7 @@ export default function AiImageModal( {
 							generateHandler={ hasError ? handleTryAgain : handleGenerate }
 							placeholder={ instructionsPlaceholder }
 							buttonLabel={ hasError ? tryAgainLabel : generateLabel }
+							minPromptLength={ minPromptLength }
 						/>
 						{ upgradePromptVisible && (
 							<QuotaExceededMessage

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -1,11 +1,13 @@
 /**
  * External dependencies
  */
+import { ImageStyle } from '@automattic/jetpack-ai-client';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
@@ -27,6 +29,9 @@ import {
 	IMAGE_GENERATION_MODEL_DALL_E_3,
 	PLACEMENT_MEDIA_SOURCE_DROPDOWN,
 } from './types';
+import type { ImageResponse } from './hooks/use-ai-image';
+
+const debug = debugFactory( 'jetpack-ai:featured-image' );
 
 export default function FeaturedImage( {
 	busy,
@@ -44,9 +49,19 @@ export default function FeaturedImage( {
 	);
 	const siteType = useSiteType();
 	const postContent = usePostContent();
+	const { postTitle, postFeaturedMedia } = useSelect( select => {
+		return {
+			// @ts-expect-error - getEditedPostAttribute is not defined in the useSelect type
+			postTitle: select( 'core/editor' ).getEditedPostAttribute( 'title' ),
+			// @ts-expect-error - getEditedPostAttribute is not defined in the useSelect type
+			postFeaturedMedia: select( 'core/editor' ).getEditedPostAttribute( 'featured_media' ),
+		};
+	}, [] );
 	const { saveToMediaLibrary } = useSaveToMediaLibrary();
 	const { tracks } = useAnalytics();
 	const { recordEvent } = tracks;
+	const [ defaultPrompt, setDefaultPrompt ] = useState( '' );
+	const [ requestStyle, setRequestStyle ] = useState< ImageStyle >( null );
 
 	// Editor actions
 	const { enableComplementaryArea } = useDispatch( 'core/interface' );
@@ -91,6 +106,8 @@ export default function FeaturedImage( {
 		currentImage,
 		currentPointer,
 		images,
+		imageStyles,
+		guessStyle,
 	} = useAiImage( {
 		autoStart: false,
 		cost: featuredImageCost,
@@ -107,22 +124,46 @@ export default function FeaturedImage( {
 		setIsFeaturedImageModalVisible( true );
 	}, [] );
 
+	/**
+	 * Handle the guess style for the image. It is reworked here to include the post content.
+	 */
+	const handleGuessStyle = useCallback(
+		prompt => {
+			const content = postTitle + '\n\n' + postContent;
+			return guessStyle( prompt, 'featured-image-guess-style', content );
+		},
+		[ postContent, postTitle, guessStyle ]
+	);
+
 	const handleGenerate = useCallback(
-		( { userPrompt }: { userPrompt?: string } ) => {
+		( {
+			userPrompt,
+			style,
+		}: {
+			userPrompt?: string;
+			style?: string;
+		} ): Promise< void | ImageResponse > => {
 			// track the generate image event
 			recordEvent( 'jetpack_ai_featured_image_generation_generate_image', {
 				placement,
 				model: featuredImageActiveModel,
 				site_type: siteType,
+				style,
 			} );
 
 			setIsFeaturedImageModalVisible( true );
-			processImageGeneration( { userPrompt, postContent, notEnoughRequests } ).catch( error => {
+			return processImageGeneration( {
+				userPrompt,
+				postContent,
+				notEnoughRequests,
+				style,
+			} ).catch( error => {
 				recordEvent( 'jetpack_ai_featured_image_generation_error', {
 					placement,
 					error: error?.message,
 					model: featuredImageActiveModel,
 					site_type: siteType,
+					style,
 				} );
 			} );
 		},
@@ -137,54 +178,74 @@ export default function FeaturedImage( {
 		]
 	);
 
+	const handleFirstGenerate = useCallback( async () => {
+		currentPointer.generating = true;
+		const guessedStyle = await handleGuessStyle( '' );
+		setRequestStyle( guessedStyle );
+
+		const response = await handleGenerate( { userPrompt: '', style: guessedStyle } );
+		if ( response ) {
+			debug( 'handleFirstGenerate', response.revisedPrompt );
+			setDefaultPrompt( response.revisedPrompt );
+		}
+	}, [ currentPointer, handleGenerate, handleGuessStyle ] );
+
 	const handleRegenerate = useCallback(
-		( { userPrompt }: { userPrompt?: string } ) => {
+		( { prompt, style }: { prompt?: string; style?: string } ) => {
 			// track the regenerate image event
 			recordEvent( 'jetpack_ai_featured_image_generation_generate_another_image', {
 				placement,
 				model: featuredImageActiveModel,
 				site_type: siteType,
+				style: style,
 			} );
 
 			setCurrent( crrt => crrt + 1 );
-			processImageGeneration( { userPrompt, postContent, notEnoughRequests } ).catch( error => {
-				recordEvent( 'jetpack_ai_featured_image_generation_error', {
-					placement,
-					error: error?.message,
-					model: featuredImageActiveModel,
-					site_type: siteType,
-				} );
-			} );
+			processImageGeneration( { userPrompt: prompt, postContent, notEnoughRequests, style } ).catch(
+				error => {
+					recordEvent( 'jetpack_ai_featured_image_generation_error', {
+						placement,
+						error: error?.message,
+						model: featuredImageActiveModel,
+						site_type: siteType,
+						style,
+					} );
+				}
+			);
 		},
 		[
 			recordEvent,
 			placement,
 			featuredImageActiveModel,
 			siteType,
+			setCurrent,
 			processImageGeneration,
 			postContent,
 			notEnoughRequests,
-			setCurrent,
 		]
 	);
 
 	const handleTryAgain = useCallback(
-		( { userPrompt }: { userPrompt?: string } ) => {
+		( { userPrompt, style }: { userPrompt?: string; style?: string } ) => {
 			// track the try again event
 			recordEvent( 'jetpack_ai_featured_image_generation_try_again', {
 				placement,
 				model: featuredImageActiveModel,
 				site_type: siteType,
+				style,
 			} );
 
-			processImageGeneration( { userPrompt, postContent, notEnoughRequests } ).catch( error => {
-				recordEvent( 'jetpack_ai_featured_image_generation_error', {
-					placement,
-					error: error?.message,
-					model: featuredImageActiveModel,
-					site_type: siteType,
-				} );
-			} );
+			processImageGeneration( { userPrompt, postContent, notEnoughRequests, style } ).catch(
+				error => {
+					recordEvent( 'jetpack_ai_featured_image_generation_error', {
+						placement,
+						error: error?.message,
+						model: featuredImageActiveModel,
+						site_type: siteType,
+						style,
+					} );
+				}
+			);
 		},
 		[
 			recordEvent,
@@ -308,8 +369,8 @@ export default function FeaturedImage( {
 			) }
 			<AiImageModal
 				postContent={ postContent }
-				autoStart={ postContent !== '' }
-				autoStartAction={ handleGenerate }
+				autoStart={ postContent !== '' && ! postFeaturedMedia }
+				autoStartAction={ handleFirstGenerate }
 				images={ images }
 				currentIndex={ current }
 				title={ __( 'Generate a featured image with AI', 'jetpack' ) }
@@ -335,6 +396,10 @@ export default function FeaturedImage( {
 					"Describe the image you'd like to create, or have the prompt written for you if you've added content to your post.",
 					'jetpack'
 				) }
+				imageStyles={ imageStyles }
+				onGuessStyle={ handleGuessStyle }
+				initialPrompt={ defaultPrompt }
+				initialStyle={ requestStyle }
 			/>
 		</>
 	);

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -379,7 +379,7 @@ export default function FeaturedImage( {
 				</>
 			) }
 			<AiImageModal
-				postContent={ postContent }
+				postContent={ postContent || postTitle }
 				autoStart={ ( postContent !== '' || postTitle ) && ! postFeaturedMedia }
 				autoStartAction={ handleFirstGenerate }
 				images={ images }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -149,6 +149,7 @@ export default function FeaturedImage( {
 				model: featuredImageActiveModel,
 				site_type: siteType,
 				style,
+				userPrompt,
 			} );
 
 			setIsFeaturedImageModalVisible( true );
@@ -192,7 +193,7 @@ export default function FeaturedImage( {
 	}, [ currentPointer, handleGenerate, handleGuessStyle ] );
 
 	const handleRegenerate = useCallback(
-		( { prompt, style }: { prompt?: string; style?: string } ) => {
+		( { userPrompt, style }: { userPrompt?: string; style?: string } ) => {
 			// track the regenerate image event
 			recordEvent( 'jetpack_ai_featured_image_generation_generate_another_image', {
 				placement,
@@ -203,7 +204,7 @@ export default function FeaturedImage( {
 
 			setCurrent( crrt => crrt + 1 );
 			processImageGeneration( {
-				userPrompt: prompt,
+				userPrompt,
 				postContent: postTitle + '\n\n' + postContent,
 				notEnoughRequests,
 				style,
@@ -214,6 +215,7 @@ export default function FeaturedImage( {
 					model: featuredImageActiveModel,
 					site_type: siteType,
 					style,
+					userPrompt,
 				} );
 			} );
 		},
@@ -409,6 +411,7 @@ export default function FeaturedImage( {
 				onGuessStyle={ handleGuessStyle }
 				initialPrompt={ defaultPrompt }
 				initialStyle={ requestStyle }
+				minPromptLength={ 0 }
 			/>
 		</>
 	);

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -154,7 +154,7 @@ export default function FeaturedImage( {
 			setIsFeaturedImageModalVisible( true );
 			return processImageGeneration( {
 				userPrompt,
-				postContent,
+				postContent: postTitle + '\n\n' + postContent,
 				notEnoughRequests,
 				style,
 			} ).catch( error => {
@@ -175,6 +175,7 @@ export default function FeaturedImage( {
 			processImageGeneration,
 			postContent,
 			notEnoughRequests,
+			postTitle,
 		]
 	);
 
@@ -201,17 +202,20 @@ export default function FeaturedImage( {
 			} );
 
 			setCurrent( crrt => crrt + 1 );
-			processImageGeneration( { userPrompt: prompt, postContent, notEnoughRequests, style } ).catch(
-				error => {
-					recordEvent( 'jetpack_ai_featured_image_generation_error', {
-						placement,
-						error: error?.message,
-						model: featuredImageActiveModel,
-						site_type: siteType,
-						style,
-					} );
-				}
-			);
+			processImageGeneration( {
+				userPrompt: prompt,
+				postContent: postTitle + '\n\n' + postContent,
+				notEnoughRequests,
+				style,
+			} ).catch( error => {
+				recordEvent( 'jetpack_ai_featured_image_generation_error', {
+					placement,
+					error: error?.message,
+					model: featuredImageActiveModel,
+					site_type: siteType,
+					style,
+				} );
+			} );
 		},
 		[
 			recordEvent,
@@ -220,6 +224,7 @@ export default function FeaturedImage( {
 			siteType,
 			setCurrent,
 			processImageGeneration,
+			postTitle,
 			postContent,
 			notEnoughRequests,
 		]
@@ -235,17 +240,20 @@ export default function FeaturedImage( {
 				style,
 			} );
 
-			processImageGeneration( { userPrompt, postContent, notEnoughRequests, style } ).catch(
-				error => {
-					recordEvent( 'jetpack_ai_featured_image_generation_error', {
-						placement,
-						error: error?.message,
-						model: featuredImageActiveModel,
-						site_type: siteType,
-						style,
-					} );
-				}
-			);
+			processImageGeneration( {
+				userPrompt,
+				postContent: postTitle + '\n\n' + postContent,
+				notEnoughRequests,
+				style,
+			} ).catch( error => {
+				recordEvent( 'jetpack_ai_featured_image_generation_error', {
+					placement,
+					error: error?.message,
+					model: featuredImageActiveModel,
+					site_type: siteType,
+					style,
+				} );
+			} );
 		},
 		[
 			recordEvent,
@@ -255,6 +263,7 @@ export default function FeaturedImage( {
 			processImageGeneration,
 			postContent,
 			notEnoughRequests,
+			postTitle,
 		]
 	);
 
@@ -369,7 +378,7 @@ export default function FeaturedImage( {
 			) }
 			<AiImageModal
 				postContent={ postContent }
-				autoStart={ postContent !== '' && ! postFeaturedMedia }
+				autoStart={ ( postContent !== '' || postTitle ) && ! postFeaturedMedia }
 				autoStartAction={ handleFirstGenerate }
 				images={ images }
 				currentIndex={ current }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
@@ -174,6 +174,7 @@ export default function useAiImage( {
 										image,
 										libraryId: savedImage?.id,
 										libraryUrl: savedImage?.url,
+										revised_prompt: result.data[ 0 ].revised_prompt,
 									} );
 								} )
 								.catch( () => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
@@ -210,7 +210,11 @@ export default function useAiImage( {
 	}, [ current, images.length ] );
 
 	const guessStyle = useCallback(
-		async function ( prompt: string ): Promise< ImageStyle | null > {
+		async function (
+			prompt: string,
+			requestType: string = '',
+			content: string = ''
+		): Promise< ImageStyle | null > {
 			if ( ! imageStyles || ! imageStyles.length ) {
 				return null;
 			}
@@ -219,8 +223,9 @@ export default function useAiImage( {
 				{
 					role: 'jetpack-ai' as RoleType,
 					context: {
-						type: 'general-image-guess-style',
+						type: requestType || 'general-image-guess-style',
 						request: prompt,
+						content,
 					},
 				},
 			];

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
@@ -30,6 +30,12 @@ type ImageFeatureControl = FeatureControl & {
 
 type AiImageType = 'featured-image-generation' | 'general-image-generation';
 type AiImageFeature = typeof FEATURED_IMAGE_FEATURE_NAME | typeof GENERAL_IMAGE_FEATURE_NAME;
+export type ImageResponse = {
+	image?: string;
+	libraryId?: string;
+	libraryUrl?: string;
+	revisedPrompt?: string;
+};
 
 export default function useAiImage( {
 	feature,
@@ -115,7 +121,7 @@ export default function useAiImage( {
 			notEnoughRequests: boolean;
 			style?: string;
 		} ) => {
-			return new Promise( ( resolve, reject ) => {
+			return new Promise< ImageResponse >( ( resolve, reject ) => {
 				updateImages( { generating: true, error: null }, pointer.current );
 
 				// Ensure the site has enough requests to generate the image.
@@ -174,7 +180,7 @@ export default function useAiImage( {
 										image,
 										libraryId: savedImage?.id,
 										libraryUrl: savedImage?.url,
-										revised_prompt: result.data[ 0 ].revised_prompt,
+										revisedPrompt: result.data[ 0 ].revised_prompt || '',
 									} );
 								} )
 								.catch( () => {


### PR DESCRIPTION
AI image generation styles dropdown implementation for Featured Image modal, following the latest implementation for General Image #39917

## Proposed changes:

**NOTE:** Requires D165926-code 

This PR implements the style dropdown on the Featured Image modal:
- adapt handlers to take the style and pass it down to the image generator
- adapt modal props and component effects to allow passing down both prompt and selected style
- auto generate image on first modal open ONLY if no featured image is set
- on auto generate, use style "Auto" to try and guess the best style for the image

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Sandbox public-api and patch it with D165926-code

Open the post editor. If there's no content on the post, Featured Image should not trigger a generation on first open. 

Type a title for the post. Open the Featured Image modal and it should now attempt both guess a style for the image and generate an image. Repeat this process after typing (or generating) some content on the post. As long as you don't set a Featured Image, the modal will trigger an auto generation on open (this is also true if you remove the Featured Image).

If the post has content or title, the modal will allow to hit "Generate" even without a prompt, in which case the contextual data (post content and/or title) is used for the image generation.

NOTE: The auto generation starts with an empty prompt (as you couldn't type anything), once the generated image is back, it also brings the "enhanced" prompt the AI generated on backend to request for the image. This is an experiment on (maybe) let the users learn how to create an effective prompt for images.

**As the components are shared between the two, also check General Image modal continues to work without glitches.**