### PR TITLE
Fix/subscription toggles template link

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -83,6 +83,7 @@ function SubscriptionsSettings( props ) {
 		? addQueryArgs( `${ siteAdminUrl }site-editor.php`, {
 				postType: 'wp_template',
 				postId: `${ themeStylesheet }//single`,
+				canvas: 'edit',
 		  } )
 		: null;
 
@@ -90,6 +91,7 @@ function SubscriptionsSettings( props ) {
 		? addQueryArgs( `${ siteAdminUrl }site-editor.php`, {
 				postType: 'wp_template',
 				postId: `${ themeStylesheet }//index`,
+				canvas: 'edit',
 		  } )
 		: null;
 

--- a/projects/plugins/jetpack/changelog/fix-subscription-toggles-template-link
+++ b/projects/plugins/jetpack/changelog/fix-subscription-toggles-template-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscription settings: fix template preview+edit link for three toggles


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/40141

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `canvas=edit` to URLs which lead to single post and index templates. Otherwise these end up at the list of templates rather than the template itself. Must've bee a change at some point in WordPress. Considering it's just URL arg addition, this should be backwards compatible with older versions.


### Before

<img width="469" alt="Screenshot 2024-11-12 at 13 29 42" src="https://github.com/user-attachments/assets/c619f8d5-ab3d-42e3-afa1-6a88145b1a6a">


### After
<img width="449" alt="Screenshot 2024-11-12 at 13 29 09" src="https://github.com/user-attachments/assets/5ffb6d6b-c624-496c-8bdf-6eb52116007d">
<img width="447" alt="Screenshot 2024-11-12 at 13 29 19" src="https://github.com/user-attachments/assets/7cd6b81b-72d0-4d03-8c8d-db5fe24b3afa">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Settings -> Newsletter
* Enable toggles highlighted in screenshot above
* Click edit; end up at template, not at index

