### PR TITLE
Repo Gardening: stop grabbing p2 comments in support refs

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/rm-repo-gardening-p2-comments-references
+++ b/projects/github-actions/repo-gardening/changelog/rm-repo-gardening-p2-comments-references
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Support references: stop gathering p2 comments in list of support references.

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -39,7 +39,6 @@ async function getListComment( issueComments ) {
  * Support references can be in the following formats:
  * - xxx-zen
  * - xxx-zd
- * - xxxx-xxx-p2#comment-xxx
  *
  * They could also be forum links:
  * - https://wordpress.com/forums/topic/xxx
@@ -55,7 +54,7 @@ async function getListComment( issueComments ) {
 async function getIssueReferences( octokit, owner, repo, number, issueComments ) {
 	const ticketReferences = [];
 	const referencesRegexP =
-		/[0-9]*-(?:zen|zd)|[a-zA-Z0-9-]+-p2#comment-[0-9]*|https:\/\/wordpress\.com\/(?:[a-z]+\/)?forums\/topic\/(?:[a-zA-Z0-9-]+)/gim;
+		/[0-9]*-(?:zen|zd)|https:\/\/wordpress\.com\/(?:[a-z]+\/)?forums\/topic\/(?:[a-zA-Z0-9-]+)/gim;
 
 	debug( `gather-support-references: Getting references from issue body.` );
 	const {


### PR DESCRIPTION
Follow-up to #33979

## Proposed changes:

We no longer need to grab p2 comments in our lists of support references.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Related conversation: p1733754131062389-slack-C03G2H51WJX

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

This is essentially a revert of #33979. You can test this in a fork, by leaving a comment on an issue with a link such as `p8oabr-1nn-p2#comment-7667`. It should not be gathered as a support reference.

Test: https://github.com/jeherve/jetpack/issues/195
