### PR TITLE
Limited Global Styles: Make editor notice non-dismissible

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-limited-gs-notice-dismissible
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-limited-gs-notice-dismissible
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/notices.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/notices.js
@@ -216,6 +216,7 @@ function GlobalStylesEditNotice() {
 			{
 				id: NOTICE_ID,
 				actions: actions,
+				isDismissible: false,
 			}
 		);
 


### PR DESCRIPTION
Temporary fix for https://github.com/Automattic/dotcom-forge/issues/9890

## Proposed changes:

The Limited Global Styles warning appears constantly after every save and during auto-save even if it was dismissed, causing frustration for users.

We're exploring different options to handle this better, but in the meantime we need something to stop the repetitive visibility changes so this PR removes the dismiss button, effectively making the notice to be visible the entire time.

Before | After
--- | ---
<img width="1279" alt="Screenshot 2024-11-25 at 16 01 00" src="https://github.com/user-attachments/assets/eae2bbb6-78de-44b4-af6a-295a47f0cb45"> | <img width="1278" alt="Screenshot 2024-11-25 at 16 04 56" src="https://github.com/user-attachments/assets/f754e55a-ff24-454e-a42d-efdf09600c1b">


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your sandbox
- Sandbox a free site
- Go to `/wp-admin/site-editor.php?canvas=edit`
- Apply some custom styles and save them
- Make sure you cannot dismiss the Limited GS notice
- Go to `/wp-admin/post-new.php`
- Make sure you cannot dismiss the Limited GS notice there either
