### PR TITLE
Social | Fix undefined index error on atomic sites

### DIFF
--- a/projects/packages/publicize/changelog/fix-undefined-index-error-on-atomic-sites
+++ b/projects/packages/publicize/changelog/fix-undefined-index-error-on-atomic-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social | Fixed undefined index error on atomic sites

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -152,7 +152,7 @@ class Publicize_Script_Data {
 		$share_status = array();
 
 		// get_post_share_status is not available on WPCOM yet.
-		if ( Utils::should_block_editor_have_social() && $post && is_callable( array( self::publicize(), 'get_post_share_status' ) ) ) {
+		if ( Utils::should_block_editor_have_social() && $post && ! $is_wpcom ) {
 			$share_status[ $post->ID ] = self::publicize()->get_post_share_status( $post->ID );
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #40335

#40328 added an `is_callable` check which seems to be true for Atomic sites and thus we need to add a WPCOM check instead to ensure that the method doesn't get called on any WPCOM site which don't have share status yet.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replace `is_callable` check for `get_post_share_status` with `$is_wpcom` check

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On an Atomic site, edit an existing post that has previously been shared
* Confirm that there is no fatal error

