### PR TITLE
[WordAds] Migrate wordads shortcode to WATL

### DIFF
--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -381,7 +381,6 @@ return [
         'modules/shortcodes/ustream.php' => ['PhanTypeMismatchArgument'],
         'modules/shortcodes/vimeo.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument'],
         'modules/shortcodes/vr.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
-        'modules/shortcodes/wordads.php' => ['PhanNoopNew'],
         'modules/shortcodes/youtube.php' => ['PhanRedefineFunction'],
         'modules/shortlinks.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal'],
         'modules/simple-payments/simple-payments.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturn'],

--- a/projects/plugins/jetpack/changelog/update-iponweb-to-watl-migration
+++ b/projects/plugins/jetpack/changelog/update-iponweb-to-watl-migration
@@ -1,5 +1,5 @@
 Significance: patch
 Type: other
 
-Migration from IPONWEB to WATL
-* Render legacy sidebar widget with the WATL
+Migration of ad formats from IPONWEB to WATL
+

--- a/projects/plugins/jetpack/extensions/blocks/wordads/wordads.php
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/wordads.php
@@ -139,12 +139,12 @@ class WordAds {
 			$format = $attr['format'];
 		}
 
-		$height             = $ad_tag_ids[ $format ]['height'];
-		$width              = $ad_tag_ids[ $format ]['width'];
-		$gutenberg_location = 'gutenberg';
-		$snippet            = $wordads->get_ad_snippet( $section_id, $height, $width, $gutenberg_location, $wordads->get_solo_unit_css() );
+		$height   = $ad_tag_ids[ $format ]['height'];
+		$width    = $ad_tag_ids[ $format ]['width'];
+		$location = 'gutenberg';
+		$snippet  = $wordads->get_ad_snippet( $section_id, $height, $width, $location, $wordads->get_solo_unit_css() );
 
-		$key          = "{$gutenberg_location}_{$width}x{$height}";
+		$key          = "{$location}_{$width}x{$height}";
 		$smart_format = self::$gutenberg_ad_snippet_x_smart_format[ $key ] ?? null;
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		$is_watl_enabled = $smart_format && ( isset( $_GET[ $smart_format ] ) && 'true' === $_GET[ $smart_format ] );

--- a/projects/plugins/jetpack/modules/shortcodes/wordads.php
+++ b/projects/plugins/jetpack/modules/shortcodes/wordads.php
@@ -70,6 +70,7 @@ class Jetpack_WordAds_Shortcode {
 			return '<div>' . __( 'The WordAds module is not active', 'jetpack' ) . '</div>';
 		}
 
+		// TODO: is jetpack-wordad tag necessary?
 		$html = '<div class="jetpack-wordad" itemscope itemtype="https://schema.org/WPAdBlock"></div>';
 		$html = $wordads->insert_inline_ad( $html );
 

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -527,7 +527,14 @@ HTML;
 		}
 
 		$ad_type  = $this->option( 'wordads_house' ) ? 'house' : 'iponweb';
-		$content .= $this->get_ad( 'inline', $ad_type );
+		$location = 'shortcode';
+		// not house ad and watl enabled
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( ! 'house' === $ad_type && ( isset( $_GET['wordads-logging'] ) && isset( $_GET[ $location ] ) && 'true' === $_GET[ $location ] ) ) {
+			$content .= $this->get_watl_ad_html_tag( $location );
+		} else {
+			$content .= $this->get_ad( 'inline', $ad_type );
+		}
 		return $content;
 	}
 

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -535,15 +535,13 @@ HTML;
 		// not house ad and watl enabled
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( 'house' !== $ad_type && ( isset( $_GET['wordads-logging'] ) && isset( $_GET[ $location ] ) && 'true' === $_GET[ $location ] ) ) {
-			$content .= $this->get_watl_ad_html_tag( $location );
-		} else {
-			$content .= sprintf(
-				'<div class="jetpack-wordad" itemscope itemtype="https://schema.org/WPAdBlock">%s</div>',
-				$this->get_ad( 'inline', $ad_type )
-			);
-
+			return $content . $this->get_watl_ad_html_tag( $location );
 		}
