### PR TITLE
Repo Gardening: handle External Media extension

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-label-external-meida
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-label-external-meida
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Labeling: automatically label changes to the External Media extension.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -218,6 +218,14 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft, isRevert )
 			}
 		}
 
+		// External Media extension.
+		const externalMedia = file.match(
+			/^projects\/plugins\/jetpack\/extensions\/shared\/external-media\//
+		);
+		if ( externalMedia !== null ) {
+			keywords.add( '[Extension] External Media' );
+		}
+
 		// React Dashboard and Boost Admin.
 		const reactAdmin = file.match(
 			/^(projects\/plugins\/(crm|boost\/app)\/admin|projects\/plugins\/jetpack\/_inc\/client)\//


### PR DESCRIPTION
## Proposed changes:

This should allow automatically labeling PRs like #40382

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

No

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

This can be tested in a fork, by merging this branch to `trunk` and then opening a PR making changes to a file like `projects/plugins/jetpack/extensions/shared/external-media/media-button/media-ai-button.js`.
