### PR TITLE
AI Assistant: Add feature flag for AI feedback feature

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-feedback-flag
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-feedback-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Add feature flag for AI feedback feature

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -211,3 +211,17 @@ add_action(
 		}
 	}
 );
+
+/**
+ * Register the `ai-response-feedback` extension.
+ */
+add_action(
+	'jetpack_register_gutenberg_extensions',
+	function () {
+		if ( apply_filters( 'jetpack_ai_enabled', true ) &&
+			apply_filters( 'ai_response_feedback_enabled', false )
+		) {
+			\Jetpack_Gutenberg::set_extension_available( 'ai-response-feedback' );
+		}
+	}
+);

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -79,7 +79,8 @@
 		"v6-video-frame-poster",
 		"videopress/video-chapters",
 		"ai-assistant-backend-prompts",
-		"ai-list-to-table-transform"
+		"ai-list-to-table-transform",
+		"ai-response-feedback"
 	],
 	"experimental": [],
 	"no-post-editor": [


### PR DESCRIPTION
Fixes #[40417](https://github.com/Automattic/jetpack/issues/40417)

## Proposed changes:
* Adds `ai-response-feedback` beta flag
* Enable only if `ai_response_feedback_enabled` filter is true 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Check out this branch and make sure you have the snippets plugin installed
* Make sure `JETPACK_BLOCKS_VARIATION` is set to `production`
* Edit/create a post and in the console paste`Jetpack_Editor_Initial_State.available_blocks['ai-response-feedback']`
* It should return `undefined`
* In an enabled snippet set `JETPACK_BLOCKS_VARIATION` to `beta`: `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );`
* Reload. `Jetpack_Editor_Initial_State.available_blocks['ai-response-feedback']` should now return:
  * `{available: false, unavailable_reason: 'missing_module', details: Array(0)}`
* Now `add_filter( 'ai_response_feedback_enabled', '__return_true' );` to your snippet
* Reload. `Jetpack_Editor_Initial_State.available_blocks['ai-response-feedback']` should now return:
  * `{available: true}`
