### PR TITLE
Site Migrations: Add `migration_source_site_domain` option to sites API

### DIFF
--- a/projects/plugins/jetpack/changelog/add-option-to-sites-api
+++ b/projects/plugins/jetpack/changelog/add-option-to-sites-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add new option to site options api

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -211,6 +211,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'blogging_prompts_settings',
 		'launchpad_screen',
 		'launchpad_checklist_tasks_statuses',
+		'migration_source_site_domain',
 		'wpcom_production_blog_id',
 		'wpcom_staging_blog_ids',
 		'can_blaze',
@@ -901,6 +902,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'launchpad_checklist_tasks_statuses':
 					$options[ $key ] = $site->get_launchpad_checklist_tasks_statuses();
+					break;
+				case 'migration_source_site_domain':
+					$options[ $key ] = $site->get_migration_source_site_domain();
 					break;
 				case 'wpcom_production_blog_id':
 					$options[ $key ] = $site->get_wpcom_production_blog_id();

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1563,6 +1563,15 @@ abstract class SAL_Site {
 	}
 
 	/**
+	 * Get site option for migration source site domain
+	 *
+	 * @return string
+	 */
+	public function get_migration_source_site_domain() {
+		return get_option( 'migration_source_site_domain' );
+	}
+
+	/**
 	 * Detect whether a site is WordPress.com Staging Site.
 	 *
 	 * @see class.json-api-site-jetpack.php for implementation.

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1568,7 +1568,7 @@ abstract class SAL_Site {
 	 * @return string
 	 */
 	public function get_migration_source_site_domain() {
-		return get_option( 'migration_source_site_domain' );
+		return get_option( 'migration_source_site_domain', '' );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/96422

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `migration_source_site_domain` option to the sites API so we can access it on the frontend in https://github.com/Automattic/wp-calypso/pull/96991

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up a test site by following the instructions in https://github.com/Automattic/wp-calypso/pull/96991
* Apply this patch to your sandbox and sandbox `public-api.wordpress.com`
* Visit the developer console and GET from `/wp.com/1.2/sites/yourtestsite.wordpress.com` with the test site you created in step 1
* You should see the `migration_source_site_domain` under the `options` array with the value you input when you went through the migration flow.