### PR TITLE
Repo Gardening: add Type labels to PRs based off changelog entries

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-type-pr-auto
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-type-pr-auto
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+PR triage: attempt to automatically add Type labels to newly opened PRs, based on changelog files committed with the PR

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -175,13 +175,18 @@ function statusEntry( isFailure, checkMessage, severity = 'error' ) {
 }
 
 /**
- * Returns list of projects with missing changelog entries
+ * Returns list of projects modified in this PR, and whether they need changelog entries.
+ *
+ * For each affected project, return an object:
+ * - name: a string with projects/<project name>.
+ * - hasChangelog: a boolean indicating if the project has a changelog entry.
+ * - changeType: a string with the type of the change, an empty string if no type is specified or no changelog exists.
  *
  * @param {GitHub} octokit - Initialized Octokit REST client.
  * @param {string} owner   - Repository owner.
  * @param {string} repo    - Repository name.
  * @param {string} number  - PR number.
- * @return {Array} - list of affected projects without changelog entry
+ * @return {Promise<Array>} - Array of affected projects: objects with project name, changelog status and path to changelog file.
  */
 async function getChangelogEntries( octokit, owner, repo, number ) {
 	const baseDir = getPrWorkspace();
@@ -211,10 +216,27 @@ async function getChangelogEntries( octokit, owner, repo, number ) {
 					'CHANGELOG.md'
 			)
 		);
-		const found = files.find( file => file === changelogFile || file.startsWith( changelogDir ) );
-		if ( ! found ) {
-			acc.push( `projects/${ project }` );
+		// Extract the changelog file path.
+		const changelogFilePath = files.find(
+			file => file === changelogFile || file.startsWith( changelogDir )
+		);
+
+		// Extract the change type from the changelog file.
+		// It can be found on the second line of the file, after a Type: prefix.
+		let changeType = '';
+		if ( changelogFilePath ) {
+			const changelogContent = fs.readFileSync( `${ baseDir }/${ changelogFilePath }` );
+			const typeMatch = changelogContent.match( /^Type: (.*)$/m );
+			if ( typeMatch ) {
+				changeType = typeMatch[ 1 ];
+			}
 		}
+
+		acc.push( {
+			name: `projects/${ project }`,
+			hasChangelog: !! changelogFilePath,
+			changeType,
+		} );
 		return acc;
 	}, [] );
 }
