### PR TITLE
Boost: Fix menu counter not showing correctly

### DIFF
--- a/projects/plugins/boost/app/admin/class-admin.php
+++ b/projects/plugins/boost/app/admin/class-admin.php
@@ -44,7 +44,7 @@ class Admin {
 		$total_problems = apply_filters( 'jetpack_boost_total_problem_count', 0 );
 		$menu_label     = _x( 'Boost', 'The Jetpack Boost product name, without the Jetpack prefix', 'jetpack-boost' );
 		if ( $total_problems ) {
-			$menu_label .= sprintf( ' <span class="update-plugins">%d</span>', $total_problems );
+			$menu_label .= sprintf( ' <span class="menu-counter count-%d"><span class="count">%d</span></span>', $total_problems, $total_problems );
 		}
 
 		$page_suffix = Admin_Menu::add_menu(

--- a/projects/plugins/boost/changelog/fix-menu-counter-missing-styles
+++ b/projects/plugins/boost/changelog/fix-menu-counter-missing-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+UI: Fix Boost's menu counter sometimes displaying incorrectly.


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/39715

## Proposed changes:

* Make sure counter has styles when viewed in Calypso.

![image](https://github.com/user-attachments/assets/12e1cc4f-e421-418f-a09e-270055e1126d)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/jetpack/issues/39715

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Setup Boost free on an Atomic site;
- Enable and generate Critical CSS;
- Go to a page and update it;
- While on a page other than Boost's settings, make sure there's a number showing next to the menu item for `Jetpack` -> `Boost`;
- The number should also have styles similar to the screenshot above.