### PR TITLE
Social | Change My Jetpack CTA for Social from "Learn more" to "Activate"

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-social-cta
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-social-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Changed My Jetpack CTA for Social from "Learn more" to "Activate"

--- a/projects/packages/my-jetpack/src/products/class-social.php
+++ b/projects/packages/my-jetpack/src/products/class-social.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
 use Automattic\Jetpack\My_Jetpack\Hybrid_Product;
+use Automattic\Jetpack\My_Jetpack\Products;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 use Automattic\Jetpack\Status\Host;
 
@@ -145,6 +146,22 @@ class Social extends Hybrid_Product {
 	}
 
 	/**
+	 * Gets the 'status' of the Social product
+	 *
+	 * @return string
+	 */
+	public static function get_status() {
+		$status = parent::get_status();
+		if ( Products::STATUS_NEEDS_PLAN === $status ) {
+			// If the status says that the site needs a plan,
+			// My Jetpack shows "Learn more" CTA,
+			// We want to instead show the "Activate" CTA.
+			$status = Products::STATUS_NEEDS_ACTIVATION;
+		}
+		return $status;
+	}
+
+	/**
 	 * Checks whether the current plan (or purchases) of the site already supports the product
 	 *
 	 * @return boolean
@@ -159,7 +176,7 @@ class Social extends Hybrid_Product {
 			'jetpack_growth',
 		);
 		// For atomic sites, do a feature check to see if the republicize feature is available
-		// This feature is available by default on all Jetpack sites
+		// This feature is available by default on all Jetpack sites.
 		if ( ( new Host() )->is_woa_site() ) {
 			return static::does_site_have_feature( 'republicize' );
 		}

--- a/projects/plugins/backup/changelog/update-my-jetpack-social-cta
+++ b/projects/plugins/backup/changelog/update-my-jetpack-social-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Changed My Jetpack CTA for Social from "Learn more" to "Activate"

--- a/projects/plugins/boost/changelog/update-my-jetpack-social-cta
+++ b/projects/plugins/boost/changelog/update-my-jetpack-social-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Changed My Jetpack CTA for Social from "Learn more" to "Activate"

--- a/projects/plugins/jetpack/changelog/update-my-jetpack-social-cta
+++ b/projects/plugins/jetpack/changelog/update-my-jetpack-social-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Social | Improved My Jetpack CTA for Social Activate the module instead of Learn More

--- a/projects/plugins/protect/changelog/update-my-jetpack-social-cta
+++ b/projects/plugins/protect/changelog/update-my-jetpack-social-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Changed My Jetpack CTA for Social from "Learn more" to "Activate"

--- a/projects/plugins/search/changelog/update-my-jetpack-social-cta
+++ b/projects/plugins/search/changelog/update-my-jetpack-social-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Changed My Jetpack CTA for Social from "Learn more" to "Activate"

--- a/projects/plugins/social/changelog/update-my-jetpack-social-cta
+++ b/projects/plugins/social/changelog/update-my-jetpack-social-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Changed My Jetpack CTA for Social from "Learn more" to "Activate"

--- a/projects/plugins/starter-plugin/changelog/update-my-jetpack-social-cta
+++ b/projects/plugins/starter-plugin/changelog/update-my-jetpack-social-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Changed My Jetpack CTA for Social from "Learn more" to "Activate"

--- a/projects/plugins/videopress/changelog/update-my-jetpack-social-cta
+++ b/projects/plugins/videopress/changelog/update-my-jetpack-social-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Changed My Jetpack CTA for Social from "Learn more" to "Activate"


### PR DESCRIPTION
Currently, in My Jetpack, the Social card shows "Learn more" on the initial activation which leads to the paid plan purchase. We instead want to increase the active sites allowing them to activate the module, instead of purchasing it

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change My Jetpack CTA for Social from "Learn more" to "Activate"

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a production JN site
* Connect user account
* Goto My Jetpack
* Notice the "Learn more" link on Social card that points to purchasing the social plan
* Now launch a JN site from this PR
* Notice the "Learn more" link above changed to "Activate"
* Click on "Activate" 
* Confirm that the Social plugin is installed and publicize module is activated

| Before | After |
|--------|--------|
| <img width="544" alt="Screenshot 2024-11-27 at 2 13 32 PM" src="https://github.com/user-attachments/assets/156702f9-17c3-40e6-a4ff-133f37b46178"> | <img width="543" alt="Screenshot 2024-11-27 at 2 12 26 PM" src="https://github.com/user-attachments/assets/0f0e5618-f081-4078-a347-2144761e4b00"> | 

Next steps:
#35908 changed the activation CTA to activate the standalone plugin even if Jetpack is already active. I don't know whether we still want to have that behavior, given that we are moving away from creating standalone plugins.
