### PR TITLE
Social: Don't call endpoint for services on WPCOM

### DIFF
--- a/projects/packages/publicize/changelog/update-social-script-data-services-wpcom-check
+++ b/projects/packages/publicize/changelog/update-social-script-data-services-wpcom-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Script data: Don't call service endpoint on wpcom

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -223,11 +223,10 @@ class Publicize_Script_Data {
 	/**
 	 * Get the list of supported Publicize services.
 	 *
-	 * @param bool $force_refresh Whether to force a refresh of the services list.
 	 * @return array List of external services and their settings.
 	 */
-	public static function get_supported_services( $force_refresh = false ) {
-		return Publicize_Services::get_all( $force_refresh );
+	public static function get_supported_services() {
+		return Publicize_Services::get_all();
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -7,11 +7,11 @@
 
 namespace Automattic\Jetpack\Publicize;
 
-use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Publicize\Jetpack_Social_Settings\Settings;
 use Automattic\Jetpack\Publicize\Publicize_Utils as Utils;
+use Automattic\Jetpack\Publicize\Services as Publicize_Services;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 use Jetpack_Options;
@@ -227,53 +227,7 @@ class Publicize_Script_Data {
 	 * @return array List of external services and their settings.
 	 */
 	public static function get_supported_services( $force_refresh = false ) {
-		if ( defined( 'IS_WPCOM' ) && constant( 'IS_WPCOM' ) ) {
-			if ( function_exists( 'require_lib' ) ) {
-				// @phan-suppress-next-line PhanUndeclaredFunction - phan is dumb not to see the function_exists check.
-				require_lib( 'external-connections' );
-			}
-
-			// @phan-suppress-next-line PhanUndeclaredClassMethod - We are here because we are on WPCOM.
-			$external_connections = \WPCOM_External_Connections::init();
-			$services             = array_values( $external_connections->get_external_services_list( 'publicize', get_current_blog_id() ) );
-
-			return $services;
-		}
-
-		// Checking the cache.
-		$services = get_transient( self::SERVICES_TRANSIENT );
-		if ( false !== $services && ! $force_refresh ) {
-			return $services;
-		}
-
-		// Fetch the services.
-		$site_id = Manager::get_site_id();
-		if ( is_wp_error( $site_id ) ) {
-			return array();
-		}
-		$path     = sprintf( '/sites/%d/external-services', $site_id );
-		$response = Client::wpcom_json_api_request_as_user( $path );
-		if ( is_wp_error( $response ) ) {
-			return array();
-		}
-		$body = json_decode( wp_remote_retrieve_body( $response ) );
-
-		$services = $body->services ?? array();
-
-		$formatted_services = array_values(
-			array_filter(
-				(array) $services,
-				function ( $service ) {
-					return isset( $service->type ) && 'publicize' === $service->type;
-				}
-			)
-		);
-
-		if ( ! empty( $formatted_services ) ) {
-			set_transient( self::SERVICES_TRANSIENT, $formatted_services, DAY_IN_SECONDS );
-		}
-
-		return $formatted_services;
+		return Publicize_Services::get_all( $force_refresh );
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -224,6 +224,19 @@ class Publicize_Script_Data {
 	 * @return array List of external services and their settings.
 	 */
 	public static function get_supported_services() {
+		if ( defined( 'IS_WPCOM' ) && constant( 'IS_WPCOM' ) ) {
+			if ( function_exists( 'require_lib' ) ) {
+				// @phan-suppress-next-line PhanUndeclaredFunction - phan is dumb not to see the function_exists check.
+				require_lib( 'external-connections' );
+			}
+
+			// @phan-suppress-next-line PhanUndeclaredClassMethod - We are here because we are on WPCOM.
+			$external_connections = \WPCOM_External_Connections::init();
+			$services             = array_values( $external_connections->get_external_services_list( 'publicize', get_current_blog_id() ) );
+
+			return $services;
+		}
+
 		$site_id = Manager::get_site_id();
 		if ( is_wp_error( $site_id ) ) {
 			return array();

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -21,6 +21,8 @@ use Jetpack_Options;
  */
 class Publicize_Script_Data {
 
+	const SERVICES_TRANSIENT = 'jetpack_social_services_list';
+
 	/**
 	 * Get the publicize instance - properly typed
 	 *
@@ -221,9 +223,10 @@ class Publicize_Script_Data {
 	/**
 	 * Get the list of supported Publicize services.
 	 *
+	 * @param bool $force_refresh Whether to force a refresh of the services list.
 	 * @return array List of external services and their settings.
 	 */
-	public static function get_supported_services() {
+	public static function get_supported_services( $force_refresh = false ) {
 		if ( defined( 'IS_WPCOM' ) && constant( 'IS_WPCOM' ) ) {
 			if ( function_exists( 'require_lib' ) ) {
 				// @phan-suppress-next-line PhanUndeclaredFunction - phan is dumb not to see the function_exists check.
@@ -237,6 +240,13 @@ class Publicize_Script_Data {
 			return $services;
 		}
 
+		// Checking the cache.
+		$services = get_transient( self::SERVICES_TRANSIENT );
+		if ( false !== $services && ! $force_refresh ) {
+			return $services;
+		}
+
+		// Fetch the services.
 		$site_id = Manager::get_site_id();
 		if ( is_wp_error( $site_id ) ) {
 			return array();
@@ -250,7 +260,7 @@ class Publicize_Script_Data {
 
 		$services = $body->services ?? array();
 
-		return array_values(
+		$formatted_services = array_values(
 			array_filter(
 				(array) $services,
 				function ( $service ) {
@@ -258,6 +268,12 @@ class Publicize_Script_Data {
 				}
 			)
 		);
+
+		if ( ! empty( $formatted_services ) ) {
+			set_transient( self::SERVICES_TRANSIENT, $formatted_services, DAY_IN_SECONDS );
+		}
+
+		return $formatted_services;
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-services.php
+++ b/projects/packages/publicize/src/class-services.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Publicize Services class.
+ *
+ * @package automattic/jetpack-publicize
+ */
+
+namespace Automattic\Jetpack\Publicize;
+
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager;
+
+/**
+ * Publicize Services class.
+ */
+class Services {
+
+	const SERVICES_TRANSIENT = 'jetpack_social_services_list';
+
+	/**
+	 * Get all services.
+	 *
+	 * @param bool $force_refresh Whether to force a refresh of the services.
+	 * @return array
+	 */
+	public static function get_all( $force_refresh = false ) {
+		if ( defined( 'IS_WPCOM' ) && constant( 'IS_WPCOM' ) ) {
+			if ( function_exists( 'require_lib' ) ) {
+				// @phan-suppress-next-line PhanUndeclaredFunction - phan is dumb not to see the function_exists check.
+				require_lib( 'external-connections' );
+			}
+
+			// @phan-suppress-next-line PhanUndeclaredClassMethod - We are here because we are on WPCOM.
+			$external_connections = \WPCOM_External_Connections::init();
+			$services             = array_values( $external_connections->get_external_services_list( 'publicize', get_current_blog_id() ) );
+
+			return $services;
+		}
+
+		// Checking the cache.
+		$services = get_transient( self::SERVICES_TRANSIENT );
+		if ( false !== $services && ! $force_refresh ) {
+			return $services;
+		}
+
+		return self::fetch_and_cache_services();
+	}
+
+	/**
+	 * Fetch services from the REST API and cache them.
+	 *
+	 * @return array
+	 */
+	public static function fetch_and_cache_services() {
+		// Fetch the services.
+		$site_id = Manager::get_site_id();
+		if ( is_wp_error( $site_id ) ) {
+			return array();
+		}
+		$path     = sprintf( '/sites/%d/external-services', $site_id );
+		$response = Client::wpcom_json_api_request_as_user( $path );
+		if ( is_wp_error( $response ) ) {
+			return array();
+		}
+		$body = json_decode( wp_remote_retrieve_body( $response ) );
+
+		$services = $body->services ?? array();
+
+		$formatted_services = array_values(
+			array_filter(
+				(array) $services,
+				function ( $service ) {
+					return isset( $service->type ) && 'publicize' === $service->type;
+				}
+			)
+		);
+
+		if ( ! empty( $formatted_services ) ) {
+			set_transient( self::SERVICES_TRANSIENT, $formatted_services, DAY_IN_SECONDS );
+		}
+
+		return $formatted_services;
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/714

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added an if branch to only call the endpoint if we are not on wpcom
* If we are we just return the data

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack-reach/issues/714
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With this sandboxed check on Simple in the editor to see the connections
* You should also see the connections in Jetpack

