### PR TITLE
Carousel: Check we can preload an image before attempting it

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-null-request
+++ b/projects/plugins/jetpack/changelog/fix-carousel-null-request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Carousel: Under rare circumstances, the carousel will make null requests when loading an image

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1320,7 +1320,7 @@
 			var max = calculateMaxSlideDimensions();
 
 			// If the startIndex is not 0 then preload the clicked image first.
-			if ( startIndex !== 0 ) {
+			if ( startIndex !== 0 && items[ startIndex ].getAttribute( 'data-gallery-src' ) !== null ) {
 				var img = new Image();
 				img.src = items[ startIndex ].getAttribute( 'data-gallery-src' );
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
If the following are true, when a carousel image is clicked for the first time, the browser will make a request for "/null" before loading the image.
1. A site has the [redirection plugin](https://wordpress.org/plugins/redirection/) enabled
2. A site is using the Image CDN
3. A site is using the carousel

Fixes #39971

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* In `initCarouselSlides` make sure that the "data-gallery-src" attribute exists before trying to use it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the [redirection plugin](https://wordpress.org/plugins/redirection/).
* Enable "Image CDN" in Boost or "Speed up image load times" in Jetpack Settings/Performance.
* Enable "Display images in a full-screen carousel gallery" in Jetpack Settings/Writing.
* Create a gallery of images.
* Load the gallery in a browser, bring up the webdev console and click an image.
* You should see a 404 attempt to load /null
* Apply this PR and repeat. The attempt to load /null won't be made.