### PR TITLE
Scan Client: Change Threat.extension.type values

### DIFF
--- a/projects/js-packages/components/changelog/fix-scan-extension-type
+++ b/projects/js-packages/components/changelog/fix-scan-extension-type
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated type values for compatibility with scan package updates.
+
+

--- a/projects/js-packages/components/components/threat-fixer-button/stories/index.stories.tsx
+++ b/projects/js-packages/components/components/threat-fixer-button/stories/index.stories.tsx
@@ -23,13 +23,13 @@ Default.args = {
 
 export const DeletePlugin = args => <ThreatFixerButton { ...args } />;
 DeletePlugin.args = {
-	threat: { fixable: { fixer: 'delete' }, extension: { type: 'plugin' } },
+	threat: { fixable: { fixer: 'delete' }, extension: { type: 'plugins' } },
 	onClick: () => alert( 'Delete fixer callback triggered' ), // eslint-disable-line no-alert
 };
 
 export const DeleteTheme = args => <ThreatFixerButton { ...args } />;
 DeleteTheme.args = {
-	threat: { fixable: { fixer: 'delete' }, extension: { type: 'theme' } },
+	threat: { fixable: { fixer: 'delete' }, extension: { type: 'themes' } },
 	onClick: () => alert( 'Delete fixer callback triggered' ), // eslint-disable-line no-alert
 };
 

--- a/projects/js-packages/components/components/threat-modal/stories/index.stories.tsx
+++ b/projects/js-packages/components/components/threat-modal/stories/index.stories.tsx
@@ -255,7 +255,7 @@ VulnerableExtension.args = {
 			name: 'WP Super Cache',
 			slug: 'wp-super-cache',
 			version: '1.6.3',
-			type: 'plugin',
+			type: 'plugins',
 		},
 	},
 	isUserConnected: true,

--- a/projects/js-packages/components/components/threats-data-views/constants.ts
+++ b/projects/js-packages/components/components/threats-data-views/constants.ts
@@ -15,8 +15,8 @@ export const THREAT_STATUSES: { value: string; label: string; variant?: 'success
 	];
 
 export const THREAT_TYPES = [
-	{ value: 'plugin', label: __( 'Plugin', 'jetpack-components' ) },
-	{ value: 'theme', label: __( 'Theme', 'jetpack-components' ) },
+	{ value: 'plugins', label: __( 'Plugin', 'jetpack-components' ) },
+	{ value: 'themes', label: __( 'Theme', 'jetpack-components' ) },
 	{ value: 'core', label: __( 'WordPress', 'jetpack-components' ) },
 	{ value: 'file', label: __( 'File', 'jetpack-components' ) },
 ];

--- a/projects/js-packages/components/components/threats-data-views/index.tsx
+++ b/projects/js-packages/components/components/threats-data-views/index.tsx
@@ -168,12 +168,12 @@ export default function ThreatsDataViews( {
 				// Extensions (Themes and Plugins)
 				if ( threat.extension ) {
 					switch ( threat.extension.type ) {
-						case 'theme':
+						case 'themes':
 							if ( ! acc.themes.find( ( { value } ) => value === threat.extension.slug ) ) {
 								acc.themes.push( { value: threat.extension.slug, label: threat.extension.name } );
 							}
 							break;
-						case 'plugin':
+						case 'plugins':
 							if ( ! acc.plugins.find( ( { value } ) => value === threat.extension.slug ) ) {
 								acc.plugins.push( { value: threat.extension.slug, label: threat.extension.name } );
 							}

--- a/projects/js-packages/components/components/threats-data-views/stories/index.stories.tsx
+++ b/projects/js-packages/components/components/threats-data-views/stories/index.stories.tsx
@@ -96,7 +96,7 @@ Default.args = {
 				name: 'WP Super Cache',
 				slug: 'wp-super-cache',
 				version: '1.6.3',
-				type: 'plugin',
+				type: 'plugins',
 			},
 		},
 		{
@@ -142,7 +142,7 @@ Default.args = {
 				name: 'WooCommerce',
 				slug: 'woocommerce',
 				version: '3.4.5',
-				type: 'plugin',
+				type: 'plugins',
 			},
 		},
 	],
@@ -197,7 +197,7 @@ FixerStatuses.args = {
 				name: 'Example Plugin',
 				slug: 'example-plugin',
 				version: '1.2.3',
-				type: 'plugin',
+				type: 'plugins',
 			},
 		},
 		{
@@ -216,7 +216,7 @@ FixerStatuses.args = {
 				name: 'Example Theme',
 				slug: 'example-theme',
 				version: '2.2.2',
-				type: 'theme',
+				type: 'themes',
 			},
 		},
 		{
@@ -235,7 +235,7 @@ FixerStatuses.args = {
 				name: 'Example Theme II',
 				slug: 'example-theme-2',
 				version: '3.3.3',
-				type: 'theme',
+				type: 'themes',
 			},
 		},
 		{
@@ -292,7 +292,7 @@ FreeResults.args = {
 				name: 'WooCommerce',
 				slug: 'woocommerce',
 				version: '3.2.3',
-				type: 'plugin',
+				type: 'plugins',
 			},
 		},
 		{
@@ -307,7 +307,7 @@ FreeResults.args = {
 				name: 'WooCommerce',
 				slug: 'woocommerce',
 				version: '3.4.5',
-				type: 'plugin',
+				type: 'plugins',
 			},
 		},
 		{
@@ -321,7 +321,7 @@ FreeResults.args = {
 				name: 'WP Super Cache',
 				slug: 'wp-super-cache',
 				version: '1.6.3',
-				type: 'plugin',
+				type: 'plugins',
 			},
 		},
 	],

