### PR TITLE
Remove support links from several blocks

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-some-block-support-links
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-some-block-support-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Block Support Links: Removed support links for the group block and varients, to avoid an issue with the group placeholder displaying the block descriptions incorrectly.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/block-links-map.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/block-links-map.ts
@@ -358,20 +358,6 @@ const blockInfoMapping: { [ key: string ]: { link: string; postId: number } } = 
 export const blockInfoWithVariations: {
 	[ key: string ]: { [ key: string ]: { link: string; postId: number } };
 } = {
-	'core/group': {
-		group: {
-			link: 'https://wordpress.com/support/wordpress-editor/blocks/group-block/',
-			postId: 161882,
-		},
-		'group-row': {
-			link: 'https://wordpress.com/support/wordpress-editor/blocks/row-block/',
-			postId: 190036,
-		},
-		'group-stack': {
-			link: 'https://wordpress.com/support/wordpress-editor/blocks/row-block/',
-			postId: 190036,
-		},
-	},
 	'core/embed': {
 		soundcloud: {
 			link: 'https://wordpress.com/support/soundcloud-audio-player/',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/96079

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The group placeholder shows a choice of group blocks, hovering over them shows [object Object]. This is because this code transforms them into ReactElements (which isn't officially supported) and they get rendered as strings.

[Discussion is ongoing in Gutenberg about the best way to display the support links](https://github.com/WordPress/gutenberg/issues/49887). For now, to avoid the [object Object] problem, this pr removes the links from the blocks that trigger the problem.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

 1. Apply patch using instructions below
 2. Sandbox the site, and also  s0.wp.com s1.wp.com s2.wp.com
 3. Enter the post editor
 4. Choose a group block from the block inserter
 5. Hover over each of the different blocks offered and note that you get a description of the block.



https://github.com/user-attachments/assets/a35e0f1a-fd36-484a-a2af-8c72cf525b00

Before | After
-------|------
![image](https://github.com/user-attachments/assets/59509ccd-3259-4f79-bbd7-b009f90d73a6) | ![image](https://github.com/user-attachments/assets/72f3f9be-8a98-436c-98cc-646f5e9f8169)
