### PR TITLE
General: Bump minimum WordPress version to 6.6

### DIFF
--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -76,7 +76,7 @@ foreach ( array( 'previous', 'trunk' ) as $wp ) {
 		'script'  => 'test-php',
 		'php'     => $phpver,
 		'wp'      => $wp,
-		'timeout' => 15, // 2024-11-12: Successful runs seem to take ~7 minutes for the 7.4 trunk run, ~5.5-6 for 7.x and 8.0.
+		'timeout' => 15, // 2024-11-12: Successful runs seem to take ~7 minutes with PHP 8.2.
 	);
 }
 

--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -65,7 +65,7 @@ foreach ( array( '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ) as $php ) {
 		'script'  => 'test-php',
 		'php'     => $php,
 		'wp'      => 'latest',
-		'timeout' => 20, // 2023-08-17: Successful runs seem to take up to ~12 minutes.
+		'timeout' => 20, // 2024-11-12: Successful runs seem to take up to ~7 minutes.
 	);
 }
 
@@ -76,7 +76,7 @@ foreach ( array( 'previous', 'trunk' ) as $wp ) {
 		'script'  => 'test-php',
 		'php'     => $phpver,
 		'wp'      => $wp,
-		'timeout' => 15, // 2021-01-18: Successful runs seem to take ~8 minutes for the 7.4 trunk run, ~5.5-6 for 7.x and 8.0.
+		'timeout' => 15, // 2024-11-12: Successful runs seem to take ~7 minutes for the 7.4 trunk run, ~5.5-6 for 7.x and 8.0.
 	);
 }
 