--- a/projects/js-packages/components/components/threats-data-views/test/index.test.tsx
+++ b/projects/js-packages/components/components/threats-data-views/test/index.test.tsx
@@ -39,7 +39,7 @@ const data = [
 			name: 'WooCommerce',
 			slug: 'woocommerce',
 			version: '3.2.3',
-			type: 'plugin' as const,
+			type: 'plugins' as const,
 		},
 		fixedIn: '3.2.4',
 	},

--- a/projects/js-packages/scan/changelog/fix-scan-extension-type
+++ b/projects/js-packages/scan/changelog/fix-scan-extension-type
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Fixed a type value.
+
+

--- a/projects/js-packages/scan/src/types/threats.ts
+++ b/projects/js-packages/scan/src/types/threats.ts
@@ -61,6 +61,6 @@ export type Threat = {
 		slug: string;
 		name: string;
 		version: string;
-		type: 'plugin' | 'theme' | 'core';
+		type: 'plugins' | 'themes' | 'core';
 	};
 };

--- a/projects/js-packages/scan/src/utils/index.ts
+++ b/projects/js-packages/scan/src/utils/index.ts
@@ -68,23 +68,22 @@ export const getDetailedFixerAction = ( threat: Threat ) => {
 				return __( 'Delete file', 'jetpack-scan' );
 			}
 
-			if ( threat.extension?.type === 'plugin' ) {
+			if ( threat.extension?.type === 'plugins' ) {
 				return __( 'Delete plugin from site', 'jetpack-scan' );
 			}
 
-			if ( threat.extension?.type === 'theme' ) {
+			if ( threat.extension?.type === 'themes' ) {
 				return __( 'Delete theme from site', 'jetpack-scan' );
 			}
 			break;
 		case 'update':
-			if ( threat.extension?.type === 'plugin' ) {
+			if ( threat.extension?.type === 'plugins' ) {
 				return __( 'Update plugin to newer version', 'jetpack-scan' );
 			}
-			if ( threat.extension?.type === 'theme' ) {
+			if ( threat.extension?.type === 'themes' ) {
 				return __( 'Update theme to newer version', 'jetpack-scan' );
 			}
 			return __( 'Update', 'jetpack-scan' );
-			break;
 		case 'replace':
 		case 'rollback':
 			if ( threat.filename ) {
@@ -115,11 +114,11 @@ export const getFixerDescription = ( threat: Threat ) => {
 				return __( 'Delete the infected file.', 'jetpack-scan' );
 			}
 
-			if ( threat.extension?.type === 'plugin' ) {
+			if ( threat.extension?.type === 'plugins' ) {
 				return __( 'Delete the plugin directory to fix the threat.', 'jetpack-scan' );
 			}
 
-			if ( threat.extension?.type === 'theme' ) {
+			if ( threat.extension?.type === 'themes' ) {
 				return __( 'Delete the theme directory to fix the threat.', 'jetpack-scan' );
 			}
 			break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* To align with the `protect-status` package, update the `Threat` type's `extension.type` property to support `"themes"` and `"plugins"` instead of `"theme"` and `"plugin"` values.
* Updates threat components accordingly.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Proof read type changes.
* Smoke test threat storybooks.
* Smoke test Jetpack Protect.
