### PR TITLE
Connection: work around a WP user caching bug

### DIFF
--- a/projects/packages/connection/changelog/fix-connection-dotorg-user-cache-bug
+++ b/projects/packages/connection/changelog/fix-connection-dotorg-user-cache-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Work around a WP user caching bug (https://core.trac.wordpress.org/ticket/62003).

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1620,6 +1620,7 @@ class Manager {
 			return $cached_date;
 		}
 
+		// We don't use the 'ID' field, but need it to overcome a WP caching bug: https://core.trac.wordpress.org/ticket/62003
 		$earliest_registered_users  = get_users(
 			array(
 				'role'    => 'administrator',

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1620,7 +1620,11 @@ class Manager {
 			return $cached_date;
 		}
 
-		// We don't use the 'ID' field, but need it to overcome a WP caching bug: https://core.trac.wordpress.org/ticket/62003
+		/**
+		 * We don't use the 'ID' field, but need it to overcome a WP caching bug: https://core.trac.wordpress.org/ticket/62003
+		 *
+		 * @todo Remote the 'ID' field from users fetching when the issue is fixed and Jetpack-supported WP versions move beyond it.
+		 */
 		$earliest_registered_users  = get_users(
 			array(
 				'role'    => 'administrator',

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1625,7 +1625,7 @@ class Manager {
 				'role'    => 'administrator',
 				'orderby' => 'user_registered',
 				'order'   => 'ASC',
-				'fields'  => array( 'user_registered' ),
+				'fields'  => array( 'ID', 'user_registered' ),
 				'number'  => 1,
 			)
 		);

--- a/projects/packages/connection/tests/php/test-class-connection-notice.php
+++ b/projects/packages/connection/tests/php/test-class-connection-notice.php
@@ -117,10 +117,15 @@ class Test_Connection_Notice extends TestCase {
 		\Jetpack_Options::update_option( 'master_user', $id_admin );
 
 		$this->users_query_filter = function ( $result, $query ) {
-			if ( str_starts_with( trim( $query ), 'SELECT wp_users.user_registered' )
+			if ( str_starts_with( trim( $query ), 'SELECT wp_users.ID,wp_users.user_registered' )
 				&& preg_match( '#wp_usermeta\.meta_value LIKE \'\{.*?\}"administrator"\{.*?\}\'#i', $query )
 			) {
-				return array( (object) array( 'user_registered' => '2012-03-19 00:00:00' ) );
+				return array(
+					(object) array(
+						'ID'              => 12346,
+						'user_registered' => '2012-03-19 00:00:00',
+					),
+				);
 			}
 
 			return $result;


### PR DESCRIPTION
## Proposed changes:
WP bug [#62003](https://core.trac.wordpress.org/ticket/62003) leads to inconsistent format of cached user data in certain circumstances.
It happens if only one field gets fetched from the database, so we add `ID` to work around the issue.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://core.trac.wordpress.org/ticket/62003
p1731513241019199-slack-C05PV073SG3
p1725570377885549-slack-C7YPW6K40

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
_First try to reproduce the issue on `trunk`._
1. Install and activate an object cache plugin (e.g. [Docket Cache](https://wordpress.org/plugins/docket-cache/)).
2. Add this code snipped to your site:
```php
add_action( 'plugins_loaded', function() {
	get_users( array( 'role' => 'administrator', 'orderby' => 'user_registered', 'fields'  => 'user_registered', 'number'  => 1 ) );
} );
```
3. Connect Jetpack in site-only mode.
4. Load Jetpack Dashboard.
5. Clean the cache and remove the transient:
```bash
wp cache flush
wp transient delete jetpack_assumed_site_creation_date
```
6. Reload Jetpack Dashboard and confirm you see the PHP warning in your `debug.log`:
```
PHP Warning:  Attempt to read property "user_registered" on string in ...
```
7. Clean the cache and remove the transient (step 5).
9. Checkout the branch, reload Jetpack Dashboard. Confirm you no longer see the warning.