### PR TITLE
Fix/error when non admin user disconnects site

### DIFF
--- a/projects/js-packages/connection/changelog/fix-error-when-non-admin-user-disconnects-site
+++ b/projects/js-packages/connection/changelog/fix-error-when-non-admin-user-disconnects-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix error when non-admin disconnects

--- a/projects/js-packages/connection/components/disconnect-dialog/index.jsx
+++ b/projects/js-packages/connection/components/disconnect-dialog/index.jsx
@@ -316,7 +316,7 @@ const DisconnectDialog = props => {
 					isDisconnecting={ isDisconnecting }
 					closeModal={ onClose }
 					onDisconnect={ handleDisconnect }
-					disconnectError={ disconnectError }
+					disconnectError={ disconnectError.toString() }
 					context={ context } // Where is the modal showing? ( most important for when it loads on the plugins page )
 					disconnectingPlugin={ disconnectingPlugin } // Which plugin is initiating the disconnect.
 					trackModalClick={ trackModalClick }

--- a/projects/js-packages/connection/components/disconnect-dialog/index.jsx
+++ b/projects/js-packages/connection/components/disconnect-dialog/index.jsx
@@ -316,7 +316,7 @@ const DisconnectDialog = props => {
 					isDisconnecting={ isDisconnecting }
 					closeModal={ onClose }
 					onDisconnect={ handleDisconnect }
-					disconnectError={ disconnectError.toString() }
+					disconnectError={ disconnectError }
 					context={ context } // Where is the modal showing? ( most important for when it loads on the plugins page )
 					disconnectingPlugin={ disconnectingPlugin } // Which plugin is initiating the disconnect.
 					trackModalClick={ trackModalClick }

--- a/projects/js-packages/connection/components/disconnect-dialog/steps/step-disconnect.jsx
+++ b/projects/js-packages/connection/components/disconnect-dialog/steps/step-disconnect.jsx
@@ -25,7 +25,6 @@ const StepDisconnect = props => {
 		context,
 		trackModalClick,
 	} = props;
-	console.log( disconnectError );
 
 	const trackLearnClick = useCallback(
 		() => trackModalClick( 'jetpack_disconnect_dialog_click_learn_about' ),
@@ -174,7 +173,7 @@ const StepDisconnect = props => {
 					</div>
 				</div>
 				{ disconnectError && (
-					<p className="jp-connection__disconnect-dialog__error">{ disconnectError }</p>
+					<p className="jp-connection__disconnect-dialog__error">{ disconnectError.toString() }</p>
 				) }
 			</div>
 		</React.Fragment>
@@ -189,7 +188,7 @@ StepDisconnect.propTypes = {
 	/** Callback function that is triggered by clicking the "Disconnect" button. */
 	onDisconnect: PropTypes.func,
 	/** An error that occurred during a request to disconnect. */
-	disconnectError: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
+	disconnectError: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 	/** A component to be rendered as part of this step */
 	disconnectStepComponent: PropTypes.element,
 	/** Plugins that are using the Jetpack connection. */

--- a/projects/js-packages/connection/components/disconnect-dialog/steps/step-disconnect.jsx
+++ b/projects/js-packages/connection/components/disconnect-dialog/steps/step-disconnect.jsx
@@ -25,6 +25,7 @@ const StepDisconnect = props => {
 		context,
 		trackModalClick,
 	} = props;
+	console.log( disconnectError );
 
 	const trackLearnClick = useCallback(
 		() => trackModalClick( 'jetpack_disconnect_dialog_click_learn_about' ),
@@ -188,7 +189,7 @@ StepDisconnect.propTypes = {
 	/** Callback function that is triggered by clicking the "Disconnect" button. */
 	onDisconnect: PropTypes.func,
 	/** An error that occurred during a request to disconnect. */
-	disconnectError: PropTypes.bool,
+	disconnectError: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 	/** A component to be rendered as part of this step */
 	disconnectStepComponent: PropTypes.element,
 	/** Plugins that are using the Jetpack connection. */

--- a/projects/packages/connection/changelog/fix-error-when-non-admin-user-disconnects-site
+++ b/projects/packages/connection/changelog/fix-error-when-non-admin-user-disconnects-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix error when non-admin tries to disconnect user account

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -549,7 +549,7 @@ class REST_Connector {
 	 * @return bool|WP_Error True if user is able to disconnect the site or the request is signed with a blog token (aka a direct request from WPCOM).
 	 */
 	public static function disconnect_site_permission_check() {
-		if ( current_user_can( 'jetpack_disconnect' ) ) {
+		if ( current_user_can( 'jetpack_disconnect' ) || current_user_can( 'jetpack_connect_user' ) ) {
 			return true;
 		}
 
@@ -917,6 +917,11 @@ class REST_Connector {
 	 */
 	public static function disconnect_site() {
 		$connection = new Manager();
+
+		if ( ! current_user_can( 'jetpack_disconnect' ) ) {
+			$connection->disconnect_user();
+			return rest_ensure_response( array( 'code' => 'success' ) );
+		}
 
 		if ( $connection->is_connected() ) {
 			$connection->disconnect_site();


### PR DESCRIPTION
## Proposed changes:

* Update Connection package to allow user disconnection even when user is non-admin
* Update the disconnect_site function to disconnect the user account if the user does not have the permissions to disconnect the site connection

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Issue: https://github.com/Automattic/jetpack/issues/34535

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Go to `/wp-admin/admin.php?page=my-jetpack` and connect the site and your user account
3. Go to `/wp-admin/user-new.php` and add a new user to the site
4. In an incognito browser, login to the site with the new user.
5. Go to `/wp-admin/admin.php?page=my-jetpack` and connect your user account under a **different** wordpress account
6. After connection, go back to `/wp-admin/admin.php?page=my-jetpack` and disconnect your site by clicking `Manage` and `Disconnect Jetpack`
![image](https://github.com/user-attachments/assets/dca5329f-104c-4f7f-a219-3181d636a706)
![image](https://github.com/user-attachments/assets/f2e2e291-990b-4c6a-979e-c66d8c87004e)
7. Ensure your user account is disconnected with no errors
![image](https://github.com/user-attachments/assets/6c6d819e-f086-41f6-8fe6-a58412ab5ed5)

