### PR TITLE
Duplicated views: Force WP Admin view for Categories, Tags, Portfolio, and Testimonials

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-duplicate-views-cpt-taxonomies
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-duplicate-views-cpt-taxonomies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -116,6 +116,14 @@ function wpcom_admin_interface_pre_update_option( $new_value, $old_value ) {
 }
 add_filter( 'pre_update_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_update_option', 10, 2 );
 
+const WPCOM_DUPLICATED_VIEW = array(
+	'edit.php',
+	'edit.php?post_type=jetpack-portfolio',
+	'edit.php?post_type=jetpack-testimonial',
+	'edit-tags.php?taxonomy=category',
+	'edit-tags.php?taxonomy=post_tag',
+);
+
 /**
  * Get the current screen section.
  *
@@ -148,13 +156,9 @@ function wpcom_admin_get_current_screen() {
  * @return string Filtered wpcom_admin_interface option.
  */
 function wpcom_admin_interface_pre_get_option( $default_value ) {
-	$enabled_screens = array(
-		'edit.php',
-	);
-
 	$current_screen = wpcom_admin_get_current_screen();
 
-	if ( in_array( $current_screen, $enabled_screens, true ) && wpcom_is_duplicate_views_experiment_enabled() ) {
+	if ( in_array( $current_screen, WPCOM_DUPLICATED_VIEW, true ) && wpcom_is_duplicate_views_experiment_enabled() ) {
 		return 'wp-admin';
 	}
 
@@ -177,7 +181,9 @@ function wpcom_admin_get_user_option_jetpack( $value ) {
 		$value = array();
 	}
 
-	$value['edit.php'] = Automattic\Jetpack\Masterbar\Base_Admin_Menu::CLASSIC_VIEW;
+	foreach ( WPCOM_DUPLICATED_VIEW as $path ) {
+		$value[ $path ] = Automattic\Jetpack\Masterbar\Base_Admin_Menu::CLASSIC_VIEW;
+	}
 
 	return $value;
 }


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/95621
Part of https://github.com/Automattic/wp-calypso/issues/96183

## Proposed changes:
Forces the WP Admin view (classic view) for users participating in the duplicated views experiment on the following screens:
- Posts > Tags
- Posts > Categories
- Portfolio > All Projects
- Testimonials > All Testimonials

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Go to the placeholder experiment page: 22124-explat-experiment
- Assign yourself to the `treatment` variation using the bookmarklets
- Apply these changes to a WP.com site with the default admin interface
- Make sure the all the menu items below point to WP Admin:
  - Posts > Tags
  - Posts > Categories
  - Portfolio > All Projects
  - Testimonials > All Testimonials

