### PR TITLE
Fix DIY migration failing to fetch migration key and throwing 403 on page reload

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-migration-diy-throws-403-on-page-reload
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-migration-diy-throws-403-on-page-reload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix migration key fetch failing when DIY migration page is reloaded

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-site-migration-wpcom-migration-key.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-site-migration-wpcom-migration-key.php
@@ -73,10 +73,6 @@ class WPCOM_REST_API_V2_Endpoint_Site_Migration_WPCOM_Migration_Key extends WP_R
 			return false;
 		}
 
-		if ( 'read' === get_option( $this->key_is_read_option_name, false ) ) {
-			return false;
-		}
-
 		return true;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-site-migration-wpcom-migration-key.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-site-migration-wpcom-migration-key.php
@@ -12,13 +12,6 @@
  * @hide-in-jetpack
  */
 class WPCOM_REST_API_V2_Endpoint_Site_Migration_WPCOM_Migration_Key extends WP_REST_Controller {
-	/**
-	 * Option name that tracks wether the key has been read or not.
-	 * The only possible value for the option is 'read'.
-	 *
-	 * @var string
-	 */
-	protected $key_is_read_option_name = 'wpcom_site_migration_wpcom_migration_key_read';
 
 	/**
 	 * Class constructor
@@ -84,8 +77,6 @@ class WPCOM_REST_API_V2_Endpoint_Site_Migration_WPCOM_Migration_Key extends WP_R
 	private function get_migration_key() {
 		$wpcom_migration_settings = new WPCOMWPSettings();
 		$wpcom_migration_info     = new WPCOMInfo( $wpcom_migration_settings );
-
-		update_option( $this->key_is_read_option_name, 'read' );
 
 		return $wpcom_migration_info->getConnectionKey();
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/96510

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removed the 'read' check so that users can see the migration key multiple times

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Start a migration choosing the "I'll do it myself" option in the "How do you want to migrate?" step. This can be done following the steps:
  1.1.  Navigate to `/start`.
  1.2. Choose "Import existing content or website" in the goals step.
  1.3. Navigate through the flow, selecting to migrate from a WordPress site, and the "I'll do it myself" option.
3. When you are in the migration instructions screen, check the key by clicking the closed eye icon, and then close the window.
4. Navigate to `/sites`.
5. Click on the site with the pending migration.
6. Click on "Start your migration".
7. In the migration instructions page, make sure you see the error or at least the key does not load for you. Also check the network tab for a call made to `/wpcom-migration-key` API and make sure it has returned 403
8. Now apply this branch to your newly created site using the _Jetpack Beta Tester_ plugin following the instructions in https://github.com/Automattic/jetpack/pull/39377#issuecomment-2346557311. In this case, in the beta tester page, click the "Manage" button on the "_WordPress.com Features_" item, and then apply this branch
9. Now try steps 4-6 again. This time, you shouldn't see any error. You should also be able to see and copy the migration key


