### PR TITLE
Social: Connections API schema front end changes

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-schema-front-end-changes
+++ b/projects/js-packages/publicize-components/changelog/update-social-schema-front-end-changes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated the shape of connections object following the schema update

--- a/projects/js-packages/publicize-components/src/components/connection-management/connection-info.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/connection-info.tsx
@@ -27,7 +27,7 @@ export function ConnectionInfo( { connection, service }: ConnectionInfoProps ) {
 			<div className={ styles[ 'connection-item' ] }>
 				<ConnectionIcon
 					serviceName={ connection.service_name }
-					label={ connection.display_name || connection.external_display }
+					label={ connection.display_name }
 					profilePicture={ connection.profile_picture }
 				/>
 				<div className={ styles[ 'connection-name-wrapper' ] }>

--- a/projects/js-packages/publicize-components/src/components/connection-management/connection-name.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/connection-name.tsx
@@ -27,12 +27,10 @@ export function ConnectionName( { connection }: ConnectionNameProps ) {
 	return (
 		<div className={ styles[ 'connection-name' ] }>
 			{ ! connection.profile_link ? (
-				<span className={ styles[ 'profile-link' ] }>
-					{ connection.display_name || connection.external_name }
-				</span>
+				<span className={ styles[ 'profile-link' ] }>{ connection.display_name }</span>
 			) : (
 				<ExternalLink className={ styles[ 'profile-link' ] } href={ connection.profile_link }>
-					{ connection.display_name || connection.external_display || connection.external_name }
+					{ connection.display_name }
 				</ExternalLink>
 			) }
 			{ isUpdating ? (

--- a/projects/js-packages/publicize-components/src/components/connection-management/reconnect.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/reconnect.tsx
@@ -63,7 +63,7 @@ export function Reconnect( { connection, service, variant = 'link' }: ReconnectP
 		const formData = new FormData();
 
 		if ( service.ID === 'mastodon' ) {
-			formData.set( 'instance', connection.external_display );
+			formData.set( 'instance', connection.external_handle );
 		}
 
 		if ( service.ID === 'bluesky' ) {

--- a/projects/js-packages/publicize-components/src/components/form/broken-connections-notice.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/broken-connections-notice.tsx
@@ -16,15 +16,9 @@ export const BrokenConnectionsNotice: React.FC = () => {
 
 	const { connectionsPageUrl } = usePublicizeConfig();
 
-	const { openConnectionsModal } = useDispatch( store );
-
-	const getServiceLabel = useServiceLabel();
-
-	if ( ! brokenConnections.length ) {
-		return null;
-	}
-
 	const { useAdminUiV1 } = getSocialScriptData().feature_flags;
+
+	const { openConnectionsModal } = useDispatch( store );
 
 	const fixLink = useAdminUiV1 ? (
 		<Button
@@ -35,6 +29,12 @@ export const BrokenConnectionsNotice: React.FC = () => {
 	) : (
 		<ExternalLink href={ connectionsPageUrl } />
 	);
+
+	const getServiceLabel = useServiceLabel();
+
+	if ( ! brokenConnections.length ) {
+		return null;
+	}
 
 	// Group broken connections by service
 	// Since Object.groupBy is not supported widely yet, we use a manual grouping

--- a/projects/js-packages/publicize-components/src/components/form/broken-connections-notice.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/broken-connections-notice.tsx
@@ -1,36 +1,30 @@
 import { Button } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement, Fragment } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import usePublicizeConfig from '../../hooks/use-publicize-config';
-import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import { store } from '../../social-store';
 import { Connection } from '../../social-store/types';
-import { checkConnectionCode } from '../../utils/connections';
 import { getSocialScriptData } from '../../utils/script-data';
 import Notice from '../notice';
 import { useServiceLabel } from '../services/use-service-label';
 import styles from './styles.module.scss';
 
 export const BrokenConnectionsNotice: React.FC = () => {
-	const { connections } = useSocialMediaConnections();
-
-	const brokenConnections = connections.filter( connection => {
-		return (
-			connection.status === 'broken' ||
-			// This is a legacy check for connections that are not healthy.
-			// TODO remove this check when we are sure that all connections have
-			// the status property (same schema for connections endpoints), e.g. on Simple/Atomic sites
-			checkConnectionCode( connection, 'broken' )
-		);
-	} );
+	const brokenConnections = useSelect( select => select( store ).getBrokenConnections(), [] );
 
 	const { connectionsPageUrl } = usePublicizeConfig();
 
-	const { useAdminUiV1 } = getSocialScriptData().feature_flags;
-
 	const { openConnectionsModal } = useDispatch( store );
+
+	const getServiceLabel = useServiceLabel();
+
+	if ( ! brokenConnections.length ) {
+		return null;
+	}
+
+	const { useAdminUiV1 } = getSocialScriptData().feature_flags;
 
 	const fixLink = useAdminUiV1 ? (
 		<Button
@@ -41,12 +35,6 @@ export const BrokenConnectionsNotice: React.FC = () => {
 	) : (
 		<ExternalLink href={ connectionsPageUrl } />
 	);
-
-	const getServiceLabel = useServiceLabel();
-
-	if ( ! brokenConnections.length ) {
-		return null;
-	}
 
 	// Group broken connections by service
 	// Since Object.groupBy is not supported widely yet, we use a manual grouping
@@ -87,11 +75,9 @@ export const BrokenConnectionsNotice: React.FC = () => {
 									{
 										// Since Intl.ListFormat is not allowed in Jetpack yet,
 										// we join the connections with a comma and space
-										connectionsList.map( ( { display_name, external_display, id }, i ) => (
-											<Fragment key={ id }>
-												<span className={ styles[ 'broken-connection' ] }>
-													{ display_name || external_display }
-												</span>
+										connectionsList.map( ( { display_name, connection_id }, i ) => (
+											<Fragment key={ connection_id }>
+												<span className={ styles[ 'broken-connection' ] }>{ display_name }</span>
 												{ i < connectionsList.length - 1 &&
 													_x(
 														',',

--- a/projects/js-packages/publicize-components/src/components/form/connections-list.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/connections-list.tsx
@@ -35,18 +35,17 @@ export const ConnectionsList: React.FC = () => {
 		<div>
 			<ul className={ styles[ 'connections-list' ] }>
 				{ connections.map( conn => {
-					const { display_name, id, service_name, profile_picture, connection_id } = conn;
-					const currentId = connection_id ? connection_id : id;
+					const { display_name, service_name, profile_picture, connection_id } = conn;
 
 					return (
 						<PublicizeConnection
 							disabled={ shouldBeDisabled( conn ) }
 							enabled={ canBeTurnedOn( conn ) && conn.enabled }
-							key={ currentId }
-							id={ currentId }
+							key={ connection_id }
+							id={ connection_id }
 							label={ display_name }
 							name={ service_name }
-							toggleConnection={ toggleConnection( currentId, conn ) }
+							toggleConnection={ toggleConnection( connection_id, conn ) }
 							profilePicture={ profile_picture }
 						/>
 					);

--- a/projects/js-packages/publicize-components/src/components/form/unsupported-connections-notice.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/unsupported-connections-notice.tsx
@@ -3,16 +3,18 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { usePublicizeConfig } from '../../..';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
-import { checkConnectionCode } from '../../utils/connections';
 import Notice from '../notice';
+import { useService } from '../services/use-service';
 
 export const UnsupportedConnectionsNotice: React.FC = () => {
 	const { connections } = useSocialMediaConnections();
 
 	const { connectionsPageUrl } = usePublicizeConfig();
 
+	const getServices = useService();
+
 	const unsupportedConnections = connections.filter( connection =>
-		checkConnectionCode( connection, 'unsupported' )
+		getServices( connection.service_name )
 	);
 
 	return (

--- a/projects/js-packages/publicize-components/src/components/form/unsupported-connections-notice.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/unsupported-connections-notice.tsx
@@ -14,6 +14,7 @@ export const UnsupportedConnectionsNotice: React.FC = () => {
 	const getServices = useService();
 
 	const unsupportedConnections = connections.filter( connection =>
+		// If getServices returns falsy, it means the service is unsupported.
 		getServices( connection.service_name )
 	);
 

--- a/projects/js-packages/publicize-components/src/components/form/unsupported-connections-notice.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/unsupported-connections-notice.tsx
@@ -13,9 +13,10 @@ export const UnsupportedConnectionsNotice: React.FC = () => {
 
 	const getServices = useService();
 
-	const unsupportedConnections = connections.filter( connection =>
-		// If getServices returns falsy, it means the service is unsupported.
-		getServices( connection.service_name )
+	const unsupportedConnections = connections.filter(
+		connection =>
+			// If getServices returns falsy, it means the service is unsupported.
+			! getServices( connection.service_name )
 	);
 
 	return (

--- a/projects/js-packages/publicize-components/src/components/form/use-connection-state.ts
+++ b/projects/js-packages/publicize-components/src/components/form/use-connection-state.ts
@@ -31,17 +31,16 @@ export const useConnectionState = () => {
 	 */
 	const isInGoodShape = useCallback(
 		( connection: Connection ) => {
-			const { id, is_healthy, connection_id, status } = connection;
-			const currentId = connection_id ? connection_id : id;
+			const { connection_id: id, status } = connection;
 
 			// 1. Be healthy
-			const isHealthy = false !== is_healthy && status !== 'broken';
+			const isHealthy = status !== 'broken';
 
 			// 2. Have no validation errors
-			const hasValidationErrors = validationErrors[ currentId ] !== undefined && ! isConvertible;
+			const hasValidationErrors = validationErrors[ id ] !== undefined && ! isConvertible;
 
 			// 3. Not have a NO_MEDIA_ERROR when media is required
-			const hasNoMediaError = validationErrors[ currentId ] === NO_MEDIA_ERROR;
+			const hasNoMediaError = validationErrors[ id ] === NO_MEDIA_ERROR;
 
 			return isHealthy && ! hasValidationErrors && ! hasNoMediaError;
 		},

--- a/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
@@ -162,7 +162,7 @@ export function ConfirmationForm( { keyringResult, onComplete, isAdmin }: Confir
 				display_name: accountInfo?.label,
 				profile_picture: accountInfo?.profile_picture,
 				service_name: service.ID,
-				external_id: external_user_ID,
+				external_id: external_user_ID.toString(),
 			} );
 
 			onComplete();

--- a/projects/js-packages/publicize-components/src/components/services/connect-form.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/connect-form.tsx
@@ -24,7 +24,7 @@ type ConnectFormProps = {
  *
  * @param {ConnectFormProps} props - Component props
  *
- * @return {import('react').ReactNode} Connect form component
+ * @return Connect form component
  */
 export function ConnectForm( {
 	service,

--- a/projects/js-packages/publicize-components/src/components/services/custom-inputs.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/custom-inputs.tsx
@@ -73,7 +73,7 @@ export function CustomInputs( { service }: CustomInputsProps ) {
 						name="handle"
 						defaultValue={
 							reconnectingAccount?.service_name === 'bluesky'
-								? reconnectingAccount?.external_name
+								? reconnectingAccount?.external_handle
 								: undefined
 						}
 						autoComplete="off"

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/post-preview.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/post-preview.tsx
@@ -33,9 +33,9 @@ export type PostPreviewProps = {
 export function PostPreview( { connection }: PostPreviewProps ) {
 	const user = useMemo(
 		() => ( {
-			displayName: connection.display_name || connection.external_display,
+			displayName: connection.display_name,
 			profileImage: connection.profile_picture,
-			externalName: connection.external_name,
+			externalName: connection.external_handle,
 		} ),
 		[ connection ]
 	);

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
@@ -33,7 +33,7 @@ export function PreviewSection() {
 					// to avoid errors for old connections like Twitter
 					.filter( ( { service_name } ) => getService( service_name ) )
 					.map( connection => {
-						const title = connection.display_name || connection.external_display;
+						const title = connection.display_name;
 						const name = `${ connection.service_name }-${ connection.connection_id }`;
 						const icon = (
 							<ConnectionIcon

--- a/projects/js-packages/publicize-components/src/social-store/actions/connection-data.ts
+++ b/projects/js-packages/publicize-components/src/social-store/actions/connection-data.ts
@@ -4,7 +4,7 @@ import { dispatch as coreDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { getSocialScriptData } from '../../utils/script-data';
-import { Connection, KeyringResult } from '../types';
+import { Connection } from '../types';
 import {
 	ADD_CONNECTION,
 	DELETE_CONNECTION,
@@ -23,10 +23,10 @@ import {
 
 /**
  * Set connections list
- * @param {Array<Connection>} connections - list of connections
+ * @param {Array<import('../types').Connection>} connections - list of connections
  * @return {object} - an action object.
  */
-export function setConnections( connections: Array< Connection > ) {
+export function setConnections( connections ) {
 	return {
 		type: SET_CONNECTIONS,
 		connections,
@@ -36,11 +36,11 @@ export function setConnections( connections: Array< Connection > ) {
 /**
  * Set keyring result
  *
- * @param {KeyringResult} [keyringResult] - keyring result
+ * @param {import('../types').KeyringResult} [keyringResult] - keyring result
  *
  * @return {object} - an action object.
  */
-export function setKeyringResult( keyringResult: KeyringResult ) {
+export function setKeyringResult( keyringResult ) {
 	return {
 		type: SET_KEYRING_RESULT,
 		keyringResult,
@@ -49,10 +49,10 @@ export function setKeyringResult( keyringResult: KeyringResult ) {
 
 /**
  * Add connection to the list
- * @param {Partial<Connection>} connection - connection object
+ * @param {import('../types').Connection} connection - connection object
  * @return {object} - an action object.
  */
-export function addConnection( connection: Partial< Connection > ) {
+export function addConnection( connection ) {
 	return {
 		type: ADD_CONNECTION,
 		connection,
@@ -65,7 +65,7 @@ export function addConnection( connection: Partial< Connection > ) {
  *
  * @return {object} Switch connection enable-status action.
  */
-export function toggleConnection( connectionId: string ) {
+export function toggleConnection( connectionId ) {
 	return {
 		type: TOGGLE_CONNECTION,
 		connectionId,
@@ -74,13 +74,13 @@ export function toggleConnection( connectionId: string ) {
 
 /**
  * Merge connections with fresh connections.
- * @param {Array< Connection >} freshConnections - list of fresh connections
+ * @param {Array} freshConnections - list of fresh connections
  * @return {Function} - a function to merge connections.
  */
-export function mergeConnections( freshConnections: Array< Connection > ) {
+export function mergeConnections( freshConnections ) {
 	return function ( { dispatch, select } ) {
 		// Combine current connections with new connections.
-		const prevConnections: Array< Connection > = select.getConnections();
+		const prevConnections = select.getConnections();
 		const connections = [];
 		const defaults = {
 			enabled: true,
@@ -113,7 +113,7 @@ export function mergeConnections( freshConnections: Array< Connection > ) {
  *
  * @return {object} - an action object.
  */
-export function createAbortController( abortController: AbortController, requestType: string ) {
+export function createAbortController( abortController, requestType ) {
 	return {
 		type: ADD_ABORT_CONTROLLER,
 		requestType,
@@ -128,7 +128,7 @@ export function createAbortController( abortController: AbortController, request
  *
  * @return {object} - an action object.
  */
-export function removeAbortControllers( requestType: string ) {
+export function removeAbortControllers( requestType ) {
 	return {
 		type: REMOVE_ABORT_CONTROLLERS,
 		requestType,
@@ -142,7 +142,7 @@ export function removeAbortControllers( requestType: string ) {
  *
  * @return {Function} - a function to abort a request.
  */
-export function abortRequest( requestType: string ) {
+export function abortRequest( requestType ) {
 	return function ( { dispatch, select } ) {
 		const abortControllers = select.getAbortControllers( requestType );
 
@@ -188,10 +188,7 @@ export function refreshConnectionTestResults( syncToMeta = false ) {
 			dispatch( createAbortController( abortController, REQUEST_TYPE_REFRESH_CONNECTIONS ) );
 
 			// Pass the abort controller signal to the fetch request.
-			const freshConnections = await apiFetch< Array< Connection > >( {
-				path,
-				signal: abortController.signal,
-			} );
+			const freshConnections = await apiFetch( { path, signal: abortController.signal } );
 
 			dispatch( mergeConnections( freshConnections ) );
 
@@ -215,7 +212,7 @@ export function refreshConnectionTestResults( syncToMeta = false ) {
  */
 export function syncConnectionsToPostMeta() {
 	return function ( { registry, select } ) {
-		const connections: Array< Connection > = select.getConnections();
+		const connections = select.getConnections();
 
 		// Update post metadata.
 		return registry.dispatch( editorStore ).editPost( {
@@ -231,7 +228,7 @@ export function syncConnectionsToPostMeta() {
  * @param {boolean} syncToMeta   - Whether to sync the connection state to the post meta.
  * @return {object} Switch connection enable-status action.
  */
-export function toggleConnectionById( connectionId: string, syncToMeta = true ) {
+export function toggleConnectionById( connectionId, syncToMeta = true ) {
 	return function ( { dispatch } ) {
 		dispatch( toggleConnection( connectionId ) );
 
@@ -248,7 +245,7 @@ export function toggleConnectionById( connectionId: string, syncToMeta = true ) 
  *
  * @return {object} Delete connection action.
  */
-export function deleteConnection( connectionId: string ) {
+export function deleteConnection( connectionId ) {
 	return {
 		type: DELETE_CONNECTION,
 		connectionId,
@@ -263,7 +260,7 @@ export function deleteConnection( connectionId: string ) {
  *
  * @return {object} Deleting connection action.
  */
-export function deletingConnection( connectionId: string, deleting = true ) {
+export function deletingConnection( connectionId, deleting = true ) {
 	return {
 		type: DELETING_CONNECTION,
 		connectionId,
@@ -280,13 +277,7 @@ export function deletingConnection( connectionId: string, deleting = true ) {
  *
  * @return {boolean} Whether the connection was deleted.
  */
-export function deleteConnectionById( {
-	connectionId,
-	showSuccessNotice = true,
-}: {
-	connectionId: string;
-	showSuccessNotice?: boolean;
-} ) {
+export function deleteConnectionById( { connectionId, showSuccessNotice = true } ) {
 	return async function ( { registry, dispatch } ) {
 		const { createErrorNotice, createSuccessNotice } = coreDispatch( globalNoticesStore );
 
@@ -343,10 +334,7 @@ let uniqueId = 1;
  * @param {Record<string, any>} optimisticData - Optimistic data for the connection.
  * @return {void}
  */
-export function createConnection(
-	data: Record< string, unknown >,
-	optimisticData: Partial< Connection > = {}
-) {
+export function createConnection( data, optimisticData = {} ) {
 	return async function ( { registry, dispatch } ) {
 		const { createErrorNotice, createSuccessNotice } = coreDispatch( globalNoticesStore );
 
@@ -416,12 +404,12 @@ export function createConnection(
 /**
  * Updates a connection.
  *
- * @param {string}                connectionId - Connection ID to update.
- * @param {Partial< Connection >} data         - The data.
+ * @param {string}              connectionId - Connection ID to update.
+ * @param {Record<string, any>} data         - The data.
  *
  * @return {object} Delete connection action.
  */
-export function updateConnection( connectionId: string, data: Partial< Connection > ) {
+export function updateConnection( connectionId, data ) {
 	return {
 		type: UPDATE_CONNECTION,
 		connectionId,
@@ -448,11 +436,11 @@ export function updatingConnection( connectionId, updating = true ) {
 /**
  * Sets the reconnecting account.
  *
- * @param {Connection} reconnectingAccount - Account being reconnected.
+ * @param {import('../types').Connection} reconnectingAccount - Account being reconnected.
  *
  * @return {object} Reconnecting account action.
  */
-export function setReconnectingAccount( reconnectingAccount: Connection ) {
+export function setReconnectingAccount( reconnectingAccount ) {
 	return {
 		type: SET_RECONNECTING_ACCOUNT,
 		reconnectingAccount,
@@ -466,7 +454,7 @@ export function setReconnectingAccount( reconnectingAccount: Connection ) {
  * @param {Record<string, any>} data         - The data for API call.
  * @return {void}
  */
-export function updateConnectionById( connectionId: string, data: Record< string, unknown > ) {
+export function updateConnectionById( connectionId, data ) {
 	return async function ( { dispatch, select } ) {
 		const { createErrorNotice, createSuccessNotice } = coreDispatch( globalNoticesStore );
 
@@ -518,7 +506,7 @@ export function updateConnectionById( connectionId: string, data: Record< string
  *
  * @return {object} - An action object.
  */
-export function toggleConnectionsModal( isOpen: boolean ) {
+export function toggleConnectionsModal( isOpen ) {
 	return {
 		type: TOGGLE_CONNECTIONS_MODAL,
 		isOpen,

--- a/projects/js-packages/publicize-components/src/social-store/actions/connection-data.ts
+++ b/projects/js-packages/publicize-components/src/social-store/actions/connection-data.ts
@@ -91,10 +91,8 @@ export function mergeConnections( freshConnections: Array< Connection > ) {
 		 * in order to refresh or update current connections.
 		 */
 		for ( const freshConnection of freshConnections ) {
-			const prevConnection = prevConnections.find( conn =>
-				conn.connection_id
-					? conn.connection_id === freshConnection.connection_id
-					: conn.id === freshConnection.id
+			const prevConnection = prevConnections.find(
+				conn => conn.connection_id === freshConnection.connection_id
 			);
 
 			const connection = {
@@ -386,7 +384,7 @@ export function createConnection(
 					sprintf(
 						/* translators: %s is the name of the social media platform e.g. "Facebook" */
 						__( '%s account connected successfully.', 'jetpack-publicize-components' ),
-						connection.label
+						connection.service_label
 					),
 					{
 						type: 'snackbar',

--- a/projects/js-packages/publicize-components/src/social-store/actions/connection-data.ts
+++ b/projects/js-packages/publicize-components/src/social-store/actions/connection-data.ts
@@ -4,7 +4,7 @@ import { dispatch as coreDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { getSocialScriptData } from '../../utils/script-data';
-import { Connection } from '../types';
+import { Connection, KeyringResult } from '../types';
 import {
 	ADD_CONNECTION,
 	DELETE_CONNECTION,
@@ -23,10 +23,10 @@ import {
 
 /**
  * Set connections list
- * @param {Array<import('../types').Connection>} connections - list of connections
+ * @param {Array<Connection>} connections - list of connections
  * @return {object} - an action object.
  */
-export function setConnections( connections ) {
+export function setConnections( connections: Array< Connection > ) {
 	return {
 		type: SET_CONNECTIONS,
 		connections,
@@ -36,11 +36,11 @@ export function setConnections( connections ) {
 /**
  * Set keyring result
  *
- * @param {import('../types').KeyringResult} [keyringResult] - keyring result
+ * @param {KeyringResult} [keyringResult] - keyring result
  *
  * @return {object} - an action object.
  */
-export function setKeyringResult( keyringResult ) {
+export function setKeyringResult( keyringResult: KeyringResult ) {
 	return {
 		type: SET_KEYRING_RESULT,
 		keyringResult,
@@ -49,10 +49,10 @@ export function setKeyringResult( keyringResult ) {
 
 /**
  * Add connection to the list
- * @param {import('../types').Connection} connection - connection object
+ * @param {Partial<Connection>} connection - connection object
  * @return {object} - an action object.
  */
-export function addConnection( connection ) {
+export function addConnection( connection: Partial< Connection > ) {
 	return {
 		type: ADD_CONNECTION,
 		connection,
@@ -65,7 +65,7 @@ export function addConnection( connection ) {
  *
  * @return {object} Switch connection enable-status action.
  */
-export function toggleConnection( connectionId ) {
+export function toggleConnection( connectionId: string ) {
 	return {
 		type: TOGGLE_CONNECTION,
 		connectionId,
@@ -74,18 +74,16 @@ export function toggleConnection( connectionId ) {
 
 /**
  * Merge connections with fresh connections.
- * @param {Array} freshConnections - list of fresh connections
+ * @param {Array< Connection >} freshConnections - list of fresh connections
  * @return {Function} - a function to merge connections.
  */
-export function mergeConnections( freshConnections ) {
+export function mergeConnections( freshConnections: Array< Connection > ) {
 	return function ( { dispatch, select } ) {
 		// Combine current connections with new connections.
-		const prevConnections = select.getConnections();
+		const prevConnections: Array< Connection > = select.getConnections();
 		const connections = [];
 		const defaults = {
-			done: false,
 			enabled: true,
-			toggleable: true,
 		};
 
 		/*
@@ -103,8 +101,6 @@ export function mergeConnections( freshConnections ) {
 				...defaults,
 				...prevConnection,
 				...freshConnection,
-				shared: prevConnection?.shared,
-				is_healthy: freshConnection.test_success,
 			};
 			connections.push( connection );
 		}
@@ -119,7 +115,7 @@ export function mergeConnections( freshConnections ) {
  *
  * @return {object} - an action object.
  */
-export function createAbortController( abortController, requestType ) {
+export function createAbortController( abortController: AbortController, requestType: string ) {
 	return {
 		type: ADD_ABORT_CONTROLLER,
 		requestType,
@@ -134,7 +130,7 @@ export function createAbortController( abortController, requestType ) {
  *
  * @return {object} - an action object.
  */
-export function removeAbortControllers( requestType ) {
+export function removeAbortControllers( requestType: string ) {
 	return {
 		type: REMOVE_ABORT_CONTROLLERS,
 		requestType,
@@ -148,7 +144,7 @@ export function removeAbortControllers( requestType ) {
  *
  * @return {Function} - a function to abort a request.
  */
-export function abortRequest( requestType ) {
+export function abortRequest( requestType: string ) {
 	return function ( { dispatch, select } ) {
 		const abortControllers = select.getAbortControllers( requestType );
 
@@ -194,7 +190,10 @@ export function refreshConnectionTestResults( syncToMeta = false ) {
 			dispatch( createAbortController( abortController, REQUEST_TYPE_REFRESH_CONNECTIONS ) );
 
 			// Pass the abort controller signal to the fetch request.
-			const freshConnections = await apiFetch( { path, signal: abortController.signal } );
+			const freshConnections = await apiFetch< Array< Connection > >( {
+				path,
+				signal: abortController.signal,
+			} );
 
 			dispatch( mergeConnections( freshConnections ) );
 
@@ -218,7 +217,7 @@ export function refreshConnectionTestResults( syncToMeta = false ) {
  */
 export function syncConnectionsToPostMeta() {
 	return function ( { registry, select } ) {
-		const connections = select.getConnections();
+		const connections: Array< Connection > = select.getConnections();
 
 		// Update post metadata.
 		return registry.dispatch( editorStore ).editPost( {
@@ -234,7 +233,7 @@ export function syncConnectionsToPostMeta() {
  * @param {boolean} syncToMeta   - Whether to sync the connection state to the post meta.
  * @return {object} Switch connection enable-status action.
  */
-export function toggleConnectionById( connectionId, syncToMeta = true ) {
+export function toggleConnectionById( connectionId: string, syncToMeta = true ) {
 	return function ( { dispatch } ) {
 		dispatch( toggleConnection( connectionId ) );
 
@@ -251,7 +250,7 @@ export function toggleConnectionById( connectionId, syncToMeta = true ) {
  *
  * @return {object} Delete connection action.
  */
-export function deleteConnection( connectionId ) {
+export function deleteConnection( connectionId: string ) {
 	return {
 		type: DELETE_CONNECTION,
 		connectionId,
@@ -266,7 +265,7 @@ export function deleteConnection( connectionId ) {
  *
  * @return {object} Deleting connection action.
  */
-export function deletingConnection( connectionId, deleting = true ) {
+export function deletingConnection( connectionId: string, deleting = true ) {
 	return {
 		type: DELETING_CONNECTION,
 		connectionId,
@@ -283,7 +282,13 @@ export function deletingConnection( connectionId, deleting = true ) {
  *
  * @return {boolean} Whether the connection was deleted.
  */
-export function deleteConnectionById( { connectionId, showSuccessNotice = true } ) {
+export function deleteConnectionById( {
+	connectionId,
+	showSuccessNotice = true,
+}: {
+	connectionId: string;
+	showSuccessNotice?: boolean;
+} ) {
 	return async function ( { registry, dispatch } ) {
 		const { createErrorNotice, createSuccessNotice } = coreDispatch( globalNoticesStore );
 
@@ -340,7 +345,10 @@ let uniqueId = 1;
  * @param {Record<string, any>} optimisticData - Optimistic data for the connection.
  * @return {void}
  */
-export function createConnection( data, optimisticData = {} ) {
+export function createConnection(
+	data: Record< string, unknown >,
+	optimisticData: Partial< Connection > = {}
+) {
 	return async function ( { registry, dispatch } ) {
 		const { createErrorNotice, createSuccessNotice } = coreDispatch( globalNoticesStore );
 
@@ -410,12 +418,12 @@ export function createConnection( data, optimisticData = {} ) {
 /**
  * Updates a connection.
  *
- * @param {string}              connectionId - Connection ID to update.
- * @param {Record<string, any>} data         - The data.
+ * @param {string}                connectionId - Connection ID to update.
+ * @param {Partial< Connection >} data         - The data.
  *
  * @return {object} Delete connection action.
  */
-export function updateConnection( connectionId, data ) {
+export function updateConnection( connectionId: string, data: Partial< Connection > ) {
 	return {
 		type: UPDATE_CONNECTION,
 		connectionId,
@@ -442,11 +450,11 @@ export function updatingConnection( connectionId, updating = true ) {
 /**
  * Sets the reconnecting account.
  *
- * @param {import('../types').Connection} reconnectingAccount - Account being reconnected.
+ * @param {Connection} reconnectingAccount - Account being reconnected.
  *
  * @return {object} Reconnecting account action.
  */
-export function setReconnectingAccount( reconnectingAccount ) {
+export function setReconnectingAccount( reconnectingAccount: Connection ) {
 	return {
 		type: SET_RECONNECTING_ACCOUNT,
 		reconnectingAccount,
@@ -460,7 +468,7 @@ export function setReconnectingAccount( reconnectingAccount ) {
  * @param {Record<string, any>} data         - The data for API call.
  * @return {void}
  */
-export function updateConnectionById( connectionId, data ) {
+export function updateConnectionById( connectionId: string, data: Record< string, unknown > ) {
 	return async function ( { dispatch, select } ) {
 		const { createErrorNotice, createSuccessNotice } = coreDispatch( globalNoticesStore );
 
@@ -512,7 +520,7 @@ export function updateConnectionById( connectionId, data ) {
  *
  * @return {object} - An action object.
  */
-export function toggleConnectionsModal( isOpen ) {
+export function toggleConnectionsModal( isOpen: boolean ) {
 	return {
 		type: TOGGLE_CONNECTIONS_MODAL,
 		isOpen,

--- a/projects/js-packages/publicize-components/src/social-store/actions/test/connection-data.js
+++ b/projects/js-packages/publicize-components/src/social-store/actions/test/connection-data.js
@@ -119,22 +119,14 @@ describe( 'Social store actions: connectionData', () => {
 
 			const freshConnections = connections.map( connection => ( {
 				...connection,
-				test_success: false,
+				status: 'broken',
 			} ) );
 
 			registry.dispatch( socialStore ).mergeConnections( freshConnections );
 
 			const connectionsAfterMerge = registry.select( socialStore ).getConnections();
 
-			expect( connectionsAfterMerge ).toEqual(
-				freshConnections.map( connection => ( {
-					...connection,
-					// These 3 are added while merging
-					done: false,
-					toggleable: true,
-					is_healthy: false,
-				} ) )
-			);
+			expect( connectionsAfterMerge ).toEqual( freshConnections );
 		} );
 	} );
 
@@ -156,10 +148,7 @@ describe( 'Social store actions: connectionData', () => {
 				if ( path.startsWith( refreshConnections ) ) {
 					return connections.map( connection => ( {
 						...connection,
-						can_refresh: false,
-						refresh_url: '',
-						test_message: 'Some message',
-						test_success: true,
+						status: 'broken',
 					} ) );
 				}
 
@@ -184,14 +173,7 @@ describe( 'Social store actions: connectionData', () => {
 			expect( connectionsAfterRefresh ).toEqual(
 				connections.map( connection => ( {
 					...connection,
-					can_refresh: false,
-					refresh_url: '',
-					test_message: 'Some message',
-					test_success: true,
-					// These 3 are added while merging
-					done: false,
-					toggleable: true,
-					is_healthy: true,
+					status: 'broken',
 				} ) )
 			);
 

--- a/projects/js-packages/publicize-components/src/social-store/reducer/connection-data.ts
+++ b/projects/js-packages/publicize-components/src/social-store/reducer/connection-data.ts
@@ -133,11 +133,7 @@ const connectionData = ( state: ConnectionData = { connections: [] }, action ) =
 			return {
 				...state,
 				connections: state.connections.map( connection => {
-					// If the connection has a connection_id, then give it priority.
-					// Otherwise, use the id.
-					const isTargetConnection = connection.connection_id
-						? connection.connection_id === action.connectionId
-						: connection.id === action.connectionId;
+					const isTargetConnection = connection.connection_id === action.connectionId;
 
 					if ( isTargetConnection ) {
 						return {

--- a/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.js
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.js
@@ -1,4 +1,3 @@
-import { checkConnectionCode } from '../../utils/connections';
 import { REQUEST_TYPE_DEFAULT } from '../actions/constants';
 
 /**
@@ -32,13 +31,7 @@ export function getConnectionById( state, connectionId ) {
  */
 export function getBrokenConnections( state ) {
 	return getConnections( state ).filter( connection => {
-		return (
-			connection.status === 'broken' ||
-			// This is a legacy check for connections that are not healthy.
-			// TODO remove this check when we are sure that all connections have
-			// the status property (same schema for connections endpoints), e.g. on Simple/Atomic sites
-			checkConnectionCode( connection, 'broken' )
-		);
+		return connection.status === 'broken';
 	} );
 }
 

--- a/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.ts
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.ts
@@ -1,23 +1,24 @@
 import { REQUEST_TYPE_DEFAULT } from '../actions/constants';
+import { Connection, SocialStoreState } from '../types';
 
 /**
  * Returns the connections list from the store.
  *
- * @param {import("../types").SocialStoreState} state - State object.
+ * @param {SocialStoreState} state - State object.
  *
- * @return {Array<import("../types").Connection>} The connections list
+ * @return {Array<Connection>} The connections list
  */
-export function getConnections( state ) {
+export function getConnections( state: SocialStoreState ): Array< Connection > {
 	return state.connectionData?.connections ?? [];
 }
 
 /**
  * Return a connection by its ID.
  *
- * @param {import("../types").SocialStoreState} state        - State object.
- * @param {string}                              connectionId - The connection ID.
+ * @param {SocialStoreState} state        - State object.
+ * @param {string}           connectionId - The connection ID.
  *
- * @return {import("../types").Connection | undefined} The connection.
+ * @return {Connection | undefined} The connection.
  */
 export function getConnectionById( state, connectionId ) {
 	return getConnections( state ).find( connection => connection.connection_id === connectionId );
@@ -26,8 +27,8 @@ export function getConnectionById( state, connectionId ) {
 /**
  * Returns the broken connections.
  *
- * @param {import("../types").SocialStoreState} state - State object.
- * @return {Array<import("../types").Connection>} List of broken connections.
+ * @param {SocialStoreState} state - State object.
+ * @return {Array<Connection>} List of broken connections.
  */
 export function getBrokenConnections( state ) {
 	return getConnections( state ).filter( connection => {
@@ -38,8 +39,8 @@ export function getBrokenConnections( state ) {
 /**
  * Returns connections by service name/ID.
  *
- * @param {import("../types").SocialStoreState} state       - State object.
- * @param {string}                              serviceName - The service name.
+ * @param {SocialStoreState} state       - State object.
+ * @param {string}           serviceName - The service name.
  *
  * @return {Array<import("../types").Connections>} The connections.
  */
@@ -49,7 +50,7 @@ export function getConnectionsByService( state, serviceName ) {
 
 /**
  * Returns whether there are connections in the store.
- * @param {import("../types").SocialStoreState} state - State object.
+ * @param {SocialStoreState} state - State object.
  * @return {boolean} Whether there are connections.
  */
 export function hasConnections( state ) {
@@ -59,35 +60,35 @@ export function hasConnections( state ) {
 /**
  * Returns the failed Publicize connections.
  *
- * @param {import("../types").SocialStoreState} state - State object.
- * @return {Array<import("../types").Connection>} List of connections.
+ * @param {SocialStoreState} state - State object.
+ * @return {Array<Connection>} List of connections.
  */
 export function getFailedConnections( state ) {
 	const connections = getConnections( state );
 
-	return connections.filter( connection => false === connection.test_success );
+	return connections.filter( connection => 'broken' === connection.status );
 }
 
 /**
  * Returns a list of Publicize connection service names that require reauthentication from users.
  * iFor example, when LinkedIn switched its API from v1 to v2.
  *
- * @param {import("../types").SocialStoreState} state - State object.
- * @return {Array<import("../types").Connection>} List of service names that need reauthentication.
+ * @param {SocialStoreState} state - State object.
+ * @return {Array<Connection>} List of service names that need reauthentication.
  */
 export function getMustReauthConnections( state ) {
 	const connections = getConnections( state );
 	return connections
-		.filter( connection => 'must_reauth' === connection.test_success )
+		.filter( connection => 'broken' === connection.status )
 		.map( connection => connection.service_name );
 }
 
 /**
  * Returns the Publicize connections that are enabled.
  *
- * @param {import("../types").SocialStoreState} state - State object.
+ * @param {SocialStoreState} state - State object.
  *
- * @return {Array<import("../types").Connection>} List of enabled connections.
+ * @return {Array<Connection>} List of enabled connections.
  */
 export function getEnabledConnections( state ) {
 	return getConnections( state ).filter( connection => connection.enabled );
@@ -96,9 +97,9 @@ export function getEnabledConnections( state ) {
 /**
  * Returns the Publicize connections that are disabled.
  *
- * @param {import("../types").SocialStoreState} state - State object.
+ * @param {SocialStoreState} state - State object.
  *
- * @return {Array<import("../types").Connection>} List of disabled connections.
+ * @return {Array<Connection>} List of disabled connections.
  */
 export function getDisabledConnections( state ) {
 	return getConnections( state ).filter( connection => ! connection.enabled );
@@ -107,10 +108,10 @@ export function getDisabledConnections( state ) {
 /**
  * Get the profile details for a connection
  *
- * @param {import("../types").SocialStoreState} state              - State object.
- * @param {string}                              service            - The service name.
- * @param {object}                              args               - Arguments.
- * @param {boolean}                             args.forceDefaults - Whether to use default values.
+ * @param {SocialStoreState} state              - State object.
+ * @param {string}           service            - The service name.
+ * @param {object}           args               - Arguments.
+ * @param {boolean}          args.forceDefaults - Whether to use default values.
  *
  * @return {object} The profile details.
  */
@@ -125,22 +126,11 @@ export function getConnectionProfileDetails( state, service, { forceDefaults = f
 		);
 
 		if ( connection ) {
-			const {
-				display_name,
-				profile_display_name,
-				profile_picture,
-				external_display,
-				external_name,
-			} = connection;
+			const { display_name, profile_picture, external_handle } = connection;
 
-			displayName = 'twitter' === service ? profile_display_name : display_name || external_display;
-			username = 'twitter' === service ? display_name : connection.username;
+			displayName = display_name;
+			username = external_handle;
 			profileImage = profile_picture;
-
-			// Connections schema is a mess
-			if ( 'bluesky' === service ) {
-				username = external_name;
-			}
 		}
 	}
 
@@ -150,7 +140,7 @@ export function getConnectionProfileDetails( state, service, { forceDefaults = f
 /**
  * Get the connections being deleted.
  *
- * @param {import("../types").SocialStoreState} state - State object.
+ * @param {SocialStoreState} state - State object.
  * @return {import("../types").ConnectionData['deletingConnections']} The connection being deleted.
  */
 export function getDeletingConnections( state ) {
@@ -160,7 +150,7 @@ export function getDeletingConnections( state ) {
 /**
  * Get the connections being updated.
  *
- * @param {import("../types").SocialStoreState} state - State object.
+ * @param {SocialStoreState} state - State object.
  * @return {import("../types").ConnectionData['updatingConnections']} The connection being updated.
  */
 export function getUpdatingConnections( state ) {
@@ -170,7 +160,7 @@ export function getUpdatingConnections( state ) {
 /**
  * Get the account being reconnected
  *
- * @param {import("../types").SocialStoreState} state - State object.
+ * @param {SocialStoreState} state - State object.
  * @return {import("../types").ConnectionData['reconnectingAccount']} The account being reconnected.
  */
 export function getReconnectingAccount( state ) {
@@ -180,8 +170,8 @@ export function getReconnectingAccount( state ) {
 /**
  * Get the abort controllers for a specific request type.
  *
- * @param {import("../types").SocialStoreState} state       - State object.
- * @param {string}                              requestType - The request type.
+ * @param {SocialStoreState} state       - State object.
+ * @param {string}           requestType - The request type.
  *
  * @return {Array<AbortController>} The abort controllers.
  */
@@ -192,35 +182,35 @@ export function getAbortControllers( state, requestType = REQUEST_TYPE_DEFAULT )
 /**
  * Whether a mastodon account is already connected.
  *
- * @param {import("../types").SocialStoreState} state    - State object.
- * @param {string}                              username - The mastodon username.
+ * @param {SocialStoreState} state  - State object.
+ * @param {string}           handle - The mastodon handle.
  *
  * @return {boolean} Whether the mastodon account is already connected.
  */
-export function isMastodonAccountAlreadyConnected( state, username ) {
+export function isMastodonAccountAlreadyConnected( state, handle ) {
 	return getConnectionsByService( state, 'mastodon' ).some( connection => {
-		return connection.external_display === username;
+		return connection.external_handle === handle;
 	} );
 }
 
 /**
  * Whether a Bluesky account is already connected.
  *
- * @param {import("../types").SocialStoreState} state  - State object.
- * @param {string}                              handle - The Bluesky handle.
+ * @param {SocialStoreState} state  - State object.
+ * @param {string}           handle - The Bluesky handle.
  *
  * @return {boolean} Whether the Bluesky account is already connected.
  */
 export function isBlueskyAccountAlreadyConnected( state, handle ) {
 	return getConnectionsByService( state, 'bluesky' ).some( connection => {
-		return connection.external_name === handle;
+		return connection.external_handle === handle;
 	} );
 }
 
 /**
  * Returns the latest KeyringResult from the store.
  *
- * @param {import("../types").SocialStoreState} state - State object.
+ * @param {SocialStoreState} state - State object.
  *
  * @return {import("../types").KeyringResult} The KeyringResult
  */
@@ -230,7 +220,7 @@ export function getKeyringResult( state ) {
 
 /**
  * Whether the connections modal is open.
- * @param {import("../types").SocialStoreState} state - State object.
+ * @param {SocialStoreState} state - State object.
  *
  * @return {boolean} Whether the connections modal is open.
  */

--- a/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.ts
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.ts
@@ -1,4 +1,5 @@
 import { REQUEST_TYPE_DEFAULT } from '../actions/constants';
+import { SocialStoreState } from '../types';
 
 /**
  * Returns the connections list from the store.
@@ -7,7 +8,7 @@ import { REQUEST_TYPE_DEFAULT } from '../actions/constants';
  *
  * @return {Array<import("../types").Connection>} The connections list
  */
-export function getConnections( state ) {
+export function getConnections( state: SocialStoreState ) {
 	return state.connectionData?.connections ?? [];
 }
 
@@ -41,7 +42,7 @@ export function getBrokenConnections( state ) {
  * @param {import("../types").SocialStoreState} state       - State object.
  * @param {string}                              serviceName - The service name.
  *
- * @return {Array<import("../types").Connections>} The connections.
+ * @return {Array<import("../types").Connection>} The connections.
  */
 export function getConnectionsByService( state, serviceName ) {
 	return getConnections( state ).filter( ( { service_name } ) => service_name === serviceName );

--- a/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.ts
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.ts
@@ -1,24 +1,23 @@
 import { REQUEST_TYPE_DEFAULT } from '../actions/constants';
-import { Connection, SocialStoreState } from '../types';
 
 /**
  * Returns the connections list from the store.
  *
- * @param {SocialStoreState} state - State object.
+ * @param {import("../types").SocialStoreState} state - State object.
  *
- * @return {Array<Connection>} The connections list
+ * @return {Array<import("../types").Connection>} The connections list
  */
-export function getConnections( state: SocialStoreState ): Array< Connection > {
+export function getConnections( state ) {
 	return state.connectionData?.connections ?? [];
 }
 
 /**
  * Return a connection by its ID.
  *
- * @param {SocialStoreState} state        - State object.
- * @param {string}           connectionId - The connection ID.
+ * @param {import("../types").SocialStoreState} state        - State object.
+ * @param {string}                              connectionId - The connection ID.
  *
- * @return {Connection | undefined} The connection.
+ * @return {import("../types").Connection | undefined} The connection.
  */
 export function getConnectionById( state, connectionId ) {
 	return getConnections( state ).find( connection => connection.connection_id === connectionId );
@@ -27,8 +26,8 @@ export function getConnectionById( state, connectionId ) {
 /**
  * Returns the broken connections.
  *
- * @param {SocialStoreState} state - State object.
- * @return {Array<Connection>} List of broken connections.
+ * @param {import("../types").SocialStoreState} state - State object.
+ * @return {Array<import("../types").Connection>} List of broken connections.
  */
 export function getBrokenConnections( state ) {
 	return getConnections( state ).filter( connection => {
@@ -39,8 +38,8 @@ export function getBrokenConnections( state ) {
 /**
  * Returns connections by service name/ID.
  *
- * @param {SocialStoreState} state       - State object.
- * @param {string}           serviceName - The service name.
+ * @param {import("../types").SocialStoreState} state       - State object.
+ * @param {string}                              serviceName - The service name.
  *
  * @return {Array<import("../types").Connections>} The connections.
  */
@@ -50,7 +49,7 @@ export function getConnectionsByService( state, serviceName ) {
 
 /**
  * Returns whether there are connections in the store.
- * @param {SocialStoreState} state - State object.
+ * @param {import("../types").SocialStoreState} state - State object.
  * @return {boolean} Whether there are connections.
  */
 export function hasConnections( state ) {
@@ -60,8 +59,8 @@ export function hasConnections( state ) {
 /**
  * Returns the failed Publicize connections.
  *
- * @param {SocialStoreState} state - State object.
- * @return {Array<Connection>} List of connections.
+ * @param {import("../types").SocialStoreState} state - State object.
+ * @return {Array<import("../types").Connection>} List of connections.
  */
 export function getFailedConnections( state ) {
 	const connections = getConnections( state );
@@ -73,8 +72,8 @@ export function getFailedConnections( state ) {
  * Returns a list of Publicize connection service names that require reauthentication from users.
  * iFor example, when LinkedIn switched its API from v1 to v2.
  *
- * @param {SocialStoreState} state - State object.
- * @return {Array<Connection>} List of service names that need reauthentication.
+ * @param {import("../types").SocialStoreState} state - State object.
+ * @return {Array<import("../types").Connection>} List of service names that need reauthentication.
  */
 export function getMustReauthConnections( state ) {
 	const connections = getConnections( state );
@@ -86,9 +85,9 @@ export function getMustReauthConnections( state ) {
 /**
  * Returns the Publicize connections that are enabled.
  *
- * @param {SocialStoreState} state - State object.
+ * @param {import("../types").SocialStoreState} state - State object.
  *
- * @return {Array<Connection>} List of enabled connections.
+ * @return {Array<import("../types").Connection>} List of enabled connections.
  */
 export function getEnabledConnections( state ) {
 	return getConnections( state ).filter( connection => connection.enabled );
@@ -97,9 +96,9 @@ export function getEnabledConnections( state ) {
 /**
  * Returns the Publicize connections that are disabled.
  *
- * @param {SocialStoreState} state - State object.
+ * @param {import("../types").SocialStoreState} state - State object.
  *
- * @return {Array<Connection>} List of disabled connections.
+ * @return {Array<import("../types").Connection>} List of disabled connections.
  */
 export function getDisabledConnections( state ) {
 	return getConnections( state ).filter( connection => ! connection.enabled );
@@ -108,10 +107,10 @@ export function getDisabledConnections( state ) {
 /**
  * Get the profile details for a connection
  *
- * @param {SocialStoreState} state              - State object.
- * @param {string}           service            - The service name.
- * @param {object}           args               - Arguments.
- * @param {boolean}          args.forceDefaults - Whether to use default values.
+ * @param {import("../types").SocialStoreState} state              - State object.
+ * @param {string}                              service            - The service name.
+ * @param {object}                              args               - Arguments.
+ * @param {boolean}                             args.forceDefaults - Whether to use default values.
  *
  * @return {object} The profile details.
  */
@@ -140,7 +139,7 @@ export function getConnectionProfileDetails( state, service, { forceDefaults = f
 /**
  * Get the connections being deleted.
  *
- * @param {SocialStoreState} state - State object.
+ * @param {import("../types").SocialStoreState} state - State object.
  * @return {import("../types").ConnectionData['deletingConnections']} The connection being deleted.
  */
 export function getDeletingConnections( state ) {
@@ -150,7 +149,7 @@ export function getDeletingConnections( state ) {
 /**
  * Get the connections being updated.
  *
- * @param {SocialStoreState} state - State object.
+ * @param {import("../types").SocialStoreState} state - State object.
  * @return {import("../types").ConnectionData['updatingConnections']} The connection being updated.
  */
 export function getUpdatingConnections( state ) {
@@ -160,7 +159,7 @@ export function getUpdatingConnections( state ) {
 /**
  * Get the account being reconnected
  *
- * @param {SocialStoreState} state - State object.
+ * @param {import("../types").SocialStoreState} state - State object.
  * @return {import("../types").ConnectionData['reconnectingAccount']} The account being reconnected.
  */
 export function getReconnectingAccount( state ) {
@@ -170,8 +169,8 @@ export function getReconnectingAccount( state ) {
 /**
  * Get the abort controllers for a specific request type.
  *
- * @param {SocialStoreState} state       - State object.
- * @param {string}           requestType - The request type.
+ * @param {import("../types").SocialStoreState} state       - State object.
+ * @param {string}                              requestType - The request type.
  *
  * @return {Array<AbortController>} The abort controllers.
  */
@@ -182,8 +181,8 @@ export function getAbortControllers( state, requestType = REQUEST_TYPE_DEFAULT )
 /**
  * Whether a mastodon account is already connected.
  *
- * @param {SocialStoreState} state  - State object.
- * @param {string}           handle - The mastodon handle.
+ * @param {import("../types").SocialStoreState} state  - State object.
+ * @param {string}                              handle - The mastodon handle.
  *
  * @return {boolean} Whether the mastodon account is already connected.
  */
@@ -196,8 +195,8 @@ export function isMastodonAccountAlreadyConnected( state, handle ) {
 /**
  * Whether a Bluesky account is already connected.
  *
- * @param {SocialStoreState} state  - State object.
- * @param {string}           handle - The Bluesky handle.
+ * @param {import("../types").SocialStoreState} state  - State object.
+ * @param {string}                              handle - The Bluesky handle.
  *
  * @return {boolean} Whether the Bluesky account is already connected.
  */
@@ -210,7 +209,7 @@ export function isBlueskyAccountAlreadyConnected( state, handle ) {
 /**
  * Returns the latest KeyringResult from the store.
  *
- * @param {SocialStoreState} state - State object.
+ * @param {import("../types").SocialStoreState} state - State object.
  *
  * @return {import("../types").KeyringResult} The KeyringResult
  */
@@ -220,7 +219,7 @@ export function getKeyringResult( state ) {
 
 /**
  * Whether the connections modal is open.
- * @param {SocialStoreState} state - State object.
+ * @param {import("../types").SocialStoreState} state - State object.
  *
  * @return {boolean} Whether the connections modal is open.
  */

--- a/projects/js-packages/publicize-components/src/social-store/selectors/test/connection-data.test.js
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/test/connection-data.test.js
@@ -12,34 +12,31 @@ const state = {
 	connectionData: {
 		connections: [
 			{
-				id: '123456789',
 				service_name: 'facebook',
 				display_name: 'Some name',
 				profile_picture: 'https://wordpress.com/some-url-of-a-picture',
-				username: 'username',
+				external_handle: 'external_handle',
 				enabled: false,
 				connection_id: '987654321',
-				test_success: true,
+				status: 'ok',
 			},
 			{
-				id: '234567891',
 				service_name: 'tumblr',
 				display_name: 'Some name',
 				profile_picture: 'https://wordpress.com/some-url-of-another-picture',
-				username: 'username',
+				external_handle: 'external_handle',
 				enabled: true,
 				connection_id: '198765432',
-				test_success: false,
+				status: 'broken',
 			},
 			{
-				id: '345678912',
 				service_name: 'mastodon',
 				display_name: 'somename',
 				profile_picture: 'https://wordpress.com/some-url-of-one-more-picture',
-				username: '@somename@mastodon.social',
+				external_handle: '@somename@mastodon.social',
 				enabled: false,
 				connection_id: '219876543',
-				test_success: 'must_reauth',
+				status: 'ok',
 			},
 		],
 	},
@@ -93,7 +90,7 @@ describe( 'Social store selectors: connectionData', () => {
 		it( 'should return must reauth connections', () => {
 			const mustReauthConnections = getMustReauthConnections( state );
 			expect( mustReauthConnections ).toEqual( [
-				state.connectionData.connections[ 2 ].service_name,
+				state.connectionData.connections[ 1 ].service_name,
 			] );
 		} );
 	} );
@@ -140,7 +137,7 @@ describe( 'Social store selectors: connectionData', () => {
 			expect( getConnectionProfileDetails( state, 'facebook' ) ).toEqual( {
 				displayName: connection.display_name,
 				profileImage: connection.profile_picture,
-				username: connection.username,
+				username: connection.external_handle,
 			} );
 		} );
 

--- a/projects/js-packages/publicize-components/src/social-store/types.ts
+++ b/projects/js-packages/publicize-components/src/social-store/types.ts
@@ -6,7 +6,6 @@ export type Connection = {
 	enabled: boolean;
 	external_handle: string;
 	external_id: string;
-	id: string;
 	profile_link: string;
 	profile_picture: string;
 	service_label: string;
@@ -37,6 +36,10 @@ export type Connection = {
 	 */
 	external_name?: string;
 	/**
+	 * @deprecated Use `connection_id` instead.
+	 */
+	id?: string;
+	/**
 	 * @deprecated Use `status` instead.
 	 */
 	is_healthy?: boolean;
@@ -51,11 +54,11 @@ export type Connection = {
 	/**
 	 * @deprecated
 	 */
-	toggleable: boolean;
+	toggleable?: boolean;
 	/**
 	 * @deprecated Use `external_handle` instead.
 	 */
-	username: string;
+	username?: string;
 };
 
 export type ConnectionData = {

--- a/projects/js-packages/publicize-components/src/social-store/types.ts
+++ b/projects/js-packages/publicize-components/src/social-store/types.ts
@@ -18,11 +18,11 @@ export type Connection = {
 	/**
 	 * @deprecated
 	 */
-	can_disconnect: boolean;
+	can_disconnect?: boolean;
 	/**
 	 * @deprecated
 	 */
-	done: boolean;
+	done?: boolean;
 	/**
 	 * @deprecated Use `status` instead.
 	 */

--- a/projects/js-packages/publicize-components/src/social-store/types.ts
+++ b/projects/js-packages/publicize-components/src/social-store/types.ts
@@ -1,25 +1,61 @@
 export type ConnectionStatus = 'ok' | 'broken';
 
 export type Connection = {
-	id: string;
-	service_name: string;
-	label?: string;
-	display_name: string;
-	external_display?: string;
-	external_id: string;
-	external_name?: string;
-	username: string;
-	enabled: boolean;
-	done: boolean;
-	toggleable: boolean;
 	connection_id: string;
-	is_healthy?: boolean;
-	error_code?: string;
-	can_disconnect: boolean;
-	profile_picture: string;
+	display_name: string;
+	enabled: boolean;
+	external_handle: string;
+	external_id: string;
+	id: string;
 	profile_link: string;
+	profile_picture: string;
+	service_label: string;
+	service_name: string;
 	shared: boolean;
 	status: ConnectionStatus;
+	user_id: number;
+
+	/* DEPRECATED FIELDS  */
+	/**
+	 * @deprecated
+	 */
+	can_disconnect: boolean;
+	/**
+	 * @deprecated
+	 */
+	done: boolean;
+	/**
+	 * @deprecated Use `status` instead.
+	 */
+	error_code?: string;
+	/**
+	 * @deprecated Use `display_name` instead.
+	 */
+	external_display?: string;
+	/**
+	 * @deprecated Use `external_handle` instead.
+	 */
+	external_name?: string;
+	/**
+	 * @deprecated Use `status` instead.
+	 */
+	is_healthy?: boolean;
+	/**
+	 * @deprecated Use `service_label` instead.
+	 */
+	label?: string;
+	/**
+	 * @deprecated Use `status` instead.
+	 */
+	test_success?: boolean;
+	/**
+	 * @deprecated
+	 */
+	toggleable: boolean;
+	/**
+	 * @deprecated Use `external_handle` instead.
+	 */
+	username: string;
 };
 
 export type ConnectionData = {

--- a/projects/js-packages/publicize-components/src/utils/connections.ts
+++ b/projects/js-packages/publicize-components/src/utils/connections.ts
@@ -1,5 +1,0 @@
-import { Connection } from '../social-store/types';
-
-export const checkConnectionCode = ( connection: Connection, code: string ) => {
-	return false === connection.is_healthy && code === ( connection.error_code ?? 'broken' );
-};

--- a/projects/js-packages/publicize-components/src/utils/test-utils.js
+++ b/projects/js-packages/publicize-components/src/utils/test-utils.js
@@ -33,34 +33,28 @@ export const testPost = {
 
 export const connections = [
 	{
-		id: '123456789',
 		service_name: 'facebook',
 		display_name: 'Some name',
 		profile_picture: 'https://wordpress.com/some-url-of-a-picture',
-		username: 'username',
+		external_handle: 'username',
 		enabled: false,
 		connection_id: '987654321',
-		test_success: true,
 	},
 	{
-		id: '234567891',
 		service_name: 'tumblr',
 		display_name: 'Some name',
 		profile_picture: 'https://wordpress.com/some-url-of-another-picture',
-		username: 'username',
+		external_handle: 'username',
 		enabled: false,
 		connection_id: '198765432',
-		test_success: false,
 	},
 	{
-		id: '345678912',
 		service_name: 'mastodon',
 		display_name: 'somename',
 		profile_picture: 'https://wordpress.com/some-url-of-one-more-picture',
-		username: '@somename@mastodon.social',
+		external_handle: '@somename@mastodon.social',
 		enabled: false,
 		connection_id: '219876543',
-		test_success: 'must_reauth',
 	},
 ];
 

--- a/projects/packages/publicize/changelog/update-unify-social-connections-schema
+++ b/projects/packages/publicize/changelog/update-unify-social-connections-schema
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Social: Use connections REST endpoint for initial state

--- a/projects/packages/publicize/src/class-connections.php
+++ b/projects/packages/publicize/src/class-connections.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Publicize;
 
+use Automattic\Jetpack\Connection;
 use Automattic\Jetpack\Publicize\REST_API\Connections_Controller;
 use Automattic\Jetpack\Status\Host;
 
@@ -32,24 +33,48 @@ class Connections {
 		$is_wpcom = ( new Host() )->is_wpcom_simple();
 
 		if ( $is_wpcom ) {
-			// We don't need to cache connections for simple sites.
-			return Connections_Controller::get_connections( $run_tests );
-		}
-
-		$clear_cache = $args['clear_cache'] ?? false;
-
-		if ( $clear_cache || $run_tests ) {
-			self::clear_transient();
-		}
-
-		$connections = get_transient( self::CONNECTIONS_TRANSIENT );
-
-		// This can be an empty array, so we need to check for false.
-		if ( false === $connections ) {
+			$connections = Connections_Controller::get_connections( $run_tests );
+		} else {
 			$connections = self::fetch_and_cache_connections( $run_tests );
 		}
 
+		// Let us add the deprecated fields for now.
+		// TODO: Remove this after https://github.com/Automattic/jetpack/pull/40539 is merged.
+		$connections = self::retain_deprecated_fields( $connections );
+
 		return $connections;
+	}
+
+	/**
+	 * Retain deprecated fields.
+	 *
+	 * @param array $connections Connections.
+	 * @return array
+	 */
+	private static function retain_deprecated_fields( $connections ) {
+		return array_map(
+			function ( $connection ) {
+				$wpcom_user_data = ( new Connection\Manager() )->get_connected_user_data();
+
+				$owns_connection = ! empty( $wpcom_user_data['ID'] ) && $wpcom_user_data['ID'] === $connection['user_id'];
+
+				$connection = array_merge(
+					$connection,
+					array(
+						'external_display' => $connection['display_name'],
+						'can_disconnect'   => current_user_can( 'edit_others_posts' ) || $owns_connection,
+						'label'            => $connection['service_label'],
+					)
+				);
+
+				if ( 'bluesky' === $connection['service_name'] ) {
+					$connection['external_name'] = $connection['external_handle'];
+				}
+
+				return $connection;
+			},
+			$connections
+		);
 	}
 
 	/**
@@ -62,17 +87,8 @@ class Connections {
 	public static function fetch_and_cache_connections( $run_tests = false ) {
 		$connections = Connections_Controller::get_connections( $run_tests );
 
-		if ( is_array( $connections ) ) {
-			set_transient( self::CONNECTIONS_TRANSIENT, $connections, HOUR_IN_SECONDS * 4 );
-		}
+		// TODO Implement caching here.
 
 		return $connections;
-	}
-
-	/**
-	 * Delete the transient.
-	 */
-	public static function clear_transient() {
-		delete_transient( self::CONNECTIONS_TRANSIENT );
 	}
 }

--- a/projects/packages/publicize/src/class-connections.php
+++ b/projects/packages/publicize/src/class-connections.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Publicize Connections class.
+ *
+ * @package automattic/jetpack-publicize
+ */
+
+namespace Automattic\Jetpack\Publicize;
+
+use Automattic\Jetpack\Connection;
+use Automattic\Jetpack\Publicize\REST_API\Connections_Controller;
+use Automattic\Jetpack\Status\Host;
+
+/**
+ * Publicize Connections class.
+ */
+class Connections {
+
+	const CONNECTIONS_TRANSIENT = 'jetpack_social_connections_list';
+
+	/**
+	 * Get all connections.
+	 *
+	 * @param array $args Arguments
+	 *                - 'clear_cache': bool Whether to clear the cache.
+	 *                - 'test_connections': bool Whether to run connection tests.
+	 * @return array
+	 */
+	public static function get_all( $args = array() ) {
+
+		$run_tests = $args['test_connections'] ?? false;
+
+		$is_wpcom = ( new Host() )->is_wpcom_simple();
+
+		if ( $is_wpcom ) {
+			$connections = Connections_Controller::get_connections( $run_tests );
+		} else {
+			$connections = self::fetch_and_cache_connections( $run_tests );
+		}
+
+		// Let us add the deprecated fields for now.
+		// TODO: Remove this after https://github.com/Automattic/jetpack/pull/40539 is merged.
+		$connections = self::retain_deprecated_fields( $connections );
+
+		return $connections;
+	}
+
+	/**
+	 * Retain deprecated fields.
+	 *
+	 * @param array $connections Connections.
+	 * @return array
+	 */
+	private static function retain_deprecated_fields( $connections ) {
+		return array_map(
+			function ( $connection ) {
+				$wpcom_user_data = ( new Connection\Manager() )->get_connected_user_data();
+
+				$owns_connection = ! empty( $wpcom_user_data['ID'] ) && $wpcom_user_data['ID'] === $connection['user_id'];
+
+				$connection = array_merge(
+					$connection,
+					array(
+						'external_display' => $connection['display_name'],
+						'can_disconnect'   => current_user_can( 'edit_others_posts' ) || $owns_connection,
+						'label'            => $connection['service_label'],
+					)
+				);
+
+				if ( 'bluesky' === $connection['service_name'] ) {
+					$connection['external_name'] = $connection['external_handle'];
+				}
+
+				return $connection;
+			},
+			$connections
+		);
+	}
+
+	/**
+	 * Fetch connections from the REST API and cache them.
+	 *
+	 * @param bool $run_tests Whether to run connection tests.
+	 *
+	 * @return array
+	 */
+	public static function fetch_and_cache_connections( $run_tests = false ) {
+		$connections = Connections_Controller::get_connections( $run_tests );
+
+		// TODO Implement caching here.
+
+		return $connections;
+	}
+}

--- a/projects/packages/publicize/src/class-connections.php
+++ b/projects/packages/publicize/src/class-connections.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Publicize;
 
-use Automattic\Jetpack\Connection;
 use Automattic\Jetpack\Publicize\REST_API\Connections_Controller;
 use Automattic\Jetpack\Status\Host;
 
@@ -33,48 +32,24 @@ class Connections {
 		$is_wpcom = ( new Host() )->is_wpcom_simple();
 
 		if ( $is_wpcom ) {
-			$connections = Connections_Controller::get_connections( $run_tests );
-		} else {
+			// We don't need to cache connections for simple sites.
+			return Connections_Controller::get_connections( $run_tests );
+		}
+
+		$clear_cache = $args['clear_cache'] ?? false;
+
+		if ( $clear_cache || $run_tests ) {
+			self::clear_transient();
+		}
+
+		$connections = get_transient( self::CONNECTIONS_TRANSIENT );
+
+		// This can be an empty array, so we need to check for false.
+		if ( false === $connections ) {
 			$connections = self::fetch_and_cache_connections( $run_tests );
 		}
 
-		// Let us add the deprecated fields for now.
-		// TODO: Remove this after https://github.com/Automattic/jetpack/pull/40539 is merged.
-		$connections = self::retain_deprecated_fields( $connections );
-
 		return $connections;
-	}
-
-	/**
-	 * Retain deprecated fields.
-	 *
-	 * @param array $connections Connections.
-	 * @return array
-	 */
-	private static function retain_deprecated_fields( $connections ) {
-		return array_map(
-			function ( $connection ) {
-				$wpcom_user_data = ( new Connection\Manager() )->get_connected_user_data();
-
-				$owns_connection = ! empty( $wpcom_user_data['ID'] ) && $wpcom_user_data['ID'] === $connection['user_id'];
-
-				$connection = array_merge(
-					$connection,
-					array(
-						'external_display' => $connection['display_name'],
-						'can_disconnect'   => current_user_can( 'edit_others_posts' ) || $owns_connection,
-						'label'            => $connection['service_label'],
-					)
-				);
-
-				if ( 'bluesky' === $connection['service_name'] ) {
-					$connection['external_name'] = $connection['external_handle'];
-				}
-
-				return $connection;
-			},
-			$connections
-		);
 	}
 
 	/**
@@ -87,8 +62,17 @@ class Connections {
 	public static function fetch_and_cache_connections( $run_tests = false ) {
 		$connections = Connections_Controller::get_connections( $run_tests );
 
-		// TODO Implement caching here.
+		if ( is_array( $connections ) ) {
+			set_transient( self::CONNECTIONS_TRANSIENT, $connections, HOUR_IN_SECONDS * 4 );
+		}
 
 		return $connections;
+	}
+
+	/**
+	 * Delete the transient.
+	 */
+	public static function clear_transient() {
+		delete_transient( self::CONNECTIONS_TRANSIENT );
 	}
 }

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -556,8 +556,8 @@ abstract class Publicize_Base {
 	public function get_display_name( $service_name, $connection ) {
 		$cmeta = $this->get_connection_meta( $connection );
 
-		if ( 'mastodon' === $service_name && isset( $cmeta['external_name'] ) ) {
-			return $cmeta['external_name'];
+		if ( 'mastodon' === $service_name && isset( $cmeta['external_display'] ) ) {
+			return $cmeta['external_display'];
 		}
 
 		if ( isset( $cmeta['connection_data']['meta']['display_name'] ) ) {

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -21,8 +21,6 @@ use Jetpack_Options;
  */
 class Publicize_Script_Data {
 
-	const SERVICES_TRANSIENT = 'jetpack_social_services_list';
-
 	/**
 	 * Get the publicize instance - properly typed
 	 *
@@ -160,8 +158,7 @@ class Publicize_Script_Data {
 
 		return array(
 			'connectionData' => array(
-				// We do not have this method on WPCOM Publicize class yet.
-				'connections' => ! $is_wpcom ? self::publicize()->get_all_connections_for_user() : array(),
+				'connections' => Connections::get_all(),
 			),
 			'shareStatus'    => $share_status,
 		);
@@ -238,17 +235,24 @@ class Publicize_Script_Data {
 
 		$is_wpcom = ( new Host() )->is_wpcom_platform();
 
+		$commom_paths = array(
+			'refreshConnections' => '/wpcom/v2/publicize/connections?test_connections=1',
+		);
+
+		$specific_paths = array();
+
 		if ( $is_wpcom ) {
-			return array(
-				'refreshConnections' => '/wpcom/v2/publicize/connection-test-results',
-				'resharePost'        => '/wpcom/v2/posts/{postId}/publicize',
+
+			$specific_paths = array(
+				'resharePost' => '/wpcom/v2/posts/{postId}/publicize',
+			);
+		} else {
+			$specific_paths = array(
+				'resharePost' => '/jetpack/v4/publicize/{postId}',
 			);
 		}
 
-		return array(
-			'refreshConnections' => '/jetpack/v4/publicize/connections?test_connections=1',
-			'resharePost'        => '/jetpack/v4/publicize/{postId}',
-		);
+		return array_merge( $commom_paths, $specific_paths );
 	}
 
 	/**


### PR DESCRIPTION
Related to #40677

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use the updated connections schema on the front-end following #40607

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to connections management
* Verify that the connection name is displayed correctly for all the connections
* Remove the display name from your Bluesky profile and reconnect it
* Verify that the display name for the connection is the blueksy handle
* Add a Mastodon connection and then break the connection by removing Jetpack [here](https://mastodon.social/oauth/authorized_applications).
* Change the tab in the edior and come back or reload the page in case of settings page to have the broken connection reflected
* In the editor, verify that the broken connection notice shows up fine.
* Reconnect the broken Mastodon account
* Verify that reconnection works fine (with the correct handle)
* In editor, toggle the connections ON/OFF to confirm it works fine
* Try to send post only to 1 network, rest toggled off to verify it works
* If you have an unsupported network like Twitter added, verify it's marked as unsupported. I verified it for my old Twitter connection.
* In the Jetpack sidebar, click on Preview social posts
* Verify that the connections are displayed fine

