### PR TITLE
Social: Added Linkedin permissions warning

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-linkedin-warning
+++ b/projects/js-packages/publicize-components/changelog/add-linkedin-warning
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added warnings when linkedin permission is cached

--- a/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
@@ -7,6 +7,7 @@ import {
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useMemo } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
+import Notice from '../../../components/notice';
 import { store as socialStore } from '../../../social-store';
 import { KeyringResult } from '../../../social-store/types';
 import { useSupportedServices } from '../../services/use-supported-services';
@@ -199,13 +200,15 @@ export function ConfirmationForm( { keyringResult, onComplete, isAdmin }: Confir
 							'jetpack'
 						) }
 					</p>
-					{ keyringResult && keyringResult.show_linkedin_warning && (
-						<p className={ styles[ 'header-text' ] }>
-							{ __(
-								`If you want to connect LinkedIn company pages and do not see them, please try again after 5 minutes.`,
-								'jetpack'
-							) }
-						</p>
+					{ keyringResult?.show_linkedin_warning && (
+						<Notice type={ 'warning' }>
+							<p>
+								{ __(
+									'If you want to connect LinkedIn company pages and do not see them, please try again after 5 minutes.',
+									'jetpack'
+								) }
+							</p>
+						</Notice>
 					) }
 					<form className={ styles.form } onSubmit={ onConfirm } id="connection-confirmation-form">
 						{

--- a/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
@@ -206,7 +206,7 @@ export function ConfirmationForm( { keyringResult, onComplete, isAdmin }: Confir
 						<Notice type={ 'warning' }>
 							<p>
 								{ __(
-									'We cannot retrieve which company pages you have access to. This is a known issue with the LinkedIn API. If you would like to connect a company page, please retry after 5 minutes. For more information, click',
+									'We could not retrieve which company pages you have access to. This is a known issue with the LinkedIn API. If you would like to connect a company page, please retry after 5 minutes.',
 									'jetpack'
 								) }
 								&nbsp;
@@ -214,7 +214,7 @@ export function ConfirmationForm( { keyringResult, onComplete, isAdmin }: Confir
 									key="linkedin-api-documentaion"
 									href={ getRedirectUrl( 'jetpack-linkedin-permissions-warning' ) }
 								>
-									{ __( 'here', 'jetpack' ) }
+									{ __( 'Learn more', 'jetpack' ) }
 								</ExternalLink>
 							</p>
 						</Notice>

--- a/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
@@ -199,6 +199,14 @@ export function ConfirmationForm( { keyringResult, onComplete, isAdmin }: Confir
 							'jetpack'
 						) }
 					</p>
+					{ keyringResult && keyringResult.show_linkedin_warning && (
+						<p className={ styles[ 'header-text' ] }>
+							{ __(
+								`If you want to connect LinkedIn company pages and do not see them, please try again after 5 minutes.`,
+								'jetpack'
+							) }
+						</p>
+					) }
 					<form className={ styles.form } onSubmit={ onConfirm } id="connection-confirmation-form">
 						{
 							//

--- a/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
@@ -206,7 +206,7 @@ export function ConfirmationForm( { keyringResult, onComplete, isAdmin }: Confir
 						<Notice type={ 'warning' }>
 							<p>
 								{ __(
-									"We can't retrieve which company pages you have access to. This is a known issue with the LinkedIn API. If you would like to connect a company page, please retry after 5 minutes. For more information, click",
+									'We cannot retrieve which company pages you have access to. This is a known issue with the LinkedIn API. If you would like to connect a company page, please retry after 5 minutes. For more information, click',
 									'jetpack'
 								) }
 								<ExternalLink

--- a/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
@@ -206,7 +206,7 @@ export function ConfirmationForm( { keyringResult, onComplete, isAdmin }: Confir
 						<Notice type={ 'warning' }>
 							<p>
 								{ __(
-									'We cannot retrieve which company pages you have access to. This is a known issue with the LinkedIn API. If you would like to connect a company page, please retry after 5 minutes. For more information, click',
+									'We cannot retrieve which company pages you have access to. This is a known issue with the LinkedIn API. If you would like to connect a company page, please retry after 5 minutes. For more information, clicku00A0',
 									'jetpack'
 								) }
 								<ExternalLink

--- a/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
@@ -209,7 +209,6 @@ export function ConfirmationForm( { keyringResult, onComplete, isAdmin }: Confir
 									'We cannot retrieve which company pages you have access to. This is a known issue with the LinkedIn API. If you would like to connect a company page, please retry after 5 minutes. For more information, click',
 									'jetpack'
 								) }
-								&nbsp;
 								<ExternalLink
 									key="linkedin-api-documentaion"
 									href={ getRedirectUrl( 'jetpack-linkedin-permissions-warning' ) }

--- a/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
@@ -206,14 +206,15 @@ export function ConfirmationForm( { keyringResult, onComplete, isAdmin }: Confir
 						<Notice type={ 'warning' }>
 							<p>
 								{ __(
-									'We cannot retrieve which company pages you have access to. This is a known issue with the LinkedIn API. If you would like to connect a company page, please retry after 5 minutes. For more information, clicku00A0',
+									'We cannot retrieve which company pages you have access to. This is a known issue with the LinkedIn API. If you would like to connect a company page, please retry after 5 minutes. For more information, click',
 									'jetpack'
 								) }
+								&nbsp;
 								<ExternalLink
 									key="linkedin-api-documentaion"
 									href={ getRedirectUrl( 'jetpack-linkedin-permissions-warning' ) }
 								>
-									{ __( 'here for more details.', 'jetpack' ) }
+									{ __( 'here', 'jetpack' ) }
 								</ExternalLink>
 							</p>
 						</Notice>

--- a/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
@@ -1,9 +1,11 @@
 import { Button, useGlobalNotices } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import {
 	BaseControl,
 	FlexBlock,
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
+import { ExternalLink } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useMemo } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
@@ -204,9 +206,15 @@ export function ConfirmationForm( { keyringResult, onComplete, isAdmin }: Confir
 						<Notice type={ 'warning' }>
 							<p>
 								{ __(
-									'If you want to connect LinkedIn company pages and do not see them, please try again after 5 minutes.',
+									"We can't retrieve which company pages you have access to. This is a known issue with the LinkedIn API. If you would like to connect a company page, please retry after 5 minutes. For more information, click",
 									'jetpack'
 								) }
+								<ExternalLink
+									key="linkedin-api-documentaion"
+									href={ getRedirectUrl( 'jetpack-linkedin-permissions-warning' ) }
+								>
+									{ __( 'here for more details.', 'jetpack' ) }
+								</ExternalLink>
 							</p>
 						</Notice>
 					) }

--- a/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
@@ -209,6 +209,7 @@ export function ConfirmationForm( { keyringResult, onComplete, isAdmin }: Confir
 									'We cannot retrieve which company pages you have access to. This is a known issue with the LinkedIn API. If you would like to connect a company page, please retry after 5 minutes. For more information, click',
 									'jetpack'
 								) }
+								&nbsp;
 								<ExternalLink
 									key="linkedin-api-documentaion"
 									href={ getRedirectUrl( 'jetpack-linkedin-permissions-warning' ) }

--- a/projects/js-packages/publicize-components/src/social-store/types.ts
+++ b/projects/js-packages/publicize-components/src/social-store/types.ts
@@ -84,7 +84,7 @@ export interface KeyringResult extends KeyringAdditionalUser {
 	label: string;
 	service: string;
 	status: ConnectionStatus;
-	show_linkedin_warning: boolean;
+	show_linkedin_warning?: boolean;
 }
 
 export type SocialImageGeneratorConfig = {

--- a/projects/js-packages/publicize-components/src/social-store/types.ts
+++ b/projects/js-packages/publicize-components/src/social-store/types.ts
@@ -84,6 +84,7 @@ export interface KeyringResult extends KeyringAdditionalUser {
 	label: string;
 	service: string;
 	status: ConnectionStatus;
+	show_linkedin_warning: boolean;
 }
 
 export type SocialImageGeneratorConfig = {

--- a/projects/plugins/jetpack/changelog/add-linkedin-warning
+++ b/projects/plugins/jetpack/changelog/add-linkedin-warning
@@ -1,0 +1,4 @@
+Significance: minor
+Type: major
+
+Added linkedin permissions warning

--- a/projects/plugins/social/changelog/add-linkedin-warning
+++ b/projects/plugins/social/changelog/add-linkedin-warning
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added linkedin warning


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added a disclaimer while connecting linkedin company pages and the pages don't get fetched due to permissions mismatch

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1731513854464099/1731396674.226669-slack-C02JJ910CNL
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See this diff D166469-code

<img width="1183" alt="Screenshot 2024-11-22 at 11 51 58 AM" src="https://github.com/user-attachments/assets/2e1e62b1-efaf-49fd-a63c-b7f8fa3a8399">
