### PR TITLE
WPSC: Check that there is cached content to display in browser

### DIFF
--- a/projects/plugins/super-cache/changelog/update-super-cache-cache-file-race-condition
+++ b/projects/plugins/super-cache/changelog/update-super-cache-cache-file-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Caching: make sure there is cache content to serve, even if the cache file was found

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -301,6 +301,16 @@ function wp_cache_serve_cache_file() {
 				}
 				header( 'Last-Modified: ' . $local_mod_time );
 			}
+
+			/*
+			 * On the rare occasion that the cache file is empty, maybe due to a race condition
+			 * between the file check and the file_get_contents call, we'll just regenerate the cache.
+			 */
+			if ( false === $cachefiledata ) {
+				wp_cache_debug( 'The cached file could not be read. Must generate a new one.' );
+				return false;
+			}
+
 			echo $cachefiledata;
 			exit();
 		} else {

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -227,18 +227,44 @@ function wp_cache_serve_cache_file() {
 				if ( $wp_cache_gzip_encoding ) {
 					if ( file_exists( $file . '.gz' ) ) {
 						$cachefiledata = file_get_contents( $file . '.gz' );
+
+						if ( false === $cachefiledata ) {
+							wp_cache_debug( 'The cached gzip file could not be read. Must generate a new one.' );
+							return false;
+						}
+
 						wp_cache_debug( "Fetched gzip static page data from supercache file using PHP. File: $file.gz" );
 					} else {
-						$cachefiledata = gzencode( file_get_contents( $file ), 6, FORCE_GZIP );
+						$cachefiledata = file_get_contents( $file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
+						if ( false === $cachefiledata ) {
+							wp_cache_debug( 'The cached file could not be read. Must generate a new one.' );
+							return false;
+						}
+
+						$cachefiledata = gzencode( $cachefiledata, 6, FORCE_GZIP );
 						wp_cache_debug( "Fetched static page data from supercache file using PHP and gzipped it. File: $file" );
 					}
 				} else {
 					$cachefiledata = file_get_contents( $file );
+
+					if ( false === $cachefiledata ) {
+						wp_cache_debug( 'The cached file could not be read. Must generate a new one.' );
+						return false;
+					}
+
 					wp_cache_debug( "Fetched static page data from supercache file using PHP. File: $file" );
 				}
 			} else {
 				// get dynamic data from filtered file
-				$cachefiledata = do_cacheaction( 'wpsc_cachedata', file_get_contents( $file ) );
+				$cachefiledata = file_get_contents( $file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
+				if ( false === $cachefiledata ) {
+					wp_cache_debug( 'The cached file could not be read. Must generate a new one.' );
+					return false;
+				}
+
+				$cachefiledata = do_cacheaction( 'wpsc_cachedata', $cachefiledata );
 				if ( $wp_cache_gzip_encoding ) {
 					$cachefiledata = gzencode( $cachefiledata, 6, FORCE_GZIP );
 					wp_cache_debug( "Fetched dynamic page data from supercache file using PHP and gzipped it. File: $file" );
@@ -300,15 +326,6 @@ function wp_cache_serve_cache_file() {
 					wp_cache_debug( 'wp_cache_serve_cache_file: 304 browser caching not possible as timestamps differ.' );
 				}
 				header( 'Last-Modified: ' . $local_mod_time );
-			}
-
-			/*
-			 * On the rare occasion that the cache file is empty, maybe due to a race condition
-			 * between the file check and the file_get_contents call, we'll just regenerate the cache.
-			 */
-			if ( false === $cachefiledata ) {
-				wp_cache_debug( 'The cached file could not be read. Must generate a new one.' );
-				return false;
 			}
 
 			echo $cachefiledata;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
If a website is using an NFS/Samba share to host their cached content, there may be a race condition when serving cache pages. This can happen when one server is serving a page, it checks for the existence of the cache file, and before the file can be read, another server deletes the file.

The check is repeated multiple times because different processing is done each time, sometimes with and without gzipping the data.

Fixes https://wordpress.org/support/topic/edge-case-can-lead-to-blank-page-being-served/

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Make sure that $cachefiledata isn't false before serving a cached page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* This would be very difficult to test as it would require two servers, one serving a page, and the other modifying it.
* However, [file_get_contents](https://www.php.net/manual/en/function.file-get-contents.php) returns false if there's an error, and it can't read the file, so this should be easy to visually check.
