### PR TITLE
CRM: Fix PHP error (and logic) on dashboard Recent Activity avatar

### DIFF
--- a/projects/plugins/crm/admin/dashboard/main.page.php
+++ b/projects/plugins/crm/admin/dashboard/main.page.php
@@ -256,8 +256,13 @@ function jpcrm_render_dashboard_page() {
 						$last_x_ago = '';
 						foreach ( $latest_logs as $log ) {
 
-							$em     = zeroBS_customerEmail( $log['owner'] );
-							$avatar = zeroBSCRM_getGravatarURLfromEmail( $em, 28 );
+							$log_avatar  = '';
+							$log_wp_user = get_userdata( $log['owner'] );
+							// If the WP user still exists, grab their email and generate a gravatar URL.
+							if ( $log_wp_user ) {
+								$log_email  = $log_wp_user->user_email;
+								$log_avatar = zeroBSCRM_getGravatarURLfromEmail( $log_email, 28 );
+							}
 							$unixts = gmdate( 'U', strtotime( $log['created'] ) );
 							$diff   = human_time_diff( $unixts, current_time( 'timestamp' ) ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
 
@@ -289,7 +294,13 @@ function jpcrm_render_dashboard_page() {
 							}
 							?>
 								<div class="feed-item">
-									<img class="ui avatar img img-rounded" alt="<?php esc_attr_e( 'Contact Image', 'zero-bs-crm' ); ?>" src="<?php echo esc_url( $avatar ); ?>"/>
+									<?php
+									if ( $log_wp_user ) {
+										?>
+										<img class="ui avatar img img-rounded" alt="<?php esc_attr_e( 'Contact Image', 'zero-bs-crm' ); ?>" src="<?php echo esc_url( $log_avatar ); ?>"/>
+										<?php
+									}
+									?>
 									<div>
 										<?php echo esc_html( $logmetatype ); ?>
 										<div><?php echo wp_kses( $logmetashot, array( 'i' => array( 'class' => true ) ) ); ?></div>

--- a/projects/plugins/crm/admin/dashboard/main.page.php
+++ b/projects/plugins/crm/admin/dashboard/main.page.php
@@ -260,8 +260,7 @@ function jpcrm_render_dashboard_page() {
 							$log_wp_user = get_userdata( $log['owner'] );
 							// If the WP user still exists, grab their email and generate a gravatar URL.
 							if ( $log_wp_user ) {
-								$log_email  = $log_wp_user->user_email;
-								$log_avatar = zeroBSCRM_getGravatarURLfromEmail( $log_email, 28 );
+								$log_avatar = zeroBSCRM_getGravatarURLfromEmail( $log_wp_user->user_email, 28 );
 							}
 							$unixts = gmdate( 'U', strtotime( $log['created'] ) );
 							$diff   = human_time_diff( $unixts, current_time( 'timestamp' ) ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested

--- a/projects/plugins/crm/changelog/fix-crm-php_error_on_dash
+++ b/projects/plugins/crm/changelog/fix-crm-php_error_on_dash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: Show correct avatar for recent activity.

--- a/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
@@ -670,27 +670,27 @@ function jpcrm_inject_contacts( $contacts, $args ) {
 		$injected_contacts = array(
 			array(
 				'id'   => 0,
-				'name' => '<i class="fa fa-diamond green"></i>',
+				'name' => 'Project Oz 🌈',
 			),
 			array(
 				'id'   => -1,
-				'name' => 'Wizard of Oz',
+				'name' => 'Dorothy 👠',
 			),
 			array(
 				'id'   => -2,
-				'name' => 'Dorothy',
+				'name' => 'Toto the Dog 🐶',
 			),
 			array(
 				'id'   => -3,
-				'name' => 'Toto the Dog',
+				'name' => 'Scarecrow 🧑‍🌾',
 			),
 			array(
 				'id'   => -4,
-				'name' => 'Scarecrow',
+				'name' => 'Tin Man 🤖',
 			),
 			array(
 				'id'   => -5,
-				'name' => 'Tin Man',
+				'name' => 'Cowardly Lion 🦁',
 			),
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This makes sure the correct Gravatar URL is used for the dashboard's Recent Activity section.

## Proposed changes:
I spotted this when clicking through a new site:
```
PHP Deprecated:  hash(): Passing null to parameter #2 ($data) of type string is deprecated in /srv/htdocs/wp-content/plugins/zero-bs-crm-dev/includes/ZeroBSCRM.GeneralFuncs.php on line 704
```

Digging around, I realized that the Recent Activity avatar was grabbing the gravatar of the contact ID that matches the WP ID that made the change. In other words, if WPID 1 (the admin) makes a change, it'll show the gravatar of Contact ID 1 (an arbitrary contact.

In other words:
* If the contact has an email, the gravatar will be wrong.
* If the contact has no email, it'll throw up the PHP notice.

I adjusted the logic to correctly generate gravatar URL for the WP user instead. If the WP user no longer exists, the image won't be rendered.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

In a new site:
1. Set your user email to your actual email if it isn't already: `/wp-admin/profile.php`
2. Create a contact _without an email_ (contact ID 1).
3. Go to the dashboard: `/wp-admin/admin.php?page=zerobscrm-dash`
4. Add a valid email to the contact (one that has an associated gravatar).
5. Go to the dashboard: `/wp-admin/admin.php?page=zerobscrm-dash`

In `trunk`, step 2 will generate a PHP notice (for each item in the Recent Activity section) and step 4 will show the contact's gravatar instead of the WP user's gravatar.

In the `fix/crm/php_error_on_dash` branch, the correct gravatar will show.