### PR TITLE
[WordAds]: Ad formats migration to WATL

### DIFF
--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -380,7 +380,6 @@ return [
         'modules/shortcodes/ustream.php' => ['PhanTypeMismatchArgument'],
         'modules/shortcodes/vimeo.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument'],
         'modules/shortcodes/vr.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
-        'modules/shortcodes/wordads.php' => ['PhanNoopNew'],
         'modules/shortcodes/youtube.php' => ['PhanRedefineFunction'],
         'modules/shortlinks.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal'],
         'modules/simple-payments/simple-payments.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturn'],

--- a/projects/plugins/jetpack/changelog/try-ipw-migration-spike
+++ b/projects/plugins/jetpack/changelog/try-ipw-migration-spike
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-debugging wordads for ipw migration spike

--- a/projects/plugins/jetpack/changelog/try-ipw-migration-spike
+++ b/projects/plugins/jetpack/changelog/try-ipw-migration-spike
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+debugging wordads for ipw migration spike

--- a/projects/plugins/jetpack/changelog/update-iponweb-to-watl-migration
+++ b/projects/plugins/jetpack/changelog/update-iponweb-to-watl-migration
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Migration from IPONWEB to WATL 
+Migration from IPONWEB to WATL

--- a/projects/plugins/jetpack/changelog/update-iponweb-to-watl-migration
+++ b/projects/plugins/jetpack/changelog/update-iponweb-to-watl-migration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Migration from IPONWEB to WATL 

--- a/projects/plugins/jetpack/changelog/update-iponweb-to-watl-migration
+++ b/projects/plugins/jetpack/changelog/update-iponweb-to-watl-migration
@@ -1,5 +1,5 @@
 Significance: patch
 Type: other
 
-Migration from IPONWEB to WATL
-* Render legacy sidebar widget with the WATL
+Migration of ad formats from IPONWEB to WATL
+

--- a/projects/plugins/jetpack/changelog/update-iponweb-to-watl-migration
+++ b/projects/plugins/jetpack/changelog/update-iponweb-to-watl-migration
@@ -2,3 +2,4 @@ Significance: patch
 Type: other
 
 Migration from IPONWEB to WATL
+* Render legacy sidebar widget with the WATL

--- a/projects/plugins/jetpack/extensions/blocks/wordads/wordads.php
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/wordads.php
@@ -148,15 +148,26 @@ class WordAds {
 		$smart_format = self::$gutenberg_ad_snippet_x_smart_format[ $key ] ?? null;
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		$is_watl_enabled = $smart_format && ( isset( $_GET[ $smart_format ] ) && 'true' === $_GET[ $smart_format ] );
-
-		$ad_div = $wordads->get_ad_div( 'inline', $snippet, array( $align ) );
+		$ad_div          = $wordads->get_ad_div( 'inline', $snippet, array( $align ) );
 		// Render IPW div if WATL is not enabled.
 		if ( ! $is_watl_enabled ) {
 			return $ad_div;
 		}
 
-		// TODO: Add sas_fallback to the ad_div.
-		return $wordads->get_watl_ad_html_tag( $smart_format );
+		// Remove linebreaks and sanitize.
+		$snippet = esc_js( str_replace( array( "\n", "\t", "\r" ), '', $ad_div ) );
+
+		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+		$fallback_snippet = <<<HTML
+			<script>
+				var sas_fallback = sas_fallback || [];
+				sas_fallback.push(
+					{ tag: "$snippet", type: '$smart_format' }
+				);
+			</script>
+HTML;
+
+		return $fallback_snippet . $wordads->get_watl_ad_html_tag( $smart_format );
 	}
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/wordads/wordads.php
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/wordads.php
@@ -139,12 +139,12 @@ class WordAds {
 			$format = $attr['format'];
 		}
 
-		$height             = $ad_tag_ids[ $format ]['height'];
-		$width              = $ad_tag_ids[ $format ]['width'];
-		$gutenberg_location = 'gutenberg';
-		$snippet            = $wordads->get_ad_snippet( $section_id, $height, $width, $gutenberg_location, $wordads->get_solo_unit_css() );
+		$height   = $ad_tag_ids[ $format ]['height'];
+		$width    = $ad_tag_ids[ $format ]['width'];
+		$location = 'gutenberg';
+		$snippet  = $wordads->get_ad_snippet( $section_id, $height, $width, $location, $wordads->get_solo_unit_css() );
 
-		$key          = "{$gutenberg_location}_{$width}x{$height}";
+		$key          = "{$location}_{$width}x{$height}";
 		$smart_format = self::$gutenberg_ad_snippet_x_smart_format[ $key ] ?? null;
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		$is_watl_enabled = $smart_format && ( isset( $_GET[ $smart_format ] ) && 'true' === $_GET[ $smart_format ] );

