### PR TITLE
Components: Add ThreatsDetailModal and integrate with ThreatsDataViews

### DIFF
--- a/projects/js-packages/components/changelog/add-threat-details-modal
+++ b/projects/js-packages/components/changelog/add-threat-details-modal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add ThreatsDetailModal component and integrate with ThreatsDataViews.

--- a/projects/js-packages/components/components/diff-viewer/styles.module.scss
+++ b/projects/js-packages/components/components/diff-viewer/styles.module.scss
@@ -14,7 +14,7 @@
 	display: flex;
 	font-family: "Courier 10 Pitch", Courier, monospace;
 	flex-direction: row;
-	overflow-x: scroll;
+	overflow-x: auto;
 	white-space: pre;
 }
 

--- a/projects/js-packages/components/components/marked-lines/styles.module.scss
+++ b/projects/js-packages/components/components/marked-lines/styles.module.scss
@@ -4,7 +4,7 @@
 	font-family: monospace;
 	display: flex;
 	flex-direction: row;
-	overflow-x: scroll;
+	overflow-x: auto;
 }
 
 .marked-lines__marked-line {

--- a/projects/js-packages/components/components/threat-details-modal/index.tsx
+++ b/projects/js-packages/components/components/threat-details-modal/index.tsx
@@ -1,0 +1,278 @@
+import { Button, ThreatSeverityBadge } from '@automattic/jetpack-components';
+import { type Threat } from '@automattic/jetpack-scan';
+import { Modal } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { useMemo } from 'react';
+import ContextualUpgradeTrigger from '../contextual-upgrade-trigger';
+import DiffViewer from '../diff-viewer';
+import MarkedLines from '../marked-lines';
+import Text from '../text';
+import styles from './styles.module.scss';
+
+const ThreatTechnicalDetails = ( { threat }: { threat: Threat } ) => {
+	if ( ! threat.filename && ! threat.context && ! threat.diff ) {
+		return null;
+	}
+
+	return (
+		<div className={ styles.section }>
+			<Text variant="title-small">{ __( 'The technical details', 'jetpack' ) }</Text>
+			{ threat.filename && (
+				<>
+					<Text>{ __( 'Threat found in file:', 'jetpack' ) }</Text>
+					<pre className={ styles.filename }>{ threat.filename }</pre>
+				</>
+			) }
+			{ threat.context && <MarkedLines context={ threat.context } /> }
+			{ threat.diff && <DiffViewer diff={ threat.diff } /> }
+		</div>
+	);
+};
+
+const ThreatFixDetails = ( {
+	threat,
+	handleUpgradeClick,
+}: {
+	threat: Threat;
+	handleUpgradeClick: () => void;
+} ) => {
+	const title = useMemo( () => {
+		if ( threat.status === 'fixed' ) {
+			return __( 'How did Jetpack fix it?', 'jetpack' );
+		}
+		if ( threat.status === 'current' && threat.fixable ) {
+			return __( 'How can Jetpack auto-fix this threat?', 'jetpack' );
+		}
+		return __( 'How to fix it?', 'jetpack' );
+	}, [ threat ] );
+
+	const fix = useMemo( () => {
+		// The threat has a fixed version available, but no auto-fix is available.
+		// The user needs to update the extension to the fixed version.
+		if ( ! threat.fixable && threat.fixedIn ) {
+			return sprintf(
+				/* translators: Translates to Updates to version. %1$s: Name. %2$s: Fixed version */
+				__( 'Update %1$s to version %2$s.', 'jetpack' ),
+				threat.extension.name,
+				threat.fixedIn
+			);
+		}
+
+		// The threat has an auto-fix available.
+		switch ( threat.fixable && threat.fixable.fixer ) {
+			case 'delete':
+				if ( threat.filename ) {
+					if ( threat.filename.endsWith( '/' ) ) {
+						return __( 'Deletes the directory that the infected file is in.', 'jetpack' );
+					}
+
+					if ( threat.signature === 'Core.File.Modification' ) {
+						return __( 'Deletes the unexpected file in a core WordPress directory.', 'jetpack' );
+					}
+
+					return __( 'Deletes the infected file.', 'jetpack' );
+				}
+
+				if ( threat.extension?.type === 'plugin' ) {
+					return __( 'Deletes the plugin directory to fix the threat.', 'jetpack' );
+				}
+
+				if ( threat.extension?.type === 'theme' ) {
+					return __( 'Deletes the theme directory to fix the threat.', 'jetpack' );
+				}
+				break;
+			case 'update':
+				if ( threat.fixedIn && threat.extension.name ) {
+					return sprintf(
+						/* translators: Translates to Updates to version. %1$s: Name. %2$s: Fixed version */
+						__( 'Updates %1$s to version %2$s', 'jetpack' ),
+						threat.extension.name,
+						threat.fixedIn
+					);
+				}
+				return __( 'Upgrades the plugin or theme to a newer version.', 'jetpack' );
+			case 'replace':
+			case 'rollback':
+				if ( threat.filename ) {
+					return threat.signature === 'Core.File.Modification'
+						? __(
+								'Replaces the modified core WordPress file with the original clean version from the WordPress source code.',
+								'jetpack'
+						  )
+						: __(
+								'Replaces the infected file with a previously backed up version that is clean.',
+								'jetpack'
+						  );
+				}
+
+				if ( threat.signature === 'php_hardening_WP_Config_NoSalts_001' ) {
+					return __(
+						'Replaces the default salt keys in wp-config.php with unique ones.',
+						'jetpack'
+					);
+				}
+				break;
+			default:
+				return __( 'Jetpack will auto-fix the threat.', 'jetpack' );
+		}
+	}, [ threat ] );
+
+	if ( ! threat.fixable && ! threat.fixedIn ) {
+		return null;
+	}
+
+	return (
+		<div className={ styles.section }>
+			<Text variant="title-small">{ title }</Text>
+			<Text>{ fix }</Text>
+
+			{ !! handleUpgradeClick && (
+				<ContextualUpgradeTrigger
+					description={ __( 'Looking for advanced scan results and one-click fixes?', 'jetpack' ) }
+					cta={ __( 'Upgrade Jetpack Protect now', 'jetpack' ) }
+					onClick={ handleUpgradeClick }
+				/>
+			) }
+		</div>
+	);
+};
+
+const ThreatActions = ( {
+	threat,
+	handleFixThreatClick,
+	handleIgnoreThreatClick,
+	handleUnignoreThreatClick,
+	isActiveFixInProgress,
+	isStaleFixInProgress,
+}: {
+	threat: Threat;
+	handleFixThreatClick?: () => void;
+	handleIgnoreThreatClick?: () => void;
+	handleUnignoreThreatClick?: () => void;
+	isActiveFixInProgress?: boolean;
+	isStaleFixInProgress?: boolean;
+} ) => {
+	if ( ! handleFixThreatClick && ! handleIgnoreThreatClick && ! handleUnignoreThreatClick ) {
+		return null;
+	}
+
+	return (
+		<div className={ styles.actions }>
+			{ 'ignored' === threat.status && !! handleUnignoreThreatClick && (
+				<Button isDestructive={ true } variant="secondary" onClick={ handleUnignoreThreatClick() }>
+					{ __( 'Un-ignore', 'jetpack' ) }
+				</Button>
+			) }
+			{ 'current' === threat.status && (
+				<>
+					{ !! handleIgnoreThreatClick && (
+						<Button
+							isDestructive={ true }
+							variant="secondary"
+							onClick={ handleIgnoreThreatClick() }
+							disabled={ isActiveFixInProgress || isStaleFixInProgress }
+						>
+							{ __( 'Ignore', 'jetpack' ) }
+						</Button>
+					) }
+					{ threat.fixable && !! handleFixThreatClick && (
+						<Button
+							isPrimary
+							disabled={ isActiveFixInProgress || isStaleFixInProgress }
+							onClick={ handleFixThreatClick() }
+						>
+							{ __( 'Auto-Fix', 'jetpack' ) }
+						</Button>
+					) }
+				</>
+			) }
+		</div>
+	);
+};
+
+/**
+ * ThreatDetailsModal component
+ *
+ * @param {object}   props                           - The props.
+ * @param {object}   props.threat                    - The threat.
+ * @param {Function} props.handleUpgradeClick        - The handleUpgradeClick function.
+ * @param {boolean}  props.isActiveFixInProgress     - The isActiveFixInProgress flag.
+ * @param {boolean}  props.isStaleFixInProgress      - The isStaleFixInProgress flag.
+ * @param {Function} props.handleFixThreatClick      - The handleFixThreatClick function.
+ * @param {Function} props.handleIgnoreThreatClick   - The handleIgnoreThreatClick function.
+ * @param {Function} props.handleUnignoreThreatClick - The handleUnignoreThreatClick function.
+ *
+ * @return {JSX.Element} The threat details modal.
+ */
+export default function ThreatDetailsModal( {
+	threat,
+	handleUpgradeClick,
+	isActiveFixInProgress,
+	isStaleFixInProgress,
+	handleFixThreatClick,
+	handleIgnoreThreatClick,
+	handleUnignoreThreatClick,
+	...modalProps
+}: {
+	threat: Threat;
+	handleUpgradeClick?: () => void;
+	isActiveFixInProgress?: boolean;
+	isStaleFixInProgress?: boolean;
+	handleFixThreatClick?: () => void;
+	handleIgnoreThreatClick?: () => void;
+	handleUnignoreThreatClick?: () => void;
+	[ key: string ]: unknown;
+} ): JSX.Element {
+	const title = useMemo( () => {
+		if ( threat.title ) {
+			return threat.title;
+		}
+
+		if ( threat.status === 'fixed' ) {
+			return __( 'What was the problem?', 'jetpack' );
+		}
+
+		return __( 'What is the problem?', 'jetpack' );
+	}, [ threat ] );
+
+	return (
+		<Modal size="large" title={ __( 'Threat Details', 'jetpack' ) } { ...modalProps }>
+			<div className={ styles[ 'threat-details' ] }>
+				<div className={ styles.section }>
+					<div className={ styles.title }>
+						<Text variant="title-small">{ title }</Text>
+						{ !! threat.severity && <ThreatSeverityBadge severity={ threat.severity } /> }
+					</div>
+
+					{ !! threat.description && <Text>{ threat.description }</Text> }
+
+					{ !! threat.source && (
+						<div>
+							<Button
+								variant="link"
+								isExternalLink={ true }
+								weight="regular"
+								href={ threat.source }
+							>
+								{ __( 'See more technical details of this threat', 'jetpack' ) }
+							</Button>
+						</div>
+					) }
+				</div>
+
+				<ThreatFixDetails threat={ threat } handleUpgradeClick={ handleUpgradeClick } />
+
+				<ThreatTechnicalDetails threat={ threat } />
+
+				<ThreatActions
+					threat={ threat }
+					handleFixThreatClick={ handleFixThreatClick }
+					handleIgnoreThreatClick={ handleIgnoreThreatClick }
+					handleUnignoreThreatClick={ handleUnignoreThreatClick }
+					isActiveFixInProgress={ isActiveFixInProgress }
+					isStaleFixInProgress={ isStaleFixInProgress }
+				/>
+			</div>
+		</Modal>
+	);
+}

--- a/projects/js-packages/components/components/threat-details-modal/stories/index.stories.tsx
+++ b/projects/js-packages/components/components/threat-details-modal/stories/index.stories.tsx
@@ -1,0 +1,67 @@
+import { useCallback, useState } from 'react';
+import Button from '../../button/index.js';
+import ThreatDetailsModal from '../index.js';
+
+export default {
+	title: 'JS Packages/Components/Threat Details Modal',
+	component: ThreatDetailsModal,
+};
+
+const Base = args => {
+	const [ isOpen, setIsOpen ] = useState( false );
+	const onClick = useCallback( () => setIsOpen( true ), [] );
+	const onRequestClose = useCallback( () => setIsOpen( false ), [] );
+	return (
+		<div>
+			<Button onClick={ onClick }>Open Threat Details Modal</Button>
+			{ isOpen ? <ThreatDetailsModal { ...args } onRequestClose={ onRequestClose } /> : null }
+		</div>
+	);
+};
+
+export const ThreatResult = Base.bind( {} );
+ThreatResult.args = {
+	threat: {
+		id: 185869885,
+		signature: 'EICAR_AV_Test',
+		title: 'Malicious code found in file: index.php',
+		description:
+			"This is the standard EICAR antivirus test code, and not a real infection. If your site contains this code when you don't expect it to, contact Jetpack support for some help.",
+		firstDetected: '2024-10-07T20:45:06.000Z',
+		fixedIn: null,
+		severity: 8,
+		fixable: { fixer: 'rollback', target: 'January 26, 2024, 6:49 am', extensionStatus: '' },
+		fixer: { status: 'not_started' },
+		status: 'current',
+		filename: '/var/www/html/wp-content/index.php',
+		context: {
+			'1': 'echo <<<HTML',
+			'2': 'X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*',
+			'3': 'HTML;',
+			marks: {},
+		},
+	},
+	handleFixThreatClick: () => {},
+	handleIgnoreThreatClick: () => {},
+	handleUnignoreThreatClick: () => {},
+};
+
+export const VulnerableExtension = Base.bind( {} );
+VulnerableExtension.args = {
+	threat: {
+		id: 184847701,
+		signature: 'Vulnerable.WP.Extension',
+		title: 'Vulnerable Plugin: WP Super Cache (version 1.6.3)',
+		description:
+			'The plugin WP Super Cache (version 1.6.3) has a known vulnerability. The WP Super Cache plugin before version 1.7.2 is vulnerable to an authenticated RCE in the settings page.',
+		fixedIn: '1.12.4',
+		source: 'https://wpscan.com/vulnerability/733d8a02-0d44-4b78-bbb2-37e447acd2f3',
+		extension: {
+			name: 'WP Super Cache',
+			slug: 'wp-super-cache',
+			version: '1.6.3',
+			type: 'plugin',
+		},
+	},
+	handleUpgradeClick: () => {},
+};

--- a/projects/js-packages/components/components/threat-details-modal/styles.module.scss
+++ b/projects/js-packages/components/components/threat-details-modal/styles.module.scss
@@ -1,0 +1,32 @@
+
+.threat-details {
+	display: flex;
+	flex-direction: column;
+	gap: calc( var( --spacing-base ) * 3 ); // 24px
+}
+
+.section {
+	display: flex;
+	flex-direction: column;
+	gap: calc( var( --spacing-base ) * 2 ); // 16px
+}
+
+.title {
+	display: flex;
+	align-items: center;
+	gap: calc( var( --spacing-base ) * 1.5 ); // 12px
+}
+
+.filename {
+	background-color: var( --jp-gray-0 );
+	padding: calc( var( --spacing-base ) * 3 ); // 24px
+	overflow-x: auto;
+}
+
+.actions {
+	display: flex;
+	gap: calc( var( --spacing-base ) * 2 ); // 16px
+	justify-content: flex-end;
+	padding-top: calc( var( --spacing-base ) * 3 ); // 24px
+	border-top: 1px solid var( --jp-gray-0 );
+}

--- a/projects/js-packages/components/components/threats-data-views/constants.ts
+++ b/projects/js-packages/components/components/threats-data-views/constants.ts
@@ -44,6 +44,6 @@ export const THREAT_FIELD_FIRST_DETECTED = 'first-detected';
 export const THREAT_FIELD_FIXED_ON = 'fixed-on';
 export const THREAT_FIELD_AUTO_FIX = 'auto-fix';
 
-export const THREAT_ACTION_FIX = 'fix';
 export const THREAT_ACTION_IGNORE = 'ignore';
 export const THREAT_ACTION_UNIGNORE = 'unignore';
+export const THREAT_ACTION_VIEW_DETAILS = 'learn-more';

--- a/projects/js-packages/components/components/threats-data-views/index.tsx
+++ b/projects/js-packages/components/components/threats-data-views/index.tsx
@@ -16,12 +16,13 @@ import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
 import { useCallback, useMemo, useState } from 'react';
 import Badge from '../badge';
+import ThreatDetailsModal from '../threat-details-modal';
 import ThreatFixerButton from '../threat-fixer-button';
 import ThreatSeverityBadge from '../threat-severity-badge';
 import {
-	THREAT_ACTION_FIX,
 	THREAT_ACTION_IGNORE,
 	THREAT_ACTION_UNIGNORE,
+	THREAT_ACTION_VIEW_DETAILS,
 	THREAT_FIELD_AUTO_FIX,
 	THREAT_FIELD_DESCRIPTION,
 	THREAT_FIELD_EXTENSION,
@@ -143,6 +144,19 @@ export default function ThreatsDataViews( {
 		type: 'table',
 		...defaultLayouts.table,
 	} );
+
+	const [ openThreat, setOpenThreat ] = useState< Threat | null >( null );
+
+	const showThreatDetails = useCallback(
+		( threat: Threat ) => () => {
+			setOpenThreat( threat );
+		},
+		[]
+	);
+
+	const hideThreatDetails = useCallback( () => {
+		setOpenThreat( null );
+	}, [] );
 
 	/**
 	 * Compute values from the provided threats data.
@@ -405,6 +419,10 @@ export default function ThreatsDataViews( {
 									return null;
 								}
 
+								if ( ! isThreatEligibleForFix( item ) ) {
+									return null;
+								}
+
 								return <ThreatFixerButton threat={ item } onClick={ onFixThreats } />;
 							},
 						},
@@ -413,7 +431,7 @@ export default function ThreatsDataViews( {
 		];
 
 		return result;
-	}, [ dataFields, plugins, themes, signatures, onFixThreats ] );
+	}, [ plugins, themes, dataFields, signatures, isThreatEligibleForFix, onFixThreats ] );
 
 	/**
 	 * DataView actions - collection of operations that can be performed upon each record.
@@ -421,26 +439,15 @@ export default function ThreatsDataViews( {
 	 * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dataviews/#actions-object
 	 */
 	const actions = useMemo( () => {
-		const result: Action< Threat >[] = [];
-
-		if ( dataFields.includes( 'fixable' ) ) {
-			result.push( {
-				id: THREAT_ACTION_FIX,
-				label: __( 'Auto-fix', 'jetpack' ),
-				isPrimary: true,
-				supportsBulk: true,
-				callback: onFixThreats,
-				isEligible( item ) {
-					if ( ! onFixThreats ) {
-						return false;
-					}
-					if ( isThreatEligibleForFix ) {
-						return isThreatEligibleForFix( item );
-					}
-					return !! item.fixable;
+		const result: Action< Threat >[] = [
+			{
+				id: THREAT_ACTION_VIEW_DETAILS,
+				label: __( 'View Details', 'jetpack' ),
+				callback: ( items: Threat[] ) => {
+					showThreatDetails( items[ 0 ] )();
 				},
-			} );
-		}
+			},
+		];
 
 		if ( dataFields.includes( 'status' ) ) {
 			result.push( {
@@ -483,11 +490,10 @@ export default function ThreatsDataViews( {
 		return result;
 	}, [
 		dataFields,
-		onFixThreats,
+		showThreatDetails,
 		onIgnoreThreats,
-		onUnignoreThreats,
-		isThreatEligibleForFix,
 		isThreatEligibleForIgnore,
+		onUnignoreThreats,
 		isThreatEligibleForUnignore,
 	] );
 
@@ -517,23 +523,28 @@ export default function ThreatsDataViews( {
 	const getItemId = useCallback( ( item: Threat ) => item.id.toString(), [] );
 
 	return (
-		<DataViews
-			actions={ actions }
-			data={ processedData }
-			defaultLayouts={ defaultLayouts }
-			fields={ fields }
-			getItemId={ getItemId }
-			onChangeSelection={ onChangeSelection }
-			onChangeView={ onChangeView }
-			paginationInfo={ paginationInfo }
-			view={ view }
-			header={
-				<ThreatsStatusToggleGroupControl
-					data={ data }
-					view={ view }
-					onChangeView={ onChangeView }
-				/>
-			}
-		/>
+		<>
+			<DataViews
+				actions={ actions }
+				data={ processedData }
+				defaultLayouts={ defaultLayouts }
+				fields={ fields }
+				getItemId={ getItemId }
+				onChangeSelection={ onChangeSelection }
+				onChangeView={ onChangeView }
+				paginationInfo={ paginationInfo }
+				view={ view }
+				header={
+					<ThreatsStatusToggleGroupControl
+						data={ data }
+						view={ view }
+						onChangeView={ onChangeView }
+					/>
+				}
+			/>
+			{ openThreat ? (
+				<ThreatDetailsModal threat={ openThreat } onRequestClose={ hideThreatDetails } />
+			) : null }
+		</>
 	);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `ThreatsDetailsModal`
* Integrates with `ThreatsDataViews`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

peb6dq-31T-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Review the Storybook entries for both components.

## Screenshots:

<img width="907" alt="Screenshot 2024-11-09 at 3 20 16 PM" src="https://github.com/user-attachments/assets/a3a7d550-14d0-481a-8751-acb0757aed55">

<img width="901" alt="Screenshot 2024-11-09 at 3 20 23 PM" src="https://github.com/user-attachments/assets/86337737-477c-40a7-9c77-ffb0e89a7aec">

<img width="941" alt="Screenshot 2024-11-09 at 3 33 48 PM" src="https://github.com/user-attachments/assets/9fa24018-0810-42fe-a793-8d08cf4b9f39">