### PR TITLE
plugins: Fix some JS lints ahead of the eslint 9 upgrade

### DIFF
--- a/projects/plugins/crm/changelog/update-plugins-fix-eslint-9-lints
+++ b/projects/plugins/crm/changelog/update-plugins-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
@@ -182,7 +182,7 @@ function zbscrm_JS_adminMenuDropdown() {
 				if ( hopscotch.getState() != null ) {
 					hopscotch.endTour();
 				}
-			} catch ( err ) {
+			} catch {
 				// Do nothing.
 			}
 

--- a/projects/plugins/debug-helper/changelog/update-plugins-fix-eslint-9-lints
+++ b/projects/plugins/debug-helper/changelog/update-plugins-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/projects/plugins/debug-helper/modules/inc/js/rest-api-tester.js
+++ b/projects/plugins/debug-helper/modules/inc/js/rest-api-tester.js
@@ -88,7 +88,7 @@ class Jetpack_Debug_REST_API_Tester {
 			try {
 				const parsedResponse = JSON.parse( responseText );
 				responseText = JSON.stringify( parsedResponse, null, 4 );
-			} catch ( e ) {
+			} catch {
 				responseText = 'Invalid JSON:\n' + responseText;
 			}
 		}

--- a/projects/plugins/inspect/changelog/update-plugins-fix-eslint-9-lints
+++ b/projects/plugins/inspect/changelog/update-plugins-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/projects/plugins/inspect/packages/Async_Option/scripts/types.d.ts
+++ b/projects/plugins/inspect/packages/Async_Option/scripts/types.d.ts
@@ -1,20 +1,20 @@
 import type { Writable } from 'svelte/store';
 
 export namespace AsyncOptions {
-	interface Options {
+	export interface Options {
 		[ key: string ]: {
-			value: any;
+			value: unknown;
 			nonce: string;
 		};
 	}
 
-	interface PendingStore {
+	export interface PendingStore {
 		subscribe: Writable< boolean >[ 'subscribe' ];
 		stop: () => void;
 		start: () => void;
 	}
 
-	interface OptionStore< T > {
+	export interface OptionStore< T > {
 		value: Writable< T >;
 		pending: PendingStore;
 	}

--- a/projects/plugins/protect/changelog/update-plugins-fix-eslint-9-lints
+++ b/projects/plugins/protect/changelog/update-plugins-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/projects/plugins/protect/src/js/components/alert-icon/stories/index.stories.jsx
+++ b/projects/plugins/protect/src/js/components/alert-icon/stories/index.stories.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/react-in-jsx-scope */
 import React from 'react';
 import AlertIcon from '../index.jsx';
 

--- a/projects/plugins/protect/src/js/components/button-group/stories/index.stories.jsx
+++ b/projects/plugins/protect/src/js/components/button-group/stories/index.stories.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/react-in-jsx-scope */
 import { Button } from '@automattic/jetpack-components';
 import React from 'react';
 import ButtonGroup from '../index.jsx';

--- a/projects/plugins/protect/src/js/components/pricing-table/stories/broken/index.stories.jsx
+++ b/projects/plugins/protect/src/js/components/pricing-table/stories/broken/index.stories.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/react-in-jsx-scope */
 import React from 'react';
 import { initStore } from '../../../state/store';
 import { jetpackProtectInitialState } from '../../interstitial-page/stories/mock.js';

--- a/projects/plugins/protect/src/js/data/scan/use-scan-status-query.ts
+++ b/projects/plugins/protect/src/js/data/scan/use-scan-status-query.ts
@@ -7,8 +7,8 @@ import {
 	SCAN_IN_PROGRESS_STATUSES,
 	SCAN_STATUS_IDLE,
 	SCAN_STATUS_UNAVAILABLE,
+	QUERY_SCAN_STATUS_KEY,
 } from '../../constants';
-import { QUERY_SCAN_STATUS_KEY } from './../../constants';
 
 export const isRequestedScanNotStarted = ( status: ScanStatus ) => {
 	if ( status.status !== 'idle' ) {

--- a/projects/plugins/protect/src/js/hooks/use-modal.tsx
+++ b/projects/plugins/protect/src/js/hooks/use-modal.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useState } from 'react';
 
 interface ModalState {
 	type?: string;

--- a/projects/plugins/protect/src/js/routes/firewall/index.jsx
+++ b/projects/plugins/protect/src/js/routes/firewall/index.jsx
@@ -150,7 +150,7 @@ const FirewallPage = () => {
 		try {
 			toggleAutomaticRules();
 			setAutomaticRulesInstallationError( false );
-		} catch ( error ) {
+		} catch {
 			setAutomaticRulesInstallationError( true );
 			setFormState( prevState => ( {
 				...prevState,

--- a/projects/plugins/protect/src/js/routes/setup/stories/broken/index.stories.jsx
+++ b/projects/plugins/protect/src/js/routes/setup/stories/broken/index.stories.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/react-in-jsx-scope */
 import React from 'react';
 import { initStore } from '../../../state/store';
 import InterstitialPage from '../index.jsx';

--- a/projects/plugins/super-cache/changelog/update-plugins-fix-eslint-9-lints
+++ b/projects/plugins/super-cache/changelog/update-plugins-fix-eslint-9-lints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some JS lints ahead of eslint 9 upgrade.
+
+

--- a/projects/plugins/super-cache/tests/e2e/lib/plugin-tools.ts
+++ b/projects/plugins/super-cache/tests/e2e/lib/plugin-tools.ts
@@ -58,7 +58,7 @@ export async function getAuthCookie(): Promise< string > {
  * @param {string} authCookie - Authentication cookie to use for the request.
  * @param {Method} method     - HTTP method to use. e.g.: 'GET'.
  * @param {string} url        - URL to request.
- * @param {Object} data       - Key / value pairs (strings) to submit as post data.
+ * @param {object} data       - Key / value pairs (strings) to submit as post data.
  */
 export async function authenticatedRequest(
 	authCookie: string,
@@ -84,7 +84,7 @@ export async function authenticatedRequest(
  * Returns a URL within the plugin site.
  *
  * @param {string} path  - The path relative to the site URL.
- * @param {Object} query - Query parameters to add to the URL.
+ * @param {object} query - Query parameters to add to the URL.
  * @return {string} The site URL.
  */
 export function getSiteUrl( path = '/', query: Record< string, string > = {} ): string {

--- a/projects/plugins/super-cache/tests/e2e/lib/test-tools.ts
+++ b/projects/plugins/super-cache/tests/e2e/lib/test-tools.ts
@@ -6,7 +6,7 @@ import { getSiteUrl } from './plugin-tools';
  * Loads the specified page and returns the response body. Expects a 200 response so tests fail otherwise.
  *
  * @param {string} path   The path within the test site to load.
- * @param {Object} params GET parameters to add to the URL.
+ * @param {object} params GET parameters to add to the URL.
  */
 export async function loadPage( path = '/', params = {} ): Promise< string > {
 	const response = await axios.get( getSiteUrl( path, params ) );

--- a/projects/plugins/super-cache/tests/e2e/lib/wordpress-tools.ts
+++ b/projects/plugins/super-cache/tests/e2e/lib/wordpress-tools.ts
@@ -2,7 +2,6 @@ import { expect } from '@jest/globals';
 import {
 	dockerExec,
 	deleteLinesFromContainerFile,
-	deleteContainerDirectory,
 	deleteContainerFile,
 	decodeContainerFile,
 	writeContainerFile,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
To make the eslint 9 upgrade PR smaller, let's fix some of the lints that it'll complain about ahead of time.

Jetpack is left for a separate PR, because it's so big.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
