### PR TITLE
Repo Gardening: cover more use-cases of changelog files

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-repo-gardening-root-changelog
+++ b/projects/github-actions/repo-gardening/changelog/fix-repo-gardening-root-changelog
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Auto-labeling: do not add a "Docs" label when a changelog.md file is modified on the root of the repo.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -184,8 +184,8 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft, isRevert )
 			keywords.add( '[Tools] Development CLI' );
 		}
 
-		const docs = file.match( /^docs\/|\.md$/ ) && ! file.match( /\/CHANGELOG\.md$/ );
-		if ( docs !== null ) {
+		const docs = file.match( /^docs\/|\.md$/ ) && ! file.match( /\/?CHANGELOG\.md$/i );
+		if ( docs ) {
 			keywords.add( 'Docs' );
 		}
 

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -184,7 +184,7 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft, isRevert )
 			keywords.add( '[Tools] Development CLI' );
 		}
 
-		const docs = file.match( /^docs\/|\.md$/ ) && ! file.match( /\/?CHANGELOG\.md$/i );
+		const docs = file.match( /^docs\/|\.md$/ ) && ! file.match( /CHANGELOG\.md$/i );
 		if ( docs ) {
 			keywords.add( 'Docs' );
 		}


### PR DESCRIPTION
## Proposed changes:

We should avoid adding a "Docs" label when a changelog.md file is modified, even if that file name does not use uppercase, or if that file is at the root of the repo.

This came up here:
https://github.com/Automattic/wordpress-activitypub/pull/988#issuecomment-2471555908

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This can only be tested in a fork. Here is an example, that should not trigger a "Docs" label:

**Before patch**: https://github.com/Automattic/jetpack/pull/40161
**After patch**: https://github.com/jeherve/jetpack/pull/174

