### PR TITLE
Repo Gardening: update Scan board ID

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-waffle-board-id
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-waffle-board-id
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Board triage: update Scan board ID.
+
+

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/automattic-label-team-assignments.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/automattic-label-team-assignments.js
@@ -153,7 +153,7 @@ export const automatticAssignments = {
 		team: 'Scan',
 		labels: [ '[Plugin] Protect', '[Feature] Protect', '[Package] WAF' ],
 		slack_id: 'C029WFNV69M',
-		board_id: 767,
+		board_id: 'https://github.com/orgs/Automattic/projects/767',
 	},
 	'React Dashboard': {
 		team: 'Vulcan',


### PR DESCRIPTION
## Proposed changes:

Updating the board identifier for Scan / Protect products.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

No

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

Not a big change, not much to test on this one.
