### PR TITLE
Repo Gardening > AI Labeling: bail when issue already has labels

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-ai-labeling-shortcircuit
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-ai-labeling-shortcircuit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Labeling: do not attempt to add feature labels to an issue where they were already provided

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/ai-labeling.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/ai-labeling.js
@@ -119,6 +119,14 @@ async function aiLabeling( payload, octokit ) {
 		return;
 	}
 
+	// If the issue already has [Feature] or [Feature Group] labels, bail.
+	if ( issueLabels.some( label => label.startsWith( '[Feature' ) ) ) {
+		debug(
+			`triage-issues > auto-label: Issue #${ number } already has [Feature] or [Feature Group] labels. Skipping.`
+		);
+		return;
+	}
+
 	if (
 		! issueLabels.includes( '[Experiment] AI labels added' ) &&
 		! issueLabels.includes( '[Type] Task' )


### PR DESCRIPTION
## Proposed changes:

If an issue already has Feature or Feature Group labels, we can assume that the person who opened the issue knew what label to add. No new label needs to be added at this point.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

This can be tested in a fork. Here is an example:

https://github.com/jeherve/jetpack/issues/179
