### PR TITLE
ci: Fix coverage munger with no coverage

### DIFF
--- a/.github/files/coverage-munger/process-coverage.sh
+++ b/.github/files/coverage-munger/process-coverage.sh
@@ -17,27 +17,39 @@ echo '::endgroup::'
 TMP_DIR=$( mktemp -d )
 trap 'rm -rf "$TMP_DIR"' exit
 
-echo "::group::Combining PHP coverage"
-composer --working-dir="$BASE" update
-"$BASE"/vendor/bin/phpcov merge --php artifacts/php-combined.cov coverage
-perl -i -pwe 'BEGIN { $prefix = shift; $prefix=~s!/*$!/!; $re = qr/\Q$prefix\E/; $l = length( $prefix ); } s!s:(\d+):"$re! sprintf( qq(s:%d:"), $1 - $l ) !ge' "$GITHUB_WORKSPACE" artifacts/php-combined.cov
-echo '::endgroup::'
+TMP=$( find "$PWD/coverage" -name '*.cov' )
+if [[ -n "$TMP" ]]; then
+	echo "::group::Combining PHP coverage"
+	composer --working-dir="$BASE" update
+	"$BASE"/vendor/bin/phpcov merge --php artifacts/php-combined.cov coverage
+	perl -i -pwe 'BEGIN { $prefix = shift; $prefix=~s!/*$!/!; $re = qr/\Q$prefix\E/; $l = length( $prefix ); } s!s:(\d+):"$re! sprintf( qq(s:%d:"), $1 - $l ) !ge' "$GITHUB_WORKSPACE" artifacts/php-combined.cov
+	echo '::endgroup::'
 
-echo "::group::Combining JS coverage"
-pnpm --filter=jetpack-gh-config-munger exec istanbul-merge --out "$PWD"/artifacts/js-combined.json $( find "$PWD/coverage" -name '*.json' )
-perl -i -pwe 'BEGIN { $prefix = shift; $prefix=~s!/*$!/!; $re = qr/\Q$prefix\E/; } s!"$re!"!g' "$GITHUB_WORKSPACE" artifacts/js-combined.json
-echo '::endgroup::'
+	echo "::group::Creating PHP coverage summary"
+	"$BASE"/extract-php-summary-data.php artifacts/php-combined.cov > "$TMP_DIR/php-summary.tsv"
+	echo '::endgroup::'
+else
+	echo "No PHP coverage files found!"
+	touch "$TMP_DIR/php-summary.tsv"
+fi
 
-echo "::group::Creating PHP coverage summary"
-"$BASE"/extract-php-summary-data.php artifacts/php-combined.cov > "$TMP_DIR/php-summary.tsv"
-echo '::endgroup::'
+TMP=$( find "$PWD/coverage" -name '*.json' )
+if [[ -n "$TMP" ]]; then
+	echo "::group::Combining JS coverage"
+	pnpm --filter=jetpack-gh-config-munger exec istanbul-merge --out "$PWD"/artifacts/js-combined.json $TMP
+	perl -i -pwe 'BEGIN { $prefix = shift; $prefix=~s!/*$!/!; $re = qr/\Q$prefix\E/; } s!"$re!"!g' "$GITHUB_WORKSPACE" artifacts/js-combined.json
+	echo '::endgroup::'
 
-echo "::group::Creating JS coverage summary"
-mkdir "$TMP_DIR/js"
-cp artifacts/js-combined.json "$TMP_DIR/js"
-pnpm --filter=jetpack-gh-config-munger exec nyc report --no-exclude-after-remap --report-dir="$TMP_DIR" --temp-dir="$TMP_DIR/js" --reporter=json-summary
-jq -r 'to_entries[] | select( .key != "total" ) | [ .key, .value.lines.total, .value.lines.covered ] | @tsv' "$TMP_DIR/coverage-summary.json" > "$TMP_DIR/js-summary.tsv"
-echo '::endgroup::'
+	echo "::group::Creating JS coverage summary"
+	mkdir "$TMP_DIR/js"
+	cp artifacts/js-combined.json "$TMP_DIR/js"
+	pnpm --filter=jetpack-gh-config-munger exec nyc report --no-exclude-after-remap --report-dir="$TMP_DIR" --temp-dir="$TMP_DIR/js" --reporter=json-summary
+	jq -r 'to_entries[] | select( .key != "total" ) | [ .key, .value.lines.total, .value.lines.covered ] | @tsv' "$TMP_DIR/coverage-summary.json" > "$TMP_DIR/js-summary.tsv"
+	echo '::endgroup::'
+else
+	echo "No JS coverage files found!"
+	touch "$TMP_DIR/js-summary.tsv"
+fi
 
 echo "::group::Combining coverage summaries"
 sort "$TMP_DIR/php-summary.tsv" "$TMP_DIR/js-summary.tsv" > artifacts/summary.tsv


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If the PR has no PHP and/or JS coverage data, the `process-coverage.sh` script should do the right thing instead of failing.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1731442301581969/1731441986.548139-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make a PR based on this one with changes only in packages/jetpack-mu-wpcom or only in js-packages/eslint-changed. Coverage artifacts should still be generated correctly.
  * [x] https://github.com/Automattic/jetpack/actions/runs/11805582535/job/32888384027?pr=40151
  * [x] https://github.com/Automattic/jetpack/actions/runs/11805591885/job/32888425001?pr=40152