### PR TITLE
Subscribe modal: fix blogname apostrophes

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-subscribe-modal-blogname-apostrophes
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-subscribe-modal-blogname-apostrophes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Subscribe modal: fix an edge case reported by a user, where the site title shows character codes.

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
@@ -223,7 +223,7 @@ class Verbum_Comments {
 					'We\'ll keep you in the loop!'       => __( 'We\'ll keep you in the loop!', 'jetpack-mu-wpcom' ),
 					'Loading your comment...'            => __( 'Loading your comment...', 'jetpack-mu-wpcom' ),
 					/* translators: %s is the name of the site */
-					'Discover more from'                 => sprintf( __( 'Discover more from %s', 'jetpack-mu-wpcom' ), get_bloginfo( 'name' ) ),
+					'Discover more from'                 => sprintf( __( 'Discover more from %s', 'jetpack-mu-wpcom' ), html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES ) ),
 					'Subscribe now to keep reading and get access to the full archive.' => __( 'Subscribe now to keep reading and get access to the full archive.', 'jetpack-mu-wpcom' ),
 					'Continue reading'                   => __( 'Continue reading', 'jetpack-mu-wpcom' ),
 					'Never miss a beat!'                 => __( 'Never miss a beat!', 'jetpack-mu-wpcom' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes issue reported by a user: 9005538-zd-a8c

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Before, an apostrophe in a site title returned a character code. With this decode change, the apostrophe displays correctly. 
* The issue was reported for a Simple site, but in testing it looks like this also fixes the issue on Atomic sites.

Before | After
------ | -----
<img width="672" alt="Screen Shot 2024-11-11 at 1 35 27 PM" src="https://github.com/user-attachments/assets/cdbc823f-b378-4d5f-b824-6e32dd9ad58f"> | <img width="679" alt="Screen Shot 2024-11-11 at 1 34 07 PM" src="https://github.com/user-attachments/assets/3b65b041-1f87-4182-993d-47612d48c26c">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

9005538-zd-a8c

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Nope.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* As a different user, create a Simple site with a title with an apostrophe and at least one post.
* Sandbox the site.
* As your a8c user, comment on the site.
* In the subscription modal that pops up, check that the apostrophe displays correctly.
* Repeat with an Atomic site, using the Jetpack beta plugin to apply the change instead of sandboxing.