### PR TITLE
Jetpack AI: Enable transform list to table functionality for all

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-enable-list-transform-to-table
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-enable-list-transform-to-table
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Enable transform list to table functionality for all

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/dropdown-content.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/dropdown-content.tsx
@@ -10,7 +10,6 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { getFeatureAvailability } from '../../../../blocks/ai-assistant/lib/utils/get-feature-availability';
 import { EXTENDED_BLOCKS } from '../../extensions/constants';
 import {
 	PROMPT_TYPE_CHANGE_TONE,
@@ -136,6 +135,16 @@ const quickActionsList: {
 					aiSuggestion: PROMPT_TYPE_MAKE_SHORTER,
 					icon: postContent,
 				},
+				{
+					name: __( 'Turn list into a table', 'jetpack' ),
+					key: 'turn-into-table',
+					aiSuggestion: PROMPT_TYPE_TRANSFORM_LIST_TO_TABLE,
+					icon: blockTable,
+					options: {
+						alwaysTransformToAIAssistant: true,
+						rootParentOnly: true,
+					},
+				},
 		  ]
 		: [
 				// Those actions are transformative in nature and are better suited for the AI Assistant block.
@@ -152,19 +161,6 @@ const quickActionsList: {
 				},
 		  ],
 };
-
-if ( getFeatureAvailability( 'ai-list-to-table-transform' ) ) {
-	quickActionsList[ 'core/list' ].push( {
-		name: __( 'Turn list into a table', 'jetpack' ),
-		key: 'turn-into-table',
-		aiSuggestion: PROMPT_TYPE_TRANSFORM_LIST_TO_TABLE,
-		icon: blockTable,
-		options: {
-			alwaysTransformToAIAssistant: true,
-			rootParentOnly: true,
-		},
-	} );
-}
 
 export type AiAssistantDropdownOnChangeOptionsArgProps = {
 	tone?: ToneProp;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #40264

## Proposed changes:
* Enabling the transform list to table functionality by no longer having the menu item behind a feature flag

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1732130768407509-slack-C02TQF5VAJD

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Verify that you do not have the `list_to_table_transform_enabled` filter enabled anywhere
* Create a new post and create a list
* On the top level list click the AI Assistant icon
* There should not be a "Turn list into table" item in the list
* Check out this branch and build Jetpack
* Reload your post and once again click the AI Assistant icon on the top level list
* There should now be an option "Turn list into table" in the menu
* Upon clicking this option the block should be converted to an AI Assistant block, and the list will be turned into a table
* If you click the trash icon ("Discard") the original list should be restored
* Bring up the AI Assistant menu again. Click "Accept" after converting the list and your original list should be replaced by the table.
