### PR TITLE
External media: Google Photos picker: Add logic to persist session in cookie

### DIFF
--- a/projects/plugins/jetpack/changelog/update-external-media-google-photos
+++ b/projects/plugins/jetpack/changelog/update-external-media-google-photos
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+External media: Add logic to persist session in cookie

--- a/projects/plugins/jetpack/extensions/shared/external-media/constants.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/constants.js
@@ -25,6 +25,7 @@ export const PATH_OPTIONS = [
 		label: __( 'Albums', 'jetpack' ),
 	},
 ];
+export const GOOGLE_PHOTOS_PICKER_SESSION = 'google_photos_picker_session';
 export const GOOGLE_PHOTOS_CATEGORIES = [
 	{
 		value: '',

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
@@ -92,7 +92,7 @@ type WpcomMediaResponse = {
 declare global {
 	interface Window {
 		wpCookies: {
-			set: ( name: string, value: string, expires: number, path: string ) => void;
+			set: ( name: string, value: string, expires: number, path: string, domain?: string ) => void;
 			get: ( name: string ) => string | null;
 		};
 	}
@@ -307,11 +307,17 @@ export const getGooglePhotosPickerSession = () => {
 };
 
 /**
- * Set Google Photos Picker session id to cookies for 7 days
+ * Set Google Photos Picker session id to cookies
  * @param {string|null} sessionId - Session id
  */
 export const setGooglePhotosPickeCachedSessionId = ( sessionId: string | null ) => {
-	wpCookies.set( GOOGLE_PHOTOS_PICKER_SESSION, sessionId, 604800, '/' );
+	wpCookies.set(
+		GOOGLE_PHOTOS_PICKER_SESSION,
+		sessionId,
+		604800, // 7 days
+		'/',
+		`.${ window.location.hostname }`
+	);
 };
 
 /**

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
@@ -97,6 +97,7 @@ declare global {
 		};
 	}
 }
+
 const wpCookies = window.wpCookies;
 
 /**
@@ -293,7 +294,7 @@ export const authenticateMediaSource = ( source: MediaSource, isAuthenticated: b
  * @param {PickerSession} session
  */
 export const setGooglePhotosPickerSession = ( session: PickerSession ) => {
-	wpCookies.set( GOOGLE_PHOTOS_PICKER_SESSION, JSON.stringify( session ), 0, '/' );
+	setGooglePhotosPickeCachedSessionId( session?.id || null );
 	dispatch( mediaStore ).mediaPhotosPickerSessionSet( session );
 };
 
@@ -302,8 +303,21 @@ export const setGooglePhotosPickerSession = ( session: PickerSession ) => {
  * @return {PickerSession} Media URL.
  */
 export const getGooglePhotosPickerSession = () => {
-	let session = wpCookies.get( GOOGLE_PHOTOS_PICKER_SESSION );
-	session = JSON.parse( session );
+	return select( mediaStore ).mediaPhotosPickerSession();
+};
 
-	return session || select( mediaStore ).mediaPhotosPickerSession();
+/**
+ * Set Google Photos Picker session id to cookies
+ * @param {string|null} sessionId - Session id
+ */
+export const setGooglePhotosPickeCachedSessionId = ( sessionId: string | null ) => {
+	wpCookies.set( GOOGLE_PHOTOS_PICKER_SESSION, sessionId, 0, '/' );
+};
+
+/**
+ * Get Google Photos Picker session id from cookies
+ * @return {string | null} Google Photos Picker session id
+ */
+export const getGooglePhotosPickerCachedSessionId = () => {
+	return wpCookies.get( GOOGLE_PHOTOS_PICKER_SESSION );
 };

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
@@ -307,11 +307,11 @@ export const getGooglePhotosPickerSession = () => {
 };
 
 /**
- * Set Google Photos Picker session id to cookies
+ * Set Google Photos Picker session id to cookies for 7 days
  * @param {string|null} sessionId - Session id
  */
 export const setGooglePhotosPickeCachedSessionId = ( sessionId: string | null ) => {
-	wpCookies.set( GOOGLE_PHOTOS_PICKER_SESSION, sessionId, 0, '/' );
+	wpCookies.set( GOOGLE_PHOTOS_PICKER_SESSION, sessionId, 604800, '/' );
 };
 
 /**

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
@@ -4,6 +4,7 @@ import { dispatch, select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { waitFor } from '../../wait-for';
+import { GOOGLE_PHOTOS_PICKER_SESSION } from '../constants';
 import { store as mediaStore } from '../store';
 import { PickerSession } from '../store/types';
 import { MediaSource } from './types';
@@ -84,6 +85,19 @@ type WpcomMediaResponse = {
 	found: number;
 	media: WpcomMediaItem[];
 };
+
+/**
+ * wpCookies global variable.
+ */
+declare global {
+	interface Window {
+		wpCookies: {
+			set: ( name: string, value: string, expires: number, path: string ) => void;
+			get: ( name: string ) => string | null;
+		};
+	}
+}
+const wpCookies = window.wpCookies;
 
 /**
  * Get media URL for a given MediaSource.
@@ -279,6 +293,7 @@ export const authenticateMediaSource = ( source: MediaSource, isAuthenticated: b
  * @param {PickerSession} session
  */
 export const setGooglePhotosPickerSession = ( session: PickerSession ) => {
+	wpCookies.set( GOOGLE_PHOTOS_PICKER_SESSION, JSON.stringify( session ), 0, '/' );
 	dispatch( mediaStore ).mediaPhotosPickerSessionSet( session );
 };
 
@@ -286,4 +301,9 @@ export const setGooglePhotosPickerSession = ( session: PickerSession ) => {
  * Get Google Photos Picker session
  * @return {PickerSession} Media URL.
  */
-export const getGooglePhotosPickerSession = () => select( mediaStore ).mediaPhotosPickerSession();
+export const getGooglePhotosPickerSession = () => {
+	let session = wpCookies.get( GOOGLE_PHOTOS_PICKER_SESSION );
+	session = JSON.parse( session );
+
+	return session || select( mediaStore ).mediaPhotosPickerSession();
+};

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/google-photos-picker-button.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/google-photos-picker-button.js
@@ -6,7 +6,7 @@ import mediaImage from '../../../../../images/media.svg';
 import GooglePhotosAccount from './google-photos-account';
 
 export default function GooglePhotosPickerButton( props ) {
-	const { pickerSession, featchPickerSession, setAuthenticated, account } = props;
+	const { pickerSession, fetchPickerSession, setAuthenticated, account } = props;
 	const isButtonBusy = ! pickerSession;
 
 	const openPicker = () => {
@@ -15,10 +15,10 @@ export default function GooglePhotosPickerButton( props ) {
 
 	useEffect( () => {
 		const interval = setInterval( () => {
-			pickerSession.id && featchPickerSession( pickerSession.id );
+			pickerSession.id && fetchPickerSession( pickerSession.id );
 		}, 3000 );
 		return () => clearInterval( interval );
-	}, [ featchPickerSession, pickerSession?.id ] );
+	}, [ fetchPickerSession, pickerSession?.id ] );
 
 	return (
 		<div className="jetpack-external-media__google-photos-picker">

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/index.js
@@ -17,7 +17,7 @@ function GooglePhotos( props ) {
 		getPickerStatus,
 	} = props;
 	const [ cachedSessionId ] = useState( getGooglePhotosPickerCachedSessionId() );
-	const [ isCashedSessionChecked, setIsCashedSessionChecked ] = useState( false );
+	const [ isCachedSessionChecked, setIsCachedSessionChecked ] = useState( false );
 	const [ pickerFeatureEnabled, setPickerFeatureEnabled ] = useState( null );
 	const isPickerSessionAccurate = pickerSession !== null && ! ( 'code' in pickerSession );
 	const isSessionExpired =
@@ -28,13 +28,13 @@ function GooglePhotos( props ) {
 			feature && setPickerFeatureEnabled( feature.enabled );
 		} );
 		cachedSessionId &&
-			fetchPickerSession( cachedSessionId ).then( () => setIsCashedSessionChecked( true ) );
+			fetchPickerSession( cachedSessionId ).then( () => setIsCachedSessionChecked( true ) );
 	}, [ getPickerStatus, fetchPickerSession, cachedSessionId ] );
 
 	useEffect( () => {
 		if (
 			pickerFeatureEnabled &&
-			isCashedSessionChecked &&
+			isCachedSessionChecked &&
 			isAuthenticated &&
 			( ! isPickerSessionAccurate || isSessionExpired )
 		) {
@@ -42,7 +42,7 @@ function GooglePhotos( props ) {
 		}
 	}, [
 		pickerFeatureEnabled,
-		isCashedSessionChecked,
+		isCachedSessionChecked,
 		isPickerSessionAccurate,
 		isAuthenticated,
 		isSessionExpired,
@@ -50,7 +50,7 @@ function GooglePhotos( props ) {
 		pickerSession,
 	] );
 
-	if ( pickerFeatureEnabled === null || ! isCashedSessionChecked ) {
+	if ( pickerFeatureEnabled === null || ! isCachedSessionChecked ) {
 		return <MediaLoadingPlaceholder />;
 	}
 

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/index.js
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import { useEffect, useState } from 'react';
 import MediaLoadingPlaceholder from '../../media-browser/placeholder';
 import { MediaSource } from '../../media-service/types';
@@ -18,10 +19,23 @@ function GooglePhotos( props ) {
 	}, [ getPickerStatus ] );
 
 	useEffect( () => {
-		if ( pickerFeatureEnabled && isAuthenticated && ! isPickerSessionAccurate ) {
+		const isSessionExpired =
+			pickerSession?.expireTime && moment( pickerSession.expireTime ).isBefore( new Date() );
+
+		if (
+			pickerFeatureEnabled &&
+			isAuthenticated &&
+			( ! isPickerSessionAccurate || isSessionExpired )
+		) {
 			createPickerSession();
 		}
-	}, [ pickerFeatureEnabled, isPickerSessionAccurate, isAuthenticated, createPickerSession ] );
+	}, [
+		pickerFeatureEnabled,
+		isPickerSessionAccurate,
+		isAuthenticated,
+		createPickerSession,
+		pickerSession,
+	] );
 
 	if ( pickerFeatureEnabled === null ) {
 		return <MediaLoadingPlaceholder />;

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/index.js
@@ -13,7 +13,7 @@ function GooglePhotos( props ) {
 		isAuthenticated,
 		pickerSession,
 		createPickerSession,
-		featchPickerSession,
+		fetchPickerSession,
 		getPickerStatus,
 	} = props;
 	const [ cachedSessionId ] = useState( getGooglePhotosPickerCachedSessionId() );
@@ -28,8 +28,8 @@ function GooglePhotos( props ) {
 			feature && setPickerFeatureEnabled( feature.enabled );
 		} );
 		cachedSessionId &&
-			featchPickerSession( cachedSessionId ).then( () => setIsCashedSessionChecked( true ) );
-	}, [ getPickerStatus, featchPickerSession, cachedSessionId ] );
+			fetchPickerSession( cachedSessionId ).then( () => setIsCashedSessionChecked( true ) );
+	}, [ getPickerStatus, fetchPickerSession, cachedSessionId ] );
 
 	useEffect( () => {
 		if (

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/index.js
@@ -1,6 +1,7 @@
 import moment from 'moment';
 import { useEffect, useState } from 'react';
 import MediaLoadingPlaceholder from '../../media-browser/placeholder';
+import { getGooglePhotosPickerCachedSessionId } from '../../media-service';
 import { MediaSource } from '../../media-service/types';
 import withMedia from '../with-media';
 import GooglePhotosAuth from './google-photos-auth';
@@ -8,22 +9,32 @@ import GooglePhotosMedia from './google-photos-media';
 import GooglePhotosPickerButton from './google-photos-picker-button';
 
 function GooglePhotos( props ) {
-	const { isAuthenticated, pickerSession, createPickerSession, getPickerStatus } = props;
+	const {
+		isAuthenticated,
+		pickerSession,
+		createPickerSession,
+		featchPickerSession,
+		getPickerStatus,
+	} = props;
+	const [ cachedSessionId ] = useState( getGooglePhotosPickerCachedSessionId() );
+	const [ isCashedSessionChecked, setIsCashedSessionChecked ] = useState( false );
 	const [ pickerFeatureEnabled, setPickerFeatureEnabled ] = useState( null );
 	const isPickerSessionAccurate = pickerSession !== null && ! ( 'code' in pickerSession );
+	const isSessionExpired =
+		pickerSession?.expireTime && moment( pickerSession.expireTime ).isBefore( new Date() );
 
 	useEffect( () => {
 		getPickerStatus().then( feature => {
 			feature && setPickerFeatureEnabled( feature.enabled );
 		} );
-	}, [ getPickerStatus ] );
+		cachedSessionId &&
+			featchPickerSession( cachedSessionId ).then( () => setIsCashedSessionChecked( true ) );
+	}, [ getPickerStatus, featchPickerSession, cachedSessionId ] );
 
 	useEffect( () => {
-		const isSessionExpired =
-			pickerSession?.expireTime && moment( pickerSession.expireTime ).isBefore( new Date() );
-
 		if (
 			pickerFeatureEnabled &&
+			isCashedSessionChecked &&
 			isAuthenticated &&
 			( ! isPickerSessionAccurate || isSessionExpired )
 		) {
@@ -31,13 +42,15 @@ function GooglePhotos( props ) {
 		}
 	}, [
 		pickerFeatureEnabled,
+		isCashedSessionChecked,
 		isPickerSessionAccurate,
 		isAuthenticated,
+		isSessionExpired,
 		createPickerSession,
 		pickerSession,
 	] );
 
-	if ( pickerFeatureEnabled === null ) {
+	if ( pickerFeatureEnabled === null || ! isCashedSessionChecked ) {
 		return <MediaLoadingPlaceholder />;
 	}
 

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/index.js
@@ -27,6 +27,8 @@ function GooglePhotos( props ) {
 		getPickerStatus().then( feature => {
 			feature && setPickerFeatureEnabled( feature.enabled );
 		} );
+
+		cachedSessionId === null && setIsCachedSessionChecked( true );
 		cachedSessionId &&
 			fetchPickerSession( cachedSessionId ).then( () => setIsCachedSessionChecked( true ) );
 	}, [ getPickerStatus, fetchPickerSession, cachedSessionId ] );

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/with-media.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/with-media.js
@@ -377,7 +377,7 @@ export default function withMedia( mediaSource = MediaSource.Unknown ) {
 								onChangePath={ this.onChangePath }
 								pickerSession={ this.props.pickerSession }
 								createPickerSession={ this.createPickerSession }
-								featchPickerSession={ this.fetchPickerSession }
+								fetchPickerSession={ this.fetchPickerSession }
 								deletePickerSession={ this.deletePickerSession }
 								getPickerStatus={ this.getPickerStatus }
 							/>

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/with-media.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/with-media.js
@@ -254,7 +254,7 @@ export default function withMedia( mediaSource = MediaSource.Unknown ) {
 			};
 
 			fetchPickerSession = sessionId => {
-				apiFetch( {
+				return apiFetch( {
 					path: `/wpcom/v2/external-media/session/google_photos/${ sessionId }`,
 					method: 'GET',
 				} ).then( setGooglePhotosPickerSession );


### PR DESCRIPTION
## Proposed changes:
* Add functions to persist and retrieve session object stored in the cookie
* Extend `createSession` condition, checking if the session has expired

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pdtkmj-36s-p2#comment-5923

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to your sandbox following instructions: https://github.com/Automattic/jetpack/pull/40382#issuecomment-2506454250
* Open post or page editor
* Make a selection with Google Photos Picker
* Close the modal or refresh the browser's tab
* Open Google Photos media
* Check if the selection is there


https://github.com/user-attachments/assets/f10d69ab-5991-47bb-813a-86a6e731ccbe

