### PR TITLE
Fix missing search overlay in some themes like Rebalance

### DIFF
--- a/projects/packages/search/changelog/fix-missing-search-overlay-in-some-themes
+++ b/projects/packages/search/changelog/fix-missing-search-overlay-in-some-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix missing instant search dialog for themes like Rebalance

--- a/projects/packages/search/src/instant-search/components/dom-event-handler.jsx
+++ b/projects/packages/search/src/instant-search/components/dom-event-handler.jsx
@@ -38,6 +38,7 @@ export default class DomEventHandler extends Component {
 		if ( this.props.isVisible !== prevProps.isVisible ) {
 			this.fixBodyScroll();
 		}
+		this.fixBodyOpacity();
 	}
 
 	disableUnnecessaryFormAndInputAttributes() {
@@ -187,6 +188,14 @@ export default class DomEventHandler extends Component {
 			window?.scrollTo( 0, 0 );
 		} else if ( ! this.props.isVisible ) {
 			this.restoreBodyScroll();
+		}
+	};
+
+	fixBodyOpacity = () => {
+		if ( '1' !== document.body.style.opacity ) {
+			// This ensures the body is visible when the search dialog opens if
+			// the theme changes body opacity dynamically
+			document.body.style.opacity = '1';
 		}
 	};
 

--- a/projects/packages/search/src/instant-search/components/dom-event-handler.jsx
+++ b/projects/packages/search/src/instant-search/components/dom-event-handler.jsx
@@ -192,7 +192,7 @@ export default class DomEventHandler extends Component {
 	};
 
 	fixBodyOpacity = () => {
-		if ( '1' !== document.body.style.opacity ) {
+		if ( '0' === document.body.style.opacity ) {
 			// This ensures the body is visible when the search dialog opens if
 			// the theme changes body opacity dynamically
 			document.body.style.opacity = '1';

--- a/projects/packages/search/src/instant-search/components/dom-event-handler.jsx
+++ b/projects/packages/search/src/instant-search/components/dom-event-handler.jsx
@@ -192,7 +192,7 @@ export default class DomEventHandler extends Component {
 	};
 
 	fixBodyOpacity = () => {
-		if ( '0' === document.body.style.opacity ) {
+		if ( '1' !== document.body.style.opacity ) {
 			// This ensures the body is visible when the search dialog opens if
 			// the theme changes body opacity dynamically
 			document.body.style.opacity = '1';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/themes/issues/7440

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Themes like Rebalance play with body opacity, e.g., they set it initially to 0 and use JS to set it to 1 when it's ready. It prevents the Jetpack instant search dialog from being displayed.

I propose to fix the body opacity if it's incorrect when the instant search dialog is updated.

### Other information:

This is the CSS code used in the mentioned theme:

```
/* Fade in page after js loads */
.js body {
	opacity: 0;
}
```

And JS code:

```
/*
 * Fade in page
 * - only if js is enabled
 */
$wrapper.animate({
	opacity: 1,
}, 30);
```

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### WoA

1. Create a WoA site
2. Install the Jetpack Beta plugin
3. Using the Jetpack Beta plugin management UI, enable this branch for the Jetpack plugin
4. Switch to Rebalance theme
5. Enable Jetpack Search
6. Open the page in frontend
7. Enter any text in the search field and press Enter
8. Confirm that the overlay is displayed

### Simple site

1. To test on Simple, run the following command on your sandbox:
```
bin/jetpack-downloader test jetpack fix/missing-search-overlay-in-some-themes
```
2. Create a Simple site
3. Follow steps 4-8 from the previous section
