### PR TITLE
Repo Gardening: log failures to send Slack messages

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -68,3 +68,14 @@ jobs:
           triage_projects_token: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
           project_board_url: ${{ secrets.PROJECT_BOARD_URL }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          labels_team_assignments: |
+            {
+              "AI Tools": {
+                "team": "Korvax",
+                "labels": [
+                  "[Feature] AI Tools",
+                  "[Block] A Block Name"
+                ],
+                "slack_id": "C029FKGK4"
+              }
+            }

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -68,14 +68,3 @@ jobs:
           triage_projects_token: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
           project_board_url: ${{ secrets.PROJECT_BOARD_URL }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
-          labels_team_assignments: |
-            {
-              "AI Tools": {
-                "team": "Korvax",
-                "labels": [
-                  "[Feature] AI Tools",
-                  "[Block] A Block Name"
-                ],
-                "slack_id": "C029FKGK4"
-              }
-            }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       '@actions/github':
         specifier: 6.0.0
         version: 6.0.0
+      '@slack/web-api':
+        specifier: 7.7.0
+        version: 7.7.0
       compare-versions:
         specifier: 3.6.0
         version: 3.6.0
@@ -49,9 +52,6 @@ importers:
       moment:
         specifier: 2.29.4
         version: 2.29.4
-      node-fetch:
-        specifier: 2.6.7
-        version: 2.6.7
       openai:
         specifier: 4.56.1
         version: 4.56.1
@@ -6721,6 +6721,10 @@ packages:
 
   '@slack/web-api@7.3.2':
     resolution: {integrity: sha512-hyxwSsUhpOEVN5ORB3ne7TAXQwXl0wxBAyNTCfp4Qc/o9rpEEvY4kfsx7mZF5AhYPcdEeI1XP2bSFrh3W/HGKQ==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/web-api@7.7.0':
+    resolution: {integrity: sha512-DtRyjgQi0mObA2uC6H8nL2OhAISKDhvtOXgRjGRBnBhiaWb6df5vPmKHsOHjpweYALBMHtiqE5ajZFkDW/ag8Q==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
 
   '@storybook/addon-a11y@8.3.5':
@@ -16453,11 +16457,28 @@ snapshots:
 
   '@slack/logger@4.0.0':
     dependencies:
-      '@types/node': 20.17.6
+      '@types/node': 22.9.0
 
   '@slack/types@2.14.0': {}
 
   '@slack/web-api@7.3.2':
+    dependencies:
+      '@slack/logger': 4.0.0
+      '@slack/types': 2.14.0
+      '@types/node': 22.9.0
+      '@types/retry': 0.12.0
+      axios: 1.7.4
+      eventemitter3: 5.0.1
+      form-data: 4.0.1
+      is-electron: 2.2.2
+      is-stream: 2.0.1
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      retry: 0.13.1
+    transitivePeerDependencies:
+      - debug
+
+  '@slack/web-api@7.7.0':
     dependencies:
       '@slack/logger': 4.0.0
       '@slack/types': 2.14.0

--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-slack-report-message
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-slack-report-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Slack messaging: when a Slack message cannot be sent to a specific channel, send a message to warn about the issue.

--- a/projects/github-actions/repo-gardening/package.json
+++ b/projects/github-actions/repo-gardening/package.json
@@ -15,10 +15,10 @@
 	"dependencies": {
 		"@actions/core": "1.10.1",
 		"@actions/github": "6.0.0",
+		"@slack/web-api": "7.7.0",
 		"compare-versions": "3.6.0",
 		"glob": "10.4.1",
 		"moment": "2.29.4",
-		"node-fetch": "2.6.7",
 		"openai": "4.56.1"
 	},
 	"devDependencies": {

--- a/projects/github-actions/repo-gardening/src/utils/slack/send-slack-message.js
+++ b/projects/github-actions/repo-gardening/src/utils/slack/send-slack-message.js
@@ -101,7 +101,6 @@ async function sendSlackMessage( message, channel, payload, customMessageFormat 
 
 		const reportingChannel =
 			owner === 'automattic' ? 'D1KN8VCCA' : getInput( 'slack_quality_channel' );
-
 		if ( ! reportingChannel ) {
 			return false;
 		}

--- a/projects/github-actions/repo-gardening/src/utils/slack/send-slack-message.js
+++ b/projects/github-actions/repo-gardening/src/utils/slack/send-slack-message.js
@@ -1,5 +1,5 @@
 const { getInput, setFailed } = require( '@actions/core' );
-const fetch = require( 'node-fetch' );
+const { WebClient, ErrorCode } = require( '@slack/web-api' );
 
 /* global WebhookPayloadPullRequest, WebhookPayloadIssue */
 
@@ -18,6 +18,8 @@ async function sendSlackMessage( message, channel, payload, customMessageFormat 
 		setFailed( 'triage-issues: Input slack_token is required but missing. Aborting.' );
 		return;
 	}
+
+	const slackApi = new WebClient( token );
 
 	let slackMessage = '';
 
@@ -77,18 +79,72 @@ async function sendSlackMessage( message, channel, payload, customMessageFormat 
 		};
 	}
 
-	const slackRequest = await fetch( 'https://slack.com/api/chat.postMessage', {
-		method: 'POST',
-		body: JSON.stringify( slackMessage ),
-		headers: {
-			'Content-Type': 'application/json; charset=utf-8',
-			'Content-Length': slackMessage.length,
-			Authorization: `Bearer ${ token }`,
-			Accept: 'application/json',
-		},
-	} );
+	try {
+		const slackRequest = await slackApi.chat.postMessage( slackMessage );
+		return !! slackRequest.ok;
+	} catch ( error ) {
+		// The request failed.
+		// At this point, we want to log specific types of errors (let's avoid noise by logging temporary errors for example).
+		if ( ! error.code === ErrorCode.PlatformError ) {
+			return false;
+		}
 
-	return !! slackRequest.ok;
+		// See the list of error messages here: https://api.slack.com/methods/chat.postMessage#errors
+		const errorMessage = error?.data?.error ?? 'Unknown error';
+
+		// Let's send a direct message to @jeherve about it, so we can investigate.
+		// For folks outside of Automattic, let's use the Quality team channel.
+		const {
+			repository: { owner },
+		} = payload;
+		const { html_url, title } = payload?.pull_request ?? payload.issue;
+
+		const reportingChannel =
+			owner === 'automattic' ? 'D1KN8VCCA' : getInput( 'slack_quality_channel' );
+
+		if ( ! reportingChannel ) {
+			return false;
+		}
+		const reportMessage = {
+			channel: reportingChannel,
+			blocks: [
+				{
+					type: 'section',
+					text: {
+						type: 'mrkdwn',
+						text: `We attempted to send a Slack message to ${ reportingChannel } about the issue below, but received the following error: \`${ errorMessage }\``,
+					},
+				},
+				{
+					type: 'divider',
+				},
+				{
+					type: 'section',
+					text: {
+						type: 'mrkdwn',
+						text: `<${ html_url }|${ title }>`,
+					},
+					accessory: {
+						type: 'button',
+						text: {
+							type: 'plain_text',
+							text: 'Review',
+							emoji: true,
+						},
+						value: 'click_review',
+						url: `${ html_url }`,
+						action_id: 'button-action',
+					},
+				},
+			],
+			text: `Error sending message to Slack: -- <${ html_url }|${ title }>`, // Fallback text for display in notifications.
+			mrkdwn: true, // Formatting of the fallback text.
+			unfurl_links: false,
+			unfurl_media: false,
+		};
+		const reportMessageSlackResponse = await slackApi.chat.postMessage( reportMessage );
+		return !! reportMessageSlackResponse.ok;
+	}
 }
 
 module.exports = sendSlackMessage;


### PR DESCRIPTION
Fixes #40366

## Proposed changes:

Until now, we used to try to send messages to Slack, and didn't do anything if the message could not be sent. We'll now log the message, either by sending a Slack message to myself, or the Quality team for folks outside of the Automattic organization.

This will allow us to better detect triage Slack actions that could not be completed, because a team no longer exists and their Slack channel has been archived for example.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1732723599754299-slack-C05KLDWRGAX

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

This can be tested in a fork. Here is an example:
https://github.com/jeherve/jetpack/issues/187

Here is the resulting message: p1732803634693709-slack-CN2FSK7L4