### PR TITLE
Social | Fix script data for simple sites

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-initial-state-for-simple-sites
+++ b/projects/packages/publicize/changelog/fix-social-initial-state-for-simple-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed initial state error in the editor for simple sites

--- a/projects/packages/publicize/src/class-publicize-utils.php
+++ b/projects/packages/publicize/src/class-publicize-utils.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Publicize;
 
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\Status\Host;
 
 /**
  * Publicize_Utils class.
@@ -49,7 +50,13 @@ class Publicize_Utils {
 			return false;
 		}
 
-		if ( ! self::is_connected() || ! self::is_publicize_active() ) {
+		$needs_jetpack_connection = ! ( new Host() )->is_wpcom_platform();
+
+		if ( $needs_jetpack_connection && ! self::is_connected() ) {
+			return false;
+		}
+
+		if ( ! self::is_publicize_active() ) {
 			return false;
 		}
 


### PR DESCRIPTION
#40311 caused a slight regression for Simple sites which caused the Social script data to be empty for simple sites. The reason for the bug was the Jetpack connection check which doesn't exist for simple sites.

So, this PR skips the Jetpack connection check for WPCOM sites.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the script data check for social to skip Jetpack connection check for simple sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On Jetpack site, on Jetpack settings page > Sharing page, Social Admin page
* Confirm that the connections screen loads fine
* Goto post editor
* Confirm that Jetpack sidebar loads fine
* Confirm that you don't see the error - `The "jetpack-publicize" plugin has encountered an error and cannot be rendered.`

