### PR TITLE
Boost: Create hash from URL without trailing slash

### DIFF
--- a/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Cornerstone_Provider.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Cornerstone_Provider.php
@@ -83,6 +83,8 @@ class Cornerstone_Provider extends Provider {
 			$url = substr( $url, strlen( $home_url ) );
 		}
 
+		$url = untrailingslashit( $url );
+
 		$hash = hash( 'md5', $url );
 
 		return substr( $hash, 0, 8 );

--- a/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Cornerstone_Provider.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Cornerstone_Provider.php
@@ -83,6 +83,7 @@ class Cornerstone_Provider extends Provider {
 			$url = substr( $url, strlen( $home_url ) );
 		}
 
+		$url = ltrim( $url, '/' );
 		$url = untrailingslashit( $url );
 
 		$hash = hash( 'md5', $url );

--- a/projects/plugins/boost/changelog/fix-cornerstone-ccss-serving
+++ b/projects/plugins/boost/changelog/fix-cornerstone-ccss-serving
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed cornerstone specific critical CSS not serving in some cases
+
+


### PR DESCRIPTION
## Proposed changes:
* Create the cornerstone hash without trailing slash. This avoids URL matching bug when the URLs end with a trailing slash

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
* Set `WP_DEBUG` to true
* Add a page as a cornerstone page
* Regenerate critical CSS
* Make sure the `Critical CSS Key` in the critical CSS block for the page starts with `cornerstone_`.
* Test it with different permalink settings, both with and without a trailing slash.

