### PR TITLE
Fix/my jetpack recommendation mobile styling

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/style.module.scss
@@ -11,7 +11,7 @@
 }
 
 ul.recommendations-list {
-	grid-template-columns: repeat( 5, 1fr );
+	grid-template-columns: repeat( 5, 100% );
 	grid-auto-flow: column;
 	overflow-x: auto;
 	scroll-snap-type: x mandatory;
@@ -25,23 +25,24 @@ ul.recommendations-list {
 	}
 
 	li {
-		min-width: 320px;
+		width: 100%;
+		max-width: 100%;
 		scroll-snap-align: start;
 		grid-column: unset;
 		grid-column-end: unset;
 	}
 
-	@media screen and (max-width: 600px) {
-		grid-template-columns: repeat( 5, 100% );
+	@media screen and (min-width: 601px) {
+		grid-template-columns: repeat( 5, 1fr );
 
 		li {
-			min-width: unset;
+			width: 420px;
 		}
 	}
 
-	@media screen and (max-width: 1024px) {
+	@media screen and (min-width: 1025px) {
 		li {
-			min-width: 450px;
+			width: 320px;
 		}
 	}
 }

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-recommendation-mobile-styling
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-recommendation-mobile-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix My Jetpack recommendation card styling on mobile


### PR DESCRIPTION
## Proposed changes:

* Update styling on recommendation cards in My Jetpack so they don't extend the width of the screen on mobile

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Go to My Jetpack and connect your account via the welcome banner
3. If you are directed to the pricing page, just go back to fill out the recommendations survey
4. When you get your results, ensure all cards on mobile don't extend the width of the screen and you can see everything. Feel free to re-take the survey to check out all of the cards
![image](https://github.com/user-attachments/assets/491ad6cb-2305-4c64-bf12-41b0e77dad53)
(Previously, the boost bar was extending into the next card on mobile and you couldn't see it all)
5. Make sure the cards still look good on Desktop
![image](https://github.com/user-attachments/assets/48b23823-2404-47b7-afeb-decd6d78dd9d)


