### PR TITLE
package.json: Add packageManager field for corepack compatibility

### DIFF
--- a/.github/files/lint-project-structure.sh
+++ b/.github/files/lint-project-structure.sh
@@ -642,6 +642,11 @@ if ! pnpm semver --range "$RANGE" "$PNPM_VERSION" &>/dev/null; then
 	LINE=$(jq --stream 'if length == 1 then .[0][:-1] else .[0] end | if . == ["engines","pnpm"] then input_line_number - 1 else empty end' package.json)
 	echo "::error file=package.json,line=$LINE::Pnpm version $PNPM_VERSION in .github/versions.sh does not satisfy requirement $RANGE from package.json"
 fi
+if ! jq -e --arg v "pnpm@$PNPM_VERSION" '.packageManager == $v' package.json &>/dev/null; then
+	EXIT=1
+	LINE=$(jq --stream 'if length == 1 then .[0][:-1] else .[0] end | if . == ["packageManager"] then input_line_number - 1 else empty end' package.json)
+	echo "::error file=package.json,line=$LINE::Version in package.json packageManager must be \"pnpm@$PNPM_VERSION\", to match .github/versions.sh."
+fi
 
 # - Check for incorrect next-version tokens.
 debug "Checking for incorrect next-version tokens."

--- a/.npmrc
+++ b/.npmrc
@@ -25,3 +25,5 @@ resolution-mode = highest
 
 # @automattic/jetpack-webpack-config looks for this.
 jetpack-webpack-config-resolve-conditions=jetpack:src
+
+manage-package-manager-versions=false

--- a/package.json
+++ b/package.json
@@ -37,5 +37,5 @@
 		"node": "^22.9.0",
 		"pnpm": "^9.3.0 <9.12.0"
 	},
-	"packageManager": "pnpm@9.11.0"
+	"packageManager": "pnpm@9.3.0"
 }

--- a/package.json
+++ b/package.json
@@ -36,5 +36,6 @@
 	"engines": {
 		"node": "^22.9.0",
 		"pnpm": "^9.3.0 <9.12.0"
-	}
+	},
+	"packageManager": "pnpm@9.11.0"
 }


### PR DESCRIPTION
## Proposed changes:

* Adds a `packageManager` field to `package.json` to specify `pnpm@9.3.0`.

This aligns with the version currently used in the GitHub Actions workflow and falls within the engines.pnpm range.

When using the repo with Devbox and Corepack, Corepack may attempt to download a newer pnpm version outside this range. Adding the packageManager field improves compatibility for Corepack users, ensuring consistency across local development and CI environments without impacting others.

I chose 9.3 specifically because it lines up with that's in the github actions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

