### PR TITLE
Charts: add skeleton for a new JS package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,12 @@ importers:
       jest:
         specifier: 29.7.0
         version: 29.7.0
+      jest-environment-jsdom:
+        specifier: 29.7.0
+        version: 29.7.0
+      jest-extended:
+        specifier: 4.0.2
+        version: 4.0.2(jest@29.7.0)
       typescript:
         specifier: 5.0.4
         version: 5.0.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,6 +291,15 @@ importers:
         specifier: 4.9.1
         version: 4.9.1(webpack@5.94.0)
 
+  projects/js-packages/charts:
+    devDependencies:
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0
+      typescript:
+        specifier: 5.0.4
+        version: 5.0.4
+
   projects/js-packages/components:
     dependencies:
       '@automattic/format-currency':

--- a/projects/js-packages/charts/.gitattributes
+++ b/projects/js-packages/charts/.gitattributes
@@ -1,0 +1,7 @@
+# Files not needed to be distributed in the package.
+.gitattributes    export-ignore
+node_modules      export-ignore
+
+# Files to exclude from the mirror repo
+/changelog/**     production-exclude
+/.eslintrc.cjs    production-exclude

--- a/projects/js-packages/charts/.gitignore
+++ b/projects/js-packages/charts/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+node_modules/

--- a/projects/js-packages/charts/CHANGELOG.md
+++ b/projects/js-packages/charts/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+

--- a/projects/js-packages/charts/README.md
+++ b/projects/js-packages/charts/README.md
@@ -1,0 +1,24 @@
+# charts
+
+Display charts within Automattic products.
+
+## How to install charts
+
+### Installation From Git Repo
+
+## Contribute
+
+## Get Help
+
+## Using this package in your WordPress plugin
+
+If you plan on using this package in your WordPress plugin, we would recommend that you use [Jetpack Autoloader](https://packagist.org/packages/automattic/jetpack-autoloader) as your autoloader. This will allow for maximum interoperability with other plugins that use this package as well.
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+charts is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)
+

--- a/projects/js-packages/charts/changelog/initial-version
+++ b/projects/js-packages/charts/changelog/initial-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Initial version.

--- a/projects/js-packages/charts/composer.json
+++ b/projects/js-packages/charts/composer.json
@@ -1,0 +1,42 @@
+{
+	"name": "automattic/charts",
+	"description": "Display charts within Automattic products.",
+	"type": "library",
+	"license": "GPL-2.0-or-later",
+	"require": {},
+	"require-dev": {
+		"automattic/jetpack-changelogger": "@dev"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"scripts": {
+		"test-coverage": [
+			"pnpm run test-coverage"
+		],
+		"test-js": [
+			"pnpm run test"
+		]
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../packages/*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"extra": {
+		"autotagger": true,
+		"npmjs-autopublish": true,
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/charts/compare/v${old}...v${new}"
+		},
+		"mirror-repo": "Automattic/charts"
+	}
+}

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "@automattic/jetpack-charts",
+	"version": "0.1.0-alpha",
+	"description": "Display charts within Automattic products.",
+	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/charts/#readme",
+	"bugs": {
+		"url": "https://github.com/Automattic/jetpack/labels/[JS Package] Charts"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Automattic/jetpack.git",
+		"directory": "projects/js-packages/charts"
+	},
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic",
+	"scripts": {
+		"test": "jest --config=tests/jest.config.cjs",
+		"test-coverage": "pnpm run test --coverage"
+	},
+	"devDependencies": {
+		"jest": "29.7.0",
+		"typescript": "5.0.4"
+	},
+	"exports": {
+		".": "./src/index.ts",
+		"./state": "./src/state",
+		"./action-types": "./src/state/action-types"
+	}
+}

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@automattic/jetpack-charts",
+	"name": "@automattic/charts",
 	"version": "0.1.0-alpha",
 	"description": "Display charts within Automattic products.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/charts/#readme",

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -19,6 +19,8 @@
 	},
 	"devDependencies": {
 		"jest": "29.7.0",
+		"jest-environment-jsdom": "29.7.0",
+		"jest-extended": "4.0.2",
 		"typescript": "5.0.4"
 	},
 	"exports": {

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -1,0 +1,2 @@
+// Put your code in this `src/` folder!
+// Feel free to delete or rename this file.

--- a/projects/js-packages/charts/tests/index.test.js
+++ b/projects/js-packages/charts/tests/index.test.js
@@ -1,0 +1,7 @@
+// We recommend using `jest` for testing. If you're testing React code, we recommend `@testing-library/react` and related packages.
+// Please match the versions used elsewhere in the monorepo.
+//
+// Please don't add new uses of `mocha`, `chai`, `sinon`, `enzyme`, and so on. We're trying to standardize on one testing framework.
+//
+// The default setup is to have files named like "name.test.js" (or .jsx, .ts, or .tsx) in this `tests/` directory.
+// But you could instead put them in `src/`, or put files like "name.js" (or .jsx, .ts, or .tsx) in `test` or `__tests__` directories somewhere.

--- a/projects/js-packages/charts/tests/index.test.js
+++ b/projects/js-packages/charts/tests/index.test.js
@@ -5,3 +5,14 @@
 //
 // The default setup is to have files named like "name.test.js" (or .jsx, .ts, or .tsx) in this `tests/` directory.
 // But you could instead put them in `src/`, or put files like "name.js" (or .jsx, .ts, or .tsx) in `test` or `__tests__` directories somewhere.
+
+// This is a placeholder test, new tests will be added soon
+const placeholderFunction = () => {
+	return true;
+};
+
+describe( 'placeholderTest', () => {
+	it( 'should be a function', () => {
+		expect( typeof placeholderFunction ).toBe( 'function' );
+	} );
+} );

--- a/projects/js-packages/charts/tests/jest.config.cjs
+++ b/projects/js-packages/charts/tests/jest.config.cjs
@@ -1,0 +1,7 @@
+const path = require( 'path' );
+const baseConfig = require( 'jetpack-js-tools/jest/config.base.js' );
+
+module.exports = {
+	...baseConfig,
+	rootDir: path.join( __dirname, '..' ),
+};

--- a/projects/js-packages/charts/tsconfig.json
+++ b/projects/js-packages/charts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "jetpack-js-tools/tsconfig.base.json",
+	"compilerOptions": {
+		"typeRoots": [ "./node_modules/@types/", "src/*" ],
+		"outDir": "./build/"
+	},
+	// List all sources and source-containing subdirs.
+	"include": [ "./src" ]
+}


### PR DESCRIPTION
## Proposed changes:

This package can then be used by multiple teams to handle charts within Automattic properties.

- [x] I created the matching mirror repo already.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* pfKYZu-1Jg-p2#comment-1530

## Does this pull request change what data or activity we track or use?
* No

## Testing instructions:

Not much to test yet. Is CI happy?
