### PR TITLE
Remove/creator recommendation on dashboard

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-text-on-stats-feature-for-growth
+++ b/projects/packages/my-jetpack/changelog/update-text-on-stats-feature-for-growth
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Just a copy change
+
+

--- a/projects/packages/my-jetpack/src/products/class-growth.php
+++ b/projects/packages/my-jetpack/src/products/class-growth.php
@@ -74,7 +74,7 @@ class Growth extends Module_Product {
 	public static function get_features() {
 		return array(
 			_x( 'Jetpack Social', 'Growth Product Feature', 'jetpack-my-jetpack' ),
-			_x( 'Jetpack Stats (up to 100K site views)', 'Growth Product Feature', 'jetpack-my-jetpack' ),
+			_x( 'Jetpack Stats (100K site views, upgradeable)', 'Growth Product Feature', 'jetpack-my-jetpack' ),
 			_x( 'Unlimited subscriber imports', 'Growth Product Feature', 'jetpack-my-jetpack' ),
 			_x( 'Earn more from your content', 'Growth Product Feature', 'jetpack-my-jetpack' ),
 			_x( 'Accept payments with PayPal', 'Growth Product Feature', 'jetpack-my-jetpack' ),

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -816,7 +816,6 @@ export const getProductCardData = ( state, productSlug ) => {
 				} ),
 				productCardCtaText: __( 'Get Jetpack Growth', 'jetpack' ),
 				productCardList: products.growth ? products.growth.features : [],
-				productCardIcon: '/recommendations/creator-icon.svg',
 			};
 		case PLAN_JETPACK_ANTI_SPAM:
 			return {

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -8,7 +8,7 @@ import {
 	PLAN_JETPACK_VIDEOPRESS,
 	PLAN_JETPACK_ANTI_SPAM,
 	PLAN_JETPACK_BACKUP_T1_YEARLY,
-	PLAN_JETPACK_CREATOR_YEARLY,
+	PLAN_JETPACK_GROWTH_YEARLY,
 } from 'lib/plans/constants';
 import {
 	getSiteAdminUrl,
@@ -806,16 +806,16 @@ export const getProductCardData = ( state, productSlug ) => {
 				productCardList: products.security ? products.security.features : [],
 				productCardIcon: '/recommendations/cloud-icon.svg',
 			};
-		// Creator Plan
-		case PLAN_JETPACK_CREATOR_YEARLY:
+		// Growth Plan
+		case PLAN_JETPACK_GROWTH_YEARLY:
 			return {
-				productCardTitle: __( 'Grow and monetize your audience', 'jetpack' ),
+				productCardTitle: __( 'Grow and track your audience effortlessly', 'jetpack' ),
 				productCardCtaLink: getRedirectUrl( 'jetpack-recommendations-product-checkout', {
 					site: siteRawUrl,
 					path: productSlug,
 				} ),
-				productCardCtaText: __( 'Get Jetpack Creator', 'jetpack' ),
-				productCardList: products.creator ? products.creator.features : [],
+				productCardCtaText: __( 'Get Jetpack Growth', 'jetpack' ),
+				productCardList: products.growth ? products.growth.features : [],
 				productCardIcon: '/recommendations/creator-icon.svg',
 			};
 		case PLAN_JETPACK_ANTI_SPAM:

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/prompt-layout/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/prompt-layout/index.jsx
@@ -80,7 +80,7 @@ const PromptLayoutComponent = props => {
 
 PromptLayoutComponent.propTypes = {
 	answer: PropTypes.element.isRequired,
-	description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ).isRequired,
+	description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
 	illustration: PropTypes.string,
 	illustrationClassName: PropTypes.string,
 	progressBar: PropTypes.element,

--- a/projects/plugins/jetpack/_inc/client/recommendations/sidebar/product-spotlight/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/sidebar/product-spotlight/index.jsx
@@ -31,11 +31,13 @@ const ProductSpotlightComponent = props => {
 			<div className="jp-recommendations-discount-card__container">
 				<div className="jp-recommendations-discount-card__card">
 					<div className="jp-recommendations-discount-card__card-header">
-						<img
-							className="jp-recommendations-discount-card__header-icon"
-							src={ imagePath + productCardIcon }
-							alt=""
-						/>
+						{ productCardIcon && (
+							<img
+								className="jp-recommendations-discount-card__header-icon"
+								src={ imagePath + productCardIcon }
+								alt=""
+							/>
+						) }
 					</div>
 					<div className="jp-recommendations-discount-card__card-body">
 						<h3 className="jp-recommendations-discount-card__heading">{ productCardTitle }</h3>

--- a/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
@@ -5,8 +5,8 @@ import {
 	PLAN_JETPACK_VIDEOPRESS,
 	PLAN_JETPACK_ANTI_SPAM,
 	PLAN_JETPACK_BACKUP_T1_YEARLY,
-	PLAN_JETPACK_CREATOR_YEARLY,
 	getPlanClass,
+	PLAN_JETPACK_GROWTH_YEARLY,
 } from 'lib/plans/constants';
 import { assign, difference, get, isArray, isEmpty, mergeWith, union } from 'lodash';
 import {
@@ -65,7 +65,7 @@ import {
 	getSitePurchases,
 	hasActiveProductPurchase,
 	hasActiveSecurityPurchase,
-	hasActiveCreatorPurchase,
+	hasActiveGrowthPurchase,
 	siteHasFeature,
 	isFetchingSiteData,
 	hasActiveAntiSpamPurchase,
@@ -575,8 +575,8 @@ export const getProductSlugForStep = ( state, step ) => {
 			}
 			break;
 		case 'newsletter':
-			if ( ! hasActiveCreatorPurchase( state ) ) {
-				return PLAN_JETPACK_CREATOR_YEARLY;
+			if ( ! hasActiveGrowthPurchase( state ) ) {
+				return PLAN_JETPACK_GROWTH_YEARLY;
 			}
 			break;
 		case 'anti-spam':

--- a/projects/plugins/jetpack/_inc/client/state/site/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site/reducer.js
@@ -6,6 +6,7 @@ import {
 	isJetpackProduct,
 	isJetpackSearch,
 	isJetpackCreator,
+	isJetpackGrowth,
 	isJetpackSecurityBundle,
 	isJetpackAntiSpam,
 	isSecurityComparableJetpackLegacyPlan,
@@ -472,6 +473,18 @@ export function getActiveCreatorPurchase( state ) {
 }
 
 /**
+ * Searches active products for Growth product
+ *
+ * @param {object} state - Global state tree
+ * @return {object}       An active Growth product if one was found, undefined otherwise.
+ */
+export function getActiveGrowthPurchase( state ) {
+	return find( getActiveProductPurchases( state ), product =>
+		isJetpackGrowth( product.product_slug )
+	);
+}
+
+/**
  * Determines if the site has an active Creator product purchase
  *
  * @param {object} state - Global state tree
@@ -480,6 +493,19 @@ export function getActiveCreatorPurchase( state ) {
 export function hasActiveCreatorPurchase( state ) {
 	return (
 		!! getActiveCreatorPurchase( state ) ||
+		'is-complete-plan' === getPlanClass( getSitePlan( state ).product_slug )
+	);
+}
+
+/**
+ * Determines if the site has an active Growth product purchase
+ *
+ * @param {object} state - Global state tree
+ * @return {boolean}      True if the site has an active Growth product purchase, false otherwise.
+ */
+export function hasActiveGrowthPurchase( state ) {
+	return (
+		!! getActiveGrowthPurchase( state ) ||
 		'is-complete-plan' === getPlanClass( getSitePlan( state ).product_slug )
 	);
 }

--- a/projects/plugins/jetpack/changelog/replace-creator-recommendation-with-growth
+++ b/projects/plugins/jetpack/changelog/replace-creator-recommendation-with-growth
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Replace Creator recommendation with Growth in Dashboard"
+Replace Creator recommendation with Growth in Dashboard

--- a/projects/plugins/jetpack/changelog/replace-creator-recommendation-with-growth
+++ b/projects/plugins/jetpack/changelog/replace-creator-recommendation-with-growth
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Replace Creator recommendation with Growth in Dashboard"

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -5937,7 +5937,7 @@ endif;
 			'included_in_plans' => array( 'complete' ),
 			'features'          => array(
 				_x( 'Jetpack Social', 'Growth Product Feature', 'jetpack' ),
-				_x( 'Jetpack Stats (up to 100K site views)', 'Growth Product Feature', 'jetpack' ),
+				_x( 'Jetpack Stats (100K site views, upgradeable)', 'Growth Product Feature', 'jetpack' ),
 				_x( 'Unlimited subscriber imports', 'Growth Product Feature', 'jetpack' ),
 				_x( 'Earn more from your content', 'Growth Product Feature', 'jetpack' ),
 				_x( 'Accept payments with PayPal', 'Growth Product Feature', 'jetpack' ),

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -5928,6 +5928,23 @@ endif;
 			),
 		);
 
+		$products['growth'] = array(
+			'title'             => __( 'Jetpack Growth', 'jetpack' ),
+			'slug'              => 'jetpack_growth_yearly',
+			'description'       => __( 'Essential tools to help you grow your audience, track visitor engagement, and turn leads into loyal customers and advocates.', 'jetpack' ),
+			'show_promotion'    => true,
+			'discount_percent'  => 50,
+			'included_in_plans' => array( 'complete' ),
+			'features'          => array(
+				_x( 'Jetpack Social', 'Growth Product Feature', 'jetpack' ),
+				_x( 'Jetpack Stats (up to 100K site views)', 'Growth Product Feature', 'jetpack' ),
+				_x( 'Unlimited subscriber imports', 'Growth Product Feature', 'jetpack' ),
+				_x( 'Earn more from your content', 'Growth Product Feature', 'jetpack' ),
+				_x( 'Accept payments with PayPal', 'Growth Product Feature', 'jetpack' ),
+				_x( 'Increase earnings with WordAds', 'Growth Product Feature', 'jetpack' ),
+			),
+		);
+
 		$products['scan'] = array(
 			'title'             => __( 'Jetpack Scan', 'jetpack' ),
 			'slug'              => 'jetpack_scan',


### PR DESCRIPTION
## Proposed changes:

* Replace the Creator recommendation on the Dashboard with Growth

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: pbNhbs-bxX-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. On your site, connect your site and user account
3. Go to `/wp-admin/admin.php?page=jetpack#/recommendations/newsletter`
4. Ensure you see the Growth recommendation instead of Creator as the upsell
![image](https://github.com/user-attachments/assets/0a99c2ab-e60b-43ec-96c5-dbd8f748c56f)
5. Make sure the CTA works as intended and goes to checkout