### PR TITLE
[WordAds] Disable IPW sticky format and fix fallback

### DIFF
--- a/projects/plugins/jetpack/changelog/update-iponweb-to-watl-migration
+++ b/projects/plugins/jetpack/changelog/update-iponweb-to-watl-migration
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Migration from IPONWEB to WATL 
+Migration from IPONWEB to WATL

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -372,8 +372,7 @@ class WordAds {
 		$consent      = (int) isset( $_COOKIE['personalized-ads-consent'] );
 		$is_logged_in = is_user_logged_in() ? '1' : '0';
 
-		$disabled_slot_formats = array();
-		$disabled_slot_formats = apply_filters( 'wordads_disabled_slot_formats', $disabled_slot_formats );
+		$disabled_slot_formats = apply_filters( 'wordads_disabled_slot_formats', array() );
 
 		if ( apply_filters( 'wordads_iponweb_bottom_sticky_ad_disable', false ) ) {
 			$disabled_slot_formats[] = 'MTS';

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -375,10 +375,6 @@ class WordAds {
 		$disabled_slot_formats = array();
 		$disabled_slot_formats = apply_filters( 'wordads_disabled_slot_formats', $disabled_slot_formats );
 
-		if ( apply_filters( 'wordads_iponweb_inline_ad_disable', false ) || ! $this->params->options['inline_enabled'] ) {
-			$disabled_slot_formats[] = 'IAD';
-		}
-
 		if ( apply_filters( 'wordads_iponweb_bottom_sticky_ad_disable', false ) ) {
 			$disabled_slot_formats[] = 'MTS';
 		}

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -436,11 +436,11 @@ class WordAds {
 
 		// phpcs:disable WordPress.Security.EscapeOutput.HeredocOutputNotEscaped
 		echo <<<HTML
-				<script>
+				<script type="text/javascript">
 					var sas_fallback = sas_fallback || [];
 					sas_fallback.push(
-						{ tag: "$tag_inline", type: 'inline' }
-						{ tag: "$tag_belowpost", type: 'belowpost' }
+						{ tag: "$tag_inline", type: 'inline' },
+						{ tag: "$tag_belowpost", type: 'belowpost' },
 						{ tag: "$tag_top", type: 'top' }
 					);
 				</script>

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -387,26 +387,32 @@ class WordAds {
 			$disabled_slot_formats[] = 'DPR';
 		}
 
+		$config    = array(
+			'pt'                    => $pagetype,
+			'ht'                    => $hosting_type,
+			'tn'                    => get_stylesheet(),
+			'uloggedin'             => $is_logged_in,
+			'amp'                   => false,
+			'siteid'                => $site_id,
+			'consent'               => $consent,
+			'ad'                    => array(
+				'label'           => array(
+					'text' => __( 'Advertisements', 'jetpack' ),
+				),
+				'reportAd'        => array(
+					'text' => __( 'Report this ad', 'jetpack' ),
+				),
+				'privacySettings' => array(
+					'text'    => __( 'Privacy', 'jetpack' ),
+					'onClick' => 'js:function() { window.__tcfapi && window.__tcfapi(\'showUi\'); }',
+				),
+			),
+			'disabled_slot_formats' => $disabled_slot_formats,
+		);
+		$js_config = WordAds_Array_Utils::array_to_js_object( $config );
 		?>
 		<script<?php echo esc_attr( $data_tags ); ?> type="text/javascript">
-			var __ATA_PP = {
-				pt: <?php echo esc_js( $pagetype ); ?>,
-				ht: <?php echo esc_js( $hosting_type ); ?>,
-				tn: '<?php echo esc_js( get_stylesheet() ); ?>',
-				uloggedin: <?php echo esc_js( $is_logged_in ); ?>,
-				amp: false,
-				siteid: <?php echo esc_js( $site_id ); ?>,
-				consent: <?php echo esc_js( $consent ); ?>,
-				ad: {
-					label: { text: '<?php echo esc_js( __( 'Advertisements', 'jetpack' ) ); ?>' },
-					reportAd: { text: '<?php echo esc_js( __( 'Report this ad', 'jetpack' ) ); ?>' },
-					privacySettings: {
-						text: '<?php echo esc_js( __( 'Privacy', 'jetpack' ) ); ?>',
-						onClick: function() { window.__tcfapi && window.__tcfapi('showUi'); }
-					}
-				},
-				disabled_slot_formats: <?php echo wp_json_encode( $disabled_slot_formats ); ?>,
-			};
+			var __ATA_PP = <?php echo $js_config; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
 			var __ATA = __ATA || {};
 			__ATA.cmd = __ATA.cmd || [];
 			__ATA.criteo = __ATA.criteo || {};

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -371,9 +371,42 @@ class WordAds {
 		$site_id      = $this->params->blog_id;
 		$consent      = (int) isset( $_COOKIE['personalized-ads-consent'] );
 		$is_logged_in = is_user_logged_in() ? '1' : '0';
+
+		$disabled_slot_formats = array();
+		$disabled_slot_formats = apply_filters( 'wordads_disabled_slot_formats', $disabled_slot_formats );
+
+		if ( apply_filters( 'wordads_iponweb_inline_ad_disable', false ) || ! $this->params->options['inline_enabled'] ) {
+			$disabled_slot_formats[] = 'IAD';
+		}
+
+		if ( apply_filters( 'wordads_iponweb_bottom_sticky_ad_disable', false ) ) {
+			$disabled_slot_formats[] = 'MTS';
+		}
+
+		if ( apply_filters( 'wordads_iponweb_sidebar_sticky_right_ad_disable', false ) ) {
+			$disabled_slot_formats[] = 'DPR';
+		}
+
 		?>
 		<script<?php echo esc_attr( $data_tags ); ?> type="text/javascript">
-			var __ATA_PP = { pt: <?php echo esc_js( $pagetype ); ?>, ht: <?php echo esc_js( $hosting_type ); ?>, tn: '<?php echo esc_js( get_stylesheet() ); ?>', uloggedin: <?php echo esc_js( $is_logged_in ); ?>, amp: false, siteid: <?php echo esc_js( $site_id ); ?>, consent: <?php echo esc_js( $consent ); ?>, ad: { label: { text: '<?php echo esc_js( __( 'Advertisements', 'jetpack' ) ); ?>' }, reportAd: { text: '<?php echo esc_js( __( 'Report this ad', 'jetpack' ) ); ?>' }, privacySettings: { text: '<?php echo esc_js( __( 'Privacy', 'jetpack' ) ); ?>', onClick: function() { window.__tcfapi && window.__tcfapi('showUi'); } } } };
+			var __ATA_PP = {
+				pt: <?php echo esc_js( $pagetype ); ?>,
+				ht: <?php echo esc_js( $hosting_type ); ?>,
+				tn: '<?php echo esc_js( get_stylesheet() ); ?>',
+				uloggedin: <?php echo esc_js( $is_logged_in ); ?>,
+				amp: false,
+				siteid: <?php echo esc_js( $site_id ); ?>,
+				consent: <?php echo esc_js( $consent ); ?>,
+				ad: {
+					label: { text: '<?php echo esc_js( __( 'Advertisements', 'jetpack' ) ); ?>' },
+					reportAd: { text: '<?php echo esc_js( __( 'Report this ad', 'jetpack' ) ); ?>' },
+					privacySettings: {
+						text: '<?php echo esc_js( __( 'Privacy', 'jetpack' ) ); ?>',
+						onClick: function() { window.__tcfapi && window.__tcfapi('showUi'); }
+					}
+				},
+				disabled_slot_formats: <?php echo wp_json_encode( $disabled_slot_formats ); ?>,
+			};
 			var __ATA = __ATA || {};
 			__ATA.cmd = __ATA.cmd || [];
 			__ATA.criteo = __ATA.criteo || {};

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -194,8 +194,6 @@ class WordAds_Smart {
 					array( $this, 'insert_inline_marker' ),
 					10
 				);
-
-				add_filter( 'wordads_iponweb_inline_ad_disable', '__return_true', 10 );
 			}
 		}
 

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -194,7 +194,19 @@ class WordAds_Smart {
 					array( $this, 'insert_inline_marker' ),
 					10
 				);
+
+				add_filter( 'wordads_iponweb_inline_ad_disable', '__return_true', 10 );
 			}
+		}
+
+		if ( $this->formats['bottom_sticky']['enabled'] ) {
+			// Disable IPW slot.
+			add_filter( 'wordads_iponweb_bottom_sticky_ad_disable', '__return_true', 10 );
+		}
+
+		if ( $this->formats['sidebar_sticky_right']['enabled'] ) {
+			// Disable IPW slot.
+			add_filter( 'wordads_iponweb_sidebar_sticky_right_ad_disable', '__return_true', 10 );
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disable IPW sticky format when smart formats are running and fix sas_fallback not getting called

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to [this test site](https://sacred-of-gophers.jurassic.ninja/2024/11/28/exercise-building-the-foundations-of-your-lifes-skyscraper/?wordads-logging=true&bottom_sticky=true) and confirm bottom sticky ad shows, check the "adjr" request in network logs to see that `pp.disabled_slot_formats` with value `[MTS]` is getting sent in the request payload
* Disable the corresponding insertion on Equativ, reload the page and confirm fallback gets called
* Repeat the above for the page with [Gutenberg ads formats](https://sacred-of-gophers.jurassic.ninja/2024/11/28/hello-world/?wordads-logging=true&gutenberg_rectangle=true&gutenberg_mobile_leaderboard=true&gutenberg_leaderboard=true) and confirm fallback gets called when the corresponding insertion on Equativ is disabled.

