### PR TITLE
Load WPCOM sidebar notice async

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-async-wpcom-sidebar-notice
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-async-wpcom-sidebar-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Load WPCOM sidebar notice async

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.js
@@ -83,7 +83,7 @@ const wpcomShowSidebarNotice = sidebarNoticeData => {
 const fetchSidebarNotice = async () => {
 	try {
 		const response = await fetch(
-			`${ wpcomSidebarNoticeConfig.ajaxUrl }?action=fetch_sidebar_notice&nonce=${ wpcomSidebarNoticeConfig.nonce }`
+			`${ wpcomSidebarNoticeConfig.ajaxUrl }?action=wpcom_fetch_sidebar_notice&nonce=${ wpcomSidebarNoticeConfig.nonce }`
 		);
 
 		if ( ! response.status === 200 ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.js
@@ -1,23 +1,23 @@
-/* global wp, wpcomSidebarNotice */
+/* global wp, wpcomSidebarNoticeConfig */
 import { wpcomTrackEvent } from '../../common/tracks';
 
 import './wpcom-sidebar-notice.scss';
 
-const wpcomSidebarNoticeRecordEvent = event => {
+const wpcomSidebarNoticeRecordEvent = ( event, sidebarNoticeData ) => {
 	if ( ! event ) {
 		return;
 	}
 	wpcomTrackEvent(
 		event.name,
 		event.props,
-		wpcomSidebarNotice.user.ID,
-		wpcomSidebarNotice.user.username
+		sidebarNoticeData.user.ID,
+		sidebarNoticeData.user.username
 	);
 };
 
-const wpcomShowSidebarNotice = () => {
+const wpcomShowSidebarNotice = sidebarNoticeData => {
 	const adminMenu = document.querySelector( '#adminmenu' );
-	if ( ! adminMenu || typeof wpcomSidebarNotice === 'undefined' ) {
+	if ( ! adminMenu || ! sidebarNoticeData ) {
 		return;
 	}
 
@@ -28,21 +28,21 @@ const wpcomShowSidebarNotice = () => {
 			<li
 				id="toplevel_page_site-notices"
 				class="wp-not-current-submenu menu-top menu-icon-generic toplevel_page_site-notices"
-				data-id="${ wpcomSidebarNotice.id }"
-				data-feature-class="${ wpcomSidebarNotice.featureClass }"
+				data-id="${ sidebarNoticeData.id }"
+				data-feature-class="${ sidebarNoticeData.featureClass }"
 			>
 				<a href="${
-					wpcomSidebarNotice.url
+					sidebarNoticeData.url
 				}" class="wp-not-current-submenu menu-top menu-icon-generic toplevel_page_site-notices">
 					<div class="wp-menu-name">
 						<div class="upsell_banner">
 							<div class="upsell_banner__icon dashicons" aria-hidden="true"></div>
-							<div class="upsell_banner__text">${ wpcomSidebarNotice.text }</div>
-							<button type="button" class="upsell_banner__action button">${ wpcomSidebarNotice.action }</button>
+							<div class="upsell_banner__text">${ sidebarNoticeData.text }</div>
+							<button type="button" class="upsell_banner__action button">${ sidebarNoticeData.action }</button>
 							${
-								wpcomSidebarNotice.dismissible
+								sidebarNoticeData.dismissible
 									? '<button type="button" class="upsell_banner__dismiss button button-link">' +
-									  wpcomSidebarNotice.dismissLabel +
+									  sidebarNoticeData.dismissLabel +
 									  '</button>'
 									: ''
 							}
@@ -54,7 +54,7 @@ const wpcomShowSidebarNotice = () => {
 	);
 
 	// Record impression event in Tracks.
-	wpcomSidebarNoticeRecordEvent( wpcomSidebarNotice.tracks?.display );
+	wpcomSidebarNoticeRecordEvent( sidebarNoticeData.tracks?.display );
 
 	const sidebarNotice = adminMenu.firstElementChild;
 	sidebarNotice.addEventListener( 'click', event => {
@@ -67,17 +67,37 @@ const wpcomShowSidebarNotice = () => {
 			wp.ajax.post( 'wpcom_dismiss_sidebar_notice', {
 				id: sidebarNotice.dataset.id,
 				feature_class: sidebarNotice.dataset.featureClass,
-				_ajax_nonce: wpcomSidebarNotice.dismissNonce,
+				_ajax_nonce: sidebarNoticeData.dismissNonce,
 			} );
 			sidebarNotice.remove();
 
 			// Record dismiss event in Tracks.
-			wpcomSidebarNoticeRecordEvent( wpcomSidebarNotice.tracks?.dismiss );
+			wpcomSidebarNoticeRecordEvent( sidebarNoticeData.tracks?.dismiss );
 		} else {
 			// Record click event in Tracks.
-			wpcomSidebarNoticeRecordEvent( wpcomSidebarNotice.tracks?.click );
+			wpcomSidebarNoticeRecordEvent( sidebarNoticeData.tracks?.click );
 		}
 	} );
 };
 
-document.addEventListener( 'DOMContentLoaded', wpcomShowSidebarNotice );
+const fetchSidebarNotice = async () => {
+	try {
+		const response = await fetch(
+			`${ wpcomSidebarNoticeConfig.ajaxUrl }?action=fetch_sidebar_notice&nonce=${ wpcomSidebarNoticeConfig.nonce }`
+		);
+
+		if ( ! response.status === 200 ) {
+			return;
+		}
+
+		const res = await response.json();
+
+		if ( res.success && res.data ) {
+			wpcomShowSidebarNotice( res.data );
+		}
+	} catch ( error ) {
+		// End silently
+	}
+};
+
+document.addEventListener( 'DOMContentLoaded', fetchSidebarNotice );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.js
@@ -3,21 +3,21 @@ import { wpcomTrackEvent } from '../../common/tracks';
 
 import './wpcom-sidebar-notice.scss';
 
-const wpcomSidebarNoticeRecordEvent = ( event, sidebarNoticeData ) => {
+const wpcomSidebarNoticeRecordEvent = ( event, wpcomSidebarNoticeData ) => {
 	if ( ! event ) {
 		return;
 	}
 	wpcomTrackEvent(
 		event.name,
 		event.props,
-		sidebarNoticeData.user.ID,
-		sidebarNoticeData.user.username
+		wpcomSidebarNoticeData.user.ID,
+		wpcomSidebarNoticeData.user.username
 	);
 };
 
-const wpcomShowSidebarNotice = sidebarNoticeData => {
+const wpcomShowSidebarNotice = wpcomSidebarNoticeData => {
 	const adminMenu = document.querySelector( '#adminmenu' );
-	if ( ! adminMenu || ! sidebarNoticeData ) {
+	if ( ! adminMenu || ! wpcomSidebarNoticeData ) {
 		return;
 	}
 
@@ -28,21 +28,23 @@ const wpcomShowSidebarNotice = sidebarNoticeData => {
 			<li
 				id="toplevel_page_site-notices"
 				class="wp-not-current-submenu menu-top menu-icon-generic toplevel_page_site-notices"
-				data-id="${ sidebarNoticeData.id }"
-				data-feature-class="${ sidebarNoticeData.featureClass }"
+				data-id="${ wpcomSidebarNoticeData.id }"
+				data-feature-class="${ wpcomSidebarNoticeData.featureClass }"
 			>
 				<a href="${
-					sidebarNoticeData.url
+					wpcomSidebarNoticeData.url
 				}" class="wp-not-current-submenu menu-top menu-icon-generic toplevel_page_site-notices">
 					<div class="wp-menu-name">
 						<div class="upsell_banner">
 							<div class="upsell_banner__icon dashicons" aria-hidden="true"></div>
-							<div class="upsell_banner__text">${ sidebarNoticeData.text }</div>
-							<button type="button" class="upsell_banner__action button">${ sidebarNoticeData.action }</button>
+							<div class="upsell_banner__text">${ wpcomSidebarNoticeData.text }</div>
+							<button type="button" class="upsell_banner__action button">${
+								wpcomSidebarNoticeData.action
+							}</button>
 							${
-								sidebarNoticeData.dismissible
+								wpcomSidebarNoticeData.dismissible
 									? '<button type="button" class="upsell_banner__dismiss button button-link">' +
-									  sidebarNoticeData.dismissLabel +
+									  wpcomSidebarNoticeData.dismissLabel +
 									  '</button>'
 									: ''
 							}
@@ -54,7 +56,7 @@ const wpcomShowSidebarNotice = sidebarNoticeData => {
 	);
 
 	// Record impression event in Tracks.
-	wpcomSidebarNoticeRecordEvent( sidebarNoticeData.tracks?.display );
+	wpcomSidebarNoticeRecordEvent( wpcomSidebarNoticeData.tracks?.display );
 
 	const sidebarNotice = adminMenu.firstElementChild;
 	sidebarNotice.addEventListener( 'click', event => {
@@ -67,20 +69,20 @@ const wpcomShowSidebarNotice = sidebarNoticeData => {
 			wp.ajax.post( 'wpcom_dismiss_sidebar_notice', {
 				id: sidebarNotice.dataset.id,
 				feature_class: sidebarNotice.dataset.featureClass,
-				_ajax_nonce: sidebarNoticeData.dismissNonce,
+				_ajax_nonce: wpcomSidebarNoticeData.dismissNonce,
 			} );
 			sidebarNotice.remove();
 
 			// Record dismiss event in Tracks.
-			wpcomSidebarNoticeRecordEvent( sidebarNoticeData.tracks?.dismiss );
+			wpcomSidebarNoticeRecordEvent( wpcomSidebarNoticeData.tracks?.dismiss );
 		} else {
 			// Record click event in Tracks.
-			wpcomSidebarNoticeRecordEvent( sidebarNoticeData.tracks?.click );
+			wpcomSidebarNoticeRecordEvent( wpcomSidebarNoticeData.tracks?.click );
 		}
 	} );
 };
 
-const fetchSidebarNotice = async () => {
+const wpcomFetchSidebarNotice = async () => {
 	try {
 		const response = await fetch(
 			`${ wpcomSidebarNoticeConfig.ajaxUrl }?action=wpcom_fetch_sidebar_notice&nonce=${ wpcomSidebarNoticeConfig.nonce }`
@@ -100,4 +102,4 @@ const fetchSidebarNotice = async () => {
 	}
 };
 
-document.addEventListener( 'DOMContentLoaded', fetchSidebarNotice );
+document.addEventListener( 'DOMContentLoaded', wpcomFetchSidebarNotice );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
@@ -43,7 +43,7 @@ function wpcom_enqueue_sidebar_notice_assets() {
 		'wpcomSidebarNoticeConfig',
 		array(
 			'ajaxUrl' => admin_url( 'admin-ajax.php' ),
-			'nonce'   => wp_create_nonce( 'fetch_sidebar_notice' ),
+			'nonce'   => wp_create_nonce( 'wpcom_fetch_sidebar_notice' ),
 		)
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
@@ -36,50 +36,14 @@ function wpcom_enqueue_sidebar_notice_assets() {
 		Jetpack_Mu_Wpcom::PACKAGE_VERSION
 	);
 
-	$notice = wpcom_get_sidebar_notice();
-	if ( $notice ) {
-		$link = $notice['link'];
-		if ( str_starts_with( $link, '/' ) ) {
-			$link = 'https://wordpress.com' . $link;
-		}
-
-		$user_id    = null;
-		$user_login = null;
-
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			global $current_user;
-			$user_id    = $current_user->ID;
-			$user_login = $current_user->user_login;
-		} else {
-			$connection_manager = new Connection_Manager();
-			$wpcom_user_data    = $connection_manager->get_connected_user_data();
-			if ( $wpcom_user_data ) {
-				$user_id    = $wpcom_user_data['ID'];
-				$user_login = $wpcom_user_data['login'];
-			}
-		}
-
-		$data = array(
-			'url'          => esc_url( $link ),
-			'text'         => wp_kses( $notice['content'], array() ),
-			'action'       => wp_kses( $notice['cta'], array() ),
-			'dismissible'  => $notice['dismissible'],
-			'dismissLabel' => esc_html__( 'Dismiss', 'jetpack-mu-wpcom' ),
-			'id'           => $notice['id'],
-			'featureClass' => $notice['feature_class'],
-			'dismissNonce' => wp_create_nonce( 'wpcom_dismiss_sidebar_notice' ),
-			'tracks'       => $notice['tracks'],
-			'user'         => array(
-				'ID'       => $user_id,
-				'username' => $user_login,
-			),
-		);
-
-		wp_add_inline_script(
-			'wpcom-sidebar-notice',
-			'window.wpcomSidebarNotice = ' . wp_json_encode( $data ) . ';'
-		);
-	}
+	wp_localize_script(
+		'wpcom-sidebar-notice',
+		'wpcomSidebarNoticeConfig',
+		array(
+			'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+			'nonce'   => wp_create_nonce( 'fetch_sidebar_notice' ),
+		)
+	);
 }
 add_action( 'admin_enqueue_scripts', 'wpcom_enqueue_sidebar_notice_assets' );
 
@@ -123,6 +87,59 @@ function wpcom_get_sidebar_notice() {
 		'tracks'        => $message->tracks ?? null,
 	);
 }
+
+/**
+ * Fetch sidebar notice data asynchronously via AJAX.
+ */
+function wpcom_fetch_sidebar_notice_data() {
+	check_ajax_referer( 'fetch_sidebar_notice', 'nonce' );
+
+	$notice = wpcom_get_sidebar_notice();
+	if ( ! $notice ) {
+		status_header( 204 );
+		wp_die();
+	}
+
+	$link = ! empty( $notice['link'] ) ? $notice['link'] : '';
+	if ( str_starts_with( $link, '/' ) ) {
+		$link = 'https://wordpress.com' . $link;
+	}
+
+	$user_id    = null;
+	$user_login = null;
+
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		global $current_user;
+		$user_id    = $current_user->ID;
+		$user_login = $current_user->user_login;
+	} else {
+		$connection_manager = new Connection_Manager();
+		$wpcom_user_data    = $connection_manager->get_connected_user_data();
+		if ( $wpcom_user_data ) {
+			$user_id    = $wpcom_user_data['ID'];
+			$user_login = $wpcom_user_data['login'];
+		}
+	}
+
+	$data = array(
+		'url'          => esc_url( $link ),
+		'text'         => wp_kses( $notice['content'], array() ),
+		'action'       => wp_kses( $notice['cta'], array() ),
+		'dismissible'  => $notice['dismissible'],
+		'dismissLabel' => esc_html__( 'Dismiss', 'jetpack-mu-wpcom' ),
+		'id'           => $notice['id'],
+		'featureClass' => $notice['feature_class'],
+		'dismissNonce' => wp_create_nonce( 'wpcom_dismiss_sidebar_notice' ),
+		'tracks'       => $notice['tracks'],
+		'user'         => array(
+			'ID'       => $user_id,
+			'username' => $user_login,
+		),
+	);
+
+	wp_send_json_success( $data );
+}
+add_action( 'wp_ajax_fetch_sidebar_notice', 'wpcom_fetch_sidebar_notice_data' );
 
 /**
  * Handle AJAX requests to dismiss a sidebar notice.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
@@ -94,7 +94,7 @@ function wpcom_get_sidebar_notice() {
  * Fetch sidebar notice data asynchronously via AJAX.
  */
 function wpcom_fetch_sidebar_notice_data() {
-	check_ajax_referer( 'fetch_sidebar_notice', 'nonce' );
+	check_ajax_referer( 'wpcom_fetch_sidebar_notice', 'nonce' );
 
 	$notice = wpcom_get_sidebar_notice();
 	if ( ! $notice ) {
@@ -141,7 +141,7 @@ function wpcom_fetch_sidebar_notice_data() {
 
 	wp_send_json_success( $data );
 }
-add_action( 'wp_ajax_fetch_sidebar_notice', 'wpcom_fetch_sidebar_notice_data' );
+add_action( 'wp_ajax_wpcom_fetch_sidebar_notice', 'wpcom_fetch_sidebar_notice_data' );
 
 /**
  * Handle AJAX requests to dismiss a sidebar notice.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
@@ -18,11 +18,13 @@ if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
  * Enqueue assets needed by the WordPress.com sidebar notice.
  */
 function wpcom_enqueue_sidebar_notice_assets() {
+	$asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-sidebar-notice/wpcom-sidebar-notice.asset.php';
+
 	wp_enqueue_script(
 		'wpcom-sidebar-notice',
 		plugins_url( 'build/wpcom-sidebar-notice/wpcom-sidebar-notice.js', Jetpack_Mu_Wpcom::BASE_FILE ),
-		array(),
-		Jetpack_Mu_Wpcom::PACKAGE_VERSION,
+		$asset_file['dependencies'] ?? array(),
+		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-sidebar-notice/wpcom-sidebar-notice.js' ),
 		array(
 			'strategy'  => 'defer',
 			'in_footer' => true,
@@ -33,7 +35,7 @@ function wpcom_enqueue_sidebar_notice_assets() {
 		'wpcom-sidebar-notice',
 		plugins_url( 'build/wpcom-sidebar-notice/wpcom-sidebar-notice.css', Jetpack_Mu_Wpcom::BASE_FILE ),
 		array(),
-		Jetpack_Mu_Wpcom::PACKAGE_VERSION
+		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-sidebar-notice/wpcom-sidebar-notice.css' )
 	);
 
 	wp_localize_script(

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
@@ -125,14 +125,14 @@ function wpcom_fetch_sidebar_notice_data() {
 
 	$data = array(
 		'url'          => esc_url( $link ),
-		'text'         => wp_kses( $notice['content'], array() ),
-		'action'       => wp_kses( $notice['cta'], array() ),
-		'dismissible'  => $notice['dismissible'],
+		'text'         => wp_kses( $notice['content'] ?? '', array() ),
+		'action'       => wp_kses( $notice['cta'] ?? '', array() ),
+		'dismissible'  => $notice['dismissible'] ?? false,
 		'dismissLabel' => esc_html__( 'Dismiss', 'jetpack-mu-wpcom' ),
-		'id'           => $notice['id'],
-		'featureClass' => $notice['feature_class'],
+		'id'           => $notice['id'] ?? '',
+		'featureClass' => $notice['feature_class'] ?? '',
 		'dismissNonce' => wp_create_nonce( 'wpcom_dismiss_sidebar_notice' ),
-		'tracks'       => $notice['tracks'],
+		'tracks'       => $notice['tracks'] ?? null,
 		'user'         => array(
 			'ID'       => $user_id,
 			'username' => $user_login,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/96940

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This PR changes to load the WPCOM sidebar notice asynchronously. 

This is to avoid requesting JITM notices synchronously while queuing scripts: https://github.com/Automattic/wp-calypso/issues/96940#issuecomment-2511747095

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Have an Atomic site
* Ensure the site has the notice on the sidebar
	* <img width="164" alt="Screenshot 2024-12-03 at 16 23 33" src="https://github.com/user-attachments/assets/87c11d96-8329-4686-9ef9-a5be88026d81">
* Patch this change to "WordPress.com Features" by Jetpack Beta
* Go to /wp-admin
* Ensure the notice is still there
