### PR TITLE
Jetpack AI: Add tracking to the thumbs up/down component, saving the component and rating to Tracks

### DIFF
--- a/projects/plugins/jetpack/changelog/change-jetpack-ai-track-ai-rating
+++ b/projects/plugins/jetpack/changelog/change-jetpack-ai-track-ai-rating
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Add tracking to the thumbs up/down component, saving the component and rating to Tracks

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-feedback/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-feedback/index.tsx
@@ -1,3 +1,4 @@
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button, Tooltip } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { thumbsUp, thumbsDown } from '@wordpress/icons';
@@ -7,8 +8,14 @@ import { getFeatureAvailability } from '../../../../blocks/ai-assistant/lib/util
 
 import './style.scss';
 
-export default function AiFeedbackThumbs( { disabled = false, iconSize = 24, ratedItem } ) {
+export default function AiFeedbackThumbs( {
+	disabled = false,
+	iconSize = 24,
+	ratedItem,
+	feature,
+} ) {
 	const [ itemsRated, setItemsRated ] = useState( {} );
+	const { tracks } = useAnalytics();
 
 	const rateAI = ( isThumbsUp: boolean ) => {
 		const aiRating = isThumbsUp ? 'thumbs-up' : 'thumbs-down';
@@ -18,7 +25,10 @@ export default function AiFeedbackThumbs( { disabled = false, iconSize = 24, rat
 			[ ratedItem ]: aiRating,
 		} );
 
-		// calls to Tracks or whatever else can be made here
+		tracks.recordEvent( 'jetpack_ai_feedback', {
+			type: feature,
+			rating: aiRating,
+		} );
 	};
 
 	const checkThumb = ( thumbValue: string ) => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.tsx
@@ -171,6 +171,7 @@ export default function Carrousel( {
 						disabled={ aiFeedbackDisabled( images[ current ] ) }
 						ratedItem={ images[ current ].libraryUrl || '' }
 						iconSize={ 20 }
+						feature="image-generator"
 					/>
 				</div>
 


### PR DESCRIPTION
Fixes #[40529](https://github.com/Automattic/jetpack/issues/40529)

## Proposed changes:
* Add tracking for thumbs up/down data so we can aggregate it.
* Saves it with Tracks

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1733258259484559-slack-C054LN8RNVA
p1733779382348769-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?

No. It adds new tracking data but does not make changes anything that already exists.

## Testing instructions:
* Check out the branch and rebuild Jetpack, or set up a JN using the branch
* Enable the feature: `add_filter( 'ai_response_feedback_enabled', '__return_true' );`
* Create a new post and open the network tab of the dev tools in your browser.
* Generate an image.
* Once generated, click the thumbs up or thumbs down in the UI under the image.
* Verify a request to t.gif was made with `type` and `rating` parameters.
    * `type` should be `image-generator`
    * `rating` should be `thumbs-up` or `thumbs-down` depending on which thumb you clicked
    * The `_en` parameter should be `jetpack_ai_feedback`
    * ![Screenshot 2024-12-10 at 3 39 06 PM](https://github.com/user-attachments/assets/f44073e5-d4ec-4c3f-8ad2-80ee82329aaa)