### PR TITLE
Jetpack AI: Adding "transform list into table" functionality back to AI Assistant

### DIFF
--- a/projects/plugins/jetpack/changelog/change-jetpack-ai-list-to-table-transform
+++ b/projects/plugins/jetpack/changelog/change-jetpack-ai-list-to-table-transform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jatpack AI: Adding "transform list into table" functionality back to AI Assistant

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/dropdown-content.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/dropdown-content.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { getFeatureAvailability } from '../../../../blocks/ai-assistant/lib/utils/get-feature-availability';
 import { EXTENDED_BLOCKS } from '../../extensions/constants';
 import {
 	PROMPT_TYPE_CHANGE_TONE,
@@ -138,15 +139,6 @@ const quickActionsList: {
 				// Those actions are transformative in nature and are better suited for the AI Assistant block.
 				// TODO: Keep the action, but transforming the block.
 				{
-					name: __( 'Turn list into a table', 'jetpack' ),
-					key: 'turn-into-table',
-					aiSuggestion: PROMPT_TYPE_USER_PROMPT,
-					icon: blockTable,
-					options: {
-						userPrompt: 'make a table from this list, do not enclose the response in a code block',
-					},
-				},
-				{
 					name: __( 'Write a post from this list', 'jetpack' ),
 					key: 'write-post-from-list',
 					aiSuggestion: PROMPT_TYPE_USER_PROMPT,
@@ -159,10 +151,24 @@ const quickActionsList: {
 		  ],
 };
 
+if ( getFeatureAvailability( 'ai-list-to-table-transform' ) ) {
+	quickActionsList[ 'core/list' ].push( {
+		name: __( 'Turn list into a table', 'jetpack' ),
+		key: 'turn-into-table',
+		aiSuggestion: PROMPT_TYPE_USER_PROMPT,
+		icon: blockTable,
+		options: {
+			userPrompt: 'make a table from this list, do not enclose the response in a code block',
+			alwaysTransformToAIAssistant: true,
+		},
+	} );
+}
+
 export type AiAssistantDropdownOnChangeOptionsArgProps = {
 	tone?: ToneProp;
 	language?: string;
 	userPrompt?: string;
+	alwaysTransformToAIAssistant?: boolean;
 };
 
 export type OnRequestSuggestion = (

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/components/ai-assistant-toolbar-dropdown/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/components/ai-assistant-toolbar-dropdown/index.tsx
@@ -53,10 +53,12 @@ function AiAssistantExtensionToolbarDropdownContent( {
 		} ) => {
 			const selectedBlockIds = getSelectedBlockClientIds();
 			const [ clientId ] = selectedBlockIds;
+			const alwaysTransform = request.options.alwaysTransformToAIAssistant || false;
 
 			if (
-				selectedBlockIds.length < 2 ||
-				! canTransformToAIAssistant( { clientId, blockName: blockType } )
+				( selectedBlockIds.length < 2 ||
+					! canTransformToAIAssistant( { clientId, blockName: blockType } ) ) &&
+				! alwaysTransform
 			) {
 				// If there is only one selected block or the block cannot be transformed, proceed to open the extension input.
 				if ( request ) {


### PR DESCRIPTION
The AI Assistant feature for transforming lists into tables was removed at some point during some code restructuring. This PR re-enables the functionality.

Fixes #40135
Fixes #40136

## Proposed changes:
* Adds `turn-into-table` menu item for `core/list` blocks when `ai-list-to-table-transform` feature is enabled
* Added new option `alwaysTransformToAIAssistant` which allows us to bypass previous criteria for converting a standard block into an AI Assistant block
* Clicking "Turn list into table" from the AI Assistant menu will always trigger `transformToAIAssistant`, utilizing this behavior used elsewhere for transforming blocks into different blocks with AI

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Check out this branch and rebuild Jetpack
* Create a new post and add a list in the body
* Select the top level list block and click the AI assistant icon
* Verify that the menu that opens does not contain a "Turn list into a table" item
* Using the snippets plugin create a new active snippet and add the following:

```
define( 'JETPACK_BLOCKS_VARIATION', 'beta' );
add_filter( 'list_to_table_transform_enabled', '__return_true' );
```

* Reload your post and click on the AI assistant icon on the top level list again
* Verify that "Turn list into a table" is now in the menu:
* ![Screenshot 2024-11-12 at 2 42 27 PM](https://github.com/user-attachments/assets/3088cc7a-e017-4362-9e8f-ed2ae7ae6ccc)
* Click "Turn list into a table"
* Verify that the list is transformed into an AI assistant block and automatically makes a request
* After the AI assistant block finishes the request, the list should be replaced with a table that contains the list's content
* Click the trash/discard icon
* Verify that the table and AI assistant are gone and your original list is present
* Once again from the top level table select the "Turn list into table" menu item
* This time click the "Accept" button
* Verify that the original list has been replaced with the table and AI assistant is gone
* Verify that the new table is actually a table block and not a list block or AI assistant block

**Known issue:** you can click "Turn list into table" on sub-lists and it will fail. This will be fixed in a future PR (see #40137)
