### PR TITLE
Jetpack JSON API: Fix Fatal in WPCOM_JSON_API_Update_Post_v1_2_Endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-fatal-in-json-api-update-post-v1-2-endpoint
+++ b/projects/plugins/jetpack/changelog/fix-fatal-in-json-api-update-post-v1-2-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Jetpack JSON API: Fix Fatal in WPCOM_JSON_API_Update_Post_v1_2_Endpoint
+
+

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -322,9 +322,14 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 
 		// If date is set, $this->input will set date_gmt, date still needs to be adjusted.
 		if ( isset( $input['date_gmt'] ) ) {
-			$gmt_offset       = get_option( 'gmt_offset' );
-			$time_with_offset = strtotime( $input['date_gmt'] ) + $gmt_offset * HOUR_IN_SECONDS;
-			$input['date']    = gmdate( 'Y-m-d H:i:s', $time_with_offset );
+			$date_gmt_timestamp = strtotime( $input['date_gmt'] );
+			if ( $date_gmt_timestamp ) {
+				$gmt_offset       = (int) get_option( 'gmt_offset' );
+				$time_with_offset = $date_gmt_timestamp + $gmt_offset * HOUR_IN_SECONDS;
+				$input['date']    = gmdate( 'Y-m-d H:i:s', $time_with_offset );
+			} else { // Invalid input.
+				unset( $input['date_gmt'] );
+			}
 		}
 
 		if ( ! empty( $author_id ) && get_current_user_id() !== $author_id ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes `Uncaught TypeError: Unsupported operand types: string * int` in `WPCOM_JSON_API_Update_Post_v1_2_Endpoint`  

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `WPCOM_JSON_API_Update_Post_v1_2_Endpoint`: Cast `get_option( 'gmt_offset' )` to int before using it.
* `WPCOM_JSON_API_Update_Post_v1_2_Endpoint`: Unset `$input['date_gmt']` if it's not a valid date format.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1732877693298469/1732877167.908289-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- In order to test you can use the [Developer console](https://developer.wordpress.com/docs/api/console/) to trigger requests to the endpoint, hardcode `$input['date_gmt']` to eg `now` and `update_option( 'gmt_offset' , '')`