### PR TITLE
Jetpack AI: Only display "turn list into table" menu item for top level lists

### DIFF
--- a/projects/plugins/jetpack/changelog/change-jetpack-ai-list-to-table-top-level-only
+++ b/projects/plugins/jetpack/changelog/change-jetpack-ai-list-to-table-top-level-only
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Only display "turn list into table" menu item for top level lists

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/dropdown-content.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/dropdown-content.tsx
@@ -202,7 +202,9 @@ export default function AiAssistantToolbarDropdownContent( {
 }: AiAssistantToolbarDropdownContentProps ): ReactElement {
 	const blockQuickActions = quickActionsList[ blockType ] ?? [];
 
-	const { getBlockParents } = select( 'core/block-editor' );
+	const { getBlockParents } = select( 'core/block-editor' ) as unknown as {
+		getBlockParents: ( blockId: string ) => string[];
+	};
 	const blockParents = getBlockParents( clientId );
 
 	return (

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/dropdown-content.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/dropdown-content.tsx
@@ -185,6 +185,7 @@ type AiAssistantToolbarDropdownContentProps = {
 	disabled?: boolean;
 	onAskAiAssistant: () => void;
 	onRequestSuggestion: OnRequestSuggestion;
+	clientId: string;
 };
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/dropdown-content.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/dropdown-content.tsx
@@ -3,6 +3,7 @@
  */
 import { aiAssistantIcon } from '@automattic/jetpack-ai-client';
 import { MenuItem, MenuGroup, Notice } from '@wordpress/components';
+import { select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { post, postContent, postExcerpt, termDescription, blockTable } from '@wordpress/icons';
 import React from 'react';
@@ -160,6 +161,7 @@ if ( getFeatureAvailability( 'ai-list-to-table-transform' ) ) {
 		options: {
 			userPrompt: 'make a table from this list, do not enclose the response in a code block',
 			alwaysTransformToAIAssistant: true,
+			rootParentOnly: true,
 		},
 	} );
 }
@@ -169,6 +171,7 @@ export type AiAssistantDropdownOnChangeOptionsArgProps = {
 	language?: string;
 	userPrompt?: string;
 	alwaysTransformToAIAssistant?: boolean;
+	rootParentOnly?: boolean;
 };
 
 export type OnRequestSuggestion = (
@@ -191,11 +194,15 @@ type AiAssistantToolbarDropdownContentProps = {
  */
 export default function AiAssistantToolbarDropdownContent( {
 	blockType,
+	clientId,
 	disabled = false,
 	onAskAiAssistant,
 	onRequestSuggestion,
 }: AiAssistantToolbarDropdownContentProps ): ReactElement {
 	const blockQuickActions = quickActionsList[ blockType ] ?? [];
+
+	const { getBlockParents } = select( 'core/block-editor' );
+	const blockParents = getBlockParents( clientId );
 
 	return (
 		<>
@@ -218,23 +225,29 @@ export default function AiAssistantToolbarDropdownContent( {
 					</div>
 				</MenuItem>
 
-				{ [ ...quickActionsList.default, ...blockQuickActions ].map( quickAction => (
-					<MenuItem
-						icon={ quickAction?.icon }
-						iconPosition="left"
-						key={ `key-${ quickAction.key }` }
-						onClick={ () => {
-							onRequestSuggestion(
-								quickAction.aiSuggestion,
-								{ ...( quickAction.options ?? {} ) },
-								quickAction.name
-							);
-						} }
-						disabled={ disabled }
-					>
-						<div className="jetpack-ai-assistant__menu-item">{ quickAction.name }</div>
-					</MenuItem>
-				) ) }
+				{ [ ...quickActionsList.default, ...blockQuickActions ]
+					.filter(
+						quickAction => ! ( quickAction.options?.rootParentOnly && blockParents.length > 0 )
+					)
+					.map( quickAction => {
+						return (
+							<MenuItem
+								icon={ quickAction?.icon }
+								iconPosition="left"
+								key={ `key-${ quickAction.key }` }
+								onClick={ () => {
+									onRequestSuggestion(
+										quickAction.aiSuggestion,
+										{ ...( quickAction.options ?? {} ) },
+										quickAction.name
+									);
+								} }
+								disabled={ disabled }
+							>
+								<div className="jetpack-ai-assistant__menu-item">{ quickAction.name }</div>
+							</MenuItem>
+						);
+					} ) }
 
 				<ToneDropdownMenu
 					onChange={ tone => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/index.tsx
@@ -144,9 +144,12 @@ function AiAssistantBlockToolbarDropdownContent( {
 		tracks.recordEvent( 'jetpack_ai_assistant_prompt_show', { block_type: blockType } );
 	};
 
+	const [ clientId ] = getSelectedBlockClientIds();
+
 	return (
 		<AiAssistantToolbarDropdownContent
 			blockType={ blockType }
+			clientId={ clientId }
 			onRequestSuggestion={ requestSuggestion }
 			onAskAiAssistant={ replaceWithAiAssistantBlock }
 			disabled={ noContent }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/components/ai-assistant-toolbar-dropdown/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/components/ai-assistant-toolbar-dropdown/index.tsx
@@ -91,9 +91,12 @@ function AiAssistantExtensionToolbarDropdownContent( {
 		handleToolbarButtonClick();
 	};
 
+	const [ clientId ] = getSelectedBlockClientIds();
+
 	return (
 		<AiAssistantToolbarDropdownContent
 			blockType={ blockType }
+			clientId={ clientId }
 			onRequestSuggestion={ handleRequestSuggestion }
 			onAskAiAssistant={ handleAskAiAssistant }
 			disabled={ false }


### PR DESCRIPTION
Fixes #40137

## Proposed changes:

* Currently the "Turn List Into Table" menu item is displayed for sub-lists, however the transform action does not work for sub-lists (also it would cause us to insert a table into a list, which is illegal)
* This removes that option in the drop down unless we are in the parent list

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A but this was mentioned in the [previous PR](https://github.com/Automattic/jetpack/pull/40148).

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

Once you've checked out the branch and built Jetpack, you will need to enable the feature via a snippet or similar means:

```
define( 'JETPACK_BLOCKS_VARIATION', 'beta' );
add_filter( 'list_to_table_transform_enabled', '__return_true' );
```

Once that's done, create a new post and create a list with multiple sub-lists, like so:

![Screenshot 2024-11-13 at 5 22 24 PM](https://github.com/user-attachments/assets/fe8a7b21-220c-4399-9ee6-0fc1f48185a7)

Validate:

* Upon clicking the AI Assistant icon on the root list you should see an option in the dropdown that says "Turn list into a table"
* If you click the AI Assistant icon at any other level of the list the option should not be present.
