### PR TITLE
Repo Gardening: comment on opened issues when they lack labels

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-triage-issues-comment-when-no-label
+++ b/projects/github-actions/repo-gardening/changelog/update-triage-issues-comment-when-no-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Issue triage: post a comment when an issue lacks labels.

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/ai-labeling.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/ai-labeling.js
@@ -125,6 +125,8 @@ function cleanIssueContent( content ) {
  *
  * @param {WebhookPayloadIssue} payload - Issue event payload.
  * @param {GitHub}              octokit - Initialized Octokit REST client.
+ *
+ * @return {Promise<Array>} Promise resolving to an array of all the labels on the issue after the task is over.
  */
 async function aiLabeling( payload, octokit ) {
 	const { issue, repository } = payload;
@@ -137,7 +139,7 @@ async function aiLabeling( payload, octokit ) {
 
 	if ( ! apiKey ) {
 		debug( `triage-issues > auto-label: No OpenAI key is provided. Bail.` );
-		return;
+		return issueLabels;
 	}
 
 	// If the issue already has [Feature] or [Feature Group] labels, bail.
@@ -145,7 +147,7 @@ async function aiLabeling( payload, octokit ) {
 		debug(
 			`triage-issues > auto-label: Issue #${ number } already has [Feature] or [Feature Group] labels. Skipping.`
 		);
-		return;
+		return issueLabels;
 	}
 
 	if (
@@ -159,7 +161,7 @@ async function aiLabeling( payload, octokit ) {
 			debug(
 				`triage-issues > auto-label: Issue #${ number } doesn't have enough content. Skipping OpenAI analysis.`
 			);
-			return;
+			return issueLabels;
 		}
 
 		debug(
@@ -209,7 +211,12 @@ ${ Object.entries( explanations )
 				issue_number: number,
 				labels: [ '[Experiment] AI labels added' ],
 			} );
+
+			// Add the labels we've added to our existing array of labels.
+			issueLabels.push( ...labels, '[Experiment] AI labels added' );
 		}
 	}
+
+	return issueLabels;
 }
 module.exports = aiLabeling;

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
@@ -69,9 +69,7 @@ async function addCommentAskLabels( octokit, ownerLogin, authorLogin, repo, issu
 async function triageIssues( payload, octokit ) {
 	const { action, issue, repository } = payload;
 	const {
-		head: {
-			user: { login: authorLogin },
-		},
+		user: { login: authorLogin },
 		number,
 		body,
 		state,

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
@@ -13,6 +13,50 @@ const updateBoard = require( './update-board' );
 /* global GitHub, WebhookPayloadIssue */
 
 /**
+ * If we could not add labels via OpenAI, let's add a comment to ask the issue author to add their own labels.
+ *
+ * We only want to do this if the author can actually add labels to the issue, i.e. if they're part of the organization.
+ *
+ * @param {GitHub} octokit     - Initialized Octokit REST client.
+ * @param {string} ownerLogin  - Owner of the repository.
+ * @param {string} authorLogin - Author of the issue.
+ * @param {string} repo        - Repository name.
+ * @param {number} issueNumber - Issue number.
+ *
+ * @return {Promise<void>} Promise resolving when the comment is added.
+ */
+async function addCommentAskLabels( octokit, ownerLogin, authorLogin, repo, issueNumber ) {
+	debug(
+		`triage-issues > auto-label: Issue #${ issueNumber } created by ${ authorLogin }, lacking label suggestions by OpenAI. Asking the author to add labels.`
+	);
+
+	// Check if issue author is org member
+	// Result is communicated by status code, and non-successful status codes throw.
+	// https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+	try {
+		await octokit.rest.orgs.checkMembershipForUser( {
+			org: ownerLogin,
+			username: authorLogin,
+		} );
+	} catch ( error ) {
+		debug(
+			`triage-issues > auto-label: Author ${ authorLogin } is not an org member. Skipping comment.`
+		);
+		return;
+	}
+
+	const commentBody = `It looks like you didn't add any labels to this issue. Could you please add a \`[Type]\`, a \`[Feature]\`, and a \`[Pri]\` label? Those labels will help us categorize and monitor activity in this repository.
+`;
+
+	await octokit.rest.issues.createComment( {
+		owner: ownerLogin,
+		repo,
+		body: commentBody,
+		issue_number: issueNumber,
+	} );
+}
+
+/**
  * Automatically add labels to issues, and send Slack notifications.
  *
  * This task can send 2 different types of Slack notifications:
@@ -24,7 +68,14 @@ const updateBoard = require( './update-board' );
  */
 async function triageIssues( payload, octokit ) {
 	const { action, issue, repository } = payload;
-	const { number, body, state } = issue;
+	const {
+		head: {
+			user: { login: authorLogin },
+		},
+		number,
+		body,
+		state,
+	} = issue;
 	const { owner, name, full_name } = repository;
 	const ownerLogin = owner.login;
 
@@ -100,7 +151,16 @@ async function triageIssues( payload, octokit ) {
 		}
 
 		// Use OpenAI to automatically add labels to issues.
-		await aiLabeling( payload, octokit );
+		const issueLabels = await aiLabeling( payload, octokit );
+
+		// At this point, if we still miss a [Type] label, a [Feature] label, or a [Pri] label, ask the author to add it.
+		if (
+			! issueLabels.includes( '[Type]' ) ||
+			! issueLabels.some( label => label.startsWith( '[Feature' ) ) ||
+			! issueLabels.some( label => label.startsWith( '[Pri' ) )
+		) {
+			await addCommentAskLabels( octokit, ownerLogin, authorLogin, name, number );
+		}
 	}
 
 	// Triage the issue to a Project board if necessary and possible.

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
@@ -152,11 +152,7 @@ async function triageIssues( payload, octokit ) {
 		const issueLabels = await aiLabeling( payload, octokit );
 
 		// At this point, if we still miss a [Type] label, a [Feature] label, or a [Pri] label, ask the author to add it.
-		if (
-			! issueLabels.includes( '[Type]' ) ||
-			! issueLabels.some( label => label.startsWith( '[Feature' ) ) ||
-			! issueLabels.some( label => label.startsWith( '[Pri' ) )
-		) {
+		if ( ! issueLabels.some( label => /^\[(Type|Feature|Pri)\]/.test( label ) ) ) {
 			await addCommentAskLabels( octokit, ownerLogin, authorLogin, name, number );
 		}
 	}

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
@@ -152,7 +152,12 @@ async function triageIssues( payload, octokit ) {
 		const issueLabels = await aiLabeling( payload, octokit );
 
 		// At this point, if we still miss a [Type] label, a [Feature] label, or a [Pri] label, ask the author to add it.
-		if ( ! issueLabels.some( label => /^\[(Type|Feature|Pri)\]/.test( label ) ) ) {
+		const requiredLabelTypes = [ '[Type]', '[Feature', '[Pri]' ];
+		const missingLabelTypes = requiredLabelTypes.filter(
+			requiredLabelType => ! issueLabels.some( label => label.startsWith( requiredLabelType ) )
+		);
+
+		if ( missingLabelTypes.length > 0 ) {
 			await addCommentAskLabels( octokit, ownerLogin, authorLogin, name, number );
 		}
 	}


### PR DESCRIPTION
## Proposed changes:

We should avoid having issues with no Type, Feature, or Priority labels. Our recent AI labeling efforts have allowed us to start labeling issues more often, but there are still situations (like issues without enough content) where we would need to ask the issue author to provide more information by adding some labels.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

This can be tested in a fork. Here are some examples:

https://github.com/jeremy-jeherve/jetpack/issues/9 -> Labels are added by OpenAI, no comment gets posted
https://github.com/jeremy-jeherve/jetpack/issues/10 -> not enough content for OpenAI, so we add a comment