### PR TITLE
Holiday snow: do not display on p2

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-snow-p2s
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-snow-p2s
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Holiday Snow: do not display on p2s.

--- a/projects/packages/jetpack-mu-wpcom/src/features/holiday-snow/class-holiday-snow.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/holiday-snow/class-holiday-snow.php
@@ -48,6 +48,18 @@ class Holiday_Snow {
 	}
 
 	/**
+	 * Check if the site uses p2.
+	 * p2 is currently not compatible with Holiday Snow.
+	 * This covers both P2 and P2020 themes.
+	 *
+	 * @return bool
+	 */
+	private static function is_p2() {
+		return str_contains( get_stylesheet(), 'pub/p2' )
+			|| function_exists( '\WPForTeams\is_wpforteams_site' ) && is_wpforteams_site( get_current_blog_id() );
+	}
+
+	/**
 	 * Check if the snow is enabled.
 	 *
 	 * @return bool
@@ -62,7 +74,7 @@ class Holiday_Snow {
 	 * @return void
 	 */
 	public static function init() {
-		if ( ! self::is_snow_season() ) {
+		if ( ! self::is_snow_season() || self::is_p2() ) {
 			return;
 		}
 


### PR DESCRIPTION
Follow-up to #40478

## Proposed changes:

The snowstorm library we use to display falling snow is not compatible with p2s. Let's consequently not offer the option to turn on snow on p2s.

Companion Calypso PR:
https://github.com/Automattic/wp-calypso/pull/97238

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p7DVsv-lOp-p2#comment-51893

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Apply this change to your WordPress.com sandbox
* Sandbox a regular simple site, and a p2 site
* Go to `yoursite.wordpress.com/wp-admin/options-general.php` for both sites
    * You should see the settings for a regular site, but not for a p2 site.
