### PR TITLE
Boost: Cornerstone Pages list UI tweaks

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -16,6 +16,7 @@ import { useRegenerationReason } from '$features/critical-css/lib/stores/suggest
 import { usePremiumFeatures } from '$lib/stores/premium-features';
 import { useNavigate } from 'react-router-dom';
 import { useRegenerateCriticalCssAction } from '$features/critical-css/lib/stores/critical-css-state';
+import { isSameSiteUrl } from '$lib/utils/is-same-site-url';
 
 const Meta = () => {
 	const [ isExpanded, setIsExpanded ] = useState( false );
@@ -233,7 +234,7 @@ const List: React.FC< ListProps > = ( {
 			} catch ( e ) {
 				// If the URL is invalid, they have provided a relative URL, which we will allow.
 			}
-			if ( url && url.origin !== siteUrl.origin ) {
+			if ( url && ! isSameSiteUrl( url, siteUrl ) ) {
 				throw new Error(
 					/* translators: %s is the URL that didn't match the site URL */
 					sprintf( __( 'The URL seems to be a different site: %s', 'jetpack-boost' ), line )

--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -224,6 +224,8 @@ const List: React.FC< ListProps > = ( {
 			throw new Error( message );
 		}
 
+		const siteUrl = new URL( Jetpack_Boost.site.url );
+
 		for ( const line of lines ) {
 			let url: URL | undefined;
 			try {
@@ -231,12 +233,7 @@ const List: React.FC< ListProps > = ( {
 			} catch ( e ) {
 				// If the URL is invalid, they have provided a relative URL, which we will allow.
 			}
-			if (
-				url &&
-				! ( url.origin + url.pathname ).replace( /\/$/, '' ).startsWith(
-					Jetpack_Boost.site.url.replace( /\/$/, '' )
-				)
-			) {
+			if ( url && url.origin !== siteUrl.origin ) {
 				throw new Error(
 					/* translators: %s is the URL that didn't match the site URL */
 					sprintf( __( 'The URL seems to be a different site: %s', 'jetpack-boost' ), line )

--- a/projects/plugins/boost/app/assets/src/js/lib/utils/is-same-site-url.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/utils/is-same-site-url.ts
@@ -1,0 +1,11 @@
+/**
+ * Returns true if the provided URL is from the same domain as the provided site URL.
+ *
+ * @param {URL} url     URL to check.
+ * @param {URL} siteUrl Site URL to compare against.
+ */
+export function isSameSiteUrl( url: URL, siteUrl: URL ): boolean {
+	const urlSanitized = url.origin + url.pathname.replace( /\/$/, '' ) + '/';
+	const siteUrlSanitized = siteUrl.origin + siteUrl.pathname.replace( /\/$/, '' ) + '/';
+	return urlSanitized.startsWith( siteUrlSanitized );
+}

--- a/projects/plugins/boost/app/data-sync/Cornerstone_Pages_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Cornerstone_Pages_Entry.php
@@ -28,8 +28,6 @@ class Cornerstone_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 	public function set( $value ) {
 		$value = $this->sanitize_value( $value );
 
-		$value = array_map( 'untrailingslashit', $value );
-
 		$updated = update_option( $this->option_key, $value );
 		if ( $updated ) {
 			( new Environment_Change_Detector() )->handle_cornerstone_pages_list_update();
@@ -38,7 +36,7 @@ class Cornerstone_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 
 	private function sanitize_value( $value ) {
 		if ( is_array( $value ) ) {
-			$value = array_values( array_unique( array_map( array( $this, 'transform_to_relative' ), $value ) ) );
+			$value = array_values( array_unique( array_map( 'untrailingslashit', array_map( array( $this, 'transform_to_relative' ), $value ) ) ) );
 		} else {
 			$value = array();
 		}

--- a/projects/plugins/boost/changelog/fix-boost-cornerstone-pages-duplicate-home-urls
+++ b/projects/plugins/boost/changelog/fix-boost-cornerstone-pages-duplicate-home-urls
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix for an unreleased feature.
+
+


### PR DESCRIPTION
## Proposed changes:

* Prevent URLs that don't belong to the current domain to be added to the website;
* Prevent duplicate home URLs in the database.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

### Test that multiple home URLs aren't saved

* Setup Boost premium
* Go to the Cornerstone Pages UI and try adding two URLs - the current domain without and with a trailing slash;
* Save the list;
* There should be just one URL in the list.

### Test that domain check works correctly

* Add the home URL without a trailing slash to the Cornerstone Pages UI;
* Add the home URL without a trailing slash, but with some random word.
  For example `https://jetpack-boost.testabout`.
* The second URL should be marked as "a different site".