### PR TITLE
Help Center: extend support interaction API

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/help-center-fix-support-interactions-api
+++ b/projects/packages/jetpack-mu-wpcom/changelog/help-center-fix-support-interactions-api
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixing a small issue in an endpoint that is not yet used
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-support-interactions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-support-interactions.php
@@ -227,7 +227,14 @@ class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
 
 		$status = $request['status'];
 
-		$body = Client::wpcom_json_api_request_as_user( "/support-interactions/$support_interaction_id/status?status={$status}" );
+		$body = Client::wpcom_json_api_request_as_user(
+			"/support-interactions/$support_interaction_id/status",
+			'2',
+			array(
+				'method' => 'PUT',
+				'body'   => array( 'status' => $status ),
+			)
+		);
 
 		if ( is_wp_error( $body ) ) {
 			return $body;


### PR DESCRIPTION
## Proposed changes:

Adjusts the status update endpoint for support-interactions. This is not a used endpoint yet. We were missing the PUT method being specified.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
No

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:

This is not being used yet so there are not any methods of testing other than checking the code.
