### PR TITLE
Jetpack AI: split component disabled prop

### DIFF
--- a/projects/js-packages/ai-client/changelog/add-jetpack-ai-prompt-input-disabled-prop
+++ b/projects/js-packages/ai-client/changelog/add-jetpack-ai-prompt-input-disabled-prop
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+AI Client: split disabled prop to allow disabling input and action button separately

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
@@ -281,6 +281,7 @@ export const Prompt = ( { initialPrompt = '' }: PromptProps ) => {
 				setPrompt={ setPrompt }
 				generateHandler={ onGenerate }
 				disabled={ isBusy || requireUpgrade }
+				actionDisabled={ isBusy || requireUpgrade || ! hasPrompt }
 				placeholder={ __(
 					'Describe your site or simply ask for a logo specifying some details about it',
 					'jetpack-ai-client'

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
@@ -42,22 +42,20 @@ export const AiModalPromptInput = ( {
 	prompt = '',
 	setPrompt = () => {},
 	disabled = false,
+	actionDisabled = false,
 	generateHandler = () => {},
 	placeholder = '',
 	buttonLabel = '',
-	minPromptLength = null,
 }: {
 	prompt: string;
 	setPrompt: Dispatch< SetStateAction< string > >;
 	disabled: boolean;
+	actionDisabled: boolean;
 	generateHandler: () => void;
 	placeholder?: string;
 	buttonLabel?: string;
-	minPromptLength?: number;
 } ) => {
 	const inputRef = useRef< HTMLDivElement | null >( null );
-	const hasPrompt =
-		prompt?.length >= ( minPromptLength === null ? MINIMUM_PROMPT_LENGTH : minPromptLength );
 
 	const onPromptInput = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		setPrompt( event.target.textContent || '' );
@@ -125,7 +123,7 @@ export const AiModalPromptInput = ( {
 				variant="primary"
 				className="jetpack-ai-logo-generator__prompt-submit"
 				onClick={ generateHandler }
-				disabled={ disabled || ! hasPrompt }
+				disabled={ actionDisabled }
 			>
 				{ buttonLabel || __( 'Generate', 'jetpack-ai-client' ) }
 			</Button>

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-prompt-input-disabled-prop
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-prompt-input-disabled-prop
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI: image generator modals now properly enable prompt input separately from action button

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -60,8 +60,8 @@ export default function FeaturedImage( {
 	const { saveToMediaLibrary } = useSaveToMediaLibrary();
 	const { tracks } = useAnalytics();
 	const { recordEvent } = tracks;
-	const [ defaultPrompt, setDefaultPrompt ] = useState( '' );
 	const [ requestStyle, setRequestStyle ] = useState< ImageStyle >( null );
+	const [ prompt, setPrompt ] = useState( '' );
 
 	// Editor actions
 	const { enableComplementaryArea } = useDispatch( 'core/interface' );
@@ -188,7 +188,7 @@ export default function FeaturedImage( {
 		const response = await handleGenerate( { userPrompt: '', style: guessedStyle } );
 		if ( response ) {
 			debug( 'handleFirstGenerate', response.revisedPrompt );
-			setDefaultPrompt( response.revisedPrompt );
+			setPrompt( response.revisedPrompt );
 		}
 	}, [ currentPointer, handleGenerate, handleGuessStyle ] );
 
@@ -341,6 +341,11 @@ export default function FeaturedImage( {
 	const generateAgainText = __( 'Generate another image', 'jetpack' );
 	const generateText = __( 'Generate', 'jetpack' );
 
+	const hasContent = postContent || postTitle;
+	const hasPrompt = hasContent ? prompt.length >= 0 : prompt.length >= 3;
+	const disableInput = notEnoughRequests || currentPointer?.generating || requireUpgrade;
+	const disableAction = disableInput || ( ! hasContent && ! hasPrompt );
+
 	const upgradeDescription = notEnoughRequests
 		? sprintf(
 				// Translators: %d is the cost of generating a featured image.
@@ -379,8 +384,8 @@ export default function FeaturedImage( {
 				</>
 			) }
 			<AiImageModal
-				postContent={ postContent || postTitle }
-				autoStart={ ( postContent !== '' || postTitle ) && ! postFeaturedMedia }
+				postContent={ hasContent }
+				autoStart={ hasContent && ! postFeaturedMedia }
 				autoStartAction={ handleFirstGenerate }
 				images={ images }
 				currentIndex={ current }
@@ -409,9 +414,11 @@ export default function FeaturedImage( {
 				) }
 				imageStyles={ imageStyles }
 				onGuessStyle={ handleGuessStyle }
-				initialPrompt={ defaultPrompt }
+				prompt={ prompt }
+				setPrompt={ setPrompt }
 				initialStyle={ requestStyle }
-				minPromptLength={ 0 }
+				inputDisabled={ disableInput }
+				actionDisabled={ disableAction }
 			/>
 		</>
 	);

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -128,9 +128,9 @@ export default function FeaturedImage( {
 	 * Handle the guess style for the image. It is reworked here to include the post content.
 	 */
 	const handleGuessStyle = useCallback(
-		prompt => {
+		userPrompt => {
 			const content = postTitle + '\n\n' + postContent;
-			return guessStyle( prompt, 'featured-image-guess-style', content );
+			return guessStyle( userPrompt, 'featured-image-guess-style', content );
 		},
 		[ postContent, postTitle, guessStyle ]
 	);

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/general-purpose-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/general-purpose-image.tsx
@@ -48,6 +48,7 @@ export default function GeneralPurposeImage( {
 	const { saveToMediaLibrary } = useSaveToMediaLibrary();
 	const { tracks } = useAnalytics();
 	const { recordEvent } = tracks;
+	const [ prompt, setPrompt ] = useState( '' );
 
 	// Get feature data
 	const { requireUpgrade, requestsCount, requestsLimit, currentTier, costs } = useAiFeature();
@@ -79,6 +80,10 @@ export default function GeneralPurposeImage( {
 		type: 'general-image-generation',
 		feature: GENERAL_IMAGE_FEATURE_NAME,
 	} );
+
+	const hasPrompt = prompt.length >= 3;
+	const disableInput = notEnoughRequests || currentPointer?.generating || requireUpgrade;
+	const disableAction = disableInput || ! hasPrompt;
 
 	const handleModalClose = useCallback( () => {
 		setIsFeaturedImageModalVisible( false );
@@ -276,6 +281,10 @@ export default function GeneralPurposeImage( {
 			instructionsPlaceholder={ __( "Describe the image you'd like to create.", 'jetpack' ) }
 			imageStyles={ imageStyles }
 			onGuessStyle={ guessStyle }
+			prompt={ prompt }
+			setPrompt={ setPrompt }
+			inputDisabled={ disableInput }
+			actionDisabled={ disableAction }
 		/>
 	);
 }


### PR DESCRIPTION
The AiModalPromptInput has a single `disabled` prop to control both the action button and the input. When the post is empty (no title, no content), the Featured Image generator not only disables the action button, but also the prompt input. While it remains an edge case (generating a Featured Image for an empty post) there is no reason we should not allow for a user to generate a featured image on such conditions.

## Proposed changes:
This PR adds a secondary `actionDisabled` prop to control them separately.
For this, it moves all the prompt state logic to the tip of the component tree, removing secondary (and likely contradictory) logic on the shared component AiModalPromptInput.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/jetpack/pull/40198#pullrequestreview-2437227971

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Generator modals (Logo AI generator, General Image AI generator, Featured Image AI generator) should remain usable, open each and confirm enabling/disabling conditions for both input and action button. Generate some image to confirm functionality with both prompt and contextual data.

**Empty post (no title, no content)** (worth noting, logo block and image block don't count as content):

- All modals: should enable the action button as soon as the prompt has **more than 3 characters**
- Featured image modal should not auto-start generating an mage
- Input should be enabled at all times (except when generating)

**Post with content (title and/or text blocks):**

- Logo and General image modals should enable the action button as soon as the prompt has **more than 3 characters**
- Featured image modal should auto-start generating. When done, a revised prompt derived from the post content should be set
- Featured image modal should **NOT** disable the action button when prompt is empty (allow for generation based on post content/title)
- Input should be enabled at all times (except when generating)