### PR TITLE
Restore visited button color in themes.php to Core's default

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-theme-button-color
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-theme-button-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Restore visited button color in themes.php to Core's default

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-theme-fixes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-theme-fixes.php
@@ -29,16 +29,3 @@ function wpcom_themes_remove_wpcom_actions() {
 	);
 }
 add_action( 'load-themes.php', 'wpcom_themes_remove_wpcom_actions' );
-
-/**
- * Adds a CSS file to fix UI issues in the theme browser.
- */
-function wpcom_themes_load_ui_fixes() {
-	wp_enqueue_style(
-		'wpcom-themes-ui-fixes',
-		plugins_url( 'css/ui-fixes.css', __FILE__ ),
-		array(),
-		Jetpack_Mu_Wpcom::PACKAGE_VERSION
-	);
-}
-add_action( 'load-themes.php', 'wpcom_themes_load_ui_fixes' );


### PR DESCRIPTION
Reverts https://github.com/Automattic/jetpack/pull/37343

The above PR caused a regression where the Activate button of a previously activated theme becomes unreadable.

The PR was a workaround to Help Center's leaked CSS. As far as I check, it seems that the CSS is not leaked anymore, so by removing it it also fixes the issue.

## Proposed changes:

|Before|After|
|-|-|
|<img width="354" alt="image" src="https://github.com/user-attachments/assets/3ad088d0-9c6c-473c-97ed-546bb008f1f5">|<img width="360" alt="image" src="https://github.com/user-attachments/assets/d6b950ce-6205-4a11-8233-e3f6c6438fe5">|


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Prepare a site with Classic admin interface
2. Go to themes.php.
3. Activate a theme.
4. Activate another theme.
5. Hover to the previously activated theme.
6. Verify that the Activate button is white (not readable).
7. Patch this PR.
8. Verify that the Activate button is now visible.
9. Test on Simple and Atomic.

