### PR TITLE
Fix wrong output type on use-module-status hook

### DIFF
--- a/projects/js-packages/shared-extension-utils/changelog/fix-shared-utils-use-module-status-output
+++ b/projects/js-packages/shared-extension-utils/changelog/fix-shared-utils-use-module-status-output
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Shared Extension Utils: fix wrong output type on use-module-status hook

--- a/projects/js-packages/shared-extension-utils/src/hooks/use-module-status/index.js
+++ b/projects/js-packages/shared-extension-utils/src/hooks/use-module-status/index.js
@@ -6,7 +6,7 @@ import { JETPACK_MODULES_STORE_ID } from '../../modules-state';
  * Manage a Jetpack module's status (get and set).
  *
  * @param {string} name - The module's name.
- * @return {boolean} Whether the module is active.
+ * @return {object} Module status/control object.
  */
 const useModuleStatus = name => {
 	const { isModuleActive, isChangingStatus, isLoadingModules } = useSelect(


### PR DESCRIPTION
Wee fix to ease the nerves of the linter

## Proposed changes:
JSDoc return type was wrong, this change just fixes the type from `boolean` to `object`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Merge it