### PR TITLE
Manual Updates: Make sure manual updates are applied when auto updates are disabled

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-manual-plugin-updates
+++ b/projects/plugins/jetpack/changelog/fix-manual-plugin-updates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+API Endpoints: make sure manual plugin updates applied when auto update is disabled

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -383,9 +383,12 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 	 */
 	protected function update() {
 		$query_args = $this->query_args();
+
+		$is_automatic_update = false;
 		if ( isset( $query_args['autoupdate'] ) && $query_args['autoupdate'] || $this->scheduled_update ) {
-			Constants::set_constant( 'JETPACK_PLUGIN_AUTOUPDATE', true );
+			$is_automatic_update = true;
 		}
+
 		if ( $this->scheduled_update ) {
 			Constants::set_constant( 'SCHEDULED_AUTOUPDATE', true );
 		}
@@ -416,7 +419,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 
 		// Early return if unable to obtain auto_updater lock.
 		// @see https://github.com/WordPress/wordpress-develop/blob/66469efa99e7978c8824e287834135aa9842e84f/src/wp-admin/includes/class-wp-automatic-updater.php#L453.
-		if ( Constants::get_constant( 'JETPACK_PLUGIN_AUTOUPDATE' ) && ! WP_Upgrader::create_lock( 'auto_updater', $lock_release_timeout ) ) {
+		if ( $is_automatic_update && ! WP_Upgrader::create_lock( 'auto_updater', $lock_release_timeout ) ) {
 			return new WP_Error( 'update_fail', __( 'Updates are already in progress.', 'jetpack' ), 400 );
 		}
 
@@ -430,7 +433,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			}
 
 			// Rely on WP_Automatic_Updater class to check if a plugin item should be updated if it is a Jetpack autoupdate request.
-			if ( Constants::get_constant( 'JETPACK_PLUGIN_AUTOUPDATE' ) && ! ( new WP_Automatic_Updater() )->should_update( 'plugin', $update_plugins->response[ $plugin ], WP_PLUGIN_DIR ) ) {
+			if ( $is_automatic_update && ! ( new WP_Automatic_Updater() )->should_update( 'plugin', $update_plugins->response[ $plugin ], WP_PLUGIN_DIR ) ) {
 				continue;
 			}
 
@@ -473,7 +476,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 		}
 
 		// release auto_udpate lock.
-		if ( Constants::get_constant( 'JETPACK_PLUGIN_AUTOUPDATE' ) ) {
+		if ( $is_automatic_update ) {
 			WP_Upgrader::release_lock( 'auto_updater' );
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/10096

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* It fixes a problem with manual plugin updates not being applied when auto-update is disabled for the plugin in WP Admin. 
* It fixes a problem by not using the `JETPACK_PLUGIN_AUTOUPDATE` constant in plugins modify endpoint

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Get WoA test site and install jetpack beta tester plugin 
* Once installed go to Jetpack -> Jetpack Beta -> Jetpack
* Select `fix/manual-plugin-updates` in feature branch option
* Download and Install an older version of .org plugin for example [Download Manager](https://wordpress.org/plugins/download-manager/advanced)
* Goto `/wp-admin/plugins.php` and disable auto-updates for the plugin. 

![CleanShot 2024-12-10 at 12 33 01@2x](https://github.com/user-attachments/assets/cb6101c5-8449-46df-bcd3-1132b791dbdd)

* Now goto All sites plugins view on WordPress.com. (https://wordpress.com/plugins/download-manager if you are using download-manager for testing)
* On the right end, look for an option to manage sites and click on it. 
![CleanShot 2024-12-10 at 12 34 31@2x](https://github.com/user-attachments/assets/074e06fa-d586-462e-8a6c-cd5ef75a7907)

* Upon clicking the button, the modal will be shown with the option to update the plugin on the site.  

![CleanShot 2024-12-10 at 12 35 51@2x](https://github.com/user-attachments/assets/4d413e3b-92cc-4302-b094-57555677b6a2)

* Click on the `Update to [Version]` button. 
* Wait for a few seconds while you see the success message.
* Go to`/wp-admin/plugins.php` and make sure updates are applied. 


