### PR TITLE
Forms Block: Fix Broken URL Input Validation

### DIFF
--- a/projects/packages/forms/changelog/fix-form-block-broken-url-input-validation
+++ b/projects/packages/forms/changelog/fix-form-block-broken-url-input-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Form Block: fixed validation of URL input types to allow query strings.

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -227,6 +227,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		switch ( $field_type ) {
 			case 'url':
 				if ( ! is_string( $field_value ) || empty( $field_value ) || ! preg_match(
+					// Changes to this regex should be synced with the regex in the render_url_field method of this class as both validate the same input. Note that this regex is in PCRE format.
 					'%^(?:(?:https?|ftp)://)?(?:\S+(?::\S*)?@|\d{1,3}(?:\.\d{1,3}){3}|(?:(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)(?:\.(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)*(?:\.[a-z\x{00a1}-\x{ffff}]{2,6}))(?::\d+)?(?:[^\s]*)?$%iu',
 					$field_value
 				) ) {
@@ -590,6 +591,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			'title'              => $custom_validation_message,
 			'oninvalid'          => 'setCustomValidity("' . $custom_validation_message . '")',
 			'oninput'            => 'setCustomValidity("")',
+			// Changes to this regex should be synced with the regex in the URL validation of the validate method of this class as both validate the same input. Note that this regex is in ECMAScript (JS) format.
 			'pattern'            => '(?:(?:[Hh][Tt][Tt][Pp][Ss]?|[Ff][Tt][Pp]):\/\/)?(?:\S+(?::\S*)?@|\d{1,3}(?:\.\d{1,3}){3}|(?:(?:[a-zA-Z\d\u00a1-\uffff]+-?)*[a-zA-Z\d\u00a1-\uffff]+)(?:\.(?:[a-zA-Z\d\u00a1-\uffff]+-?)*[a-zA-Z\d\u00a1-\uffff]+)*(?:\.[a-zA-Z\u00a1-\uffff]{2,6}))(?::\d+)?(?:[^\s]*)?',
 			'data-type-override' => 'url',
 		);

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -590,7 +590,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			'title'              => $custom_validation_message,
 			'oninvalid'          => 'setCustomValidity("' . $custom_validation_message . '")',
 			'oninput'            => 'setCustomValidity("")',
-			'pattern'            => '(([:\/a-zA-Z0-9_\-]+)?(\.[a-zA-Z0-9_\-\/]+)+)',
+			'pattern'            => '(?:(?:[Hh][Tt][Tt][Pp][Ss]?|[Ff][Tt][Pp]):\/\/)?(?:\S+(?::\S*)?@|\d{1,3}(?:\.\d{1,3}){3}|(?:(?:[a-zA-Z\d\u00a1-\uffff]+-?)*[a-zA-Z\d\u00a1-\uffff]+)(?:\.(?:[a-zA-Z\d\u00a1-\uffff]+-?)*[a-zA-Z\d\u00a1-\uffff]+)*(?:\.[a-zA-Z\u00a1-\uffff]{2,6}))(?::\d+)?(?:[^\s]*)?',
 			'data-type-override' => 'url',
 		);
 

--- a/projects/plugins/jetpack/changelog/fix-form-block-broken-url-input-validation
+++ b/projects/plugins/jetpack/changelog/fix-form-block-broken-url-input-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Form Block: fixed validation of URL input types to allow query strings.


### PR DESCRIPTION
Fixes https://github.com/Automattic/jpop-issues/issues/9387

A [wp.org support request](https://wordpress.org/support/topic/jetpack-forms-url-field-rejects-any-url-containing/) reported that the `=` character as part of a query string was not passing validation. Looking at the code, the URL input was validated in two ways: as an HTML `pattern` attribute regex and as a PHP regex match. These validations were added in #27138, and the two types of validation have different regexes.

This PR fixes the issue by updating the HTML `pattern` attribute regex to match the regex pattern used by PHP. Since the PHP regex doesn't suffer the reported bug and matches many more forms of URLs than the replaced `pattern` attribute regex, this fix addresses the reported issue and fixes other undesired validation failures that the original `pattern` attribute regex has.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

### Does this pull request change what data or activity we track or use?

No.

## Testing instructions:
1. Don't switch to this PR branch yet.
2. Add a Forms block to a page, add a URL input to the form, publish the page, and view the page.
3. Input a URL with a query string into the URL input, such as `http://example.com/?test=test`, and try to submit the form. The form submission should be blocked, and the URL input should show an error: "Please enter a valid URL".
4. Switch to this PR branch.
5. Refresh the testing page.
6. Input a URL with a query string into the URL input, such as `http://example.com/?test=test`, and try to submit the form. The form submission should be approved or no longer show a URL input error.