### PR TITLE
Jetpack AI: Adding tooltips to AI feedback component

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-feedback-add-tooltips
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-feedback-add-tooltips
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Adding tooltips to AI feedback component

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-feedback/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-feedback/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@wordpress/components';
+import { Button, Tooltip } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { thumbsUp, thumbsDown } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -31,26 +31,30 @@ export default function AiFeedbackThumbs( { disabled = false, iconSize = 24, rat
 
 	return getFeatureAvailability( 'ai-response-feedback' ) ? (
 		<div className="ai-assistant-feedback__selection">
-			<Button
-				aria-label={ __( 'Good Response', 'jetpack' ) }
-				disabled={ disabled }
-				icon={ thumbsUp }
-				onClick={ () => rateAI( true ) }
-				iconSize={ iconSize }
-				showTooltip={ false }
-				className={ clsx( { 'ai-assistant-feedback__thumb-selected': checkThumb( 'thumbs-up' ) } ) }
-			/>
-			<Button
-				aria-label={ __( 'Bad Response', 'jetpack' ) }
-				disabled={ disabled }
-				icon={ thumbsDown }
-				onClick={ () => rateAI( false ) }
-				iconSize={ iconSize }
-				showTooltip={ false }
-				className={ clsx( {
-					'ai-assistant-feedback__thumb-selected': checkThumb( 'thumbs-down' ),
-				} ) }
-			/>
+			<Tooltip text={ __( 'I like this', 'jetpack' ) }>
+				<Button
+					disabled={ disabled }
+					icon={ thumbsUp }
+					onClick={ () => rateAI( true ) }
+					iconSize={ iconSize }
+					showTooltip={ false }
+					className={ clsx( {
+						'ai-assistant-feedback__thumb-selected': checkThumb( 'thumbs-up' ),
+					} ) }
+				/>
+			</Tooltip>
+			<Tooltip text={ __( "I don't find this useful", 'jetpack' ) }>
+				<Button
+					disabled={ disabled }
+					icon={ thumbsDown }
+					onClick={ () => rateAI( false ) }
+					iconSize={ iconSize }
+					showTooltip={ false }
+					className={ clsx( {
+						'ai-assistant-feedback__thumb-selected': checkThumb( 'thumbs-down' ),
+					} ) }
+				/>
+			</Tooltip>
 		</div>
 	) : (
 		<></>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #[40505](https://github.com/Automattic/jetpack/issues/40505)

## Proposed changes:
* Adding tooltips to the thumbs up/down buttons in the AI feedback component

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No!

## Testing instructions:
* Check out or otherwise utilize this branch somewhere.
* Enable the component with `add_filter( 'ai_response_feedback_enabled', '__return_true' );`
* Open the AI image modal. The empty modal should have disabled thumbs up and down buttons. Hovering over them should not display a tooltip.
* Generate any image. Once it's done generating hover over the thumbs up and down. They should have tooltips:

Thumbs up: 
![Screenshot 2024-12-06 at 4 53 03 PM](https://github.com/user-attachments/assets/29612cc4-c74e-46f9-9f4f-d67df447c7f2)

Thumbs down (the tooltip should say "I don't find this useful"):
![Screenshot 2024-12-06 at 4 53 12 PM](https://github.com/user-attachments/assets/90bb9069-ce84-429f-b866-885832c89489)
