### PR TITLE
Social | Publicize - Fix call to undefined method on WPCOM

### DIFF
--- a/projects/packages/publicize/changelog/fix-fatal-on-simple-sites
+++ b/projects/packages/publicize/changelog/fix-fatal-on-simple-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social | Publicize - Fixed call to undefined method on WPCOM

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -151,7 +151,8 @@ class Publicize_Script_Data {
 
 		$share_status = array();
 
-		if ( Utils::should_block_editor_have_social() && $post ) {
+		// get_post_share_status is not available on WPCOM yet.
+		if ( Utils::should_block_editor_have_social() && $post && is_callable( array( self::publicize(), 'get_post_share_status' ) ) ) {
 			$share_status[ $post->ID ] = self::publicize()->get_post_share_status( $post->ID );
 		}
 


### PR DESCRIPTION
WPCOM has its own Publicize class and is different from Jetpack one. #40301 added a method to `Publicize` class which does not exist on WPCOM yet.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix fatal on WPCOM for non-existent method on Publicize class

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On simple sites, goto editor, watching for PHP errors
* Confirm that there is no fatal error for call to undefined method
