### PR TITLE
js-packages: Fix some JS lints ahead of the eslint 9 upgrade

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-js-packages-fix-eslint-9-lints
+++ b/projects/github-actions/repo-gardening/changelog/update-js-packages-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/projects/github-actions/repo-gardening/src/tasks/flag-oss/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/flag-oss/index.js
@@ -28,7 +28,7 @@ async function flagOss( payload, octokit ) {
 			org: owner.login,
 			username: head.user.login,
 		} );
-	} catch ( error ) {
+	} catch {
 		debug( `flag-oss: Adding OSS Citizen label to PR #${ number }` );
 		await octokit.rest.issues.addLabels( {
 			owner: owner.login,

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
@@ -38,7 +38,7 @@ async function addCommentAskLabels( octokit, ownerLogin, authorLogin, repo, issu
 			org: ownerLogin,
 			username: authorLogin,
 		} );
-	} catch ( error ) {
+	} catch {
 		debug(
 			`triage-issues > auto-label: Author ${ authorLogin } is not an org member. Skipping comment.`
 		);

--- a/projects/js-packages/ai-client/changelog/update-js-packages-fix-eslint-9-lints
+++ b/projects/js-packages/ai-client/changelog/update-js-packages-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/projects/js-packages/ai-client/src/data-flow/context.tsx
+++ b/projects/js-packages/ai-client/src/data-flow/context.tsx
@@ -8,8 +8,7 @@ import React, { createContext } from 'react';
 import SuggestionsEventSource from '../suggestions-event-source/index.js';
 import type { AskQuestionOptionsArgProps } from '../ask-question/index.js';
 import type { RequestingErrorProps } from '../hooks/use-ai-suggestions/index.js';
-import type { PromptProp } from '../types.js';
-import type { RequestingStateProp } from '../types.js';
+import type { PromptProp, RequestingStateProp } from '../types.js';
 
 export type AiDataContextProps = {
 	/*

--- a/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
@@ -21,8 +21,7 @@ import {
  */
 import type { AskQuestionOptionsArgProps } from '../../ask-question/index.js';
 import type SuggestionsEventSource from '../../suggestions-event-source/index.js';
-import type { PromptProp, SuggestionErrorCode } from '../../types.js';
-import type { RequestingStateProp } from '../../types.js';
+import type { PromptProp, SuggestionErrorCode, RequestingStateProp } from '../../types.js';
 
 export type RequestingErrorProps = {
 	/*

--- a/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
@@ -200,7 +200,6 @@ export const LogoPresenter: React.FC< LogoPresenterProps > = ( {
 	logoAccepted = false,
 	siteId,
 } ) => {
-	// eslint-disable-next-line @wordpress/no-unused-vars-before-return -- @todo Start extending jetpack-js-tools/eslintrc/react in eslintrc, then we can remove this disable comment.
 	const { isRequestingImage } = useLogoGenerator();
 	const { saveToLibraryError, logoUpdateError } = useRequestErrors();
 

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
@@ -6,8 +6,7 @@ import { Button, Tooltip, SelectControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
 import debugFactory from 'debug';
-import { useCallback, useEffect, useState, useRef } from 'react';
-import { Dispatch, SetStateAction } from 'react';
+import { useCallback, useEffect, useState, useRef, Dispatch, SetStateAction } from 'react';
 /**
  * Internal dependencies
  */

--- a/projects/js-packages/babel-plugin-replace-textdomain/changelog/update-js-packages-fix-eslint-9-lints
+++ b/projects/js-packages/babel-plugin-replace-textdomain/changelog/update-js-packages-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/projects/js-packages/babel-plugin-replace-textdomain/tests/plugin.test.js
+++ b/projects/js-packages/babel-plugin-replace-textdomain/tests/plugin.test.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/order */
-
 const mockOrigDebug = jest.requireActual( 'debug' );
 const mockDebug = jest.fn();
 jest.mock( 'debug', () => {

--- a/projects/js-packages/boost-score-api/changelog/update-js-packages-fix-eslint-9-lints
+++ b/projects/js-packages/boost-score-api/changelog/update-js-packages-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/projects/js-packages/boost-score-api/src/utils/json-types.ts
+++ b/projects/js-packages/boost-score-api/src/utils/json-types.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-use-before-define */
 /**
  * Generic type for handling JSON-like objects.
  *

--- a/projects/js-packages/components/changelog/update-js-packages-fix-eslint-9-lints
+++ b/projects/js-packages/components/changelog/update-js-packages-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/projects/js-packages/components/components/boost-score-bar/test/component.tsx
+++ b/projects/js-packages/components/components/boost-score-bar/test/component.tsx
@@ -18,14 +18,12 @@ describe( 'BoostScrollBar', () => {
 	it( 'renders the boost scroll bar when active is true', () => {
 		const { container } = render( <BoostScoreBar { ...defaultProps } /> );
 
-		// eslint-disable-next-line testing-library/no-node-access
 		expect( container.firstChild ).toHaveAttribute( 'class', 'jb-score-bar jb-score-bar--desktop' );
 	} );
 
 	it( 'does not render the boost scroll bar when active is false', () => {
 		const { container } = render( <BoostScoreBar { ...defaultProps } active={ false } /> );
 
-		// eslint-disable-next-line testing-library/no-node-access
 		expect( container ).toBeEmptyDOMElement();
 	} );
 

--- a/projects/js-packages/components/components/boost-score-graph/tooltips-plugin.ts
+++ b/projects/js-packages/components/components/boost-score-graph/tooltips-plugin.ts
@@ -17,10 +17,9 @@ export function tooltipsPlugin( periods ) {
 	/**
 	 * Initializes the tooltips plugin.
 	 *
-	 * @param {uPlot}  u     - The uPlot instance.
-	 * @param {object} _opts - Options for the uPlot instance.
+	 * @param {uPlot} u - The uPlot instance.
 	 */
-	function init( u: uPlot, _opts: object ) {
+	function init( u: uPlot ) {
 		container.classList.add( 'jb-score-tooltips-container' );
 		if ( ! reactDom ) {
 			reactDom = ReactDOM.createRoot( reactRoot );

--- a/projects/js-packages/components/components/dialog/stories/index.stories.tsx
+++ b/projects/js-packages/components/components/dialog/stories/index.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/react-in-jsx-scope */
 import React from 'react';
 import Dialog from '..';
 import ProductOffer from '../../product-offer';

--- a/projects/js-packages/components/components/diff-viewer/stories/index.stories.tsx
+++ b/projects/js-packages/components/components/diff-viewer/stories/index.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/react-in-jsx-scope */
 import React from 'react';
 import DiffViewer from '..';
 

--- a/projects/js-packages/components/components/number-slider/index.tsx
+++ b/projects/js-packages/components/components/number-slider/index.tsx
@@ -68,7 +68,7 @@ const NumberSlider: React.FC< NumberSliderProps > = ( {
 				min={ minValue }
 				step={ step }
 				renderThumb={ renderThumbCallback } // eslint-disable-line react/jsx-no-bind
-				onChange={ onChange } // eslint-disable-line react/jsx-no-bind
+				onChange={ onChange }
 				onBeforeChange={ onBeforeChangeCallback } // eslint-disable-line react/jsx-no-bind
 				onAfterChange={ onAfterChangeCallback } // eslint-disable-line react/jsx-no-bind
 			/>

--- a/projects/js-packages/components/components/pricing-table/index.tsx
+++ b/projects/js-packages/components/components/pricing-table/index.tsx
@@ -1,15 +1,15 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, check, closeSmall } from '@wordpress/icons';
 import clsx from 'clsx';
-import {
+import React, {
 	createContext,
 	useContext,
 	Children,
 	cloneElement,
 	PropsWithChildren,
 	ReactElement,
+	CSSProperties,
 } from 'react';
-import React, { CSSProperties } from 'react';
 import IconTooltip from '../icon-tooltip';
 import useBreakpointMatch from '../layout/use-breakpoint-match';
 import TermsOfService from '../terms-of-service';

--- a/projects/js-packages/components/components/pricing-table/test/component.tsx
+++ b/projects/js-packages/components/components/pricing-table/test/component.tsx
@@ -36,6 +36,6 @@ describe( 'PricingTable', () => {
 		render( <PricingTable { ...testProps }></PricingTable> );
 		expect( screen.getAllByText( 'Dummy Item 1' ) ).toHaveLength( 2 );
 		expect( screen.getAllByText( 'Dummy Item 2' ) ).toHaveLength( 2 );
-		expect( screen.getAllByText( 'Dummy Item 3' ) ).toHaveLength( 1 ); // eslint-disable-line jest-dom/prefer-in-document
+		expect( screen.getAllByText( 'Dummy Item 3' ) ).toHaveLength( 1 );
 	} );
 } );

--- a/projects/js-packages/components/components/spinner/stories/index.stories.jsx
+++ b/projects/js-packages/components/components/spinner/stories/index.stories.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/react-in-jsx-scope */
 import React from 'react';
 import Spinner from '../index.jsx';
 

--- a/projects/js-packages/components/components/upsell-banner/stories/index.stories.tsx
+++ b/projects/js-packages/components/components/upsell-banner/stories/index.stories.tsx
@@ -9,7 +9,6 @@ export default {
 	},
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const BannerTemplate = args => {
 	// Set up the first CTA
 	const secondaryCtaLabel = 'Learn more';

--- a/projects/js-packages/connection/changelog/update-js-packages-fix-eslint-9-lints
+++ b/projects/js-packages/connection/changelog/update-js-packages-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/projects/js-packages/connection/components/connect-screen/basic/stories/index.stories.jsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/stories/index.stories.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/react-in-jsx-scope */
 import { action } from '@storybook/addon-actions';
 import React from 'react';
 import ConnectScreenVisual from '../visual';

--- a/projects/js-packages/connection/components/connect-screen/basic/visual.tsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/visual.tsx
@@ -1,5 +1,4 @@
-import { ActionButton, TermsOfService } from '@automattic/jetpack-components';
-import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ActionButton, TermsOfService, getRedirectUrl } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import React from 'react';

--- a/projects/js-packages/connection/components/connect-screen/required-plan/stories/index.stories.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/stories/index.stories.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/react-in-jsx-scope */
 import { action } from '@storybook/addon-actions';
 import React from 'react';
 import ConnectScreenRequiredPlanVisual from '../visual';

--- a/projects/js-packages/connection/components/disconnect-dialog/steps/step-survey.jsx
+++ b/projects/js-packages/connection/components/disconnect-dialog/steps/step-survey.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-noninteractive-tabindex */
-
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/projects/js-packages/eslint-config-target-es/changelog/update-js-packages-fix-eslint-9-lints
+++ b/projects/js-packages/eslint-config-target-es/changelog/update-js-packages-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/projects/js-packages/eslint-config-target-es/src/flatconfig/base.js
+++ b/projects/js-packages/eslint-config-target-es/src/flatconfig/base.js
@@ -14,7 +14,7 @@ try {
 	if ( globals?.es2022 ) {
 		flatBase.languageOptions.globals = globals.es2022;
 	}
-} catch ( e ) {
+} catch {
 	// `globals` is optional.
 }
 

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/update-js-packages-fix-eslint-9-lints
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/update-js-packages-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/projects/js-packages/i18n-loader-webpack-plugin/tests/globals.js
+++ b/projects/js-packages/i18n-loader-webpack-plugin/tests/globals.js
@@ -23,7 +23,7 @@ class I18nLoader {
 		if ( ret === null ) {
 			throw new Error( `Path ${ path } was requested multiple times` );
 		}
-		this.expect[ expect ] = null;
+		this.expect[ path ] = null;
 		return ret( domain );
 	}
 

--- a/projects/js-packages/licensing/changelog/update-js-packages-fix-eslint-9-lints
+++ b/projects/js-packages/licensing/changelog/update-js-packages-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/projects/js-packages/licensing/components/golden-token-modal/index.jsx
+++ b/projects/js-packages/licensing/components/golden-token-modal/index.jsx
@@ -79,7 +79,6 @@ function GoldenTokenModal( {
 							onClick={ maybeReanimate }
 							role="presentation"
 						>
-							{ /* eslint-disable-next-line jsx-a11y/media-has-caption */ }
 							<video
 								ref={ videoRef }
 								src="https://videos.files.wordpress.com/oSlNIBQO/jetpack-golden-token.mp4"

--- a/projects/js-packages/publicize-components/changelog/update-js-packages-fix-eslint-9-lints
+++ b/projects/js-packages/publicize-components/changelog/update-js-packages-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/projects/js-packages/publicize-components/src/components/connection-management/tests/pageObjects/PanelPage.js
+++ b/projects/js-packages/publicize-components/src/components/connection-management/tests/pageObjects/PanelPage.js
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 export class Panel {
@@ -11,19 +11,19 @@ export class Panel {
 	}
 
 	get disconnectButton() {
-		return screen.queryByRole( this.container, 'button', { name: 'Disconnect' } );
+		return within( this.container ).queryByRole( 'button', { name: 'Disconnect' } );
 	}
 
 	get closeButton() {
-		return screen.getByRole( this.container, 'button', { name: 'Close panel' } );
+		return within( this.container ).getByRole( 'button', { name: 'Close panel' } );
 	}
 
 	get openButton() {
-		return screen.getByRole( this.container, 'button', { name: 'Open panel' } );
+		return within( this.container ).getByRole( 'button', { name: 'Open panel' } );
 	}
 
 	get markAsSharedToggle() {
-		return screen.queryByRole( this.container, 'checkbox', {
+		return within( this.container ).queryByRole( 'checkbox', {
 			name: 'Mark the connection as shared',
 		} );
 	}

--- a/projects/js-packages/publicize-components/src/components/connection-management/tests/pageObjects/PanelPage.js
+++ b/projects/js-packages/publicize-components/src/components/connection-management/tests/pageObjects/PanelPage.js
@@ -1,4 +1,4 @@
-import { getByRole, queryByRole, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 export class Panel {
@@ -11,19 +11,21 @@ export class Panel {
 	}
 
 	get disconnectButton() {
-		return queryByRole( this.container, 'button', { name: 'Disconnect' } );
+		return screen.queryByRole( this.container, 'button', { name: 'Disconnect' } );
 	}
 
 	get closeButton() {
-		return getByRole( this.container, 'button', { name: 'Close panel' } );
+		return screen.getByRole( this.container, 'button', { name: 'Close panel' } );
 	}
 
 	get openButton() {
-		return getByRole( this.container, 'button', { name: 'Open panel' } );
+		return screen.getByRole( this.container, 'button', { name: 'Open panel' } );
 	}
 
 	get markAsSharedToggle() {
-		return queryByRole( this.container, 'checkbox', { name: 'Mark the connection as shared' } );
+		return screen.queryByRole( this.container, 'checkbox', {
+			name: 'Mark the connection as shared',
+		} );
 	}
 
 	isOpen() {

--- a/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
@@ -1,11 +1,10 @@
-import { Button, useGlobalNotices } from '@automattic/jetpack-components';
-import { getRedirectUrl } from '@automattic/jetpack-components';
+import { Button, useGlobalNotices, getRedirectUrl } from '@automattic/jetpack-components';
 import {
 	BaseControl,
 	FlexBlock,
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	ExternalLink,
 } from '@wordpress/components';
-import { ExternalLink } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useMemo } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';

--- a/projects/js-packages/publicize-components/src/components/share-buttons/share-buttons.tsx
+++ b/projects/js-packages/publicize-components/src/components/share-buttons/share-buttons.tsx
@@ -1,5 +1,4 @@
-import { SocialServiceIcon, Button, Text } from '@automattic/jetpack-components';
-import { CopyToClipboard } from '@automattic/jetpack-components';
+import { SocialServiceIcon, Button, Text, CopyToClipboard } from '@automattic/jetpack-components';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
@@ -1,6 +1,5 @@
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { TabPanel } from '@wordpress/components';
-import { ToggleControl } from '@wordpress/components';
+import { TabPanel, ToggleControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
 import { useCallback } from 'react';

--- a/projects/js-packages/publicize-components/src/components/video-preview/index.js
+++ b/projects/js-packages/publicize-components/src/components/video-preview/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/media-has-caption */
 import { useCallback, useRef, useState, useEffect } from '@wordpress/element';
 import styles from './styles.module.scss';
 

--- a/projects/js-packages/react-data-sync-client/changelog/update-js-packages-fix-eslint-9-lints
+++ b/projects/js-packages/react-data-sync-client/changelog/update-js-packages-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/projects/js-packages/react-data-sync-client/src/DataSync.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSync.ts
@@ -223,7 +223,6 @@ export class DataSync< Schema extends z.ZodSchema, Value extends z.infer< Schema
 		try {
 			data = JSON.parse( text );
 		} catch ( error ) {
-			// eslint-disable-next-line no-console
 			throw new DataSyncError( 'Failed to JSON.parse() the response from the server.', {
 				...this.describeSelf(),
 				location: url,

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -8,8 +8,7 @@ import {
 	useMutation,
 	QueryClientProvider,
 } from '@tanstack/react-query';
-import React from 'react';
-import { useRef, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { z } from 'zod';
 import { DataSync } from './DataSync';
 import { DataSyncError } from './DataSyncError';

--- a/projects/js-packages/react-data-sync-client/tests/jest.config.cjs
+++ b/projects/js-packages/react-data-sync-client/tests/jest.config.cjs
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const path = require( 'path' );
 const coverageConfig = require( 'jetpack-js-tools/jest/config.coverage.js' );
 

--- a/projects/js-packages/react-data-sync-client/webpack.config.cjs
+++ b/projects/js-packages/react-data-sync-client/webpack.config.cjs
@@ -1,6 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require( 'path' );
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
 
 module.exports = {

--- a/projects/js-packages/shared-extension-utils/changelog/update-js-packages-fix-eslint-9-lints
+++ b/projects/js-packages/shared-extension-utils/changelog/update-js-packages-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/projects/js-packages/shared-extension-utils/src/modules-state/actions.js
+++ b/projects/js-packages/shared-extension-utils/src/modules-state/actions.js
@@ -25,7 +25,7 @@ export function* updateJetpackModuleStatus( settings ) {
 		const data = yield fetchJetpackModules();
 		yield setJetpackModules( { data } );
 		return true;
-	} catch ( e ) {
+	} catch {
 		const oldSettings = select( JETPACK_MODULES_STORE_ID ).getJetpackModules();
 		yield setJetpackModules( oldSettings );
 		return false;
@@ -49,7 +49,7 @@ export function* fetchModules() {
 		const data = yield fetchJetpackModules();
 		yield setJetpackModules( { data } );
 		return true;
-	} catch ( e ) {
+	} catch {
 		const oldSettings = select( JETPACK_MODULES_STORE_ID ).getJetpackModules();
 		yield setJetpackModules( oldSettings );
 		return false;

--- a/projects/js-packages/shared-extension-utils/src/register-jetpack-plugin.js
+++ b/projects/js-packages/shared-extension-utils/src/register-jetpack-plugin.js
@@ -13,6 +13,7 @@ export default function registerJetpackPlugin( name, settings ) {
 	const unavailable = ! available;
 
 	if ( unavailable ) {
+		// eslint-disable-next-line no-undef -- webpack defines it
 		if ( 'production' !== process.env.NODE_ENV ) {
 			// eslint-disable-next-line no-console
 			console.warn(

--- a/projects/js-packages/shared-extension-utils/src/with-has-warning-is-interactive-class-names/index.jsx
+++ b/projects/js-packages/shared-extension-utils/src/with-has-warning-is-interactive-class-names/index.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/react-in-jsx-scope */
-
 import { createHigherOrderComponent } from '@wordpress/compose';
 
 import './style.scss';

--- a/projects/js-packages/storybook/changelog/update-js-packages-fix-eslint-9-lints
+++ b/projects/js-packages/storybook/changelog/update-js-packages-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/projects/js-packages/storybook/storybook/preview.mjs
+++ b/projects/js-packages/storybook/storybook/preview.mjs
@@ -1,9 +1,7 @@
 import { ThemeProvider } from '@automattic/jetpack-components';
 import React from 'react';
 
-/* eslint-disable no-restricted-syntax */
 // import '@wordpress/components/build-style/style.css';
-/* eslint-enable no-restricted-syntax */
 
 import './style.scss';
 

--- a/projects/js-packages/storybook/storybook/stories/playground/index.stories.jsx
+++ b/projects/js-packages/storybook/storybook/stories/playground/index.stories.jsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/react-in-jsx-scope,jsdoc/no-undefined-types */
+/* eslint-disable jsdoc/no-undefined-types */
 import {
 	BlockEditorKeyboardShortcuts,
 	BlockEditorProvider,

--- a/projects/js-packages/svelte-data-sync-client/changelog/update-js-packages-fix-eslint-9-lints
+++ b/projects/js-packages/svelte-data-sync-client/changelog/update-js-packages-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/projects/js-packages/svelte-data-sync-client/tests/jest.config.cjs
+++ b/projects/js-packages/svelte-data-sync-client/tests/jest.config.cjs
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const path = require( 'path' );
 const coverageConfig = require( 'jetpack-js-tools/jest/config.coverage.js' );
 

--- a/projects/js-packages/svelte-data-sync-client/webpack.config.cjs
+++ b/projects/js-packages/svelte-data-sync-client/webpack.config.cjs
@@ -1,6 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require( 'path' );
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
 
 module.exports = {

--- a/projects/js-packages/videopress-core/changelog/update-js-packages-fix-eslint-9-lints
+++ b/projects/js-packages/videopress-core/changelog/update-js-packages-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/projects/js-packages/videopress-core/webpack.config.cjs
+++ b/projects/js-packages/videopress-core/webpack.config.cjs
@@ -1,6 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require( 'path' );
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
 
 module.exports = {

--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -146,7 +146,6 @@ const List: React.FC< ListProps > = ( {
 	inputRows = 10,
 } ) => {
 	const [ inputValue, setInputValue ] = useState( items );
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const [ inputInvalid, setInputInvalid ] = useState( false );
 	const [ validationError, setValidationError ] = useState< Error | null >( null );
 	const premiumFeatures = usePremiumFeatures();

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -159,7 +159,6 @@ const BypassPatterns = ( {
 }: BypassPatternsProps ) => {
 	const [ inputValue, setInputValue ] = useState( patterns );
 	const [ showNotice, setShowNotice ] = useState( showErrorNotice );
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const [ inputInvalid, setInputInvalid ] = useState( false );
 
 	const exclusionsLink = getRedirectUrl( 'jetpack-boost-cache-how-to-exclude' );

--- a/projects/plugins/boost/app/assets/src/js/lib/utils/json-types.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/utils/json-types.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-use-before-define */
-
 import { z } from 'zod';
 
 /**

--- a/projects/plugins/boost/app/assets/src/js/main.tsx
+++ b/projects/plugins/boost/app/assets/src/js/main.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
 	createHashRouter,
 	redirect,

--- a/projects/plugins/boost/changelog/update-js-packages-fix-eslint-9-lints
+++ b/projects/plugins/boost/changelog/update-js-packages-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/tools/js-tools/eslintrc/base.js
+++ b/tools/js-tools/eslintrc/base.js
@@ -34,7 +34,6 @@ module.exports = {
 		'plugin:@wordpress/custom',
 		'plugin:@wordpress/esnext',
 		'plugin:@wordpress/i18n',
-		'plugin:jsx-a11y/recommended',
 		'plugin:prettier/recommended',
 	],
 	env: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
To make the eslint 9 upgrade PR smaller, let's fix some of the lints that it'll complain about ahead of time.

Of particular note is that, when we added 'plugin:@wordpress/jsx-a11y' in #38436, we accidentally left 'plugin:jsx-a11y/recommended' in place after it which overrides some of the configuration that 'plugin:@wordpress/jsx-a11y' does. Fixing that disables a few rules we had been inline-ignoring in various places: jsx-a11y/media-has-caption, jsx-a11y/no-noninteractive-tabindex, and jsx-a11y/role-has-required-aria-props.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
