### PR TITLE
Classic Theme Helper : Add testimonials-shortcode.css file to package

### DIFF
--- a/projects/packages/classic-theme-helper/changelog/add-testimonial-shortcode-css-package
+++ b/projects/packages/classic-theme-helper/changelog/add-testimonial-shortcode-css-package
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Testimonials: Include shortcode CSS file.

--- a/projects/packages/classic-theme-helper/src/custom-post-types/css/testimonial-shortcode.css
+++ b/projects/packages/classic-theme-helper/src/custom-post-types/css/testimonial-shortcode.css
@@ -1,0 +1,102 @@
+.jetpack-testimonial-shortcode {
+	clear: both;
+	margin: 0;
+	overflow: hidden;
+	padding: 0;
+}
+
+.testimonial-entry {
+	float: left;
+	margin: 0 0 3em;
+	padding: 0;
+	width: 100%;
+}
+
+/* Column setting */
+.testimonial-entry-column-1 {
+	width: 100%;
+}
+
+.testimonial-entry-column-2 {
+	margin-right: 4%;
+	width: 48%;
+}
+
+.testimonial-entry-column-3 {
+	margin-right: 3.5%;
+	width: 31%;
+}
+
+.testimonial-entry-column-4 {
+	margin-right: 3%;
+	width: 22%;
+}
+
+.testimonial-entry-column-5 {
+	margin-right: 2.5%;
+	width: 18%;
+}
+
+.testimonial-entry-column-6 {
+	margin-right: 2%;
+	width: 15%;
+}
+.testimonial-entry-first-item-row {
+	clear: both;
+}
+.testimonial-entry-last-item-row {
+	margin-right: 0;
+}
+
+@media screen and (max-width:768px) {
+	.testimonial-entry-mobile-first-item-row{
+		margin-right: 4%;
+		width: 48%;
+		clear:both;
+	}
+	.testimonial-entry-first-item-row {
+		clear:none;
+	}
+	.testimonial-entry-mobile-last-item-row{
+		width: 48%;
+		margin-right: 0;
+	}
+}
+
+.testimonial-featured-image {
+	padding: 0;
+	margin: 0;
+}
+
+.testimonial-featured-image img {
+	border: 0;
+	height: auto;
+	max-width: 100%;
+	vertical-align: middle;
+}
+
+.testimonial-entry-title {
+	font-weight: 700;
+	margin: 0;
+	padding: 0;
+	display: block;
+}
+
+.testimonial-featured-image + .testimonial-entry-title {
+	margin-top: 1.0em;
+}
+
+.testimonial-entry-title a {
+	border: 0;
+	text-decoration: none;
+}
+
+/* Entry Content */
+.testimonial-entry-content {
+	margin: 0.75em 0;
+	padding: 0;
+}
+
+.testimonial-entry-content > :last-child {
+	margin: 0;
+}


### PR DESCRIPTION
## Proposed changes:

* This PR adds the `testimonial-shortcode.css` file to the Classic Theme Helper package, which was missed in the earlier move.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Without the PR applied, on trunk on a self hosted site, activate Jetpack testimonials from Jetpack > Settings > Writing
* Add a new testimonial at `/wp-admin/edit.php?post_type=jetpack-testimonial`. Add a featured image as well.
* Create a new draft post, and add a shortcode block. Add the `testimonials` shortcode.
* Preview the post. What you see should be similar to the screenshot shared below (featured image location off, testimonial link not bold).

Test the changes:
* Apply this PR, and refresh the post preview. What you see should be similar to the 'fix' screenshot version below - featured image underneath the testimonial text, ad the testimonial link is bold.

---

Without CSS file (before):

<img width="638" alt="Screenshot 2024-12-12 at 12 43 52" src="https://github.com/user-attachments/assets/24a306d6-289a-4404-8f82-c11157e0396d" />

With CSS file (after):
<img width="633" alt="Screenshot 2024-12-12 at 12 52 08" src="https://github.com/user-attachments/assets/6e7afbfe-dd27-4a8c-a83f-204be25fa76b" />
