### PR TITLE
Social | Convert activate social button in the editor to link

### DIFF
--- a/projects/plugins/jetpack/changelog/update-social-convert-activate-social-in-the-editor-to-link
+++ b/projects/plugins/jetpack/changelog/update-social-convert-activate-social-in-the-editor-to-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Social | Changed activate social button in the editor to link

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/placeholder.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/placeholder.js
@@ -40,15 +40,13 @@ export const PublicizePlaceholder = () => {
 			<Button
 				onClick={ enablePublicizeModule }
 				variant="link"
-				target="_blank"
-				rel="noopener noreferrer"
 				href={ getJetpackAdminPageUrl( '#/settings?term=publicize' ) }
 			>
 				{ __( 'Activate Jetpack Social', 'jetpack' ) }
 			</Button>
 			<div className="components-placeholder__learn-more">
 				<ExternalLink href={ getRedirectUrl( 'jetpack-support-publicize' ) }>
-					{ __( 'Learn more about Jetpack Social.', 'jetpack' ) }
+					{ __( 'Learn more', 'jetpack' ) }
 				</ExternalLink>
 			</div>
 		</PanelBody>

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/placeholder.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/placeholder.js
@@ -44,7 +44,7 @@ export const PublicizePlaceholder = () => {
 				rel="noopener noreferrer"
 				href={ getJetpackAdminPageUrl( '#/settings?term=publicize' ) }
 			>
-				{ __( 'Activating Jetpack Social', 'jetpack' ) }
+				{ __( 'Activate Jetpack Social', 'jetpack' ) }
 			</Button>
 			<div className="components-placeholder__learn-more">
 				<ExternalLink href={ getRedirectUrl( 'jetpack-support-publicize' ) }>

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/placeholder.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/placeholder.js
@@ -1,16 +1,16 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
+import { getJetpackAdminPageUrl } from '@automattic/jetpack-script-data';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { PanelBody, Button, ExternalLink } from '@wordpress/components';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-export const PublicizePlaceholder = ( { changeStatus, isLoading, isModuleActive } ) => {
+export const PublicizePlaceholder = () => {
 	const { tracks } = useAnalytics();
 	const [ isOpened, setIsOpened ] = useState( false );
 
 	const enablePublicizeModule = () => {
 		tracks.recordEvent( 'jetpack_editor_publicize_enable' );
-		return changeStatus( true );
 	};
 
 	// Track when the placeholder is viewed.
@@ -38,18 +38,13 @@ export const PublicizePlaceholder = ( { changeStatus, isLoading, isModuleActive 
 				) }
 			</p>
 			<Button
-				disabled={ isModuleActive || isLoading }
-				isBusy={ isLoading }
 				onClick={ enablePublicizeModule }
-				variant="secondary"
+				variant="link"
+				target="_blank"
+				rel="noopener noreferrer"
+				href={ getJetpackAdminPageUrl( '#/settings?term=publicize' ) }
 			>
-				{ isLoading
-					? __( 'Activating Jetpack Social', 'jetpack' )
-					: __(
-							'Activate Jetpack Social',
-							'jetpack',
-							/* dummy arg to avoid bad minification */ 0
-					  ) }
+				{ __( 'Activating Jetpack Social', 'jetpack' ) }
 			</Button>
 			<div className="components-placeholder__learn-more">
 				<ExternalLink href={ getRedirectUrl( 'jetpack-support-publicize' ) }>

--- a/projects/plugins/jetpack/extensions/plugins/publicize/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/index.js
@@ -27,8 +27,7 @@ import './editor.scss';
 export const name = 'publicize';
 
 const PublicizeSettings = () => {
-	const { isLoadingModules, isChangingStatus, isModuleActive, changeStatus } =
-		useModuleStatus( name );
+	const { isLoadingModules, isModuleActive } = useModuleStatus( name );
 	const postCanUseSig = usePostCanUseSig();
 
 	let children = null;
@@ -37,13 +36,7 @@ const PublicizeSettings = () => {
 	if ( isLoadingModules ) {
 		children = <PublicizeSkeletonLoader />;
 	} else if ( ! isModuleActive ) {
-		children = (
-			<PublicizePlaceholder
-				changeStatus={ changeStatus }
-				isModuleActive={ isModuleActive }
-				isLoading={ isChangingStatus }
-			/>
-		);
+		children = <PublicizePlaceholder />;
 	} else {
 		children = (
 			<>


### PR DESCRIPTION
Supercedes #40375

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change the activate social button in the editor to the link to settings page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Turn OFF publicize from Jetpack settings > Sharing
- Goto Editor
- Open Jetpack sidebar
- Expand "Share this post" panel
- Confirm that you see the "Activate Jetpack Social" link instead of a button
- Click on the "Activate Jetpack Social" link
- Confirm that it opens the Jetpack settings page social section

| BEFORE | AFTER |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/e08818f7-1dde-4dd2-93e8-6fa29f6fd098) | ![image](https://github.com/user-attachments/assets/998a2f41-fc86-4781-9a6f-1113b9b7197f) |  
