### PR TITLE
Starter page templates: correctly insert the pattern to the Content block

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-starter-page-templates
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-starter-page-templates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Starter page templates: correctly insert the pattern to the Content block when rendering mode is template-locked


### PR DESCRIPTION
Context: p1733852360016879-slack-CBTN58FTJ

## Proposed changes:

In Gutenberg 19.8, we started defaulting to `template-locked` rendering mode when creating a new page with this PR:

- https://github.com/WordPress/gutenberg/pull/62304

This breaks the Starter Page Templates feature in wpcom at this line:

https://github.com/Automattic/jetpack/blob/3c012a818223d53c22c27d1f124bcee68b46981e/projects/packages/jetpack-mu-wpcom/src/features/starter-page-templates/page-patterns-plugin.tsx#L97

because in `template-locked` mode, the blocks includes the template parts, so the post content block might be buried in the middle inside some Group blocks.

This PR fixes that by recursively finding the Content block.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Prepare an Atomic site.
2. Verify it's running Gutenberg 19.7.
3. Patch this PR to Jetpack Beta Tester's WordPress.com Features.
4. Activate TT5 theme.
5. Go to Pages -> Add New Page.
6. Verify you see the dotcom's Add a page modal.
7. Select any pattern.
8. Verify you can edit the pattern in the Editor afterwards.
9. Now, download and install and activate Gutenberg 19.8 https://github.com/WordPress/gutenberg/releases/tag/v19.8.0
10. Repeat the above steps and verify it still works.