### PR TITLE
Jetpack AI: do not extend form if module isn't available

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-form-extension-module-availability
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-form-extension-module-availability
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI: check module availability for mapped blocks (so far, contact-form)

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-form/index.tsx
@@ -1,8 +1,7 @@
 /**
  * External
  */
-import { parse, serialize } from '@wordpress/blocks';
-import { createBlock } from '@wordpress/blocks';
+import { parse, serialize, createBlock } from '@wordpress/blocks';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 /**

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/lib/is-possible-to-extend-block.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/lib/is-possible-to-extend-block.ts
@@ -1,8 +1,17 @@
 /*
+ * External dependencies
+ */
+import { JETPACK_MODULES_STORE_ID } from '@automattic/jetpack-shared-extension-utils';
+import { select } from '@wordpress/data';
+/*
  * Internal dependencies
  */
 import { EXTENDED_BLOCKS } from '../constants';
 import { canAIAssistantBeEnabled } from './can-ai-assistant-be-enabled';
+
+const BLOCK_TO_MODULE_MAP = {
+	'jetpack/contact-form': 'contact-form',
+};
 
 /**
  * Check if it is possible to extend a block with AI Assistant capabilities.
@@ -20,6 +29,19 @@ export function isPossibleToExtendBlock( blockName: string ): boolean {
 	// Only extend the blocks in the inline blocks list
 	if ( ! EXTENDED_BLOCKS.includes( blockName ) ) {
 		return false;
+	}
+
+	const blockRequiredModule = BLOCK_TO_MODULE_MAP[ blockName ];
+	if ( blockRequiredModule ) {
+		// This call is the same as useModuleStatus( blockRequiredModule ).isModuleActive,
+		// yet we can't use a hook outside a component.
+		// See: js-packages/shared-extension-utils/src/hooks/use-module-status/index.js
+		const blockModuleIsEnabled =
+			select( JETPACK_MODULES_STORE_ID )?.isModuleActive?.( blockRequiredModule ) || false;
+
+		if ( ! blockModuleIsEnabled ) {
+			return false;
+		}
 	}
 
 	return true;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/lib/is-possible-to-extend-block.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/lib/is-possible-to-extend-block.ts
@@ -1,17 +1,8 @@
 /*
- * External dependencies
- */
-import { useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
-/*
  * Internal dependencies
  */
 import { EXTENDED_BLOCKS } from '../constants';
 import { canAIAssistantBeEnabled } from './can-ai-assistant-be-enabled';
-
-// Maps the block name to the module name.
-const blockToModuleMapper = {
-	'jetpack/contact-form': 'contact-form',
-};
 
 /**
  * Check if it is possible to extend a block with AI Assistant capabilities.
@@ -32,18 +23,4 @@ export function isPossibleToExtendBlock( blockName: string ): boolean {
 	}
 
 	return true;
-}
-
-/**
- * Hook that checks if a block can be extended with AI Assistant capabilities.
- * @param {string} blockName - The block name.
- * @return {boolean} Whether the block can be extended.
- */
-export function useIsPossibleToExtendBlock( blockName: string ): boolean {
-	const moduleName = blockToModuleMapper[ blockName ];
-
-	const { isModuleActive } = useModuleStatus( moduleName );
-	const canExtend = isPossibleToExtendBlock( blockName );
-
-	return ! moduleName || ( isModuleActive && canExtend );
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/lib/is-possible-to-extend-block.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/lib/is-possible-to-extend-block.ts
@@ -1,15 +1,15 @@
 /*
  * External dependencies
  */
-import { JETPACK_MODULES_STORE_ID } from '@automattic/jetpack-shared-extension-utils';
-import { select } from '@wordpress/data';
+import { useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
 /*
  * Internal dependencies
  */
 import { EXTENDED_BLOCKS } from '../constants';
 import { canAIAssistantBeEnabled } from './can-ai-assistant-be-enabled';
 
-const BLOCK_TO_MODULE_MAP = {
+// Maps the block name to the module name.
+const blockToModuleMapper = {
 	'jetpack/contact-form': 'contact-form',
 };
 
@@ -31,18 +31,19 @@ export function isPossibleToExtendBlock( blockName: string ): boolean {
 		return false;
 	}
 
-	const blockRequiredModule = BLOCK_TO_MODULE_MAP[ blockName ];
-	if ( blockRequiredModule ) {
-		// This call is the same as useModuleStatus( blockRequiredModule ).isModuleActive,
-		// yet we can't use a hook outside a component.
-		// See: js-packages/shared-extension-utils/src/hooks/use-module-status/index.js
-		const blockModuleIsEnabled =
-			select( JETPACK_MODULES_STORE_ID )?.isModuleActive?.( blockRequiredModule ) || false;
-
-		if ( ! blockModuleIsEnabled ) {
-			return false;
-		}
-	}
-
 	return true;
+}
+
+/**
+ * Hook that checks if a block can be extended with AI Assistant capabilities.
+ * @param {string} blockName - The block name.
+ * @return {boolean} Whether the block can be extended.
+ */
+export function useIsPossibleToExtendBlock( blockName: string ): boolean {
+	const moduleName = blockToModuleMapper[ blockName ];
+
+	const { isModuleActive } = useModuleStatus( moduleName );
+	const canExtend = isPossibleToExtendBlock( blockName );
+
+	return ! moduleName || ( isModuleActive && canExtend );
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
@@ -23,7 +23,10 @@ import { mapInternalPromptTypeToBackendPromptType } from '../lib/prompt/backend-
 import AiAssistantInput from './components/ai-assistant-input';
 import AiAssistantExtensionToolbarDropdown from './components/ai-assistant-toolbar-dropdown';
 import { getBlockHandler, InlineExtensionsContext } from './get-block-handler';
-import { isPossibleToExtendBlock } from './lib/is-possible-to-extend-block';
+import {
+	isPossibleToExtendBlock,
+	useIsPossibleToExtendBlock,
+} from './lib/is-possible-to-extend-block';
 /*
  * Types
  */
@@ -89,6 +92,9 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		const lastRequest = useRef< RequestOptions | null >( null );
 		// Ref to the requesting state to use it in the hideOnBlockFocus effect.
 		const requestingStateRef = useRef< RequestingStateProp | null >( null );
+
+		const canExtendBlock = useIsPossibleToExtendBlock( blockName );
+
 		// Data and functions from the editor.
 		const { undo } = useDispatch( 'core/editor' ) as CoreEditorDispatch;
 		const { postId } = useSelect( select => {
@@ -498,7 +504,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			<>
 				<BlockEdit { ...props } />
 
-				{ showAiControl && (
+				{ showAiControl && canExtendBlock && (
 					<AiAssistantInput
 						customPlaceholder={ customPlaceholder ? customPlaceholder : null }
 						className={ className }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
@@ -19,14 +19,12 @@ import React from 'react';
  */
 import useAiFeature from '../hooks/use-ai-feature';
 import useAutoScroll from '../hooks/use-auto-scroll';
+import useBlockModuleStatus from '../hooks/use-block-module-status';
 import { mapInternalPromptTypeToBackendPromptType } from '../lib/prompt/backend-prompt';
 import AiAssistantInput from './components/ai-assistant-input';
 import AiAssistantExtensionToolbarDropdown from './components/ai-assistant-toolbar-dropdown';
 import { getBlockHandler, InlineExtensionsContext } from './get-block-handler';
-import {
-	isPossibleToExtendBlock,
-	useIsPossibleToExtendBlock,
-} from './lib/is-possible-to-extend-block';
+import { isPossibleToExtendBlock } from './lib/is-possible-to-extend-block';
 /*
  * Types
  */
@@ -93,8 +91,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		// Ref to the requesting state to use it in the hideOnBlockFocus effect.
 		const requestingStateRef = useRef< RequestingStateProp | null >( null );
 
-		const canExtendBlock = useIsPossibleToExtendBlock( blockName );
-
+		const isRequiredModulePresent = useBlockModuleStatus( blockName );
 		// Data and functions from the editor.
 		const { undo } = useDispatch( 'core/editor' ) as CoreEditorDispatch;
 		const { postId } = useSelect( select => {
@@ -504,7 +501,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			<>
 				<BlockEdit { ...props } />
 
-				{ showAiControl && canExtendBlock && (
+				{ showAiControl && isRequiredModulePresent && (
 					<AiAssistantInput
 						customPlaceholder={ customPlaceholder ? customPlaceholder : null }
 						className={ className }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
@@ -69,7 +69,7 @@ type CoreEditorSelect = { getCurrentPostId: () => number };
 
 // HOC to populate the block's edit component with the AI Assistant control inpuit and toolbar button.
 const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
-	return props => {
+	function ExtendedBlock( props ) {
 		// Block props. isSelectionEnabled is used to determine if the block is in the editor or in the preview.
 		const { clientId, isSelected, name: blockName, isSelectionEnabled } = props;
 		// Ref to the control wrapper, its height and its ResizeObserver, for positioning adjustments.
@@ -91,7 +91,6 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		// Ref to the requesting state to use it in the hideOnBlockFocus effect.
 		const requestingStateRef = useRef< RequestingStateProp | null >( null );
 
-		const isRequiredModulePresent = useBlockModuleStatus( blockName );
 		// Data and functions from the editor.
 		const { undo } = useDispatch( 'core/editor' ) as CoreEditorDispatch;
 		const { postId } = useSelect( select => {
@@ -501,7 +500,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			<>
 				<BlockEdit { ...props } />
 
-				{ showAiControl && isRequiredModulePresent && (
+				{ showAiControl && (
 					<AiAssistantInput
 						customPlaceholder={ customPlaceholder ? customPlaceholder : null }
 						className={ className }
@@ -521,14 +520,12 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 				) }
 
 				<BlockControls { ...blockControlsProps }>
-					{ isRequiredModulePresent && (
-						<AiAssistantExtensionToolbarDropdown
-							blockType={ blockName }
-							onAskAiAssistant={ handleAskAiAssistant }
-							onRequestSuggestion={ handleRequestSuggestion }
-							behavior={ behavior }
-						/>
-					) }
+					<AiAssistantExtensionToolbarDropdown
+						blockType={ blockName }
+						onAskAiAssistant={ handleAskAiAssistant }
+						onRequestSuggestion={ handleRequestSuggestion }
+						behavior={ behavior }
+					/>
 				</BlockControls>
 			</>
 		);
@@ -546,6 +543,17 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 				{ aiInlineExtensionContent }
 			</InlineExtensionsContext.Provider>
 		);
+	}
+
+	return props => {
+		const isRequiredModulePresent = useBlockModuleStatus( props.name );
+
+		// If the required module is not enabled, return the original block edit component early.
+		if ( ! isRequiredModulePresent ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		return <ExtendedBlock { ...props } />;
 	};
 }, 'blockEditWithAiComponents' );
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
@@ -521,12 +521,14 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 				) }
 
 				<BlockControls { ...blockControlsProps }>
-					<AiAssistantExtensionToolbarDropdown
-						blockType={ blockName }
-						onAskAiAssistant={ handleAskAiAssistant }
-						onRequestSuggestion={ handleRequestSuggestion }
-						behavior={ behavior }
-					/>
+					{ isRequiredModulePresent && (
+						<AiAssistantExtensionToolbarDropdown
+							blockType={ blockName }
+							onAskAiAssistant={ handleAskAiAssistant }
+							onRequestSuggestion={ handleRequestSuggestion }
+							behavior={ behavior }
+						/>
+					) }
 				</BlockControls>
 			</>
 		);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-block-module-status/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-block-module-status/index.ts
@@ -1,0 +1,22 @@
+/*
+ * External dependencies
+ */
+import { useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
+
+// Maps the block name to the module name.
+const blockToModuleMapper = {
+	'jetpack/contact-form': 'contact-form',
+};
+
+/**
+ * Hook that checks if a block's module is active.
+ * @param {string} blockName - The block name.
+ * @return {boolean} Whether the block can be extended.
+ */
+export default function useBlockModuleStatus( blockName: string ): boolean {
+	const moduleName = blockToModuleMapper[ blockName ];
+
+	const { isModuleActive } = useModuleStatus( moduleName );
+
+	return ! moduleName || isModuleActive;
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/get-feature-availability.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/get-feature-availability.ts
@@ -1,3 +1,8 @@
+/*
+ * External dependencies
+ */
+import { getJetpackExtensionAvailability } from '@automattic/jetpack-shared-extension-utils';
+
 export function getFeatureAvailability( feature: string ): boolean {
-	return window?.Jetpack_Editor_Initial_State?.available_blocks?.[ feature ]?.available === true;
+	return getJetpackExtensionAvailability( feature ).available === true;
 }


### PR DESCRIPTION
`contact-form` extension should only happen if `contact-form` module is enabled.

Fixes #40332

## Proposed changes:
Add a store check for module availability on our lib responsible for allowing the extension.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/jetpack/issues/40332#issuecomment-2499028060

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Go to Posts > Add New
- Type /contact and insert a contact form block
- [ ] See the AI assistant input shows under the variation selector

- Go to Jetpack > Settings > Modules
- Deactivate the Contact Form feature
- Go to Posts > Add New
- Type /contact and insert a contact form block
- [ ] See the AI assistant input is NOT present
- [ ] Confirm other AI assistant features remain available 
