### PR TITLE
Comments: Make endpoint comment types filterable

### DIFF
--- a/projects/plugins/jetpack/changelog/add-comment-type-filter
+++ b/projects/plugins/jetpack/changelog/add-comment-type-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Comments: Make list of allowable comment types filterable so custom types can be returned if needed.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-comment-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-comment-endpoint.php
@@ -80,7 +80,7 @@ abstract class WPCOM_JSON_API_Comment_Endpoint extends WPCOM_JSON_API_Endpoint {
 		 *
 		 * @param array $types Array of comment types.
 		 */
-		$types = apply_filters( 'wpcom_json_api_comment_types', array( '', 'comment', 'pingback', 'trackback', 'review' ) );
+		$types = apply_filters( 'jetpack_json_api_comment_types', array( '', 'comment', 'pingback', 'trackback', 'review' ) );
 
 		// @todo - can we make this comparison strict without breaking anything?
 		// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-comment-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-comment-endpoint.php
@@ -71,7 +71,13 @@ abstract class WPCOM_JSON_API_Comment_Endpoint extends WPCOM_JSON_API_Endpoint {
 			return new WP_Error( 'unknown_comment', 'Unknown comment', 404 );
 		}
 
-		$types = array( '', 'comment', 'pingback', 'trackback', 'review' );
+		/**
+		 * Filter the comment types that are allowed to be returned.
+		 *
+		 * @param array $types Array of comment types.
+		 */
+		$types = apply_filters( 'wpcom_json_api_comment_types', array( '', 'comment', 'pingback', 'trackback', 'review' ) );
+
 		// @todo - can we make this comparison strict without breaking anything?
 		// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 		if ( ! in_array( $comment->comment_type, $types ) ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-comment-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-comment-endpoint.php
@@ -74,6 +74,10 @@ abstract class WPCOM_JSON_API_Comment_Endpoint extends WPCOM_JSON_API_Endpoint {
 		/**
 		 * Filter the comment types that are allowed to be returned.
 		 *
+		 * @since $$next-version$$
+		 *
+		 * @module json-api
+		 *
 		 * @param array $types Array of comment types.
 		 */
 		$types = apply_filters( 'wpcom_json_api_comment_types', array( '', 'comment', 'pingback', 'trackback', 'review' ) );


### PR DESCRIPTION
Activitypub registers custom comment types to handle Likes and Reblogs in the Fediverse. To let users on WordPress.com manage them from within Calypso's comment screen, we'll need to add these comment types to the list of allowed types in the endpoint.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add filter for comment types in v1.1 comments API endpoint

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Not quite sure…

