### PR TITLE
Update/growth stats feature to 10k rather than 100k

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-growth-stats-feature-to-10k-rather-than-100k
+++ b/projects/packages/my-jetpack/changelog/update-growth-stats-feature-to-10k-rather-than-100k
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated feature for stats in growth to 10K instead of 100K

--- a/projects/packages/my-jetpack/src/products/class-growth.php
+++ b/projects/packages/my-jetpack/src/products/class-growth.php
@@ -74,7 +74,7 @@ class Growth extends Module_Product {
 	public static function get_features() {
 		return array(
 			_x( 'Jetpack Social', 'Growth Product Feature', 'jetpack-my-jetpack' ),
-			_x( 'Jetpack Stats (100K site views, upgradeable)', 'Growth Product Feature', 'jetpack-my-jetpack' ),
+			_x( 'Jetpack Stats (10K site views, upgradeable)', 'Growth Product Feature', 'jetpack-my-jetpack' ),
 			_x( 'Unlimited subscriber imports', 'Growth Product Feature', 'jetpack-my-jetpack' ),
 			_x( 'Earn more from your content', 'Growth Product Feature', 'jetpack-my-jetpack' ),
 			_x( 'Accept payments with PayPal', 'Growth Product Feature', 'jetpack-my-jetpack' ),

--- a/projects/plugins/jetpack/changelog/update-growth-stats-feature-to-10k-rather-than-100k
+++ b/projects/plugins/jetpack/changelog/update-growth-stats-feature-to-10k-rather-than-100k
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update feature for stats in growth to 10K instead of 100K

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -5937,7 +5937,7 @@ endif;
 			'included_in_plans' => array( 'complete' ),
 			'features'          => array(
 				_x( 'Jetpack Social', 'Growth Product Feature', 'jetpack' ),
-				_x( 'Jetpack Stats (100K site views, upgradeable)', 'Growth Product Feature', 'jetpack' ),
+				_x( 'Jetpack Stats (10K site views, upgradeable)', 'Growth Product Feature', 'jetpack' ),
 				_x( 'Unlimited subscriber imports', 'Growth Product Feature', 'jetpack' ),
 				_x( 'Earn more from your content', 'Growth Product Feature', 'jetpack' ),
 				_x( 'Accept payments with PayPal', 'Growth Product Feature', 'jetpack' ),


### PR DESCRIPTION
## Proposed changes:

* Update copy for Growth stats feature to 10K instead of 100K

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pbNhbs-bxX-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

N/A