### PR TITLE
Facebook Embeds: add a white background for better readability

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-facebook-embed-background-color
+++ b/projects/plugins/jetpack/changelog/fix-facebook-embed-background-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Facebook Embeds: add a white background to embeds to avoid transparent background interfering with readability.

--- a/projects/plugins/jetpack/modules/shortcodes/facebook.php
+++ b/projects/plugins/jetpack/modules/shortcodes/facebook.php
@@ -55,12 +55,18 @@ wp_embed_register_handler( 'facebook-alternate-video', JETPACK_FACEBOOK_VIDEO_AL
  * @return string Facebook embed markup.
  */
 function jetpack_facebook_embed_handler( $matches, $attr, $url ) {
+	$extra_styles = 'style="background-color: #fff;"';
+
 	if (
 		str_contains( $url, 'video.php' )
 		|| str_contains( $url, '/videos/' )
 		|| str_contains( $url, '/watch' )
 	) {
-		$embed = sprintf( '<div class="fb-video" data-allowfullscreen="true" data-href="%s"></div>', esc_url( $url ) );
+		$embed = sprintf(
+			'<div class="fb-video" data-allowfullscreen="true" data-href="%1$s" %2$s></div>',
+			esc_url( $url ),
+			$extra_styles
+		);
 	} else {
 		$width = 552; // As of 01/2017, the default width of Facebook embeds when no width attribute provided.
 
@@ -69,7 +75,12 @@ function jetpack_facebook_embed_handler( $matches, $attr, $url ) {
 			$width = min( $width, $content_width );
 		}
 
-		$embed = sprintf( '<div class="fb-post" data-href="%s" data-width="%s"></div>', esc_url( $url ), esc_attr( $width ) );
+		$embed = sprintf(
+			'<div class="fb-post" data-href="%1$s" data-width="%2$s" %3$s></div>',
+			esc_url( $url ),
+			esc_attr( $width ),
+			$extra_styles
+		);
 	}
 
 	// Skip rendering scripts in an AMP context.

--- a/projects/plugins/jetpack/modules/shortcodes/facebook.php
+++ b/projects/plugins/jetpack/modules/shortcodes/facebook.php
@@ -55,6 +55,8 @@ wp_embed_register_handler( 'facebook-alternate-video', JETPACK_FACEBOOK_VIDEO_AL
  * @return string Facebook embed markup.
  */
 function jetpack_facebook_embed_handler( $matches, $attr, $url ) {
+	// This is a stop-gap solution until Facebook hopefully resolves this ticket
+	// https://developers.facebook.com/community/threads/1675075423353415/?post_id=1675075426686748
 	$extra_styles = 'style="background-color: #fff; display: inline-block;"';
 
 	if (

--- a/projects/plugins/jetpack/modules/shortcodes/facebook.php
+++ b/projects/plugins/jetpack/modules/shortcodes/facebook.php
@@ -55,7 +55,7 @@ wp_embed_register_handler( 'facebook-alternate-video', JETPACK_FACEBOOK_VIDEO_AL
  * @return string Facebook embed markup.
  */
 function jetpack_facebook_embed_handler( $matches, $attr, $url ) {
-	$extra_styles = 'style="background-color: #fff;"';
+	$extra_styles = 'style="background-color: #fff; display: inline-block;"';
 
 	if (
 		str_contains( $url, 'video.php' )

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.facebook.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.facebook.php
@@ -57,7 +57,7 @@ class WP_Test_Jetpack_Shortcodes_Facebook extends WP_UnitTestCase {
 		$actual = ob_get_clean();
 		$this->assertStringContainsString(
 			sprintf(
-				'<div class="fb-video" data-allowfullscreen="true" data-href="%s"></div>',
+				'<div class="fb-video" data-allowfullscreen="true" data-href="%s" style="background-color: #fff;"></div>',
 				$url
 			),
 			$actual
@@ -86,7 +86,7 @@ class WP_Test_Jetpack_Shortcodes_Facebook extends WP_UnitTestCase {
 		$actual = ob_get_clean();
 		$this->assertStringContainsString(
 			sprintf(
-				'<div class="fb-video" data-allowfullscreen="true" data-href="%s"></div>',
+				'<div class="fb-video" data-allowfullscreen="true" data-href="%s" style="background-color: #fff;"></div>',
 				$url
 			),
 			$actual
@@ -115,7 +115,7 @@ class WP_Test_Jetpack_Shortcodes_Facebook extends WP_UnitTestCase {
 		$actual = ob_get_clean();
 		$this->assertStringContainsString(
 			sprintf(
-				'<div class="fb-video" data-allowfullscreen="true" data-href="%s"></div>',
+				'<div class="fb-video" data-allowfullscreen="true" data-href="%s" style="background-color: #fff;"></div>',
 				$url
 			),
 			$actual

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.facebook.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.facebook.php
@@ -57,7 +57,7 @@ class WP_Test_Jetpack_Shortcodes_Facebook extends WP_UnitTestCase {
 		$actual = ob_get_clean();
 		$this->assertStringContainsString(
 			sprintf(
-				'<div class="fb-video" data-allowfullscreen="true" data-href="%s" style="background-color: #fff;"></div>',
+				'<div class="fb-video" data-allowfullscreen="true" data-href="%s" style="background-color: #fff; display: inline-block;"></div>',
 				$url
 			),
 			$actual
@@ -86,7 +86,7 @@ class WP_Test_Jetpack_Shortcodes_Facebook extends WP_UnitTestCase {
 		$actual = ob_get_clean();
 		$this->assertStringContainsString(
 			sprintf(
-				'<div class="fb-video" data-allowfullscreen="true" data-href="%s" style="background-color: #fff;"></div>',
+				'<div class="fb-video" data-allowfullscreen="true" data-href="%s" style="background-color: #fff; display: inline-block;"></div>',
 				$url
 			),
 			$actual
@@ -115,7 +115,7 @@ class WP_Test_Jetpack_Shortcodes_Facebook extends WP_UnitTestCase {
 		$actual = ob_get_clean();
 		$this->assertStringContainsString(
 			sprintf(
-				'<div class="fb-video" data-allowfullscreen="true" data-href="%s" style="background-color: #fff;"></div>',
+				'<div class="fb-video" data-allowfullscreen="true" data-href="%s" style="background-color: #fff; display: inline-block;"></div>',
 				$url
 			),
 			$actual


### PR DESCRIPTION
Fixes #40546

## Proposed changes:

Add a background to Facebook embeds to avoid transparent backgrounds interfering with readability.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Apply branch to your test site.
* In a new post, paste both a Facebook post and a Facebook image
    * `https://www.facebook.com/VenusWilliams/posts/10151647007373076?ref=embed_post`
    * `https://www.facebook.com/officialcuteoverload/photos/a.398410140072/10151609960150073/?type=3&ref=embed_post`
* Publish your post.
* Ensure that both embeds include a white background.
