### PR TITLE
Newsletter sidebar: fix no space under toggle

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-panel-whitespace
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-panel-whitespace
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter sidebar: fix no space under toggle

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -38,9 +38,10 @@ const NewsletterMenu = ( { openPreviewModal } ) => {
 
 	return (
 		<PluginSidebar
-			name="newsletter-settings-sidebar"
+			name="jetpack-newsletter-settings-sidebar"
 			title={ __( 'Newsletter', 'jetpack' ) }
 			icon={ <SendIcon /> }
+			className="jetpack-newsletter-settings-sidebar"
 		>
 			<PanelBody>
 				{ ! isPublished && <NewsletterEmailDocumentSettings /> }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.scss
@@ -15,14 +15,14 @@
 	}
 
 	.components-notice__content {
-		margin-top: 0px;
+		margin-top: 0;
 	}
 
 	&__notice {
 		&.components-notice {
-			margin: 0px;
-			padding: 0px;
-			margin-top: 0px;
+			margin: 0;
+			padding: 0;
+			margin-top: 0;
 
 			&.is-info {
 				border-inline-start-color: #fff;
@@ -53,8 +53,11 @@
 	.components-panel__body-toggle svg {
 		margin: 0 0 0 0.5em;
 	}
+}
 
-	p {
-		margin-top: 0px;
+// Dedicated Newsletter sidebar
+.jetpack-newsletter-settings-sidebar {
+	.jetpack-subscribe-email-document-setting {
+		margin-bottom: 1em;
 	}
 }

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -327,7 +327,11 @@ export function NewsletterEmailDocumentSettings() {
 						disabled={ isPostPublished || ! canEdit }
 						onChange={ toggleSendEmail }
 						isBlock
+						label={ __( 'Send as email to email subscribers?', 'jetpack' ) }
+						hideLabelFromVision={ true }
+						className="jetpack-subscribe-email-document-setting"
 						__nextHasNoMarginBottom={ true }
+						__next40pxDefaultSize={ true }
 					>
 						<ToggleGroupControlOption label={ __( 'Post & email', 'jetpack' ) } value={ true } />
 						<ToggleGroupControlOption label={ __( 'Post only', 'jetpack' ) } value={ false } />

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -327,7 +327,7 @@ export function NewsletterEmailDocumentSettings() {
 						disabled={ isPostPublished || ! canEdit }
 						onChange={ toggleSendEmail }
 						isBlock
-						label={ __( 'Send as email to email subscribers?', 'jetpack' ) }
+						label={ __( 'Send as email to subscribers?', 'jetpack' ) }
 						hideLabelFromVision={ true }
 						className="jetpack-subscribe-email-document-setting"
 						__nextHasNoMarginBottom={ true }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Keeping the componentry up to latest Gutenberg changes.

In pre/post publish panels `p` tags have 1em top/bottom margin so `__nextHasNoMarginBottom` for the toggle component works fine, but in Newsletter sidebar it didn't.

Note also slightly bigger toggle size, which will be the default in future Gutenberg.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Couple small fixes:

- Fix no space under toggle
- Opt-in into 40px default size for the toggle
- Add accessibility label


**Before**

<img width="301" alt="Screenshot 2024-11-28 at 10 44 42" src="https://github.com/user-attachments/assets/cbeca36d-963f-4b70-b324-81aed14deb76">

**After**

<img width="301" alt="Screenshot 2024-11-28 at 10 35 37" src="https://github.com/user-attachments/assets/03d4b8cd-a12a-4a30-8a0a-b38eecfdd5b5">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

