### PR TITLE
Add/bluesky to social network feature copy

### DIFF
--- a/projects/plugins/social/changelog/add-bluesky-to-social-network-feature-copy
+++ b/projects/plugins/social/changelog/add-bluesky-to-social-network-feature-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add Bluesky to social feature copy

--- a/projects/plugins/social/src/js/components/connection-screen/index.js
+++ b/projects/plugins/social/src/js/components/connection-screen/index.js
@@ -30,7 +30,7 @@ const ConnectionScreen = () => {
 						) }
 						features={ [
 							__(
-								'Share to Facebook, Instagram, LinkedIn, Mastodon, Tumblr, and Nextdoor',
+								'Share to Facebook, Instagram, LinkedIn, Mastodon, Tumblr, Threads, Bluesky, and Nextdoor',
 								'jetpack-social'
 							),
 							__( 'Post to multiple channels at once', 'jetpack-social' ),

--- a/projects/plugins/social/src/js/components/pricing-page/index.js
+++ b/projects/plugins/social/src/js/components/pricing-page/index.js
@@ -41,7 +41,7 @@ const PricingPage = ( { onDismiss = () => {} } = {} ) => {
 				{ name: __( 'Schedule posting', 'jetpack-social' ) },
 				{
 					name: __(
-						'Instagram, Facebook, Mastodon, LinkedIn, Nextdoor, & Tumblr',
+						'Share to Facebook, Instagram, LinkedIn, Mastodon, Tumblr, Threads, Bluesky, and Nextdoor',
 						'jetpack-social'
 					),
 				},


### PR DESCRIPTION
## Proposed changes:

* Add BlueSky to social feature copy

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/jpop-issues/issues/9307#issue-2632081502

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Install/Activate the Jetpack Social plugin
3. Without a user connection, go to `/wp-admin/admin.php?page=jetpack-social`. On the connection screen, ensure you see Bluesky and Threads listed

![Screenshot 2024-12-05 at 2 05 03 PM](https://github.com/user-attachments/assets/d847217e-6067-438d-bab2-4138997c5df7)
4. Connect your user account
5. Go back to `/wp-admin/admin.php?page=jetpack-social` and ensure you see BlueSky and Threads in the pricing table features
![Screenshot 2024-12-05 at 2 02 09 PM](https://github.com/user-attachments/assets/ae2d4636-d7f2-4f86-a93e-65888c087716)
