### PR TITLE
Connection: allow using application password for site registration

### DIFF
--- a/projects/packages/connection/changelog/add-jetpack-app-site-registration
+++ b/projects/packages/connection/changelog/add-jetpack-app-site-registration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Allow using application password for site registration. 

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -221,7 +221,6 @@ class REST_Connector {
 					'registration_nonce' => array(
 						'description' => __( 'The registration nonce', 'jetpack-connection' ),
 						'type'        => 'string',
-						'required'    => true,
 					),
 					'redirect_uri'       => array(
 						'description' => __( 'URI of the admin page where the user should be redirected after connection flow', 'jetpack-connection' ),
@@ -791,7 +790,10 @@ class REST_Connector {
 	 * @return \WP_REST_Response|WP_Error
 	 */
 	public function connection_register( $request ) {
-		if ( ! wp_verify_nonce( $request->get_param( 'registration_nonce' ), 'jetpack-registration-nonce' ) ) {
+		$is_app = did_action( 'application_password_did_authenticate' );
+
+		// We don't need the nonce if application password was provided.
+		if ( ! $is_app && ! wp_verify_nonce( $request->get_param( 'registration_nonce' ), 'jetpack-registration-nonce' ) ) {
 			return new WP_Error( 'invalid_nonce', __( 'Unable to verify your request.', 'jetpack-connection' ), array( 'status' => 403 ) );
 		}
 

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -790,10 +790,8 @@ class REST_Connector {
 	 * @return \WP_REST_Response|WP_Error
 	 */
 	public function connection_register( $request ) {
-		$is_app = did_action( 'application_password_did_authenticate' );
-
-		// We don't need the nonce if application password was provided.
-		if ( ! $is_app && ! wp_verify_nonce( $request->get_param( 'registration_nonce' ), 'jetpack-registration-nonce' ) ) {
+		// Only require nonce if cookie authentication is used.
+		if ( did_action( 'auth_cookie_valid' ) && ! wp_verify_nonce( $request->get_param( 'registration_nonce' ), 'jetpack-registration-nonce' ) ) {
 			return new WP_Error( 'invalid_nonce', __( 'Unable to verify your request.', 'jetpack-connection' ), array( 'status' => 403 ) );
 		}
 


### PR DESCRIPTION
## Proposed changes:
* Adjust REST API to allow site registration without WP nonce if an application password is used.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/vulcan/issues/555

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Disconnect Jetpack.
2. Run the cURL command to register the site with WPCOM:
```bash
curl 'https://example.com/index.php?rest_route=/jetpack/v4/connection/register' -X POST -H 'Content-Type: application/json' --data-raw '{"from":"jetpack-app","plugin_slug":"jetpack"}'
```
Confirm you get the `invalid_user_permission_jetpack_connect` error along with error message and 401 status code.
3. User "Jetpack Debug" plugin's "REST API Tester" to send a REST request:
   * route: `jetpack/v4/connection/register`
   * method: POST
   * body: `{"from":"jetpack-app","plugin_slug":"jetpack"}`
4. Confirm you receive the 403 "invalid_nonce" error.
4. Go to "Users -> Profile" and create an application password.
5. Run the same cURL command with additional `-u username:app_password` in the end.
6. Confirm it responded with an authorization URL, and the site is now connected in site-only mode.