### PR TITLE
Introduce component usage stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ jetpack_vendor/
 /.nova/
 /logs
 /allure-results/
+/results
 
 ## FILES
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"cli-link": "jetpack cli link",
 		"cli-setup": "pnpm install && jetpack cli link",
 		"cli-unlink": "jetpack cli unlink",
+		"component-usage-stats": "node ./node_modules/react-scanner/bin/react-scanner -c ./react-scanner.config.js",
 		"lint": "pnpm run lint-file .",
 		"lint-changed": "eslint-changed --ext .js,.jsx,.cjs,.mjs,.ts,.tsx,.svelte --git",
 		"lint-file": "eslint --ext .js,.jsx,.cjs,.mjs,.ts,.tsx,.svelte",
@@ -31,7 +32,8 @@
 		"eslint": "8.57.1",
 		"husky": "8.0.3",
 		"jetpack-cli": "workspace:*",
-		"jetpack-js-tools": "workspace:*"
+		"jetpack-js-tools": "workspace:*",
+		"react-scanner": "1.2.0"
 	},
 	"engines": {
 		"node": "^22.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       jetpack-js-tools:
         specifier: workspace:*
         version: link:tools/js-tools
+      react-scanner:
+        specifier: 1.2.0
+        version: 1.2.0
 
   .github/files/coverage-munger:
     devDependencies:
@@ -7286,6 +7289,9 @@ packages:
   '@types/escodegen@0.0.6':
     resolution: {integrity: sha512-AjwI4MvWx3HAOaZqYsjKWyEObT9lcVV0Y0V8nXo6cXzN8ZiMxVhf6F3d/UNvXVGKrEzL/Dluc5p+y9GkzlTWig==}
 
+  '@types/estree@0.0.45':
+    resolution: {integrity: sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==}
+
   '@types/estree@0.0.51':
     resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
 
@@ -7538,8 +7544,21 @@ packages:
     resolution: {integrity: sha512-gY2TVzeve3z6crqh2Ic7Cr+CAv6pfb0Egee7J5UAVWCpVvDI/F71wNfolIim4FE6hT15EbpZFVUj9j5i38jYXA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.8.0':
+    resolution: {integrity: sha512-QJwc50hRCgBd/k12sTykOJbESe1RrzmX6COk8Y525C9l7oweZ+1lw9JiU56im7Amm8swlz00DRIlxMYLizr2Vw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.17.0':
     resolution: {integrity: sha512-JqkOopc1nRKZpX+opvKqnM3XUlM7LpFMD0lYxTqOTKQfCWAmxw45e3qlOCsEqEB2yuacujivudOFpCnqkBDNMw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/typescript-estree@8.8.0':
+    resolution: {integrity: sha512-ZaMJwc/0ckLz5DaAZ+pNLmHv8AMVGtfWxZe/x2JVEkD5LnmhWiQMMcYT7IY7gkdJuzJ9P14fRy28lUrlDSWYdw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '*'
@@ -7559,6 +7578,10 @@ packages:
 
   '@typescript-eslint/visitor-keys@8.17.0':
     resolution: {integrity: sha512-1Hm7THLpO6ww5QU6H/Qp+AusUUl+z/CAm3cNZZ0jQvon9yicgO7Rwd+/WWRpMKLYV6p2UvdbR27c86rzCPpreg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.8.0':
+    resolution: {integrity: sha512-8mq51Lx6Hpmd7HnA2fcHQo3YgfX1qbccxQOgZcb4tvasu//zXRaA1j5ZRFeCw/VRAdFi4mRM9DnZw0Nu0Q2d1g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.2.0':
@@ -8311,6 +8334,10 @@ packages:
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
+
+  astray@1.1.1:
+    resolution: {integrity: sha512-LizvbENqdc8tdvrms/YyYoTtlr43INJni4YZSFr8nNdfOgafi82Hcrfhjm0MdwLhRFBrDhRwtH/0fnntlESxsQ==}
+    engines: {node: '>=8'}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -9258,6 +9285,9 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
@@ -9337,6 +9367,10 @@ packages:
   dotenv@16.0.2:
     resolution: {integrity: sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA==}
     engines: {node: '>=12'}
+
+  dset@3.1.4:
+    resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
+    engines: {node: '>=4'}
 
   earcut@2.2.4:
     resolution: {integrity: sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==}
@@ -9853,6 +9887,14 @@ packages:
 
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+
+  fdir@5.2.0:
+    resolution: {integrity: sha512-skyI2Laxtj9GYzmktPgY6DT8uswXq+VoxH26SskykvEhTSbi7tRM/787uZt/p8maxrQCJdzC90zX1btbxiJ6lw==}
+    peerDependencies:
+      picomatch: 2.x
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fdir@6.4.2:
     resolution: {integrity: sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==}
@@ -11532,6 +11574,10 @@ packages:
   mousetrap@1.6.5:
     resolution: {integrity: sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==}
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -12574,6 +12620,11 @@ packages:
     peerDependencies:
       react: '>=16.8'
 
+  react-scanner@1.2.0:
+    resolution: {integrity: sha512-gxdliEPTHpT5pQi23Efx+cvCEAzrRx9LeZXuptNRojBpQhOsPk+nQ3o/U8pfqFFc/BWwGipV1TqbG1I7zBgVZQ==}
+    engines: {node: '>=14.x'}
+    hasBin: true
+
   react-slider@2.0.5:
     resolution: {integrity: sha512-MU5gaK1yYCKnbDDN3CMiVcgkKZwMvdqK2xUEW7fFU37NAzRgS1FZbF9N7vP08E3XXNVhiuZnwVzUa3PYQAZIMg==}
     peerDependencies:
@@ -12873,6 +12924,10 @@ packages:
 
   rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   safe-array-concat@1.1.2:
     resolution: {integrity: sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==}
@@ -13716,6 +13771,11 @@ packages:
   typescript@5.0.4:
     resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
     engines: {node: '>=12.20'}
+    hasBin: true
+
+  typescript@5.6.2:
+    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   uc.micro@2.1.0:
@@ -17304,6 +17364,9 @@ snapshots:
 
   '@types/escodegen@0.0.6': {}
 
+  '@types/estree@0.0.45':
+    optional: true
+
   '@types/estree@0.0.51': {}
 
   '@types/estree@1.0.6': {}
@@ -17608,6 +17671,8 @@ snapshots:
 
   '@typescript-eslint/types@8.17.0': {}
 
+  '@typescript-eslint/types@8.8.0': {}
+
   '@typescript-eslint/typescript-estree@8.17.0(typescript@5.0.4)':
     dependencies:
       '@typescript-eslint/types': 8.17.0
@@ -17620,6 +17685,21 @@ snapshots:
       ts-api-utils: 1.4.0(typescript@5.0.4)
     optionalDependencies:
       typescript: 5.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.8.0(typescript@5.6.2)':
+    dependencies:
+      '@typescript-eslint/types': 8.8.0
+      '@typescript-eslint/visitor-keys': 8.8.0
+      debug: 4.3.7
+      fast-glob: 3.3.2
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.6.3
+      ts-api-utils: 1.4.0(typescript@5.6.2)
+    optionalDependencies:
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
@@ -17639,6 +17719,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.17.0
       eslint-visitor-keys: 4.2.0
+
+  '@typescript-eslint/visitor-keys@8.8.0':
+    dependencies:
+      '@typescript-eslint/types': 8.8.0
+      eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.2.0': {}
 
@@ -19902,6 +19987,10 @@ snapshots:
     dependencies:
       tslib: 2.5.0
 
+  astray@1.1.1:
+    optionalDependencies:
+      '@types/estree': 0.0.45
+
   async@3.2.6: {}
 
   asynckit@0.4.0: {}
@@ -21025,6 +21114,8 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  dlv@1.1.3: {}
+
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
@@ -21120,6 +21211,8 @@ snapshots:
       is-obj: 2.0.0
 
   dotenv@16.0.2: {}
+
+  dset@3.1.4: {}
 
   earcut@2.2.4: {}
 
@@ -21859,6 +21952,10 @@ snapshots:
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
+
+  fdir@5.2.0(picomatch@2.3.1):
+    optionalDependencies:
+      picomatch: 2.3.1
 
   fdir@6.4.2(picomatch@4.0.2):
     optionalDependencies:
@@ -24031,6 +24128,8 @@ snapshots:
 
   mousetrap@1.6.5: {}
 
+  mri@1.2.0: {}
+
   ms@2.0.0: {}
 
   ms@2.1.2: {}
@@ -25119,6 +25218,20 @@ snapshots:
       '@remix-run/router': 1.2.1
       react: 18.3.1
 
+  react-scanner@1.2.0:
+    dependencies:
+      '@typescript-eslint/typescript-estree': 8.8.0(typescript@5.6.2)
+      astray: 1.1.1
+      dlv: 1.1.3
+      dset: 3.1.4
+      fdir: 5.2.0(picomatch@2.3.1)
+      is-plain-object: 5.0.0
+      picomatch: 2.3.1
+      sade: 1.8.1
+      typescript: 5.6.2
+    transitivePeerDependencies:
+      - supports-color
+
   react-slider@2.0.5(@babel/runtime@7.26.0)(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.26.0
@@ -25476,6 +25589,10 @@ snapshots:
   rxjs@7.8.1:
     dependencies:
       tslib: 2.5.0
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
 
   safe-array-concat@1.1.2:
     dependencies:
@@ -26240,6 +26357,10 @@ snapshots:
     dependencies:
       typescript: 5.0.4
 
+  ts-api-utils@1.4.0(typescript@5.6.2):
+    dependencies:
+      typescript: 5.6.2
+
   ts-dedent@2.2.0: {}
 
   ts-jest-resolver@2.0.1:
@@ -26371,6 +26492,8 @@ snapshots:
       typescript-compare: 0.0.2
 
   typescript@5.0.4: {}
+
+  typescript@5.6.2: {}
 
   uc.micro@2.1.0: {}
 

--- a/react-scanner.config.js
+++ b/react-scanner.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+	// Crawl the entire repo
+	crawlFrom: './',
+	// Needed for properly reporting components with dot notation
+	includeSubComponents: true,
+	// Exclude usage in tests and stories.
+	globs: [ '**/!(test|stories)/!(*stories).@(js|ts)?(x)' ],
+	// Exclude any vendor or docs directories
+	exclude: [
+		'docs',
+		'node_modules',
+		'tools',
+	],
+	// Consider only imports of `@wordpress/components`
+	importedFrom: '@wordpress/components',
+	// Full usage report
+	processors: [ [ 'raw-report', { outputTo: './results/jetpack.json' } ] ],
+};

--- a/react-scanner.config.js
+++ b/react-scanner.config.js
@@ -6,11 +6,7 @@ module.exports = {
 	// Exclude usage in tests and stories.
 	globs: [ '**/!(test|stories)/!(*stories).@(js|ts)?(x)' ],
 	// Exclude any vendor or docs directories
-	exclude: [
-		'docs',
-		'node_modules',
-		'tools',
-	],
+	exclude: [ 'docs', 'node_modules', 'tools' ],
 	// Consider only imports of `@wordpress/components`
 	importedFrom: '@wordpress/components',
 	// Full usage report

--- a/react-scanner.config.js
+++ b/react-scanner.config.js
@@ -6,7 +6,7 @@ module.exports = {
 	// Exclude usage in tests and stories.
 	globs: [ '**/!(test|stories)/!(*stories).@(js|ts)?(x)' ],
 	// Exclude any vendor or docs directories
-	exclude: [ 'docs', 'node_modules', 'tools' ],
+	exclude: [ 'docs', 'jetpack_vendor', 'node_modules', 'tools', 'vendor' ],
 	// Consider only imports of `@wordpress/components`
 	importedFrom: '@wordpress/components',
 	// Full usage report


### PR DESCRIPTION
## Proposed changes:
This PR introduces [`react-scanner`](https://www.npmjs.com/package/react-scanner) to keep an eye on component usage stats.

It can be useful to track the adoption of our components over time, and we're automating that as part of our work on design systems (bjpUB-p2).

See https://github.com/WordPress/gutenberg/pull/65463 for the same in Gutenberg and https://github.com/Automattic/wp-calypso/pull/96882 for Calypso.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
* Checkout this branch
* Run `pnpm install`
* Run `pnpm run component-usage-stats`
* Check out the output in `/results/jetpack.json`
