### PR TITLE
Stats: add sparkline chart to WP Admin bar

### DIFF
--- a/projects/plugins/jetpack/changelog/add-stats-admin-bar
+++ b/projects/plugins/jetpack/changelog/add-stats-admin-bar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Stats: enable sparkline chart in the WP Admin bar

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -55,6 +55,7 @@ function stats_load() {
 
 	// Only run the callback for those who can see the stats.
 	if ( is_user_logged_in() && current_user_can( 'view_stats' ) ) {
+		add_action( 'admin_head', 'stats_admin_bar_head', 100 );
 		add_action( 'wp_head', 'stats_admin_bar_head', 100 );
 	}
 


### PR DESCRIPTION
Fixes Automattic/red-team#160.
Fixes #621

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

The stats sparkline chart is currently only being shown in the frontpage when logged in. This PR adds it to the WP Admin bar as well.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `/wp-admin/index.php`
* The stats sparkline chart should be present in the admin bar.

| Before | After |
| :-: | :-: |
| ![image](https://github.com/user-attachments/assets/427252a4-214c-4266-bb30-bd540820f968) | ![image](https://github.com/user-attachments/assets/049ad8e4-564e-40e7-8d02-2539e89a01d7) |