### PR TITLE
Sync Checksums: Refactor checksum logic to allow 'jetpack_sync_checksum_allowed_tables' filter to work with audits

### DIFF
--- a/projects/packages/sync/changelog/update-sync-checksum
+++ b/projects/packages/sync/changelog/update-sync-checksum
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Sync Checksums: Refactor checksum logic to allow 'jetpack_sync_checksum_allowed_tables' filter to work with audits
+
+

--- a/projects/packages/sync/src/class-replicastore.php
+++ b/projects/packages/sync/src/class-replicastore.php
@@ -1183,82 +1183,25 @@ class Replicastore implements Replicastore_Interface {
 	 * @return array Checksums.
 	 */
 	public function checksum_all( $perform_text_conversion = false ) {
-		$post_checksum               = $this->checksum_histogram( 'posts', null, null, null, null, true, '', false, false, $perform_text_conversion );
-		$comments_checksum           = $this->checksum_histogram( 'comments', null, null, null, null, true, '', false, false, $perform_text_conversion );
-		$post_meta_checksum          = $this->checksum_histogram( 'postmeta', null, null, null, null, true, '', false, false, $perform_text_conversion );
-		$comment_meta_checksum       = $this->checksum_histogram( 'commentmeta', null, null, null, null, true, '', false, false, $perform_text_conversion );
-		$terms_checksum              = $this->checksum_histogram( 'terms', null, null, null, null, true, '', false, false, $perform_text_conversion );
-		$term_relationships_checksum = $this->checksum_histogram( 'term_relationships', null, null, null, null, true, '', false, false, $perform_text_conversion );
-		$term_taxonomy_checksum      = $this->checksum_histogram( 'term_taxonomy', null, null, null, null, true, '', false, false, $perform_text_conversion );
+		$all_checksum_tables = Table_Checksum::get_allowed_tables();
 
-		$result = array(
-			'posts'              => $this->summarize_checksum_histogram( $post_checksum ),
-			'comments'           => $this->summarize_checksum_histogram( $comments_checksum ),
-			'post_meta'          => $this->summarize_checksum_histogram( $post_meta_checksum ),
-			'comment_meta'       => $this->summarize_checksum_histogram( $comment_meta_checksum ),
-			'terms'              => $this->summarize_checksum_histogram( $terms_checksum ),
-			'term_relationships' => $this->summarize_checksum_histogram( $term_relationships_checksum ),
-			'term_taxonomy'      => $this->summarize_checksum_histogram( $term_taxonomy_checksum ),
-		);
+		unset( $all_checksum_tables['users'] ); // Handled separately - TODO.
+		unset( $all_checksum_tables['usermeta'] ); // Handled separately - TODO.
+		unset( $all_checksum_tables['termmeta'] ); // Handled separately - TODO.
+		unset( $all_checksum_tables['links'] ); // Not supported yet.  Consider removing from default config.
+		unset( $all_checksum_tables['options'] );  // Not supported yet. Consider removing from default config.
 
-		/**
-		 * WooCommerce tables
-		 */
+		$all_checksum_tables = array_unique( array_keys( $all_checksum_tables ) );
 
-		/**
-		 * On WordPress.com, we can't directly check if the site has support for WooCommerce.
-		 * Having the option to override the functionality here helps with syncing WooCommerce tables.
-		 *
-		 * @since 10.1
-		 *
-		 * @param bool If we should we force-enable WooCommerce tables support.
-		 */
-		$force_woocommerce_support = apply_filters( 'jetpack_table_checksum_force_enable_woocommerce', false );
+		$result = array();
 
-		if ( $force_woocommerce_support || class_exists( 'WooCommerce' ) ) {
-			/**
-			 * Guard in Try/Catch as it's possible for the WooCommerce class to exist, but
-			 * the tables to not. If we don't do this, the response will be just the exception, without
-			 * returning any valid data. This will prevent us from ever performing a checksum/fix
-			 * for sites like this.
-			 * It's better to just skip the tables in the response, instead of completely failing.
-			 */
-
+		foreach ( $all_checksum_tables as $table ) {
+			$result_key = in_array( $table, array( 'postmeta', 'commentmeta' ), true ) ? str_replace( 'meta', '_meta', $table ) : $table;
 			try {
-				$woocommerce_order_items_checksum  = $this->checksum_histogram( 'woocommerce_order_items' );
-				$result['woocommerce_order_items'] = $this->summarize_checksum_histogram( $woocommerce_order_items_checksum );
+				$checksum              = $this->checksum_histogram( $table, null, null, null, null, true, '', false, false, $perform_text_conversion );
+				$result[ $result_key ] = $this->summarize_checksum_histogram( $checksum );
 			} catch ( Exception $ex ) {
-				$result['woocommerce_order_items'] = null;
-			}
-
-			try {
-				$woocommerce_order_itemmeta_checksum  = $this->checksum_histogram( 'woocommerce_order_itemmeta' );
-				$result['woocommerce_order_itemmeta'] = $this->summarize_checksum_histogram( $woocommerce_order_itemmeta_checksum );
-			} catch ( Exception $ex ) {
-				$result['woocommerce_order_itemmeta'] = null;
-			}
-
-			if ( Table_Checksum::enable_woocommerce_hpos_tables() ) {
-				try {
-					$woocommerce_hpos_orders_checksum = $this->checksum_histogram( 'wc_orders' );
-					$result['wc_orders']              = $this->summarize_checksum_histogram( $woocommerce_hpos_orders_checksum );
-				} catch ( Exception $ex ) {
-					$result['wc_orders'] = null;
-				}
-
-				try {
-					$woocommerce_hpos_order_addresses_checksum = $this->checksum_histogram( 'wc_order_addresses' );
-					$result['wc_order_addresses']              = $this->summarize_checksum_histogram( $woocommerce_hpos_order_addresses_checksum );
-				} catch ( Exception $ex ) {
-					$result['wc_order_addresses'] = null;
-				}
-
-				try {
-					$woocommerce_hpos_order_operational_data_checksum = $this->checksum_histogram( 'wc_order_operational_data' );
-					$result['wc_order_operational_data']              = $this->summarize_checksum_histogram( $woocommerce_hpos_order_operational_data_checksum );
-				} catch ( Exception $ex ) {
-					$result['wc_order_operational_data'] = null;
-				}
+				$result[ $result_key ] = null;
 			}
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The purpose of this PR is to refactor the Checksum Audit functionality, `Replicastore::checksum_all` to allow dynamic support for additional checksums and provide a single source of truth for the supported ones.

So far, we were manually creating audit checksums for default Sync modules (tables), like eg `posts` and `comments` and explicitly checking the `jetpack_table_checksum_force_enable_*` filters we knew about, eg for `woocommerce` and `woocommerce_hpos_orders` modules.

However, this approach will not work if Sync package consumers want to add their own custom table support for checksums. Here's an [example PR for the WooCommerce Analytics plugin](https://github.com/woocommerce/woocommerce-analytics/pull/302). 

Therefore, we are refactoring `Replicastore::checksum_all` to fetch all the supported ones dynamically by: 
- Introducing `Table_Checksum::get_allowed_tables`: A public static method that uses the `jetpack_sync_checksum_allowed_tables` filter under the hood, so that the allowed checksum tables become available to all consumers
- Using the method above in `Replicastore::checksum_all` to fetch the allowed tables and iterate on those instead of hardcoding the tables

This way if a consumer adds checksum support for an additional custom table via the `jetpack_sync_checksum_allowed_tables` filter, Audit Checksums will take that table into account to both on remote sites and WPCOM.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Replicastore\Table_Checksum`: Introduce public static `get_allowed_tables` for fetching the allowed checksum tables via the `jetpack_sync_checksum_allowed_tables` filter.
* `Automattic\Jetpack\Sync\Replicastore`: Refactor `checksum_all` to rely on `Table_Checksum::get_allowed_tables` for fetching the allowed checksum tables

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pfKYZu-1Po-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- D166997-code