### PR TITLE
Newsletters: Fix warnings for non connected authors.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-menu-for-authors
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-menu-for-authors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter: Fix error for not connected authors using the Newsletter menu.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -43,12 +43,12 @@ const NewsletterMenu = ( { openPreviewModal } ) => {
 			icon={ <SendIcon /> }
 		>
 			<PanelBody>
-				{ ! isPublished && <NewsletterEmailDocumentSettings /> }
-				<SubscribersAffirmation accessLevel={ accessLevel } prePublish={ ! isPublished } />
 				{ isSendEmailEnabled && ! isPublished && (
 					<>
 						{ ! shouldPromptForConnection ? (
 							<>
+								{ ! isPublished && <NewsletterEmailDocumentSettings /> }
+								<SubscribersAffirmation accessLevel={ accessLevel } prePublish={ ! isPublished } />
 								<p>
 									{ __(
 										'Ensure your email looks perfect. Use the buttons below to view a preview or send a test email.',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #39911

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Address warnings encountered by non-connected authors in the newsletters feature of the Jetpack plugin.
* These shouldn't show up:

![image](https://github.com/user-attachments/assets/afdf5bc3-193f-4caf-baba-3e0f8eb6ebef)

After:

<img width="1507" alt="Screenshot 2024-11-15 at 10 26 51 AM" src="https://github.com/user-attachments/assets/cc66c8d5-4a85-4e89-ad84-f5a98aee6c38">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create an Author level user
* Enable the Newsletter module
* Create a draft post
* Click on Publish
* Confirm warnings don't show up


