### PR TITLE
Repo Gardening: add Photon auto-triage

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-assignment-photon
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-assignment-photon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Board triage: add automated triage for Photon.

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/automattic-label-team-assignments.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/automattic-label-team-assignments.js
@@ -86,7 +86,12 @@ export const automatticAssignments = {
 	},
 	Boost: {
 		team: 'Heart of Gold',
-		labels: [ '[Plugin] Boost' ],
+		labels: [
+			'[Plugin] Boost',
+			'[Boost Feature] Lazy Images',
+			'[Boost Feature] Image Guide',
+			'[Boost Feature] Image Size Analysis',
+		],
 		slack_id: 'C016BBAFHHS',
 		board_id: 'https://github.com/orgs/Automattic/projects/548',
 	},
@@ -125,6 +130,12 @@ export const automatticAssignments = {
 		labels: [ '[Block] Subscriptions', '[Block] Paywall' ],
 		slack_id: 'C02NQ4HMJKV',
 		board_id: 'https://github.com/orgs/Automattic/projects/657',
+	},
+	Photon: {
+		team: 'Heart of Gold',
+		labels: [ '[Feature] Photon', '[Boost Feature] Image CDN', '[Package] Image CDN' ],
+		slack_id: 'C016BBAFHHS',
+		board_id: 'https://github.com/orgs/Automattic/projects/548',
 	},
 	Protect: {
 		team: 'Scan',


### PR DESCRIPTION
## Proposed changes:

Automatically triage Photon issue as well.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

No

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

This can be tested once it's been merged, by opening an issue with any of the labels added in this PR.
