### PR TITLE
Fix Content Options elements alignment in Customizer

### DIFF
--- a/projects/packages/classic-theme-helper/changelog/fix-tags-elements-alignment-in-customizer
+++ b/projects/packages/classic-theme-helper/changelog/fix-tags-elements-alignment-in-customizer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Customizer: Fix spacing issue in Content Options

--- a/projects/packages/classic-theme-helper/src/content-options/customizer.js
+++ b/projects/packages/classic-theme-helper/src/content-options/customizer.js
@@ -104,7 +104,7 @@ function updatePostDetails( selectors, to, hiddenClass ) {
 		} else {
 			element.style.clip = 'auto';
 			element.style.height = 'auto';
-			element.style.overflow = 'auto';
+			element.style.overflow = 'visible';
 			element.style.position = 'relative';
 			element.style.width = 'auto';
 			document.body.classList.remove( hiddenClass );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/themes/issues/8077

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

I propose to fix the issue with the incorrect alignment of items that are disabled and enabled in the Content Options tab of the Customizer.

### Other information:

The issue seems to be caused by the code that shows and hides the elements when they are enabled or disabled in the Content Options tab.

When the user disables the element, the classic theme helper sets `overflow` to `hidden`. When the user enables it again, it sets `overflow` to `auto`. According to [CSS docs](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow), the default value of the `overflow` attribute is `visible` and not `auto`, and the current flow results in changing it from `visible` through `hidden` to `auto`, which can result in spacing issues.


- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### WoA

1. Create a WoA site
2. Install the Jetpack Beta plugin
3. Using the Jetpack Beta plugin management pah, enable this branch for 'Classic Theme Helper Plugin'
4. Switch to Dara theme
5. Edit post, add any tag and save
6. Navigate to Customizer
7. Open the Content Options section
8. Uncheck and check 'Display tags'
9. Confirm that tags are correctly aligned with 'Leave a comment'
10. Test the same for other elements, e.g., 'Display date'

### Simple site

1. To test on Simple, run the following command on your sandbox:
```
bin/jetpack-downloader test jetpack fix/tags-elements-alignment-in-customizer
bin/jetpack-downloader test jetpack-mu-wpcom-plugin fix/tags-elements-alignment-in-customizer
```
2. Create a Simple site
3. Follow steps 4-10 from the previous section
