### PR TITLE
Sharing: be more defensive in sharing output to avoid warnings

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharing-module-warning
+++ b/projects/plugins/jetpack/changelog/fix-sharing-module-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sharing: avoid PHP warnings when customizing the output of the sharing buttons.

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -1241,6 +1241,10 @@ function sharing_display( $text = '', $echo = false ) {
 	 */
 	$sharing_markup = apply_filters( 'jetpack_sharing_display_markup', $sharing_content, $enabled );
 
+	if ( ! is_string( $sharing_markup ) || ! is_string( $text ) ) {
+		return $text;
+	}
+	l( $text, $sharing_markup );
 	if ( $echo ) {
 		echo $text . $sharing_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	} else {

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -1244,7 +1244,7 @@ function sharing_display( $text = '', $echo = false ) {
 	if ( ! is_string( $sharing_markup ) || ! is_string( $text ) ) {
 		return $text;
 	}
-	l( $text, $sharing_markup );
+
 	if ( $echo ) {
 		echo $text . $sharing_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	} else {


### PR DESCRIPTION
Fixes #40338

## Proposed changes:

This should avoid any PHP warnings in some edge-cases with the sharing buttons.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

I wasn't able to reproduce the original warning, so I can only recommend using the feature and seeing that the buttons still work.

1. Activate a classic theme like Twenty Twenty
2. Go to Jetpack > Settings > Sharing
3. Enable sharing module
4. Follow the link to configure sharing buttons.
5. Make a few changes to your sharing settings, save your changes.
6. Ensure the buttons are properly displayed on your site.
