### PR TITLE
Protect: Update onboarding popover placement

### DIFF
--- a/projects/plugins/protect/src/js/routes/scan/index.jsx
+++ b/projects/plugins/protect/src/js/routes/scan/index.jsx
@@ -83,14 +83,14 @@ const ScanPage = () => {
 								<OnboardingPopover
 									id={ hasPlan ? 'paid-scan-results' : 'free-scan-results' }
 									anchor={ scanResultsAnchor }
-									position={ 'top left' }
+									position={ 'top' }
 								/>
 							) }
 							{ !! status && ! isScanInProgress( status ) && hasPlan && (
 								<OnboardingPopover
 									id={ 'paid-understand-severity' }
 									anchor={ scanResultsAnchor }
-									position={ 'top right' }
+									position={ 'top' }
 								/>
 							) }
 						</Col>

--- a/projects/plugins/protect/src/js/routes/scan/scan-admin-section-hero.tsx
+++ b/projects/plugins/protect/src/js/routes/scan/scan-admin-section-hero.tsx
@@ -107,7 +107,7 @@ const ScanAdminSectionHero: React.FC = () => {
 	return (
 		<AdminSectionHero>
 			<AdminSectionHero.Main>
-				<Text mb={ 2 } ref={ setDailyScansPopoverAnchor }>
+				<Text className={ styles[ 'last-checked' ] } mb={ 2 } ref={ setDailyScansPopoverAnchor }>
 					{ lastCheckedLocalTimestamp
 						? sprintf(
 								// translators: %s: date and time of the last scan
@@ -118,7 +118,7 @@ const ScanAdminSectionHero: React.FC = () => {
 				</Text>
 				<OnboardingPopover
 					id={ hasPlan ? 'paid-daily-and-manual-scans' : 'free-daily-scans' }
-					position={ isSm ? 'bottom' : 'middle right' }
+					position={ isSm ? 'bottom right' : 'middle right' }
 					anchor={ dailyScansPopoverAnchor }
 				/>
 				<AdminSectionHero.Heading icon={ numThreats > 0 ? 'error' : 'success' }>
@@ -157,11 +157,8 @@ const ScanAdminSectionHero: React.FC = () => {
 				) }
 				{ fixableList.length > 0 && (
 					<>
-						<div ref={ setShowAutoFixersPopoverAnchor }>
-							<Button
-								className={ styles[ 'auto-fixers' ] }
-								onClick={ handleShowAutoFixersClick( fixableList ) }
-							>
+						<div className={ styles[ 'auto-fixers' ] } ref={ setShowAutoFixersPopoverAnchor }>
+							<Button onClick={ handleShowAutoFixersClick( fixableList ) }>
 								{ sprintf(
 									/* translators: Translates to Show auto fixers $s: Number of fixable threats. */
 									__( 'Show auto fixers (%s)', 'jetpack-protect' ),
@@ -171,7 +168,7 @@ const ScanAdminSectionHero: React.FC = () => {
 						</div>
 						<OnboardingPopover
 							id="paid-fix-all-threats"
-							position={ isSm ? 'bottom right' : 'middle left' }
+							position={ isSm ? 'bottom right' : 'middle right' }
 							anchor={ showAutoFixersPopoverAnchor }
 						/>
 					</>

--- a/projects/plugins/protect/src/js/routes/scan/styles.module.scss
+++ b/projects/plugins/protect/src/js/routes/scan/styles.module.scss
@@ -4,6 +4,7 @@
 
 .auto-fixers {
 	margin-top: calc( var( --spacing-base ) * 4 ); // 32px
+	width: fit-content;
 }
 
 .scan-results-container {
@@ -21,4 +22,8 @@
 	@media (max-width: 1099px) {
 		display: none;
 	}
+}
+
+.last-checked {
+	width: fit-content;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
Updates the placement of onboarding popovers to account for changes made in the UI with introduction of the `ThreastDataViews` component.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://github.com/Automattic/jetpack-scan-team/issues/1595

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load this branch of Protect in JT
* Proceed through the free onboarding flow and verify popover location is clear/sufficient
* Proceed through the paid onboarding flow and verify popover location is clear/sufficient

## Screen Captures
Free - Desktop:
![Screen Capture on 2024-12-10 at 09-56-14](https://github.com/user-attachments/assets/22ff4b86-f79d-4a3d-8448-6d6f964012a9)

Free - Mobile:
![Screen Capture on 2024-12-10 at 09-57-09](https://github.com/user-attachments/assets/be14e530-2a03-4d85-9dc0-1bd49fc80338)

Paid - Desktop:
![Screen Capture on 2024-12-10 at 09-49-49](https://github.com/user-attachments/assets/553f4081-4c1c-4933-8f98-af6a15f5e58d)

Paid - Mobile
![Screen Capture on 2024-12-10 at 09-51-42](https://github.com/user-attachments/assets/dc9d3e61-e19d-4e0d-84e8-c2339046ea9d)
