### PR TITLE
Protect: Update Scan History extension types

### DIFF
--- a/projects/plugins/protect/src/class-scan-history.php
+++ b/projects/plugins/protect/src/class-scan-history.php
@@ -219,6 +219,13 @@ class Scan_History {
 		}
 
 		foreach ( $scan_data->threats as $source_threat ) {
+			if ( isset( $source_threat->extension ) && isset( $source_threat->extension->type ) ) {
+				$type = $source_threat->extension->type;
+				if ( 'plugin' === $type || 'theme' === $type ) {
+					$source_threat->extension->type = $type . 's';
+				}
+			}
+
 			$history->threats[] = new Threat_Model( $source_threat );
 		}
 

--- a/projects/plugins/protect/src/class-scan-history.php
+++ b/projects/plugins/protect/src/class-scan-history.php
@@ -219,11 +219,8 @@ class Scan_History {
 		}
 
 		foreach ( $scan_data->threats as $source_threat ) {
-			if ( isset( $source_threat->extension ) && isset( $source_threat->extension->type ) ) {
-				$type = $source_threat->extension->type;
-				if ( 'plugin' === $type || 'theme' === $type ) {
-					$source_threat->extension->type = $type . 's';
-				}
+			if ( ! empty( $source_threat->extension ) && in_array( $source_threat->extension->type, array( 'plugin', 'theme' ), true ) ) {
+				$source_threat->extension->type .= 's';
 			}
 
 			$history->threats[] = new Threat_Model( $source_threat );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
Historical scan results must use either `"plugins"`/`"themes"` for the extension types.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Modify types received from endpoint accordingly.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://github.com/Automattic/jetpack-scan-team/issues/1598

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run this branch of Protect on JT
* Review the scanHistory initial state property in your console and ensure that each applicable results now as `"plugins"` or `"themes"` for `threats->extension->type`

