### PR TITLE
Jetpack AI: Moving transform list to table prompt to backend

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-transform-list-prompt-to-backend
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-transform-list-prompt-to-backend
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Moving transform list to table prompt to backend

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/dropdown-content.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/dropdown-content.tsx
@@ -21,6 +21,7 @@ import {
 	PROMPT_TYPE_SUMMARIZE,
 	PROMPT_TYPE_CHANGE_LANGUAGE,
 	PROMPT_TYPE_USER_PROMPT,
+	PROMPT_TYPE_TRANSFORM_LIST_TO_TABLE,
 } from '../../lib/prompt';
 import { capitalize } from '../../lib/utils/capitalize';
 import { I18nMenuDropdown, TRANSLATE_LABEL } from '../i18n-dropdown-control';
@@ -156,10 +157,9 @@ if ( getFeatureAvailability( 'ai-list-to-table-transform' ) ) {
 	quickActionsList[ 'core/list' ].push( {
 		name: __( 'Turn list into a table', 'jetpack' ),
 		key: 'turn-into-table',
-		aiSuggestion: PROMPT_TYPE_USER_PROMPT,
+		aiSuggestion: PROMPT_TYPE_TRANSFORM_LIST_TO_TABLE,
 		icon: blockTable,
 		options: {
-			userPrompt: 'make a table from this list, do not enclose the response in a code block',
 			alwaysTransformToAIAssistant: true,
 			rootParentOnly: true,
 		},

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/backend-prompt.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/backend-prompt.ts
@@ -13,6 +13,7 @@ import {
 	PROMPT_TYPE_SUMMARIZE,
 	PROMPT_TYPE_CHANGE_LANGUAGE,
 	PROMPT_TYPE_USER_PROMPT,
+	PROMPT_TYPE_TRANSFORM_LIST_TO_TABLE,
 	PromptTypeProp,
 	PromptItemProps,
 	BuildPromptProps,
@@ -109,6 +110,9 @@ export function buildMessagesForBackendPrompt( {
 		case PROMPT_TYPE_SUMMARIZE:
 		case PROMPT_TYPE_CHANGE_LANGUAGE:
 			relevantContent = isContentGenerated ? generatedContent : allPostContent;
+			break;
+		case PROMPT_TYPE_TRANSFORM_LIST_TO_TABLE:
+			relevantContent = postContentAbove;
 			break;
 		case PROMPT_TYPE_USER_PROMPT:
 			relevantContent = generatedContent || allPostContent;
@@ -224,6 +228,7 @@ export function mapInternalPromptTypeToBackendPromptType(
 		[ PROMPT_TYPE_SUMMARIZE ]: 'ai-assistant-summarize',
 		[ PROMPT_TYPE_CHANGE_LANGUAGE ]: 'ai-assistant-change-language',
 		[ PROMPT_TYPE_USER_PROMPT ]: 'ai-assistant-user-prompt',
+		[ PROMPT_TYPE_TRANSFORM_LIST_TO_TABLE ]: 'ai-assistant-transform-list-to-table',
 	};
 
 	// Handle specific Jetpack Form AI migration.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -21,6 +21,7 @@ export const PROMPT_TYPE_SUMMARIZE = 'summarize' as const;
 export const PROMPT_TYPE_CHANGE_LANGUAGE = 'changeLanguage' as const;
 export const PROMPT_TYPE_USER_PROMPT = 'userPrompt' as const;
 export const PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT = 'jetpackFormCustomPrompt' as const;
+export const PROMPT_TYPE_TRANSFORM_LIST_TO_TABLE = 'transformListToTable' as const;
 
 export const PROMPT_TYPE_LIST = [
 	PROMPT_TYPE_SUMMARY_BY_TITLE,
@@ -35,6 +36,7 @@ export const PROMPT_TYPE_LIST = [
 	PROMPT_TYPE_CHANGE_LANGUAGE,
 	PROMPT_TYPE_USER_PROMPT,
 	PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT,
+	PROMPT_TYPE_TRANSFORM_LIST_TO_TABLE,
 ] as const;
 
 export type PromptTypeProp = ( typeof PROMPT_TYPE_LIST )[ number ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #40154 

## Proposed changes:
* Frontend component. Moves the transform list-to-table prompt to the backend.
* Corresponding backend change: D166563-code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Check out this branch and rebuild Jetpack
* Sandbox the public API and apply this patch: D166563-code
* Enable the feature via a snippet or other means:
```
define( 'JETPACK_BLOCKS_VARIATION', 'beta' );
add_filter( 'list_to_table_transform_enabled', '__return_true' );
```

* On a top level list select the AI Assistant icon and click "Turn list into a table"
![Screenshot 2024-11-18 at 4 51 35 PM](https://github.com/user-attachments/assets/17d53609-13da-4e2d-8f31-fcd3a5646d48)
* The list should be transformed into an AI Assistant block, and the query automatically run. Upon completion it should have changed your list into a table:
![Screenshot 2024-11-18 at 4 51 56 PM](https://github.com/user-attachments/assets/af370859-58ef-43a6-801b-94bf4ee914bc)

