### PR TITLE
Boost: Fix broken Beta tag for "Auto-Resize Lazy Images"

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -272,7 +272,7 @@ const List: React.FC< ListProps > = ( {
 				onChange={ e => validateInputValue( e.target.value ) }
 				id="jb-cornerstone-pages"
 			/>
-			{ inputInvalid && <p className={ styles.error }>{ validationError?.message }</p> }
+			{ inputInvalid && <span className={ styles.error }>{ validationError?.message }</span> }
 			{ description && <div className={ styles.description }>{ description }</div> }
 			<Button
 				disabled={ items === inputValue || inputInvalid }

--- a/projects/plugins/boost/app/assets/src/js/features/image-cdn/image-cdn-liar/image-cdn-liar.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/image-cdn/image-cdn-liar/image-cdn-liar.tsx
@@ -2,11 +2,10 @@ import { useDataSync } from '@automattic/jetpack-react-data-sync-client';
 import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { z } from 'zod';
-import indexStyles from '../../../pages/index/index.module.scss';
 import styles from './image-cdn-liar.module.scss';
-import clsx from 'clsx';
 import ModuleSubsection from '$features/ui/module-subsection/module-subsection';
 import { recordBoostEvent } from '$lib/utils/analytics';
+import Pill from '$features/ui/pill/pill';
 
 type ImageCdnLiarProps = {
 	isPremium: boolean;
@@ -35,7 +34,7 @@ export default function ImageCdnLiar( { isPremium }: ImageCdnLiarProps ) {
 				<div className={ styles.title }>
 					<h4>
 						{ __( 'Auto-Resize Lazy Images', 'jetpack-boost' ) }
-						<span className={ clsx( indexStyles.beta, styles.beta ) }>Beta</span>
+						<Pill text="Beta" />
 					</h4>
 					<ToggleControl
 						className={ styles[ 'toggle-control' ] }

--- a/projects/plugins/boost/changelog/fix-liar-beta-tag-missing-styles
+++ b/projects/plugins/boost/changelog/fix-liar-beta-tag-missing-styles
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix issue caused by unreleased feature.
+
+


### PR DESCRIPTION
> [!Note]
> Includes a change for the Cornerstone Pages project.

## Proposed changes:

* Fix missing styles for beta tag.

![CleanShot 2024-11-12 at 13 38 19](https://github.com/user-attachments/assets/70634233-169c-45c8-8816-3add0a513cd2)

* Fix Cornerstone Pages error message showing slightly larger than the description text.

![CleanShot 2024-11-12 at 14 35 52](https://github.com/user-attachments/assets/13d6cf4c-de31-4d95-b15b-48da9e733b9e)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

### Test beta tag showing correctly

* Setup Boost premium;
* Enable `Image CDN`;
* Make sure the `Beta` tag next to `Auto-Resize Lazy Images` is showing correctly.

### Test Cornerstone Pages error UI

* Delete everything from the Cornerstone Pages list;
* Make sure the error message is using the same font size as the description.