### PR TITLE
Jetpack AI: Adding AI feedback component and implementing on carousel

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-feedback-component
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-feedback-component
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Adding AI feedback component and implementing it on the image carousel

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-feedback/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-feedback/index.tsx
@@ -1,0 +1,67 @@
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { thumbsUp, thumbsDown } from '@wordpress/icons';
+import clsx from 'clsx';
+import { useState } from 'react';
+import { getFeatureAvailability } from '../../../../blocks/ai-assistant/lib/utils/get-feature-availability';
+
+import './style.scss';
+
+export default function AiFeedbackThumbs( { shouldBeDisabled = false, iconSize = 24, ratedItem } ) {
+	const [ itemsRated, setItemsRated ] = useState( {} );
+
+	const isDisabled = () => {
+		if ( shouldBeDisabled ) {
+			return true;
+		}
+
+		//return itemsRated[ ratedItem ] || false;
+		return false;
+	};
+
+	const rateAI = ( isThumbsUp: boolean ) => {
+		const aiRating = isThumbsUp ? 'thumbs-up' : 'thumbs-down';
+
+		setItemsRated( {
+			...itemsRated,
+			[ ratedItem ]: aiRating,
+		} );
+
+		// calls to Tracks or whatever else can be made here
+	};
+
+	const checkThumb = ( thumbValue: string ) => {
+		if ( ! itemsRated[ ratedItem ] ) {
+			return false;
+		}
+
+		return itemsRated[ ratedItem ] === thumbValue;
+	};
+
+	return getFeatureAvailability( 'ai-response-feedback' ) ? (
+		<div className="ai-assistant-feedback__selection">
+			<Button
+				aria-label={ __( 'Good Response', 'jetpack' ) }
+				disabled={ isDisabled() }
+				icon={ thumbsUp }
+				onClick={ () => rateAI( true ) }
+				iconSize={ iconSize }
+				showTooltip={ false }
+				className={ clsx( { 'ai-assistant-feedback__thumb-selected': checkThumb( 'thumbs-up' ) } ) }
+			/>
+			<Button
+				aria-label={ __( 'Bad Response', 'jetpack' ) }
+				disabled={ isDisabled() }
+				icon={ thumbsDown }
+				onClick={ () => rateAI( false ) }
+				iconSize={ iconSize }
+				showTooltip={ false }
+				className={ clsx( {
+					'ai-assistant-feedback__thumb-selected': checkThumb( 'thumbs-down' ),
+				} ) }
+			/>
+		</div>
+	) : (
+		<></>
+	);
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-feedback/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-feedback/index.tsx
@@ -7,17 +7,8 @@ import { getFeatureAvailability } from '../../../../blocks/ai-assistant/lib/util
 
 import './style.scss';
 
-export default function AiFeedbackThumbs( { shouldBeDisabled = false, iconSize = 24, ratedItem } ) {
+export default function AiFeedbackThumbs( { disabled = false, iconSize = 24, ratedItem } ) {
 	const [ itemsRated, setItemsRated ] = useState( {} );
-
-	const isDisabled = () => {
-		if ( shouldBeDisabled ) {
-			return true;
-		}
-
-		//return itemsRated[ ratedItem ] || false;
-		return false;
-	};
 
 	const rateAI = ( isThumbsUp: boolean ) => {
 		const aiRating = isThumbsUp ? 'thumbs-up' : 'thumbs-down';
@@ -42,7 +33,7 @@ export default function AiFeedbackThumbs( { shouldBeDisabled = false, iconSize =
 		<div className="ai-assistant-feedback__selection">
 			<Button
 				aria-label={ __( 'Good Response', 'jetpack' ) }
-				disabled={ isDisabled() }
+				disabled={ disabled }
 				icon={ thumbsUp }
 				onClick={ () => rateAI( true ) }
 				iconSize={ iconSize }
@@ -51,7 +42,7 @@ export default function AiFeedbackThumbs( { shouldBeDisabled = false, iconSize =
 			/>
 			<Button
 				aria-label={ __( 'Bad Response', 'jetpack' ) }
-				disabled={ isDisabled() }
+				disabled={ disabled }
 				icon={ thumbsDown }
 				onClick={ () => rateAI( false ) }
 				iconSize={ iconSize }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-feedback/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-feedback/style.scss
@@ -1,0 +1,16 @@
+@import "@wordpress/base-styles/colors";
+
+.ai-assistant-feedback {
+	&__selection {
+		display: flex;
+
+		.components-button.has-icon {
+			padding: 0;
+			min-width: 28px;
+		}
+	}
+
+	&__thumb-selected {
+		color: var(--wp-components-color-accent,var(--wp-admin-theme-color,#3858e9));
+	}
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.scss
@@ -95,12 +95,18 @@
 			margin-top: 8px;
 		}
 
+		&-footer-left {
+			display: flex;
+			width: 25%;
+		}
+
 		&-counter {
 			display: flex;
 			justify-content: flex-start;
 			align-items: center;
 			font-size: 13px;
 			padding: 6px 0;
+			width: 50%;
 
 			.ai-carrousel {
 				&__prev,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.tsx
@@ -8,6 +8,7 @@ import clsx from 'clsx';
 /**
  * Internal dependencies
  */
+import AiFeedbackThumbs from '../../ai-feedback';
 import AiIcon from '../../ai-icon';
 import './carrousel.scss';
 
@@ -86,6 +87,23 @@ export default function Carrousel( {
 
 	const actual = current === 0 && total === 0 ? 0 : current + 1;
 
+	const aiFeedbackDisabled = imageData => {
+		const { image, generating, error } = imageData;
+
+		// disable if there's an empty modal
+		if ( ! image && ! generating && ! error ) {
+			return true;
+		}
+
+		// also disable if we're generating or have an error
+		if ( generating || error ) {
+			return true;
+		}
+
+		// otherwise we're fine
+		return false;
+	};
+
 	return (
 		<div className="ai-assistant-image__carrousel">
 			<div className="ai-assistant-image__carrousel-images">
@@ -142,11 +160,20 @@ export default function Carrousel( {
 				{ images.length > 1 && nextButton }
 			</div>
 			<div className="ai-assistant-image__carrousel-footer">
-				<div className="ai-assistant-image__carrousel-counter">
-					{ prevButton }
-					{ actual } / { total }
-					{ nextButton }
+				<div className="ai-assistant-image__carrousel-footer-left">
+					<div className="ai-assistant-image__carrousel-counter">
+						{ prevButton }
+						{ actual } / { total }
+						{ nextButton }
+					</div>
+
+					<AiFeedbackThumbs
+						shouldBeDisabled={ aiFeedbackDisabled( images[ current ] ) }
+						ratedItem={ images[ current ].libraryUrl || '' }
+						iconSize={ 20 }
+					/>
 				</div>
+
 				<div className="ai-assistant-image__carrousel-actions">{ actions }</div>
 			</div>
 		</div>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.tsx
@@ -168,7 +168,7 @@ export default function Carrousel( {
 					</div>
 
 					<AiFeedbackThumbs
-						shouldBeDisabled={ aiFeedbackDisabled( images[ current ] ) }
+						disabled={ aiFeedbackDisabled( images[ current ] ) }
 						ratedItem={ images[ current ].libraryUrl || '' }
 						iconSize={ 20 }
 					/>


### PR DESCRIPTION
Fixes #40458

## Proposed changes:
* Adding a new component that can be used for giving a quick thumbs up or thumbs down for Jetpack AI stuff
* Implement the component on the image carousel since it's the most complex use case
* Currently the callback (`rateAI`) only saves the item rated in memory. A call to a tracking system can be added later.
* Require the `ai_response_feedback_enabled` filter to be enabled.
* As per the designs you can change your choice at any time.
* Also I don't actually know how to make React components (I just looked at some other ones), so please let me know if the code looks weird or I did something silly! Thank you!

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Mainly this P2 post with design info: p1HpG7-uzm-p2

## Does this pull request change what data or activity we track or use?

Nope

## Testing instructions:

* Check out this branch or create a Jurassic Ninja using it
* Make a new post and with the `/image` command click the "Generate with AI" button
* There should be no thumbs up/down present on the modal at any time (you can generate an image if you want)
* Using a snippet or similar means, enable the filter: `add_filter( 'ai_response_feedback_enabled', '__return_true' );`
* Reload the page and open up the AI image modal again
* When there are no images on the modal the thumbs up/down should be present but disabled at the bottom of the modal next to the carousel left/right and page count.
* Type something into the prompt and click "Generate". While the image is generating the thumbs up/down should remain disabled.
* Once the image has finished generating the thumbs up/down should now be enabled: hovering over either thumb should cause the thumb to turn blue
* Clicking a thumb should change the color of the thumb to a (different) blue. The blue should persist even if the thumb is no longer being hovered over
* You should be able to pick either thumb at any time.
* Generate a second image. Once it's been generated observe that the thumbs up/down is selectable. If you press the left arrow on the carousel to go back to the first image, your rating there should remain the same.
* If you go back to your second image it should likewise retain the thumbs up/down rating, or have no rating if you didn't rate the image yet.