### PR TITLE
Jetpack: remove deprecated hooks and methods on Jetpack admin pages

### DIFF
--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -106,7 +106,7 @@ return [
         '_inc/genericons.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         '_inc/lib/admin-pages/class-jetpack-about-page.php' => ['PhanTypeMismatchArgument'],
         '_inc/lib/admin-pages/class-jetpack-redux-state-helper.php' => ['PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDimAssignment'],
-        '_inc/lib/admin-pages/class.jetpack-admin-page.php' => ['PhanDeprecatedProperty', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredProperty'],
+        '_inc/lib/admin-pages/class.jetpack-admin-page.php' => ['PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredProperty'],
         '_inc/lib/class-jetpack-ai-helper.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchPropertyDefault'],
         '_inc/lib/class-jetpack-instagram-gallery-helper.php' => ['PhanTypeMismatchArgument'],
         '_inc/lib/class-jetpack-mapbox-helper.php' => ['PhanTypeMismatchArgumentNullable'],

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -15,14 +15,6 @@ use Automattic\Jetpack\Status;
  */
 abstract class Jetpack_Admin_Page {
 	/**
-	 * Jetpack Object.
-	 *
-	 * @var Jetpack
-	 * @deprecated 13.9 Use `Jetpack::init()` instead.
-	 */
-	public $jetpack;
-
-	/**
 	 * Add page specific actions given the page hook.
 	 *
 	 * @param string $hook Hook of current page.
@@ -52,30 +44,6 @@ abstract class Jetpack_Admin_Page {
 	 * @since 4.3.0
 	 */
 	public function additional_styles() {}
-
-	/**
-	 * The constructor.
-	 */
-	public function __construct() {
-		/**
-		 * Keeping it for backward compatibility in case the `$jetpack` property is still in use.
-		 * To be removed.
-		 *
-		 * @deprecated 13.9
-		 */
-		add_action( 'jetpack_loaded', array( $this, 'on_jetpack_loaded' ) );
-	}
-
-	/**
-	 * Runs on Jetpack being ready to load its packages.
-	 *
-	 * @deprecated 13.9
-	 *
-	 * @param Jetpack $jetpack object.
-	 */
-	public function on_jetpack_loaded( $jetpack ) {
-		$this->jetpack = $jetpack;
-	}
 
 	/**
 	 * Add common page actions and attach page-specific actions.
@@ -141,13 +109,6 @@ abstract class Jetpack_Admin_Page {
 
 		self::wrap_ui( array( $this, 'page_render' ), $args );
 	}
-
-	/**
-	 * Doesn't do anything anymore.
-	 *
-	 * @deprecated 13.9 No longer used.
-	 */
-	public function admin_help() {}
 
 	/**
 	 * Call the existing admin page events.

--- a/projects/plugins/jetpack/changelog/remove-jetpack-page-deprecated-functionality
+++ b/projects/plugins/jetpack/changelog/remove-jetpack-page-deprecated-functionality
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Remove deprecated hooks and methods on Jetpack admin pages.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3488,16 +3488,6 @@ p {
 	}
 
 	/**
-	 * Doesn't do anything anymore.
-	 *
-	 * @deprecated 13.9 We no longer show the "Help" button.
-	 *
-	 * @since Jetpack (1.2.3)
-	 * @return void
-	 */
-	public function admin_help() {}
-
-	/**
 	 * Add action links for the Jetpack plugin.
 	 *
 	 * @param array $actions Plugin actions.


### PR DESCRIPTION
## Proposed changes:
* Get rid of excessive `jetpack_loaded` hook callbacks by methods and properties deprecated in Jetpack 13.9 (#39547)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/vulcan/issues/529

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Visit all the Jetpack admin pages and confirm they work as expected:
- Dashboard
- Settings
- About
- Privacy
- Modules
- Debug