### PR TITLE
External media: Show connection upgrade screen in transition from Photos to Picker

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
@@ -189,17 +189,6 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 			)
 		);
 
-		// Get connections route
-		register_rest_route(
-			$this->namespace,
-			'/me/connections',
-			array(
-				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_connections' ),
-				'permission_callback' => array( $this, 'permission_callback' ),
-			)
-		);
-
 		// Add new session route, currently for Google Photos Picker only
 		register_rest_route(
 			$this->namespace,
@@ -537,33 +526,6 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 			'2',
 			array(
 				'method' => 'DELETE',
-			)
-		);
-
-		return json_decode( wp_remote_retrieve_body( $response ), true );
-	}
-
-	/**
-	 * Gets connections for the current user.
-	 *
-	 * @param \WP_REST_Request $request Full details about the request.
-	 * @return array|\WP_Error|mixed
-	 */
-	public function get_connections( \WP_REST_Request $request ) {
-		$wpcom_path = '/me/connections';
-
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$internal_request = new \WP_REST_Request( 'GET', '/' . $this->namespace . $wpcom_path );
-			$internal_request->set_query_params( $request->get_params() );
-
-			return rest_do_request( $internal_request );
-		}
-
-		$response = Client::wpcom_json_api_request_as_user(
-			$wpcom_path,
-			'2',
-			array(
-				'method' => 'GET',
 			)
 		);
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
@@ -189,6 +189,17 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 			)
 		);
 
+		// Get connections route
+		register_rest_route(
+			$this->namespace,
+			'/me/connections',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_connections' ),
+				'permission_callback' => array( $this, 'permission_callback' ),
+			)
+		);
+
 		// Add new session route, currently for Google Photos Picker only
 		register_rest_route(
 			$this->namespace,
@@ -526,6 +537,33 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 			'2',
 			array(
 				'method' => 'DELETE',
+			)
+		);
+
+		return json_decode( wp_remote_retrieve_body( $response ), true );
+	}
+
+	/**
+	 * Gets connections for the current user.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return array|\WP_Error|mixed
+	 */
+	public function get_connections( \WP_REST_Request $request ) {
+		$wpcom_path = '/me/connections';
+
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$internal_request = new \WP_REST_Request( 'GET', '/' . $this->namespace . $wpcom_path );
+			$internal_request->set_query_params( $request->get_params() );
+
+			return rest_do_request( $internal_request );
+		}
+
+		$response = Client::wpcom_json_api_request_as_user(
+			$wpcom_path,
+			'2',
+			array(
+				'method' => 'GET',
 			)
 		);
 

--- a/projects/plugins/jetpack/changelog/update-external-media-google-photos-picker-connection
+++ b/projects/plugins/jetpack/changelog/update-external-media-google-photos-picker-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Cover case with connection transition from Google Photos to Google Photos Picker 

--- a/projects/plugins/jetpack/extensions/shared/external-media/editor.scss
+++ b/projects/plugins/jetpack/extensions/shared/external-media/editor.scss
@@ -568,13 +568,13 @@ $grid-size: 8px;
 }
 
 .jetpack-external-media-auth {
-	max-width: 340px;
+	max-width: 400px;
 	margin: 0 auto;
 	padding-bottom: 80px;
 	text-align: center;
 
 	p {
-		margin: 2em 0;
+		margin: 0 0 2em 0;
 	}
 }
 

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
@@ -316,7 +316,7 @@ export const setGooglePhotosPickeCachedSessionId = ( sessionId: string | null ) 
 		sessionId,
 		604800, // 7 days
 		'/',
