### PR TITLE
Gardening: update conditions to include "[<plugin> Feature]" labels

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-label-type-catch
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-label-type-catch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Prompt for labels: update conditions to include "[<plugin> Feature]" labels.

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
@@ -152,9 +152,9 @@ async function triageIssues( payload, octokit ) {
 		const issueLabels = await aiLabeling( payload, octokit );
 
 		// At this point, if we still miss a [Type] label, a [Feature] label, or a [Pri] label, ask the author to add it.
-		const requiredLabelTypes = [ '[Type]', '[Feature', '[Pri]' ];
+		const requiredLabelTypes = [ /^\[Type\]/, /^\[Pri/, /^\[.*?Feature/ ];
 		const missingLabelTypes = requiredLabelTypes.filter(
-			requiredLabelType => ! issueLabels.some( label => label.startsWith( requiredLabelType ) )
+			requiredLabelType => ! issueLabels.some( label => requiredLabelType.test( label ) )
 		);
 
 		if ( missingLabelTypes.length > 0 ) {

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
@@ -152,7 +152,7 @@ async function triageIssues( payload, octokit ) {
 		const issueLabels = await aiLabeling( payload, octokit );
 
 		// At this point, if we still miss a [Type] label, a [Feature] label, or a [Pri] label, ask the author to add it.
-		const requiredLabelTypes = [ /^\[Type\]/, /^\[Pri/, /^\[.*?Feature/ ];
+		const requiredLabelTypes = [ /^\[Type\]/, /^\[Pri/, /^\[[^\]]*Feature/ ];
 		const missingLabelTypes = requiredLabelTypes.filter(
 			requiredLabelType => ! issueLabels.some( label => requiredLabelType.test( label ) )
 		);


### PR DESCRIPTION
## Proposed changes:

Some of our standalone plugins do not use [Feature] labels ; they use [PluginName Feature] labels instead. Let's update our conditions to be happy with such labels as well.

This commit also makes the priority condition a bit more broad, so it is satisfied with both "[Pri]" and "[Priority]" labels.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?
## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This can only be tested in a fork, where you'll merge this branch into `trunk`, then create an issue with no content and the "[Priority] High", "[Type] Bug", and "[Boost Feature] Cloud CSS" labels. No commment prompting for labels should get posted.
