### PR TITLE
Protect Status: Refactor data handling

### DIFF
--- a/projects/packages/protect-status/.phan/baseline.php
+++ b/projects/packages/protect-status/.phan/baseline.php
@@ -9,10 +9,9 @@
  */
 return [
     // # Issue statistics:
-    // PhanPluginDuplicateConditionalNullCoalescing : 45+ occurrences
-    // PhanTypeMismatchArgument : 5 occurrences
-    // PhanParamTooMany : 4 occurrences
-    // PhanTypeMismatchProperty : 2 occurrences
+    // PhanPluginDuplicateConditionalNullCoalescing : 25+ occurrences
+    // PhanTypeMismatchArgument : 3 occurrences
+    // PhanParamTooMany : 2 occurrences
     // PhanPluginSimplifyExpressionBool : 1 occurrence
     // PhanRedundantCondition : 1 occurrence
     // PhanTypeMismatchReturnProbablyReal : 1 occurrence
@@ -22,7 +21,7 @@ return [
         'src/class-plan.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'src/class-protect-status.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/class-rest-controller.php' => ['PhanParamTooMany'],
-        'src/class-scan-status.php' => ['PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchProperty'],
+        'src/class-scan-status.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition'],
         'src/class-status.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchArgument'],
         'tests/php/test-scan-status.php' => ['PhanTypeMismatchArgument'],
         'tests/php/test-status.php' => ['PhanTypeMismatchArgument'],

--- a/projects/packages/protect-status/changelog/add-extension-to-threats-data
+++ b/projects/packages/protect-status/changelog/add-extension-to-threats-data
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add extension data to threats.

--- a/projects/packages/protect-status/src/class-protect-status.php
+++ b/projects/packages/protect-status/src/class-protect-status.php
@@ -145,129 +145,184 @@ class Protect_Status extends Status {
 		$status->num_threats         = isset( $report_data->num_vulnerabilities ) ? $report_data->num_vulnerabilities : null;
 		$status->num_themes_threats  = isset( $report_data->num_themes_vulnerabilities ) ? $report_data->num_themes_vulnerabilities : null;
 		$status->num_plugins_threats = isset( $report_data->num_plugins_vulnerabilities ) ? $report_data->num_plugins_vulnerabilities : null;
-
-		// merge plugins from report with all installed plugins before mapping into the Status_Model
-		$installed_plugins   = Plugins_Installer::get_plugins();
-		$last_report_plugins = isset( $report_data->plugins ) ? $report_data->plugins : new \stdClass();
-		$status->plugins     = self::merge_installed_and_checked_lists( $installed_plugins, $last_report_plugins, array( 'type' => 'plugins' ) );
-
-		// merge themes from report with all installed plugins before mapping into the Status_Model
-		$installed_themes   = Sync_Functions::get_themes();
-		$last_report_themes = isset( $report_data->themes ) ? $report_data->themes : new \stdClass();
-		$status->themes     = self::merge_installed_and_checked_lists( $installed_themes, $last_report_themes, array( 'type' => 'themes' ) );
-
-		// normalize WordPress core report data and map into Status_Model
-		$status->core = self::normalize_core_information( isset( $report_data->core ) ? $report_data->core : new \stdClass() );
-
-		// loop through all items to merge threats and check if there are any unchecked items
-		$all_items                   = array_merge( $status->plugins, $status->themes, array( $status->core ) );
 		$status->has_unchecked_items = false;
-		foreach ( $all_items as $item ) {
-			if ( $item->threats ) {
-				$status->threats = array_merge( $status->threats, $item->threats );
-			}
-			if ( ! isset( $item->checked ) || ! $item->checked ) {
-				$status->has_unchecked_items = true;
-			}
-		}
+
+		// normalize extension information
+		self::normalize_extension_data( $status, $report_data, 'themes' );
+		self::normalize_extension_data( $status, $report_data, 'plugins' );
+		self::normalize_core_data( $status, $report_data );
+
+		// sort extensions by number of threats
+		$status->themes  = self::sort_threats( $status->themes );
+		$status->plugins = self::sort_threats( $status->plugins );
 
 		return $status;
 	}
 
 	/**
-	 * Merges the list of installed extensions with the list of extensions that were checked for known vulnerabilities and return a normalized list to be used in the UI
+	 * Normalize theme and plugin information from the Protect Report data source.
 	 *
 	 * @phan-suppress PhanDeprecatedProperty -- Maintaining backwards compatibility.
-	 * @phan-suppress PhanDeprecatedFunction -- Maintaining backwards compatibility.
 	 *
-	 * @param array  $installed The list of installed extensions, where each attribute key is the extension slug.
-	 * @param object $checked   The list of checked extensions.
-	 * @param array  $append    Additional data to append to each result in the list.
-	 * @return array Normalized list of extensions.
+	 * @param object $status The status object to normalize.
+	 * @param object $report_data Data from the Protect Report.
+	 * @param string $extension_type The type of extension to normalize. Either 'themes' or 'plugins'.
+	 *
+	 * @return void
 	 */
