### PR TITLE
Repo Gardening: update wording in labeling comments

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-need-label-message-update
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-need-label-message-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Prompt for labels: update wording.

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/ai-labeling.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/ai-labeling.js
@@ -192,10 +192,16 @@ async function aiLabeling( payload, octokit ) {
 			} );
 
 			// During testing, post a comment on the issue with the explanations.
-			const explanationComment = `**OpenAI suggested the following labels for this issue:**
+			let explanationComment = `**OpenAI suggested the following labels for this issue:**
 ${ Object.entries( explanations )
 	.map( ( [ labelName, explanation ] ) => `- ${ labelName }: ${ explanation }` )
 	.join( '\n' ) }`;
+
+			if ( ownerLogin === 'automattic' ) {
+				explanationComment += `
+
+If you have feedback about the labels suggested, please let us know in #repo-gardening!`;
+			}
 
 			await octokit.rest.issues.createComment( {
 				owner: ownerLogin,

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
@@ -45,7 +45,7 @@ async function addCommentAskLabels( octokit, ownerLogin, authorLogin, repo, issu
 		return;
 	}
 
-	const commentBody = `It looks like you didn't add any labels to this issue. Could you please add a \`[Type]\`, a \`[Feature]\`, and a \`[Pri]\` label? Those labels will help us categorize and monitor activity in this repository.
+	const commentBody = `This issue could use some more labels, to help prioritize and categorize our work. Could you please add at least a \`[Type]\`, a \`[Feature]\`, and a \`[Pri]\` label?
 `;
 
 	await octokit.rest.issues.createComment( {


### PR DESCRIPTION
## Proposed changes:

Let's update the wording in the 2 coments that get posted on newly opened issues:

- For issues that lack some labels, let's make it clear that we need at least one of each type.
- For issues that have been auto-labeled, invite folks to give feedback in slack, at least when in the automattic org.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This can be tested in a fork.

https://github.com/jeremy-jeherve/jetpack/issues/12#issuecomment-2507652380
https://github.com/jeremy-jeherve/jetpack/issues/13#issuecomment-2507663845
