### PR TITLE
Fix incorrect usage of publicize config in subscribe block

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-incorrect-usage-of-publicize-in-subscribe-block
+++ b/projects/plugins/jetpack/changelog/fix-incorrect-usage-of-publicize-in-subscribe-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed block error when editing Subscribe block

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
@@ -1,6 +1,5 @@
 import { numberFormat } from '@automattic/jetpack-components';
-import { usePublicizeConfig } from '@automattic/jetpack-publicize-components';
-import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
+import { isSimpleSite, useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
 import {
 	ContrastChecker,
 	PanelColorSettings,
@@ -56,7 +55,7 @@ export default function SubscriptionControls( {
 	subscribePlaceholder = DEFAULT_SUBSCRIBE_PLACEHOLDER,
 	successMessage = DEFAULT_SUCCESS_MESSAGE,
 } ) {
-	const { isPublicizeEnabled } = usePublicizeConfig();
+	const { isModuleActive: isPublicizeEnabled } = useModuleStatus( 'publicize' );
 
 	return (
 		<>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/test/controls.js
@@ -36,6 +36,17 @@ afterAll( () => {
 
 jest.mock( '@wordpress/notices', () => {}, { virtual: true } );
 
+jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
+	__esModule: true,
+	...jest.requireActual( '@automattic/jetpack-shared-extension-utils' ),
+	useModuleStatus: jest.fn().mockReturnValue( {
+		isModuleActive: true,
+		isLoadingModules: false,
+		isChangingStatus: false,
+		changeStatus: jest.fn(),
+	} ),
+} ) );
+
 const setButtonBackgroundColor = jest.fn();
 const setGradient = jest.fn();
 const setTextColor = jest.fn();
@@ -74,13 +85,6 @@ beforeEach( () => {
 } );
 
 describe( 'Inspector controls', () => {
-	beforeEach( () => {
-		window.JetpackScriptData = {
-			social: {
-				urls: {},
-			},
-		};
-	} );
 	describe( 'Gradient settings panel', () => {
 		test( 'displays gradient settings control panel', () => {
 			render( <SubscriptionsInspectorControls { ...defaultProps } /> );


### PR DESCRIPTION
Fixes #40354

I had [previously warned](https://github.com/Automattic/jetpack/pull/28944#discussion_r1715184860) about a potential issue with the Subscribe block's incorrect usage of Publicize module config, but I think it wasn’t fixed.

Now, we received reports of that block crashing when it's edited in FSE.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use `useModuleStatus` hook instead of `usePublicizeConfig` to check the publicize module status in subscribe block controls

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Goto Jetpack Settings
- Enable Newsletter
- Goto Site editor
- Add the Subscribe widget
- Confirm that there is no error
- Confirm that the block settings work as expected when Publicize is turned ON/OFF

