### PR TITLE
Repo Gardening: add automated board triage of ActivityPub issues

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/add-repo-gardening-fediverse-board
+++ b/projects/github-actions/repo-gardening/changelog/add-repo-gardening-fediverse-board
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Board triage: add automatic triage to Fediverse project board.

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/automattic-label-team-assignments.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/automattic-label-team-assignments.js
@@ -50,6 +50,18 @@ export const automatticAssignments = {
 		slack_id: 'C048CUFRGFQ',
 		board_id: 'https://github.com/orgs/Automattic/projects/1106/',
 	},
+	ActivityPub: {
+		team: 'Fediverse',
+		labels: [
+			'[Feature] Federated comments',
+			'[Block] Federated reply',
+			'[Block] Follow Me',
+			'[Block] Followers',
+			'[Block] Post settings',
+			'[Block] Remote Reply',
+		],
+		board_id: 'https://github.com/orgs/Automattic/projects/1208/',
+	},
 	// Jetpack Division.
 	'AI Tools': {
 		team: 'Agora',


### PR DESCRIPTION
## Proposed changes:

When an issue is labeled with labels specific to the ActivityPub features, it will be triaged to the Fediverse board.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See p1733234813951669-slack-C04TJ8P900J

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

This can only be tested once the PR is merged. Any new bug report with the labels added in this PR will be added to the board.

To test, check the list of labels and compare with the labels in use in the ActivityPub repo:
https://github.com/Automattic/wordpress-activitypub/labels/