-	protected static function merge_installed_and_checked_lists( $installed, $checked, $append ) {
-		$new_list = array();
+	protected static function normalize_extension_data( &$status, $report_data, $extension_type ) {
+		if ( ! in_array( $extension_type, array( 'plugins', 'themes' ), true ) ) {
+			return;
+		}
 
-		foreach ( array_keys( $installed ) as $slug ) {
+		$installed_extensions = 'plugins' === $extension_type ? Plugins_Installer::get_plugins() : Sync_Functions::get_themes();
+		$checked_extensions   = isset( $report_data->{ $extension_type } ) ? $report_data->{ $extension_type } : new \stdClass();
 
-			$checked = (object) $checked;
+		/**
+		 * Extension slug <=> threats data map.
+		 *
+		 * @var Extension_Model[] $extension_threats Array of Extension_Model objects indexed by slug.
+		 */
+		$extension_threats = array();
+
+		// Initialize the extension threats map with all extensions currently installed on the site
+		foreach ( $installed_extensions as $slug => $installed_extension ) {
+			$extension_threats[ $slug ] = new Extension_Model(
+				array(
+					'slug'    => $slug,
+					'name'    => $installed_extension['Name'],
+					'version' => $installed_extension['Version'],
+					'type'    => $extension_type,
+					'checked' => isset( $checked_extensions->{ $slug } ),
+				)
+			);
+		}
+
+		foreach ( $checked_extensions as $slug => $checked_extension ) {
+			$installed_extension = $installed_extensions[ $slug ] ?? null;
+
+			// extension is no longer installed on the site
+			if ( ! $installed_extension ) {
+				continue;
+			}
 
 			$extension = new Extension_Model(
-				array_merge(
-					array(
-						'name'    => $installed[ $slug ]['Name'],
-						'version' => $installed[ $slug ]['Version'],
-						'slug'    => $slug,
-						'threats' => array(),
-						'checked' => false,
-					),
-					$append
+				array(
+					'name'    => $installed_extension['Name'],
+					'version' => $installed_extension['Version'],
+					'slug'    => $slug,
+					'checked' => false,
+					'type'    => $extension_type,
 				)
 			);
 
-			if ( isset( $checked->{ $slug } ) && $checked->{ $slug }->version === $installed[ $slug ]['Version'] ) {
-				$extension->version = $checked->{ $slug }->version;
-				$extension->checked = true;
-
-				if ( is_array( $checked->{ $slug }->vulnerabilities ) ) {
-					foreach ( $checked->{ $slug }->vulnerabilities as $threat ) {
-						$extension->threats[] = new Threat_Model(
-							array(
-								'id'          => $threat->id,
-								'title'       => $threat->title,
-								'fixed_in'    => $threat->fixed_in,
-								'description' => isset( $threat->description ) ? $threat->description : null,
-								'source'      => isset( $threat->id ) ? Redirect::get_url( 'jetpack-protect-vul-info', array( 'path' => $threat->id ) ) : null,
-							)
-						);
-					}
-				}
+			// extension version has changed since the report
+			if ( $installed_extension['Version'] !== $checked_extension->version ) {
+				// maintain $status->{ themes|plugins } for backwards compatibility.
+				$extension_threats[ $slug ] = $extension;
+				continue;
 			}
 
-			$new_list[] = $extension;
+			$extension->checked = true;
 
+			foreach ( $checked_extension->vulnerabilities as $vulnerability ) {
+				$threat         = new Threat_Model( $vulnerability );
+				$threat->source = isset( $vulnerability->id ) ? Redirect::get_url( 'jetpack-protect-vul-info', array( 'path' => $vulnerability->id ) ) : null;
+
+				$threat_extension            = clone $extension;
+				$extension_threat            = clone $threat;
+				$extension_threat->extension = null;
+
+				$extension_threats[ $slug ]->threats[] = $extension_threat;
+
+				$threat->extension = $threat_extension;
+				$status->threats[] = $threat;
+
+			}
 		}
 
-		$new_list = parent::sort_threats( $new_list );
-
-		return $new_list;
+		$status->{ $extension_type } = array_values( $extension_threats );
 	}
 
 	/**
-	 * Check if the WordPress version that was checked matches the current installed version.
+	 * Normalize the core information from the Protect Report data source.
 	 *
-	 * @phan-suppress PhanDeprecatedFunction -- Maintaining backwards compatibility.
+	 * @phan-suppress PhanDeprecatedProperty -- Maintaining backwards compatibility.
 	 *
-	 * @param object $core_check The object returned by Protect wpcom endpoint.
-	 * @return object The object representing the current status of core checks.
+	 * @param object $status The status object to normalize.
+	 * @param object $report_data Data from the Protect Report.
+	 *
+	 * @return void
 	 */
-	protected static function normalize_core_information( $core_check ) {
+	protected static function normalize_core_data( &$status, $report_data ) {
 		global $wp_version;
+
+		// Ensure the report data has the core property.
+		if ( ! $report_data->core || ! $report_data->core->version ) {
+			$report_data->core = new \stdClass();
+		}
 
 		$core = new Extension_Model(
 			array(
 				'type'    => 'core',
 				'name'    => 'WordPress',
+				'slug'    => 'wordpress',
 				'version' => $wp_version,
 				'checked' => false,
 			)
 		);
 
-		if ( isset( $core_check->version ) && $core_check->version === $wp_version ) {
-			if ( is_array( $core_check->vulnerabilities ) ) {
-				$core->checked = true;
-				$core->set_threats(
-					array_map(
-						function ( $vulnerability ) {
-							$vulnerability->source = isset( $vulnerability->id ) ? Redirect::get_url( 'jetpack-protect-vul-info', array( 'path' => $vulnerability->id ) ) : null;
-							return $vulnerability;
-						},
-						$core_check->vulnerabilities
+		// Core version has changed since the report.
+		if ( $report_data->core->version !== $wp_version ) {
+			// Maintain $status->core for backwards compatibility.
+			$status->core = $core;
+			return;
+		}
+
+		// If we've made it this far, the core version has been checked.
+		$core->checked = true;
+
+		// Extract threat data from the report.
+		if ( is_array( $report_data->core->vulnerabilities ) ) {
+			foreach ( $report_data->core->vulnerabilities as $vulnerability ) {
+				$threat = new Threat_Model(
+					array(
+						'id'          => $vulnerability->id,
+						'title'       => $vulnerability->title,
+						'fixed_in'    => $vulnerability->fixed_in,
+						'description' => isset( $vulnerability->description ) ? $vulnerability->description : null,
+						'source'      => isset( $vulnerability->id ) ? Redirect::get_url( 'jetpack-protect-vul-info', array( 'path' => $vulnerability->id ) ) : null,
 					)
 				);
+
+				$threat_extension = clone $core;
+				$extension_threat = clone $threat;
+
+				$core->threats[]   = $extension_threat;
+				$threat->extension = $threat_extension;
+
+				$status->threats[] = $threat;
 			}
 		}
 
-		return $core;
+		$status->core = $core;
+	}
+
+	/**
+	 * Sort By Threats
+	 *
+	 * @param array<Extension_Model> $threats Array of threats to sort.
+	 *
+	 * @return array<Extension_Model> The sorted $threats array.
+	 */
+	protected static function sort_threats( $threats ) {
+		usort(
+			$threats,
+			function ( $a, $b ) {
+				return count( $a->threats ) - count( $b->threats );
+			}
+		);
+
+		return $threats;
 	}
 }

--- a/projects/packages/protect-status/src/class-scan-status.php
+++ b/projects/packages/protect-status/src/class-scan-status.php
@@ -135,6 +135,7 @@ class Scan_Status extends Status {
 
 	/**
 	 * Normalize API Data
+	 *
 	 * Formats the payload from the Scan API into an instance of Status_Model.
 	 *
 	 * @phan-suppress PhanDeprecatedProperty -- Maintaining backwards compatibility.
@@ -146,15 +147,35 @@ class Scan_Status extends Status {
 	private static function normalize_api_data( $scan_data ) {
 		global $wp_version;
 
-		$status                      = new Status_Model();
-		$status->data_source         = 'scan_api';
-		$status->status              = isset( $scan_data->state ) ? $scan_data->state : null;
-		$status->num_threats         = 0;
-		$status->num_themes_threats  = 0;
-		$status->num_plugins_threats = 0;
-		$status->has_unchecked_items = false;
-		$status->current_progress    = isset( $scan_data->current->progress ) ? $scan_data->current->progress : null;
+		$installed_plugins = Plugins_Installer::get_plugins();
+		$installed_themes  = Sync_Functions::get_themes();
 
+		$plugins = array();
+		$themes  = array();
+		$core    = new Extension_Model(
+			array(
+				'name'    => 'WordPress',
+				'slug'    => 'wordpress',
+				'version' => $wp_version,
+				'type'    => 'core',
+				'checked' => true, // to do: default to false once Scan API has manifest
+			)
+		);
+		$files   = array();
+
+		$status = new Status_Model(
+			array(
+				'data_source'         => 'scan_api',
+				'status'              => isset( $scan_data->state ) ? $scan_data->state : null,
+				'num_threats'         => 0,
+				'num_themes_threats'  => 0,
+				'num_plugins_threats' => 0,
+				'has_unchecked_items' => false,
+				'current_progress'    => isset( $scan_data->current->progress ) ? $scan_data->current->progress : null,
+			)
+		);
+
+		// Format the "last checked" timestamp.
 		if ( ! empty( $scan_data->most_recent->timestamp ) ) {
 			$date = new \DateTime( $scan_data->most_recent->timestamp );
 			if ( $date ) {
@@ -162,229 +183,158 @@ class Scan_Status extends Status {
 			}
 		}
 
-		$status->core = new Extension_Model(
-			array(
-				'type'    => 'core',
-				'name'    => 'WordPress',
-				'version' => $wp_version,
-				'checked' => true, // to do: default to false once Scan API has manifest
-			)
-		);
+		// Ensure all installed plugins and themes are represented in the status.
+		foreach ( $installed_plugins as $path => $installed_plugin ) {
+			$slug   = str_replace( '.php', '', explode( '/', $path )[0] );
+			$plugin = new Extension_Model(
+				array(
+					'name'    => $installed_plugin['Name'],
+					'version' => $installed_plugin['Version'],
+					'slug'    => $slug,
+					'type'    => 'plugins',
+					'checked' => true, // to do: default to false once Scan API has manifest
+				)
+			);
 
+			$plugins[ $slug ] = $plugin;
+		}
+		foreach ( $installed_themes as $path => $installed_theme ) {
+			$slug  = str_replace( '.php', '', explode( '/', $path )[0] );
+			$theme = new Extension_Model(
+				array(
+					'name'    => $installed_theme['Name'],
+					'version' => $installed_theme['Version'],
+					'slug'    => $slug,
+					'type'    => 'themes',
+					'checked' => true, // to do: default to false once Scan API has manifest
+				)
+			);
+
+			$themes[ $slug ] = $theme;
+		}
+
+		// Merge the threats into the status model.
 		if ( isset( $scan_data->threats ) && is_array( $scan_data->threats ) ) {
-			foreach ( $scan_data->threats as $threat ) {
-				if ( isset( $threat->fixable ) && $threat->fixable ) {
-					$status->fixable_threat_ids[] = $threat->id;
+			foreach ( $scan_data->threats as $scan_threat ) {
+				if ( isset( $scan_threat->fixable ) && $scan_threat->fixable ) {
+					$status->fixable_threat_ids[] = $scan_threat->id;
 				}
 
-				if ( isset( $threat->extension->type ) ) {
-					if ( 'plugin' === $threat->extension->type ) {
-						// add the extension if it does not yet exist in the status
-						if ( ! isset( $status->plugins[ $threat->extension->slug ] ) ) {
-							$status->plugins[ $threat->extension->slug ] = new Extension_Model(
-								array(
-									'name'    => isset( $threat->extension->name ) ? $threat->extension->name : null,
-									'slug'    => isset( $threat->extension->slug ) ? $threat->extension->slug : null,
-									'version' => isset( $threat->extension->version ) ? $threat->extension->version : null,
-									'type'    => 'plugin',
-									'checked' => true,
-									'threats' => array(),
-								)
-							);
-						}
+				$threat = new Threat_Model(
+					array(
+						'id'                        => isset( $scan_threat->id ) ? $scan_threat->id : null,
+						'signature'                 => isset( $scan_threat->signature ) ? $scan_threat->signature : null,
+						'title'                     => isset( $scan_threat->title ) ? $scan_threat->title : null,
+						'description'               => isset( $scan_threat->description ) ? $scan_threat->description : null,
+						'vulnerability_description' => isset( $scan_threat->vulnerability_description ) ? $scan_threat->vulnerability_description : null,
+						'fix_description'           => isset( $scan_threat->fix_description ) ? $scan_threat->fix_description : null,
+						'payload_subtitle'          => isset( $scan_threat->payload_subtitle ) ? $scan_threat->payload_subtitle : null,
+						'payload_description'       => isset( $scan_threat->payload_description ) ? $scan_threat->payload_description : null,
+						'first_detected'            => isset( $scan_threat->first_detected ) ? $scan_threat->first_detected : null,
+						'fixed_in'                  => isset( $scan_threat->fixer->fixer ) && 'update' === $scan_threat->fixer->fixer ? $scan_threat->fixer->target : null,
+						'severity'                  => isset( $scan_threat->severity ) ? $scan_threat->severity : null,
+						'fixable'                   => isset( $scan_threat->fixer ) ? $scan_threat->fixer : null,
+						'status'                    => isset( $scan_threat->status ) ? $scan_threat->status : null,
+						'filename'                  => isset( $scan_threat->filename ) ? $scan_threat->filename : null,
+						'context'                   => isset( $scan_threat->context ) ? $scan_threat->context : null,
+						'source'                    => isset( $scan_threat->source ) ? $scan_threat->source : null,
+					)
+				);
 
-						$threat_model = new Threat_Model(
-							array(
-								'id'                  => isset( $threat->id ) ? $threat->id : null,
-								'signature'           => isset( $threat->signature ) ? $threat->signature : null,
-								'title'               => isset( $threat->title ) ? $threat->title : null,
-								'description'         => isset( $threat->description ) ? $threat->description : null,
-								'vulnerability_description' => isset( $threat->vulnerability_description ) ? $threat->vulnerability_description : null,
-								'fix_description'     => isset( $threat->fix_description ) ? $threat->fix_description : null,
-								'payload_subtitle'    => isset( $threat->payload_subtitle ) ? $threat->payload_subtitle : null,
-								'payload_description' => isset( $threat->payload_description ) ? $threat->payload_description : null,
-								'first_detected'      => isset( $threat->first_detected ) ? $threat->first_detected : null,
-								'fixed_in'            => isset( $threat->fixer->fixer ) && 'update' === $threat->fixer->fixer ? $threat->fixer->target : null,
-								'severity'            => isset( $threat->severity ) ? $threat->severity : null,
-								'fixable'             => isset( $threat->fixer ) ? $threat->fixer : null,
-								'status'              => isset( $threat->status ) ? $threat->status : null,
-								'filename'            => isset( $threat->filename ) ? $threat->filename : null,
-								'context'             => isset( $threat->context ) ? $threat->context : null,
-								'source'              => isset( $threat->source ) ? $threat->source : null,
-							)
-						);
+				// Theme and Plugin Threats
+				if ( ! empty( $scan_threat->extension ) && in_array( $scan_threat->extension->type, array( 'plugin', 'theme' ), true ) ) {
+					$installed_extension = 'plugin' === $scan_threat->extension->type ? $plugins[ $scan_threat->extension->slug ] : $themes[ $scan_threat->extension->slug ];
 
-						$status->plugins[ $threat->extension->slug ]->threats[] = $threat_model;
-						$status->threats[]                                      = $threat_model;
-
-						++$status->num_threats;
-						++$status->num_plugins_threats;
+					// If the extension is no longer installed, skip this threat.
+					// todo: use version_compare()
+					if ( ! $installed_extension ) {
 						continue;
 					}
 
-					if ( 'theme' === $threat->extension->type ) {
-						// add the extension if it does not yet exist in the status
-						if ( ! isset( $status->themes[ $threat->extension->slug ] ) ) {
-							$status->themes[ $threat->extension->slug ] = new Extension_Model(
-								array(
-									'name'    => isset( $threat->extension->name ) ? $threat->extension->name : null,
-									'slug'    => isset( $threat->extension->slug ) ? $threat->extension->slug : null,
-									'version' => isset( $threat->extension->version ) ? $threat->extension->version : null,
-									'type'    => 'theme',
-									'checked' => true,
-									'threats' => array(),
-								)
-							);
-						}
-
-						$threat_model = new Threat_Model(
-							array(
-								'id'                  => isset( $threat->id ) ? $threat->id : null,
-								'signature'           => isset( $threat->signature ) ? $threat->signature : null,
-								'title'               => isset( $threat->title ) ? $threat->title : null,
-								'description'         => isset( $threat->description ) ? $threat->description : null,
-								'vulnerability_description' => isset( $threat->vulnerability_description ) ? $threat->vulnerability_description : null,
-								'fix_description'     => isset( $threat->fix_description ) ? $threat->fix_description : null,
-								'payload_subtitle'    => isset( $threat->payload_subtitle ) ? $threat->payload_subtitle : null,
-								'payload_description' => isset( $threat->payload_description ) ? $threat->payload_description : null,
-								'first_detected'      => isset( $threat->first_detected ) ? $threat->first_detected : null,
-								'fixed_in'            => isset( $threat->fixer->fixer ) && 'update' === $threat->fixer->fixer ? $threat->fixer->target : null,
-								'severity'            => isset( $threat->severity ) ? $threat->severity : null,
-								'fixable'             => isset( $threat->fixer ) ? $threat->fixer : null,
-								'status'              => isset( $threat->status ) ? $threat->status : null,
-								'filename'            => isset( $threat->filename ) ? $threat->filename : null,
-								'context'             => isset( $threat->context ) ? $threat->context : null,
-								'source'              => isset( $threat->source ) ? $threat->source : null,
-							)
-						);
-
-						$status->themes[ $threat->extension->slug ]->threats[] = $threat_model;
-						$status->threats[]                                     = $threat_model;
-
-						++$status->num_threats;
-						++$status->num_themes_threats;
-						continue;
-					}
-				}
-
-				if ( isset( $threat->signature ) && 'Vulnerable.WP.Core' === $threat->signature ) {
-					if ( $threat->version !== $wp_version ) {
-						continue;
+					// Push the threat to the appropriate extension.
+					switch ( $scan_threat->extension->type ) {
+						case 'plugin':
+							$plugins[ $scan_threat->extension->slug ]->threats[] = clone $threat;
+							++$status->num_plugins_threats;
+							break;
+						case 'theme':
+							$themes[ $scan_threat->extension->slug ]->threats[] = clone $threat;
+							++$status->num_themes_threats;
+							break;
+						default:
+							break;
 					}
 
-					$threat_model = new Threat_Model(
+					$threat->extension = new Extension_Model(
 						array(
-							'id'             => $threat->id,
-							'signature'      => $threat->signature,
-							'title'          => $threat->title,
-							'description'    => $threat->description,
-							'first_detected' => $threat->first_detected,
-							'severity'       => $threat->severity,
+							'name'    => isset( $scan_threat->extension->name ) ? $scan_threat->extension->name : null,
+							'slug'    => isset( $scan_threat->extension->slug ) ? $scan_threat->extension->slug : null,
+							'version' => isset( $scan_threat->extension->version ) ? $scan_threat->extension->version : null,
+							'type'    => $scan_threat->extension->type . 's',
+							'checked' => $installed_extension->version === $scan_threat->extension->version,
 						)
 					);
+				} elseif ( isset( $threat->signature ) && 'Vulnerable.WP.Core' === $threat->signature ) {
+					// Vulnerable WordPress Core Version Threats
 
-					$status->core->threats[] = $threat_model;
-					$status->threats[]       = $threat_model;
+					// If the core version has changed, skip this threat.
+					// todo: use version_compare()
+					if ( $scan_threat->version !== $wp_version ) {
+						continue;
+					}
 
-					++$status->num_threats;
-
-					continue;
+					$core->threats[] = $threat;
+				} elseif ( ! empty( $threat->filename ) ) {
+					// File Threats
+					$files[] = $threat;
 				}
 
-				if ( ! empty( $threat->filename ) ) {
-					$threat_model      = new Threat_Model( $threat );
-					$status->files[]   = $threat_model;
-					$status->threats[] = $threat_model;
-					++$status->num_threats;
-					continue;
-				}
-
-				if ( ! empty( $threat->table ) ) {
-					$threat_model       = new Threat_Model( $threat );
-					$status->database[] = $threat_model;
-					$status->threats[]  = $threat_model;
-					++$status->num_threats;
-					continue;
-				}
+				$status->threats[] = $threat;
+				++$status->num_threats;
 			}
 		}
 
-		$installed_plugins = Plugins_Installer::get_plugins();
-		$status->plugins   = self::merge_installed_and_checked_lists( $installed_plugins, $status->plugins, array( 'type' => 'plugins' ), true );
+		$status->threats = static::sort_threats( $status->threats );
 
-		$installed_themes = Sync_Functions::get_themes();
-		$status->themes   = self::merge_installed_and_checked_lists( $installed_themes, $status->themes, array( 'type' => 'themes' ), true );
-
-		foreach ( array_merge( $status->themes, $status->plugins ) as $extension ) {
-			if ( ! $extension->checked ) {
-				$status->has_unchecked_items = true;
-				break;
-			}
-		}
+		// maintain deprecated properties for backwards compatibility
+		$status->plugins = array_values( $plugins );
+		$status->themes  = array_values( $themes );
+		$status->core    = $core;
+		$status->files   = $files;
 
 		return $status;
 	}
 
 	/**
-	 * Merges the list of installed extensions with the list of extensions that were checked for known vulnerabilities and return a normalized list to be used in the UI
+	 * Sort By Threats
 	 *
-	 * @phan-suppress PhanDeprecatedProperty -- Maintaining backwards compatibility.
-	 * @phan-suppress PhanDeprecatedFunction -- Maintaining backwards compatibility.
+	 * @param array<Threat_Model> $threats Array of threats to sort.
 	 *
-	 * @param array  $installed The list of installed extensions, where each attribute key is the extension slug.
-	 * @param object $checked   The list of checked extensions.
-	 * @param array  $append    Additional data to append to each result in the list.
-	 *
-	 * @return array Normalized list of extensions.
+	 * @return array<Threat_Model> The sorted $threats array.
 	 */
-	protected static function merge_installed_and_checked_lists( $installed, $checked, $append ) {
-		$new_list = array();
-		$checked  = (object) $checked;
-
-		foreach ( array_keys( $installed ) as $slug ) {
-			/**
-			 * Extension Type Map
-			 *
-			 * @var array $extension_type_map Key value pairs of extension types and their corresponding
-			 *                                 identifier used by the Scan API data source.
-			 */
-			$extension_type_map = array(
-				'themes'  => 'r1',
-				'plugins' => 'r2',
-			);
-
-			$version        = $installed[ $slug ]['Version'];
-			$short_slug     = str_replace( '.php', '', explode( '/', $slug )[0] );
-			$scanifest_slug = $extension_type_map[ $append['type'] ] . ":$short_slug@$version";
-
-			$extension = new Extension_Model(
-				array_merge(
-					array(
-						'name'    => $installed[ $slug ]['Name'],
-						'version' => $version,
-						'slug'    => $slug,
-						'threats' => array(),
-						'checked' => false,
-					),
-					$append
-				)
-			);
-
-			if ( ! isset( $checked->extensions ) // no extension data available from Scan API
-				|| is_array( $checked->extensions ) && in_array( $scanifest_slug, $checked->extensions, true ) // extension data matches Scan API
-			) {
-				$extension->checked = true;
-				if ( isset( $checked->{ $short_slug }->threats ) ) {
-					$extension->threats = $checked->{ $short_slug }->threats;
+	protected static function sort_threats( $threats ) {
+		usort(
+			$threats,
+			function ( $a, $b ) {
+				// Order by active status first...
+				if ( $a->status !== $b->status ) {
+					return 'active' === $a->status ? -1 : 1;
 				}
+
+				// ...then by severity...
+				if ( $a->severity !== $b->severity ) {
+					return $a->severity > $b->severity ? -1 : 1;
+				}
+
+				// ...then date added.
+				if ( $a->first_detected !== $b->first_detected ) {
+					return strtotime( $a->first_detected ) < strtotime( $b->first_detected ) ? -1 : 1;
+				}
+
+				return 0;
 			}
+		);
 
-			$new_list[] = $extension;
-
-		}
-
-		$new_list = parent::sort_threats( $new_list );
-
-		return $new_list;
+		return $threats;
 	}
 }

--- a/projects/packages/protect-status/src/class-status.php
+++ b/projects/packages/protect-status/src/class-status.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Protect_Status;
 
-use Automattic\Jetpack\Protect_Models\Extension_Model;
 use Automattic\Jetpack\Protect_Models\Status_Model;
 
 /**
@@ -269,36 +268,6 @@ class Status {
 		}
 
 		return $status->threats;
-	}
-
-	/**
-	 * Check if the WordPress version that was checked matches the current installed version.
-	 *
-	 * @phan-suppress PhanDeprecatedFunction -- Maintaining backwards compatibility.
-	 *
-	 * @param object $core_check The object returned by Protect wpcom endpoint.
-	 * @return object The object representing the current status of core checks.
-	 */
-	protected static function normalize_core_information( $core_check ) {
-		global $wp_version;
-
-		$core = new Extension_Model(
-			array(
-				'type'    => 'core',
-				'name'    => 'WordPress',
-				'version' => $wp_version,
-				'checked' => false,
-			)
-		);
-
-		if ( isset( $core_check->version ) && $core_check->version === $wp_version ) {
-			if ( is_array( $core_check->vulnerabilities ) ) {
-				$core->checked = true;
-				$core->set_threats( $core_check->vulnerabilities );
-			}
-		}
-
-		return $core;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Improves the data handling in the `protect-status` package.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check CLI tests.
* Smoke test implementing features:
  * Protect status card in My Jetpack
  * Protect plugin scan results
