### PR TITLE
Social | Make post share status immediately available on page load

### DIFF
--- a/projects/packages/publicize/changelog/update-social-load-share-status-from-initial-state
+++ b/projects/packages/publicize/changelog/update-social-load-share-status-from-initial-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Social | Added initial post share status to the initial state

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -147,14 +147,20 @@ class Publicize_Script_Data {
 
 		$is_wpcom = ( new Host() )->is_wpcom_platform();
 
+		$post = get_post();
+
+		$share_status = array();
+
+		if ( Utils::should_block_editor_have_social() && $post ) {
+			$share_status[ $post->ID ] = self::publicize()->get_post_share_status( $post->ID );
+		}
+
 		return array(
 			'connectionData' => array(
 				// We do not have this method on WPCOM Publicize class yet.
 				'connections' => ! $is_wpcom ? self::publicize()->get_all_connections_for_user() : array(),
 			),
-			'shareStatus'    => array(
-				// Here goes the share status data for posts with key as post ID.
-			),
+			'shareStatus'    => $share_status,
 		);
 	}
 

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -751,4 +751,50 @@ class Publicize extends Publicize_Base {
 
 		return $flags;
 	}
+
+	/**
+	 * Gets the share status for a post.
+	 *
+	 * @param int $post_id The post ID.
+	 */
+	public function get_post_share_status( $post_id ) {
+		$shares = get_post_meta( $post_id, REST_Controller::SOCIAL_SHARES_POST_META_KEY, true );
+
+		// If the data is not an array, it means that sharing is not done yet.
+		$done = is_array( $shares );
+
+		if ( $done ) {
+			// The site could have multiple admins, editors and authors connected. Load shares information that only the current user has access to.
+			$connection_ids = array_map(
+				function ( $connection ) {
+					if ( isset( $connection['connection_id'] ) ) {
+						return (int) $connection['connection_id'];
+					}
+					return 0;
+				},
+				$this->get_all_connections_for_user()
+			);
+
+			$shares = array_filter(
+				$shares,
+				function ( $share ) use ( $connection_ids ) {
+					return in_array( (int) $share['connection_id'], $connection_ids, true );
+				}
+			);
+
+			usort(
+				$shares,
+				function ( $a, $b ) {
+					return $b['timestamp'] - $a['timestamp'];
+				}
+			);
+
+			$shares = array_values( $shares );
+		}
+
+		return array(
+			'shares' => $done ? $shares : array(),
+			'done'   => $done,
+		);
+	}
 }

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -788,8 +788,6 @@ class Publicize extends Publicize_Base {
 					return $b['timestamp'] - $a['timestamp'];
 				}
 			);
-
-			$shares = array_values( $shares );
 		}
 
 		return array(

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -692,40 +692,10 @@ class REST_Controller {
 	 * @param WP_REST_Request $request The request object.
 	 */
 	public function get_post_share_status( WP_REST_Request $request ) {
+		global $publicize;
+
 		$post_id = $request->get_param( 'post_id' );
 
-		$shares = get_post_meta( $post_id, self::SOCIAL_SHARES_POST_META_KEY, true );
-
-		// If the data is not an array, it means that sharing is not done yet.
-		$done = is_array( $shares );
-
-		if ( $done ) {
-			// The site could have multiple admins, editors and authors connected. Load shares information that only the current user has access to.
-			global $publicize;
-			$connection_ids = array_map(
-				function ( $connection ) {
-					if ( isset( $connection['connection_id'] ) ) {
-						return (int) $connection['connection_id'];
-					}
-					return 0;
-				},
-				$publicize->get_all_connections_for_user()
-			);
-			$shares         = array_values(
-				array_filter(
-					$shares,
-					function ( $share ) use ( $connection_ids ) {
-						return in_array( (int) $share['connection_id'], $connection_ids, true );
-					}
-				)
-			);
-		}
-
-		return rest_ensure_response(
-			array(
-				'shares' => $done ? $shares : array(),
-				'done'   => $done,
-			)
-		);
+		return rest_ensure_response( $publicize->get_post_share_status( $post_id ) );
 	}
 }

--- a/projects/plugins/jetpack/changelog/update-social-load-share-status-from-initial-state
+++ b/projects/plugins/jetpack/changelog/update-social-load-share-status-from-initial-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Social | Post share status in the editor is now immediately available on page load

--- a/projects/plugins/social/changelog/update-social-load-share-status-from-initial-state
+++ b/projects/plugins/social/changelog/update-social-load-share-status-from-initial-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Post share status in the editor is now immediately available on page load


### PR DESCRIPTION
> Currently, we don't show share status until we fetch it from the API. It will be good to add it to the initial state to show it instantly when available.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add post share status to the initial state to make it immediately available

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a post and share it to a few social media networks
* Confirm that share status shows up fine
* Reload the post edit page
* Open Jetpack sidebar
* Confirm that the share status is immediately available
* Click on "View sharing history"
* Confirm that the history shows up fine.


https://github.com/user-attachments/assets/a991f280-5c19-4c5d-a46a-10c99ff998b9



