### PR TITLE
Stats: no caching for purchases and usage endpoints

### DIFF
--- a/projects/packages/stats-admin/changelog/update-no-cache-for-purchases-and-usage
+++ b/projects/packages/stats-admin/changelog/update-no-cache-for-purchases-and-usage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stast: removed cache for purchases and usage endpoints

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -710,7 +710,8 @@ class REST_Controller {
 			'v2',
 			array( 'timeout' => 5 ),
 			null,
-			'wpcom'
+			'wpcom',
+			false
 		);
 	}
 
@@ -1185,7 +1186,12 @@ class REST_Controller {
 				Jetpack_Options::get_option( 'id' ),
 				$this->filter_and_build_query_string(
 					$req->get_query_params()
-				)
+				),
+				'v1.1',
+				array( 'timeout' => 10 ),
+				null,
+				'rest',
+				false
 			)
 		);
 	}

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -1186,13 +1186,13 @@ class REST_Controller {
 				Jetpack_Options::get_option( 'id' ),
 				$this->filter_and_build_query_string(
 					$req->get_query_params()
-				),
-				'v1.1',
-				array( 'timeout' => 10 ),
-				null,
-				'rest',
-				false
-			)
+				)
+			),
+			'v1.1',
+			array( 'timeout' => 10 ),
+			null,
+			'rest',
+			false
 		);
 	}
 


### PR DESCRIPTION
## Proposed changes:


* No caching for `jetpack/v4/stats-app/purchases` and `jetpack/v4/stats-app/usage` as the frontend is already caching + it affect new purchases a lot

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1731902929401049-slack-C82FZ5T4G

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

* Open a site without any plans
* Purchase a Growth plan through `https://wordpress.com/checkout/jetpack/jetpack_growth_monthly`
* Assign it to the site
* Open `/wp-admin/admin.php?page=stats`
* Ensure the plan is recognized straight away
* Scroll down to `Your Stats plan usage`
* Ensure usage is recognized as well