### PR TITLE
Repo Gardening: add check for a [Type] label on PRs

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/add-repo-gardening-type-label-check-pr
+++ b/projects/github-actions/repo-gardening/changelog/add-repo-gardening-type-label-check-pr
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+PR checks: add new check to ensure that PRs include a [Type] label.

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -13,35 +13,6 @@ const getLabels = require( '../../utils/labels/get-labels' );
 /* global GitHub, WebhookPayloadPullRequest */
 
 /**
- * Check for status labels on a PR.
- *
- * @param {GitHub} octokit - Initialized Octokit REST client.
- * @param {string} owner   - Repository owner.
- * @param {string} repo    - Repository name.
- * @param {string} number  - PR number.
- * @return {Promise<boolean>} Promise resolving to boolean.
- */
-async function hasStatusLabels( octokit, owner, repo, number ) {
-	const labels = await getLabels( octokit, owner, repo, number );
-	// We're only interested in status labels, but not the "Needs Reply" label since it can be added by the action.
-	return !! labels.find( label => label.match( /^\[Status\].*(?<!Author Reply)$/ ) );
-}
-
-/**
- * Check for Type labels on a PR.
- *
- * @param {GitHub} octokit - Initialized Octokit REST client.
- * @param {string} owner   - Repository owner.
- * @param {string} repo    - Repository name.
- * @param {string} number  - PR number.
- * @return {Promise<boolean>} Promise resolving to boolean.
- */
-async function hasTypeLabels( octokit, owner, repo, number ) {
-	const labels = await getLabels( octokit, owner, repo, number );
-	return !! labels.find( label => label.match( /^\[Type\]/ ) );
-}
-
-/**
  * Check for a "Need Review" label on a PR.
  *
  * @param {GitHub} octokit - Initialized Octokit REST client.
@@ -269,22 +240,35 @@ async function getStatusChecks( payload, octokit ) {
 	const ownerLogin = owner.login;
 
 	const hasLongDescription = body?.length > 200;
-	const isLabeled = await hasStatusLabels( octokit, ownerLogin, repo, number );
-	const hasType = await hasTypeLabels( octokit, ownerLogin, repo, number );
 	const hasTesting = !! body?.includes( 'Testing instructions' );
 	const hasPrivacy = !! body?.includes( 'data or activity we track or use' );
 	const projectsWithoutChangelog = await getChangelogEntries( octokit, ownerLogin, repo, number );
 	const isFromContributor = head.repo.full_name === base.repo.full_name;
 
+	const prLabels = await getLabels( octokit, ownerLogin, repo, number );
+	const { hasStatusLabels, hasTypeLabels } = prLabels.reduce(
+		( acc, label ) => {
+			// We're only interested in status labels, but not the "Needs Reply" label since it can be added by the action.
+			if ( label.match( /^\[Status\].*(?<!Author Reply)$/ ) ) {
+				acc.hasStatusLabels = true;
+			}
+			if ( label.match( /^\[Type\]/ ) ) {
+				acc.hasTypeLabels = true;
+			}
+			return acc;
+		},
+		{ hasStatusLabels: false, hasTypeLabels: false }
+	);
+
 	return {
 		hasLongDescription,
-		isLabeled,
+		hasStatusLabels,
 		hasTesting,
 		hasPrivacy,
 		projectsWithoutChangelog,
 		hasChangelogEntries: projectsWithoutChangelog.length === 0,
 		isFromContributor,
-		hasType,
+		hasTypeLabels,
 	};
 }
 
@@ -304,9 +288,9 @@ function renderStatusChecks( statusChecks ) {
 	// Use labels please!
 	// Only check this for PRs created by a12s. External contributors cannot add labels.
 	if ( statusChecks.isFromContributor ) {
-		debug( `check-description: this PR has a Status label: ${ statusChecks.isLabeled }` );
+		debug( `check-description: this PR has a Status label: ${ statusChecks.hasStatusLabels }` );
 		checks += statusEntry(
-			! statusChecks.isLabeled,
+			! statusChecks.hasStatusLabels,
 			'Add a "[Status]" label (In Progress, Needs Team Review, ...).'
 		);
 	}
@@ -314,9 +298,9 @@ function renderStatusChecks( statusChecks ) {
 	// Add a [Type] label please.
 	// Only check this for PRs created by a12s. External contributors cannot add labels.
 	if ( statusChecks.isFromContributor ) {
-		debug( `check-description: this PR has a Type label: ${ statusChecks.hasType }` );
+		debug( `check-description: this PR has a Type label: ${ statusChecks.hasTypeLabels }` );
 		checks += statusEntry(
-			! statusChecks.hasType,
+			! statusChecks.hasTypeLabels,
 			'Add a "[Type]" label (Bug, Enhancement, Janitorial, Task).'
 		);
 	}

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -28,6 +28,20 @@ async function hasStatusLabels( octokit, owner, repo, number ) {
 }
 
 /**
+ * Check for Type labels on a PR.
+ *
+ * @param {GitHub} octokit - Initialized Octokit REST client.
+ * @param {string} owner   - Repository owner.
+ * @param {string} repo    - Repository name.
+ * @param {string} number  - PR number.
+ * @return {Promise<boolean>} Promise resolving to boolean.
+ */
+async function hasTypeLabels( octokit, owner, repo, number ) {
+	const labels = await getLabels( octokit, owner, repo, number );
+	return !! labels.find( label => label.match( /^\[Type\]/ ) );
+}
+
+/**
  * Check for a "Need Review" label on a PR.
  *
  * @param {GitHub} octokit - Initialized Octokit REST client.
@@ -256,6 +270,7 @@ async function getStatusChecks( payload, octokit ) {
 
 	const hasLongDescription = body?.length > 200;
 	const isLabeled = await hasStatusLabels( octokit, ownerLogin, repo, number );
+	const hasType = await hasTypeLabels( octokit, ownerLogin, repo, number );
 	const hasTesting = !! body?.includes( 'Testing instructions' );
 	const hasPrivacy = !! body?.includes( 'data or activity we track or use' );
 	const projectsWithoutChangelog = await getChangelogEntries( octokit, ownerLogin, repo, number );
@@ -269,6 +284,7 @@ async function getStatusChecks( payload, octokit ) {
 		projectsWithoutChangelog,
 		hasChangelogEntries: projectsWithoutChangelog.length === 0,
 		isFromContributor,
+		hasType,
 	};
 }
 
@@ -288,10 +304,20 @@ function renderStatusChecks( statusChecks ) {
 	// Use labels please!
 	// Only check this for PRs created by a12s. External contributors cannot add labels.
 	if ( statusChecks.isFromContributor ) {
-		debug( `check-description: this PR is correctly labeled: ${ statusChecks.isLabeled }` );
+		debug( `check-description: this PR has a Status label: ${ statusChecks.isLabeled }` );
 		checks += statusEntry(
 			! statusChecks.isLabeled,
 			'Add a "[Status]" label (In Progress, Needs Team Review, ...).'
+		);
+	}
+
+	// Add a [Type] label please.
+	// Only check this for PRs created by a12s. External contributors cannot add labels.
+	if ( statusChecks.isFromContributor ) {
+		debug( `check-description: this PR has a Type label: ${ statusChecks.hasType }` );
+		checks += statusEntry(
+			! statusChecks.hasType,
+			'Add a "[Type]" label (Bug, Enhancement, Janitorial, Task).'
 		);
 	}
 

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -263,12 +263,12 @@ async function getStatusChecks( payload, octokit ) {
 	return {
 		hasLongDescription,
 		hasStatusLabels,
+		hasTypeLabels,
 		hasTesting,
 		hasPrivacy,
 		projectsWithoutChangelog,
 		hasChangelogEntries: projectsWithoutChangelog.length === 0,
 		isFromContributor,
-		hasTypeLabels,
 	};
 }
 


### PR DESCRIPTION
## Proposed changes:

Let's start recommending to PR authors that they include a [Type] label in their PR.

<img width="1011" alt="image" src="https://github.com/user-attachments/assets/d4d7f8db-cacb-47aa-a589-a39580475a8a">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1HpG7-uPQ-p2#comment-74890

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

This can be tested in a fork. Here is an example:

- https://github.com/jeherve/jetpack/pull/193

