### PR TITLE
Repo Gardening > AI Labeling: allow plugin-specific feature labels

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-ai-labeling-feature-labels
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-ai-labeling-feature-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Labeling: allow plugin-specific feature labels as well.

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/ai-labeling.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/ai-labeling.js
@@ -21,8 +21,8 @@ const sendOpenAiRequest = require( '../../utils/openai/send-request' );
 async function fetchOpenAiLabelsSuggestions( octokit, owner, repo, title, body ) {
 	const suggestions = { labels: [], explanations: {} };
 
-	// Get all the Feature and Feature Group labels in the repo.
-	const pattern = /^(\[Feature\]|\[Feature Group\])/;
+	// Get all the Feature, Feature Group labels, and Plugin feature labels in the repo.
+	const pattern = /^\[[^\]]*Feature/;
 	const repoLabels = await getAvailableLabels( octokit, owner, repo, pattern );
 
 	// If no labels are found, bail.

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/ai-labeling.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/ai-labeling.js
@@ -62,7 +62,7 @@ ${ repoLabels
 Analyze the issue and suggest relevant labels. Rules:
 - Use only existing labels provided.
 - Include 1 '[Feature Group]' label.
-- Include 1 to 3 '[Feature]' labels.
+- Include 1 to 3 '[Feature]' labels, or '["Plugin" Feature]' labels (where "Plugin" matches a plugin name) if more relevant.
 - Briefly explain each label choice in 1 sentence.
 - Format your response as a JSON object, with each suggested label as a key, and your explanation of the label choice as the value.
 

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/ai-labeling.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/ai-labeling.js
@@ -65,6 +65,7 @@ Analyze the issue and suggest relevant labels. Rules:
 - Include 1 to 3 '[Feature]' labels, or '["Plugin" Feature]' labels (where "Plugin" matches a plugin name) if more relevant.
 - Briefly explain each label choice in 1 sentence.
 - Format your response as a JSON object, with each suggested label as a key, and your explanation of the label choice as the value.
+- If the issue contents specify that a specific plugin is impacted, you must only suggest Feature labels related to that plugin.
 
 Example response format:
 {


### PR DESCRIPTION
## Proposed changes:

Just like in #40396, let's support plugin-specific feature labels in the auto-labeler.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

No

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

This can be tested in a fork. Here is an example:

- For a Boost issue: https://github.com/jeherve/jetpack/issues/191
- For a Comments issue: https://github.com/jeherve/jetpack/issues/192
