### PR TITLE
Import: setting WP_IMPORTING to true when doing an import

### DIFF
--- a/projects/packages/import/changelog/fix-wp-import-issue
+++ b/projects/packages/import/changelog/fix-wp-import-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Import: setting WP_IMPORTING when doing an import

--- a/projects/packages/import/src/endpoints/class-attachment.php
+++ b/projects/packages/import/src/endpoints/class-attachment.php
@@ -105,6 +105,8 @@ class Attachment extends \WP_REST_Attachments_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, WP_Error object on failure.
 	 */
 	public function create_item( $request ) {
+		// Set the WP_IMPORTING constant to prevent sync notifications
+		$this->set_importing();
 		$file_info  = $this->get_file_info( $request );
 		$attachment = $this->get_attachment_by_file_info( $file_info );
 		if ( $attachment ) {

--- a/projects/packages/import/src/endpoints/class-comment.php
+++ b/projects/packages/import/src/endpoints/class-comment.php
@@ -50,6 +50,8 @@ class Comment extends \WP_REST_Comments_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or error object on failure.
 	 */
 	public function create_item( $request ) {
+		// Set the WP_IMPORTING constant to prevent sync notifications
+		$this->set_importing();
 		// Resolve comment post ID.
 		if ( ! empty( $request['post'] ) ) {
 			$posts = \get_posts( $this->get_import_db_query( $request['post'] ) );

--- a/projects/packages/import/src/endpoints/class-custom-css.php
+++ b/projects/packages/import/src/endpoints/class-custom-css.php
@@ -51,6 +51,8 @@ class Custom_CSS extends \WP_REST_Posts_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function create_item( $request ) {
+		// Set the WP_IMPORTING constant to prevent sync notifications
+		$this->set_importing();
 		$args = array(
 			'stylesheet' => $request['title'],
 		);

--- a/projects/packages/import/src/endpoints/class-global-style.php
+++ b/projects/packages/import/src/endpoints/class-global-style.php
@@ -71,6 +71,9 @@ class Global_Style extends \WP_REST_Posts_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function create_item( $request ) {
+		// Set the WP_IMPORTING constant to prevent sync notifications
+		$this->set_importing();
+
 		if ( ! class_exists( 'WP_Theme_JSON_Resolver' ) ) {
 			require_once ABSPATH . 'wp-includes/class-wp-theme-json-resolver.php';
 		}

--- a/projects/packages/import/src/endpoints/class-menu-item.php
+++ b/projects/packages/import/src/endpoints/class-menu-item.php
@@ -67,6 +67,9 @@ class Menu_Item extends \WP_REST_Menu_Items_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function create_item( $request ) {
+		// Set the WP_IMPORTING constant to prevent sync notifications
+		$this->set_importing();
+
 		if ( ! empty( $request['menus'] ) ) {
 			$menu_id = \term_exists( $request['menus'], 'nav_menu' );
 

--- a/projects/packages/import/src/endpoints/class-menu.php
+++ b/projects/packages/import/src/endpoints/class-menu.php
@@ -50,6 +50,9 @@ class Menu extends \WP_REST_Menus_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function create_item( $request ) {
+		// Set the WP_IMPORTING constant to prevent sync notifications
+		$this->set_importing();
+
 		$response = parent::create_item( $request );
 
 		// Ensure that the HTTP status is a valid one.

--- a/projects/packages/import/src/endpoints/class-page.php
+++ b/projects/packages/import/src/endpoints/class-page.php
@@ -30,6 +30,9 @@ class Page extends Post {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function create_item( $request ) {
+		// Set the WP_IMPORTING constant to prevent sync notifications
+		$this->set_importing();
+
 		if ( ! empty( $request['parent'] ) ) {
 			$pages = \get_pages( $this->get_import_db_query( $request['parent'] ) );
 

--- a/projects/packages/import/src/endpoints/class-post.php
+++ b/projects/packages/import/src/endpoints/class-post.php
@@ -74,6 +74,9 @@ class Post extends \WP_REST_Posts_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function create_item( $request ) {
+		// Set the WP_IMPORTING constant to prevent sync notifications
+		$this->set_importing();
+
 		// Skip if the post already exists.
 		$post_id = \post_exists(
 			$request['title'],

--- a/projects/packages/import/src/endpoints/class-template.php
+++ b/projects/packages/import/src/endpoints/class-template.php
@@ -47,6 +47,9 @@ class Template extends \WP_REST_Templates_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function create_item( $request ) {
+		// Set the WP_IMPORTING constant to prevent sync notifications
+		$this->set_importing();
+
 		$response = parent::create_item( $request );
 
 		return $this->add_import_id_metadata( $request, $response );

--- a/projects/packages/import/src/endpoints/trait-import.php
+++ b/projects/packages/import/src/endpoints/trait-import.php
@@ -94,4 +94,13 @@ trait Import {
 
 		return $response;
 	}
+
+	/**
+	 * Set the importing constant.
+	 */
+	public function set_importing() {
+		if ( ! defined( 'WP_IMPORTING' ) ) {
+			define( 'WP_IMPORTING', true );
+		}
+	}
 }

--- a/projects/plugins/jetpack/changelog/fix-wp-import-issue
+++ b/projects/plugins/jetpack/changelog/fix-wp-import-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Import: setting WP_IMPORTING when doing an import


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/dotcom-forge#10111

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Setting WP_IMPORTING to true when doing an import, so when doing a jetpack sync later it won't trigger other services like Sync, Publicize, Subscriptions etc.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

See discussions here: p1732881875604489-slack-C05PV073SG3

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your WoA dev testing site or a connected self-hosted site following the instructions below.
* Sandbox the WPCOM traffic to your sandbox by setting `JETPACK__SANDBOX_DOMAIN`.
* In your `0-sandbox.php` on WPCOM, add an action to monitor `jetpack_sync_remote_action`, something like the following:
```
add_action( 'jetpack_sync_remote_action', function( $action_name, $args, $user_id, $silent, $timestamp, $sent_timestamp, $queue_id ) {
    l( '>>>>>>>>>>>>>>>>>>>> jetpack_sync_remote_action :' . $action_name );
    l( 'USER ID:', $user_id );
    l( 'SILENT:', $silent );
    l( 'TIMESTAMP:', $timestamp );
    l( 'SENT TIMESTAMP:', $sent_timestamp );
    l( 'QUEUE ID:', $queue_id );

}, 10, 7 );
```
* Navigate to the Import flow: `https://wordpress.com/setup/site-setup/importerWordpress?siteSlug=YOUR_SITE_SLUG&from=&option=content&backToFlow=%2Fsite-migration%2Fsite-migration-import-or-migrate`
* Perform an import
* Go back to your sandbox and monitor the `jetpack_sync_remote_action`, the `$silent` should be `true` for those import related actions 