### PR TITLE
Jetpack: optimize the Sharing module hook

### DIFF
--- a/projects/plugins/jetpack/changelog/update-optimize-sharing-hook
+++ b/projects/plugins/jetpack/changelog/update-optimize-sharing-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Optimize the Sharing module hook callback.

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
@@ -202,7 +202,11 @@ function sharing_process_requests() {
 		}
 	}
 }
-add_action( 'template_redirect', __NAMESPACE__ . '\sharing_process_requests', 9 );
+
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Only checking for the data being present.
+if ( isset( $_GET['share'] ) ) {
+	add_action( 'template_redirect', __NAMESPACE__ . '\sharing_process_requests', 9 );
+}
 
 /**
  * Automatically add the Sharing Buttons block to the end of the Single Posts template.

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -930,7 +930,11 @@ function sharing_process_requests() {
 		}
 	}
 }
-add_action( 'template_redirect', 'sharing_process_requests', 9 );
+
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Only checking for the data being present.
+if ( isset( $_GET['share'] ) ) {
+	add_action( 'template_redirect', 'sharing_process_requests', 9 );
+}
 
 /**
  * Gets the url to customise the sharing buttons in Calypso.


### PR DESCRIPTION
## Proposed changes:
* Make the Sharing module run the `template_redirect` action callback only when necessary.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/vulcan/issues/529

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Go to "Jetpack -> Settings -> Sharing" and activate the "Sharing buttons".
2. Visit a post, confirm the sharing buttons show up under the content.
3. Click on a social service and confirm you get redirected to its sharing page.