### PR TITLE
eslint-changed: use fs.realpath() for tests

### DIFF
--- a/projects/js-packages/eslint-changed/changelog/fix-eslint-changed-macos_paths
+++ b/projects/js-packages/eslint-changed/changelog/fix-eslint-changed-macos_paths
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tests: Use fs.realpath() for macOS compatibility.

--- a/projects/js-packages/eslint-changed/tests/cli.test.js
+++ b/projects/js-packages/eslint-changed/tests/cli.test.js
@@ -70,7 +70,8 @@ describe( 'bin/eslint-changed.js', () => {
 			await fs.rm( tmpdir, { force: true, recursive: true } );
 			tmpdir = null;
 		}
-		tmpdir = await fs.mkdtemp( path.join( os.tmpdir(), 'eslint-changed-test-' ) );
+		const parentTmpdir = await fs.realpath( os.tmpdir() );
+		tmpdir = await fs.mkdtemp( path.join( parentTmpdir, 'eslint-changed-test-' ) );
 	}
 
 	// Clean up after each test.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Running tests in this package on macOS has issues due to how the temp dir is set up (see nodejs/node#11422). The fix is simple: resolve the path prior to comparison.

For reference, a similar thing happens in PHP: e66c7aa2bdc3e189120d711d7188e1e355ada4f9

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Run on macOS, or at least make sure CI is still happy.