### PR TITLE
[WordAds]: Render legacy sidebar widget with the WATL

### DIFF
--- a/projects/plugins/jetpack/changelog/update-iponweb-to-watl-migration
+++ b/projects/plugins/jetpack/changelog/update-iponweb-to-watl-migration
@@ -2,3 +2,4 @@ Significance: patch
 Type: other
 
 Migration from IPONWEB to WATL
+* Render legacy sidebar widget with the WATL

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -774,7 +774,7 @@ HTML;
 
 		// Allow overriding and printing of the tag parsed by the WATL.
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		$is_location_enabled = ( isset( $_GET[ $location ] ) && 'true' === $_GET[ $location ] );
+		$is_location_enabled = isset( $_GET['wordads-logging'] ) && isset( $_GET[ $location ] ) && 'true' === $_GET[ $location ];
 
 		if ( ( 'top' === $location || 'belowpost' === $location ) && $is_location_enabled ) {
 			// TODO: Confirm if it's best here or there is a way to get it via the adflow config endpoint

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-sidebar-widget.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-sidebar-widget.php
@@ -74,7 +74,6 @@ class WordAds_Sidebar_Widget extends WP_Widget {
 		}
 
 		++self::$num_widgets;
-		$about      = __( 'Advertisements', 'jetpack' );
 		$width      = WordAds::$ad_tag_ids[ $instance['unit'] ]['width'];
 		$height     = WordAds::$ad_tag_ids[ $instance['unit'] ]['height'];
 		$unit_id    = 1 === self::$num_widgets ? 3 : self::$num_widgets + 3; // 2nd belowpost is '4'
@@ -84,22 +83,55 @@ class WordAds_Sidebar_Widget extends WP_Widget {
 
 		// Use the Gutenberg existing formats to render the legacy sidebar instead of creating new ones.
 		$sizes_x_smart_format = array(
-			'300x250' => 'gutenberg_rectangle',
-			'728x90'  => 'gutenberg_leaderboard',
-			'160x600' => 'gutenberg_skyscraper',
+			'300x250' => 'sidebar_widget_mediumrectangle',
+			'728x90'  => 'sidebar_widget_leaderboard',
+			'160x600' => 'sidebar_widget_wideskyscraper',
 		);
 
+		$smart_format = $sizes_x_smart_format[ "{$width}x{$height}" ];
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		$smart_format    = $sizes_x_smart_format[ "{$width}x{$height}" ] ?? '';
 		$is_watl_enabled = $smart_format && isset( $_GET['wordads-logging'] ) && isset( $_GET[ $smart_format ] ) && 'true' === $_GET[ $smart_format ];
 
-		if ( $is_watl_enabled ) {
+		// Get the widget snippet.
+		$widget_snippet = $this->get_widget_snippet( $instance, $section_id, $height, $width );
+
+		// Render the IPW or house ad if WATL is disabled.
+		if ( ! $is_watl_enabled ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			echo $wordads::get_watl_ad_html_tag( $smart_format );
+			echo $widget_snippet;
 			return;
 		}
 
-		$snippet = '';
+		// Remove linebreaks and sanitize.
+		$tag = esc_js( str_replace( array( "\n", "\t", "\r" ), '', $widget_snippet ) );
+
+		// Add the fallback to be processed by WATL.
+		$fallback_snippet = <<<HTML
+		<script type="text/javascript">
+			var sas_fallback = sas_fallback || [];
+			sas_fallback.push(
+				{ tag: "$tag", type: '$smart_format' }
+			);
+		</script>
+HTML;
+
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $fallback_snippet . $wordads::get_watl_ad_html_tag( $smart_format );
+	}
+
+	/**
+	 * The widget snippet.
+	 *
+	 * @param array  $instance The widget instance.
+	 * @param string $section_id The section id.
+	 * @param int    $height The ad height.
+	 * @param int    $width The ad width.
+	 *
+	 * @return string
+	 */
+	private function get_widget_snippet( $instance, $section_id, $height, $width ) {
+		global $wordads;
+
 		if ( $wordads->option( 'wordads_house', true ) ) {
 			$unit = 'mrec';
 			if ( 'leaderboard' === $instance['unit'] && ! $this->params->mobile_device ) {
@@ -110,21 +142,22 @@ class WordAds_Sidebar_Widget extends WP_Widget {
 
 			$snippet = $wordads->get_house_ad( $unit );
 		} else {
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			echo $wordads->get_ad_snippet( $section_id, $height, $width, 'widget' );
-			return;
+			return $wordads->get_ad_snippet( $section_id, $height, $width, 'widget' );
 		}
 
-		?>
+		$about = __( 'Advertisements', 'jetpack' );
+		$unit  = esc_attr( $instance['unit'] );
+
+		return <<<HTML
 		<div class="wpcnt">
 			<div class="wpa">
-				<span class="wpa-about"><?php echo esc_html( $about ); ?></span>
-				<div class="u <?php echo esc_attr( $instance['unit'] ); ?>">
-					<?php echo $snippet; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<span class="wpa-about">$about</span>
+				<div class="u $unit">
+					$snippet
 				</div>
 			</div>
 		</div>
-		<?php
+HTML;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-sidebar-widget.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-sidebar-widget.php
@@ -90,7 +90,7 @@ class WordAds_Sidebar_Widget extends WP_Widget {
 		);
 
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		$smart_format    = $sizes_x_smart_format[ "{$width}x{$height}" ] ?? null;
+		$smart_format    = $sizes_x_smart_format[ "{$width}x{$height}" ] ?? '';
 		$is_watl_enabled = $smart_format && isset( $_GET['wordads-logging'] ) && isset( $_GET[ $smart_format ] ) && 'true' === $_GET[ $smart_format ];
 
 		if ( $is_watl_enabled ) {

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-sidebar-widget.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-sidebar-widget.php
@@ -90,7 +90,7 @@ class WordAds_Sidebar_Widget extends WP_Widget {
 
 		$smart_format = $sizes_x_smart_format[ "{$width}x{$height}" ];
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		$is_watl_enabled = $smart_format && isset( $_GET['wordads-logging'] ) && isset( $_GET[ $smart_format ] ) && 'true' === $_GET[ $smart_format ];
+		$is_watl_enabled = isset( $_GET['wordads-logging'] ) && isset( $_GET[ $smart_format ] ) && 'true' === $_GET[ $smart_format ];
 
 		// Get the widget snippet.
 		$widget_snippet = $this->get_widget_snippet( $instance, $section_id, $height, $width );

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-sidebar-widget.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-sidebar-widget.php
@@ -82,6 +82,23 @@ class WordAds_Sidebar_Widget extends WP_Widget {
 			WORDADS_API_TEST_ID :
 			$wordads->params->blog_id . $unit_id;
 
+		// Use the Gutenberg existing formats to render the legacy sidebar instead of creating new ones.
+		$sizes_x_smart_format = array(
+			'300x250' => 'gutenberg_rectangle',
+			'728x90'  => 'gutenberg_leaderboard',
+			'160x600' => 'gutenberg_skyscraper',
+		);
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$smart_format    = $sizes_x_smart_format[ "{$width}x{$height}" ] ?? null;
+		$is_watl_enabled = $smart_format && isset( $_GET['wordads-logging'] ) && isset( $_GET[ $smart_format ] ) && 'true' === $_GET[ $smart_format ];
+
+		if ( $is_watl_enabled ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $wordads::get_watl_ad_html_tag( $smart_format );
+			return;
+		}
+
 		$snippet = '';
 		if ( $wordads->option( 'wordads_house', true ) ) {
 			$unit = 'mrec';

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-sidebar-widget.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-sidebar-widget.php
@@ -20,6 +20,17 @@ class WordAds_Sidebar_Widget extends WP_Widget {
 	private static $allowed_tags = array( 'mrec', 'wideskyscraper', 'leaderboard' );
 
 	/**
+	 * Mapping array of widget sizes with the WordAds_Smart formats.
+	 *
+	 * @var string[]
+	 */
+	private static $sizes_x_smart_format = array(
+		'300x250' => 'sidebar_widget_mediumrectangle',
+		'728x90'  => 'sidebar_widget_leaderboard',
+		'160x600' => 'sidebar_widget_wideskyscraper',
+	);
+
+	/**
 	 * Number of widgets.
 	 *
 	 * @var int
@@ -81,14 +92,7 @@ class WordAds_Sidebar_Widget extends WP_Widget {
 			WORDADS_API_TEST_ID :
 			$wordads->params->blog_id . $unit_id;
 
-		// Use the Gutenberg existing formats to render the legacy sidebar instead of creating new ones.
-		$sizes_x_smart_format = array(
-			'300x250' => 'sidebar_widget_mediumrectangle',
-			'728x90'  => 'sidebar_widget_leaderboard',
-			'160x600' => 'sidebar_widget_wideskyscraper',
-		);
-
-		$smart_format = $sizes_x_smart_format[ "{$width}x{$height}" ];
+		$smart_format = self::$sizes_x_smart_format[ "{$width}x{$height}" ];
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		$is_watl_enabled = isset( $_GET['wordads-logging'] ) && isset( $_GET[ $smart_format ] ) && 'true' === $_GET[ $smart_format ];
 

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -39,35 +39,45 @@ class WordAds_Smart {
 
 	/**
 	 * Supported formats.
+	 * sidebar_widget formats represents the legacy Jetpack sidebar widget.
 	 *
 	 * @var array
 	 */
 	private $formats = array(
-		'top'                          => array(
+		'top'                            => array(
 			'enabled' => false,
 		),
-		'inline'                       => array(
+		'inline'                         => array(
 			'enabled' => false,
 		),
-		'belowpost'                    => array(
+		'belowpost'                      => array(
 			'enabled' => false,
 		),
-		'bottom_sticky'                => array(
+		'bottom_sticky'                  => array(
 			'enabled' => false,
 		),
-		'sidebar_sticky_right'         => array(
+		'sidebar_sticky_right'           => array(
 			'enabled' => false,
 		),
-		'gutenberg_rectangle'          => array(
+		'gutenberg_rectangle'            => array(
 			'enabled' => false,
 		),
-		'gutenberg_leaderboard'        => array(
+		'gutenberg_leaderboard'          => array(
 			'enabled' => false,
 		),
-		'gutenberg_mobile_leaderboard' => array(
+		'gutenberg_mobile_leaderboard'   => array(
 			'enabled' => false,
 		),
-		'gutenberg_skyscraper'         => array(
+		'gutenberg_skyscraper'           => array(
+			'enabled' => false,
+		),
+		'sidebar_widget_mediumrectangle' => array(
+			'enabled' => false,
+		),
+		'sidebar_widget_leaderboard'     => array(
+			'enabled' => false,
+		),
+		'sidebar_widget_wideskyscraper'  => array(
 			'enabled' => false,
 		),
 	);


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Render the WATL tags for the legacy sidebar widget.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the steps described at the patch D167914
*  Comment the [line](https://github.com/Automattic/jetpack/blob/c72d64c2f1e4737c24accbc9f403c2603053ebe9/projects/plugins/jetpack/modules/wordads/php/class-wordads-sidebar-widget.php#L54-L54) that removes the legacy widget block
* On your Jetpack test site, go to the WP dashboard
* Go to the menu `Appearance > Widgets`
* Add multiple `Ads (Jetpack)` widget block breaking by the ad size

<img width="384" alt="image" src="https://github.com/user-attachments/assets/471c487b-63bb-4569-b8b1-276851518d90">

* Visit your blog appending the following query string `?wordads-logging=true&sidebar_widget_mediumrectangle=true&sidebar_widget_leaderboard=true&sidebar_widget_wideskyscraper=true` to get the ad rendering
* Visit your blog without the query string and ensure that the IPW `/adjr` requests are being made by sending the div IDs of the sidebar widget added before

**Note:** If you use the theme Twenty Twenty for testing, you'll be able to see the mediumrectangle and the wideskyscraper rendered.

