### PR TITLE
Use custom button for threat details toggle

### DIFF
--- a/projects/js-packages/components/components/threat-modal/fixer-state-notice.tsx
+++ b/projects/js-packages/components/components/threat-modal/fixer-state-notice.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { useMemo } from 'react';
 import styles from './styles.module.scss';
 import ThreatNotice from './threat-notice';
 
@@ -18,29 +19,39 @@ const FixerStateNotice = ( {
 }: {
 	fixerState: { inProgress: boolean; error: boolean; stale: boolean };
 } ) => {
-	let status: 'error' | 'success' | undefined;
-	let title: string | undefined;
-	let content: string | undefined;
+	const { status, title, content } = useMemo( () => {
+		if ( fixerState.error ) {
+			return {
+				status: 'error' as const,
+				title: __( 'An error occurred auto-fixing this threat', 'jetpack' ),
+				content: __(
+					'Jetpack encountered a filesystem error while attempting to auto-fix this threat. Please try again later or contact support.',
+					'jetpack'
+				),
+			};
+		}
 
-	if ( fixerState.error ) {
-		status = 'error';
-		title = __( 'An error occurred auto-fixing this threat', 'jetpack' );
-		content = __(
-			'Jetpack encountered a filesystem error while attempting to auto-fix this threat. Please try again later or contact support.',
-			'jetpack'
-		);
-	} else if ( fixerState.stale ) {
-		status = 'error';
-		title = __( 'The auto-fixer is taking longer than expected', 'jetpack' );
-		content = __(
-			'Jetpack has been attempting to auto-fix this threat for too long, and something may have gone wrong. Please try again later or contact support.',
-			'jetpack'
-		);
-	} else if ( fixerState.inProgress ) {
-		status = 'success';
-		title = __( 'An auto-fixer is in progress', 'jetpack' );
-		content = __( 'Please wait while Jetpack auto-fixes the threat.', 'jetpack' );
-	}
+		if ( fixerState.stale ) {
+			return {
+				status: 'error' as const,
+				title: __( 'The auto-fixer is taking longer than expected', 'jetpack' ),
+				content: __(
+					'Jetpack has been attempting to auto-fix this threat for too long, and something may have gone wrong. Please try again later or contact support.',
+					'jetpack'
+				),
+			};
+		}
+
+		if ( fixerState.inProgress ) {
+			return {
+				status: 'success' as const,
+				title: __( 'An auto-fixer is in progress', 'jetpack' ),
+				content: __( 'Please wait while Jetpack auto-fixes the threat.', 'jetpack' ),
+			};
+		}
+
+		return {};
+	}, [ fixerState ] );
 
 	return title ? (
 		<div className={ styles[ 'fixer-notice' ] }>

--- a/projects/js-packages/components/components/threat-modal/styles.module.scss
+++ b/projects/js-packages/components/components/threat-modal/styles.module.scss
@@ -14,15 +14,24 @@
 		justify-content: flex-start;
 		align-items: center;
 	}
+}
 
-	&__closed {
-		max-height: 0;
-		overflow: hidden;
-	}
+.section__toggle {
+	border: none;
+	background: none;
+	padding: 0;
+	font-size: 1rem;
+	font-weight: 600;
+	cursor: pointer;
+	display: flex;
+	gap: calc( var( --spacing-base ) / 2 ); // 4px
+	align-items: center;
+	transition: text-underline-offset 0.2s;
 
-	&__open {
-		max-height: fit-content;
-		overflow: hidden;
+	&:hover {
+		text-decoration: underline;
+		text-decoration-thickness: 2px;
+		text-underline-offset: calc( var( --spacing-base ) / 2 ); // 4px
 	}
 }
 

--- a/projects/js-packages/components/components/threat-modal/threat-technical-details.tsx
+++ b/projects/js-packages/components/components/threat-modal/threat-technical-details.tsx
@@ -1,7 +1,7 @@
-import { Text, Button } from '@automattic/jetpack-components';
+import { Text } from '@automattic/jetpack-components';
 import { Threat } from '@automattic/jetpack-scan';
 import { __ } from '@wordpress/i18n';
-import { chevronDown, chevronUp } from '@wordpress/icons';
+import { chevronDown, chevronUp, Icon } from '@wordpress/icons';
 import { useState, useCallback } from 'react';
 import DiffViewer from '../diff-viewer';
 import MarkedLines from '../marked-lines';
@@ -29,25 +29,35 @@ const ThreatTechnicalDetails = ( { threat }: { threat: Threat } ): JSX.Element =
 	return (
 		<div className={ styles.section }>
 			<div className={ styles.section__title }>
-				<Text variant="title-small">{ __( 'The technical details', 'jetpack' ) }</Text>
-				<Button
-					variant="icon"
+				<button
 					className={ styles.section__toggle }
-					icon={ open ? chevronUp : chevronDown }
 					aria-expanded={ open }
+					aria-controls={ `threat-details-${ threat.id }` }
 					onClick={ toggleOpen }
-				/>
+				>
+					<span>
+						{ open
+							? __( 'Hide the technical details', 'jetpack' )
+							: __( 'Show the technical details', 'jetpack' ) }
+					</span>
+					<Icon icon={ open ? chevronUp : chevronDown } size={ 24 } />
+				</button>
 			</div>
-			<div className={ open ? styles.section__open : styles.section__closed }>
-				{ threat.filename && (
-					<>
-						<Text>{ __( 'Threat found in file:', 'jetpack' ) }</Text>
-						<pre className={ styles.filename }>{ threat.filename }</pre>
-					</>
-				) }
-				{ threat.context && <MarkedLines context={ threat.context } /> }
-				{ threat.diff && <DiffViewer diff={ threat.diff } /> }
-			</div>
+			{ open && (
+				<div
+					className={ open ? styles.section__open : styles.section__closed }
+					id={ `threat-details-${ threat.id }` }
+				>
+					{ threat.filename && (
+						<>
+							<Text>{ __( 'Threat found in file:', 'jetpack' ) }</Text>
+							<pre className={ styles.filename }>{ threat.filename }</pre>
+						</>
+					) }
+					{ threat.context && <MarkedLines context={ threat.context } /> }
+					{ threat.diff && <DiffViewer diff={ threat.diff } /> }
+				</div>
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Uses custom styles for the "show threat details" button.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack/pull/40214

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* N/A

