### PR TITLE
Social | Standardize connections API schema

### DIFF
--- a/projects/packages/publicize/changelog/update-unify-schema-for-connections-management
+++ b/projects/packages/publicize/changelog/update-unify-schema-for-connections-management
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Social | Enabled connections management on WPCOM

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -605,10 +605,10 @@ abstract class Publicize_Base {
 			return $cmeta['external_display'];
 		}
 
-		$connection_display = $cmeta['external_display'] ?? '';
+		$connection_display = $cmeta['external_display'];
 
 		if ( empty( $connection_display ) ) {
-			$connection_display = $cmeta['external_name'] ?? '';
+			$connection_display = $cmeta['external_name'];
 		}
 
 		return $connection_display;

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -605,7 +605,7 @@ abstract class Publicize_Base {
 			return $cmeta['external_display'];
 		}
 
-		$connection_display = $cmeta['external_display'];
+		$connection_display = $cmeta['external_display'] ?? '';
 
 		if ( empty( $connection_display ) ) {
 			$connection_display = $cmeta['external_name'];

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -478,6 +478,32 @@ abstract class Publicize_Base {
 	abstract public function unglobalize_connection( $connection_id );
 
 	/**
+	 * Returns the external handle for the Connection.
+	 *
+	 * @param string       $service_name 'facebook', 'linkedin', etc.
+	 * @param object|array $connection The Connection object (WordPress.com) or array (Jetpack).
+	 * @return string
+	 */
+	public function get_external_handle( $service_name, $connection ) {
+		$cmeta = $this->get_connection_meta( $connection );
+
+		switch ( $service_name ) {
+			case 'mastodon':
+				return $cmeta['external_display'] ?? '';
+
+			case 'bluesky':
+			case 'threads':
+				return $cmeta['external_name'] ?? '';
+
+			case 'instagram-business':
+				return $cmeta['connection_data']['meta']['username'] ?? '';
+
+			default:
+				return '';
+		}
+	}
+
+	/**
 	 * Returns an external URL to the Connection's profile
 	 *
 	 * @param string       $service_name 'facebook', 'twitter', etc.
@@ -615,7 +641,7 @@ abstract class Publicize_Base {
 	 * @param object|array $connection The Connection object (WordPress.com) or array (Jetpack).
 	 * @return string
 	 */
-	private function get_profile_picture( $connection ) {
+	public function get_profile_picture( $connection ) {
 		$cmeta = $this->get_connection_meta( $connection );
 
 		if ( isset( $cmeta['profile_picture'] ) ) {

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -608,7 +608,7 @@ abstract class Publicize_Base {
 		$connection_display = $cmeta['external_display'] ?? '';
 
 		if ( empty( $connection_display ) ) {
-			$connection_display = $cmeta['external_name'];
+			$connection_display = $cmeta['external_name'] ?? '';
 		}
 
 		return $connection_display;

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -398,6 +398,13 @@ abstract class Publicize_Base {
 	abstract public function get_connections( $service_name, $_blog_id = false, $_user_id = false );
 
 	/**
+	 * Get all Connections from all services for a user
+	 *
+	 * @param array $args Arguments to run operations such as force refresh and connection test results.
+	 */
+	abstract public function get_all_connections_for_user( $args = array() );
+
+	/**
 	 * Get a single Connection of a Service
 	 *
 	 * @param string    $service_name 'facebook', 'twitter', etc.

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -530,8 +530,8 @@ abstract class Publicize_Base {
 			return 'https://instagram.com/' . $cmeta['connection_data']['meta']['username'];
 		}
 
-		if ( 'threads' === $service_name && isset( $connection['external_name'] ) ) {
-			return 'https://www.threads.net/@' . $connection['external_name'];
+		if ( 'threads' === $service_name && isset( $cmeta['external_name'] ) ) {
+			return 'https://www.threads.net/@' . $cmeta['external_name'];
 		}
 
 		if ( 'mastodon' === $service_name && isset( $cmeta['external_name'] ) ) {

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -158,8 +158,7 @@ class Publicize_Script_Data {
 
 		return array(
 			'connectionData' => array(
-				// We do not have this method on WPCOM Publicize class yet.
-				'connections' => ! $is_wpcom ? self::publicize()->get_all_connections_for_user() : array(),
+				'connections' => self::publicize()->get_all_connections_for_user(),
 			),
 			'shareStatus'    => $share_status,
 		);

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -19,7 +19,7 @@ use WP_Post;
  */
 class Publicize extends Publicize_Base {
 
-	const JETPACK_SOCIAL_CONNECTIONS_TRANSIENT = 'jetpack_social_connections';
+	const JETPACK_SOCIAL_CONNECTIONS_TRANSIENT = 'jetpack_social_connection_list';
 
 	/**
 	 * Transitory storage of connection testing results.

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -242,25 +242,25 @@ class Publicize extends Publicize_Base {
 		$connections_to_return = array();
 		if ( ! empty( $connections ) ) {
 			foreach ( (array) $connections as $service_name => $connections_for_service ) {
-				foreach ( $connections_for_service as $id => $connection ) {
+				foreach ( $connections_for_service as $connection ) {
 					$user_id = (int) $connection['connection_data']['user_id'];
+
+					$connection_meta = $this->get_connection_meta( $connection );
 					// phpcs:ignore WordPress.PHP.YodaConditions.NotYoda
 					if ( $user_id === 0 || $this->user_id() === $user_id ) {
-						if ( $this->use_admin_ui_v1() ) {
-							$connections_to_return[] = array_merge(
-								$connection,
-								array(
-									'service_name'   => $service_name,
-									'connection_id'  => $connection['connection_data']['id'],
-									'can_disconnect' => self::can_manage_connection( $connection['connection_data'] ),
-									'profile_link'   => $this->get_profile_link( $service_name, $connection ),
-									'shared'         => '0' === $connection['connection_data']['user_id'],
-									'status'         => 'ok',
-								)
-							);
-						} else {
-							$connections_to_return[ $service_name ][ $id ] = $connection;
-						}
+						$connections_to_return[] = array(
+							'connection_id'   => (string) $this->get_connection_id( $connection ),
+							'display_name'    => $this->get_display_name( $service_name, $connection ),
+							'external_handle' => $this->get_external_handle( $service_name, $connection ),
+							'external_id'     => $connection_meta['external_id'] ?? '',
+							'profile_link'    => $this->get_profile_link( $service_name, $connection ),
+							'profile_picture' => $this->get_profile_picture( $connection ),
+							'service_label'   => $this->get_service_label( $service_name ),
+							'service_name'    => $service_name,
+							'shared'          => ! $user_id,
+							'status'          => 'ok',
+							'user_id'         => $user_id,
+						);
 					}
 				}
 			}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/publicize-connection-test-results.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/publicize-connection-test-results.php
@@ -79,6 +79,14 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connection_Test_Results extends 
 					'type'        => 'string',
 					'format'      => 'uri',
 				),
+				'status'       => array(
+					'type'        => 'string',
+					'description' => __( 'The connection status.', 'jetpack' ),
+					'enum'        => array(
+						'ok',
+						'broken',
+					),
+				),
 			),
 		);
 
@@ -120,6 +128,8 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connection_Test_Results extends 
 			foreach ( $mapping as $field => $test_result_field ) {
 				$item[ $field ] = $test_result[ $test_result_field ];
 			}
+			// Compare to `true` because the API returns a 'must_reauth' for LinkedIn.
+			$item['status'] = true === $test_result['connectionTestPassed'] ? 'ok' : 'broken';
 		}
 
 		if (

--- a/projects/plugins/jetpack/changelog/update-unify-schema-for-connections-management
+++ b/projects/plugins/jetpack/changelog/update-unify-schema-for-connections-management
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated publicize connection test restults endpoint to add status field

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/test-post-fields-publicize-connections.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/test-post-fields-publicize-connections.php
@@ -153,7 +153,7 @@ class Test_WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WP_Test_Je
 
 	public static function setup_connections_jetpack() {
 		set_transient(
-			'jetpack_social_connections',
+			'jetpack_social_connection_list',
 			array(
 				// Normally connected facebook.
 				'facebook' => array(

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/test_post-fields-publicize-connections-inactive.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/test_post-fields-publicize-connections-inactive.php
@@ -50,7 +50,7 @@ class Test_WPCOM_REST_API_V2_Post_Publicize_Connections_Field_Inactive extends W
 		self::$user_id = $factory->user->create( array( 'role' => 'administrator' ) );
 
 		set_transient(
-			'jetpack_social_connections',
+			'jetpack_social_connection_list',
 			array(
 				// Normally connected facebook.
 				'facebook' => array(

--- a/projects/plugins/jetpack/tests/php/modules/publicize/test_class.publicize.php
+++ b/projects/plugins/jetpack/tests/php/modules/publicize/test_class.publicize.php
@@ -255,6 +255,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 			'id_number' => array(
 				'connection_data' => array(
 					'user_id' => 0,
+					'id'      => '456',
 				),
 			),
 		);
@@ -262,6 +263,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 			'id_number_2' => array(
 				'connection_data' => array(
 					'user_id' => 1,
+					'id'      => '456',
 				),
 			),
 		);

--- a/projects/plugins/jetpack/tests/php/modules/publicize/test_class.publicize.php
+++ b/projects/plugins/jetpack/tests/php/modules/publicize/test_class.publicize.php
@@ -253,18 +253,22 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	public function test_publicize_get_all_connections_for_user() {
 		$facebook_connection = array(
 			'id_number' => array(
-				'connection_data' => array(
+				'connection_data'  => array(
 					'user_id' => 0,
 					'id'      => '456',
 				),
+				'external_display' => 'Test',
+				'external_name'    => 'test',
 			),
 		);
 		$twitter_connection  = array(
 			'id_number_2' => array(
-				'connection_data' => array(
+				'connection_data'  => array(
 					'user_id' => 1,
 					'id'      => '456',
 				),
+				'external_display' => 'Test',
+				'external_name'    => 'test',
 			),
 		);
 
@@ -277,23 +281,54 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 
 		$publicize = publicize_init();
 
+		$fb_result = array(
+			'connection_id'   => '456',
+			'display_name'    => 'Test',
+			'external_handle' => '',
+			'external_id'     => '',
+			'profile_link'    => false,
+			'profile_picture' => '',
+			'service_label'   => 'Facebook',
+			'service_name'    => 'facebook',
+			'shared'          => true,
+			'status'          => 'ok',
+			'user_id'         => 0,
+		);
+
+		$twitter_result = array(
+			'connection_id'   => '456',
+			'display_name'    => 'Test',
+			'external_handle' => '',
+			'external_id'     => '',
+			'profile_link'    => 'https://twitter.com/est',
+			'profile_picture' => '',
+			'service_label'   => 'Twitter',
+			'service_name'    => 'twitter',
+			'shared'          => false,
+			'status'          => 'ok',
+			'user_id'         => 1,
+		);
+
 		// When logged out, assert that blog-level connections are returned.
 		wp_set_current_user( 0 );
-		$this->assertSame( array( 'facebook' => $facebook_connection ), $publicize->get_all_connections_for_user() );
+		$this->assertSame(
+			array( $fb_result ),
+			$publicize->get_all_connections_for_user()
+		);
 
 		// When logged in, assert that blog-level connections AND any connections for the current user are returned.
 		wp_set_current_user( 1 );
 		$this->assertSame(
 			array(
-				'facebook' => $facebook_connection,
-				'twitter'  => $twitter_connection,
+				$fb_result,
+				$twitter_result,
 			),
 			$publicize->get_all_connections_for_user()
 		);
 
 		// There are no connections for user 2, so we should only get blog-level connections.
 		wp_set_current_user( 2 );
-		$this->assertSame( array( 'facebook' => $facebook_connection ), $publicize->get_all_connections_for_user() );
+		$this->assertSame( array( $fb_result ), $publicize->get_all_connections_for_user() );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/changelog/update-unify-schema-for-connections-management
+++ b/projects/plugins/wpcomsh/changelog/update-unify-schema-for-connections-management
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Social | Enabled connections management on WPCOM

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -1089,8 +1089,12 @@ class WPCOM_Features {
 			),
 		),
 		self::SOCIAL_CONNECTIONS_MANAGEMENT     => array(
-			self::WPCOM_ALL_SITES,
-			self::JETPACK_ALL_SITES,
+			array(
+				// This feature isn't launched yet, so we're ensuring that it's not available on any plans.
+				'before' => '1900-01-01',
+				self::WPCOM_ALL_SITES,
+				self::JETPACK_ALL_SITES,
+			),
 		),
 		self::SOCIAL_EDITOR_PREVIEW             => array(
 			array(

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -1089,12 +1089,8 @@ class WPCOM_Features {
 			),
 		),
 		self::SOCIAL_CONNECTIONS_MANAGEMENT     => array(
-			array(
-				// This feature isn't launched yet, so we're ensuring that it's not available on any plans.
-				'before' => '1900-01-01',
-				self::WPCOM_ALL_SITES,
-				self::JETPACK_ALL_SITES,
-			),
+			self::WPCOM_ALL_SITES,
+			self::JETPACK_ALL_SITES,
 		),
 		self::SOCIAL_EDITOR_PREVIEW             => array(
 			array(


### PR DESCRIPTION
Supercedes #40536

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Declare `get_all_connections_for_user` abstract method in `Publicize_Base` class
* Update `get_all_connections_for_user` method in jetpack to return the data as per the new schema
* Use `get_all_connections_for_user` method for script data on WPCOM
* Add `status` field to `wpcom/v2/connection-test-results` endpoint
* Fix PHP fatal on WPCOM when getting profile link for Threads connection
* Changed the transient name for connections to ensure to clear old transients to avoid data mismatch

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply D168243-code to your sandbox and point public API and your site to it.
* Goto connections management on a Jetpack site and verify that everything works same as before like adding, removing and updating connections.
* On a Simple site, goto editor
* Open Jetpack sidebar
* Verify that Connections management now opens the modal, instead of pointing to Calypso
* In the modal, confirm that the connections show up fine.
* Note that adding/removing connections is not yet implemented for simple sites

