### PR TITLE
Social | Add `wpcom/v3/publicize/services` endpoint

### DIFF
--- a/projects/packages/publicize/.phan/baseline.php
+++ b/projects/packages/publicize/.phan/baseline.php
@@ -39,6 +39,7 @@ return [
         'src/class-publicize.php' => ['PhanParamSignatureMismatch', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMissingReturn'],
         'src/class-rest-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
         'src/rest-endpoints/class-connections-controller.php' => ['PhanPluginMixedKeyNoKey'],
+        'src/rest-endpoints/class-services-controller.php' => ['PhanPluginMixedKeyNoKey'],
         'src/social-image-generator/class-post-settings.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/social-image-generator/class-rest-settings-controller.php' => ['PhanPluginMixedKeyNoKey'],
         'src/social-image-generator/class-settings.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],

--- a/projects/packages/publicize/changelog/add-social-unified-services-endpoint
+++ b/projects/packages/publicize/changelog/add-social-unified-services-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added wpcom/v3/publicize/services endpoint

--- a/projects/packages/publicize/src/class-publicize-assets.php
+++ b/projects/packages/publicize/src/class-publicize-assets.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Publicize;
 
 use Automattic\Jetpack\Publicize\Rest_Endpoints\Connections_Controller;
+use Automattic\Jetpack\Publicize\Rest_Endpoints\Services_Controller;
 
 /**
  * Publicize_Assets class.
@@ -20,5 +21,6 @@ class Publicize_Assets {
 	public static function configure() {
 		Publicize_Script_Data::configure();
 		new Connections_Controller();
+		new Services_Controller();
 	}
 }

--- a/projects/packages/publicize/src/rest-endpoints/class-services-controller.php
+++ b/projects/packages/publicize/src/rest-endpoints/class-services-controller.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * The Publicize services Controller class.
+ *
+ * @package automattic/jetpack-publicize
+ */
+
+namespace Automattic\Jetpack\Publicize\Rest_Endpoints;
+
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Registers the REST routes
+ */
+class Services_Controller extends WP_REST_Controller {
+
+	/**
+	 * Whether we are on WPCOM.
+	 *
+	 * @var bool $is_wpcom
+	 */
+	protected $is_wpcom = false;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'wpcom/v3';
+		$this->rest_base = 'publicize/services';
+
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+
+		$this->is_wpcom = defined( 'IS_WPCOM' ) && IS_WPCOM;
+
+		$this->wpcom_is_wpcom_only_endpoint = true;
+	}
+
+	/**
+	 * Register the routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permission_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Schema for the endpoint.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'jetpack-publicize-connection',
+			'type'       => 'object',
+			'properties' => array(
+				'ID'                                => array(
+					'type'        => 'string',
+					'description' => __( 'Alphanumeric identifier for the service.', 'jetpack-publicize-pkg' ),
+				),
+				'label'                             => array(
+					'type'        => 'string',
+					'description' => __( 'Human-readable label for the Jetpack Social service.', 'jetpack-publicize-pkg' ),
+				),
+				'type'                              => array(
+					'type'        => 'string',
+					'description' => __( 'Type of service.', 'jetpack-publicize-pkg' ),
+					'enum'        => array(
+						'publicize',
+						'other',
+					),
+				),
+				'description'                       => array(
+					'type'        => 'string',
+					'description' => __( 'Description for the service.', 'jetpack-publicize-pkg' ),
+				),
+				'connect_URL'                       => array(
+					'type'        => 'string',
+					'description' => __( 'URL to use for connecting an account for the service.', 'jetpack-publicize-pkg' ),
+				),
+				'external_users_only'               => array(
+					'type'        => 'boolean',
+					'description' => __( 'Whether the service supports only the external users and not the main user account.', 'jetpack-publicize-pkg' ),
+				),
+				'multiple_external_user_ID_support' => array(
+					'type'        => 'boolean',
+					'description' => __( 'Whether the service is supported for multiple external user accounts.', 'jetpack-publicize-pkg' ),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Get list of connected Publicize connections.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response suitable for 1-page collection
+	 */
+	public function get_items( $request ) {
+		if ( $this->is_wpcom ) {
+			if ( function_exists( 'require_lib' ) ) {
+				// @phan-suppress-next-line PhanUndeclaredFunction - phan is dumb not to see the function_exists check.
+				require_lib( 'external-connections' );
+			}
+
+			// @phan-suppress-next-line PhanUndeclaredClassMethod - We are here because we are on WPCOM.
+			$external_connections = \WPCOM_External_Connections::init();
+
+			$services = $external_connections->get_external_services_list( 'publicize', get_current_blog_id() );
+
+			$services = array_values( $services );
+
+			return rest_ensure_response( $services );
+
+		} else {
+			$site_id = Manager::get_site_id( true );
+			if ( ! $site_id ) {
+				return rest_ensure_response( array() );
+			}
+
+			$path = add_query_arg(
+				$request->get_query_params(),
+				sprintf( '/sites/%d/' . $this->rest_base, $site_id )
+			);
+
+			$response = Client::wpcom_json_api_request_as_user( $path, 'v3', array( 'method' => 'GET' ) );
+
+			if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+				// TODO log error.
+				return rest_ensure_response( array() );
+			}
+
+			return rest_ensure_response(
+				json_decode( wp_remote_retrieve_body( $response ), true )
+			);
+		}
+	}
+
+	/**
+	 * Filters out data based on ?_fields= request parameter
+	 *
+	 * @param array           $item    Item to prepare.
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response filtered item
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		if ( ! is_callable( array( $this, 'get_fields_for_response' ) ) ) {
+			return rest_ensure_response( $item );
+		}
+
+		$fields = $this->get_fields_for_response( $request );
+
+		$response_data = array();
+		foreach ( $item as $field => $value ) {
+			if ( in_array( $field, $fields, true ) ) {
+				$response_data[ $field ] = $value;
+			}
+		}
+
+		return rest_ensure_response( $response_data );
+	}
+
+	/**
+	 * Verify that user can access Publicize data
+	 *
+	 * @return true|WP_Error
+	 */
+	public function get_items_permission_check() {
+		global $publicize;
+
+		if ( ! $publicize ) {
+			return new WP_Error(
+				'publicize_not_available',
+				__( 'Sorry, Jetpack Social is not available on your site right now.', 'jetpack-publicize-pkg' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		if ( $publicize->current_user_can_access_publicize_data() ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'invalid_user_permission_publicize',
+			__( 'Sorry, you are not allowed to access Jetpack Social data on this site.', 'jetpack-publicize-pkg' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+}
+
+if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+	wpcom_rest_api_v2_load_plugin( Services_Controller::class );
+}

--- a/projects/packages/publicize/src/rest-endpoints/class-services-controller.php
+++ b/projects/packages/publicize/src/rest-endpoints/class-services-controller.php
@@ -42,6 +42,15 @@ class Services_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Check if we are on WPCOM.
+	 *
+	 * @return bool
+	 */
+	protected static function is_wpcom() {
+		return defined( 'IS_WPCOM' ) && IS_WPCOM;
+	}
+
+	/**
 	 * Register the routes.
 	 */
 	public function register_routes() {
@@ -111,12 +120,10 @@ class Services_Controller extends WP_REST_Controller {
 	/**
 	 * Get a list of Publicize supported services.
 	 *
-	 * @param bool $is_wpcom Whether we are on WPCOM.
-	 *
 	 * @return array
 	 */
-	public static function get_supported_services( $is_wpcom = false ) {
-		if ( $is_wpcom ) {
+	public static function get_supported_services() {
+		if ( self::is_wpcom() ) {
 			if ( function_exists( 'require_lib' ) ) {
 				// @phan-suppress-next-line PhanUndeclaredFunction - phan is dumb not to see the function_exists check.
 				require_lib( 'external-connections' );
@@ -164,7 +171,7 @@ class Services_Controller extends WP_REST_Controller {
 	public function get_items( $request ) {
 		$items = array();
 
-		foreach ( self::get_supported_services( $this->is_wpcom ) as $item ) {
+		foreach ( self::get_supported_services() as $item ) {
 			$data = $this->prepare_item_for_response( $item, $request );
 
 			$items[] = $this->prepare_response_for_collection( $data );

--- a/projects/packages/publicize/src/rest-endpoints/class-services-controller.php
+++ b/projects/packages/publicize/src/rest-endpoints/class-services-controller.php
@@ -109,14 +109,14 @@ class Services_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Get list of connected Publicize connections.
+	 * Get a list of Publicize supported services.
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
+	 * @param bool $is_wpcom Whether we are on WPCOM.
 	 *
-	 * @return WP_REST_Response suitable for 1-page collection
+	 * @return array
 	 */
-	public function get_items( $request ) {
-		if ( $this->is_wpcom ) {
+	public static function get_supported_services( $is_wpcom = false ) {
+		if ( $is_wpcom ) {
 			if ( function_exists( 'require_lib' ) ) {
 				// @phan-suppress-next-line PhanUndeclaredFunction - phan is dumb not to see the function_exists check.
 				require_lib( 'external-connections' );
@@ -129,30 +129,52 @@ class Services_Controller extends WP_REST_Controller {
 
 			$services = array_values( $services );
 
-			return rest_ensure_response( $services );
+			return $services;
 
 		} else {
 			$site_id = Manager::get_site_id( true );
 			if ( ! $site_id ) {
-				return rest_ensure_response( array() );
+				return array();
 			}
 
-			$path = add_query_arg(
-				$request->get_query_params(),
-				sprintf( '/sites/%d/' . $this->rest_base, $site_id )
-			);
+			$path = sprintf( '/sites/%d/publicize/services', $site_id );
 
 			$response = Client::wpcom_json_api_request_as_user( $path, 'v3', array( 'method' => 'GET' ) );
 
 			if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 				// TODO log error.
-				return rest_ensure_response( array() );
+				return array();
 			}
 
-			return rest_ensure_response(
-				json_decode( wp_remote_retrieve_body( $response ), true )
-			);
+			$body = wp_remote_retrieve_body( $response );
+
+			$items = json_decode( $body, true );
+
+			return $items ? $items : array();
 		}
+	}
+
+	/**
+	 * Get list of connected Publicize connections.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response suitable for 1-page collection
+	 */
+	public function get_items( $request ) {
+		$items = array();
+
+		foreach ( self::get_supported_services( $this->is_wpcom ) as $item ) {
+			$data = $this->prepare_item_for_response( $item, $request );
+
+			$items[] = $this->prepare_response_for_collection( $data );
+		}
+
+		$response = rest_ensure_response( $items );
+		$response->header( 'X-WP-Total', count( $items ) );
+		$response->header( 'X-WP-TotalPages', 1 );
+
+		return $response;
 	}
 
 	/**

--- a/projects/packages/publicize/src/rest-endpoints/class-services-controller.php
+++ b/projects/packages/publicize/src/rest-endpoints/class-services-controller.php
@@ -9,45 +9,24 @@ namespace Automattic\Jetpack\Publicize\Rest_Endpoints;
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager;
-use WP_Error;
-use WP_REST_Controller;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
 
 /**
- * Registers the REST routes
+ * Services Controller class.
  */
-class Services_Controller extends WP_REST_Controller {
-
-	/**
-	 * Whether we are on WPCOM.
-	 *
-	 * @var bool $is_wpcom
-	 */
-	protected $is_wpcom = false;
+class Services_Controller extends Base_Controller {
 
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->namespace = 'wpcom/v3';
+		parent::__construct();
+
 		$this->rest_base = 'publicize/services';
 
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
-
-		$this->is_wpcom = defined( 'IS_WPCOM' ) && IS_WPCOM;
-
-		$this->wpcom_is_wpcom_only_endpoint = true;
-	}
-
-	/**
-	 * Check if we are on WPCOM.
-	 *
-	 * @return bool
-	 */
-	protected static function is_wpcom() {
-		return defined( 'IS_WPCOM' ) && IS_WPCOM;
 	}
 
 	/**
@@ -183,60 +162,8 @@ class Services_Controller extends WP_REST_Controller {
 
 		return $response;
 	}
-
-	/**
-	 * Filters out data based on ?_fields= request parameter
-	 *
-	 * @param array           $item    Item to prepare.
-	 * @param WP_REST_Request $request Full details about the request.
-	 *
-	 * @return WP_REST_Response filtered item
-	 */
-	public function prepare_item_for_response( $item, $request ) {
-		if ( ! is_callable( array( $this, 'get_fields_for_response' ) ) ) {
-			return rest_ensure_response( $item );
-		}
-
-		$fields = $this->get_fields_for_response( $request );
-
-		$response_data = array();
-		foreach ( $item as $field => $value ) {
-			if ( in_array( $field, $fields, true ) ) {
-				$response_data[ $field ] = $value;
-			}
-		}
-
-		return rest_ensure_response( $response_data );
-	}
-
-	/**
-	 * Verify that user can access Publicize data
-	 *
-	 * @return true|WP_Error
-	 */
-	public function get_items_permission_check() {
-		global $publicize;
-
-		if ( ! $publicize ) {
-			return new WP_Error(
-				'publicize_not_available',
-				__( 'Sorry, Jetpack Social is not available on your site right now.', 'jetpack-publicize-pkg' ),
-				array( 'status' => rest_authorization_required_code() )
-			);
-		}
-
-		if ( $publicize->current_user_can_access_publicize_data() ) {
-			return true;
-		}
-
-		return new WP_Error(
-			'invalid_user_permission_publicize',
-			__( 'Sorry, you are not allowed to access Jetpack Social data on this site.', 'jetpack-publicize-pkg' ),
-			array( 'status' => rest_authorization_required_code() )
-		);
-	}
 }
 
-if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+if ( Base_Controller::is_wpcom() ) {
 	wpcom_rest_api_v2_load_plugin( Services_Controller::class );
 }

--- a/projects/packages/publicize/src/rest-endpoints/class-services-controller.php
+++ b/projects/packages/publicize/src/rest-endpoints/class-services-controller.php
@@ -171,8 +171,8 @@ class Services_Controller extends WP_REST_Controller {
 		}
 
 		$response = rest_ensure_response( $items );
-		$response->header( 'X-WP-Total', count( $items ) );
-		$response->header( 'X-WP-TotalPages', 1 );
+		$response->header( 'X-WP-Total', (string) count( $items ) );
+		$response->header( 'X-WP-TotalPages', '1' );
 
 		return $response;
 	}


### PR DESCRIPTION
Extracted out of #40536

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `wpcom/v3/publicize/services` endpoint that can be used in every scenario the publicize module is used
    * WPCOM sites
    * Jetpack sites - both Jetpack and Social plugins

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Apply this PR to your sandbox and point public API to the sandbox
* Goto [Developer console](https://developer.wordpress.com/docs/api/console/)
* Hit WP REST API - `wpcom/v3/sites/<site_id>/publicize/services`
* Confirm that the services are displayed correctly as per the schema in this PR
* Point your Jetpack site to the sandbox
* Goto any page which uses `wp.apiFetch` e.g. Block Editor
* In console, run this
```js
await wp.apiFetch({
    path: '/wpcom/v3/publicize/services'
});
```
* Confirm that the services are displayed correctly as per the schema in this PR


<img width="1156" alt="Screenshot 2024-12-11 at 10 24 25 AM" src="https://github.com/user-attachments/assets/de246807-ae29-4f05-b11f-01315fbf7bca">

<img width="714" alt="Screenshot 2024-12-11 at 10 24 55 AM" src="https://github.com/user-attachments/assets/56d8ba9c-652d-4668-8b46-097a818def26">


