### PR TITLE
SupportInteractions: Pass params on get

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-hc-support-interactions
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-hc-support-interactions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Bugfix behind feature flag
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-support-interactions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-support-interactions.php
@@ -143,8 +143,13 @@ class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
 	 * @param \WP_REST_Request $request    The request sent to the API.
 	 */
 	public function get_support_interactions( \WP_REST_Request $request ) {
-		$support_interaction_id = isset( $request['support_interaction_id'] ) ? (int) $request['support_interaction_id'] : null;
-		$body                   = Client::wpcom_json_api_request_as_user( "/support-interactions/$support_interaction_id" );
+		if ( isset( $request['support_interaction_id'] ) ) {
+			$url = "/support-interactions/{$request['support_interaction_id']}";
+		} else {
+			$url = '/support-interactions/?' . http_build_query( stripslashes_deep( $request->get_params() ) );
+		}
+
+		$body = Client::wpcom_json_api_request_as_user( $url );
 
 		if ( is_wp_error( $body ) ) {
 			return $body;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/9801

Our support interactions endpoint was not passing the parameters. This lead to returning results not respecting the filters which later lead to unpredictable issues on atomic sites.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Pass the parameters for getting support interactions

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync this PR to your atomic site via the beta tester plugin
* Open the help center using the flag: `help-center-experience`
* Verify that the request `/wp-json/help-center/support-interactions?per_page=10&page=1&status=open&_locale=user` returns only `open` interactions.

