### PR TITLE
My Jetpack:  Plans section- Paid plan expiration date improvements.

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.tsx
@@ -103,7 +103,7 @@ const PlanExpiry: FC< PlanSectionProps > = ( { purchase } ) => {
 			__( 'Expires on %1$s', 'jetpack-my-jetpack' ),
 			expiryDate
 		);
-	}, [ expiry_date, isExpiringPurchase, isExpiringSoon ] );
+	}, [ expiry_date, isExpiringPurchase, isExpiringSoon, partner_name, subscribed_date ] );
 
 	const expiryAction = useCallback( () => {
 		if ( ! isExpiringPurchase ) {

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.tsx
@@ -68,9 +68,7 @@ const PlanExpiry: FC< PlanSectionProps > = ( { purchase } ) => {
 		hundredYearDate.setFullYear( hundredYearDate.getFullYear() + 100 );
 
 		// If expiry_date is null, we'll default to 100 years in the future (same behavior in Store Admin).
-		const expiryDate = expiry_date
-			? dateI18n( 'F jS, Y', expiry_date )
-			: dateI18n( 'F jS, Y', hundredYearDate );
+		const expiryDate = dateI18n( 'F jS, Y', expiry_date ?? hundredYearDate );
 
 		if ( isExpiringPurchase ) {
 			// Expiring soon

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.tsx
@@ -1,5 +1,5 @@
 import { Text, H3, Title, Button } from '@automattic/jetpack-components';
-import { dateI18n } from '@wordpress/date';
+import { getDate, dateI18n } from '@wordpress/date';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useCallback } from 'react';
@@ -40,8 +40,16 @@ const PlanSection: FC< PlanSectionProps > = ( { purchase } ) => {
 };
 
 const PlanExpiry: FC< PlanSectionProps > = ( { purchase } ) => {
-	const { ID, expiry_date, expiry_status, product_name, product_slug, subscribed_date, domain } =
-		purchase;
+	const {
+		ID,
+		expiry_date,
+		expiry_status,
+		partner_name,
+		product_name,
+		product_slug,
+		subscribed_date,
+		domain,
+	} = purchase;
 
 	const managePurchaseUrl = `https://wordpress.com/me/purchases/${ domain }/${ ID }`;
 	const renewUrl = `https://wordpress.com/checkout/${ product_slug }/renew/${ ID }/${ domain }`;
@@ -56,14 +64,21 @@ const PlanExpiry: FC< PlanSectionProps > = ( { purchase } ) => {
 	} );
 
 	const expiryMessage = useCallback( () => {
-		const displayDate = dateI18n( 'F jS, Y', expiry_date );
+		const hundredYearDate = getDate( subscribed_date );
+		hundredYearDate.setFullYear( hundredYearDate.getFullYear() + 100 );
+
+		// If expiry_date is null, we'll default to 100 years in the future (same behavior in Store Admin).
+		const expiryDate = expiry_date
+			? dateI18n( 'F jS, Y', expiry_date )
+			: dateI18n( 'F jS, Y', hundredYearDate );
+
 		if ( isExpiringPurchase ) {
 			// Expiring soon
 			if ( isExpiringSoon ) {
 				return sprintf(
 					// translators: %1$s is the formatted date to display, i.e.- November 24th, 2024
 					__( 'Expiring soon on %1$s', 'jetpack-my-jetpack' ),
-					displayDate
+					expiryDate
 				);
 			}
 
@@ -71,14 +86,22 @@ const PlanExpiry: FC< PlanSectionProps > = ( { purchase } ) => {
 			return sprintf(
 				// translators: %1$s is the formatted date to display, i.e.- November 24th, 2024
 				__( 'Expired on %1$s', 'jetpack-my-jetpack' ),
-				displayDate
+				expiryDate
 			);
 		}
 
+		if ( ! expiry_date && partner_name ) {
+			// This means the subscription was provisioned by a hosting partner.
+			return sprintf(
+				// translators: %1$s is the name of the hosting partner. i.e.- Bluehost, InMotion, Pressable, Jurassic Ninja, etc..
+				__( 'Managed by: %1$s', 'jetpack-my-jetpack' ),
+				partner_name
+			);
+		}
 		return sprintf(
 			// translators: %1$s is the formatted date to display, i.e.- November 24th, 2024
 			__( 'Expires on %1$s', 'jetpack-my-jetpack' ),
-			displayDate
+			expiryDate
 		);
 	}, [ expiry_date, isExpiringPurchase, isExpiringSoon ] );
 

--- a/projects/packages/my-jetpack/changelog/fix-mj-plans-section-expire-date
+++ b/projects/packages/my-jetpack/changelog/fix-mj-plans-section-expire-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Plans section: Improvements to how we display plan expiration date.


### PR DESCRIPTION
This PR makes some improvements to how we display the subscription expiration date for the site's paid plans. Basically this PR displays "Managed by [hosting partner name]" when a plan/product is provisioned by a hosting partner.
Calypso also displays partner provisioned plans/products in this way, so this PR is just making the Plugin and Calypso consistent with each other.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* If subscription was provisioned by partner, show: "Managed by: [the partner name]" (like Calypso (blue & green) does)
* If no expiry date (`expiry_date: null`), display expiry date as subscription date + 100 years (like Store Admin does).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Create a Jurassic Ninja site (Click the "See more options" button).
    - Select any Jetpack product(s) to add a license for. (Under section that says, "Optionally, select Jetpack products to issue licenses for:"
    - Select to add "Jetpack Beta". - Add this PR branch (`fix/mj-plans-section-expire-date`) to Jetpack plugin.
    - Click "Launch single site".  When it's ready to go, click "Go to your site".
- Go to Jetpack --> My Jetpack
- Click to "Connect Jetpack in one click". - Site connection- (If redirect to the pricing page, select "Jetpack Free" to get back to your site).
- Now click to connect your User account - User connection- (If redirect to the pricing page, select "Jetpack Free" to get back to your site).
    - Upon User connection, Jurassic Ninja will add the Product license you selected.
- In My Jetpack, scroll down to the Your Plan(s) section (at the bottom-left):
    - Verify the Product you selected to add a license for is listed/displaying as a plan you own.
    - Verify it says "Managed by Jurassic Ninja" under the plan/product name.
    - You can click "Manage my plan" link to be taken to your site's purchases/subscriptions page in Jetpack Cloud where you can see it also says "Managed by Jurassic Ninja" there also, so now they are consistent with each other. - See screenshot:

![Screen Shot 2024-12-13 at 20 19 14](https://github.com/user-attachments/assets/cf431397-932f-4653-b4fb-55890de4c184)

![Screen Shot 2024-12-13 at 20 30 54](https://github.com/user-attachments/assets/85f15710-1f7f-4b34-9e71-e05c15139e7d)



<strong>Bonus:</strong> (I have already tested this PR with the following methods below, but if you feel compelled, you can test these other methods of testing a Partner site also, if you want) - See Screenshot below ⤵️
- You can test this PR in the same way above, on any other Hosting Partner sites such as a Pressable site: PCYsg-9TF-p2
- Or even create your own Partner account/key in Jetpack Manage(the Partner Portal) and issue a license to your site: PCYsg-WPe-p2

![Screen Shot 2024-12-13 at 20 16 48](https://github.com/user-attachments/assets/fd061db0-8e51-4c42-bff5-7a672dd9f5de)
