### PR TITLE
Add filesystem based cacheable storage support

### DIFF
--- a/projects/packages/boost-core/changelog/add-filebased-kv-storage
+++ b/projects/packages/boost-core/changelog/add-filebased-kv-storage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Cachable: Added a file-system based storage driver.

--- a/projects/packages/boost-core/changelog/allow-expiry-override
+++ b/projects/packages/boost-core/changelog/allow-expiry-override
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Cachable: Make the expiry overridable by child classes.

--- a/projects/packages/boost-core/src/lib/class-cacheable.php
+++ b/projects/packages/boost-core/src/lib/class-cacheable.php
@@ -14,8 +14,9 @@ abstract class Cacheable implements \JsonSerializable {
 
 	/**
 	 * Default cache expiry.
+	 * Can be overridden by child classes.
 	 */
-	const DEFAULT_EXPIRY = 300; // 5 minutes.
+	protected const DEFAULT_EXPIRY = 300; // 5 minutes.
 
 	/**
 	 * The ID of this object, if cached as a transient.
@@ -31,7 +32,11 @@ abstract class Cacheable implements \JsonSerializable {
 	 *
 	 * @return mixed|void
 	 */
-	public function store( $expiry = self::DEFAULT_EXPIRY ) {
+	public function store( $expiry = null ) {
+		if ( null === $expiry ) {
+			$expiry = static::DEFAULT_EXPIRY;
+		}
+
 		if ( ! $this->cache_id ) {
 			$this->cache_id = $this->generate_cache_id();
 		}

--- a/projects/packages/boost-core/src/lib/class-cacheable.php
+++ b/projects/packages/boost-core/src/lib/class-cacheable.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Boost_Core\Lib;
 
+use Automattic\Jetpack\Boost_Core\Lib\Storage\KV_Storage;
+
 /**
  * Class Cacheable.
  */
@@ -41,14 +43,21 @@ abstract class Cacheable implements \JsonSerializable {
 			$this->cache_id = $this->generate_cache_id();
 		}
 
-		Transient::set(
-			static::cache_prefix() . $this->cache_id,
+		static::get_storage()->set(
+			$this->cache_id,
 			$this->jsonSerialize(),
 			$expiry
 		);
 
 		return $this->cache_id;
 	}
+
+	/**
+	 * Get the storage driver.
+	 *
+	 * @return KV_Storage
+	 */
+	abstract protected static function get_storage(): KV_Storage;
 
 	/**
 	 * Default implementation for generating cache key. Generates a random ASCII string.
@@ -74,7 +83,9 @@ abstract class Cacheable implements \JsonSerializable {
 	 * @return null|mixed
 	 */
 	public static function get( $id ) {
-		$data = Transient::get( static::cache_prefix() . $id, false );
+		$storage = static::get_storage();
+		$data    = $storage->get( $id );
+
 		if ( ! $data ) {
 			return null;
 		}
@@ -111,14 +122,14 @@ abstract class Cacheable implements \JsonSerializable {
 	 * Delete the cache entry.
 	 */
 	public function delete() {
-		$this->cache_id && static::delete_by_cache_id( $this->cache_id );
+		$this->cache_id && self::get_storage()->delete( $this->cache_id );
 	}
 
 	/**
 	 * Delete all currently cached entries.
 	 */
-	public static function clear_cache() {
-		Transient::delete_by_prefix( static::cache_prefix() );
+	public function clear_cache() {
+		self::get_storage()->clear();
 	}
 
 	/**
@@ -126,14 +137,7 @@ abstract class Cacheable implements \JsonSerializable {
 	 *
 	 * @param string $cache_id The cache ID.
 	 */
-	public static function delete_by_cache_id( $cache_id ) {
-		Transient::delete( static::cache_prefix() . $cache_id );
+	public function delete_by_cache_id( $cache_id ) {
+		self::get_storage()->delete( $cache_id );
 	}
-
-	/**
-	 * Returns the cache prefix
-	 *
-	 * @throws \Exception Throw an exception to remind to implement the method in child classes.
-	 */
-	abstract protected static function cache_prefix();
 }

--- a/projects/packages/boost-core/src/lib/class-transient.php
+++ b/projects/packages/boost-core/src/lib/class-transient.php
@@ -9,6 +9,8 @@ namespace Automattic\Jetpack\Boost_Core\Lib;
 
 /**
  * Class Transient
+ *
+ * @deprecated since $$next-version$$ Use Transient_Storage instead.
  */
 class Transient {
 

--- a/projects/packages/boost-core/src/lib/storage/class-filesystem-storage.php
+++ b/projects/packages/boost-core/src/lib/storage/class-filesystem-storage.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Filesystem-based key-value storage implementation.
+ *
+ * @package automattic/jetpack-boost-core
+ */
+
+namespace Automattic\Jetpack\Boost_Core\Lib\Storage;
+
+/**
+ * Class Filesystem_Storage
+ */
+class Filesystem_Storage implements KV_Storage {
+	const FILE_CONTENT_PREFIX = "<?php \n//";
+
+	/**
+	 * The path to the storage directory.
+	 *
+	 * @var string
+	 */
+	private $path;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $path The path to the storage directory.
+	 */
+	public function __construct( $path ) {
+		$this->path = $path;
+	}
+
+	/**
+	 * Get a value from storage.
+	 *
+	 * @param string $key Storage key.
+	 * @return mixed|null Value or null if not found.
+	 */
+	public function get( $key ) {
+		$file = $this->get_storage_file_path( $key );
+
+		$wp_filesystem = $this->get_wp_filesystem();
+
+		$content = $wp_filesystem->get_contents( $file );
+		if ( ! $content ) {
+			return null;
+		}
+		$content = substr( $content, strlen( self::FILE_CONTENT_PREFIX ) );
+		$data    = json_decode( $content, true );
+
+		// Check if the data is expired.
+		if ( $data['expire'] !== null && $data['expire'] < time() ) {
+			$this->delete( $key );
+			return null;
+		}
+
+		return $data['data'];
+	}
+
+	/**
+	 * Set a value in storage.
+	 *
+	 * @param string $key Storage key.
+	 * @param mixed  $value Value to store.
+	 * @param int    $expiry Expiry in seconds.
+	 * @return bool Success.
+	 */
+	public function set( $key, $value, $expiry = YEAR_IN_SECONDS ) {
+		$file = $this->get_storage_file_path( $key );
+
+		// Ensure the directory exists.
+		$wp_filesystem = $this->get_wp_filesystem();
+		$this->ensure_directory_exists( $file );
+
+		$data = array(
+			'expire' => time() + $expiry,
+			'data'   => $value,
+		);
+
+		$file_content = self::FILE_CONTENT_PREFIX . wp_json_encode( $data, true );
+
+		return $wp_filesystem->put_contents( $file, $file_content, FS_CHMOD_FILE );
+	}
+
+	/**
+	 * Ensures the directory exists for the given file path.
+	 *
+	 * @param string $file File path to check directory for.
+	 */
+	private function ensure_directory_exists( $file ) {
+		$wp_filesystem = $this->get_wp_filesystem();
+		$dir           = dirname( $file );
+
+		if ( ! $wp_filesystem->exists( $dir ) ) {
+			// Recursively ensure the directory exists.
+			$this->ensure_directory_exists( $dir );
+
+			$wp_filesystem->mkdir( $dir, FS_CHMOD_DIR, true );
+		}
+	}
+
+	/**
+	 * Delete a value from storage.
+	 *
+	 * @param string $key Storage key.
+	 * @return bool Success.
+	 */
+	public function delete( $key ) {
+		$file = $this->get_storage_file_path( $key );
+
+		$wp_filesystem = $this->get_wp_filesystem();
+
+		return $wp_filesystem->delete( $file );
+	}
+
+	/**
+	 * Clear all values from storage.
+	 */
+	public function clear() {
+		$wp_filesystem = $this->get_wp_filesystem();
+
+		return $wp_filesystem->delete( $this->path, true );
+	}
+
+	/**
+	 * Remove expired entries from storage.
+	 */
+	public function garbage_collect() {
+		// Loop through all files in the storage directory and delete expired ones.
+		$files = glob( $this->path . '/*' );
+		$count = 0;
+		foreach ( $files as $file ) {
+			if ( is_file( $file ) ) {
+				$wp_filesystem = $this->get_wp_filesystem();
+				$content       = $wp_filesystem->get_contents( $file );
+
+				if ( null === $content ) {
+					$wp_filesystem->delete( $file );
+					++$count;
+					continue;
+				}
+				$data = maybe_unserialize( $content );
+				if ( null === $data || ! isset( $data['expire'] ) ) {
+					$wp_filesystem->delete( $file );
+					++$count;
+					continue;
+				}
+				if ( null !== $data['expire'] && $data['expire'] < time() ) {
+					$wp_filesystem->delete( $file );
+					++$count;
+				}
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Get the path to the storage file for a given key.
+	 *
+	 * @param string $key Storage key.
+	 * @return string Path to the storage file.
+	 */
+	private function get_storage_file_path( $key ) {
+		$key = sanitize_key( $key );
+		return WP_CONTENT_DIR . '/boost-cache/kv/' . $this->path . '/' . $key . '.php';
+	}
+
+	/**
+	 * Get the WordPress filesystem instance.
+	 *
+	 * @return \WP_Filesystem_Base WordPress filesystem instance.
+	 */
+	private function get_wp_filesystem() {
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		WP_Filesystem();
+		global $wp_filesystem;
+
+		return $wp_filesystem;
+	}
+}

--- a/projects/packages/boost-core/src/lib/storage/class-transient-storage.php
+++ b/projects/packages/boost-core/src/lib/storage/class-transient-storage.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Transients for Jetpack Boost.
+ *
+ * @package automattic/jetpack-boost-core
+ */
+
+namespace Automattic\Jetpack\Boost_Core\Lib\Storage;
+
+/**
+ * Class Transient
+ */
+class Transient_Storage implements KV_Storage {
+
+	/**
+	 * Global prefix for all transient keys.
+	 *
+	 * @var string
+	 */
+	const GLOBAL_PREFIX = 'jb_transient_';
+
+	/**
+	 * Additional prefix for transient keys.
+	 *
+	 * @var string
+	 */
+	private $prefix;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $prefix Optional prefix to prepend to all transient keys.
+	 */
+	public function __construct( $prefix = '' ) {
+		$this->prefix = $prefix;
+	}
+
+	/**
+	 * Get the key with prefix.
+	 *
+	 * @param string $key the key to be prefixed.
+	 */
+	public function key( $key = '' ) {
+		return self::GLOBAL_PREFIX . $this->prefix . $key;
+	}
+
+	/**
+	 * Updates a cache entry. Creates the cache entry if it doesn't exist.
+	 *
+	 * @param string $key    Cache key name.
+	 * @param mixed  $value  Cache value.
+	 * @param int    $expiry Cache expiration in seconds.
+	 *
+	 * @return void
+	 */
+	public function set( $key, $value, $expiry = YEAR_IN_SECONDS ) {
+		$data = array(
+			'expire' => time() + $expiry,
+			'data'   => $value,
+		);
+		update_option( $this->key( $key ), $data, false );
+	}
+
+	/**
+	 * Gets an entry.
+	 *
+	 * @param string $key     Cache key name.
+	 * @param mixed  $default Default value.
+	 *
+	 * @return mixed
+	 */
+	public function get( $key, $default = null ) {
+		// Ensure everything's there.
+		$option = get_option( $this->key( $key ), $default );
+		if ( $default === $option || ! isset( $option['expire'] ) || ! isset( $option['data'] )
+		) {
+			return $default;
+		}
+
+		// Maybe expire the result instead of returning it.
+		$expire = $option['expire'];
+		$data   = $option['data'];
+		if ( false !== $expire && $expire < time() ) {
+			$this->delete( $key );
+
+			return $default;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Delete an entry.
+	 *
+	 * @param string $key Cache key name.
+	 *
+	 * @return void
+	 */
+	public function delete( $key ) {
+		delete_option( $this->key( $key ) );
+	}
+
+	/**
+	 * Remove all expired values from the storage.
+	 *
+	 * @return int The number of expired values removed.
+	 */
+	public function garbage_collect() {
+		global $wpdb;
+
+		/**
+		 * The prefix used in option_name.
+		 */
+		$option_prefix = $this->key();
+
+		/**
+		 * LIKE search pattern for the delete query.
+		 */
+		$prefix_search_pattern = $wpdb->esc_like( $option_prefix ) . '%';
+
+		//phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$options = $wpdb->get_results(
+			$wpdb->prepare(
+				"
+					SELECT option_name, option_value
+					FROM   $wpdb->options
+					WHERE  `option_name` LIKE %s
+				",
+				$prefix_search_pattern
+			)
+		);
+		// phpcs:enable
+
+		$count = 0;
+		foreach ( $options as $option ) {
+			$value = maybe_unserialize( $option->option_value );
+			if ( ! isset( $value['expire'] ) || $value['expire'] < time() ) {
+				delete_option( $option->option_name );
+				++$count;
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Clear all transient values from database.
+	 *
+	 * @return void
+	 */
+	public function clear() {
+		$this->delete_by_prefix( '' );
+	}
+
+	/**
+	 * Delete all `Transient` values with certain prefix from database.
+	 *
+	 * @param string $prefix Cache key prefix.
+	 */
+	private function delete_by_prefix( $prefix ) {
+		global $wpdb;
+
+		/**
+		 * The prefix used in option_name.
+		 */
+		$option_prefix = $this->key( $prefix );
+
+		/**
+		 * LIKE search pattern for the delete query.
+		 */
+		$prefix_search_pattern = $wpdb->esc_like( $option_prefix ) . '%';
+
+		//phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$option_names = $wpdb->get_col(
+			$wpdb->prepare(
+				"
+					SELECT option_name
+					FROM   $wpdb->options
+					WHERE  `option_name` LIKE %s
+				",
+				$prefix_search_pattern
+			)
+		);
+		// phpcs:enable
+
+		// Go through each option individually to ensure caches are handled properly.
+		foreach ( $option_names as $option_name ) {
+			delete_option( $option_name );
+		}
+	}
+}

--- a/projects/packages/boost-core/src/lib/storage/interface-kv-storage.php
+++ b/projects/packages/boost-core/src/lib/storage/interface-kv-storage.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * An interface for key-value storage.
+ *
+ * @package automattic/jetpack-boost-core
+ */
+
+namespace Automattic\Jetpack\Boost_Core\Lib\Storage;
+
+interface KV_Storage {
+	/**
+	 * Get a value from the storage.
+	 *
+	 * @param string $key The key to get the value for.
+	 * @return mixed The value.
+	 */
+	public function get( $key );
+
+	/**
+	 * Set a value in the storage.
+	 *
+	 * @param string   $key The key to set the value for.
+	 * @param mixed    $value The value to set.
+	 * @param int|null $expiry The expiry time in seconds.
+	 */
+	public function set( $key, $value, $expiry = null );
+
+	/**
+	 * Delete a value from the storage.
+	 *
+	 * @param string $key The key to delete the value for.
+	 */
+	public function delete( $key );
+
+	/**
+	 * Remove all expired values from the storage.
+	 *
+	 * @return int The number of expired values removed.
+	 */
+	public function garbage_collect();
+
+	/**
+	 * Clear the storage by removing all values.
+	 */
+	public function clear();
+}

--- a/projects/packages/boost-speed-score/changelog/add-filebased-kv-storage
+++ b/projects/packages/boost-speed-score/changelog/add-filebased-kv-storage
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Changed interface to match dependency
+
+

--- a/projects/packages/boost-speed-score/src/class-speed-score-graph-history-request.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score-graph-history-request.php
@@ -9,6 +9,8 @@ namespace Automattic\Jetpack\Boost_Speed_Score;
 
 use Automattic\Jetpack\Boost_Core\Lib\Boost_API;
 use Automattic\Jetpack\Boost_Core\Lib\Cacheable;
+use Automattic\Jetpack\Boost_Core\Lib\Storage\KV_Storage;
+use Automattic\Jetpack\Boost_Core\Lib\Storage\Transient_Storage;
 
 /**
  * Class Speed_Score_Graph_History_Request
@@ -68,11 +70,21 @@ class Speed_Score_Graph_History_Request extends Cacheable {
 		$this->retry_count = 0;
 	}
 
-		/**
-	 * Convert this object to a plain array for JSON serialization.
+	/**
+	 * Get the storage driver.
+	 *
+	 * @return KV_Storage
 	 */
-	#[\ReturnTypeWillChange]
-	public function jsonSerialize() {
+	protected static function get_storage(): KV_Storage {
+		return new Transient_Storage( 'jetpack_boost_speed_scores_graph_history_' );
+	}
+
+	/**
+	 * Convert this object to a plain array for JSON serialization.
+	 *
+	 * @return array
+	 */
+	public function jsonSerialize(): array {
 		return array(
 			'start'       => $this->start,
 			'end'         => $this->end,
@@ -100,15 +112,6 @@ class Speed_Score_Graph_History_Request extends Cacheable {
 		}
 
 		return $object;
-	}
-
-	/**
-	 * Return the cache prefix.
-	 *
-	 * @return string
-	 */
-	protected static function cache_prefix() {
-		return 'jetpack_boost_speed_scores_graph_history_';
 	}
 
 	/**

--- a/projects/packages/boost-speed-score/src/class-speed-score-request.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score-request.php
@@ -9,6 +9,8 @@ namespace Automattic\Jetpack\Boost_Speed_Score;
 
 use Automattic\Jetpack\Boost_Core\Lib\Boost_API;
 use Automattic\Jetpack\Boost_Core\Lib\Cacheable;
+use Automattic\Jetpack\Boost_Core\Lib\Storage\KV_Storage;
+use Automattic\Jetpack\Boost_Core\Lib\Storage\Transient_Storage;
 use Automattic\Jetpack\Boost_Core\Lib\Url;
 
 /**
@@ -92,6 +94,15 @@ class Speed_Score_Request extends Cacheable {
 	}
 
 	/**
+	 * Get the storage driver.
+	 *
+	 * @return KV_Storage
+	 */
+	protected static function get_storage(): KV_Storage {
+		return new Transient_Storage( 'jetpack_boost_speed_scores_' );
+	}
+
+	/**
 	 * Generate the cache ID from the URL.
 	 *
 	 * @param string $url The URL to get the Speed Scores for.
@@ -113,9 +124,10 @@ class Speed_Score_Request extends Cacheable {
 
 	/**
 	 * Convert this object to a plain array for JSON serialization.
+	 *
+	 * @return array
 	 */
-	#[\ReturnTypeWillChange]
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return array(
 			'id'             => $this->get_cache_id(),
 			'url'            => $this->url,
@@ -154,15 +166,6 @@ class Speed_Score_Request extends Cacheable {
 		}
 
 		return $object;
-	}
-
-	/**
-	 * Return the cache prefix.
-	 *
-	 * @return string
-	 */
-	protected static function cache_prefix() {
-		return 'jetpack_boost_speed_scores_';
 	}
 
 	/**

--- a/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
@@ -195,26 +195,7 @@ class Concatenate_CSS extends WP_Styles {
 					}
 					continue;
 				} elseif ( count( $css ) > 1 ) {
-					$fs_paths = array();
-					foreach ( $css as $css_uri_path ) {
-						$fs_paths[] = $this->dependency_path_mapping->uri_path_to_fs_path( $css_uri_path );
-					}
-
-					$mtime = max( array_map( 'filemtime', $fs_paths ) );
-					if ( jetpack_boost_page_optimize_use_concat_base_dir() ) {
-						$path_str = implode( ',', array_map( 'jetpack_boost_page_optimize_remove_concat_base_prefix', $fs_paths ) );
-					} else {
-						$path_str = implode( ',', $css );
-					}
-					$path_str = "$path_str?m=$mtime&cb=" . jetpack_boost_minify_cache_buster();
-
-					if ( $this->allow_gzip_compression ) {
-						// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-						$path_64 = base64_encode( gzcompress( $path_str ) );
-						if ( strlen( $path_str ) > ( strlen( $path_64 ) + 1 ) ) {
-							$path_str = '-' . $path_64;
-						}
-					}
+					$path_str = jetpack_boost_page_optimize_generate_concat_path( $css, $this->dependency_path_mapping );
 
 					$href = $siteurl . jetpack_boost_get_static_prefix() . '??' . $path_str;
 				} else {

--- a/projects/plugins/boost/app/lib/minify/Concatenate_JS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_JS.php
@@ -254,26 +254,7 @@ class Concatenate_JS extends WP_Scripts {
 				array_map( array( $this, 'print_extra_script' ), $js_array['handles'] );
 
 				if ( isset( $js_array['paths'] ) && count( $js_array['paths'] ) > 1 ) {
-					$fs_paths = array();
-					foreach ( $js_array['paths'] as $js_url ) {
-						$fs_paths[] = $this->dependency_path_mapping->uri_path_to_fs_path( $js_url );
-					}
-
-					$mtime = max( array_map( 'filemtime', $fs_paths ) );
-					if ( jetpack_boost_page_optimize_use_concat_base_dir() ) {
-						$path_str = implode( ',', array_map( 'jetpack_boost_page_optimize_remove_concat_base_prefix', $fs_paths ) );
-					} else {
-						$path_str = implode( ',', $js_array['paths'] );
-					}
-					$path_str = "$path_str?m=$mtime&cb=" . jetpack_boost_minify_cache_buster();
-
-					if ( $this->allow_gzip_compression ) {
-						// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-						$path_64 = base64_encode( gzcompress( $path_str ) );
-						if ( strlen( $path_str ) > ( strlen( $path_64 ) + 1 ) ) {
-							$path_str = '-' . $path_64;
-						}
-					}
+					$path_str = jetpack_boost_page_optimize_generate_concat_path( $js_array['paths'], $this->dependency_path_mapping );
 
 					$href = $siteurl . jetpack_boost_get_static_prefix() . '??' . $path_str;
 				} elseif ( isset( $js_array['paths'] ) && is_array( $js_array['paths'] ) ) {

--- a/projects/plugins/boost/app/lib/minify/Config.php
+++ b/projects/plugins/boost/app/lib/minify/Config.php
@@ -27,4 +27,43 @@ class Config {
 
 		return $path;
 	}
+
+	public static function can_use_cache() {
+		$cache_dir = static::get_cache_dir_path();
+		$use_cache = ! empty( $cache_dir );
+
+		// Ensure the cache directory exists.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+		if ( $use_cache && ! is_dir( $cache_dir ) && ! mkdir( $cache_dir, 0775, true ) ) {
+			$use_cache = false;
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log(
+					sprintf(
+					/* translators: a filesystem path to a directory */
+						__( "Disabling page-optimize cache. Unable to create cache directory '%s'.", 'jetpack-boost' ),
+						$cache_dir
+					)
+				);
+			}
+		}
+
+		// Ensure the cache directory is writable.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
+		if ( $use_cache && ( ! is_dir( $cache_dir ) || ! is_writable( $cache_dir ) || ! is_executable( $cache_dir ) ) ) {
+			$use_cache = false;
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log(
+					sprintf(
+					/* translators: a filesystem path to a directory */
+						__( "Disabling page-optimize cache. Unable to write to cache directory '%s'.", 'jetpack-boost' ),
+						$cache_dir
+					)
+				);
+			}
+		}
+
+		return $use_cache;
+	}
 }

--- a/projects/plugins/boost/app/lib/minify/File_Paths.php
+++ b/projects/plugins/boost/app/lib/minify/File_Paths.php
@@ -3,6 +3,8 @@
 namespace Automattic\Jetpack_Boost\Lib\Minify;
 
 use Automattic\Jetpack\Boost_Core\Lib\Cacheable;
+use Automattic\Jetpack\Boost_Core\Lib\Storage\Filesystem_Storage;
+use Automattic\Jetpack\Boost_Core\Lib\Storage\KV_Storage;
 
 /**
  * Store the hash of the path string so that the concatenated file can be constructed
@@ -38,9 +40,20 @@ final class File_Paths extends Cacheable {
 		return $this->paths;
 	}
 
+	/**
+	 * Get the storage driver.
+	 *
+	 * @return KV_Storage
+	 */
+	protected static function get_storage(): KV_Storage {
+		return new Filesystem_Storage( 'minify-file-paths' );
+	}
+
 	public static function jsonUnserialize( $data ) {
 		$instance = new self();
-		return $instance->set( $data['paths'], $data['mtime'], $data['cache_buster'] );
+		$instance->set( $data['paths'], $data['mtime'], $data['cache_buster'] );
+
+		return $instance;
 	}
 
 	protected function generate_cache_id() {
@@ -48,9 +61,5 @@ final class File_Paths extends Cacheable {
 
 		// Keep cache id small as option keys have a character limit.
 		return substr( $hash, 0, 10 );
-	}
-
-	protected static function cache_prefix() {
-		return 'concat_paths_';
 	}
 }

--- a/projects/plugins/boost/app/lib/minify/File_Paths.php
+++ b/projects/plugins/boost/app/lib/minify/File_Paths.php
@@ -24,11 +24,6 @@ final class File_Paths extends Cacheable {
 		$this->paths        = $paths;
 		$this->mtime        = $mtime;
 		$this->cache_buster = $cache_buster;
-
-		$cache_id = $this->cache_id_from_content();
-		$this->set_cache_id( $cache_id );
-
-		return $this;
 	}
 
 	public function jsonSerialize(): array {
@@ -48,7 +43,7 @@ final class File_Paths extends Cacheable {
 		return $instance->set( $data['paths'], $data['mtime'], $data['cache_buster'] );
 	}
 
-	private function cache_id_from_content() {
+	protected function generate_cache_id() {
 		$hash = md5( implode( ',', $this->paths ) . '_' . $this->mtime . '_' . $this->cache_buster );
 
 		// Keep cache id small as option keys have a character limit.

--- a/projects/plugins/boost/app/lib/minify/File_Paths.php
+++ b/projects/plugins/boost/app/lib/minify/File_Paths.php
@@ -18,7 +18,7 @@ final class File_Paths extends Cacheable {
 	private $mtime;
 	private $cache_buster;
 
-	const DEFAULT_EXPIRY = YEAR_IN_SECONDS;
+	protected const DEFAULT_EXPIRY = YEAR_IN_SECONDS;
 
 	public function set( $paths, $mtime, $cache_buster ) {
 

--- a/projects/plugins/boost/app/lib/minify/File_Paths.php
+++ b/projects/plugins/boost/app/lib/minify/File_Paths.php
@@ -21,7 +21,6 @@ final class File_Paths extends Cacheable {
 	protected const DEFAULT_EXPIRY = YEAR_IN_SECONDS;
 
 	public function set( $paths, $mtime, $cache_buster ) {
-
 		$this->paths        = $paths;
 		$this->mtime        = $mtime;
 		$this->cache_buster = $cache_buster;

--- a/projects/plugins/boost/app/lib/minify/File_Paths.php
+++ b/projects/plugins/boost/app/lib/minify/File_Paths.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Lib\Minify;
+
+use Automattic\Jetpack\Boost_Core\Lib\Cacheable;
+
+/**
+ * Store the hash of the path string so that the concatenated file can be constructed
+ * on-demand.
+ *
+ * We are setting the transient for a long time because, if the content of the hash is not accessible, the concatenated file
+ * will not be able to construct itself. Because of page caching, there may be situations where this function will not
+ * get called for a long time, and we still want to serve the concatenated file in those cases. Having the value in
+ * a Boost Transient ensures that the value is cleaned up when Boost is uninstalled.
+ */
+final class File_Paths extends Cacheable {
+	private $paths;
+	private $mtime;
+	private $cache_buster;
+
+	const DEFAULT_EXPIRY = YEAR_IN_SECONDS;
+
+	public function set( $paths, $mtime, $cache_buster ) {
+
+		$this->paths        = $paths;
+		$this->mtime        = $mtime;
+		$this->cache_buster = $cache_buster;
+
+		$cache_id = $this->cache_id_from_content();
+		$this->set_cache_id( $cache_id );
+
+		return $this;
+	}
+
+	public function jsonSerialize(): array {
+		return array(
+			'paths'        => $this->paths,
+			'mtime'        => $this->mtime,
+			'cache_buster' => $this->cache_buster,
+		);
+	}
+
+	public function get_paths() {
+		return $this->paths;
+	}
+
+	public static function jsonUnserialize( $data ) {
+		$instance = new self();
+		return $instance->set( $data['paths'], $data['mtime'], $data['cache_buster'] );
+	}
+
+	private function cache_id_from_content() {
+		$hash = md5( implode( ',', $this->paths ) . '_' . $this->mtime . '_' . $this->cache_buster );
+
+		// Keep cache id small as option keys have a character limit.
+		return substr( $hash, 0, 10 );
+	}
+
+	protected static function cache_prefix() {
+		return 'concat_paths_';
+	}
+}

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -198,6 +198,13 @@ function jetpack_boost_page_optimize_bail() {
 		return true;
 	}
 
+	// Bail in elementor preview
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	if ( isset( $_GET['elementor-preview'] ) ) {
+		$should_bail = true;
+		return true;
+	}
+
 	return $should_bail;
 }
 

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -2,6 +2,7 @@
 
 use Automattic\Jetpack_Boost\Lib\Minify\Config;
 use Automattic\Jetpack_Boost\Lib\Minify\Dependency_Path_Mapping;
+use Automattic\Jetpack_Boost\Lib\Minify\File_Paths;
 
 /**
  * Get an extra cache key for requests. We can manually bump this when we want
@@ -314,4 +315,24 @@ function jetpack_boost_minify_setup() {
 		// Disable Jetpack Site Accelerator CDN for static JS/CSS, if we're minifying this page.
 		add_filter( 'jetpack_force_disable_site_accelerator', '__return_true' );
 	}
+}
+
+function jetpack_boost_page_optimize_generate_concat_path( $url_paths, $dependency_path_mapping ) {
+	$fs_paths = array();
+	foreach ( $url_paths as $url_path ) {
+		$fs_paths[] = $dependency_path_mapping->uri_path_to_fs_path( $url_path );
+	}
+
+	$mtime = max( array_map( 'filemtime', $fs_paths ) );
+	if ( jetpack_boost_page_optimize_use_concat_base_dir() ) {
+		$paths = array_map( 'jetpack_boost_page_optimize_remove_concat_base_prefix', $fs_paths );
+	} else {
+		$paths = $url_paths;
+	}
+
+	$file_paths = new File_Paths();
+	$file_paths->set( $paths, $mtime, jetpack_boost_minify_cache_buster() );
+	$file_paths->store();
+
+	return $file_paths->get_cache_id();
 }

--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -3,6 +3,7 @@
 use Automattic\Jetpack_Boost\Lib\Minify;
 use Automattic\Jetpack_Boost\Lib\Minify\Config;
 use Automattic\Jetpack_Boost\Lib\Minify\Dependency_Path_Mapping;
+use Automattic\Jetpack_Boost\Lib\Minify\File_Paths;
 use Automattic\Jetpack_Boost\Lib\Minify\Utils;
 
 function jetpack_boost_page_optimize_types() {
@@ -21,47 +22,15 @@ function jetpack_boost_page_optimize_service_request() {
 	$use_wp = defined( 'JETPACK_BOOST_CONCAT_USE_WP' ) && JETPACK_BOOST_CONCAT_USE_WP;
 	$utils  = new Utils( $use_wp );
 
-	$cache_dir = Config::get_cache_dir_path();
-	$use_cache = ! empty( $cache_dir );
-
 	// We handle the cache here, tell other caches not to.
 	if ( ! defined( 'DONOTCACHEPAGE' ) ) {
 		define( 'DONOTCACHEPAGE', true );
 	}
 
-	// Ensure the cache directory exists.
-	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
-	if ( $use_cache && ! is_dir( $cache_dir ) && ! mkdir( $cache_dir, 0775, true ) ) {
-		$use_cache = false;
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log(
-				sprintf(
-				/* translators: a filesystem path to a directory */
-					__( "Disabling page-optimize cache. Unable to create cache directory '%s'.", 'jetpack-boost' ),
-					$cache_dir
-				)
-			);
-		}
-	}
-
-	// Ensure the cache directory is writable.
-	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
-	if ( $use_cache && ( ! is_dir( $cache_dir ) || ! is_writable( $cache_dir ) || ! is_executable( $cache_dir ) ) ) {
-		$use_cache = false;
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log(
-				sprintf(
-				/* translators: a filesystem path to a directory */
-					__( "Disabling page-optimize cache. Unable to write to cache directory '%s'.", 'jetpack-boost' ),
-					$cache_dir
-				)
-			);
-		}
-	}
+	$use_cache = Config::can_use_cache();
 
 	if ( $use_cache ) {
+		$cache_dir = Config::get_cache_dir_path();
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		$request_uri      = isset( $_SERVER['REQUEST_URI'] ) ? $utils->unslash( $_SERVER['REQUEST_URI'] ) : '';
 		$request_uri_hash = md5( $request_uri );
@@ -173,28 +142,11 @@ function jetpack_boost_page_optimize_build_output() {
 
 	$args = substr( $args, strpos( $args, '?' ) + 1 );
 
-	// Detect paths with - in their filename - this implies a base64 encoded gzipped string for the file list.
-	// e.g.: /_jb_static/??-eJzTT8vP109KLNJLLi7W0QdyDEE8IK4CiVjn2hpZGluYmKcDABRMDPM=
-	if ( '-' === $args[0] ) {
-		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
-		$args = @gzuncompress( base64_decode( substr( $args, 1 ) ) );
-
+	$paths = File_Paths::get( $args );
+	if ( $paths ) {
+		$args = $paths->get_paths();
+	} elseif ( false === $args ) {
 		// Invalid data, abort!
-		if ( false === $args ) {
-			jetpack_boost_page_optimize_status_exit( 400 );
-		}
-	}
-
-	// Handle comma separated list of files. e.g.:
-	// /foo/bar.css,/foo1/bar/baz.css?m=293847g
-	$version_string_pos = strpos( $args, '?' );
-	if ( false !== $version_string_pos ) {
-		$args = substr( $args, 0, $version_string_pos );
-	}
-
-	// /foo/bar.css,/foo1/bar/baz.css
-	$args = explode( ',', $args );
-	if ( ! $args ) {
 		jetpack_boost_page_optimize_status_exit( 400 );
 	}
 

--- a/projects/plugins/boost/changelog/fix-elementor-compatibility
+++ b/projects/plugins/boost/changelog/fix-elementor-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Compatibility: Fixed situations where minify could break due to too many files being enqueued in the elementor editor.


### PR DESCRIPTION
## Proposed changes:
* Add a key-value storage driver using the filesystem for cachable
* Refactor to make it easier to clear and garbage collect cachable data

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Make sure
* Minification module is working
* Speed score is working
* Speed score history is working
* Data is cleared on uninstall   [TODO]