### PR TITLE
Introduce the Attachment pages control in media settings screen in wp-admin

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/attachment-pages-settings-in-media
+++ b/projects/packages/jetpack-mu-wpcom/changelog/attachment-pages-settings-in-media
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Introduces setting for controlling the Attachment pages to media options in wp-admin. Controlls the `wp_attachment_pages_enabled` option via checkbox.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -282,6 +282,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/post-categories/quick-actions.php';
 		require_once __DIR__ . '/features/site-editor-dashboard-link/site-editor-dashboard-link.php';
 		require_once __DIR__ . '/features/wpcom-admin-dashboard/wpcom-admin-dashboard.php';
+		require_once __DIR__ . '/features/wpcom-attachment-pages/wpcom-attachment-pages.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/class-jetpack-wpcom-block-editor.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/functions.editor-type.php';
 		require_once __DIR__ . '/features/wpcom-hotfixes/wpcom-hotfixes.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-attachment-pages/wpcom-attachment-pages.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-attachment-pages/wpcom-attachment-pages.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * WPCOM attachment pages settings.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare( strict_types = 1 );
+
+/**
+ * Registers the attachment pages settings section, field, and the setting.
+ *
+ * @return void.
+ */
+function wpcom_attachment_pages_settings_init() {
+	add_settings_section( 'wpcom_attachment_pages', esc_html__( 'Attachment pages', 'jetpack-mu-wpcom' ), null, 'media' );
+	add_settings_field( 'wp_attachment_pages_enabled', esc_html__( 'Attachment pages settings', 'jetpack-mu-wpcom' ), 'wpcom_attachment_pages_settings_display', 'media', 'wpcom_attachment_pages' );
+	register_setting( 'media', 'wp_attachment_pages_enabled', 'wpcom_attachment_pages_setting_sanitization' );
+}
+
+add_action( 'admin_init', 'wpcom_attachment_pages_settings_init' );
+
+/**
+ * Renders the attachment pages settings section.
+ *
+ * @return void.
+ */
+function wpcom_attachment_pages_settings_display() {
+	printf(
+		'<label><input type="checkbox" name="wp_attachment_pages_enabled" id="wp_attachment_pages_enabled" value="1" %s/> <label for="wp_attachment_pages_enabled">%s</label>',
+		checked( '1', get_option( 'wp_attachment_pages_enabled' ), false ),
+		esc_html__( 'Enable attachment pages.', 'jetpack-mu-wpcom' )
+	);
+}
+
+/**
+ * Sanitizes the wp_attachment_pages option value.
+ *
+ * Turns the input value into either '1' or '0' based
+ * on the bool value of the input.
+ *
+ * @param string|null $value Value provided by the WordPress settings API.
+ * @return string. '1' or '0'.
+ */
+function wpcom_attachment_pages_setting_sanitization( $value ) {
+	return $value ? '1' : '0';
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-attachment-pages/wpcom-attachment-pages.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-attachment-pages/wpcom-attachment-pages.php
@@ -10,7 +10,7 @@ declare( strict_types = 1 );
 /**
  * Registers the attachment pages settings section, field, and the setting.
  *
- * @return void.
+ * @return void
  */
 function wpcom_attachment_pages_settings_init() {
 	add_settings_section( 'wpcom_attachment_pages', esc_html__( 'Attachment pages', 'jetpack-mu-wpcom' ), null, 'media' );
@@ -23,7 +23,7 @@ add_action( 'admin_init', 'wpcom_attachment_pages_settings_init' );
 /**
  * Renders the attachment pages settings section.
  *
- * @return void.
+ * @return void
  */
 function wpcom_attachment_pages_settings_display() {
 	printf(
@@ -40,7 +40,7 @@ function wpcom_attachment_pages_settings_display() {
  * on the bool value of the input.
  *
  * @param string|null $value Value provided by the WordPress settings API.
- * @return string. '1' or '0'.
+ * @return string '1' or '0'.
  */
 function wpcom_attachment_pages_setting_sanitization( $value ) {
 	return $value ? '1' : '0';

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-attachment-pages/wpcom-attachment-pages.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-attachment-pages/wpcom-attachment-pages.php
@@ -18,7 +18,7 @@ function wpcom_attachment_pages_settings_init() {
 	register_setting( 'media', 'wp_attachment_pages_enabled', array( 'sanitize_callback' => 'wpcom_attachment_pages_setting_sanitization' ) );
 }
 
-add_action( 'admin_init', 'wpcom_attachment_pages_settings_init' );
+add_action( 'admin_init', 'wpcom_attachment_pages_settings_init', 11 );
 
 /**
  * Renders the attachment pages settings section.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-attachment-pages/wpcom-attachment-pages.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-attachment-pages/wpcom-attachment-pages.php
@@ -13,9 +13,9 @@ declare( strict_types = 1 );
  * @return void
  */
 function wpcom_attachment_pages_settings_init() {
-	add_settings_section( 'wpcom_attachment_pages', esc_html__( 'Attachment pages', 'jetpack-mu-wpcom' ), null, 'media' );
+	add_settings_section( 'wpcom_attachment_pages', esc_html__( 'Attachment pages', 'jetpack-mu-wpcom' ), function () {}, 'media' );
 	add_settings_field( 'wp_attachment_pages_enabled', esc_html__( 'Attachment pages settings', 'jetpack-mu-wpcom' ), 'wpcom_attachment_pages_settings_display', 'media', 'wpcom_attachment_pages' );
-	register_setting( 'media', 'wp_attachment_pages_enabled', 'wpcom_attachment_pages_setting_sanitization' );
+	register_setting( 'media', 'wp_attachment_pages_enabled', array( 'sanitize_callback' => 'wpcom_attachment_pages_setting_sanitization' ) );
 }
 
 add_action( 'admin_init', 'wpcom_attachment_pages_settings_init' );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-attachment-pages/WPCOM_Attachment_Pages_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-attachment-pages/WPCOM_Attachment_Pages_Test.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * WPCOM attachment pages settings test file.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare( strict_types = 1 );
+
+//phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
+require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-attachment-pages/wpcom-attachment-pages.php';
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Tests for WPCOM attachment pages settings.
+ *
+ * @covers \wpcom_attachment_pages_setting_sanitization
+ * @covers \wpcom_attachment_pages_settings_init
+ * @covers ::wpcom_attachment_pages_settings_init
+ * @covers ::wpcom_launchpad_is_task_list_dismissed
+ */
+#[CoversFunction( 'wpcom_launchpad_is_task_list_dismissed' )]
+#[CoversFunction( 'wpcom_attachment_pages_settings_init' )]
+#[CoversClass( wpcom_attachment_pages_setting_sanitization::class )]
+#[CoversClass( wpcom_attachment_pages_settings_init::class )]
+class WPCOM_Attachment_Pages_Test extends \WorDBless\BaseTestCase {
+	/**
+	 * Tests the sanitization function.
+	 *
+	 * @dataProvider wpcom_attachment_pages_setting_sanitization_provider
+	 *
+	 * @param string|int|null $value    Value passed to the sanitization callback.
+	 * @param string          $expected Expected string value returned from the sanitization callback.
+	 * @return void
+	 */
+	#[DataProvider( 'wpcom_attachment_pages_setting_sanitization_provider' )]
+	public function test_wpcom_attachment_pages_setting_sanitization( $value, $expected ) {
+		$sanitized_value = wpcom_attachment_pages_setting_sanitization( $value );
+
+		$this->assertSame( $expected, $sanitized_value );
+	}
+
+	/**
+	 * Data provider for the wpcom_attachment_pages_setting_sanitization_provider test
+	 *
+	 * @return array Array of values and expected returns.
+	 */
+	public static function wpcom_attachment_pages_setting_sanitization_provider() {
+		return array(
+			'int 1 value'      => array(
+				'value'    => 1,
+				'expected' => '1',
+			),
+			'int 0 value'      => array(
+				'value'    => 0,
+				'expected' => '0',
+			),
+			'bool true value'  => array(
+				'value'    => true,
+				'expected' => '1',
+			),
+			'bool false value' => array(
+				'value'    => false,
+				'expected' => '0',
+			),
+			'string 1 value'   => array(
+				'value'    => '1',
+				'expected' => '1',
+			),
+			'string 0 value'   => array(
+				'value'    => '0',
+				'expected' => '0',
+			),
+			'string 2 value'   => array(
+				'value'    => '2',
+				'expected' => '1',
+			),
+			'null value'       => array(
+				'value'    => null,
+				'expected' => '0',
+			),
+		);
+	}
+
+	/**
+	 * Tests whether the attachment pages settings is being hooked to admin_init
+	 * and on correct priority.
+	 *
+	 * @return void
+	 */
+	public function test_wpcom_attachment_pages_settings_init_hooked() {
+		$this->assertSame( 11, has_action( 'admin_init', 'wpcom_attachment_pages_settings_init' ) );
+	}
+
+	/**
+	 * Tests whether the wpcom_attachment_pages_settings_init function registers the setting to correct section.
+	 *
+	 * @return void
+	 */
+	public function test_wpcom_attachment_pages_settings_init() {
+		wpcom_attachment_pages_settings_init();
+
+		$expected_settings = array(
+			'type'              => 'string',
+			'group'             => 'media',
+			'label'             => '',
+			'description'       => '',
+			'sanitize_callback' => 'wpcom_attachment_pages_setting_sanitization',
+			'show_in_rest'      => false,
+		);
+
+		$this->assertSame( $expected_settings, $GLOBALS['wp_registered_settings']['wp_attachment_pages_enabled'] );
+		$this->assertTrue( isset( $GLOBALS['wp_settings_sections']['media']['wpcom_attachment_pages'] ) );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-attachment-pages/WPCOM_Attachment_Pages_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-attachment-pages/WPCOM_Attachment_Pages_Test.php
@@ -10,22 +10,17 @@ declare( strict_types = 1 );
 //phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
 require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-attachment-pages/wpcom-attachment-pages.php';
 
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests for WPCOM attachment pages settings.
  *
- * @covers \wpcom_attachment_pages_setting_sanitization
- * @covers \wpcom_attachment_pages_settings_init
+ * @covers ::wpcom_attachment_pages_setting_sanitization
  * @covers ::wpcom_attachment_pages_settings_init
- * @covers ::wpcom_launchpad_is_task_list_dismissed
  */
-#[CoversFunction( 'wpcom_launchpad_is_task_list_dismissed' )]
+#[CoversFunction( 'wpcom_attachment_pages_setting_sanitization' )]
 #[CoversFunction( 'wpcom_attachment_pages_settings_init' )]
-#[CoversClass( wpcom_attachment_pages_setting_sanitization::class )]
-#[CoversClass( wpcom_attachment_pages_settings_init::class )]
 class WPCOM_Attachment_Pages_Test extends \WorDBless\BaseTestCase {
 	/**
 	 * Tests the sanitization function.

--- a/projects/plugins/mu-wpcom-plugin/changelog/attachment-pages-settings-in-media
+++ b/projects/plugins/mu-wpcom-plugin/changelog/attachment-pages-settings-in-media
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Introduces Attachment pages setting in the media settings screen in wp-admin which controlls the `wp_attachment_pages_enabled` option.

--- a/projects/plugins/wpcomsh/changelog/attachment-pages-settings-in-media
+++ b/projects/plugins/wpcomsh/changelog/attachment-pages-settings-in-media
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Introduces Attachment pages setting in the media settings screen in wp-admin which controlls the `wp_attachment_pages_enabled` option.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

On WPCOM simple sites, there is no way for site admin to control the `wp_attachment_pages_enabled` option ( see https://github.com/Automattic/wp-calypso/issues/90139 ).

This changeset introduces a checkbox to the media settings screen in wp-admin controlling the `wp_attachment_pages_enabled` option.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Introduces new `wp_attachment_pages_enabled` control checkbox to /wp-admin > Settings > Media

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to wp-admin/options-media.php
* Check if the `Enable attachment pages.` checkbox reflects the current status of the `wp_attachment_pages_enabled` option ( enabled by default on WPCOM simple sites, disabled for newly created sites on Atomic sites )
* Toggle the `Enable attachment pages.` checkbox; save the settings.
* Check if it effectively controls the enabled / disabled status of the attachment pages ( go to wp-admin > Media and click on `View` for some of the attachments and check if attachment or attachment page is being dislayed, based on the status of the checkbox )