### PR TITLE
Docker: fix debugging log permissions

### DIFF
--- a/tools/docker/bin/tail.sh
+++ b/tools/docker/bin/tail.sh
@@ -4,6 +4,7 @@ WP_DEBUG_LOG=/var/www/html/wp-content/debug.log
 
 if [ ! -e "$WP_DEBUG_LOG" ] ; then
 	touch "$WP_DEBUG_LOG"
+	chown www-data:www-data "$WP_DEBUG_LOG"
 fi
 
 tail -F --lines 100 "$WP_DEBUG_LOG"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/jetpack-backup-team#737.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

The `jetpack docker tail` command used to read the [WordPress debugging log][1] creates a new log file if it doesn't exist. The problem is that it does this as `root`, preventing the Apache HTTP server running as the `www-data` user from writing to the same log file.

When unable to write to the WordPress debugging log, Apache writes error messages to `tools/docker/logs/jetpack_dev/apache2/error.log`. This results in a confusing situation where debugging messages from `jetpack docker wp shell`, for instance, are stored in the proper log file, but any debugging messages from HTTP requests end up in a different one.

This PR ensures that the debugging file's ownership allows Apache to write to the file.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

> [!WARNING]
>
> When switching between branches, delete the debugging log to ensure it gets recreated:
>
> `jetpack docker exec rm /var/www/html/wp-content/debug.log`

- Start reading the debugging log in the terminal with `jetpack docker tail`
- Add a [debugging message using the `l()` function][2] to a file like `projects/plugins/jetpack/modules/stats.php`:
  - `l( 'debug from HTTP request' );`
- Access it via HTTP at `/wp-admin/admin.php?page=stats`
- On another terminal, start `jetpack docker wp shell` and send another debugging message:
  - `l( 'debug from WP CLI' );`
- Go back to the debugging log, opened in the first step, and check its messages.

### On trunk

Only the second message will be shown:

```
[04-Dec-2024 00:34:10 UTC] [b181-332 => /usr/local/bin/wp --allow-root --path=/var/www/html/ shell]
[04-Dec-2024 00:34:10 UTC] [b181-332] debug from WP CLI
```

### On this branch

Both messages will be shown:

```
[04-Dec-2024 00:35:41 UTC] [0823-34 => jetpack.myhrowp.com/wp-admin/admin.php?page=stats]
[04-Dec-2024 00:35:41 UTC] [0823-34] debug from HTTP request
(...)
[04-Dec-2024 00:36:01 UTC] [4678-366 => /usr/local/bin/wp --allow-root --path=/var/www/html/ shell]
[04-Dec-2024 00:36:01 UTC] [4678-366] debug from WP CLI
```


[1]: https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/#example-wp-config-php-for-debugging
[2]: https://github.com/Automattic/jetpack/blob/eafa13ac3d3021a9c561c9b11736b30c651d2d52/tools/docker/README.md#debug-helper-functions