### PR TITLE
ScanReport: Disable hiding relevant fields

### DIFF
--- a/projects/js-packages/components/components/scan-report/index.tsx
+++ b/projects/js-packages/components/components/scan-report/index.tsx
@@ -57,7 +57,7 @@ export default function ScanReport( { dataSource, data, onChangeSelection } ): J
 		},
 		list: {
 			...baseView,
-			fields: [ FIELD_STATUS, FIELD_VERSION ],
+			fields: [ FIELD_STATUS, FIELD_VERSION, FIELD_TYPE ],
 			titleField: FIELD_NAME,
 			mediaField: FIELD_ICON,
 			showMedia: true,
@@ -159,10 +159,6 @@ export default function ScanReport( { dataSource, data, onChangeSelection } ): J
 				enableHiding: false,
 				enableGlobalSearch: true,
 				getValue( { item }: { item: ScanReportExtension } ) {
-					if ( view.type === 'list' && item.type === 'files' ) {
-						return 'Files';
-					}
-
 					return item.name ? item.name : '';
 				},
 			},

--- a/projects/js-packages/components/components/scan-report/index.tsx
+++ b/projects/js-packages/components/components/scan-report/index.tsx
@@ -86,6 +86,7 @@ export default function ScanReport( { dataSource, data, onChangeSelection } ): J
 				id: FIELD_STATUS,
 				elements: STATUS_TYPES,
 				label: __( 'Status', 'jetpack-components' ),
+				enableHiding: false,
 				getValue( { item } ) {
 					if ( item.checked ) {
 						if ( item.threats.length > 0 ) {
@@ -150,18 +151,25 @@ export default function ScanReport( { dataSource, data, onChangeSelection } ): J
 				id: FIELD_TYPE,
 				label: __( 'Type', 'jetpack-components' ),
 				elements: TYPES,
+				enableHiding: false,
 			},
 			{
 				id: FIELD_NAME,
 				label: __( 'Name', 'jetpack-components' ),
+				enableHiding: false,
 				enableGlobalSearch: true,
 				getValue( { item }: { item: ScanReportExtension } ) {
+					if ( view.type === 'list' && item.type === 'files' ) {
+						return 'Files';
+					}
+
 					return item.name ? item.name : '';
 				},
 			},
 			{
 				id: FIELD_VERSION,
 				label: __( 'Version', 'jetpack-components' ),
+				enableHiding: false,
 				enableSorting: false,
 				enableGlobalSearch: true,
 				getValue( { item }: { item: ScanReportExtension } ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
Currently you can manually hide many relevant `ScanReport` fields using the `DataViews` settings, enough so that what can remain is unclear what it refers to. Additionally, in list view the `Files` entry does not have title.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `enableHiding: false` to all relevant fields.
* Add `Type` field as default in list view

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://github.com/Automattic/jetpack-scan-team/issues/1600

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Review ScanReport storybooks and ensure
   * You cannot hide fields
   * In list view the `Files` entry has a title

