### PR TITLE
Add comment redirect cache busting

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-comment-reload
+++ b/projects/plugins/jetpack/changelog/fix-comment-reload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Comments: fix reload after posting

--- a/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/subscription-modal.js
+++ b/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/subscription-modal.js
@@ -27,7 +27,9 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			// eslint-disable-next-line no-empty
 		} catch ( e ) {}
 
-		window.location = destinationUrl.toString();
+		// Add cache-busting parameter
+		destinationUrl.searchParams.set( '_ctn', Date.now() );
+		window.location.href = destinationUrl.toString();
 	}
 
 	function JetpackSubscriptionModalOnCommentMessageListener( event ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jpop-issues/issues/9289

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We received report that for some users the page hangs on 'Submitting Comment` and never reloads.
<img width="551" alt="Screenshot 2024-11-12 at 11 49 12" src="https://github.com/user-attachments/assets/c65304f3-090b-48a0-953f-b42093ebbd90">

This PR adds cache busting parameter to the destination url

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to one of the affected sites reported in the ticket
* Load a post
* Search for `subscriptionModalShow` in the sources tab in dev tools
* Add override for the found file which maps to a local folder
* Apply the fix from this PR to the override
* After posting a comment the page should reload

