### PR TITLE
register_block_metadata_collection: Silence path validation notices

### DIFF
--- a/projects/plugins/jetpack/changelog/add-block-registration-bypass
+++ b/projects/plugins/jetpack/changelog/add-block-registration-bypass
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+register_block_metadata_collection: Silence path validation notices

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -1333,6 +1333,32 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
+	 * Temporarily bypasses _doing_it_wrong() notices for block metadata collection registration.
+	 *
+	 * WordPress 6.7 introduced block metadata collections (with strict path validation).
+	 * Any sites using symlinks for plugins will fail the validation which causes the metadata
+	 * collection to not be registered. However, the blocks will still fall back to the regular
+	 * registration and no functionality is affected.
+	 * While this validation is being discussed in WordPress Core (#62140),
+	 * this method allows registration to proceed by temporarily disabling
+	 * the relevant notice.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool   $trigger       Whether to trigger the error.
+	 * @param string $function      The function that was called.
+	 * @param string $message       A message explaining what was done incorrectly.
+	 * @param string $version       The version of WordPress where the message was added.
+	 * @return bool Whether to trigger the error.
+	 */
+	public static function bypass_block_metadata_doing_it_wrong( $trigger, $function, $message, $version ) {
+		if ( $function === 'WP_Block_Metadata_Registry::register_collection' ) {
+			return false;
+		}
+		return $trigger;
+	}
+
+	/**
 	 * Register block metadata collection for Jetpack blocks.
 	 * This allows for more efficient block metadata loading by avoiding
 	 * individual block.json file reads at runtime.
@@ -1351,11 +1377,15 @@ class Jetpack_Gutenberg {
 	public static function register_block_metadata_collection() {
 		$meta_file_path = JETPACK__PLUGIN_DIR . '_inc/blocks/blocks-manifest.php';
 		if ( function_exists( 'wp_register_block_metadata_collection' ) && file_exists( $meta_file_path ) ) {
+			add_filter( 'doing_it_wrong_trigger_error', array( __CLASS__, 'bypass_block_metadata_doing_it_wrong' ), 10, 4 );
+
 			// @phan-suppress-next-line PhanUndeclaredFunction -- New in WP 6.7. We're checking if it exists first.
 			wp_register_block_metadata_collection(
 				JETPACK__PLUGIN_DIR . '_inc/blocks/',
 				$meta_file_path
 			);
+
+			remove_filter( 'doing_it_wrong_trigger_error', array( __CLASS__, 'bypass_block_metadata_doing_it_wrong' ), 10 );
 		}
 	}
 }

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -1351,7 +1351,7 @@ class Jetpack_Gutenberg {
 	 * @param string $version       The version of WordPress where the message was added.
 	 * @return bool Whether to trigger the error.
 	 */
-	public static function bypass_block_metadata_doing_it_wrong( $trigger, $function, $message, $version ) {
+	public static function bypass_block_metadata_doing_it_wrong( $trigger, $function, $message, $version ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		if ( $function === 'WP_Block_Metadata_Registry::register_collection' ) {
 			return false;
 		}


### PR DESCRIPTION
When registering a block_metadata_collection, some real world configs like symlinks are causing regular registrations to fail with `_doing_it_wrong()` notices. These are harmless, as WordPress falls back to regular block registration. However, some users are understandably worried about the notices, and in some cases they can be promoted to errors.

This PR temporarily suppresses the `_doing_it_wrong()` errors via filter.

See: https://core.trac.wordpress.org/ticket/62140#comment:16

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a new `bypass_block_metadata_doing_it_wrong()` function, and hook it on the filter `doing_it_wrong_trigger_error` just before calling `wp_register_block_metadata_collection()`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure you are running the latest WP
* Symlink wp-content/plugins/jetpack to /tmp/jetpack
* Turn on WP_DEBUG in wp_config.php
* Without the PR, you should see `Notice: Function WP_Block_Metadata_Registry::register_collection was called incorrectly.` somewhere (top of page for me)
* With the PR, the message should go away

