### PR TITLE
Fix: Contact form block dropdown arrow wrapping under field

### DIFF
--- a/projects/packages/forms/changelog/fix-select-arrow
+++ b/projects/packages/forms/changelog/fix-select-arrow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fixed arrow positioning on select elements

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -320,8 +320,8 @@
 
 .contact-form .contact-form__select-wrapper::after {
 	position: absolute;
-	inset-inline-end: calc(var(--jetpack--contact-form--input-padding) + 4px);
-	top: calc(var(--jetpack--contact-form--input-padding) + var(--jetpack--contact-form--line-height) / 2);  
+	inset-inline-end: calc(var(--jetpack--contact-form--input-padding-left) + 4px);
+	top: calc(var(--jetpack--contact-form--input-padding-top) + var(--jetpack--contact-form--line-height) / 2);  
 
   content: "";
   display: block;


### PR DESCRIPTION

Fixes https://github.com/Automattic/themes/issues/8035
Fixes #38470

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR fixes how we calculate the position for the arrow on a select element using the correct CSS variables. Before, it would only work if a theme had a singular value for all sides of padding (or none at all) on the element

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install Assembler theme
* Insert the Register form on a post and save
* Go to the frontend and see the arrow is not aligned properly
* Checkout this PR and the arrow should be placed correctly
* This shouldn't break other themes

