### PR TITLE
My Jetpack: Remove "Connection" management section for Atomic sites.

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -84,7 +84,7 @@ export default function MyJetpackScreen() {
 	} );
 	useNotificationWatcher();
 	const { redBubbleAlerts } = getMyJetpackWindowInitialState();
-	const { jetpackManage = {}, adminUrl } = getMyJetpackWindowInitialState();
+	const { isAtomic = false, jetpackManage = {}, adminUrl } = getMyJetpackWindowInitialState();
 
 	const { isWelcomeBannerVisible } = useWelcomeBanner();
 	const { isSectionVisible } = useEvaluationRecommendations();
@@ -190,7 +190,7 @@ export default function MyJetpackScreen() {
 						<PlansSection />
 					</Col>
 					<Col sm={ 4 } md={ 4 } lg={ 6 }>
-						<ConnectionsSection />
+						{ ! isAtomic && <ConnectionsSection /> }
 					</Col>
 				</Container>
 			</AdminSection>

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-atomic-remove-connection
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-atomic-remove-connection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: My Jetpack: Removed the Connection management section on Atomic sites (Not needed for Atomic sites).
+
+


### PR DESCRIPTION
This PR removes the "Connection" status & management section in My Jetpack for Atomic sites.

Jetpack should always be Active on WoA sites and users should not be able or allowed to manually "disconnect" their Jetpack connection. Therefore, the "Connection" section in My Jetpack is not needed and not wanted on WoA sites because it may cause user confusion and possibly invite and allow users to disconnect their Jetpack connection on their Atomic site. Removing the "Connection" section for WoA sites will prevent users from manually disconnecting their site.

P2 post & discussion: pf5801-1d5-p2

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-marketing/issues/1078

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Don't render <ConnectionSection /> component if site `isAtomic`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pf5801-1d5-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### Prerequisite:
- You'll need a WordPress on Atomic (WoA) site to test this PR. 
- If you don't already have one, you can create a WoA site via the WoA Developer Blog Manager in MC (/atomic/wpcom-dev-blogs/)

### Instructions:
- Ensure you are using the WP-Admin interface to manage your site:
    - Go to Settings --> General --> Admin interface style --> Classic style (then click "Save").
- Open the My Jetpack page, notice that there is a "Connection" section on the bottom-right corner of the page. Notice that this section allows the user to "Manage" the connection (and disconnect). We don't wan't to allow this on Atomic (WoA) sites.
- Upload and install & activate the latest version of the [Jetpack Beta Tester](https://github.com/Automattic/jetpack-beta/releases) plugin.
- Open Jetpack Beta, select the Jetpack plugin, and enable the `update/my-jetpack-atomic-remove-connection` branch.
- Open the My Jetpack page.
- Verify that the "Connection" section is not showing or available (See Screenshot ⤵️):

### Screenshot:

![Screen Shot 2024-11-13 at 15 25 06](https://github.com/user-attachments/assets/24c40540-5ae0-4025-a830-093b9adaa789)
