### PR TITLE
jetpack: Limit test-coverage concurrency

### DIFF
--- a/projects/plugins/jetpack/changelog/update-limit-jetpack-test-concurrency
+++ b/projects/plugins/jetpack/changelog/update-limit-jetpack-test-concurrency
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Limit test-coverage concurrency
+
+

--- a/projects/plugins/jetpack/tests/action-test-coverage.sh
+++ b/projects/plugins/jetpack/tests/action-test-coverage.sh
@@ -20,4 +20,4 @@ TESTS[client]="pnpm run test-client --coverage"
 TESTS[gui]="pnpm run test-gui --coverage"
 TESTS[extensions]="pnpm run test-extensions --coverage"
 
-pnpm exec concurrently --max-processes '100%' --names "$( IFS=,; echo "${!TESTS[*]}" )" "${TESTS[@]}"
+pnpm exec concurrently --max-processes '50%' --names "$( IFS=,; echo "${!TESTS[*]}" )" "${TESTS[@]}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Too many different projects with too many threads makes a test time out.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1731611354854109-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the CI run and see if Jetpack's tests are only starting two at a time instead of 4.
* Then merge and hope it stops the timeouts.