### PR TITLE
Stats: allow overriding default blog ID via arg in stats_get_csv

### DIFF
--- a/projects/plugins/jetpack/changelog/update-stats-get-csv-blog_id-override
+++ b/projects/plugins/jetpack/changelog/update-stats-get-csv-blog_id-override
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Stats: allow fetching stats for specific sites when programatically fetching stats using Jetpack's tools.

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -1578,11 +1578,11 @@ function stats_get_csv( $table, $args = null ) {
 		'limit'     => 3,
 		'post_id'   => false,
 		'summarize' => '',
+		'blog_id'   => Jetpack_Options::get_option( 'id' ),
 	);
 
-	$args            = wp_parse_args( $args, $defaults );
-	$args['table']   = $table;
-	$args['blog_id'] = Jetpack_Options::get_option( 'id' );
+	$args          = wp_parse_args( $args, $defaults );
+	$args['table'] = $table;
 
 	$stats_csv_url = add_query_arg( $args, 'https://stats.wordpress.com/csv.php' );
 

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -1555,6 +1555,7 @@ function stats_print_wp_remote_error( $get, $url ) {
  *      @type int     $limit      The maximum number of records to return. Default is 10. Maximum 100.
  *      @type int     $post_id    The ID of the post to retrieve stats data for
  *      @type string  $summarize  If present, summarizes all matching records. Default Null.
+ *      @type int     $blog_id    The WordPress.com blog ID to retrieve stats data for. Default is the current blog.
  *
  * }
  *


### PR DESCRIPTION
## Proposed changes:

This would allow sites that use `stats_get_csv` in third-party plugins to fetch stats about different sites they own, all from one site, by specifying a different `blog_id` when calling `stats_get_csv`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See p1733278660045129-slack-CDD9LQRSN

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Start with 2 sites connected to WordPress.com, where the stats module is active.
2. In a functionality plugin, add the following:

```php
add_action( 'wp_footer', function () {
	$options = array( 'blog_id' => YOUR_BLOG_ID );
	var_dump( stats_get_csv( 'postviews', $options ) );
} );
```

3. View the site's frontend.
    * You should see different stats when changing the blog ID, or removing that custom blog id and leaving `$options` as an empty array.
