### PR TITLE
Jetpack Podcast Player Block: Fix Uncaught TypeError Fatal

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -108,14 +108,20 @@ class Jetpack_Podcast_Helper {
 			// Get a list of episodes by guid or all tracks in feed.
 			if ( count( $guids ) ) {
 				$tracks = array_map( array( $this, 'get_track_data' ), $guids );
-				$tracks = array_filter(
-					$tracks,
-					function ( $track ) {
-						return ! is_wp_error( $track );
-					}
-				);
+				if ( is_array( $tracks ) ) {
+					$tracks = array_filter(
+						$tracks,
+						function ( $track ) {
+							return ! is_wp_error( $track );
+						}
+					);
+				}
 			} else {
 				$tracks = $this->get_track_list();
+			}
+
+			if ( is_wp_error( $tracks ) ) {
+				return $tracks;
 			}
 
 			if ( empty( $tracks ) ) {

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -108,14 +108,12 @@ class Jetpack_Podcast_Helper {
 			// Get a list of episodes by guid or all tracks in feed.
 			if ( count( $guids ) ) {
 				$tracks = array_map( array( $this, 'get_track_data' ), $guids );
-				if ( is_array( $tracks ) ) {
-					$tracks = array_filter(
-						$tracks,
-						function ( $track ) {
-							return ! is_wp_error( $track );
-						}
-					);
-				}
+				$tracks = array_filter(
+					$tracks,
+					function ( $track ) {
+						return ! is_wp_error( $track );
+					}
+				);
 			} else {
 				$tracks = $this->get_track_list();
 			}

--- a/projects/plugins/jetpack/changelog/fix-fatal-podcast-player-block
+++ b/projects/plugins/jetpack/changelog/fix-fatal-podcast-player-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack Podcast Player Block: Fix Uncaught TypeError Fatal

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/podcast-player.php
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/podcast-player.php
@@ -109,6 +109,10 @@ function render_player( $player_data, $attributes ) {
 		return render_error( __( 'No tracks available to play.', 'jetpack' ) );
 	}
 
+	if ( is_wp_error( $player_data['tracks'] ) ) {
+		return render_error( $player_data['tracks']->get_error_message() );
+	}
+
 	// Only use the amount of tracks requested.
 	$player_data['tracks'] = array_slice(
 		$player_data['tracks'],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes the following Fatal: `Uncaught TypeError: array_slice(): Argument #1 ($array) must be of type array, WP_Error given in podcast-player.php:116`

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `podcast-player.php`: Check if `$player_data['tracks']` is `WP_Error` before handling it as an array
* `Jetpack_Podcast_Helper`: Be more defensive when fetching the tracks in `get_player_data` by ensuring we early return in case `get_track_list` returns `WP_Error`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1731028867886779-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Core Review
* Manually test the Podcast Block with a valid/invalid RSS feed and ensure everything works as expected.