### PR TITLE
Add/improve upsell notification for custom styles

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-improve-upsell-notification-for-custom-styles
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-improve-upsell-notification-for-custom-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Removed the option to close upsell notification for custom styles

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/notices.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/notices.js
@@ -216,6 +216,7 @@ function GlobalStylesEditNotice() {
 			{
 				id: NOTICE_ID,
 				actions: actions,
+				isDismissible: false,
 			}
 		);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Remove Dismiss Button from Custom Styles Upsell Notification

Fixes: 
- https://github.com/Automattic/dotcom-forge/issues/9890

## Proposed changes:
* Remove the dismiss button from the custom styles upsell notification to ensure persistent visibility of the feature upgrade option

| Before | After |
| ---- | ---- |
| <img width="1671" alt="image" src="https://github.com/user-attachments/assets/7da5b985-20b5-4184-8fbd-63ff20eff458"> | <img width="1672" alt="image" src="https://github.com/user-attachments/assets/e9ba62c1-f2a6-4214-837f-319fce571f1b"> |

## Testing instructions:
* Navigate to the editor on a site without a qualifying plan
* Verify that the upsell notification for custom styles is visible
* Make changes to any styles setting and save
* Confirm that:
  * The notification remains visible after saving
  * There is no dismiss button present
  * The notification persists during the entire editing session

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable?

## Does this pull request change what data or activity we track or use?
No tracking changes are included in this PR.