-		return $content;
+
+		return $content .= sprintf(
+			'<div class="jetpack-wordad" itemscope itemtype="https://schema.org/WPAdBlock">%s</div>',
+			$this->get_ad( 'inline', $ad_type )
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -530,7 +530,7 @@ HTML;
 		$location = 'shortcode';
 		// not house ad and watl enabled
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( ! 'house' === $ad_type && ( isset( $_GET['wordads-logging'] ) && isset( $_GET[ $location ] ) && 'true' === $_GET[ $location ] ) ) {
+		if ( 'house' !== $ad_type && ( isset( $_GET['wordads-logging'] ) && isset( $_GET[ $location ] ) && 'true' === $_GET[ $location ] ) ) {
 			$content .= $this->get_watl_ad_html_tag( $location );
 		} else {
 			$content .= $this->get_ad( 'inline', $ad_type );

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -21,6 +21,7 @@ require_once WORDADS_ROOT . '/php/class-wordads-california-privacy.php';
 require_once WORDADS_ROOT . '/php/class-wordads-ccpa-do-not-sell-link-widget.php';
 require_once WORDADS_ROOT . '/php/class-wordads-consent-management-provider.php';
 require_once WORDADS_ROOT . '/php/class-wordads-smart.php';
+require_once WORDADS_ROOT . '/php/class-wordads-shortcode.php';
 
 /**
  * Primary WordAds class.
@@ -214,6 +215,9 @@ class WordAds {
 		if ( isset( $this->params->options['wordads_cmp_enabled'] ) && $this->params->options['wordads_cmp_enabled'] ) {
 			WordAds_Consent_Management_Provider::init();
 		}
+
+		// Initialize [wordads] shortcode.
+		WordAds_Shortcode::init();
 
 		// Initialize Smart.
 		WordAds_Smart::instance()->init( $this->params );

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -969,7 +969,7 @@ HTML;
 	 * @since 8.7
 	 */
 	public static function get_watl_ad_html_tag( string $slot_type ): string {
-		return "<div class=\"wordads-tag\" data-slot-type=\"$slot_type\" data-tag-origin=\"jetpack\" style=\"display: none;\"></div>";
+		return "<div class=\"wordads-tag\" data-slot-type=\"$slot_type\" style=\"display: none;\"></div>";
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -537,7 +537,11 @@ HTML;
 		if ( 'house' !== $ad_type && ( isset( $_GET['wordads-logging'] ) && isset( $_GET[ $location ] ) && 'true' === $_GET[ $location ] ) ) {
 			$content .= $this->get_watl_ad_html_tag( $location );
 		} else {
-			$content .= $this->get_ad( 'inline', $ad_type );
+			$content .= sprintf(
+				'<div class="jetpack-wordad" itemscope itemtype="https://schema.org/WPAdBlock">%s</div>',
+				$this->get_ad( 'inline', $ad_type )
+			);
+
 		}
 		return $content;
 	}
@@ -967,7 +971,7 @@ HTML;
 	 * @since 8.7
 	 */
 	public static function get_watl_ad_html_tag( string $slot_type ): string {
-		return "<div class=\"wordads-tag\" data-slot-type=\"$slot_type\" style=\"display: none;\"></div>";
+		return "<div class=\"wordads-tag\" data-slot-type=\"$slot_type\" data-tag-origin=\"jetpack\" style=\"display: none;\"></div>";
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-shortcode.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-shortcode.php
@@ -1,4 +1,4 @@
-<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+<?php
 /**
  * Wordads shortcode.
  *
@@ -9,35 +9,23 @@
  */
 
 /**
- * Embed WordAds 'ad' in post
+ * Class WordAds_Shortcode
+ *
+ * Handles the [wordads] shortcode.
  */
-class Jetpack_WordAds_Shortcode {
-
-	/**
-	 * Used to determine whether scripts and styles have been enqueued already.
-	 *
-	 * @var bool false Should we enqueue scripts and styles.
-	 */
-	private $scripts_and_style_included = false;
-
-	/**
-	 * Initialize.
-	 */
-	public function __construct() {
-		add_action( 'init', array( $this, 'action_init' ) );
-	}
+class WordAds_Shortcode {
 
 	/**
 	 * Register our shortcode and enqueue necessary files.
 	 */
-	public function action_init() {
+	public static function init() {
 		global $wordads;
 
 		if ( empty( $wordads ) ) {
 			return null;
 		}
 
-		add_shortcode( 'wordads', array( $this, 'wordads_shortcode' ) );
+		add_shortcode( 'wordads', array( self::class, 'handle_wordads_shortcode' ) );
 	}
 
 	/**
@@ -49,7 +37,7 @@ class Jetpack_WordAds_Shortcode {
 	 *
 	 * @return string HTML for WordAds shortcode.
 	 */
-	public static function wordads_shortcode( $atts, $content = '' ) {
+	public static function handle_wordads_shortcode( $atts, $content = '' ) {
 		$atts = shortcode_atts( array(), $atts, 'wordads' );
 
 		return self::wordads_shortcode_html( $atts, $content );
@@ -77,5 +65,3 @@ class Jetpack_WordAds_Shortcode {
 		return $html;
 	}
 }
-
-new Jetpack_WordAds_Shortcode();

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-shortcode.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-shortcode.php
@@ -58,9 +58,7 @@ class WordAds_Shortcode {
 			return '<div>' . __( 'The WordAds module is not active', 'jetpack' ) . '</div>';
 		}
 
-		// TODO: is jetpack-wordad tag necessary?
-		$html = '<div class="jetpack-wordad" itemscope itemtype="https://schema.org/WPAdBlock"></div>';
-		$html = $wordads->insert_inline_ad( $html );
+		$html = $wordads->insert_inline_ad( '' );
 
 		return $html;
 	}

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -213,6 +213,7 @@ class WordAds_Smart {
 
 		$config = array(
 			'post_id' => ( $post instanceof WP_Post ) && is_singular( 'post' ) ? $post->ID : null,
+			'origin'  => 'jetpack',
 			'theme'   => get_stylesheet(),
 			'target'  => $this->target_keywords(),
 		) + $this->formats;

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -80,6 +80,9 @@ class WordAds_Smart {
 		'sidebar_widget_wideskyscraper'  => array(
 			'enabled' => false,
 		),
+		'shortcode'                      => array(
+			'enabled' => false,
+		),
 	);
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Run `[wordads]` shortcode with WATL when watl is enabled

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Include the `[wordads]` shortcode in your test site's post content
* Visit your test site with the following query string `<site-url>?wordads-logging=true&shortcode=true`
* You should get a 300x250 ad from the test insertion on smart.
* If `wordads_house` option is set, you should get a house ad instead.
* This should work without the need to enable `Jetpack → Settings → Writing → Compose using shortcodes to embed media from popular sites.` in the admin.
