### PR TITLE
Jetpack: show connection cards with disabled promotions

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
@@ -151,6 +151,7 @@ export class ConnectButton extends React.Component {
 					eventFeature="connect-account"
 					path="dashboard"
 					eventProps={ { type: 'connect' } }
+					isPromotion={ false }
 				/>
 			);
 		}
@@ -194,6 +195,7 @@ export class ConnectButton extends React.Component {
 					eventFeature="manage-site-connection"
 					path="dashboard"
 					eventProps={ { type: 'manage' } }
+					isPromotion={ false }
 				/>
 			);
 		}

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-banner/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-banner/index.jsx
@@ -25,6 +25,7 @@ export class JetpackBanner extends Banner {
 		title: PropTypes.node.isRequired,
 		noIcon: PropTypes.bool,
 		rna: PropTypes.bool,
+		isPromotion: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -33,6 +34,7 @@ export class JetpackBanner extends Banner {
 		plan: '',
 		rna: false,
 		noIcon: false,
+		isPromotion: true,
 	};
 
 	componentDidMount() {
@@ -43,11 +45,13 @@ export class JetpackBanner extends Banner {
 
 	render() {
 		// Hide promotion banners from non-admins, since they can't upgrade the site.
-		if ( this.props.hidePromotionBanner ) {
+		if ( this.props.isPromotion && this.props.hidePromotionBanner ) {
 			return null;
 		}
 
-		return this.props.arePromotionsActive ? <Banner { ...this.props } /> : null;
+		return ! this.props.isPromotion || this.props.arePromotionsActive ? (
+			<Banner { ...this.props } />
+		) : null;
 	}
 }
 

--- a/projects/plugins/jetpack/changelog/fix-jetpack-disconnect-not-promotion
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-disconnect-not-promotion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Dashboard: fix a bug with connection cards in "promotions disabled" mode.


### PR DESCRIPTION
## Proposed changes:
#39585 introduced a bug with Jetpack Dashboard not displaying connection cards correctly in "no promotions" mode:
- no text content
- no connection management button
- no user connection link for non-linked users

This PR fixes the issue by explicitly marking those cards as "not promotional" to make them always show up properly.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Activate the "no promotions" mode by adding the filter below (or installing the Docket Cache plugin):
```php
add_filter( 'jetpack_show_promotions', '__return_false', \PHP_INT_MAX );
```
2. Connect Jetpack in site-only mode.
3. Visit Jetpack Dashboard, confirm "Site connection" and "Account connection" cards show up with text content.
4. Click "Site connection -> Manage" button, confirm the disconnect modal shows up.
5. Click "Account connection -> Connect" button, connect the user.
6. Confirm the "Site connection" card still contains the text and the button.
7. Confirm the "Account connection" card now shows your data.