### PR TITLE
Social | Fix publicize crashing when activated from the editor

### DIFF
--- a/projects/packages/publicize/changelog/fix-publicize-activation-crash-in-the-editor
+++ b/projects/packages/publicize/changelog/fix-publicize-activation-crash-in-the-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social | Fixed publicize crashing when activated in the editor

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -91,7 +91,7 @@ class Publicize_Script_Data {
 		}
 
 		$basic_data = array(
-			'api_paths'            => array(),
+			'api_paths'            => self::get_api_paths(),
 			'is_publicize_enabled' => Utils::is_publicize_active(),
 			'feature_flags'        => self::get_feature_flags(),
 			'supported_services'   => array(),
@@ -114,7 +114,6 @@ class Publicize_Script_Data {
 		return array_merge(
 			$basic_data,
 			array(
-				'api_paths'           => self::get_api_paths(),
 				'supported_services'  => self::get_supported_services(),
 				'shares_data'         => self::get_shares_data(),
 				'urls'                => self::get_urls(),

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -84,7 +84,7 @@ class Publicize_Script_Data {
 		// the Jetpack settings page, or the block editor.
 		$should_set_script_data = Utils::is_jetpack_settings_page()
 			|| Utils::is_social_settings_page()
-			|| Utils::should_block_editor_have_social();
+			|| Utils::should_block_editor_have_social( false );
 
 		if ( ! $should_set_script_data ) {
 			return array();

--- a/projects/packages/publicize/src/class-publicize-utils.php
+++ b/projects/packages/publicize/src/class-publicize-utils.php
@@ -56,10 +56,6 @@ class Publicize_Utils {
 			return false;
 		}
 
-		if ( ! self::is_publicize_active() ) {
-			return false;
-		}
-
 		$post_type = get_post_type();
 
 		if ( empty( $post_type ) || ! post_type_supports( $post_type, 'publicize' ) ) {

--- a/projects/packages/publicize/src/class-publicize-utils.php
+++ b/projects/packages/publicize/src/class-publicize-utils.php
@@ -37,9 +37,11 @@ class Publicize_Utils {
 	/**
 	 * Whether the block editor should have the social features.
 	 *
+	 * @param bool $should_publicize_be_active Whether the Publicize module should be active.
+	 *
 	 * @return bool
 	 */
-	public static function should_block_editor_have_social() {
+	public static function should_block_editor_have_social( $should_publicize_be_active = true ) {
 		if ( ! is_admin() ) {
 			return false;
 		}
@@ -53,6 +55,10 @@ class Publicize_Utils {
 		$needs_jetpack_connection = ! ( new Host() )->is_wpcom_platform();
 
 		if ( $needs_jetpack_connection && ! self::is_connected() ) {
+			return false;
+		}
+
+		if ( $should_publicize_be_active && ! self::is_publicize_active() ) {
 			return false;
 		}
 

--- a/projects/plugins/jetpack/changelog/fix-publicize-activation-crash-in-the-editor
+++ b/projects/plugins/jetpack/changelog/fix-publicize-activation-crash-in-the-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Social | Fixed publicize crashing when activated in the editor

--- a/projects/plugins/social/changelog/fix-publicize-activation-crash-in-the-editor
+++ b/projects/plugins/social/changelog/fix-publicize-activation-crash-in-the-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed publicize crashing when activated in the editor

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -18,6 +18,7 @@ use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
 use Automattic\Jetpack\Publicize\Jetpack_Social_Settings\Dismissed_Notices;
+use Automattic\Jetpack\Publicize\Publicize_Utils;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
@@ -224,6 +225,10 @@ class Jetpack_Social {
 	 * @return array
 	 */
 	public function set_social_admin_script_data( $data ) {
+		// We need this data only on the social settings page.
+		if ( ! Publicize_Utils::is_social_settings_page() ) {
+			return $data;
+		}
 
 		$data['plugin_info']['social'] = array(
 			'version' => $this->get_plugin_version(),


### PR DESCRIPTION
When Jetpack is active and the publicize module is off, if you try to activate publicize from the editor, it crashes.

![Image](https://github.com/user-attachments/assets/ddaa9f06-1834-4104-88d1-b190055f1371)

The reason for the issue is lack of some script data (initial state) that sets things up when social is activated.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Pass the bare minimum scipt-data to the editor when Social is turned OFF

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Turn OFF publicize from Jetpack settings > Sharing
- Goto Editor
- Open Jetpack sidebar
- Expand "Share this post" panel
- Click on "Activate Jetpack Social"
- Confirm that the module is activated and there is no error
- Goto Social settings page
- Confirm that the information and settings on the page are correct
