### PR TITLE
Repo Gardening: handle auto-labeling for more Publicize locations

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-publicize-labels
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-publicize-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Labels: automatically label all changes to the Publicize feature.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -137,16 +137,24 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft, isRevert )
 			}
 		}
 
-		// The SSO feature nows lives in both a package and a Jetpack module.
+		// The SSO feature now lives in both a package and a Jetpack module.
 		const sso = file.match( /^projects\/packages\/connection\/src\/sso\// );
 		if ( sso !== null ) {
 			keywords.add( '[Feature] SSO' );
 		}
 
-		// The Google Analytics feature nows lives in both a package and a Jetpack module.
+		// The Google Analytics feature now lives in both a package and a Jetpack module.
 		const googleAnalytics = file.match( /^projects\/packages\/google-analytics\// );
 		if ( googleAnalytics !== null ) {
 			keywords.add( '[Feature] Google Analytics' );
+		}
+
+		// The Publicize feature now lives in a package, a Jetpack module, and a js package.
+		const publicize = file.match(
+			/^projects\/(packages\/publicize)|(js-packages\/publicize-components)\//
+		);
+		if ( publicize !== null ) {
+			keywords.add( '[Feature] Publicize' );
 		}
 
 		// Theme Tools have now been extracted to their own package.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -151,7 +151,7 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft, isRevert )
 
 		// The Publicize feature now lives in a package, a Jetpack module, and a js package.
 		const publicize = file.match(
-			/^projects\/(packages\/publicize)|(js-packages\/publicize-components)\//
+			/^projects\/(packages\/publicize|js-packages\/publicize-components)\//
 		);
 		if ( publicize !== null ) {
 			keywords.add( '[Feature] Publicize' );


### PR DESCRIPTION
## Proposed changes:

The Publicize feature now lives in a package, a Jetpack module, and a js package. We should support that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

This can be tested in a fork, by merging this branch to `trunk`, and then opening a PR making a change to `projects/js-packages/publicize-components/index.ts` or `projects/packages/publicize/src/class-publicize-script-data.php` for example.
