### PR TITLE
Boost: Deduplicate cornerstone URLs from other providers

### DIFF
--- a/projects/plugins/boost/app/lib/critical-css/source-providers/Source_Providers.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/Source_Providers.php
@@ -120,13 +120,18 @@ class Source_Providers {
 	 * @return array
 	 */
 	public function get_provider_sources( $context_posts = array() ) {
-		$sources = array();
+		$sources                        = array();
+		$flat_core_and_cornerstone_urls = array();
 
 		$wp_core_provider_urls = WP_Core_Provider::get_critical_source_urls( $context_posts );
-		$flat_wp_core_urls     = array();
 		foreach ( $wp_core_provider_urls as $urls ) {
-			$flat_wp_core_urls = array_merge( $flat_wp_core_urls, $urls );
+			$flat_core_and_cornerstone_urls = array_merge( $flat_core_and_cornerstone_urls, $urls );
 		}
+		$cornerstone_provider_urls = Cornerstone_Provider::get_critical_source_urls( $context_posts );
+		foreach ( $cornerstone_provider_urls as $urls ) {
+			$flat_core_and_cornerstone_urls = array_merge( $flat_core_and_cornerstone_urls, $urls );
+		}
+		$flat_core_and_cornerstone_urls = array_values( array_unique( $flat_core_and_cornerstone_urls ) );
 
 		foreach ( $this->get_providers() as $provider ) {
 			$provider_name = $provider::get_provider_name();
@@ -138,10 +143,10 @@ class Source_Providers {
 					continue;
 				}
 
-				// This removes the home and blog pages from the list of pages,
+				// This removes core and cornerstone URLs from the list of URLs,
 				// so they don't belong to two separate groups.
 				if ( ! in_array( $provider, array( WP_Core_Provider::class, Cornerstone_Provider::class ), true ) ) {
-					$urls = array_values( array_diff( $urls, $flat_wp_core_urls ) );
+					$urls = array_values( array_diff( $urls, $flat_core_and_cornerstone_urls ) );
 				}
 
 				if ( empty( $urls ) ) {

--- a/projects/plugins/boost/changelog/update-cornerstone-deduplicate
+++ b/projects/plugins/boost/changelog/update-cornerstone-deduplicate
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Deduplicate cornerstone pages from other providers.
+
+


### PR DESCRIPTION
## Proposed changes:
* Remove cornerstone URLs from being part of other providers.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Automattic/jpop-quill#357

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* On a fresh site, keep less than 10 pages.
* Mark a page as a cornerstone page.
* Make sure that page doesn't appear in the `singular_page` provider.
* This should work with the post type `post` or any other post type as well.
