### PR TITLE
Add/jetpack growth to constants

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/plans/plan-icon/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/plans/plan-icon/index.jsx
@@ -103,6 +103,9 @@ import {
 	PLAN_JETPACK_CREATOR_BI_YEARLY,
 	PLAN_JETPACK_CREATOR_YEARLY,
 	PLAN_JETPACK_CREATOR_MONTHLY,
+	PLAN_JETPACK_GROWTH_BI_YEARLY,
+	PLAN_JETPACK_GROWTH_YEARLY,
+	PLAN_JETPACK_GROWTH_MONTHLY,
 	FEATURE_JETPACK_CRM,
 } from 'lib/plans/constants';
 import PropTypes from 'prop-types';
@@ -222,11 +225,13 @@ const DEFAULT_SIZE = 32;
 export default class PlanIcon extends Component {
 	render() {
 		const { className, alt, plan } = this.props;
+		const fallback = imagePath + 'plans/jetpack.svg';
+		const imageSrc = PRODUCT_ICON_MAP[ plan ] ? imagePath + PRODUCT_ICON_MAP[ plan ] : fallback;
 
 		return (
 			<img
 				className={ className }
-				src={ imagePath + PRODUCT_ICON_MAP[ plan ] }
+				src={ imageSrc }
 				width={ DEFAULT_SIZE }
 				height={ DEFAULT_SIZE }
 				alt={ alt || '' }
@@ -310,6 +315,9 @@ PlanIcon.propTypes = {
 		PLAN_JETPACK_CREATOR_BI_YEARLY,
 		PLAN_JETPACK_CREATOR_YEARLY,
 		PLAN_JETPACK_CREATOR_MONTHLY,
+		PLAN_JETPACK_GROWTH_BI_YEARLY,
+		PLAN_JETPACK_GROWTH_YEARLY,
+		PLAN_JETPACK_GROWTH_MONTHLY,
 
 		// DEPRECATED: Daily and Real-time variations will soon be retired.
 		// Remove after all customers are migrated to new products.

--- a/projects/plugins/jetpack/_inc/client/components/plans/plan-icon/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/plans/plan-icon/index.jsx
@@ -194,6 +194,9 @@ const PRODUCT_ICON_MAP = {
 	[ PLAN_JETPACK_CREATOR_BI_YEARLY ]: 'plans/jetpack.svg',
 	[ PLAN_JETPACK_CREATOR_YEARLY ]: 'plans/jetpack.svg',
 	[ PLAN_JETPACK_CREATOR_MONTHLY ]: 'plans/jetpack.svg',
+	[ PLAN_JETPACK_GROWTH_BI_YEARLY ]: 'plans/jetpack.svg',
+	[ PLAN_JETPACK_GROWTH_YEARLY ]: 'plans/jetpack.svg',
+	[ PLAN_JETPACK_GROWTH_MONTHLY ]: 'plans/jetpack.svg',
 
 	// DEPRECATED: Daily and Real-time variations will soon be retired.
 	// Remove after all customers are migrated to new products.

--- a/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
+++ b/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
@@ -90,6 +90,9 @@ export const PLAN_JETPACK_GOLDEN_TOKEN_LIFETIME = 'jetpack_golden_token_lifetime
 export const PLAN_JETPACK_CREATOR_MONTHLY = 'jetpack_creator_monthly';
 export const PLAN_JETPACK_CREATOR_YEARLY = 'jetpack_creator_yearly';
 export const PLAN_JETPACK_CREATOR_BI_YEARLY = 'jetpack_creator_bi_yearly';
+export const PLAN_JETPACK_GROWTH_MONTHLY = 'jetpack_growth_monthly';
+export const PLAN_JETPACK_GROWTH_YEARLY = 'jetpack_growth_yearly';
+export const PLAN_JETPACK_GROWTH_BI_YEARLY = 'jetpack_growth_bi_yearly';
 // DEPRECATED: Daily and Real-time variations will soon be retired.
 // Remove after all customers are migrated to new products.
 export const PLAN_JETPACK_BACKUP_DAILY = 'jetpack_backup_daily';
@@ -116,6 +119,7 @@ export const JETPACK_MONTHLY_PLANS = [
 	PLAN_JETPACK_STARTER_MONTHLY,
 	PLAN_JETPACK_SECURITY_T1_MONTHLY,
 	PLAN_JETPACK_SECURITY_T2_MONTHLY,
+	PLAN_JETPACK_COMPLETE_MONTHLY,
 	PLAN_JETPACK_COMPLETE_MONTHLY,
 
 	// DEPRECATED: Daily and Real-time variations will soon be retired.
@@ -333,6 +337,12 @@ export const JETPACK_CREATOR_PRODUCTS = [
 	PLAN_JETPACK_CREATOR_MONTHLY,
 	PLAN_JETPACK_CREATOR_YEARLY,
 	PLAN_JETPACK_CREATOR_BI_YEARLY,
+];
+
+export const JETPACK_GROWTH_PRODUCTS = [
+	PLAN_JETPACK_GROWTH_MONTHLY,
+	PLAN_JETPACK_GROWTH_YEARLY,
+	PLAN_JETPACK_GROWTH_BI_YEARLY,
 ];
 
 export const PLAN_MONTHLY_PERIOD = 31;
@@ -580,6 +590,16 @@ export function isJetpackCreator( product ) {
 }
 
 /**
+ * Determines if a product is Jetpack Growth.
+ *
+ * @param {string} product - The product id.
+ * @return {boolean} True if the product is Jetpack Growth, false otherwise.
+ */
+export function isJetpackGrowth( product ) {
+	return JETPACK_GROWTH_PRODUCTS.includes( product );
+}
+
+/**
  * Checks if a product slug is a Jetpack product.
  *
  * @param {string} product - The product id.
@@ -757,6 +777,10 @@ export function getPlanClass( plan ) {
 		case PLAN_JETPACK_CREATOR_YEARLY:
 		case PLAN_JETPACK_CREATOR_MONTHLY:
 			return 'is-jetpack-creator-plan';
+		case PLAN_JETPACK_GROWTH_BI_YEARLY:
+		case PLAN_JETPACK_GROWTH_YEARLY:
+		case PLAN_JETPACK_GROWTH_MONTHLY:
+			return 'is-jetpack-growth-plan';
 
 		// DEPRECATED: Daily and Real-time variations will soon be retired.
 		// Remove after all customers are migrated to new products.

--- a/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
+++ b/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
@@ -120,7 +120,7 @@ export const JETPACK_MONTHLY_PLANS = [
 	PLAN_JETPACK_SECURITY_T1_MONTHLY,
 	PLAN_JETPACK_SECURITY_T2_MONTHLY,
 	PLAN_JETPACK_COMPLETE_MONTHLY,
-	PLAN_JETPACK_COMPLETE_MONTHLY,
+	PLAN_JETPACK_GROWTH_MONTHLY,
 
 	// DEPRECATED: Daily and Real-time variations will soon be retired.
 	// Remove after all customers are migrated to new products.

--- a/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
+++ b/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
@@ -854,6 +854,8 @@ export function getMonthlyPlanByYearly( plan ) {
 			return PLAN_JETPACK_SECURITY_T2_MONTHLY;
 		case PLAN_JETPACK_COMPLETE:
 			return PLAN_JETPACK_COMPLETE_MONTHLY;
+		case PLAN_JETPACK_GROWTH_YEARLY:
+			return PLAN_JETPACK_GROWTH_MONTHLY;
 
 		// DEPRECATED: Daily and Real-time variations will soon be retired.
 		// Remove after all customers are migrated to new products.

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
@@ -310,6 +310,7 @@ class MyPlanBody extends React.Component {
 			case 'is-personal-plan':
 			case 'is-premium-plan':
 			case 'is-jetpack-starter-plan':
+			case 'is-jetpack-growth-plan':
 			case 'is-security-t1-plan':
 			case 'is-security-t2-plan':
 			case 'is-business-plan':

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
@@ -484,6 +484,13 @@ class MyPlanHeader extends React.Component {
 					),
 					title: __( 'Jetpack Creator', 'jetpack' ),
 				};
+			case 'is-jetpack-growth-plan':
+				return {
+					...productProps,
+					details: [ activation, expiration ],
+					tagLine: __( 'Grow your audience effortlessly', 'jetpack' ),
+					title: __( 'Jetpack Growth', 'jetpack' ),
+				};
 
 			default:
 				return {

--- a/projects/plugins/jetpack/changelog/add-jetpack-growth-to-constants
+++ b/projects/plugins/jetpack/changelog/add-jetpack-growth-to-constants
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add Jetpack Growth constants so My Plan section doesn't error out


### PR DESCRIPTION
## Proposed changes:

* Add Jetpack Growth constants so the My Plan section displays the new bundle

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: pbNhbs-bxX-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout the store sandbox on your sandbox in wpcom
2. Go to https://wordpress.com/checkout/jetpack/jetpack_growth_yearly and purchase the product
3. Start up a JN site with sandbox access active and activate your sandbox on the site
4. Go to `/wp-admin/admin.php?page=my-jetpack#/add-license` and Activate the growth license
![image](https://github.com/user-attachments/assets/576c27ae-7ed9-49c1-9334-15bfa80d26b1)
5. Go to `/wp-admin/admin.php?page=jetpack#/my-plan` and ensure that the Growth plan loads with no errors or wonky UI
![image](https://github.com/user-attachments/assets/0cb0b1ec-51ee-4620-b754-eaebab6fbb0f)