-		`.${ window.location.hostname }`
+		`.${ window.location.hostname.split( '.' ).slice( -2 ).join( '.' ) }`
 	);
 };
 

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/google-photos-auth-upgrade.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/google-photos-auth-upgrade.js
@@ -1,0 +1,22 @@
+import { __ } from '@wordpress/i18n';
+import { GooglePhotosLogo } from '../../../icons';
+import GooglePhotosDisconnect from './google-photos-disconnect';
+
+export default function GooglePhotosAuthUpgrade( props ) {
+	const { setAuthenticated } = props;
+
+	return (
+		<div className="jetpack-external-media-auth">
+			<GooglePhotosLogo />
+
+			<p>
+				{ __(
+					"We've updated our Google Photos service. You will need to disconnect and reconnect to continue accessing your photos.",
+					'jetpack'
+				) }
+			</p>
+
+			<GooglePhotosDisconnect setAuthenticated={ setAuthenticated } />
+		</div>
+	);
+}

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/google-photos-picker-button.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/google-photos-picker-button.js
@@ -15,7 +15,7 @@ export default function GooglePhotosPickerButton( props ) {
 
 	useEffect( () => {
 		const interval = setInterval( () => {
-			pickerSession.id && fetchPickerSession( pickerSession.id );
+			pickerSession?.id && fetchPickerSession( pickerSession.id );
 		}, 3000 );
 		return () => clearInterval( interval );
 	}, [ fetchPickerSession, pickerSession?.id ] );

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/index.js
@@ -32,9 +32,9 @@ function GooglePhotos( props ) {
 				setAuthenticated( false );
 			}
 
-			// Invalid JSON error means the user is not authenticated
-			// transition between old and new auth flow
-			if ( error.code === 'invalid_json' ) {
+			// If the picker session endpoint returns a 404
+			// the user needs to upgrade their auth
+			if ( error.code === 'rest_not_found' ) {
 				setAuthUpgradeRequired( true );
 			}
 		},

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/index.js
@@ -1,10 +1,11 @@
 import moment from 'moment';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import MediaLoadingPlaceholder from '../../media-browser/placeholder';
 import { getGooglePhotosPickerCachedSessionId } from '../../media-service';
 import { MediaSource } from '../../media-service/types';
 import withMedia from '../with-media';
 import GooglePhotosAuth from './google-photos-auth';
+import GooglePhotosAuthUpgrade from './google-photos-auth-upgrade';
 import GooglePhotosMedia from './google-photos-media';
 import GooglePhotosPickerButton from './google-photos-picker-button';
 
@@ -15,13 +16,34 @@ function GooglePhotos( props ) {
 		createPickerSession,
 		fetchPickerSession,
 		getPickerStatus,
+		setAuthenticated,
 	} = props;
 	const [ cachedSessionId ] = useState( getGooglePhotosPickerCachedSessionId() );
 	const [ isCachedSessionChecked, setIsCachedSessionChecked ] = useState( false );
 	const [ pickerFeatureEnabled, setPickerFeatureEnabled ] = useState( null );
+	const [ authUpgradeRequired, setAuthUpgradeRequired ] = useState( false );
 	const isPickerSessionAccurate = pickerSession !== null && ! ( 'code' in pickerSession );
 	const isSessionExpired =
 		pickerSession?.expireTime && moment( pickerSession.expireTime ).isBefore( new Date() );
+
+	const catchAuthErrors = useCallback(
+		error => {
+			if ( error.code === 'authorization_required' ) {
+				setAuthenticated( false );
+			}
+
+			// Invalid JSON error means the user is not authenticated
+			// transition between old and new auth flow
+			if ( error.code === 'invalid_json' ) {
+				setAuthUpgradeRequired( true );
+			}
+		},
+		[ setAuthenticated, setAuthUpgradeRequired ]
+	);
+
+	useEffect( () => {
+		! isAuthenticated && setAuthUpgradeRequired( false );
+	}, [ isAuthenticated ] );
 
 	useEffect( () => {
 		getPickerStatus().then( feature => {
@@ -40,7 +62,7 @@ function GooglePhotos( props ) {
 			isAuthenticated &&
 			( ! isPickerSessionAccurate || isSessionExpired )
 		) {
-			createPickerSession();
+			createPickerSession().catch( catchAuthErrors );
 		}
 	}, [
 		pickerFeatureEnabled,
@@ -50,10 +72,15 @@ function GooglePhotos( props ) {
 		isSessionExpired,
 		createPickerSession,
 		pickerSession,
+		catchAuthErrors,
 	] );
 
 	if ( pickerFeatureEnabled === null || ! isCachedSessionChecked ) {
 		return <MediaLoadingPlaceholder />;
+	}
+
+	if ( authUpgradeRequired ) {
+		return <GooglePhotosAuthUpgrade { ...props } />;
 	}
 
 	if ( ! isAuthenticated ) {

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/index.js
@@ -51,9 +51,15 @@ function GooglePhotos( props ) {
 		} );
 
 		cachedSessionId === null && setIsCachedSessionChecked( true );
-		cachedSessionId &&
-			fetchPickerSession( cachedSessionId ).then( () => setIsCachedSessionChecked( true ) );
-	}, [ getPickerStatus, fetchPickerSession, cachedSessionId ] );
+		fetchPickerSession( cachedSessionId )
+			.then( () => {
+				setIsCachedSessionChecked( true );
+			} )
+			.catch( error => {
+				setIsCachedSessionChecked( true );
+				catchAuthErrors( error );
+			} );
+	}, [ getPickerStatus, fetchPickerSession, cachedSessionId, catchAuthErrors ] );
 
 	useEffect( () => {
 		if (

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/index.js
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState } from 'react';
 import MediaLoadingPlaceholder from '../../media-browser/placeholder';
 import { getGooglePhotosPickerCachedSessionId } from '../../media-service';
 import { MediaSource } from '../../media-service/types';
@@ -18,70 +18,80 @@ function GooglePhotos( props ) {
 		getPickerStatus,
 		setAuthenticated,
 	} = props;
+
 	const [ cachedSessionId ] = useState( getGooglePhotosPickerCachedSessionId() );
-	const [ isCachedSessionChecked, setIsCachedSessionChecked ] = useState( false );
 	const [ pickerFeatureEnabled, setPickerFeatureEnabled ] = useState( null );
-	const [ authUpgradeRequired, setAuthUpgradeRequired ] = useState( false );
+	const [ isCachedSessionChecked, setIsCachedSessionChecked ] = useState( false );
+	const [ isAuthUpgradeRequired, setIsAuthUpgradeRequired ] = useState( false );
+
+	const isLoadingState = pickerFeatureEnabled === null;
 	const isPickerSessionAccurate = pickerSession !== null && ! ( 'code' in pickerSession );
 	const isSessionExpired =
 		pickerSession?.expireTime && moment( pickerSession.expireTime ).isBefore( new Date() );
 
-	const catchAuthErrors = useCallback(
-		error => {
-			if ( error.code === 'authorization_required' ) {
-				setAuthenticated( false );
-			}
-
-			// If the picker session endpoint returns a 404
-			// the user needs to upgrade their auth
-			if ( error.code === 'rest_not_found' ) {
-				setAuthUpgradeRequired( true );
-			}
-		},
-		[ setAuthenticated, setAuthUpgradeRequired ]
-	);
-
+	// Check if the picker feature is enabled and the connection status
 	useEffect( () => {
-		! isAuthenticated && setAuthUpgradeRequired( false );
-	}, [ isAuthenticated ] );
+		getPickerStatus().then( picker => {
+			setPickerFeatureEnabled( picker.enabled );
 
-	useEffect( () => {
-		getPickerStatus().then( feature => {
-			feature && setPickerFeatureEnabled( feature.enabled );
+			switch ( picker.connection_status ) {
+				case 'ok':
+					setAuthenticated( true );
+					setIsAuthUpgradeRequired( false );
+					break;
+
+				case 'invalid':
+					setAuthenticated( true );
+					setIsAuthUpgradeRequired( true );
+					break;
+
+				case 'not_connected':
+					setAuthenticated( false );
+					setIsAuthUpgradeRequired( false );
+					break;
+			}
 		} );
+	}, [ isAuthenticated, getPickerStatus, setAuthenticated ] );
 
-		cachedSessionId === null && setIsCachedSessionChecked( true );
-		fetchPickerSession( cachedSessionId )
-			.then( () => {
-				setIsCachedSessionChecked( true );
-			} )
-			.catch( error => {
-				setIsCachedSessionChecked( true );
-				catchAuthErrors( error );
-			} );
-	}, [ getPickerStatus, fetchPickerSession, cachedSessionId, catchAuthErrors ] );
+	// Check if the user has a cached session
+	useEffect( () => {
+		if ( pickerFeatureEnabled && isAuthenticated && ! isAuthUpgradeRequired ) {
+			Promise.resolve( cachedSessionId )
+				.then( id => ( id ? fetchPickerSession( id ) : id ) )
+				.finally( () => setIsCachedSessionChecked( true ) );
+		}
+	}, [
+		isAuthenticated,
+		pickerFeatureEnabled,
+		isAuthUpgradeRequired,
+		cachedSessionId,
+		fetchPickerSession,
+	] );
 
+	// Create a new picker session if the cached session is not accurate
+	// or if the session has expired
 	useEffect( () => {
 		if (
 			pickerFeatureEnabled &&
 			isCachedSessionChecked &&
 			isAuthenticated &&
+			! isAuthUpgradeRequired &&
 			( ! isPickerSessionAccurate || isSessionExpired )
 		) {
-			createPickerSession().catch( catchAuthErrors );
+			createPickerSession();
 		}
 	}, [
 		pickerFeatureEnabled,
+		isAuthUpgradeRequired,
 		isCachedSessionChecked,
 		isPickerSessionAccurate,
 		isAuthenticated,
 		isSessionExpired,
 		createPickerSession,
 		pickerSession,
-		catchAuthErrors,
 	] );
 
-	if ( pickerFeatureEnabled === null || ! isCachedSessionChecked ) {
+	if ( isLoadingState ) {
 		return <MediaLoadingPlaceholder />;
 	}
 
@@ -89,7 +99,7 @@ function GooglePhotos( props ) {
 		return <GooglePhotosAuth { ...props } />;
 	}
 
-	if ( authUpgradeRequired ) {
+	if ( isAuthUpgradeRequired ) {
 		return <GooglePhotosAuthUpgrade { ...props } />;
 	}
 

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/google-photos/index.js
@@ -85,12 +85,12 @@ function GooglePhotos( props ) {
 		return <MediaLoadingPlaceholder />;
 	}
 
-	if ( authUpgradeRequired ) {
-		return <GooglePhotosAuthUpgrade { ...props } />;
-	}
-
 	if ( ! isAuthenticated ) {
 		return <GooglePhotosAuth { ...props } />;
+	}
+
+	if ( authUpgradeRequired ) {
+		return <GooglePhotosAuthUpgrade { ...props } />;
 	}
 
 	if ( pickerFeatureEnabled && ! pickerSession?.mediaItemsSet ) {

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/with-media.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/with-media.js
@@ -259,7 +259,17 @@ export default function withMedia( mediaSource = MediaSource.Unknown ) {
 				return apiFetch( {
 					path: `/wpcom/v2/external-media/session/google_photos/${ sessionId }`,
 					method: 'GET',
-				} ).then( setGooglePhotosPickerSession );
+				} )
+					.then( response => {
+						if ( 'code' in response ) {
+							throw response;
+						}
+						return response;
+					} )
+					.then( session => {
+						setGooglePhotosPickerSession( session );
+						return session;
+					} );
 			};
 
 			deletePickerSession = ( sessionId, updateState = true ) => {

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/with-media.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/with-media.js
@@ -252,8 +252,7 @@ export default function withMedia( mediaSource = MediaSource.Unknown ) {
 					.then( session => {
 						setGooglePhotosPickerSession( session );
 						return session;
-					} )
-					.catch( this.handleApiError );
+					} );
 			};
 
 			fetchPickerSession = sessionId => {


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Created `GooglePhotosAuthUpgrade` component
* Catch the error when a connection is not valid and show the upgrade screen
* Adjust the `GooglePhotosAuth` style, reducing the margin around the paragraphs

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pdtkmj-36s-p2#comment-5923

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure that your Google Photos connection is established
* Turn ON `google-photos-picker` feature
* Go to post/page editor and choose image block
* Select Google Photos
* Check if you see a connection Upgrade screen

<img width="926" alt="Screenshot 2024-12-03 at 18 15 06" src="https://github.com/user-attachments/assets/b0659f82-2e97-48ab-8979-44526d94db2a">

| Before | After |
|--------|--------|
| <img width="942" alt="Screenshot 2024-12-03 at 18 14 15" src="https://github.com/user-attachments/assets/38c1ea49-ef15-402c-bc41-13d94dd61e36"> | <img width="929" alt="Screenshot 2024-12-03 at 18 13 04" src="https://github.com/user-attachments/assets/d47fe5dd-3d4e-4c8e-92dc-2a34564d4a72"> | 

