### PR TITLE
Check path of cornerstone urls as well as domain

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -225,9 +225,9 @@ const List: React.FC< ListProps > = ( { items, setItems, maxItems, description }
 			}
 			if (
 				url &&
-				! ( url.origin + url.pathname )
-					.replace( /\/$/, '' )
-					.startsWith( Jetpack_Boost.site.url.replace( /\/$/, '' ) )
+				! ( url.origin + url.pathname ).replace( /\/$/, '' ).startsWith(
+					Jetpack_Boost.site.url.replace( /\/$/, '' )
+				)
 			) {
 				throw new Error(
 					/* translators: %s is the URL that didn't match the site URL */

--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -225,8 +225,9 @@ const List: React.FC< ListProps > = ( { items, setItems, maxItems, description }
 			}
 			if (
 				url &&
-				( url.origin + url.pathname ).replace( /\/$/, '' ) !==
-					Jetpack_Boost.site.url.replace( /\/$/, '' )
+				! ( url.origin + url.pathname )
+					.replace( /\/$/, '' )
+					.startsWith( Jetpack_Boost.site.url.replace( /\/$/, '' ) )
 			) {
 				throw new Error(
 					/* translators: %s is the URL that didn't match the site URL */

--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -225,7 +225,8 @@ const List: React.FC< ListProps > = ( { items, setItems, maxItems, description }
 			}
 			if (
 				url &&
-				url.origin.replace( /\/$/, '' ) !== Jetpack_Boost.site.url.replace( /\/$/, '' )
+				( url.origin + url.pathname ).replace( /\/$/, '' ) !==
+					Jetpack_Boost.site.url.replace( /\/$/, '' )
 			) {
 				throw new Error(
 					/* translators: %s is the URL that didn't match the site URL */

--- a/projects/plugins/boost/changelog/update-jetpack-boost-fix-sub-directory-cornerstone-check
+++ b/projects/plugins/boost/changelog/update-jetpack-boost-fix-sub-directory-cornerstone-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Boost: fix checking of cornerstone URLs where a site has a directory in the URL

--- a/projects/plugins/boost/changelog/update-jetpack-boost-fix-sub-directory-cornerstone-check
+++ b/projects/plugins/boost/changelog/update-jetpack-boost-fix-sub-directory-cornerstone-check
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
+Comment: Change to an unreleased feature.
 
-Boost: fix checking of cornerstone URLs where a site has a directory in the URL


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

If a site is installed in a directory, rather than "/" then the check of the URL in cornerstone pages will fail. This patch adds the pathname to the check.

Fixes [#40069](https://github.com/Automattic/jetpack/issues/40069)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add pathname to URL check in meta.tsx -> validateItems()
* It removes trailing slashes so a site without a pathname should still work.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test cornerstone pages on a site with a directory in the URL.
* Edit a URL and it will show a warning about the URL being different to the site.
* Apply this patch and the error should go away.
