### PR TITLE
Fix/stats not showing discount for sale

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/pricing-component.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/pricing-component.tsx
@@ -6,7 +6,6 @@ import usePricingData from './use-pricing-data';
 
 const PriceComponent = ( { slug }: { slug: string } ) => {
 	const { discountPrice, fullPrice, currencyCode } = usePricingData( slug );
-
 	return (
 		<div className={ styles.priceContainer }>
 			{ discountPrice && (

--- a/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
@@ -11,7 +11,6 @@ import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 
 const parsePricingData = ( pricingForUi: ProductCamelCase[ 'pricingForUi' ] ) => {
 	const { tiers, wpcomFreeProductSlug, introductoryOffer } = pricingForUi;
-
 	if ( pricingForUi.tiers ) {
 		const {
 			discountPrice,
@@ -33,18 +32,21 @@ const parsePricingData = ( pricingForUi: ProductCamelCase[ 'pricingForUi' ] ) =>
 	}
 
 	const {
+		discountPrice,
 		discountPricePerMonth,
+		fullPrice,
 		fullPricePerMonth,
 		currencyCode,
-		isIntroductoryOffer,
 		wpcomProductSlug,
 	} = pricingForUi;
+	const hasDiscount = discountPrice && discountPrice !== fullPrice;
+	const eligibleForIntroDiscount = ! introductoryOffer?.reason;
 	return {
 		wpcomFreeProductSlug,
 		wpcomProductSlug,
 		discountPrice:
 			// Only display discount if site is elgible
-			isIntroductoryOffer && ! introductoryOffer?.reason ? discountPricePerMonth : null,
+			hasDiscount && eligibleForIntroDiscount ? discountPricePerMonth : null,
 		fullPrice: fullPricePerMonth,
 		currencyCode,
 	};

--- a/projects/packages/my-jetpack/_inc/data/evaluation-recommendations/use-evaluation-recommendations.ts
+++ b/projects/packages/my-jetpack/_inc/data/evaluation-recommendations/use-evaluation-recommendations.ts
@@ -41,7 +41,7 @@ const useEvaluationRecommendations = () => {
 		// in zero(0) unownedRecommendedModules.
 		const ownedProducts = (
 			process?.env?.NODE_ENV === 'development'
-				? [ 'anti-spam', 'extras', 'stats', 'jetpack-ai' ]
+				? [ 'anti-spam', 'extras', 'jetpack-ai' ]
 				: getMyJetpackWindowInitialState( 'lifecycleStats' )?.ownedProducts || []
 		) as JetpackModule[];
 		// We filter out owned modules, and return the top recommendations

--- a/projects/packages/my-jetpack/changelog/fix-stats-not-showing-discount-for-sale
+++ b/projects/packages/my-jetpack/changelog/fix-stats-not-showing-discount-for-sale
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix stats not showing sale discount


### PR DESCRIPTION
## Proposed changes:

* Fix issue where stats is not showing the sale discount

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Slack: p1732620155389439-slack-C02LK1W8T4Z

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin
2. On your new site, go to My Jetpack and fill out the survey with only "Grow My Audience"
![image](https://github.com/user-attachments/assets/d27eaa5a-93b0-4c51-ab93-6218fb55f10c)
3. Ensure you can see the sale discount on the Stats card
![image](https://github.com/user-attachments/assets/3dbc43f9-207f-40e3-ac5b-7fc6a4ef67c6)
