### PR TITLE
Repo Gardening: autolabel changes to Social previews in js package

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-social-previews
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-social-previews
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Labeling: automatically label changes to Social Previews made in the js package.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -173,6 +173,14 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft, isRevert )
 			keywords.add( '[Feature] Calypsoify' );
 		}
 
+		// Social Previews are now developed in a separate package.
+		const socialPreviews = file.match(
+			/^projects\/js-packages\/publicize-components\/src\/components\/social-previews\//
+		);
+		if ( socialPreviews !== null ) {
+			keywords.add( '[Extension] Social Previews' );
+		}
+
 		// Docker.
 		const docker = file.match( /^(projects\/plugins\/boost\/docker|tools\/docker)\// );
 		if ( docker !== null ) {


### PR DESCRIPTION
## Proposed changes:

Social Previews used to only live in their extension. That's no longer the case, so let's automate that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

No

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

This can be tested in a fork. Merge this branch to `trunk` in your fork, then open a PR making changes to one of the files in the Social Previews component, e.g. `projects/js-packages/publicize-components/src/components/social-previews/modal.js`. Ensure that the Social Previews label is automatically added.