@@ -224,6 +246,7 @@ async function getChangelogEntries( octokit, owner, repo, number ) {
  * Covers:
  * - Short PR description
  * - Missing `[Status]` label
+ * - Missing `[Type]` label
  * - Missing "Testing instructions"
  * - Missing Changelog entry
  * - Privacy section
@@ -242,7 +265,13 @@ async function getStatusChecks( payload, octokit ) {
 	const hasLongDescription = body?.length > 200;
 	const hasTesting = !! body?.includes( 'Testing instructions' );
 	const hasPrivacy = !! body?.includes( 'data or activity we track or use' );
-	const projectsWithoutChangelog = await getChangelogEntries( octokit, ownerLogin, repo, number );
+	const changelogEntries = await getChangelogEntries( octokit, ownerLogin, repo, number );
+	const projectsWithoutChangelog = changelogEntries.reduce( ( acc, project ) => {
+		if ( ! project.hasChangelog ) {
+			acc.push( project.name );
+		}
+		return acc;
+	}, [] );
 	const isFromContributor = head.repo.full_name === base.repo.full_name;
 
 	const prLabels = await getLabels( octokit, ownerLogin, repo, number );
@@ -261,6 +290,7 @@ async function getStatusChecks( payload, octokit ) {
 	);
 
 	return {
+		changelogEntries,
 		hasLongDescription,
 		hasStatusLabels,
 		hasTypeLabels,
@@ -447,6 +477,64 @@ async function updateLabels( payload, octokit ) {
 }
 
 /**
+ * Based off the changelog entries committed with the PR,
+ * let's attempt to infer the type of the PR.
+ * If we can infer a type, we'll add a label to the PR, matching that type.
+ * If we cannot, we'll leave the PR as is.
+ *
+ * @param {WebhookPayloadPullRequest} payload          - Pull request event payload.
+ * @param {GitHub}                    octokit          - Initialized Octokit REST client.
+ * @param {Array}                     changelogEntries - List of changelog entries.
+ *
+ * @return {Promise<boolean>} Promise resolving to boolean ; true if we were able to infer a type, false otherwise.
+ */
+async function inferType( payload, octokit, changelogEntries ) {
+	const {
+		repository: {
+			owner: { login: ownerLogin },
+			name: repo,
+		},
+		pull_request: { number },
+	} = payload;
+	let type = '';
+	for ( const entry of changelogEntries ) {
+		if ( entry.changeType ) {
+			type = entry.changeType;
+			break;
+		}
+	}
+
+	if ( ! type ) {
+		return false;
+	}
+
+	// Mapping between the different changelogger types
+	// (default and custom ones created for the Jetpack plugin)
+	// and the labels we use.
+	const typeMapping = {
+		Bug: [ 'security', 'fixed', 'bugfix' ],
+		Task: [ 'added', 'major' ],
+		Enhancement: [ 'changed', 'enhancement' ],
+		Janitorial: [ 'deprecated', 'removed', 'compat', 'other' ],
+	};
+
+	// Does the PR's type match one of the types we have in our mapping?
+	const prType = Object.keys( typeMapping ).find( key => typeMapping[ key ].includes( type ) );
+
+	if ( ! prType ) {
+		return false;
+	}
+
+	await octokit.rest.issues.addLabels( {
+		owner: ownerLogin,
+		repo,
+		issue_number: number,
+		labels: [ `[Type] ${ prType }` ],
+	} );
+	return true;
+}
+
+/**
  * Checks the contents of a PR description.
  *
  * @param {WebhookPayloadPullRequest} payload - Pull request event payload.
@@ -475,6 +563,13 @@ async function checkDescription( payload, octokit ) {
 	) {
 		debug( `check-description: Automated stub update, skipping` );
 		return;
+	}
+
+	// If no "[Type]" label is present, let's try to figure out the type of the PR.
+	// We'll use the changelog entries to determine the type of the PR.
+	if ( ! statusChecks.hasTypeLabels && statusChecks.changelogEntries.length ) {
+		debug( `check-description: No type label found, trying to determine the type of the PR` );
+		statusChecks.hasTypeLabels = await inferType( payload, octokit, statusChecks.changelogEntries );
 	}
 
 	debug( `check-description: start building our comment` );

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -518,7 +518,7 @@ async function inferType( payload, octokit, changelogEntries ) {
 	const typeMapping = {
 		Bug: [ 'security', 'fixed', 'bugfix' ],
 		Task: [ 'added', 'major' ],
-		Enhancement: [ 'changed', 'enhancement' ],
+		Enhancement: [ 'enhancement' ],
 		Janitorial: [ 'deprecated', 'removed', 'compat' ],
 	};
 

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -250,6 +250,7 @@ async function getChangelogEntries( octokit, owner, repo, number ) {
  * - Missing "Testing instructions"
  * - Missing Changelog entry
  * - Privacy section
+ * - Also includes information about the changelog entries.
  *
  * Note: All the checks should be truthy to resolve as success check.
  *

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -497,6 +497,8 @@ async function inferType( payload, octokit, changelogEntries ) {
 		},
 		pull_request: { number },
 	} = payload;
+
+	// Extract the type of the PR from the changelog entries.
 	let type = '';
 	for ( const entry of changelogEntries ) {
 		if ( entry.changeType ) {
@@ -504,7 +506,6 @@ async function inferType( payload, octokit, changelogEntries ) {
 			break;
 		}
 	}
-
 	if ( ! type ) {
 		return false;
 	}
@@ -521,7 +522,6 @@ async function inferType( payload, octokit, changelogEntries ) {
 
 	// Does the PR's type match one of the types we have in our mapping?
 	const prType = Object.keys( typeMapping ).find( key => typeMapping[ key ].includes( type ) );
-
 	if ( ! prType ) {
 		return false;
 	}

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -519,7 +519,7 @@ async function inferType( payload, octokit, changelogEntries ) {
 		Bug: [ 'security', 'fixed', 'bugfix' ],
 		Task: [ 'added', 'major' ],
 		Enhancement: [ 'changed', 'enhancement' ],
-		Janitorial: [ 'deprecated', 'removed', 'compat', 'other' ],
+		Janitorial: [ 'deprecated', 'removed', 'compat' ],
 	};
 
 	// Does the PR's type match one of the types we have in our mapping?

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -225,7 +225,9 @@ async function getChangelogEntries( octokit, owner, repo, number ) {
 		// It can be found on the second line of the file, after a Type: prefix.
 		let changeType = '';
 		if ( changelogFilePath ) {
-			const changelogContent = fs.readFileSync( `${ baseDir }/${ changelogFilePath }` );
+			const changelogContent = fs
+				.readFileSync( `${ baseDir }/${ changelogFilePath }`, 'utf8' )
+				.toString();
 			const typeMatch = changelogContent.match( /^Type: (.*)$/m );
 			if ( typeMatch ) {
 				changeType = typeMatch[ 1 ];


### PR DESCRIPTION
Follow-up to #40428.

## Proposed changes:

Let's try to automate the addition of "Type" labels to each PR.

When PR includes changelog files, and when that PR does not already has a [Type] label, let's scan the contents of the changelog files, pick the first "Type" definition we can find, and match that to one of our existing Type labels.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1HpG7-uPQ-p2#comment-74890

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

This can be tested in a fork. Here is an example:

https://github.com/jeherve/jetpack/pull/194#event-15527256529

