### PR TITLE
WordPress 6.7 compat: Removes early i18n calls to fix notices.

### DIFF
--- a/projects/packages/connection/changelog/add-idc-custom-content-callback
+++ b/projects/packages/connection/changelog/add-idc-custom-content-callback
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a mechanism to use callbacks for package options.

--- a/projects/packages/connection/src/identity-crisis/class-ui.php
+++ b/projects/packages/connection/src/identity-crisis/class-ui.php
@@ -168,6 +168,10 @@ class UI {
 				continue;
 			}
 
+			if ( isset( $consumer['customContent'] ) && is_callable( $consumer['customContent'] ) ) {
+				$consumer['customContent'] = call_user_func( $consumer['customContent'] );
+			}
+
 			if ( isset( $_SERVER['REQUEST_URI'] ) && str_starts_with( filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ) ), $consumer['admin_page'] ) && strlen( $consumer['admin_page'] ) > $consumer_url_length ) {
 				$consumer_chosen     = $consumer;
 				$consumer_url_length = strlen( $consumer['admin_page'] );

--- a/projects/plugins/jetpack/changelog/removed-i18n-from-early-deprecation-notices
+++ b/projects/plugins/jetpack/changelog/removed-i18n-from-early-deprecation-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+WordPress 6.7 Compatibility: Fixed notices caused by translation calls happening too early in the load order.

--- a/projects/plugins/jetpack/functions.global.php
+++ b/projects/plugins/jetpack/functions.global.php
@@ -50,7 +50,7 @@ function jetpack_deprecated_function( $function, $replacement, $version ) { // p
 	) {
 		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			sprintf(
-				did_action( 'init' ) ?
+				doing_action( 'after_setup_theme' ) || did_action( 'after_setup_theme' ) ?
 					/* Translators: 1. Function name. 2. Jetpack version number. */
 					__( 'The %1$s function will be removed from the Jetpack plugin in version %2$s.', 'jetpack' )
 					: 'The %1$s function will be removed from the Jetpack plugin in version %2$s.',

--- a/projects/plugins/jetpack/functions.global.php
+++ b/projects/plugins/jetpack/functions.global.php
@@ -50,8 +50,10 @@ function jetpack_deprecated_function( $function, $replacement, $version ) { // p
 	) {
 		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			sprintf(
-				/* Translators: 1. Function name. 2. Jetpack version number. */
-				__( 'The %1$s function will be removed from the Jetpack plugin in version %2$s.', 'jetpack' ),
+				did_action( 'init' ) ?
+					/* Translators: 1. Function name. 2. Jetpack version number. */
+					__( 'The %1$s function will be removed from the Jetpack plugin in version %2$s.', 'jetpack' )
+					: 'The %1$s function will be removed from the Jetpack plugin in version %2$s.',
 				$function,
 				$removed_version
 			)

--- a/projects/plugins/social/changelog/move-admin-menu-to-init
+++ b/projects/plugins/social/changelog/move-admin-menu-to-init
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Moved the admin menu initialization to the init hook.

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -47,17 +47,6 @@ class Jetpack_Social {
 		// Set up the REST authentication hooks.
 		Connection_Rest_Authentication::init();
 
-		$page_suffix = Admin_Menu::add_menu(
-			__( 'Jetpack Social', 'jetpack-social' ),
-			_x( 'Social', 'The Jetpack Social product name, without the Jetpack prefix', 'jetpack-social' ),
-			'manage_options',
-			'jetpack-social',
-			array( $this, 'plugin_settings_page' ),
-			4
-		);
-
-		add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
-
 		// Init Jetpack packages
 		add_action(
 			'plugins_loaded',
@@ -93,6 +82,8 @@ class Jetpack_Social {
 			1
 		);
 
+		add_action( 'init', array( $this, 'do_init' ) );
+
 		// Activate the module as the plugin is activated
 		add_action( 'admin_init', array( $this, 'do_plugin_activation_activities' ) );
 		add_action( 'activated_plugin', array( $this, 'redirect_after_activation' ) );
@@ -105,7 +96,6 @@ class Jetpack_Social {
 				My_Jetpack_Initializer::init();
 			}
 		);
-		add_action( 'init', array( new Automattic\Jetpack\Social\Note(), 'init' ) );
 
 		$this->manager = $connection_manager ? $connection_manager : new Connection_Manager();
 
@@ -128,6 +118,25 @@ class Jetpack_Social {
 		add_shortcode( 'jp_shares_shortcode', array( $this, 'add_shares_shortcode' ) );
 
 		add_filter( 'jetpack_social_admin_script_data', array( $this, 'set_social_admin_script_data' ) );
+	}
+
+	/**
+	 * Initialize the parts of the plugin that have to be initialized later than
+	 * plugins_loaded is firing. This includes translated strings.
+	 */
+	public function do_init() {
+		$page_suffix = Admin_Menu::add_menu(
+			__( 'Jetpack Social', 'jetpack-social' ),
+			_x( 'Social', 'The Jetpack Social product name, without the Jetpack prefix', 'jetpack-social' ),
+			'manage_options',
+			'jetpack-social',
+			array( $this, 'plugin_settings_page' ),
+			4
+		);
+
+		add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
+
+		( new Automattic\Jetpack\Social\Note() )->init();
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes notices appearing when using a site in a language other than US English caused by early i18n calls.

## Proposed changes:
* Adds a callback to Config option mechanisms for third party packages to work around the problem.
* Moves Social admin menu initialization to the `init` hook.
* Removes an i18n call in case a deprecation notice is issued too early in the load.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
paJDYF-fWD-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Reproduce the notices with the steps detailed in the WooCommerce Payments issue linked above.
* Observe notices from Jetpack, Jetpack Social, and WooCommerce Payments.
* Use this PR.
* Observe no more notices from Jetpack or Jetpack Social.