### PR TITLE
Blogging prompts endpoint: Disable bloganuary

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
@@ -335,17 +335,16 @@ class WPCOM_REST_API_V3_Endpoint_Blogging_Prompts extends WP_REST_Posts_Controll
 	/**
 	 * Return true if the post is in "Bloganuary"
 	 *
-	 * @param string $post_date_gmt Post date in GMT.
 	 * @return bool True if the post is in "Bloganuary".
 	 */
-	protected function is_in_bloganuary( $post_date_gmt ) {
-		// Disable for January 2025 (see https://wp.me/p5uIfZ-gxX).
-		$enable_bloganuary = false;
-		if ( ! $enable_bloganuary ) {
-			return false;
-		}
-		$post_month = gmdate( 'm', strtotime( $post_date_gmt ) );
-		return $post_month === '01';
+	protected function is_in_bloganuary() {
+		/*
+		Disable for January 2025 and beyond (see https://wp.me/p5uIfZ-gxX).
+			Previously, this method would check if the post was published in January:
+			- Extract month from post_date_gmt
+			- Return true if month was '01'
+		*/
+		return false;
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
@@ -339,6 +339,11 @@ class WPCOM_REST_API_V3_Endpoint_Blogging_Prompts extends WP_REST_Posts_Controll
 	 * @return bool True if the post is in "Bloganuary".
 	 */
 	protected function is_in_bloganuary( $post_date_gmt ) {
+		// Disable for January 2025 (see https://wp.me/p5uIfZ-gxX).
+		$enable_bloganuary = false;
+		if ( ! $enable_bloganuary ) {
+			return false;
+		}
 		$post_month = gmdate( 'm', strtotime( $post_date_gmt ) );
 		return $post_month === '01';
 	}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
@@ -338,7 +338,8 @@ class WPCOM_REST_API_V3_Endpoint_Blogging_Prompts extends WP_REST_Posts_Controll
 	 * @param string $post_date_gmt Unused - Post date in GMT.
 	 * @return bool Always returns false as Bloganuary is disabled.
 	 */
-	protected function is_in_bloganuary( $post_date_gmt ) {
+	protected function is_in_bloganuary( $post_date_gmt ) { //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+
 		/*
 		Disable for January 2025 and beyond (see https://wp.me/p5uIfZ-gxX).
 			Previously, this method would check if the post was published in January:

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
@@ -335,14 +335,15 @@ class WPCOM_REST_API_V3_Endpoint_Blogging_Prompts extends WP_REST_Posts_Controll
 	/**
 	 * Return true if the post is in "Bloganuary"
 	 *
-	 * @return bool True if the post is in "Bloganuary".
+	 * @param string $post_date_gmt Unused - Post date in GMT.
+	 * @return bool Always returns false as Bloganuary is disabled.
 	 */
-	protected function is_in_bloganuary() {
+	protected function is_in_bloganuary( $post_date_gmt ) {
 		/*
 		Disable for January 2025 and beyond (see https://wp.me/p5uIfZ-gxX).
 			Previously, this method would check if the post was published in January:
-			- Extract month from post_date_gmt
-			- Return true if month was '01'
+			- Extract month from post_date_gmt -- $post_month = gmdate( 'm', strtotime( $post_date_gmt ) );
+			- Return true if month was '01' -- return $post_month === '01';
 		*/
 		return false;
 	}

--- a/projects/plugins/jetpack/changelog/disable-bloganuary
+++ b/projects/plugins/jetpack/changelog/disable-bloganuary
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Blogging prompts endpoint: disable bloganuary for 2025.
+Blogging prompts endpoint: disable bloganuary for 2025 and beyond.

--- a/projects/plugins/jetpack/changelog/disable-bloganuary
+++ b/projects/plugins/jetpack/changelog/disable-bloganuary
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Blogging prompts endpoint: disable bloganuary for 2025.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/loop/issues/242

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disable bloganuary by returning `false` for `is_in_bloganuary`. Because we're not sure if we'll resume it in 2026, I want to leave as much code in place as possible. But I also don't want to check for the year 2025, because we may not want this to kick in in 2026. Checking for >= 2025 seems excessive since that's basically the same as `return false`. So I've commented out the code and suppressed the unused variable warning.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open https://developer.wordpress.com/docs/api/console/
* Choose WP Rest API, wpcom/v3, GET /sites/{site}/blogging-prompts and pick a {site} to test with.
* Run the query with `after` `--01-01` and `force_year` `2025`. The prompts will be returned with label "Bloganuary writing prompt."
* Apply this change to your sandbox (`bin/jetpack-downloader test jetpack disable/bloganuary`) and sandbox the API.
* Run the query with `after` `--01-01` and `force_year` `2025`. The prompts will be returned with label "Daily writing prompt."
