### PR TITLE
Tooling: allow alpha release suffix on release branches

### DIFF
--- a/tools/create-release-branch.sh
+++ b/tools/create-release-branch.sh
@@ -197,7 +197,7 @@ fi
 # - Else if the prefix matches a plugin dir name, use that plugin's version.
 # - Else ask.
 if [[ "${PREFIXES[$PREFIX]}" != *$'\n'* ]]; then
-	BRANCH="$PREFIX/branch-${VERSIONS[0]%%-*}"
+	BRANCH="$PREFIX/branch-${VERSIONS[0]%%-beta}"
 else
 	BRANCH=
 	for ((i=0; i < ${#DIRS[@]}; i++)); do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Currently when creating a release branch, it removes any suffix starting with a hyphen. This was probably intended to remove the `-beta` suffix (p1725907150549519/1725905587.302229-slack-C05Q5HSS013) but now that Jetpack no longer creates `weekly/*` branches, it uses `-a.*` as the base branch, and the code strips said suffix. This is means each alpha release tries to push to the same branch rather than an alpha-specific branch.

This PR is quite simple: it switches the code to only remove the `-beta` suffix.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Verify the following create branches matching the passed version (no need to checkout `prerelease`):

* `tools/create-release-branch.sh jetpack 14.1`
* `tools/create-release-branch.sh jetpack 14.1-a.5`
* `tools/create-release-branch.sh jetpack 14.1-beta`