### PR TITLE
Jetpack AI: change image modals placeholders

### DIFF
--- a/projects/plugins/jetpack/changelog/change-jetpack-ai-image=modals-placeholders
+++ b/projects/plugins/jetpack/changelog/change-jetpack-ai-image=modals-placeholders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: change placeholders on image generation modals to try and improve styles discoverability

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.tsx
@@ -182,8 +182,6 @@ export default function AiImageModal( {
 										value={ style }
 										options={ styles }
 										onChange={ updateStyle }
-										// TODO: disable when necessary
-										// disabled={ isBusy || requireUpgrade }
 									/>
 								</div>
 							</div>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -409,7 +409,7 @@ export default function FeaturedImage( {
 				acceptButton={ acceptButton }
 				generateButtonLabel={ pointer?.current > 0 ? generateAgainText : generateText }
 				instructionsPlaceholder={ __(
-					"Describe the image you'd like to create, or have the prompt written for you if you've added content to your post.",
+					"Describe the featured image you'd like to create and select a style.",
 					'jetpack'
 				) }
 				imageStyles={ imageStyles }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/general-purpose-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/general-purpose-image.tsx
@@ -278,7 +278,10 @@ export default function GeneralPurposeImage( {
 			handleNextImage={ handleNextImage }
 			acceptButton={ acceptButton }
 			generateButtonLabel={ pointer?.current > 0 ? generateAgainText : generateText }
-			instructionsPlaceholder={ __( "Describe the image you'd like to create.", 'jetpack' ) }
+			instructionsPlaceholder={ __(
+				"Describe the image you'd like to create and select a style.",
+				'jetpack'
+			) }
 			imageStyles={ imageStyles }
 			onGuessStyle={ guessStyle }
 			prompt={ prompt }


### PR DESCRIPTION
Try to improve styles discoverability

## Proposed changes:
This PR changes the AI input placeholders on the image generation modals, including a small CTA for the user to try the styles dropdown

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1733511575532349-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add an image block and choose to "Generate with AI", see the placeholder reads:
> Describe the image you'd like to create and select a style.

Use the sidebar dropdown to "Set featured image" and choose "Generate with AI, see the placeholder reads:
> Describe the featured image you'd like to create and select a style.

NOTE: if you have content on your post, the Featured Image modal will immediately generate a prompt and an image, hence the placeholder won't be seen. You can delete the prompt input to see the placeholder.