--- a/projects/plugins/jetpack/extensions/blocks/wordads/wordads.php
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/wordads.php
@@ -21,6 +21,18 @@ use Jetpack_Gutenberg;
  */
 class WordAds {
 	/**
+	 * Mapping array of gutenberg ad snippet with the WordAds_Smart formats.
+	 *
+	 * @var array
+	 */
+	public static $gutenberg_ad_snippet_x_smart_format = array(
+		'gutenberg_300x250' => 'gutenberg_rectangle',
+		'gutenberg_728x90'  => 'gutenberg_leaderboard',
+		'gutenberg_320x50'  => 'gutenberg_mobile_leaderboard',
+		'gutenberg_160x600' => 'gutenberg_skyscraper',
+	);
+
+	/**
 	 * Check if site is on WP.com Simple.
 	 *
 	 * @return bool
@@ -127,10 +139,24 @@ class WordAds {
 			$format = $attr['format'];
 		}
 
-		$height  = $ad_tag_ids[ $format ]['height'];
-		$width   = $ad_tag_ids[ $format ]['width'];
-		$snippet = $wordads->get_ad_snippet( $section_id, $height, $width, 'gutenberg', $wordads->get_solo_unit_css() );
-		return $wordads->get_ad_div( 'inline', $snippet, array( $align ) );
+		$height             = $ad_tag_ids[ $format ]['height'];
+		$width              = $ad_tag_ids[ $format ]['width'];
+		$gutenberg_location = 'gutenberg';
+		$snippet            = $wordads->get_ad_snippet( $section_id, $height, $width, $gutenberg_location, $wordads->get_solo_unit_css() );
+
+		$key          = "{$gutenberg_location}_{$width}x{$height}";
+		$smart_format = self::$gutenberg_ad_snippet_x_smart_format[ $key ] ?? null;
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$is_watl_enabled = $smart_format && ( isset( $_GET[ $smart_format ] ) && 'true' === $_GET[ $smart_format ] );
+
+		$ad_div = $wordads->get_ad_div( 'inline', $snippet, array( $align ) );
+		// Render IPW div if WATL is not enabled.
+		if ( ! $is_watl_enabled ) {
+			return $ad_div;
+		}
+
+		// TODO: Add sas_fallback to the ad_div.
+		return $wordads->get_watl_ad_html_tag( $smart_format );
 	}
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/wordads/wordads.php
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/wordads.php
@@ -25,7 +25,7 @@ class WordAds {
 	 *
 	 * @var array
 	 */
-	public static $gutenberg_ad_snippet_x_smart_format = array(
+	private static $gutenberg_ad_snippet_x_smart_format = array(
 		'gutenberg_300x250' => 'gutenberg_rectangle',
 		'gutenberg_728x90'  => 'gutenberg_leaderboard',
 		'gutenberg_320x50'  => 'gutenberg_mobile_leaderboard',

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -382,7 +382,7 @@ class WordAds {
 		<?php
 
 		// Get an inline tag with a macro as id handled on JS side to use as a fallback.
-		$tag_inline = $this->get_dynamic_ad_snippet( $this->params->blog_id . 5, 'square', 'inline', '', '{{unique_id}}' );
+		$tag_inline = $this->get_fallback_ad_snippet( $this->params->blog_id . 5, 'square', 'inline', '', '{{unique_id}}' );
 
 		// Remove linebreaks and sanitize.
 		$tag_inline = esc_js( str_replace( array( "\n", "\t", "\r" ), '', $tag_inline ) );
@@ -703,6 +703,7 @@ HTML;
 			$form_factor = 'leaderboard';
 		}
 
+		// TODO: Still investigating required change. Potentially update with respect with what get_ad_div on WPCOM for gutenberg
 		return $this->get_dynamic_ad_snippet( $section_id, $form_factor, $location );
 	}
 
@@ -720,6 +721,33 @@ HTML;
 	 * @since 8.7
 	 */
 	public function get_dynamic_ad_snippet( $section_id, $form_factor = 'square', $location = '', $relocate = '', $id = null ) {
+
+		// Allow overriding and printing of the tag parsed by the WATL.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$is_location_enabled = ( isset( $_GET[ $location ] ) && 'true' === $_GET[ $location ] );
+
+		if ( ( 'top' === $location || 'belowpost' === $location || 'sidebar' === $location ) && $is_location_enabled ) {
+			// TODO: Confirm if it's best here or there is a way to get it via the adflow config endpoint
+			return "<div class=\"wordads-tag\" data-slot-type=\"$location\" style=\"display: none;\"></div>";
+		}
+
+		return $this->get_fallback_ad_snippet( $section_id, $form_factor, $location, $relocate, $id );
+	}
+
+	/**
+	 * Returns the fallback dynamic snippet to be inserted into the ad unit
+	 *
+	 * @param int           $section_id section_id.
+	 * @param string        $form_factor form_factor.
+	 * @param string        $location location.
+	 * @param string        $relocate location to be moved after the fact for themes without required hook.
+	 * @param string | null $id A unique string ID or placeholder.
+	 *
+	 * @return string
+	 *
+	 * @since 8.7
+	 */
+	public function get_fallback_ad_snippet( $section_id, $form_factor = 'square', $location = '', $relocate = '', $id = null ) {
 		$div_id = 'atatags-' . $section_id . '-' . ( $id ?? uniqid() );
 		$div_id = esc_attr( $div_id );
 

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -766,7 +766,6 @@ HTML;
 			$form_factor = 'leaderboard';
 		}
 
-		// TODO: Still investigating required change. Potentially update with respect with what get_ad_div on WPCOM for gutenberg
 		return $this->get_dynamic_ad_snippet( $section_id, $form_factor, $location );
 	}
 
@@ -790,7 +789,6 @@ HTML;
 		$is_location_enabled = isset( $_GET['wordads-logging'] ) && isset( $_GET[ $location ] ) && 'true' === $_GET[ $location ];
 
 		if ( ( 'top' === $location || 'belowpost' === $location ) && $is_location_enabled ) {
-			// TODO: Confirm if it's best here or there is a way to get it via the adflow config endpoint
 			return self::get_watl_ad_html_tag( $location );
 		}
 

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -21,6 +21,7 @@ require_once WORDADS_ROOT . '/php/class-wordads-california-privacy.php';
 require_once WORDADS_ROOT . '/php/class-wordads-ccpa-do-not-sell-link-widget.php';
 require_once WORDADS_ROOT . '/php/class-wordads-consent-management-provider.php';
 require_once WORDADS_ROOT . '/php/class-wordads-smart.php';
+require_once WORDADS_ROOT . '/php/class-wordads-shortcode.php';
 
 /**
  * Primary WordAds class.
@@ -214,6 +215,9 @@ class WordAds {
 		if ( isset( $this->params->options['wordads_cmp_enabled'] ) && $this->params->options['wordads_cmp_enabled'] ) {
 			WordAds_Consent_Management_Provider::init();
 		}
+
+		// Initialize [wordads] shortcode.
+		WordAds_Shortcode::init();
 
 		// Initialize Smart.
 		WordAds_Smart::instance()->init( $this->params );
@@ -527,8 +531,17 @@ HTML;
 		}
 
 		$ad_type  = $this->option( 'wordads_house' ) ? 'house' : 'iponweb';
-		$content .= $this->get_ad( 'inline', $ad_type );
-		return $content;
+		$location = 'shortcode';
+		// not house ad and watl enabled
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( 'house' !== $ad_type && ( isset( $_GET['wordads-logging'] ) && isset( $_GET[ $location ] ) && 'true' === $_GET[ $location ] ) ) {
+			return $content . $this->get_watl_ad_html_tag( $location );
+		}
+
+		return $content .= sprintf(
+			'<div class="jetpack-wordad" itemscope itemtype="https://schema.org/WPAdBlock">%s</div>',
+			$this->get_ad( 'inline', $ad_type )
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -774,7 +774,7 @@ HTML;
 
 		// Allow overriding and printing of the tag parsed by the WATL.
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		$is_location_enabled = ( isset( $_GET[ $location ] ) && 'true' === $_GET[ $location ] );
+		$is_location_enabled = isset( $_GET['wordads-logging'] ) && isset( $_GET[ $location ] ) && 'true' === $_GET[ $location ];
 
 		if ( ( 'top' === $location || 'belowpost' === $location ) && $is_location_enabled ) {
 			// TODO: Confirm if it's best here or there is a way to get it via the adflow config endpoint

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -381,8 +381,16 @@ class WordAds {
 		</script>
 		<?php
 
+		$section_id = $this->params->blog_id . 5;
+
+		// Get below post tag.
+		$tag_belowpost = $this->get_fallback_ad_snippet( $section_id, 'square', 'belowpost', '', '{{unique_id}}' );
+
+		// Remove linebreaks and sanitize.
+		$tag_belowpost = esc_js( str_replace( array( "\n", "\t", "\r" ), '', $tag_belowpost ) );
+
 		// Get an inline tag with a macro as id handled on JS side to use as a fallback.
-		$tag_inline = $this->get_fallback_ad_snippet( $this->params->blog_id . 5, 'square', 'inline', '', '{{unique_id}}' );
+		$tag_inline = $this->get_fallback_ad_snippet( $section_id, 'square', 'inline', '', '{{unique_id}}' );
 
 		// Remove linebreaks and sanitize.
 		$tag_inline = esc_js( str_replace( array( "\n", "\t", "\r" ), '', $tag_inline ) );
@@ -393,6 +401,7 @@ class WordAds {
 					var sas_fallback = sas_fallback || [];
 					sas_fallback.push(
 						{ tag: "$tag_inline", type: 'inline' }
+						{ tag: "$tag_belowpost", type: 'belowpost' }
 					);
 				</script>
 HTML;

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -532,16 +532,14 @@ HTML;
 
 		$ad_type  = $this->option( 'wordads_house' ) ? 'house' : 'iponweb';
 		$location = 'shortcode';
-		// not house ad and watl enabled
+
+		// Not house ad and WATL enabled.
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( 'house' !== $ad_type && ( isset( $_GET['wordads-logging'] ) && isset( $_GET[ $location ] ) && 'true' === $_GET[ $location ] ) ) {
 			return $content . $this->get_watl_ad_html_tag( $location );
 		}
 
-		return $content .= sprintf(
-			'<div class="jetpack-wordad" itemscope itemtype="https://schema.org/WPAdBlock">%s</div>',
-			$this->get_ad( 'inline', $ad_type )
-		);
+		return $content . $this->get_ad( 'inline', $ad_type );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -735,9 +735,9 @@ HTML;
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		$is_location_enabled = ( isset( $_GET[ $location ] ) && 'true' === $_GET[ $location ] );
 
-		if ( ( 'top' === $location || 'belowpost' === $location || 'sidebar' === $location ) && $is_location_enabled ) {
+		if ( ( 'belowpost' === $location ) && $is_location_enabled ) {
 			// TODO: Confirm if it's best here or there is a way to get it via the adflow config endpoint
-			return "<div class=\"wordads-tag\" data-slot-type=\"$location\" style=\"display: none;\"></div>";
+			return self::get_watl_ad_html_tag( $location );
 		}
 
 		return $this->get_fallback_ad_snippet( $section_id, $form_factor, $location, $relocate, $id );
@@ -903,6 +903,19 @@ HTML;
 			marginwidth="0">
 		</iframe>
 HTML;
+	}
+
+	/**
+	 * Returns the html ad tag used by WordAds Tag Library
+	 *
+	 * @param  string $slot_type e.g belowpost, gutenberg_rectangle.
+	 *
+	 * @return string
+	 *
+	 * @since 8.7
+	 */
+	public static function get_watl_ad_html_tag( string $slot_type ): string {
+		return "<div class=\"wordads-tag\" data-slot-type=\"$slot_type\" style=\"display: none;\"></div>";
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -371,9 +371,43 @@ class WordAds {
 		$site_id      = $this->params->blog_id;
 		$consent      = (int) isset( $_COOKIE['personalized-ads-consent'] );
 		$is_logged_in = is_user_logged_in() ? '1' : '0';
+
+		$disabled_slot_formats = apply_filters( 'wordads_disabled_slot_formats', array() );
+
+		if ( apply_filters( 'wordads_iponweb_bottom_sticky_ad_disable', false ) ) {
+			$disabled_slot_formats[] = 'MTS';
+		}
+
+		if ( apply_filters( 'wordads_iponweb_sidebar_sticky_right_ad_disable', false ) ) {
+			$disabled_slot_formats[] = 'DPR';
+		}
+
+		$config    = array(
+			'pt'                    => $pagetype,
+			'ht'                    => $hosting_type,
+			'tn'                    => get_stylesheet(),
+			'uloggedin'             => $is_logged_in,
+			'amp'                   => false,
+			'siteid'                => $site_id,
+			'consent'               => $consent,
+			'ad'                    => array(
+				'label'           => array(
+					'text' => __( 'Advertisements', 'jetpack' ),
+				),
+				'reportAd'        => array(
+					'text' => __( 'Report this ad', 'jetpack' ),
+				),
+				'privacySettings' => array(
+					'text'    => __( 'Privacy', 'jetpack' ),
+					'onClick' => 'js:function() { window.__tcfapi && window.__tcfapi(\'showUi\'); }',
+				),
+			),
+			'disabled_slot_formats' => $disabled_slot_formats,
+		);
+		$js_config = WordAds_Array_Utils::array_to_js_object( $config );
 		?>
 		<script<?php echo esc_attr( $data_tags ); ?> type="text/javascript">
-			var __ATA_PP = { pt: <?php echo esc_js( $pagetype ); ?>, ht: <?php echo esc_js( $hosting_type ); ?>, tn: '<?php echo esc_js( get_stylesheet() ); ?>', uloggedin: <?php echo esc_js( $is_logged_in ); ?>, amp: false, siteid: <?php echo esc_js( $site_id ); ?>, consent: <?php echo esc_js( $consent ); ?>, ad: { label: { text: '<?php echo esc_js( __( 'Advertisements', 'jetpack' ) ); ?>' }, reportAd: { text: '<?php echo esc_js( __( 'Report this ad', 'jetpack' ) ); ?>' }, privacySettings: { text: '<?php echo esc_js( __( 'Privacy', 'jetpack' ) ); ?>', onClick: function() { window.__tcfapi && window.__tcfapi('showUi'); } } } };
+			var __ATA_PP = <?php echo $js_config; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 			var __ATA = __ATA || {};
 			__ATA.cmd = __ATA.cmd || [];
 			__ATA.criteo = __ATA.criteo || {};
@@ -403,11 +437,11 @@ class WordAds {
 
 		// phpcs:disable WordPress.Security.EscapeOutput.HeredocOutputNotEscaped
 		echo <<<HTML
-				<script>
+				<script type="text/javascript">
 					var sas_fallback = sas_fallback || [];
 					sas_fallback.push(
-						{ tag: "$tag_inline", type: 'inline' }
-						{ tag: "$tag_belowpost", type: 'belowpost' }
+						{ tag: "$tag_inline", type: 'inline' },
+						{ tag: "$tag_belowpost", type: 'belowpost' },
 						{ tag: "$tag_top", type: 'top' }
 					);
 				</script>

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -395,6 +395,12 @@ class WordAds {
 		// Remove linebreaks and sanitize.
 		$tag_inline = esc_js( str_replace( array( "\n", "\t", "\r" ), '', $tag_inline ) );
 
+		// Get top tag.
+		$tag_top = $this->get_fallback_ad_snippet( $section_id, 'leaderboard', 'top', '', '{{unique_id}}' );
+
+		// Remove linebreaks and sanitize.
+		$tag_top = esc_js( str_replace( array( "\n", "\t", "\r" ), '', $tag_top ) );
+
 		// phpcs:disable WordPress.Security.EscapeOutput.HeredocOutputNotEscaped
 		echo <<<HTML
 				<script>
@@ -402,6 +408,7 @@ class WordAds {
 					sas_fallback.push(
 						{ tag: "$tag_inline", type: 'inline' }
 						{ tag: "$tag_belowpost", type: 'belowpost' }
+						{ tag: "$tag_top", type: 'top' }
 					);
 				</script>
 HTML;
@@ -735,7 +742,7 @@ HTML;
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		$is_location_enabled = ( isset( $_GET[ $location ] ) && 'true' === $_GET[ $location ] );
 
-		if ( ( 'belowpost' === $location ) && $is_location_enabled ) {
+		if ( ( 'top' === $location || 'belowpost' === $location ) && $is_location_enabled ) {
 			// TODO: Confirm if it's best here or there is a way to get it via the adflow config endpoint
 			return self::get_watl_ad_html_tag( $location );
 		}

--- a/projects/plugins/jetpack/modules/wordads/js/adflow-loader.js
+++ b/projects/plugins/jetpack/modules/wordads/js/adflow-loader.js
@@ -1,5 +1,4 @@
 function a8c_adflow_callback( data ) {
-	console.log( 'watl call, a8c_adflow_callback', data );
 	if ( data && data.scripts && Array.isArray( data.scripts ) ) {
 		if ( data.config ) {
 			let configurationScript = document.createElement( 'script' );

--- a/projects/plugins/jetpack/modules/wordads/js/adflow-loader.js
+++ b/projects/plugins/jetpack/modules/wordads/js/adflow-loader.js
@@ -1,5 +1,5 @@
 function a8c_adflow_callback( data ) {
-	console.log( 'a8c_adflow_callback', data );
+	console.log( 'watl call, a8c_adflow_callback', data );
 	if ( data && data.scripts && Array.isArray( data.scripts ) ) {
 		if ( data.config ) {
 			let configurationScript = document.createElement( 'script' );

--- a/projects/plugins/jetpack/modules/wordads/js/adflow-loader.js
+++ b/projects/plugins/jetpack/modules/wordads/js/adflow-loader.js
@@ -1,4 +1,5 @@
 function a8c_adflow_callback( data ) {
+	console.log( 'a8c_adflow_callback', data );
 	if ( data && data.scripts && Array.isArray( data.scripts ) ) {
 		if ( data.config ) {
 			let configurationScript = document.createElement( 'script' );

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-params.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-params.php
@@ -72,6 +72,13 @@ class WordAds_Params {
 	public $page_type_ipw;
 
 	/**
+	 * Is this an AMP request?
+	 *
+	 * @var bool
+	 */
+	public $is_amp;
+
+	/**
 	 * Setup parameters for serving the ads
 	 *
 	 * @since 4.5.0
@@ -79,22 +86,24 @@ class WordAds_Params {
 	public function __construct() {
 		// WordAds setting => default.
 		$settings = array(
-			'wordads_approved'                => false,
-			'wordads_active'                  => false,
-			'wordads_house'                   => true,
-			'wordads_unsafe'                  => false,
-			'enable_header_ad'                => true,
-			'wordads_second_belowpost'        => true,
-			'wordads_inline_enabled'          => true,
-			'wordads_display_front_page'      => true,
-			'wordads_display_post'            => true,
-			'wordads_display_page'            => true,
-			'wordads_display_archive'         => true,
-			'wordads_custom_adstxt'           => '',
-			'wordads_custom_adstxt_enabled'   => false,
-			'wordads_ccpa_enabled'            => false,
-			'wordads_ccpa_privacy_policy_url' => get_option( 'wp_page_for_privacy_policy' ) ? get_permalink( (int) get_option( 'wp_page_for_privacy_policy' ) ) : '',
-			'wordads_cmp_enabled'             => false,
+			'wordads_approved'                     => false,
+			'wordads_active'                       => false,
+			'wordads_house'                        => true,
+			'wordads_unsafe'                       => false,
+			'enable_header_ad'                     => true,
+			'wordads_second_belowpost'             => true,
+			'wordads_inline_enabled'               => true,
+			'wordads_bottom_sticky_enabled'        => false,
+			'wordads_sidebar_sticky_right_enabled' => false,
+			'wordads_display_front_page'           => true,
+			'wordads_display_post'                 => true,
+			'wordads_display_page'                 => true,
+			'wordads_display_archive'              => true,
+			'wordads_custom_adstxt'                => '',
+			'wordads_custom_adstxt_enabled'        => false,
+			'wordads_ccpa_enabled'                 => false,
+			'wordads_ccpa_privacy_policy_url'      => get_option( 'wp_page_for_privacy_policy' ) ? get_permalink( (int) get_option( 'wp_page_for_privacy_policy' ) ) : '',
+			'wordads_cmp_enabled'                  => false,
 		);
 
 		// Grab settings, or set as default if it doesn't exist.
@@ -136,6 +145,7 @@ class WordAds_Params {
 			'LangId'  => str_contains( get_bloginfo( 'language' ), 'en' ) ? 1 : 0, // TODO something else?
 			'AdSafe'  => 1, // TODO.
 		);
+		$this->is_amp         = function_exists( 'amp_is_request' ) && amp_is_request();
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-shortcode.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-shortcode.php
@@ -32,34 +32,17 @@ class WordAds_Shortcode {
 	 * Our [wordads] shortcode.
 	 * Prints a WordAds Ad.
 	 *
-	 * @param array  $atts    Array of shortcode attributes.
-	 * @param string $content Post content.
-	 *
 	 * @return string HTML for WordAds shortcode.
 	 */
-	public static function handle_wordads_shortcode( $atts, $content = '' ) {
-		$atts = shortcode_atts( array(), $atts, 'wordads' );
-
-		return self::wordads_shortcode_html( $atts, $content );
-	}
-
-	/**
-	 * The shortcode output
-	 *
-	 * @param array  $atts    Array of shortcode attributes.
-	 * @param string $content Post content.
-	 *
-	 * @return string HTML output
-	 */
-	private static function wordads_shortcode_html( $atts, $content = '' ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public static function handle_wordads_shortcode() {
 		global $wordads;
 
 		if ( empty( $wordads ) ) {
 			return '<div>' . __( 'The WordAds module is not active', 'jetpack' ) . '</div>';
 		}
 
-		$html = $wordads->insert_inline_ad( '' );
+		$html = '<div class="jetpack-wordad" itemscope itemtype="https://schema.org/WPAdBlock"></div>';
 
-		return $html;
+		return $wordads->insert_inline_ad( $html );
 	}
 }

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-shortcode.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-shortcode.php
@@ -1,4 +1,4 @@
-<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+<?php
 /**
  * Wordads shortcode.
  *
@@ -9,35 +9,23 @@
  */
 
 /**
- * Embed WordAds 'ad' in post
+ * Class WordAds_Shortcode
+ *
+ * Handles the [wordads] shortcode.
  */
-class Jetpack_WordAds_Shortcode {
-
-	/**
-	 * Used to determine whether scripts and styles have been enqueued already.
-	 *
-	 * @var bool false Should we enqueue scripts and styles.
-	 */
-	private $scripts_and_style_included = false;
-
-	/**
-	 * Initialize.
-	 */
-	public function __construct() {
-		add_action( 'init', array( $this, 'action_init' ) );
-	}
+class WordAds_Shortcode {
 
 	/**
 	 * Register our shortcode and enqueue necessary files.
 	 */
-	public function action_init() {
+	public static function init() {
 		global $wordads;
 
 		if ( empty( $wordads ) ) {
 			return null;
 		}
 
-		add_shortcode( 'wordads', array( $this, 'wordads_shortcode' ) );
+		add_shortcode( 'wordads', array( self::class, 'handle_wordads_shortcode' ) );
 	}
 
 	/**
@@ -49,7 +37,7 @@ class Jetpack_WordAds_Shortcode {
 	 *
 	 * @return string HTML for WordAds shortcode.
 	 */
-	public static function wordads_shortcode( $atts, $content = '' ) {
+	public static function handle_wordads_shortcode( $atts, $content = '' ) {
 		$atts = shortcode_atts( array(), $atts, 'wordads' );
 
 		return self::wordads_shortcode_html( $atts, $content );
@@ -70,11 +58,8 @@ class Jetpack_WordAds_Shortcode {
 			return '<div>' . __( 'The WordAds module is not active', 'jetpack' ) . '</div>';
 		}
 
-		$html = '<div class="jetpack-wordad" itemscope itemtype="https://schema.org/WPAdBlock"></div>';
-		$html = $wordads->insert_inline_ad( $html );
+		$html = $wordads->insert_inline_ad( '' );
 
 		return $html;
 	}
 }
-
-new Jetpack_WordAds_Shortcode();

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -80,6 +80,9 @@ class WordAds_Smart {
 		'sidebar_widget_wideskyscraper'  => array(
 			'enabled' => false,
 		),
+		'shortcode'                      => array(
+			'enabled' => false,
+		),
 	);
 
 	/**
@@ -210,6 +213,7 @@ class WordAds_Smart {
 
 		$config = array(
 			'post_id' => ( $post instanceof WP_Post ) && is_singular( 'post' ) ? $post->ID : null,
+			'origin'  => 'jetpack',
 			'theme'   => get_stylesheet(),
 			'target'  => $this->target_keywords(),
 		) + $this->formats;

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -52,6 +52,41 @@ class WordAds_Smart {
 	private $is_inline_enabled;
 
 	/**
+	 * Supported formats.
+	 *
+	 * @var array
+	 */
+	private $formats = array(
+		'top'                          => array(
+			'enabled' => false,
+		),
+		'inline'                       => array(
+			'enabled' => false,
+		),
+		'belowpost'                    => array(
+			'enabled' => false,
+		),
+		'bottom_sticky'                => array(
+			'enabled' => false,
+		),
+		'sidebar_sticky_right'         => array(
+			'enabled' => false,
+		),
+		'gutenberg_rectangle'          => array(
+			'enabled' => false,
+		),
+		'gutenberg_leaderboard'        => array(
+			'enabled' => false,
+		),
+		'gutenberg_mobile_leaderboard' => array(
+			'enabled' => false,
+		),
+		'gutenberg_skyscraper'         => array(
+			'enabled' => false,
+		),
+	);
+
+	/**
 	 * Private constructor.
 	 */
 	private function __construct() {
@@ -83,11 +118,11 @@ class WordAds_Smart {
 		$this->theme             = get_stylesheet();
 		$this->is_inline_enabled = is_singular( 'post' ) && $params->options['wordads_inline_enabled'];
 
-		// Allow override.
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['inline'] ) && 'true' === $_GET['inline'] ) {
-			$this->is_inline_enabled = true;
-		}
+		// Allow enabled format override by query string.
+		$this->override_formats_from_query_string();
+		// TODO: refactor to remove the need to do this
+		$this->is_inline_enabled = $this->formats['inline']['enabled'];
+
 		if ( $this->is_inline_enabled ) {
 			// Insert ads.
 			$this->insert_ads();
@@ -170,42 +205,15 @@ class WordAds_Smart {
 		global $post;
 
 		$config = array(
-			'blog_id'                      => $this->get_blog_id(),
-			'post_id'                      => ( $post instanceof WP_Post ) && is_singular( 'post' ) ? $post->ID : null,
-			'theme'                        => $this->theme,
-			'target'                       => $this->target_keywords(),
-			'_'                            => array(
+			'blog_id' => $this->get_blog_id(),
+			'post_id' => ( $post instanceof WP_Post ) && is_singular( 'post' ) ? $post->ID : null,
+			'theme'   => $this->theme,
+			'target'  => $this->target_keywords(),
+			'_'       => array(
 				'title'            => __( 'Advertisement', 'jetpack' ),
 				'privacy_settings' => __( 'Privacy Settings', 'jetpack' ),
 			),
-			'top'                          => array(
-				'enabled' => true, // TODO: this will not be true by default
-			),
-			'inline'                       => array(
-				'enabled' => $this->is_inline_enabled,
-			),
-			'belowpost'                    => array(
-				'enabled' => true, // TODO: this will not be true by default
-			),
-			'bottom_sticky'                => array(
-				'enabled' => true, // TODO: this will not be true by default
-			),
-			'sidebar_sticky_right'         => array(
-				'enabled' => true, // TODO: this will not be true by default
-			),
-			'gutenberg_rectangle'          => array(
-				'enabled' => true, // TODO: this will not be true by default
-			),
-			'gutenberg_leaderboard'        => array(
-				'enabled' => true, // TODO: this will not be true by default
-			),
-			'gutenberg_mobile_leaderboard' => array(
-				'enabled' => true, // TODO: this will not be true by default
-			),
-			'gutenberg_skyscraper'         => array(
-				'enabled' => true, // TODO: this will not be true by default
-			),
-		);
+		) + $this->formats;
 
 		// Do conversion.
 		$js_config = WordAds_Array_Utils::array_to_js_object( $config );
@@ -224,6 +232,20 @@ class WordAds_Smart {
 			'https://public-api.wordpress.com/wpcom/v2/sites/%1$d/adflow/conf/?_jsonp=a8c_adflow_callback',
 			$this->get_blog_id()
 		);
+	}
+
+	/**
+	 * Allow format enabled override from query string, eg. ?inline=true.
+	 *
+	 * @return void
+	 */
+	private function override_formats_from_query_string(): void {
+		foreach ( $this->formats as $format_type => $_ ) {
+			// phpcs:disable WordPress.Security.NonceVerification.Recommended
+			if ( isset( $_GET[ $format_type ] ) && 'true' === $_GET[ $format_type ] ) {
+				$this->formats[ $format_type ]['enabled'] = true;
+			}
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -170,21 +170,33 @@ class WordAds_Smart {
 		global $post;
 
 		$config = array(
-			'blog_id'       => $this->get_blog_id(),
-			'post_id'       => ( $post instanceof WP_Post ) && is_singular( 'post' ) ? $post->ID : null,
-			'theme'         => $this->theme,
-			'target'        => $this->target_keywords(),
-			'_'             => array(
+			'blog_id'                      => $this->get_blog_id(),
+			'post_id'                      => ( $post instanceof WP_Post ) && is_singular( 'post' ) ? $post->ID : null,
+			'theme'                        => $this->theme,
+			'target'                       => $this->target_keywords(),
+			'_'                            => array(
 				'title'            => __( 'Advertisement', 'jetpack' ),
 				'privacy_settings' => __( 'Privacy Settings', 'jetpack' ),
 			),
-			'inline'        => array(
+			'inline'                       => array(
 				'enabled' => $this->is_inline_enabled,
 			),
-			'bottom_sticky' => array(
+			'bottom_sticky'                => array(
 				'enabled' => true, // TODO: this will not be true by default
 			),
-			'belowpost'     => array(
+			'belowpost'                    => array(
+				'enabled' => true, // TODO: this will not be true by default
+			),
+			'gutenberg_rectangle'          => array(
+				'enabled' => true, // TODO: this will not be true by default
+			),
+			'gutenberg_leaderboard'        => array(
+				'enabled' => true, // TODO: this will not be true by default
+			),
+			'gutenberg_mobile_leaderboard' => array(
+				'enabled' => true, // TODO: this will not be true by default
+			),
+			'gutenberg_skyscraper'         => array(
 				'enabled' => true, // TODO: this will not be true by default
 			),
 		);

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -182,7 +182,10 @@ class WordAds_Smart {
 				'enabled' => $this->is_inline_enabled,
 			),
 			'bottom_sticky' => array(
-				'enabled' => true,
+				'enabled' => true, // TODO: this will not be true by default
+			),
+			'belowpost'     => array(
+				'enabled' => true, // TODO: this will not be true by default
 			),
 		);
 

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -196,6 +196,16 @@ class WordAds_Smart {
 				);
 			}
 		}
+
+		if ( $this->formats['bottom_sticky']['enabled'] ) {
+			// Disable IPW slot.
+			add_filter( 'wordads_iponweb_bottom_sticky_ad_disable', '__return_true', 10 );
+		}
+
+		if ( $this->formats['sidebar_sticky_right']['enabled'] ) {
+			// Disable IPW slot.
+			add_filter( 'wordads_iponweb_sidebar_sticky_right_ad_disable', '__return_true', 10 );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -123,10 +123,8 @@ class WordAds_Smart {
 		// TODO: refactor to remove the need to do this
 		$this->is_inline_enabled = $this->formats['inline']['enabled'];
 
-		if ( $this->is_inline_enabled ) {
-			// Insert ads.
-			$this->insert_ads();
-		}
+		// Insert ads.
+		$this->insert_ads();
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -39,35 +39,45 @@ class WordAds_Smart {
 
 	/**
 	 * Supported formats.
+	 * sidebar_widget formats represents the legacy Jetpack sidebar widget.
 	 *
 	 * @var array
 	 */
 	private $formats = array(
-		'top'                          => array(
+		'top'                            => array(
 			'enabled' => false,
 		),
-		'inline'                       => array(
+		'inline'                         => array(
 			'enabled' => false,
 		),
-		'belowpost'                    => array(
+		'belowpost'                      => array(
 			'enabled' => false,
 		),
-		'bottom_sticky'                => array(
+		'bottom_sticky'                  => array(
 			'enabled' => false,
 		),
-		'sidebar_sticky_right'         => array(
+		'sidebar_sticky_right'           => array(
 			'enabled' => false,
 		),
-		'gutenberg_rectangle'          => array(
+		'gutenberg_rectangle'            => array(
 			'enabled' => false,
 		),
-		'gutenberg_leaderboard'        => array(
+		'gutenberg_leaderboard'          => array(
 			'enabled' => false,
 		),
-		'gutenberg_mobile_leaderboard' => array(
+		'gutenberg_mobile_leaderboard'   => array(
 			'enabled' => false,
 		),
-		'gutenberg_skyscraper'         => array(
+		'gutenberg_skyscraper'           => array(
+			'enabled' => false,
+		),
+		'sidebar_widget_mediumrectangle' => array(
+			'enabled' => false,
+		),
+		'sidebar_widget_leaderboard'     => array(
+			'enabled' => false,
+		),
+		'sidebar_widget_wideskyscraper'  => array(
 			'enabled' => false,
 		),
 	);

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -187,6 +187,9 @@ class WordAds_Smart {
 			'belowpost'                    => array(
 				'enabled' => true, // TODO: this will not be true by default
 			),
+			'sidebar_sticky_right'         => array(
+				'enabled' => true, // TODO: this will not be true by default
+			),
 			'gutenberg_rectangle'          => array(
 				'enabled' => true, // TODO: this will not be true by default
 			),

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -123,8 +123,12 @@ class WordAds_Smart {
 		// TODO: refactor to remove the need to do this
 		$this->is_inline_enabled = $this->formats['inline']['enabled'];
 
-		// Insert ads.
-		$this->insert_ads();
+		// TODO: Is this necessary? if we want to always run Smart insert ads logic after IPW migrations
+		$has_any_format_enabled = in_array( true, array_column( $this->formats, 'enabled' ), true );
+		if ( $has_any_format_enabled ) {
+			// Insert ads.
+			$this->insert_ads();
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -24,18 +24,11 @@ class WordAds_Smart {
 	protected static $instance = null;
 
 	/**
-	 * Is this an AMP request?
+	 * The parameters for WordAds.
 	 *
-	 * @var bool
+	 * @var WordAds_Params
 	 */
-	private $is_amp;
-
-	/**
-	 * Current blog theme from get_stylesheet().
-	 *
-	 * @var string
-	 */
-	private $theme;
+	private $params;
 
 	/**
 	 * Has Smart asset been enqueued?
@@ -43,13 +36,6 @@ class WordAds_Smart {
 	 * @var bool True if Smart asset has been enqueued.
 	 */
 	private $is_asset_enqueued = false;
-
-	/**
-	 * Toggle for inline ads.
-	 *
-	 * @var bool True if inline ads are enabled.
-	 */
-	private $is_inline_enabled;
 
 	/**
 	 * Supported formats.
@@ -99,8 +85,8 @@ class WordAds_Smart {
 	 *
 	 * @return WordAds_Smart
 	 */
-	public static function instance() {
-		if ( self::$instance === null ) {
+	public static function instance(): self {
+		if ( null === self::$instance ) {
 			self::$instance = new self();
 		}
 		return self::$instance;
@@ -114,19 +100,12 @@ class WordAds_Smart {
 	 * @return void
 	 */
 	public function init( WordAds_Params $params ) {
-		$this->is_amp            = function_exists( 'amp_is_request' ) && amp_is_request();
-		$this->theme             = get_stylesheet();
-		$this->is_inline_enabled = is_singular( 'post' ) && $params->options['wordads_inline_enabled'];
+		$this->params = $params;
 
-		// Allow enabled format override by query string.
+		$this->enable_formats();
 		$this->override_formats_from_query_string();
-		// TODO: refactor to remove the need to do this
-		$this->is_inline_enabled = $this->formats['inline']['enabled'];
 
-		// TODO: Is this necessary? if we want to always run Smart insert ads logic after IPW migrations
-		$has_any_format_enabled = in_array( true, array_column( $this->formats, 'enabled' ), true );
-		if ( $has_any_format_enabled ) {
-			// Insert ads.
+		if ( $this->has_any_format_enabled() ) {
 			$this->insert_ads();
 		}
 	}
@@ -173,7 +152,7 @@ class WordAds_Smart {
 	 * @return void
 	 */
 	private function insert_ads() {
-		if ( $this->is_amp ) {
+		if ( $this->params->is_amp ) {
 			return;
 		}
 
@@ -182,13 +161,16 @@ class WordAds_Smart {
 			return;
 		}
 
+		// Add the resource hints.
+		add_filter( 'wp_resource_hints', array( $this, 'resource_hints' ), 10, 2 );
+
 		// Enqueue JS assets.
 		$this->enqueue_assets();
 
 		$is_static_front_page = is_front_page() && 'page' === get_option( 'show_on_front' );
 
 		if ( ! ( $is_static_front_page || is_home() ) ) {
-			if ( $this->is_inline_enabled ) {
+			if ( $this->formats['inline']['enabled'] ) {
 				add_filter(
 					'the_content',
 					array( $this, 'insert_inline_marker' ),
@@ -217,14 +199,9 @@ class WordAds_Smart {
 		global $post;
 
 		$config = array(
-			'blog_id' => $this->get_blog_id(),
 			'post_id' => ( $post instanceof WP_Post ) && is_singular( 'post' ) ? $post->ID : null,
-			'theme'   => $this->theme,
+			'theme'   => get_stylesheet(),
 			'target'  => $this->target_keywords(),
-			'_'       => array(
-				'title'            => __( 'Advertisement', 'jetpack' ),
-				'privacy_settings' => __( 'Privacy Settings', 'jetpack' ),
-			),
 		) + $this->formats;
 
 		// Do conversion.
@@ -235,6 +212,22 @@ class WordAds_Smart {
 	}
 
 	/**
+	 * Add the Smart resource hints.
+	 *
+	 * @param array  $hints Domains for hinting.
+	 * @param string $relation_type Resource type.
+	 *
+	 * @return array Domains for hinting.
+	 */
+	public function resource_hints( $hints, $relation_type ) {
+		if ( 'dns-prefetch' === $relation_type ) {
+			$hints[] = '//af.pubmine.com';
+		}
+
+		return $hints;
+	}
+
+	/**
 	 * Gets the URL to a JSONP endpoint with configuration data.
 	 *
 	 * @return string The URL.
@@ -242,22 +235,8 @@ class WordAds_Smart {
 	private function get_config_url(): string {
 		return sprintf(
 			'https://public-api.wordpress.com/wpcom/v2/sites/%1$d/adflow/conf/?_jsonp=a8c_adflow_callback',
-			$this->get_blog_id()
+			$this->params->blog_id
 		);
-	}
-
-	/**
-	 * Allow format enabled override from query string, eg. ?inline=true.
-	 *
-	 * @return void
-	 */
-	private function override_formats_from_query_string(): void {
-		foreach ( $this->formats as $format_type => $_ ) {
-			// phpcs:disable WordPress.Security.NonceVerification.Recommended
-			if ( isset( $_GET[ $format_type ] ) && 'true' === $_GET[ $format_type ] ) {
-				$this->formats[ $format_type ]['enabled'] = true;
-			}
-		}
 	}
 
 	/**
@@ -266,9 +245,9 @@ class WordAds_Smart {
 	 * @param string|null $content The post content.
 	 * @return string|null The post content with the marker appended.
 	 */
-	public function insert_inline_marker( $content ) {
-		if ( $content === null ) {
-			return $content;
+	public function insert_inline_marker( ?string $content ): ?string {
+		if ( null === $content ) {
+			return null;
 		}
 		$inline_ad_marker = '<span id="wordads-inline-marker" style="display: none;"></span>';
 
@@ -285,7 +264,6 @@ class WordAds_Smart {
 		$target_keywords = array_merge(
 			$this->get_blog_keywords(),
 			$this->get_language_keywords()
-			// TODO: Include categorization.
 		);
 
 		return implode( ';', $target_keywords );
@@ -297,7 +275,7 @@ class WordAds_Smart {
 	 * @return array The list of blog keywords.
 	 */
 	private function get_blog_keywords(): array {
-		return array( 'wp_blog_id=' . $this->get_blog_id() );
+		return array( 'wp_blog_id=' . $this->params->blog_id );
 	}
 
 	/**
@@ -310,11 +288,43 @@ class WordAds_Smart {
 	}
 
 	/**
-	 * Gets the blog's ID.
+	 * Enable formats by post types and the display options.
 	 *
-	 * @return int The blog's ID.
+	 * @return void
 	 */
-	private function get_blog_id(): int {
-		return Jetpack::get_option( 'id', 0 );
+	private function enable_formats(): void {
+		$this->formats['top']['enabled']                  = $this->params->options['enable_header_ad'];
+		$this->formats['inline']['enabled']               = is_singular( 'post' ) && $this->params->options['wordads_inline_enabled'];
+		$this->formats['belowpost']['enabled']            = $this->params->should_show();
+		$this->formats['bottom_sticky']['enabled']        = $this->params->options['wordads_bottom_sticky_enabled'];
+		$this->formats['sidebar_sticky_right']['enabled'] = $this->params->options['wordads_sidebar_sticky_right_enabled'];
+	}
+
+	/**
+	 * Allow format enabled override from query string, eg. ?inline=true.
+	 *
+	 * @return void
+	 */
+	private function override_formats_from_query_string(): void {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET['wordads-logging'] ) ) {
+			return;
+		}
+
+		foreach ( $this->formats as $format_type => $_ ) {
+			// phpcs:disable WordPress.Security.NonceVerification.Recommended
+			if ( isset( $_GET[ $format_type ] ) && 'true' === $_GET[ $format_type ] ) {
+				$this->formats[ $format_type ]['enabled'] = true;
+			}
+		}
+	}
+
+	/**
+	 * Check if has any format enabled.
+	 *
+	 * @return bool True if enabled, false otherwise.
+	 */
+	private function has_any_format_enabled(): bool {
+		return in_array( true, array_column( $this->formats, 'enabled' ), true );
 	}
 }

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -170,16 +170,19 @@ class WordAds_Smart {
 		global $post;
 
 		$config = array(
-			'blog_id' => $this->get_blog_id(),
-			'post_id' => ( $post instanceof WP_Post ) && is_singular( 'post' ) ? $post->ID : null,
-			'theme'   => $this->theme,
-			'target'  => $this->target_keywords(),
-			'_'       => array(
+			'blog_id'       => $this->get_blog_id(),
+			'post_id'       => ( $post instanceof WP_Post ) && is_singular( 'post' ) ? $post->ID : null,
+			'theme'         => $this->theme,
+			'target'        => $this->target_keywords(),
+			'_'             => array(
 				'title'            => __( 'Advertisement', 'jetpack' ),
 				'privacy_settings' => __( 'Privacy Settings', 'jetpack' ),
 			),
-			'inline'  => array(
+			'inline'        => array(
 				'enabled' => $this->is_inline_enabled,
+			),
+			'bottom_sticky' => array(
+				'enabled' => true,
 			),
 		);
 

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -178,13 +178,16 @@ class WordAds_Smart {
 				'title'            => __( 'Advertisement', 'jetpack' ),
 				'privacy_settings' => __( 'Privacy Settings', 'jetpack' ),
 			),
+			'top'                          => array(
+				'enabled' => true, // TODO: this will not be true by default
+			),
 			'inline'                       => array(
 				'enabled' => $this->is_inline_enabled,
 			),
-			'bottom_sticky'                => array(
+			'belowpost'                    => array(
 				'enabled' => true, // TODO: this will not be true by default
 			),
-			'belowpost'                    => array(
+			'bottom_sticky'                => array(
 				'enabled' => true, // TODO: this will not be true by default
 			),
 			'sidebar_sticky_right'         => array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR migrates supported ad formats due to migration away from IPONWEB to our Adflow + WATL (WordAds Tag Library) setup

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enabled WordAds on your test site
* Visit your test site and test all migrated formats using the query string. 
* Test Gutenberg ad blocks `<site-url>?wordads-logging=true&gutenberg_rectangle=true&gutenberg_leaderboard=true&gutenberg_mobile_leaderboard=true&gutenberg_skyscraper=true`
* [Test Legacy sidebar widget](https://github.com/Automattic/jetpack/pull/40462) `<site-url>?wordads-logging=true&sidebar_widget_mediumrectangle=true&sidebar_widget_leaderboard=true&sidebar_widget_wideskyscraper=true`
* Test bottom sticky format `<site-url>?wordads-logging=true&bottom_sticky=true`
* Test sidebar sticky right format `<site-url>?wordads-logging=true&sidebar_sticky_right=true`
* Test top format `<site-url>?wordads-logging=true&top=true`
* Test belowpost `<site-url>?wordads-logging=true&belowpost=true`
* Test shortcode `<site-url>?wordads-logging=true&shortcode=true`
