### PR TITLE
Jetpack AI: bug hotfix - general image disabled input

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-general-image-disabled-input
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-general-image-disabled-input
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: hotfix for input disabled bug (https://github.com/Automattic/wp-calypso/issues/96430)

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.tsx
@@ -74,7 +74,7 @@ export default function AiImageModal( {
 	isUnlimited: boolean;
 	upgradeDescription: string;
 	hasError: boolean;
-	postContent?: string;
+	postContent?: string | boolean | null;
 	handlePreviousImage: () => void;
 	handleNextImage: () => void;
 	acceptButton: React.JSX.Element;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/general-purpose-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/general-purpose-image.tsx
@@ -251,6 +251,7 @@ export default function GeneralPurposeImage( {
 
 	return (
 		<AiImageModal
+			postContent={ true }
 			images={ images }
 			currentIndex={ current }
 			title={ __( 'Generate an image with AI', 'jetpack' ) }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/96430

## Proposed changes:
Pass down `postContent` prop as `boolean` `true` on General Image generator modal. 
The `postContent` is a condition for Featured Image modal, so it's fine that it's force to `true` on General Image

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1731611483630749-slack-CBTN58FTJ
p1731606462948849-slack-C010KDAPG49

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Apply and test both General Image and Featured Image generator modal. 

General Image can be accessed through an `/image` block, choosing "Generate with AI"

Featured Image modal can be invoked from the sidebar. Empty posts (no title, no content) should not allow an image generation unless the post has content. Will address this flaky condition immediately, but for now this fix should reinstate the General Image generation and allow Featured Image to work under "normal" conditions