### PR TITLE
Duplicate views: Use Calypso admin menu for untangled WP-Admin screens

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-pre-option-filter-duplicate-views
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-pre-option-filter-duplicate-views
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Switch to WP-Admin some sections while keeping some untangling changes

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -263,7 +263,7 @@ add_action( 'admin_bar_menu', 'wpcom_replace_edit_profile_menu_to_me', 9999 );
  * @return string Name of the admin bar class.
  */
 function wpcom_custom_wpcom_admin_bar_class( $wp_admin_bar_class ) {
-	if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+	if ( ! wpcom_is_using_default_admin_menu() ) {
 		return $wp_admin_bar_class;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -117,6 +117,65 @@ function wpcom_admin_interface_pre_update_option( $new_value, $old_value ) {
 add_filter( 'pre_update_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_update_option', 10, 2 );
 
 /**
+ * Get the current screen section. 
+ * 
+ * Temporary function copied from Base_Admin_Menu.
+ * 
+ * return string
+ */
+function wpcom_admin_get_current_screen() {
+	// phpcs:disable WordPress.Security.NonceVerification
+	global $pagenow;
+	$screen = isset( $_REQUEST['screen'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['screen'] ) ) : $pagenow;
+	if ( isset( $_GET['post_type'] ) ) {
+		$screen = add_query_arg( 'post_type', sanitize_text_field( wp_unslash( $_GET['post_type'] ) ), $screen );
+	}
+	if ( isset( $_GET['taxonomy'] ) ) {
+		$screen = add_query_arg( 'taxonomy', sanitize_text_field( wp_unslash( $_GET['taxonomy'] ) ), $screen );
+	}
+	if ( isset( $_GET['page'] ) ) {
+		$screen = add_query_arg( 'page', sanitize_text_field( wp_unslash( $_GET['page'] ) ), $screen );
+	}
+	return $screen;
+	// phpcs:enable WordPress.Security.NonceVerification
+}
+
+/**
+ * Override the wpcom_admin_interface option with experiment variation.
+ */
+function wpcom_admin_interface_pre_get_option( $default_value ) {
+	$enabled_screens = array(
+		'edit.php',
+	);
+	
+	$current_screen = wpcom_admin_get_current_screen();
+
+	if ( in_array( $current_screen, $enabled_screens ) && wpcom_is_duplicate_views_experiment_enabled() ) {
+		return 'wp-admin';
+	}
+
+	return $default_value;
+}
+
+/**
+ * Change the Admin menu links to WP-Admin for specific sections.
+ * 
+ * return array
+ */
+function wpcom_admin_get_user_option_jetpack( $value ) {
+    if ( ! wpcom_is_duplicate_views_experiment_enabled() ) {
+        return $value;
+    }
+
+    $value['edit.php'] = Automattic\Jetpack\Masterbar\Base_Admin_Menu::CLASSIC_VIEW;
+
+    return $value;
+}
+
+add_filter( 'get_user_option_jetpack_admin_menu_preferred_views', 'wpcom_admin_get_user_option_jetpack' );
+add_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option', 10 );
+
+/**
  * Determines whether the admin interface has been recently changed by checking the presence of the `admin-interface-changed` query param.
  *
  * @return bool

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -174,7 +174,7 @@ function wpcom_admin_get_user_option_jetpack( $value ) {
 	}
 
 	if ( ! is_array( $value ) ) {
-		$value = [];
+		$value = array();
 	}
 
 	$value['edit.php'] = Automattic\Jetpack\Masterbar\Base_Admin_Menu::CLASSIC_VIEW;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -117,10 +117,10 @@ function wpcom_admin_interface_pre_update_option( $new_value, $old_value ) {
 add_filter( 'pre_update_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_update_option', 10, 2 );
 
 /**
- * Get the current screen section. 
- * 
+ * Get the current screen section.
+ *
  * Temporary function copied from Base_Admin_Menu.
- * 
+ *
  * return string
  */
 function wpcom_admin_get_current_screen() {
@@ -142,15 +142,19 @@ function wpcom_admin_get_current_screen() {
 
 /**
  * Override the wpcom_admin_interface option with experiment variation.
+ *
+ * @param mixed $default_value The value to return instead of the option value.
+ *
+ * @return string Filtered wpcom_admin_interface option.
  */
 function wpcom_admin_interface_pre_get_option( $default_value ) {
 	$enabled_screens = array(
 		'edit.php',
 	);
-	
+
 	$current_screen = wpcom_admin_get_current_screen();
 
-	if ( in_array( $current_screen, $enabled_screens ) && wpcom_is_duplicate_views_experiment_enabled() ) {
+	if ( in_array( $current_screen, $enabled_screens, true ) && wpcom_is_duplicate_views_experiment_enabled() ) {
 		return 'wp-admin';
 	}
 
@@ -159,17 +163,19 @@ function wpcom_admin_interface_pre_get_option( $default_value ) {
 
 /**
  * Change the Admin menu links to WP-Admin for specific sections.
- * 
- * return array
+ *
+ * @param array $value Preferred views.
+ *
+ * @return array Filtered preferred views.
  */
 function wpcom_admin_get_user_option_jetpack( $value ) {
-    if ( ! wpcom_is_duplicate_views_experiment_enabled() ) {
-        return $value;
-    }
+	if ( ! wpcom_is_duplicate_views_experiment_enabled() ) {
+		return $value;
+	}
 
-    $value['edit.php'] = Automattic\Jetpack\Masterbar\Base_Admin_Menu::CLASSIC_VIEW;
+	$value['edit.php'] = Automattic\Jetpack\Masterbar\Base_Admin_Menu::CLASSIC_VIEW;
 
-    return $value;
+	return $value;
 }
 
 add_filter( 'get_user_option_jetpack_admin_menu_preferred_views', 'wpcom_admin_get_user_option_jetpack' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -173,6 +173,10 @@ function wpcom_admin_get_user_option_jetpack( $value ) {
 		return $value;
 	}
 
+	if ( ! is_array( $value ) ) {
+		$value = [];
+	}
+
 	$value['edit.php'] = Automattic\Jetpack\Masterbar\Base_Admin_Menu::CLASSIC_VIEW;
 
 	return $value;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -34,10 +34,23 @@ function current_user_has_wpcom_account() {
 }
 
 /**
+ * Check if the user has the default (Calypso) Admin menu.
+ *
+ * @return bool
+ */
+function wpcom_is_using_default_admin_menu() {
+	remove_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option' );
+	$option = get_option( 'wpcom_admin_interface' ) !== 'wp-admin';
+	add_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option', 10 );
+
+	return $option;
+}
+
+/**
  * Adds a Hosting menu.
  */
 function wpcom_add_hosting_menu() {
-	if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
+	if ( wpcom_is_using_default_admin_menu() ) {
 		return;
 	}
 
@@ -149,7 +162,7 @@ add_action( 'admin_menu', 'wpcom_add_hosting_menu' );
 function wpcom_add_jetpack_submenu() {
 	$is_simple_site          = defined( 'IS_WPCOM' ) && IS_WPCOM;
 	$is_atomic_site          = ! $is_simple_site;
-	$uses_wp_admin_interface = get_option( 'wpcom_admin_interface' ) === 'wp-admin';
+	$uses_wp_admin_interface = ! wpcom_is_using_default_admin_menu();
 
 	if ( ! $uses_wp_admin_interface ) {
 		return;
@@ -379,7 +392,7 @@ function wpcom_add_plugins_menu() {
 	global $menu;
 	$is_simple_site          = defined( 'IS_WPCOM' ) && IS_WPCOM;
 	$is_atomic_site          = ! $is_simple_site;
-	$uses_wp_admin_interface = get_option( 'wpcom_admin_interface' ) === 'wp-admin';
+	$uses_wp_admin_interface = ! wpcom_is_using_default_admin_menu();
 
 	if ( $is_simple_site ) {
 		$has_plugins_menu = false;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
@@ -10,7 +10,7 @@
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 
-if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
+if ( wpcom_is_using_default_admin_menu() ) {
 	return;
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
@@ -56,7 +56,7 @@ add_action( 'load-theme-install.php', 'wpcom_themes_show_banner' );
  * Registers an "Appearance > Theme Showcase" menu.
  */
 function wpcom_themes_add_theme_showcase_menu() {
-	if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
+	if ( wpcom_is_using_default_admin_menu() ) {
 		return;
 	}
 

--- a/projects/packages/masterbar/changelog/add-pre-option-filter-duplicate-views
+++ b/projects/packages/masterbar/changelog/add-pre-option-filter-duplicate-views
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+

--- a/projects/packages/masterbar/composer.json
+++ b/projects/packages/masterbar/composer.json
@@ -73,7 +73,11 @@
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"
 		},
+	  "dependencies": {
 		"mirror-repo": "Automattic/jetpack-masterbar",
+		"test-only": [
+			"packages/jetpack-mu-wpcom"
+		],
 		"textdomain": "jetpack-masterbar",
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-main.php"

--- a/projects/packages/masterbar/composer.json
+++ b/projects/packages/masterbar/composer.json
@@ -19,6 +19,7 @@
 		"brain/monkey": "^2.6.2",
 		"yoast/phpunit-polyfills": "^1.1.1",
 		"automattic/jetpack-changelogger": "@dev",
+		"automattic/jetpack-mu-wpcom": "@dev",
 		"automattic/patchwork-redefine-exit": "@dev",
 		"automattic/wordbless": "^0.4.2"
 	},

--- a/projects/packages/masterbar/composer.json
+++ b/projects/packages/masterbar/composer.json
@@ -73,11 +73,12 @@
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"
 		},
-	  "dependencies": {
+		"dependencies": {
+			"test-only": [
+				"packages/jetpack-mu-wpcom"
+			]
+		},
 		"mirror-repo": "Automattic/jetpack-masterbar",
-		"test-only": [
-			"packages/jetpack-mu-wpcom"
-		],
 		"textdomain": "jetpack-masterbar",
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-main.php"

--- a/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
@@ -356,7 +356,7 @@ class Admin_Menu extends Base_Admin_Menu {
 
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		add_submenu_page( 'tools.php', esc_attr__( 'Marketing', 'jetpack-masterbar' ), __( 'Marketing', 'jetpack-masterbar' ), 'publish_posts', 'https://wordpress.com/marketing/tools/' . $this->domain, null, 0 );
-		if ( ! $this->use_wp_admin_interface() ) {
+		if ( $this->is_using_default_admin_menu() ) {
 			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 			add_submenu_page( 'tools.php', esc_attr__( 'Monetize', 'jetpack-masterbar' ), __( 'Monetize', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain, null, 1 );
 		}

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -79,7 +79,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		$this->remove_gutenberg_menu();
 
 		// We don't need the `My Mailboxes` when the interface is set to wp-admin or the site is a staging site,
-		if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' && ! get_option( 'wpcom_is_staging_site' ) ) {
+		if ( $this->is_using_default_admin_menu() && ! get_option( 'wpcom_is_staging_site' ) ) {
 			$this->add_my_mailboxes_menu();
 		}
 
@@ -132,7 +132,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			$this->update_submenus( $slug, $submenus_to_update );
 		}
 
-		if ( ! $this->use_wp_admin_interface() ) {
+		if ( $this->is_using_default_admin_menu() ) {
 			// The 'Subscribers' menu exists in the Jetpack menu for Classic wp-admin interface, so only add it for non-wp-admin interfaces.
 			// // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 			add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack-masterbar' ), __( 'Subscribers', 'jetpack-masterbar' ), 'list_users', 'https://wordpress.com/subscribers/' . $this->domain, null );
@@ -322,7 +322,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 */
 	public function add_jetpack_menu() {
 		// This is supposed to be the same as class-admin-menu but with a different position specified for the Jetpack menu.
-		if ( 'wp-admin' === get_option( 'wpcom_admin_interface' ) ) {
+		if ( ! $this->is_using_default_admin_menu() ) {
 			parent::create_jetpack_menu( 2, false );
 		} else {
 			parent::add_jetpack_menu();
@@ -445,7 +445,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 
 		// Hide Settings > Performance when the interface is set to wp-admin.
 		// This is due to these settings are mostly also available in Jetpack > Settings, in the Performance tab.
-		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+		if ( ! $this->is_using_default_admin_menu() ) {
 			$this->hide_submenu_page( 'options-general.php', 'https://wordpress.com/settings/performance/' . $this->domain );
 		}
 	}
@@ -457,7 +457,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		parent::add_tools_menu();
 
 		// Link the Tools menu to Available Tools when the interface is set to wp-admin.
-		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+		if ( ! $this->is_using_default_admin_menu() ) {
 			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 			add_submenu_page( 'tools.php', esc_attr__( 'Available Tools', 'jetpack-masterbar' ), __( 'Available Tools', 'jetpack-masterbar' ), 'edit_posts', 'tools.php', null, 0 );
 		}

--- a/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
@@ -77,7 +77,9 @@ abstract class Base_Admin_Menu {
 			add_filter( 'admin_menu', array( $this, 'override_svg_icons' ), 99999 );
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 11 );
 			add_action( 'admin_head', array( $this, 'set_site_icon_inline_styles' ) );
-			add_action( 'in_admin_header', array( $this, 'add_dashboard_switcher' ) );
+			if ( ! wpcom_is_duplicate_views_experiment_enabled() ) {
+				add_action( 'in_admin_header', array( $this, 'add_dashboard_switcher' ) );
+			}
 			add_action( 'admin_footer', array( $this, 'dashboard_switcher_scripts' ) );
 			add_action( 'admin_menu', array( $this, 'handle_preferred_view' ), 99997 );
 			add_filter( 'admin_body_class', array( $this, 'admin_body_class' ) );

--- a/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
@@ -77,7 +77,7 @@ abstract class Base_Admin_Menu {
 			add_filter( 'admin_menu', array( $this, 'override_svg_icons' ), 99999 );
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 11 );
 			add_action( 'admin_head', array( $this, 'set_site_icon_inline_styles' ) );
-			if ( ! \wpcom_is_duplicate_views_experiment_enabled() ) {
+			if ( ! function_exists( 'wpcom_is_duplicate_views_experiment_enabled' ) || ! \wpcom_is_duplicate_views_experiment_enabled() ) {
 				add_action( 'in_admin_header', array( $this, 'add_dashboard_switcher' ) );
 			}
 			add_action( 'admin_footer', array( $this, 'dashboard_switcher_scripts' ) );

--- a/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
@@ -752,6 +752,19 @@ abstract class Base_Admin_Menu {
 	}
 
 	/**
+	 * Check if the user has the default (Calypso) Admin menu.
+	 *
+	 * @return bool
+	 */
+	public function is_using_default_admin_menu() {
+		remove_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option' );
+		$option = get_option( 'wpcom_admin_interface' ) !== 'wp-admin';
+		add_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option', 10 );
+
+		return $option;
+	}
+
+	/**
 	 * Create the desired menu output.
 	 */
 	abstract public function reregister_menu_items();

--- a/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
@@ -77,7 +77,7 @@ abstract class Base_Admin_Menu {
 			add_filter( 'admin_menu', array( $this, 'override_svg_icons' ), 99999 );
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 11 );
 			add_action( 'admin_head', array( $this, 'set_site_icon_inline_styles' ) );
-			if ( ! wpcom_is_duplicate_views_experiment_enabled() ) {
+			if ( ! \wpcom_is_duplicate_views_experiment_enabled() ) {
 				add_action( 'in_admin_header', array( $this, 'add_dashboard_switcher' ) );
 			}
 			add_action( 'admin_footer', array( $this, 'dashboard_switcher_scripts' ) );

--- a/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
@@ -759,7 +759,9 @@ abstract class Base_Admin_Menu {
 	public function is_using_default_admin_menu() {
 		remove_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option' );
 		$option = get_option( 'wpcom_admin_interface' ) !== 'wp-admin';
-		add_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option', 10 );
+		if ( function_exists( 'wpcom_admin_interface_pre_get_option' ) ) {
+			add_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option', 10 );
+		}
 
 		return $option;
 	}

--- a/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
@@ -77,9 +77,7 @@ abstract class Base_Admin_Menu {
 			add_filter( 'admin_menu', array( $this, 'override_svg_icons' ), 99999 );
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 11 );
 			add_action( 'admin_head', array( $this, 'set_site_icon_inline_styles' ) );
-			if ( ! function_exists( 'wpcom_is_duplicate_views_experiment_enabled' ) || ! \wpcom_is_duplicate_views_experiment_enabled() ) {
-				add_action( 'in_admin_header', array( $this, 'add_dashboard_switcher' ) );
-			}
+			add_action( 'in_admin_header', array( $this, 'add_dashboard_switcher' ) );
 			add_action( 'admin_footer', array( $this, 'dashboard_switcher_scripts' ) );
 			add_action( 'admin_menu', array( $this, 'handle_preferred_view' ), 99997 );
 			add_filter( 'admin_body_class', array( $this, 'admin_body_class' ) );

--- a/projects/packages/masterbar/src/admin-menu/load.php
+++ b/projects/packages/masterbar/src/admin-menu/load.php
@@ -64,7 +64,6 @@ function hide_customizer_menu_on_block_theme() {
 
 				remove_action( 'customize_register', 'Automattic\Jetpack\Masterbar\register_css_nudge_control' );
 
-				// @phan-suppress-next-line PhanUndeclaredClassInCallable
 				remove_action( 'customize_register', array( 'Jetpack_Custom_CSS_Enhancements', 'customize_register' ) );
 			}
 		}

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -31,7 +31,10 @@ class Main {
 
 		remove_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option' );
 		$is_wp_admin_interface = get_option( 'wpcom_admin_interface' ) === 'wp-admin';
-		add_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option', 10 );
+		if ( function_exists( 'wpcom_admin_interface_pre_get_option' ) ) {
+			add_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option', 10 );
+		}
+
 		if ( $is_wp_admin_interface ) {
 			return;
 		}

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -29,7 +29,10 @@ class Main {
 
 		new Admin_Color_Schemes();
 
-		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+		remove_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option' );
+		$is_wp_admin_interface = get_option( 'wpcom_admin_interface' ) === 'wp-admin';
+		add_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option', 10 );
+		if ( $is_wp_admin_interface ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/changelog/add-pre-option-filter-duplicate-views
+++ b/projects/plugins/jetpack/changelog/add-pre-option-filter-duplicate-views
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Changes related to WoA
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1741,7 +1741,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/masterbar",
-				"reference": "dfb426192c3dd1e3da2e651f4d425bd1b19342c6"
+				"reference": "f4317f289a90af787f81e695268be1ef00cd0255"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -1757,6 +1757,7 @@
 			},
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
+				"automattic/jetpack-mu-wpcom": "@dev",
 				"automattic/patchwork-redefine-exit": "@dev",
 				"automattic/wordbless": "^0.4.2",
 				"brain/monkey": "^2.6.2",
@@ -1773,6 +1774,11 @@
 				},
 				"changelogger": {
 					"link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"
+				},
+				"dependencies": {
+					"test-only": [
+						"packages/jetpack-mu-wpcom"
+					]
 				},
 				"mirror-repo": "Automattic/jetpack-masterbar",
 				"textdomain": "jetpack-masterbar",

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-pre-option-filter-duplicate-views
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-pre-option-filter-duplicate-views
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Changes related to WoA
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -971,7 +971,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "dfb426192c3dd1e3da2e651f4d425bd1b19342c6"
+                "reference": "f4317f289a90af787f81e695268be1ef00cd0255"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -987,6 +987,7 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-mu-wpcom": "@dev",
                 "automattic/patchwork-redefine-exit": "@dev",
                 "automattic/wordbless": "^0.4.2",
                 "brain/monkey": "^2.6.2",
@@ -1003,6 +1004,11 @@
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"
+                },
+                "dependencies": {
+                    "test-only": [
+                        "packages/jetpack-mu-wpcom"
+                    ]
                 },
                 "mirror-repo": "Automattic/jetpack-masterbar",
                 "textdomain": "jetpack-masterbar",

--- a/projects/plugins/wpcomsh/changelog/add-pre-option-filter-duplicate-views
+++ b/projects/plugins/wpcomsh/changelog/add-pre-option-filter-duplicate-views
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1108,7 +1108,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "dfb426192c3dd1e3da2e651f4d425bd1b19342c6"
+                "reference": "f4317f289a90af787f81e695268be1ef00cd0255"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1124,6 +1124,7 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-mu-wpcom": "@dev",
                 "automattic/patchwork-redefine-exit": "@dev",
                 "automattic/wordbless": "^0.4.2",
                 "brain/monkey": "^2.6.2",
@@ -1140,6 +1141,11 @@
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"
+                },
+                "dependencies": {
+                    "test-only": [
+                        "packages/jetpack-mu-wpcom"
+                    ]
                 },
                 "mirror-repo": "Automattic/jetpack-masterbar",
                 "textdomain": "jetpack-masterbar",

--- a/projects/plugins/wpcomsh/feature-plugins/masterbar.php
+++ b/projects/plugins/wpcomsh/feature-plugins/masterbar.php
@@ -92,8 +92,12 @@ add_action( 'setted_transient', 'wpcomsh_set_connected_user_data_as_user_options
  * @return bool Whether Nav Unification should be enabled.
  */
 function wpcomsh_activate_nav_unification() {
+	remove_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option' );
+	$is_wp_admin_menu = get_option( 'wpcom_admin_interface' ) === 'wp-admin';
+	add_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option', 10 );
+
 	// Disable when in the redesigned nav.
-	if ( ! wpcom_is_using_default_admin_menu() ) {
+	if ( $is_wp_admin_menu ) {
 		return false;
 	}
 

--- a/projects/plugins/wpcomsh/feature-plugins/masterbar.php
+++ b/projects/plugins/wpcomsh/feature-plugins/masterbar.php
@@ -93,7 +93,7 @@ add_action( 'setted_transient', 'wpcomsh_set_connected_user_data_as_user_options
  */
 function wpcomsh_activate_nav_unification() {
 	// Disable when in the redesigned nav.
-	if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+	if ( ! wpcom_is_using_default_admin_menu() ) {
 		return false;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Integrate the navigation experiment for Simple and WoA sites - users part of the treatment will now receive the Core WP-Admin interface but with the Calypso admin menu.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Enable wpcom_admin_interface option for screens in an allowlist
* Keep the Calypso navigation for them


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use the Jetpack downloader instructions to test the changes on Simple and Atomic sites
* Enable the experiment treatment on your user: 22124-explat-experiment
* Go to a Simple Site and make sure it's using Calypso for Posts
* Sandbox it and make sure that the admin menu is still Calypso
* Click on Posts and make sure that Calypso admin menu is used but the page is WP-Admin
* Make sure that the untangling changes are applied on the page (e.g. there's no Classic Editor in the post quick links)
* Repeat the steps for an Atomic site
* Since we don't have untangling changes there, just make sure that /edit.php loads and we still use Calypso admin menu