### PR TITLE
Janitorial: fix css cursor on AI prompt

### DIFF
--- a/projects/js-packages/ai-client/changelog/fix-ai-client-prompt-cursor
+++ b/projects/js-packages/ai-client/changelog/fix-ai-client-prompt-cursor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Client: fix prompt cursor to text when editable

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.scss
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.scss
@@ -64,6 +64,10 @@
 			color: var(--studio-gray-50, #646970);
 		}
 
+		&:not([contentEditable="false"]) {
+			cursor: text;
+		}
+
 		&[data-placeholder]:empty::before {
 			content: attr(data-placeholder);
 			color: var(--studio-gray-50, #646970);


### PR DESCRIPTION
Wee fix to use cursor: text on AI modal prompt

## Proposed changes:
`cursor: text`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1731963817851369/1731695409.176599-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
When invoking an AI image generator modal (logo, general image, featured image) as long as the prompt is ready to type a prompt its cursor should be `text` as in any regular input element