### PR TITLE
Write Brief: Add alternative apostrophe char to spelling mistakes regex

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-write-brief-apostrophe
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-write-brief-apostrophe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Write Brief: Add alternative apostroph char to spelling mistakes regex

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
@@ -132,9 +132,9 @@ export default function spellingMistakes( text: string ): Array< HighlightedText
 	// \p{M} matches any Unicode mark (combining characters)
 	// The regex has three main parts:
 	// 1. [@#+$/]{0,1} - Optionally matches a single special character at the start
-	// 2. [\p{L}\p{M}\p{N}'-]+ - Matches one or more letters, marks, numbers, apostrophes, or hyphens
-	// 3. (?:\/[\p{L}\p{M}\p{N}'-]+)* - Optionally matches additional parts separated by slashes
-	const wordRegex = new RegExp( /[@#+$/]{0,1}[\p{L}\p{M}\p{N}'-]+(?:\/[\p{L}\p{M}\p{N}'-]+)*/gu );
+	// 2. [\p{L}\p{M}\p{N}'’-] - Matches one or more letters, marks, numbers, apostrophes, or hyphens
+	// 3. (?:\/[\p{L}\p{M}\p{N}'’-]+)* - Optionally matches additional parts separated by slashes
+	const wordRegex = new RegExp( /[@#+$/]{0,1}[\p{L}\p{M}\p{N}'’-]+(?:\/[\p{L}\p{M}\p{N}'’-]+)*/gu );
 	const matches = Array.from( text.matchAll( wordRegex ) );
 
 	matches.forEach( match => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
@@ -155,8 +155,8 @@ export default function spellingMistakes( text: string ): Array< HighlightedText
 		const subWords = word.split( /[-/]/ );
 
 		subWords.forEach( subWord => {
-			// remove single quotes from beginning/end
-			subWord = subWord.replace( /^'+|'+$/g, '' );
+			// remove single quotes from beginning/end and apostrophes from the end
+			subWord = subWord.replace( /^'+|['’]+$/g, '' );
 
 			if ( ! spellChecker.correct( subWord ) ) {
 				const subWordStartIndex = startIndex + word.indexOf( subWord );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
ref p1732738458925179-slack-C054LN8RNVA

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the `’` character to the regex, treated the same as `'`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor with spell checking enabled
* Test with something like:
```
balance isn’t always perfect, but the cats’ toys are
balance isn't always perfect, but the cats' toys are
```

| Before | After
| - | -
| ![Screenshot from 2024-11-29 12-17-40](https://github.com/user-attachments/assets/262dcc42-46c5-4f0b-9e8e-e0d7e7e91c8d) | ![Screenshot from 2024-11-29 12-17-46](https://github.com/user-attachments/assets/38f26544-99e4-4713-9334-745865e216bd)