### PR TITLE
Update @wordpress/editor and remove @types/wordpress__editor

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1039,8 +1039,8 @@ importers:
         specifier: 8.11.0
         version: 8.11.0(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/editor':
-        specifier: 14.11.0
-        version: 14.11.0(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 14.12.0
+        version: 14.12.0(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/element':
         specifier: 6.11.0
         version: 6.11.0
@@ -1111,9 +1111,6 @@ importers:
       '@types/react':
         specifier: 18.3.12
         version: 18.3.12
-      '@types/wordpress__editor':
-        specifier: 13.6.8
-        version: 13.6.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/babel-plugin-import-jsx-pragma':
         specifier: 5.11.0
         version: 5.11.0(@babel/core@7.26.0)
@@ -2897,8 +2894,8 @@ importers:
         specifier: 4.11.0
         version: 4.11.0
       '@wordpress/editor':
-        specifier: 14.11.0
-        version: 14.11.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 14.12.0
+        version: 14.12.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/element':
         specifier: 6.11.0
         version: 6.11.0
@@ -4051,9 +4048,6 @@ importers:
       '@types/wordpress__block-editor':
         specifier: 11.5.15
         version: 11.5.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/wordpress__editor':
-        specifier: 13.6.8
-        version: 13.6.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/api-fetch':
         specifier: 7.11.0
         version: 7.11.0
@@ -4076,8 +4070,8 @@ importers:
         specifier: 4.11.0
         version: 4.11.0
       '@wordpress/editor':
-        specifier: 14.11.0
-        version: 14.11.0(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 14.12.0
+        version: 14.12.0(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/escape-html':
         specifier: 3.11.0
         version: 3.11.0
@@ -7457,13 +7451,6 @@ packages:
   '@types/wordpress__blocks@12.5.14':
     resolution: {integrity: sha512-eXEnCRKYu+39KEJ/OYpoYxWTATxI+eJHd+meMGZ14hYydFtxA0Y8M7zJT8D8f4klBo8wINLvP7zrO8vYrjWjPQ==}
 
-  '@types/wordpress__editor@13.6.8':
-    resolution: {integrity: sha512-YTOfNUtqzdtXt0e8AMZvcWzXuPQ3vyGyHyo2/VgD8UEaB6cZDWWpYAFSBWvLCYAR8IV38+hvMr9SszoIXPZhpg==}
-
-  '@types/wordpress__media-utils@5.8.0':
-    resolution: {integrity: sha512-VVT45fQciZz5dPMM4ERy8W0BpmvqoLsEdXglXki1xj8FEr86IjhIN7fwsZRz0hm0onmMCUSUeJFlm/UhUA5hZA==}
-    deprecated: This is a stub types definition. @wordpress/media-utils provides its own type definitions, so you do not need this installed.
-
   '@types/wordpress__shortcode@2.3.6':
     resolution: {integrity: sha512-H8BVov7QWyLLoxCaI9QyZVC4zTi1mFkZ+eEKiXBCFlaJ0XV8UVfQk+cAetqD5mWOeWv2d4b8uzzyn0TTQ/ep2g==}
 
@@ -7784,8 +7771,8 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@wordpress/editor@14.11.0':
-    resolution: {integrity: sha512-XNwBZ54yQrZszum7OW4wAbFFs7lKlwTkj9ILnbc+a6fuCE9Pg6On/vbtDmRJVXi0TrRb+mY2VhNrsXJybdleQQ==}
+  '@wordpress/editor@14.12.0':
+    resolution: {integrity: sha512-HZ6iJn7hQ+o2YgjSR0nq6DUm4EcrGuZSu9IW2pT9XGe5oq5qCzen1jSBd5Mh6jk/HWwK8kuz6sKGLlTwuexyHA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
@@ -17441,29 +17428,6 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@types/wordpress__editor@13.6.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@types/react': 18.3.12
-      '@types/wordpress__block-editor': 11.5.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/wordpress__blocks': 12.5.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/wordpress__media-utils': 5.8.0
-      '@wordpress/components': 28.11.0(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/core-data': 7.11.0(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.11.0(react@18.3.1)
-      '@wordpress/element': 6.11.0
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - '@types/react-dom'
-      - bufferutil
-      - react
-      - react-dom
-      - supports-color
-      - utf-8-validate
-
-  '@types/wordpress__media-utils@5.8.0':
-    dependencies:
-      '@wordpress/media-utils': 5.11.0
-
   '@types/wordpress__shortcode@2.3.6': {}
 
   '@types/yargs-parser@21.0.3': {}
@@ -18614,7 +18578,7 @@ snapshots:
       '@wordpress/data': 10.11.0(react@18.3.1)
       '@wordpress/deprecated': 4.11.0
       '@wordpress/dom': 4.11.0
-      '@wordpress/editor': 14.11.0(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/editor': 14.12.0(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/element': 6.11.0
       '@wordpress/hooks': 4.11.0
       '@wordpress/html-entities': 4.11.0
@@ -18658,7 +18622,7 @@ snapshots:
       '@wordpress/data': 10.11.0(react@18.3.1)
       '@wordpress/deprecated': 4.11.0
       '@wordpress/dom': 4.11.0
-      '@wordpress/editor': 14.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/editor': 14.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/element': 6.11.0
       '@wordpress/hooks': 4.11.0
       '@wordpress/html-entities': 4.11.0
@@ -18686,7 +18650,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@wordpress/editor@14.11.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@wordpress/editor@14.12.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
       '@wordpress/a11y': 4.11.0
@@ -18745,7 +18709,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@wordpress/editor@14.11.0(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@wordpress/editor@14.12.0(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
       '@wordpress/a11y': 4.11.0
@@ -18804,7 +18768,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@wordpress/editor@14.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@wordpress/editor@14.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
       '@wordpress/a11y': 4.11.0

--- a/projects/js-packages/publicize-components/changelog/update-wordpress-editor
+++ b/projects/js-packages/publicize-components/changelog/update-wordpress-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed TS errors following @wordpress/editor update

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -37,7 +37,7 @@
 		"@wordpress/dataviews": "4.7.0",
 		"@wordpress/date": "5.11.0",
 		"@wordpress/edit-post": "8.11.0",
-		"@wordpress/editor": "14.11.0",
+		"@wordpress/editor": "14.12.0",
 		"@wordpress/element": "6.11.0",
 		"@wordpress/hooks": "4.11.0",
 		"@wordpress/html-entities": "4.11.0",

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -63,7 +63,6 @@
 		"@testing-library/user-event": "14.5.2",
 		"@types/jest": "29.5.12",
 		"@types/react": "18.3.12",
-		"@types/wordpress__editor": "13.6.8",
 		"@wordpress/babel-plugin-import-jsx-pragma": "5.11.0",
 		"babel-jest": "29.4.3",
 		"jest": "29.7.0",

--- a/projects/js-packages/publicize-components/src/components/form/use-auto-save-and-redirect.ts
+++ b/projects/js-packages/publicize-components/src/components/form/use-auto-save-and-redirect.ts
@@ -9,7 +9,6 @@ import { useCallback } from '@wordpress/element';
  * @return {Function} Function to handle autosaving and redirecting.
  */
 export function useAutoSaveAndRedirect(): React.DOMAttributes< HTMLAnchorElement >[ 'onClick' ] {
-	// @ts-expect-error -- `@wordpress/editor` is a nightmare to work with TypeScript
 	const { isEditedPostDirty } = useSelect( editorStore, [] );
 	const { autosave } = useDispatch( editorStore );
 

--- a/projects/js-packages/publicize-components/src/components/post-publish-share-status/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-share-status/index.tsx
@@ -23,7 +23,6 @@ export function PostPublishShareStatus() {
 		const _editorStore = select( editorStore );
 
 		return {
-			// @ts-expect-error -- `@wordpress/editor` is a nightmare to work with TypeScript
 			isPostPublished: _editorStore.isCurrentPostPublished(),
 		};
 	}, [] );

--- a/projects/js-packages/publicize-components/src/components/share-buttons/useShareButtonText.ts
+++ b/projects/js-packages/publicize-components/src/components/share-buttons/useShareButtonText.ts
@@ -1,4 +1,5 @@
 import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import { useCallback } from '@wordpress/element';
 import { usePostMeta } from '../../hooks/use-post-meta';
 
@@ -11,9 +12,7 @@ export function useShareButtonText() {
 	const { shareMessage } = usePostMeta();
 	const { message, link } = useSelect(
 		select => {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const getEditedPostAttribute = ( select( 'core/editor' ) as any )
-				.getEditedPostAttribute satisfies ( attribute: string ) => unknown;
+			const { getEditedPostAttribute } = select( editorStore );
 
 			return {
 				link: getEditedPostAttribute( 'link' ),

--- a/projects/js-packages/publicize-components/src/components/share-status/retry.tsx
+++ b/projects/js-packages/publicize-components/src/components/share-status/retry.tsx
@@ -27,7 +27,6 @@ export type RetryProps = {
  */
 export function Retry( { shareItem }: RetryProps ) {
 	const { recordEvent } = useAnalytics();
-	// @ts-expect-error -- `@wordpress/editor` is badly typed, causes issue in CI
 	const postId = useSelect( select => select( editorStore ).getCurrentPostId(), [] );
 	const connections = useSelect( select => select( socialStore ).getConnections(), [] );
 

--- a/projects/js-packages/publicize-components/src/components/social-previews/bluesky.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-previews/bluesky.tsx
@@ -9,7 +9,6 @@ import { store, CONNECTION_SERVICE_BLUESKY } from '../../social-store';
 const BlueskyPreview = props => {
 	const { message } = useSocialMediaMessage();
 	const { content, siteName } = useSelect( select => {
-		// @ts-expect-error -- `@wordpress/editor` is a nightmare to work with TypeScript
 		const { getEditedPostAttribute } = select( editorStore );
 		// @ts-expect-error -- It says, "Property 'getUnstableBase' does not exist..." but it does
 		const { getUnstableBase } = select( coreStore );

--- a/projects/js-packages/publicize-components/src/hooks/use-post-can-use-sig/index.ts
+++ b/projects/js-packages/publicize-components/src/hooks/use-post-can-use-sig/index.ts
@@ -10,9 +10,7 @@ import { features } from '../../utils/constants';
  */
 export function usePostCanUseSig() {
 	const isJetpackSocialNote = useSelect( select => {
-		const currentPostType = select( editorStore )
-			// @ts-expect-error -- `@wordpress/editor` is a nightmare to work with TypeScript - getCurrentPostType exists on the editor store
-			.getCurrentPostType();
+		const currentPostType = select( editorStore ).getCurrentPostType();
 
 		return 'jetpack-social-note' === currentPostType;
 	}, [] );

--- a/projects/js-packages/publicize-components/src/hooks/use-post-pre-publish-value/index.ts
+++ b/projects/js-packages/publicize-components/src/hooks/use-post-pre-publish-value/index.ts
@@ -13,11 +13,7 @@ import { useEffect, useRef, useState } from '@wordpress/element';
  * @return {V} The preserved value.
  */
 export function usePostPrePublishValue< V >( value: V ) {
-	const isPublishing = useSelect(
-		// @ts-expect-error -- `@wordpress/editor` is a nightmare to work with TypeScript
-		select => select( editorStore ).isPublishingPost(),
-		[]
-	);
+	const isPublishing = useSelect( select => select( editorStore ).isPublishingPost(), [] );
 
 	const [ currentValue, setCurrentValue ] = useState( value );
 

--- a/projects/packages/videopress/changelog/update-wordpress-editor
+++ b/projects/packages/videopress/changelog/update-wordpress-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed TS errors following @wordpress/editor update

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -74,7 +74,7 @@
 		"@wordpress/data": "10.11.0",
 		"@wordpress/date": "5.11.0",
 		"@wordpress/dom-ready": "4.11.0",
-		"@wordpress/editor": "14.11.0",
+		"@wordpress/editor": "14.12.0",
 		"@wordpress/element": "6.11.0",
 		"@wordpress/html-entities": "4.11.0",
 		"@wordpress/i18n": "5.11.0",

--- a/projects/plugins/jetpack/changelog/update-wordpress-editor
+++ b/projects/plugins/jetpack/changelog/update-wordpress-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fixed TS errors following @wordpress/editor update

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -10,6 +10,7 @@ import { ThemeProvider } from '@automattic/jetpack-components';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button, Modal, Icon } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { external } from '@wordpress/icons';
@@ -24,7 +25,6 @@ import useTranscriptionInserter from './hooks/use-transcription-inserter';
 /**
  * Types
  */
-import type { Block } from '@automattic/jetpack-ai-client';
 import type {
 	RecordingState,
 	TranscriptionState,
@@ -62,9 +62,7 @@ export default function VoiceToContentEdit( { clientId } ) {
 		removeBlock: ( id: string ) => void;
 	};
 
-	const { getBlocks } = useSelect( select => select( 'core/editor' ), [] ) as {
-		getBlocks: () => Block[];
-	};
+	const { getBlocks } = useSelect( select => select( editorStore ), [] );
 
 	const destroyBlock = useCallback( () => {
 		// Remove the block from the editor

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -38,7 +38,6 @@ import './style.scss';
  * Types
  */
 import type { CoreSelect, JetpackSettingsContentProps } from './types';
-import type * as EditorSelectors from '@wordpress/editor/store/selectors';
 
 const debug = debugFactory( 'jetpack-ai-assistant-plugin:sidebar' );
 /**
@@ -163,7 +162,7 @@ export default function AiAssistantPluginSidebar() {
 	const { tracks } = useAnalytics();
 
 	const isViewable = useSelect( select => {
-		const postTypeName = ( select( editorStore ) as typeof EditorSelectors ).getCurrentPostType();
+		const postTypeName = select( editorStore ).getCurrentPostType();
 		// The coreStore select type lacks the getPostType method, so we need to cast it to the correct type
 		const postTypeObject = ( select( coreStore ) as unknown as CoreSelect ).getPostType(
 			postTypeName

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/feedback/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/feedback/index.tsx
@@ -5,6 +5,7 @@ import { useAiSuggestions } from '@automattic/jetpack-ai-client';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import React from 'react';
@@ -14,10 +15,6 @@ import React from 'react';
 import usePostContent from '../../hooks/use-post-content';
 import AiAssistantModal from '../modal';
 import './style.scss';
-/**
- * Types
- */
-import type * as EditorSelectors from '@wordpress/editor/store/selectors';
 
 export default function Feedback( {
 	disabled = false,
@@ -32,10 +29,7 @@ export default function Feedback( {
 	const [ suggestion, setSuggestion ] = useState< Array< React.JSX.Element | null > >( [ null ] );
 	const { tracks } = useAnalytics();
 
-	const postId = useSelect(
-		select => ( select( 'core/editor' ) as typeof EditorSelectors ).getCurrentPostId(),
-		[]
-	);
+	const postId = useSelect( select => select( editorStore ).getCurrentPostId(), [] );
 	const postContent = usePostContent();
 
 	const toggleFeedbackModal = () => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -27,7 +27,6 @@ import { AiExcerptControl } from '../../components/ai-excerpt-control';
 import type { LanguageProp } from '../../../../blocks/ai-assistant/components/i18n-dropdown-control';
 import type { ToneProp } from '../../../../blocks/ai-assistant/components/tone-dropdown-control';
 import type { AiModelTypeProp, PromptProp } from '@automattic/jetpack-ai-client';
-import type * as EditorSelectors from '@wordpress/editor/store/selectors';
 
 import './style.scss';
 
@@ -45,9 +44,7 @@ type ContentLensMessageContextProps = {
 
 function AiPostExcerpt() {
 	const { excerpt, postId } = useSelect( select => {
-		const { getEditedPostAttribute, getCurrentPostId } = select(
-			editorStore
-		) as typeof EditorSelectors;
+		const { getEditedPostAttribute, getCurrentPostId } = select( editorStore );
 
 		return {
 			excerpt: getEditedPostAttribute( 'excerpt' ) ?? '',
@@ -109,7 +106,7 @@ function AiPostExcerpt() {
 
 	// Pick raw post content
 	const postContent = useSelect( select => {
-		const content = ( select( editorStore ) as typeof EditorSelectors ).getEditedPostContent();
+		const content = select( editorStore ).getEditedPostContent();
 		if ( ! content ) {
 			return '';
 		}
@@ -298,7 +295,7 @@ ${ postContent }
 
 export const PluginDocumentSettingPanelAiExcerpt = () => {
 	const isExcerptUsedAsDescription = useSelect( select => {
-		const { getCurrentPostType } = select( editorStore ) as typeof EditorSelectors;
+		const { getCurrentPostType } = select( editorStore );
 		const postType = getCurrentPostType();
 		const isTemplateOrTemplatePart = postType === 'wp_template' || postType === 'wp_template_part';
 		const isPattern = postType === 'wp_block';

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -305,14 +305,18 @@ export const PluginDocumentSettingPanelAiExcerpt = () => {
 		return null;
 	}
 	return (
-		<PostTypeSupportCheck supportKeys="excerpt">
-			<PluginDocumentSettingPanel
-				className={ isBetaExtension( 'ai-content-lens' ) ? 'is-beta-extension inset-shadow' : '' }
-				name="ai-content-lens-plugin"
-				title={ __( 'Excerpt', 'jetpack' ) }
-			>
-				<AiPostExcerpt />
-			</PluginDocumentSettingPanel>
-		</PostTypeSupportCheck>
+		<PostTypeSupportCheck
+			supportKeys="excerpt"
+			// @ts-expect-error Types for PostTypeSupportCheck children are not correct. It's `Element` instead of `ReactElement`.
+			children={
+				<PluginDocumentSettingPanel
+					className={ isBetaExtension( 'ai-content-lens' ) ? 'is-beta-extension inset-shadow' : '' }
+					name="ai-content-lens-plugin"
+					title={ __( 'Excerpt', 'jetpack' ) }
+				>
+					<AiPostExcerpt />
+				</PluginDocumentSettingPanel>
+			}
+		/>
 	);
 };

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
@@ -1,7 +1,6 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import apiFetch from '@wordpress/api-fetch';
 import { dispatch, select } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { waitFor } from '../../wait-for';
@@ -197,7 +196,8 @@ const isMediaSourceConnected = async ( source: MediaSource ) =>
  * @return {boolean} True if the inserter is opened false otherwise.
  */
 const isInserterOpened = (): boolean => {
-	const selectIsInserterOpened = select( editorStore )?.isInserterOpened;
+	/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+	const selectIsInserterOpened = ( select( 'core/editor' ) as any )?.isInserterOpened;
 
 	const editorIsInserterOpened = selectIsInserterOpened?.();
 

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
@@ -1,6 +1,7 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import apiFetch from '@wordpress/api-fetch';
 import { dispatch, select } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { waitFor } from '../../wait-for';
@@ -196,8 +197,7 @@ const isMediaSourceConnected = async ( source: MediaSource ) =>
  * @return {boolean} True if the inserter is opened false otherwise.
  */
 const isInserterOpened = (): boolean => {
-	/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-	const selectIsInserterOpened = ( select( 'core/editor' ) as any )?.isInserterOpened;
+	const selectIsInserterOpened = select( editorStore )?.isInserterOpened;
 
 	const editorIsInserterOpened = selectIsInserterOpened?.();
 

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -144,7 +144,7 @@
 		"@wordpress/components": "28.11.0",
 		"@wordpress/core-data": "7.11.0",
 		"@wordpress/dom-ready": "4.11.0",
-		"@wordpress/editor": "14.11.0",
+		"@wordpress/editor": "14.12.0",
 		"@wordpress/escape-html": "3.11.0",
 		"@wordpress/keycodes": "4.11.0",
 		"@wordpress/notices": "5.11.0",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -136,7 +136,6 @@
 		"@types/jest": "29.5.12",
 		"@types/react": "18.3.12",
 		"@types/wordpress__block-editor": "11.5.15",
-		"@types/wordpress__editor": "13.6.8",
 		"@wordpress/api-fetch": "7.11.0",
 		"@wordpress/babel-plugin-import-jsx-pragma": "5.11.0",
 		"@wordpress/blob": "4.11.0",


### PR DESCRIPTION
Following the PR I created in Gutenberg ([Fix TS types for editor package](https://github.com/WordPress/gutenberg/pull/66754)), we no longer need buggy assertions in TS code.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update `@wordpress/editor` to the latest version
* Remove `@types/wordpress__editor` which is no longer needed
* Fix the TS error following the update

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Just check if CI is happy

## What is next?
Following this PR we should replace the string selector (`'core/editor'`) with `store` from `@wordpress/editor` to ensure that the types work correctly. For example, in `projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx`.

CC: @Automattic/jetpack-agora 