### PR TITLE
Google Fonts: Clean up the google fonts data if either google fonts module is disabled or Jetpack is disabled

### DIFF
--- a/projects/plugins/jetpack/changelog/feat-google-fonts-deactivate-hook
+++ b/projects/plugins/jetpack/changelog/feat-google-fonts-deactivate-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Google Fonts: Clean up the google fonts data if either google fonts module is disabled or Jetpack is disabled

--- a/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
@@ -211,6 +211,38 @@ function jetpack_unregister_deprecated_google_fonts_from_theme_json_data( $theme
 add_filter( 'wp_theme_json_data_theme', 'jetpack_unregister_deprecated_google_fonts_from_theme_json_data' );
 add_filter( 'wp_theme_json_data_user', 'jetpack_unregister_deprecated_google_fonts_from_theme_json_data' );
 
+/**
+ * Clean up the Google Fonts data if either google fonts module is disabled or Jetpack is disabled.
+ */
+function jetpack_unregister_google_fonts() {
+	$post_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
+
+	// Get user config
+	$user_config          = WP_Theme_JSON_Resolver::get_user_data();
+	$user_config_raw_data = $user_config->get_raw_data();
+	$user_config_raw_data['isGlobalStylesUserThemeJSON'] = true;
+
+	// Prepare data for saving
+	if ( ! empty( $user_config_raw_data['settings']['typography']['fontFamilies']['default'] ) ) {
+		$user_config_raw_data['settings']['typography']['fontFamilies']['default'] = array();
+	}
+
+	if ( ! empty( $user_config_raw_data['settings']['typography']['fontFamilies']['theme'] ) ) {
+		$user_config_raw_data['settings']['typography']['fontFamilies']['theme'] = jetpack_google_fonts_filter_out_deprecated_font_data(
+			$user_config_raw_data['settings']['typography']['fontFamilies']['theme']
+		);
+	}
+
+	// Prepare changes
+	$changes               = new stdClass();
+	$changes->ID           = $post_id;
+	$changes->post_content = wp_json_encode( $user_config_raw_data );
+
+	// Update user config
+	wp_update_post( wp_slash( (array) $changes ), true );
+}
+add_action( 'jetpack_deactivate_module_google-fonts', 'jetpack_unregister_google_fonts' );
+
 // Initialize Jetpack Google Font Face to avoid printing **ALL** google fonts provided by this module.
 // See p1700040028362329-slack-C4GAQ900P and p7DVsv-jib-p2
 new Jetpack_Google_Font_Face();

--- a/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
@@ -229,7 +229,7 @@ function jetpack_unregister_google_fonts() {
 
 	if ( ! empty( $user_config_raw_data['settings']['typography']['fontFamilies']['theme'] ) ) {
 		$user_config_raw_data['settings']['typography']['fontFamilies']['theme'] = jetpack_google_fonts_filter_out_deprecated_font_data(
-			$user_config_raw_data['settings']['typography']['fontFamilies']['theme']
+			$user_config_raw_data['settings']['typography']['fontFamilies']['theme'] // @phan-suppress-current-line PhanTypeInvalidDimOffset, PhanTypeMismatchArgument
 		);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/36371

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Clean up the google fonts data if either google fonts module is disabled or Jetpack is disabled

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new JN site
* Connect to Jetpack
* Activate Jetpack Google Fonts module via `/wp-admin/admin.php?page=jetpack_modules`
* Apply global styles to your site as follows:
  * SSH to your site
  * Copy [broken_global_styles.json](https://github.com/user-attachments/files/18017597/broken_global_styles.json) to your site
  * Run
    ```sh
    # Get the post ID of the global styles
    $ wp post list --post_type=wp_global_styles
    # Update the global styles
    $ wp post update <ID> <broken_global_styles.json>
    ```
* Open the Editor > Styles > Typography
* Ensure you **CAN** see the full list of Google fonts
* Deactivate Jetpack Google Fonts module
* Open the Editor > Styles > Typography
* Ensure you **CAN** still see the full list of Google fonts
* Apply this patch to your site via Jetpack Beta Tester
* Activate & Deactivate Jetpack Google Fonts module again
* Open the Editor > Styles > Typography
* Ensure you **CANNOT** see the full list of Google fonts
