### PR TITLE
AI Assistant: Fix bug with error message when user is not over requests limit

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-is-over-limit
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-is-over-limit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: Fix bug with error message when user is not over requests limit

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/reducer.ts
@@ -118,10 +118,9 @@ export default function reducer( state = INITIAL_STATE, action ) {
 				requestsLimit = state.features.aiAssistant.requestsLimit as TierLimitProp;
 			}
 
-			const currentCount =
-				isUnlimitedTierPlan || isFreeTierPlan // @todo: update once tier data is available
-					? requestsCount
-					: state.features.aiAssistant.usagePeriod?.requestsCount;
+			const currentCount = isFreeTierPlan
+				? requestsCount // Free tier plan counts all time requests
+				: state.features.aiAssistant.usagePeriod?.requestsCount; // Unlimited tier plan counts usage period requests
 
 			/**
 			 * Compute the AI Assistant Feature data optimistically,

--- a/projects/plugins/jetpack/extensions/store/wordpress-com/test/index.ts
+++ b/projects/plugins/jetpack/extensions/store/wordpress-com/test/index.ts
@@ -101,7 +101,7 @@ describe( 'reducer', () => {
 					usagePeriod: {
 						currentStart: 'ai-assistant-tier-unlimited',
 						nextStart: '',
-						requestsCount: 4,
+						requestsCount: 2999,
 					},
 				},
 			},
@@ -120,7 +120,7 @@ describe( 'reducer', () => {
 					requireUpgrade: false,
 					usagePeriod: {
 						...initialState.features.aiAssistant.usagePeriod,
-						requestsCount: 5,
+						requestsCount: 3000,
 					},
 				},
 			},
@@ -136,7 +136,7 @@ describe( 'reducer', () => {
 				aiAssistant: {
 					hasFeature: true,
 					isOverLimit: false,
-					requestsCount: 2998,
+					requestsCount: 12345,
 					requestsLimit: UNLIMITED_PLAN_REQUESTS_LIMIT,
 					requireUpgrade: false,
 					upgradeType: 'default',
@@ -145,7 +145,7 @@ describe( 'reducer', () => {
 					usagePeriod: {
 						currentStart: 'ai-assistant-tier-unlimited',
 						nextStart: '',
-						requestsCount: 4,
+						requestsCount: 2998,
 					},
 				},
 			},
@@ -160,11 +160,11 @@ describe( 'reducer', () => {
 					...initialState.features.aiAssistant,
 					hasFeature: true,
 					isOverLimit: false,
-					requestsCount: 2999,
+					requestsCount: 12346,
 					requireUpgrade: false,
 					usagePeriod: {
 						...initialState.features.aiAssistant.usagePeriod,
-						requestsCount: 5,
+						requestsCount: 2999,
 					},
 				},
 			},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #40234

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Counts the usage period requests instead of all-time requests to check if user is over fair usage limit

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In your sandbox, simulate being over the fair usage limit on all-time requests, but below it on the current period
* On `trunk`, go to the editor and add an AI Assistant block
* Ask for something
* Check that the fair usage error notice is visible
* Checkout this branch and reload
* Send another request
* Check that the fair usage error notice is not visible anymore
* Change the simulated requests count of the current period to be over the fair usage limit and reload
* Send another request
* Check that the fair usage error notice is displayed correctly
