### PR TITLE
Jetpack AI: remove initial fetch and dead code

### DIFF
--- a/projects/plugins/jetpack/changelog/change-jetpack-ai-assistant-feature-fetch
+++ b/projects/plugins/jetpack/changelog/change-jetpack-ai-assistant-feature-fetch
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI: remove dead and deprecated code

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/lib/can-ai-assistant-be-enabled.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/lib/can-ai-assistant-be-enabled.ts
@@ -37,12 +37,6 @@ export function canAIAssistantBeEnabled(): boolean {
 		return false;
 	}
 
-	// Do not enable if there is an error getting the feature.
-	const { errorCode } = select( 'wordpress-com/plans' )?.getAiAssistantFeature?.() || {};
-	if ( errorCode ) {
-		return false;
-	}
-
 	/*
 	 * Do not enable if the AI Assistant block is hidden
 	 * ToDo: the `editPostStore` is undefined for P2 sites.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -156,9 +156,7 @@ const JetpackAndSettingsContent = ( {
 };
 
 export default function AiAssistantPluginSidebar() {
-	const { requireUpgrade, upgradeType, currentTier, tierPlansEnabled, isOverLimit } =
-		useAiFeature();
-	const { checkoutUrl } = useAICheckout();
+	const { requireUpgrade, upgradeType, currentTier, isOverLimit } = useAiFeature();
 	const { tracks } = useAnalytics();
 
 	const isViewable = useSelect( select => {
@@ -185,8 +183,7 @@ export default function AiAssistantPluginSidebar() {
 		tracks.recordEvent( 'jetpack_ai_panel_open', { placement } );
 	};
 
-	const showUsagePanel =
-		planType === PLAN_TYPE_FREE || ( tierPlansEnabled && planType !== PLAN_TYPE_UNLIMITED );
+	const showUsagePanel = planType === PLAN_TYPE_FREE;
 	const showFairUsageNotice = planType === PLAN_TYPE_UNLIMITED && isOverLimit;
 	const isBreveAvailable = getBreveAvailability();
 
@@ -244,14 +241,6 @@ export default function AiAssistantPluginSidebar() {
 						busy={ false }
 						disabled={ requireUpgrade }
 					/>
-					{ requireUpgrade && tierPlansEnabled && (
-						<Upgrade
-							placement={ PLACEMENT_PRE_PUBLISH }
-							type={ upgradeType }
-							currentTier={ currentTier }
-							upgradeUrl={ checkoutUrl }
-						/>
-					) }
 				</>
 			</PluginPrePublishPanel>
 		</>

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createReduxStore, register, select } from '@wordpress/data';
+import { createReduxStore, register } from '@wordpress/data';
 /**
  * Internal dependencies
  */
@@ -95,14 +95,6 @@ export const wordpressPlansStore = createReduxStore( store, {
 } );
 
 register( wordpressPlansStore );
-
-/*
- * Ensure to request the AI Assistant feature data
- * by calling the selector. Resolver will take care.
- */
-if ( window.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'is-enabled' ] ) {
-	select( store ).getAiAssistantFeature();
-}
 
 // Types
 

--- a/projects/plugins/jetpack/extensions/types.ts
+++ b/projects/plugins/jetpack/extensions/types.ts
@@ -7,7 +7,6 @@ import type { TierProp, UpgradeTypeProp, FeaturesControl } from './store/wordpre
  * `sites/$site/ai-assistant-feature` endpoint response body props
  */
 export type SiteAIAssistantFeatureEndpointResponseProps = {
-	'is-enabled': boolean;
 	'has-feature': boolean;
 	'is-over-limit': boolean;
 	'requests-count': number;


### PR DESCRIPTION
Fixes #33839

## Proposed changes:
This PR removes some old code and avoids an early fetch to ai-assistant-feature endpoint. It might not be enough to fully address the mentioned issue though.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
#33319 
#33391 

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

**Without this branch:**
Watch plugins/jetpack: `jetpack watch plugins/jetpack`

Open devtools and load the editor, look for `ai-assistant-feature` request and check its initiator. Go to the bottom of the list, skip the usual suspects (such as anonymous calls or react-dom) and see the initiator is some unrelated ads JS file or canAIAssistantBeEnabled call.

**Apply the branch:**
Let the watched rebuild and reload the editor. See the initiator for the `ai-assistant-feature` request is now the AiAssistantPluginSidebar 