### PR TITLE
Use `wp_add_inline_script` for WPCOM sidebar notice

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-async-wpcom-sidebar-notice
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-async-wpcom-sidebar-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use wp_add_inline_script

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.js
@@ -88,7 +88,7 @@ const wpcomFetchSidebarNotice = async () => {
 			`${ wpcomSidebarNoticeConfig.ajaxUrl }?action=wpcom_fetch_sidebar_notice&nonce=${ wpcomSidebarNoticeConfig.nonce }`
 		);
 
-		if ( ! response.status === 200 ) {
+		if ( response.status !== 200 ) {
 			return;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
@@ -38,14 +38,12 @@ function wpcom_enqueue_sidebar_notice_assets() {
 		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-sidebar-notice/wpcom-sidebar-notice.css' )
 	);
 
-	wp_localize_script(
-		'wpcom-sidebar-notice',
-		'wpcomSidebarNoticeConfig',
-		array(
-			'ajaxUrl' => admin_url( 'admin-ajax.php' ),
-			'nonce'   => wp_create_nonce( 'wpcom_fetch_sidebar_notice' ),
-		)
+	$data          = array(
+		'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+		'nonce'   => wp_create_nonce( 'wpcom_fetch_sidebar_notice' ),
 	);
+	$inline_script = 'const wpcomSidebarNoticeConfig = ' . wp_json_encode( $data ) . ';';
+	wp_add_inline_script( 'wpcom-sidebar-notice', $inline_script, 'before' );
 }
 add_action( 'admin_enqueue_scripts', 'wpcom_enqueue_sidebar_notice_assets' );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This is a follow-up on https://github.com/Automattic/jetpack/pull/40422 to use `wp_add_inline_script` instead of `wp_localize_script`.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Follow the instructions in https://github.com/Automattic/jetpack/pull/40422.