### PR TITLE
Remove duplicate views: Use the iframe editor in WP-Admin screens

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-redirect-to-iframe
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-redirect-to-iframe
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use the Editor iframe for users that are part of the remove duplicate views treatment group

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/remove-duplicate-views-experiment.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/remove-duplicate-views-experiment.php
@@ -5,6 +5,8 @@
  * Added in the context of the Remove Duplicate views Project thread (https://wp.me/pekYwv-4PY).
  *
  * @todo: Move the remaining code for duplicate reviews from wpcom-admin-interface.php
+ *
+ * @package automattic/jetpack-mu-wpcom
  */
 
 declare( strict_types=1 );
@@ -29,7 +31,7 @@ function wpcom_get_preferred_configured_view( string $post_type ) {
  * This is a temporary solution until we remove the iFramed Editor.
  *
  * @param string $link    The original link.
- * @param int    $post_id The post id
+ * @param int    $post_id The post id.
  * @return mixed|string
  */
 function wpcom_update_editor_edit_link_in_edit_page_when_experiment_enabled( $link, $post_id ) {
@@ -72,7 +74,7 @@ add_filter( 'get_edit_post_link', 'wpcom_update_editor_edit_link_in_edit_page_wh
  * When set to classic, the iframe editor will point to Core as before.
  *
  * @param bool   $use_core_editor If the user should get the Core Editor link.
- * @param string $menu_item_slug  The menu item slug - in this case, the edit.php slug
+ * @param string $menu_item_slug  The menu item slug - in this case, the edit.php slug.
  * @return false|mixed
  */
 function wpcom_admin_menu_set_editor_type( $use_core_editor, $menu_item_slug ) {
@@ -116,12 +118,11 @@ function wpcom_duplicate_views_experiment_update_admin_menu_post_new() {
 	$domain = ( new Automattic\Jetpack\Status() )->get_site_suffix();
 
 	$admin_menu = Automattic\Jetpack\Masterbar\Admin_Menu::get_instance();
-	$admin_menu->update_submenus('edit.php', array( 'post-new.php' => 'https://wordpress.com/post/' . $domain));
-	$admin_menu->update_submenus('edit.php?post_type=page', array( 'post-new.php?post_type=page' => 'https://wordpress.com/page/' . $domain));
+	$admin_menu->update_submenus( 'edit.php', array( 'post-new.php' => 'https://wordpress.com/post/' . $domain ) );
+	$admin_menu->update_submenus( 'edit.php?post_type=page', array( 'post-new.php?post_type=page' => 'https://wordpress.com/page/' . $domain ) );
 
-	$admin_menu->update_submenus('edit.php?post_type=jetpack-portfolio', array( 'post-new.php?post_type=jetpack-portfolio' => 'https://wordpress.com/edit/jetpack-portfolio/' . $domain));
-	$admin_menu->update_submenus('edit.php?post_type=jetpack-testimonial', array( 'post-new.php?post_type=jetpack-testimonial' => 'https://wordpress.com/edit/jetpack-testimonial/' . $domain));
-
+	$admin_menu->update_submenus( 'edit.php?post_type=jetpack-portfolio', array( 'post-new.php?post_type=jetpack-portfolio' => 'https://wordpress.com/edit/jetpack-portfolio/' . $domain ) );
+	$admin_menu->update_submenus( 'edit.php?post_type=jetpack-testimonial', array( 'post-new.php?post_type=jetpack-testimonial' => 'https://wordpress.com/edit/jetpack-testimonial/' . $domain ) );
 }
 
 add_action( 'admin_menu', 'wpcom_duplicate_views_experiment_update_admin_menu_post_new', PHP_INT_MAX, 0 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/remove-duplicate-views-experiment.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/remove-duplicate-views-experiment.php
@@ -1,0 +1,126 @@
+<?php
+declare( strict_types=1 );
+
+/**
+ * Functions that alter the behavior of WP-Admin screens.
+ *
+ * Added in the context of the Remove Duplicate views Project thread (https://wp.me/pekYwv-4PY).
+ *
+ * @todo: Move the remaining code for duplicate reviews from wpcom-admin-interface.php
+ */
+
+/**
+ * Get the preferred configured view for a given post type.
+ *
+ * @param string $post_type
+ * @return mixed|null
+ */
+function wpcom_get_preferred_configured_view( string $post_type ) {
+	remove_filter( 'get_user_option_jetpack_admin_menu_preferred_views', 'wpcom_admin_get_user_option_jetpack' );
+	$option = get_user_option( 'jetpack_admin_menu_preferred_views' );
+	add_filter( 'get_user_option_jetpack_admin_menu_preferred_views', 'wpcom_admin_get_user_option_jetpack' );
+
+	return $option[ $post_type ] ?? null;
+}
+
+/**
+ * Update the editor edit link in the edit.php screen to point to Calypso iframe for users that have the remove duplicate experiment enabled.
+ *
+ * This is a temporary solution until we remove the iFramed Editor.
+ *
+ * @param $link
+ * @param $post_id
+ * @return mixed|string
+ */
+function wpcom_update_editor_edit_link_in_edit_page_when_experiment_enabled( $link, $post_id ) {
+	global $pagenow, $post_type;
+
+	if ( 'edit.php' !== $pagenow ) {
+		return $link;
+	}
+
+	$post_slug_list = array(
+		'post',
+		'page',
+		'jetpack-testimonial',
+		'jetpack-portfolio'
+	);
+
+	if ( ! in_array( $post_type, $post_slug_list, true ) ) {
+		return $link;
+	}
+
+	// if the user is on the control variation or if they opted for WP-Admin Classic.
+	if ( ! wpcom_is_duplicate_views_experiment_enabled() || ! wpcom_is_using_default_admin_menu() ) {
+		return $link;
+	}
+
+	$preferred_view = wpcom_get_preferred_configured_view( 'edit.php?post_type=' . $post_type );
+
+	if ( null !== $preferred_view ) {
+		return $link;
+	}
+
+	return 'https://wordpress.com/' . $post_type . '/' . ( new Automattic\Jetpack\Status() )->get_site_suffix() . '/' . $post_id;
+}
+add_filter( 'get_edit_post_link', 'wpcom_update_editor_edit_link_in_edit_page_when_experiment_enabled', 10, 2 );
+
+/**
+ * Set the editor type in the admin menu to the iframe for users that are in the treatment group.
+ *
+ * When set to classic, the iframe editor will point to Core as before.
+ *
+ * @param $use_core_editor
+ * @param $menu_item_slug
+ * @return false|mixed
+ */
+function wpcom_admin_menu_set_editor_type( $use_core_editor, $menu_item_slug ) {
+	$post_slug_list = array(
+		'edit-php'                             => 'post',
+		'edit-phppost_typepage'                => 'page',
+		'edit-phppost_typejetpack-portfolio'   => 'jetpack-portfolio',
+		'edit-phppost_typejetpack-testimonial' => 'jetpack-testimonial',
+	);
+
+	if ( ! isset( $post_slug_list[ $menu_item_slug ] ) ) {
+		return $use_core_editor;
+	}
+
+	// bail if the user is on the control variation or if they opted for WP-Admin Classic.
+	if ( ! wpcom_is_duplicate_views_experiment_enabled() || ! wpcom_is_using_default_admin_menu() ) {
+		return $use_core_editor;
+	}
+
+	$preferred_view = wpcom_get_preferred_configured_view( 'edit.php?post_type=' . $post_slug_list[ $menu_item_slug ] );
+
+	if ( null !== $preferred_view ) {
+		return $use_core_editor;
+	}
+
+	return false;
+}
+
+add_filter( 'wpcom_admin_menu_use_core_editor', 'wpcom_admin_menu_set_editor_type', 10, 2 );
+
+/**
+ * Use the Calypso editor iframe for users that are part of the treatment variation.
+ *
+ * @return void
+ */
+function wpcom_duplicate_views_experiment_update_admin_menu_post_new() {
+	if ( ! wpcom_is_duplicate_views_experiment_enabled() || ! wpcom_is_using_default_admin_menu() ) {
+		return;
+	}
+
+	$domain = ( new Automattic\Jetpack\Status() )->get_site_suffix();
+
+	$admin_menu = Automattic\Jetpack\Masterbar\Admin_Menu::get_instance();
+	$admin_menu->update_submenus('edit.php', array( 'post-new.php' => 'https://wordpress.com/post/' . $domain));
+	$admin_menu->update_submenus('edit.php?post_type=page', array( 'post-new.php?post_type=page' => 'https://wordpress.com/page/' . $domain));
+
+	$admin_menu->update_submenus('edit.php?post_type=jetpack-portfolio', array( 'post-new.php?post_type=jetpack-portfolio' => 'https://wordpress.com/edit/jetpack-portfolio/' . $domain));
+	$admin_menu->update_submenus('edit.php?post_type=jetpack-testimonial', array( 'post-new.php?post_type=jetpack-testimonial' => 'https://wordpress.com/edit/jetpack-testimonial/' . $domain));
+
+}
+
+add_action( 'admin_menu', 'wpcom_duplicate_views_experiment_update_admin_menu_post_new', PHP_INT_MAX, 0 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/remove-duplicate-views-experiment.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/remove-duplicate-views-experiment.php
@@ -1,6 +1,4 @@
 <?php
-declare( strict_types=1 );
-
 /**
  * Functions that alter the behavior of WP-Admin screens.
  *
@@ -9,10 +7,12 @@ declare( strict_types=1 );
  * @todo: Move the remaining code for duplicate reviews from wpcom-admin-interface.php
  */
 
+declare( strict_types=1 );
+
 /**
  * Get the preferred configured view for a given post type.
  *
- * @param string $post_type
+ * @param string $post_type The post type.
  * @return mixed|null
  */
 function wpcom_get_preferred_configured_view( string $post_type ) {
@@ -28,8 +28,8 @@ function wpcom_get_preferred_configured_view( string $post_type ) {
  *
  * This is a temporary solution until we remove the iFramed Editor.
  *
- * @param $link
- * @param $post_id
+ * @param string $link    The original link.
+ * @param int    $post_id The post id
  * @return mixed|string
  */
 function wpcom_update_editor_edit_link_in_edit_page_when_experiment_enabled( $link, $post_id ) {
@@ -43,7 +43,7 @@ function wpcom_update_editor_edit_link_in_edit_page_when_experiment_enabled( $li
 		'post',
 		'page',
 		'jetpack-testimonial',
-		'jetpack-portfolio'
+		'jetpack-portfolio',
 	);
 
 	if ( ! in_array( $post_type, $post_slug_list, true ) ) {
@@ -63,6 +63,7 @@ function wpcom_update_editor_edit_link_in_edit_page_when_experiment_enabled( $li
 
 	return 'https://wordpress.com/' . $post_type . '/' . ( new Automattic\Jetpack\Status() )->get_site_suffix() . '/' . $post_id;
 }
+
 add_filter( 'get_edit_post_link', 'wpcom_update_editor_edit_link_in_edit_page_when_experiment_enabled', 10, 2 );
 
 /**
@@ -70,8 +71,8 @@ add_filter( 'get_edit_post_link', 'wpcom_update_editor_edit_link_in_edit_page_wh
  *
  * When set to classic, the iframe editor will point to Core as before.
  *
- * @param $use_core_editor
- * @param $menu_item_slug
+ * @param bool   $use_core_editor If the user should get the Core Editor link.
+ * @param string $menu_item_slug  The menu item slug - in this case, the edit.php slug
  * @return false|mixed
  */
 function wpcom_admin_menu_set_editor_type( $use_core_editor, $menu_item_slug ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -117,6 +117,11 @@ function wpcom_admin_interface_pre_update_option( $new_value, $old_value ) {
 add_filter( 'pre_update_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_update_option', 10, 2 );
 
 /**
+ * Remove duplicate views experiment: load the script.
+ */
+require_once __DIR__ . '/remove-duplicate-views-experiment.php';
+
+/**
  * Get the current screen section.
  *
  * Temporary function copied from Base_Admin_Menu.

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -203,6 +203,9 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 				'slug'       => array(
 					'type' => 'string',
 				),
+				'use_core_editor' => array(
+					'type' => 'boolean',
+				),
 				'children'   => array(
 					'items' => array(
 						'count'  => array(
@@ -302,6 +305,11 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			'type'  => 'menu-item',
 			'url'   => $this->prepare_menu_item_url( $url, $parent_slug ),
 		);
+
+		$post_types = array( 'edit-php', 'edit-phppost_typepage', 'edit-phppost_typejetpack-portfolio', 'edit-phppost_typejetpack-testimonial' );
+		if ( in_array( $item['slug'], $post_types, true ) ) {
+			$item['use_core_editor'] = apply_filters( 'wpcom_admin_menu_use_core_editor', str_contains( 'wp-admin/edit.php', $item['url'] ), $item['slug'] );
+		}
 
 		$parsed_item = $this->parse_menu_item( $item['title'] );
 		if ( ! empty( $parsed_item ) ) {

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -184,23 +184,23 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			'title'      => 'Admin Menu',
 			'type'       => 'object',
 			'properties' => array(
-				'count'      => array(
+				'count'           => array(
 					'description' => 'Core/Plugin/Theme update count or unread comments count.',
 					'type'        => 'integer',
 				),
-				'icon'       => array(
+				'icon'            => array(
 					'description' => 'Menu item icon. Dashicon slug or base64-encoded SVG.',
 					'type'        => 'string',
 				),
-				'inlineText' => array(
+				'inlineText'      => array(
 					'description' => 'Additional text to be added inline with the menu title.',
 					'type'        => 'string',
 				),
-				'badge'      => array(
+				'badge'           => array(
 					'description' => 'Badge to be added inline with the menu title.',
 					'type'        => 'string',
 				),
-				'slug'       => array(
+				'slug'            => array(
 					'type' => 'string',
 				),
 				'use_core_editor' => array(
@@ -308,7 +308,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 
 		$post_types = array( 'edit-php', 'edit-phppost_typepage', 'edit-phppost_typejetpack-portfolio', 'edit-phppost_typejetpack-testimonial' );
 		if ( in_array( $item['slug'], $post_types, true ) ) {
-			$item['use_core_editor'] = apply_filters( 'wpcom_admin_menu_use_core_editor', str_contains( 'wp-admin/edit.php', $item['url'] ), $item['slug'] );
+			$item['use_core_editor'] = apply_filters( 'wpcom_admin_menu_use_core_editor', str_contains( $item['url'], 'wp-admin/edit.php' ), $item['slug'] );
 		}
 
 		$parsed_item = $this->parse_menu_item( $item['title'] );

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -206,7 +206,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 				'use_core_editor' => array(
 					'type' => 'boolean',
 				),
-				'children'   => array(
+				'children'        => array(
 					'items' => array(
 						'count'  => array(
 							'description' => 'Core/Plugin/Theme update count or unread comments count.',
@@ -232,14 +232,14 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 					),
 					'type'  => 'array',
 				),
-				'title'      => array(
+				'title'           => array(
 					'type' => 'string',
 				),
-				'type'       => array(
+				'type'            => array(
 					'enum' => array( 'separator', 'menu-item' ),
 					'type' => 'string',
 				),
-				'url'        => array(
+				'url'             => array(
 					'format' => 'uri',
 					'type'   => 'string',
 				),

--- a/projects/plugins/jetpack/changelog/add-redirect-to-iframe
+++ b/projects/plugins/jetpack/changelog/add-redirect-to-iframe
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Added a new property in the admin-menu endpoint that configures which post editor to load in the nav-unification


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Update the post editor links in edit.php screens to point to the iframe editor for users that are part of the treatment group of the remove duplicate screens experiment.

Fix: https://github.com/Automattic/wp-calypso/issues/97396

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a new property in the nav-unification admin-menu to configure which post editor to use (iframe or core) - this will be used in Calypso to avoid a redirect.
* Update the Nav-Unification links to the Post editor to point to the iframe one.
* Update the edit links on edit.php to point to the iframe
* Update the Add new Post in edit.php to point to the iframe

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test this on both Simple and Atomic
* Make sure your user is in the treatment group
* Go to WP-Admin and notice that the Admin Menu > Posts > Add new Post menu item is pointing to the iframe editor
* Go to WP-Admin > Posts > All Posts and check if the "Add new post" and the post edit links are pointing to the iframe editor
* **Remark**: If you click on the edit link for post, you'll be sent to the iframe editor and **redirected** to the Core editor. This is expected and is handled in a separate Calypso PR.
