### PR TITLE
External media: Update UX opening picker right after pressing "change selection" CTA

### DIFF
--- a/projects/plugins/jetpack/changelog/update-external-media-google-photos-picker
+++ b/projects/plugins/jetpack/changelog/update-external-media-google-photos-picker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+External media: Google Photos Picker: Update UX opening picker right after pressing "change selection" CTA

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/google-photos-media.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/google-photos-media.js
@@ -94,13 +94,12 @@ function GooglePhotosMedia( props ) {
 
 	const onChangeSelection = useCallback( () => {
 		setSelectionChanged( true );
-		pickerSession &&
-			deletePickerSession( pickerSession?.id )
-				.then( createPickerSession )
-				.then( newSession => {
-					newSession?.pickerUri && window.open( newSession.pickerUri );
-				} );
-	}, [ pickerSession, deletePickerSession, createPickerSession ] );
+
+		pickerSession?.id && deletePickerSession( pickerSession.id, false );
+		createPickerSession().then( newSession => {
+			newSession?.pickerUri && window.open( newSession.pickerUri );
+		} );
+	}, [ pickerSession, createPickerSession, deletePickerSession ] );
 
 	// Load media when the query changes.
 	useEffect( () => {

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/google-photos-media.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/google-photos-media.js
@@ -94,11 +94,12 @@ function GooglePhotosMedia( props ) {
 
 	const onChangeSelection = useCallback( () => {
 		setSelectionChanged( true );
-		createPickerSession &&
-			createPickerSession().then( newSession => {
-				pickerSession && deletePickerSession( pickerSession?.id );
-				newSession?.pickerUri && window.open( newSession.pickerUri );
-			} );
+		pickerSession &&
+			deletePickerSession( pickerSession?.id )
+				.then( createPickerSession )
+				.then( newSession => {
+					newSession?.pickerUri && window.open( newSession.pickerUri );
+				} );
 	}, [ pickerSession, deletePickerSession, createPickerSession ] );
 
 	// Load media when the query changes.

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/google-photos-media.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/google-photos-media.js
@@ -94,8 +94,11 @@ function GooglePhotosMedia( props ) {
 
 	const onChangeSelection = useCallback( () => {
 		setSelectionChanged( true );
-		pickerSession && deletePickerSession( pickerSession?.id );
-		createPickerSession && createPickerSession();
+		createPickerSession &&
+			createPickerSession().then( newSession => {
+				pickerSession && deletePickerSession( pickerSession?.id );
+				newSession?.pickerUri && window.open( newSession.pickerUri );
+			} );
 	}, [ pickerSession, deletePickerSession, createPickerSession ] );
 
 	// Load media when the query changes.

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/with-media.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/with-media.js
@@ -263,11 +263,11 @@ export default function withMedia( mediaSource = MediaSource.Unknown ) {
 				} ).then( setGooglePhotosPickerSession );
 			};
 
-			deletePickerSession = sessionId => {
+			deletePickerSession = ( sessionId, updateState = true ) => {
 				return apiFetch( {
 					path: `/wpcom/v2/external-media/session/google_photos/${ sessionId }`,
 					method: 'DELETE',
-				} ).then( () => setGooglePhotosPickerSession( null ) );
+				} ).then( () => updateState && setGooglePhotosPickerSession( null ) );
 			};
 
 			getPickerStatus = () => {

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/with-media.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/with-media.js
@@ -264,7 +264,7 @@ export default function withMedia( mediaSource = MediaSource.Unknown ) {
 			};
 
 			deletePickerSession = sessionId => {
-				apiFetch( {
+				return apiFetch( {
 					path: `/wpcom/v2/external-media/session/google_photos/${ sessionId }`,
 					method: 'DELETE',
 				} ).then( () => setGooglePhotosPickerSession( null ) );

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/with-media.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/with-media.js
@@ -239,7 +239,7 @@ export default function withMedia( mediaSource = MediaSource.Unknown ) {
 			};
 
 			createPickerSession = () => {
-				apiFetch( {
+				return apiFetch( {
 					path: '/wpcom/v2/external-media/session/google_photos',
 					method: 'POST',
 				} )
@@ -249,7 +249,10 @@ export default function withMedia( mediaSource = MediaSource.Unknown ) {
 						}
 						return response;
 					} )
-					.then( setGooglePhotosPickerSession )
+					.then( session => {
+						setGooglePhotosPickerSession( session );
+						return session;
+					} )
 					.catch( this.handleApiError );
 			};
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related https://github.com/Automattic/wp-calypso/pull/96938

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update UX: open picker right after pressing "change selection" CTA


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pdtkmj-36s-p2#comment-5914

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to your sandbox following instructions: https://github.com/Automattic/jetpack/pull/40410#issuecomment-2511377118
* Open post or page editor
* Make a selection with Google Photos Picker
* Press "Change selection"
* Check if the picker is opened automatically in the new tab without need to press "Open Google Photos Picker" manually