### PR TITLE
Subscriptions / Verbum Comments: more strictly check for the site URL when handling the comment subscription modal

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscription-modal-2814421
+++ b/projects/plugins/jetpack/changelog/fix-subscription-modal-2814421
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: ensure that we correct detect the site URL when handling the Subscription modal appearing leaving a comment.

--- a/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/class-jetpack-subscription-modal-on-comment.php
+++ b/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/class-jetpack-subscription-modal-on-comment.php
@@ -62,10 +62,19 @@ class Jetpack_Subscription_Modal_On_Comment {
 	 * @return void
 	 */
 	public function enqueue_assets() {
-		if ( $this->should_user_see_modal() ) {
-			wp_enqueue_style( 'subscription-modal-css', plugins_url( 'subscription-modal.css', __FILE__ ), array(), JETPACK__VERSION );
-			wp_enqueue_script( 'subscription-modal-js', plugins_url( 'subscription-modal.js', __FILE__ ), array( 'wp-dom-ready' ), JETPACK__VERSION, true );
+		if ( ! $this->should_user_see_modal() ) {
+			return;
 		}
+
+		wp_enqueue_style( 'subscription-modal-css', plugins_url( 'subscription-modal.css', __FILE__ ), array(), JETPACK__VERSION );
+		wp_enqueue_script( 'subscription-modal-js', plugins_url( 'subscription-modal.js', __FILE__ ), array( 'wp-dom-ready' ), JETPACK__VERSION, true );
+		wp_localize_script(
+			'subscription-modal-js',
+			'subscriptionData',
+			array(
+				'homeUrl' => wp_parse_url( home_url(), PHP_URL_HOST ),
+			)
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/subscription-modal.js
+++ b/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/subscription-modal.js
@@ -46,7 +46,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			return;
 		}
 
-		if ( ! event.origin.includes( window.location.host ) ) {
+		if ( ! event.origin.endsWith( window.location.host ) ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/subscription-modal.js
+++ b/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/subscription-modal.js
@@ -1,3 +1,4 @@
+/* global subscriptionData */
 document.addEventListener( 'DOMContentLoaded', function () {
 	const modal = document.getElementsByClassName( 'jetpack-subscription-modal' )[ 0 ];
 
@@ -46,7 +47,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			return;
 		}
 
-		if ( ! event.origin.endsWith( window.location.host ) ) {
+		if ( subscriptionData.homeUrl !== event.origin ) {
 			return;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Let's be more strict when checking the site URL in the comment subscription modal.

Internal reference: p1730381560559409-slack-CRA4UEQQ3

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
