### PR TITLE
Jetpack AI: increase response cache TTL

### DIFF
--- a/projects/plugins/jetpack/changelog/change-jetpack-ai-feature-request-caching
+++ b/projects/plugins/jetpack/changelog/change-jetpack-ai-feature-request-caching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: increase response cache TTL, add error response caching and increase request timeout


### PR DESCRIPTION
Fixes #37936


## Proposed changes:
- increase the ai-assistant-feature response cache TTL
- add a 10 second cache for error responses
- increase JP Client's request timeout to 30 seconds

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
#37936 
TBD

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Test using a local env and a sandboxed API. Apply the change to your sandbox:
```bash
bin/jetpack-downloader test jetpack change/jetpack-ai-feature-request-caching
```
Checkout this branch and build/watch on your local env.

Figure out the Jetpack working directory on your sandbox (sun/moon on `wp-content/mu-plugins`) and edit `_inc/lib/class-jetpack-ai-helper.php`.

Add a log on line 396 (right before the payload return): `l( 'non-cached response' )`
```php
$upgrade_type = wpcom_is_vip( $blog_id ) ? 'vip' : 'default';
// HERE!
return array(
```

Add a log on line 422: `l( 'cached response' )`
```php
if ( $cache ) {
  // HERE!
  return $cache;
}
```

Keep an eye on the logs on your sandbox: `tail -f /tmp/php-errors`.

Open your site and go to the editor, use the Network tab on devtools to see the request to `ai-assistant-feature`, but you should see already the log on your sandbox. Reload the editor page within a minute to get the "cached response" log. You should be able to repeat this after a minute has passed.

Force an error response by adding a `false` condition around line 446:
```php
if ( 200 === $response_code ) { // turn this into if ( false && 200 === $response_code ) {
```

Reload the editor and check the request to verify you got a 200 error response, it should carry a `ts` property with a timestamp.

Here's the tricky part, as we only cache errors for 10 seconds. You either refresh very quickly or multiply the cache TTL for errors on line 464:

```php
// add some multiplier to the last argument, say, * 3?
set_transient( $transient_name, $error, self::$ai_assistant_feature_error_cache_timeout );
```

If you're getting a cached error, the timestamp property will be the same and the sandbox should log "cached response". If cache TTL has passed, you'll get a new response.