### PR TITLE
Protect: use link style for "go to cloud" header button

### DIFF
--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -55,7 +55,7 @@ const AdminPage = ( { children } ) => {
 					<JetpackProtectLogo />
 					{ hasPlan && viewingScanPage && (
 						<div className={ styles.header__scan_buttons }>
-							<Button variant="secondary" weight={ 'regular' } href={ goToCloudUrl }>
+							<Button variant="link" isExternalLink weight={ 'regular' } href={ goToCloudUrl }>
 								{ __( 'Go to Cloud', 'jetpack-protect' ) }
 							</Button>
 							<ScanButton />

--- a/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
@@ -8,7 +8,7 @@
 
     &__scan_buttons {
         display: flex;
-        gap: calc( var( --spacing-base ) * 2 ); // 16px
+        gap: calc( var( --spacing-base ) * 3 ); // 24px
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Uses the `link` variant and `isExternalLink` property to make the "go to cloud" button secondary to the "scan now" button beside it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a site with a Scan plan, go to `/wp-admin/admin.php?page=jetpack-protect#/scan`.
* Review and test the header buttons.

## Screenshots:

Before:
<img width="1179" alt="Screenshot 2024-11-15 at 1 34 03 PM" src="https://github.com/user-attachments/assets/0babc187-3ea7-4e12-a3ef-9e696f881ca7">

After:
<img width="1174" alt="Screenshot 2024-11-15 at 1 27 43 PM" src="https://github.com/user-attachments/assets/6fcd6773-ee30-4611-91d7-14155f1b6b81">
