### PR TITLE
Threats DataViews: Remove bulk actions

### DIFF
--- a/projects/js-packages/components/changelog/threats-data-views-remove-bulk-actions
+++ b/projects/js-packages/components/changelog/threats-data-views-remove-bulk-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove bulk action support from the ThreatsDataViews component

--- a/projects/js-packages/components/components/threats-data-views/index.tsx
+++ b/projects/js-packages/components/components/threats-data-views/index.tsx
@@ -428,7 +428,6 @@ export default function ThreatsDataViews( {
 				id: THREAT_ACTION_FIX,
 				label: __( 'Auto-fix', 'jetpack-components' ),
 				isPrimary: true,
-				supportsBulk: true,
 				callback: onFixThreats,
 				isEligible( item ) {
 					if ( ! onFixThreats ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes bulk action support from the `ThreatsDataViews` table.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1HpG7-uNC-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Review the component storybook and validate the table checkboxes do not appear, and individual threat actions can still be triggered.

<img width="1056" alt="Screenshot 2024-12-05 at 12 30 48 PM" src="https://github.com/user-attachments/assets/63630934-2d29-4943-9d90-ff09cb82052a">