### PR TITLE
Jetpack AI: fix feature control selection on image styles

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-image-feature-control-selection
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-image-feature-control-selection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: use the right feature control to pick the styles from

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
@@ -49,7 +49,7 @@ export default function useAiImage( {
 	autoStart?: boolean;
 } ) {
 	const { generateImageWithParameters } = useImageGenerator();
-	const { increaseRequestsCount } = useAiFeature();
+	const { increaseRequestsCount, featuresControl } = useAiFeature();
 	const { saveToMediaLibrary } = useSaveToMediaLibrary();
 	const { createNotice } = useDispatch( 'core/notices' );
 
@@ -58,8 +58,9 @@ export default function useAiImage( {
 	const [ current, setCurrent ] = useState( 0 );
 	const [ images, setImages ] = useState< CarrouselImages >( [ { generating: autoStart } ] );
 
-	const { featuresControl } = useAiFeature();
-	const imageFeatureControl = featuresControl?.image as ImageFeatureControl;
+	// map feature-to-control prop, if this goes over 2 options, make a hook for it
+	const featureControl = feature === FEATURED_IMAGE_FEATURE_NAME ? 'featured-image' : 'image';
+	const imageFeatureControl = featuresControl?.[ featureControl ] as ImageFeatureControl;
 	const imageStyles: Array< ImageStyleObject > = imageFeatureControl?.styles;
 
 	/* Merge the image data with the new data. */


### PR DESCRIPTION
Both Featured Image and General Image are using the styles provided by `image` feature.


## Proposed changes:
This PR fixes where each feature gets the styles from, allowing individual control of styles for each of them (as it was originally intended)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1732040780706559-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Patch D166696-code on your sandbox.

NOTE: after each change, you can run on devtools console `wp.data.dispatch('wordpress-com/plans').fetchAiAssistantFeature()` to refresh the AI Assistant data, but remember we hold a 60 secs cache on it. Might as well use that time to test an image generation?

Add this filter `add_filter( 'jetpack_ai_image_style_selector_enabled', '__return_false' );` and verify that the General Image generator modal doesn't show the styles dropdown but the Featured Image does.

Change the filter above to `add_filter( 'jetpack_ai_featured_image_style_selector_enabled', '__return_false' );`, now Featured Image generator modal should show the styles dropdown and General Image should not.