@@ -104,7 +104,7 @@ $matrix[] = array(
 $matrix[] = array(
 	'name'    => 'JS tests',
 	'script'  => 'test-js',
-	'timeout' => 15, // 2021-01-18: Successful runs seem to take ~5 minutes.
+	'timeout' => 15, // 2024-11-12: Successful runs seem to take ~5 minutes.
 );
 
 // Add Coverage tests.
@@ -112,7 +112,7 @@ $matrix[] = array(
 	'name'    => 'Code coverage',
 	'script'  => 'test-coverage',
 	'wp'      => 'latest',
-	'timeout' => 40, // 2024-10-30: Successful runs seem to take ~30 minutes. We'll need to improve that.
+	'timeout' => 40, // 2024-11-12: Successful runs seem to take ~14 minutes.
 );
 
 // END matrix definitions.

--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -69,17 +69,6 @@ foreach ( array( '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ) as $php ) {
 	);
 }
 
-// TODO: When WordPress 6.5 is no longer supported, this can be removed. Runs too slow on ubuntu-24.04 (ubuntu-latest).
-$matrix[] = array(
-	'name'                => 'PHP tests: PHP 7.0 WP previous',
-	'runner'              => 'ubuntu-22.04',
-	'script'              => 'test-php',
-	'php'                 => '7.0',
-	'wp'                  => 'previous',
-	'timeout'             => 20, // 2023-08-17: Successful runs seem to take up to ~12 minutes.
-	'force-package-tests' => true,
-);
-
 foreach ( array( 'previous', 'trunk' ) as $wp ) {
 	$phpver   = $versions['PHP_VERSION'];
 	$matrix[] = array(

--- a/.github/files/select-wordpress-tag.sh
+++ b/.github/files/select-wordpress-tag.sh
@@ -20,7 +20,7 @@ case "$WP_BRANCH" in
 	previous)
 		# We hard-code the version here because there's a time near WP releases where
 		# we've dropped the old 'previous' but WP hasn't actually released the new 'latest'
-		WORDPRESS_TAG=6.5
+		WORDPRESS_TAG=6.6
 		;;
 	*)
 		echo "Unrecognized value for WP_BRANCH: $WP_BRANCH" >&2

--- a/.phpcs.config.xml
+++ b/.phpcs.config.xml
@@ -2,7 +2,7 @@
 <!-- This file configures everything except the list of rules. -->
 <!-- The separation is so .github/files/phpcompatibility-dev-phpcs.xml can use the same config with a different rule set. -->
 <ruleset>
-	<config name="minimum_supported_wp_version" value="6.5" />
+	<config name="minimum_supported_wp_version" value="6.6" />
 	<config name="testVersion" value="7.0-"/>
 
 	<!-- Use our custom filter for `.phpcsignore` and `.phpcs.dir.xml` support. -->

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
 		"phan/phan": "^5.4",
 		"php-parallel-lint/php-parallel-lint": "^1.4.0",
 		"php-stubs/woocommerce-stubs": ">=8.7",
-		"php-stubs/wordpress-stubs": ">=6.5",
-		"php-stubs/wordpress-tests-stubs": ">=6.5",
+		"php-stubs/wordpress-stubs": ">=6.6",
+		"php-stubs/wordpress-tests-stubs": ">=6.6",
 		"php-stubs/wp-cli-stubs": "^2.10",
 		"sirbrillig/phpcs-changed": "^2.11.5",
 		"squizlabs/php_codesniffer": "^3.6.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c9fc8342729e916410c963d050a22782",
+    "content-hash": "4e5d0ab379d2df5496c6454eccaeff2b",
     "packages": [],
     "packages-dev": [
         {
@@ -1059,16 +1059,16 @@
         },
         {
             "name": "php-stubs/woocommerce-stubs",
-            "version": "v9.3.3",
+            "version": "v9.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/woocommerce-stubs.git",
-                "reference": "1995245b3ebfd82eeaf3a8e9d3ec962f00ab3b73"
+                "reference": "008a5e9dfee9488bd2f063337e29078c0e8df65d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/1995245b3ebfd82eeaf3a8e9d3ec962f00ab3b73",
-                "reference": "1995245b3ebfd82eeaf3a8e9d3ec962f00ab3b73",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/008a5e9dfee9488bd2f063337e29078c0e8df65d",
+                "reference": "008a5e9dfee9488bd2f063337e29078c0e8df65d",
                 "shasum": ""
             },
             "require": {
@@ -1097,9 +1097,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
-                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v9.3.3"
+                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v9.4.0"
             },
-            "time": "2024-09-25T17:38:08+00:00"
+            "time": "2024-11-11T22:34:03+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",
@@ -3126,6 +3126,6 @@
     "platform": {
         "ext-json": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/projects/plugins/automattic-for-agencies-client/changelog/update-bump_min_wp_to_6.6
+++ b/projects/plugins/automattic-for-agencies-client/changelog/update-bump_min_wp_to_6.6
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: Update minimum WordPress version to 6.6.

--- a/projects/plugins/automattic-for-agencies-client/readme.txt
+++ b/projects/plugins/automattic-for-agencies-client/readme.txt
@@ -1,7 +1,7 @@
 === Automattic For Agencies Client ===
 Contributors: automattic, jeherve, njweller, rcanepa
 Tags: agency, dashboard, management, sites, monitoring
-Requires at least: 6.5
+Requires at least: 6.6
 Requires PHP: 7.0
 Tested up to: 6.7
 Stable tag: 0.2.1

--- a/projects/plugins/backup/changelog/update-bump_min_wp_to_6.6
+++ b/projects/plugins/backup/changelog/update-bump_min_wp_to_6.6
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: Update minimum WordPress version to 6.6.

--- a/projects/plugins/backup/readme.txt
+++ b/projects/plugins/backup/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack VaultPress Backup ===
 Contributors: automattic, bjorsch, fgiannar, initsogar, jeherve, jwebbdev, kraftbj, macbre, pypt, samiff, sermitr, williamvianas
 Tags: jetpack, backup, restore
-Requires at least: 6.5
+Requires at least: 6.6
 Requires PHP: 7.0
 Tested up to: 6.7
 Stable tag: 2.2

--- a/projects/plugins/boost/changelog/update-bump_min_wp_to_6.6
+++ b/projects/plugins/boost/changelog/update-bump_min_wp_to_6.6
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: Update minimum WordPress version to 6.6.

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -16,7 +16,7 @@
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       jetpack-boost
  * Domain Path:       /languages
- * Requires at least: 6.5
+ * Requires at least: 6.6
  * Requires PHP:      7.0
  *
  * @package automattic/jetpack-boost

--- a/projects/plugins/boost/readme.txt
+++ b/projects/plugins/boost/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, xwp, adnan007, bjorsch, danwalmsley, davidlonjon, dilirity, donncha, ebinnion, exelero, jeherve, jpolakovic, karthikbhatb, kraftbj, luchad0res, pyronaur, rheinardkorf, scruffian, thingalon
 Donate link: https://automattic.com
 Tags: performance, speed, web vitals, critical css, cache
-Requires at least: 6.5
+Requires at least: 6.6
 Tested up to: 6.7
 Requires PHP: 7.0
 Stable tag: 3.5.2

--- a/projects/plugins/classic-theme-helper-plugin/changelog/update-bump_min_wp_to_6.6
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/update-bump_min_wp_to_6.6
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: Update minimum WordPress version to 6.6.

--- a/projects/plugins/classic-theme-helper-plugin/readme.txt
+++ b/projects/plugins/classic-theme-helper-plugin/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Classic Theme Helper Plugin ===
 Contributors: automattic,
 Tags: jetpack, stuff
-Requires at least: 6.5
+Requires at least: 6.6
 Requires PHP: 7.0
 Tested up to: 6.7
 Stable tag: 0.1.0-alpha

--- a/projects/plugins/crm/changelog/update-bump_min_wp_to_6.6
+++ b/projects/plugins/crm/changelog/update-bump_min_wp_to_6.6
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: Update minimum WordPress version to 6.6.

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -31,7 +31,7 @@ final class ZeroBSCRM {
 	 *
 	 * @var string
 	 */
-	public $wp_tested = '6.5';
+	public $wp_tested = '6.7';
 
 	/**
 	 * WordPress update API version.

--- a/projects/plugins/inspect/changelog/update-bump_min_wp_to_6.6
+++ b/projects/plugins/inspect/changelog/update-bump_min_wp_to_6.6
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: Update minimum WordPress version to 6.6.

--- a/projects/plugins/inspect/readme.txt
+++ b/projects/plugins/inspect/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack inspect ===
 Contributors: automattic,
 Tags: jetpack, stuff
-Requires at least: 6.5
+Requires at least: 6.6
 Requires PHP: 7.0
 Tested up to: 6.7
 Stable tag: 1.0.0-alpha

--- a/projects/plugins/jetpack/changelog/update-bump_min_wp_to_6.6
+++ b/projects/plugins/jetpack/changelog/update-bump_min_wp_to_6.6
@@ -1,0 +1,4 @@
+Significance: major
+Type: major
+
+General: Update minimum WordPress version to 6.6.

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -8,7 +8,7 @@
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
- * Requires at least: 6.5
+ * Requires at least: 6.6
  * Requires PHP: 7.0
  *
  * @package automattic/jetpack
@@ -32,7 +32,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-define( 'JETPACK__MINIMUM_WP_VERSION', '6.5' );
+define( 'JETPACK__MINIMUM_WP_VERSION', '6.6' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
 define( 'JETPACK__VERSION', '14.1-a.1' );
 

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, adamkheckler, adrianmoldovanwp, aduth, akirk, allendav, alternatekev, andy, annamcphee, annezazu, apeatling, arcangelini, arsihasi, azaozz, barry, batmoo, beaulebens, bindlegirl, biskobe, bjorsch, blobaugh, brbrr, brileyhooper, cainm, cena, cfinke, cgastrell, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, daniloercoli, davoraltman, delawski, designsimply, dkmyta, dllh, drawmyface, dsmart, dun2mis, dzver, ebinnion, egregor, eliorivero, enej, eoigal, erania-pinnera, ethitter, fgiannar, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, joen, jblz, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, kbrownkd, keoshi, koke, kraftbj, lancewillett, leogermani, lhkowalski, lschuyler, macmanx, martinremy, matt, mattwiebe, matveb, maverick3x6, mcsf, mdawaffe, mdbitz, MichaelArestad, migueluy, miguelxavierpenha, mikeyarce, mkaz, nancythanki, nickmomrik, njweller, nunyvega, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, renatoagds, retrofox, richardmtl, richardmuscat, robertbpugh, roccotripaldi, ryancowles, samhotchkiss, samiff, scarstocea, scottsweb, sdixon194, sdquirk, sermitr, simison, stephdau, thehenridev, tmoorewp, tyxla, Viper007Bond, westi, williamvianas, wpkaren, yoavf, zinigor
 Tags: Security, backup, malware, scan, performance
 Stable tag: 14.0
-Requires at least: 6.5
+Requires at least: 6.6
 Requires PHP: 7.0
 Tested up to: 6.7
 License: GPLv2 or later

--- a/projects/plugins/migration/changelog/update-bump_min_wp_to_6.6
+++ b/projects/plugins/migration/changelog/update-bump_min_wp_to_6.6
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: Update minimum WordPress version to 6.6.

--- a/projects/plugins/migration/readme.txt
+++ b/projects/plugins/migration/readme.txt
@@ -1,7 +1,7 @@
 === Move to WordPress.com ===
 Contributors: automattic
 Tags: migrate, migration, backup, restore, transfer, move, copy, wordpress.com, automattic, import, importer, hosting
-Requires at least: 6.5
+Requires at least: 6.6
 Requires PHP: 7.0
 Tested up to: 6.7
 Stable tag: 2.0.0

--- a/projects/plugins/protect/changelog/update-bump_min_wp_to_6.6
+++ b/projects/plugins/protect/changelog/update-bump_min_wp_to_6.6
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: Update minimum WordPress version to 6.6.

--- a/projects/plugins/protect/readme.txt
+++ b/projects/plugins/protect/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Protect ===
 Contributors: automattic, retrofox, leogermani, renatoagds, bjorsch, ebinnion, fgiannar, zinigor, miguelxavierpenha, dsmart, jeherve, manzoorwanijk, njweller, oskosk, samiff, siddarthan, wpkaren, arsihasi, kraftbj, kev, sermitr, kangzj, pabline, dkmyta
 Tags: jetpack, protect, security, malware, scan
-Requires at least: 6.5
+Requires at least: 6.6
 Requires PHP: 7.0
 Tested up to: 6.7
 Stable tag: 1.4.1

--- a/projects/plugins/search/changelog/update-bump_min_wp_to_6.6
+++ b/projects/plugins/search/changelog/update-bump_min_wp_to_6.6
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: Update minimum WordPress version to 6.6.

--- a/projects/plugins/search/readme.txt
+++ b/projects/plugins/search/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Search ===
 Contributors: automattic, annamcphee, bluefuton, kangzj, jsnmoon, robfelty, gibrown, trakos, dognose24, a8ck3n
 Tags: search, filter, woocommerce search, ajax search, product search, free cloud-based search
-Requires at least: 6.5
+Requires at least: 6.6
 Requires PHP: 7.0
 Tested up to: 6.7
 Stable tag: 1.4.0

--- a/projects/plugins/social/changelog/update-bump_min_wp_to_6.6
+++ b/projects/plugins/social/changelog/update-bump_min_wp_to_6.6
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: Update minimum WordPress version to 6.6.

--- a/projects/plugins/social/readme.txt
+++ b/projects/plugins/social/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Social  ===
 Contributors: automattic, pabline, siddarthan, gmjuhasz, manzoorwanijk
 Tags: social media automation, social media scheduling, auto share, social sharing, social media marketing
-Requires at least: 6.5
+Requires at least: 6.6
 Requires PHP: 7.0
 Tested up to: 6.7
 Stable tag: 4.5.1

--- a/projects/plugins/starter-plugin/changelog/update-bump_min_wp_to_6.6
+++ b/projects/plugins/starter-plugin/changelog/update-bump_min_wp_to_6.6
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: Update minimum WordPress version to 6.6.

--- a/projects/plugins/starter-plugin/readme.txt
+++ b/projects/plugins/starter-plugin/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Starter Plugin ===
 Contributors: automattic,
 Tags: jetpack, stuff
-Requires at least: 6.5
+Requires at least: 6.6
 Requires PHP: 7.0
 Tested up to: 6.7
 Stable tag: 0.1.0-alpha

--- a/projects/plugins/super-cache/changelog/update-bump_min_wp_to_6.6
+++ b/projects/plugins/super-cache/changelog/update-bump_min_wp_to_6.6
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: Update minimum WordPress version to 6.6.

--- a/projects/plugins/super-cache/readme.txt
+++ b/projects/plugins/super-cache/readme.txt
@@ -1,7 +1,7 @@
 === WP Super Cache ===
 Contributors: donncha, automattic, adnan007, dilirity, mikemayhem3030, pyronaur, thingalon
 Tags: performance, caching, wp-cache, wp-super-cache, cache
-Requires at least: 6.5
+Requires at least: 6.6
 Requires PHP: 7.0
 Tested up to: 6.7
 Stable tag: 1.12.3

--- a/projects/plugins/videopress/changelog/update-bump_min_wp_to_6.6
+++ b/projects/plugins/videopress/changelog/update-bump_min_wp_to_6.6
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: Update minimum WordPress version to 6.6.

--- a/projects/plugins/videopress/readme.txt
+++ b/projects/plugins/videopress/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, retrofox, oskosk, thehenridev, renatoagds, lhkowalski, nunyvega, leogermani, cgastrell
 Tags: video, video-hosting, video-player, cdn, video-streaming
 
-Requires at least: 6.5
+Requires at least: 6.6
 Tested up to: 6.7
 Stable tag: 1.5
 Requires PHP: 7.0

--- a/projects/plugins/wpcomsh/changelog/update-bump_min_wp_to_6.6
+++ b/projects/plugins/wpcomsh/changelog/update-bump_min_wp_to_6.6
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: Update minimum WordPress version to 6.6.

--- a/projects/plugins/wpcomsh/readme.txt
+++ b/projects/plugins/wpcomsh/readme.txt
@@ -1,7 +1,7 @@
 === WP.com Site Helper ===
 Contributors: lamosty, obenland, automattic
 Tags: WP.com
-Requires at least: 6.5
+Requires at least: 6.6
 Requires PHP: 7.4
 Tested up to: 6.7
 Stable tag: trunk

--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -958,7 +958,7 @@ function createReadMeTxt( answers ) {
 		`=== Jetpack ${ answers.name } ===\n` +
 		'Contributors: automattic,\n' +
 		'Tags: jetpack, stuff\n' +
-		'Requires at least: 6.5\n' +
+		'Requires at least: 6.6\n' +
 		'Requires PHP: 7.0\n' +
 		'Tested up to: 6.7\n' +
 		`Stable tag: ${ answers.version }\n` +


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This bumps the minimum WP version for our plugins (other than CRM) to 6.6. We support the latest two versions, and WordPress 6.7 was released today.

This is listed as a major change.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Verify the PR does what it says?