### PR TITLE
Jetpack AI: Add thumbs up/down component to AI logo generator

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       '@wordpress/api-fetch':
         specifier: 7.14.0
         version: 7.14.0
+      '@wordpress/base-styles':
+        specifier: 5.14.0
+        version: 5.14.0
       '@wordpress/blob':
         specifier: 4.14.0
         version: 4.14.0

--- a/projects/js-packages/ai-client/changelog/change-jetpack-ai-rate-logo-generator
+++ b/projects/js-packages/ai-client/changelog/change-jetpack-ai-rate-logo-generator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Jetpack AI: Add thumbs up/down component to AI logo generator

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -52,6 +52,7 @@
 		"@types/react": "18.3.12",
 		"@types/wordpress__block-editor": "11.5.15",
 		"@wordpress/api-fetch": "7.14.0",
+		"@wordpress/base-styles": "5.14.0",
 		"@wordpress/blob": "4.14.0",
 		"@wordpress/block-editor": "14.9.0",
 		"@wordpress/components": "29.0.0",

--- a/projects/js-packages/ai-client/src/components/ai-feedback/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-feedback/index.tsx
@@ -25,6 +25,11 @@ type AiFeedbackThumbsProps = {
 	ratedItem?: string;
 	feature?: string;
 	savedRatings?: Record< string, string >;
+	options?: {
+		mediaLibraryId?: number;
+		prompt?: string;
+		revisedPrompt?: string;
+	};
 	onRate?: ( rating: string ) => void;
 };
 
@@ -50,6 +55,7 @@ export default function AiFeedbackThumbs( {
 	ratedItem = '',
 	feature = '',
 	savedRatings = {},
+	options = {},
 	onRate,
 }: AiFeedbackThumbsProps ): React.ReactElement {
 	if ( ! getFeatureAvailability( 'ai-response-feedback' ) ) {
@@ -60,7 +66,11 @@ export default function AiFeedbackThumbs( {
 	const { tracks } = useAnalytics();
 
 	useEffect( () => {
-		setItemsRated( { ...savedRatings, ...itemsRated } );
+		const newItemsRated = { ...savedRatings, ...itemsRated };
+
+		if ( JSON.stringify( newItemsRated ) !== JSON.stringify( itemsRated ) ) {
+			setItemsRated( newItemsRated );
+		}
 	}, [ savedRatings ] );
 
 	const checkThumb = ( thumbValue: string ) => {
@@ -85,6 +95,9 @@ export default function AiFeedbackThumbs( {
 			tracks.recordEvent( 'jetpack_ai_feedback', {
 				type: feature,
 				rating: aiRating,
+				mediaLibraryId: options.mediaLibraryId || null,
+				prompt: options.prompt || null,
+				revisedPrompt: options.revisedPrompt || null,
 			} );
 		}
 	};

--- a/projects/js-packages/ai-client/src/components/ai-feedback/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-feedback/index.tsx
@@ -55,26 +55,28 @@ export default function AiFeedbackThumbs( {
 	const [ itemsRated, setItemsRated ] = useState( {} );
 	const { tracks } = useAnalytics();
 
-	const rateAI = ( isThumbsUp: boolean ) => {
-		const aiRating = isThumbsUp ? 'thumbs-up' : 'thumbs-down';
-
-		setItemsRated( {
-			...itemsRated,
-			[ ratedItem ]: aiRating,
-		} );
-
-		tracks.recordEvent( 'jetpack_ai_feedback', {
-			type: feature,
-			rating: aiRating,
-		} );
-	};
-
 	const checkThumb = ( thumbValue: string ) => {
 		if ( ! itemsRated[ ratedItem ] ) {
 			return false;
 		}
 
 		return itemsRated[ ratedItem ] === thumbValue;
+	};
+
+	const rateAI = ( isThumbsUp: boolean ) => {
+		const aiRating = isThumbsUp ? 'thumbs-up' : 'thumbs-down';
+
+		if ( ! checkThumb( aiRating ) ) {
+			setItemsRated( {
+				...itemsRated,
+				[ ratedItem ]: aiRating,
+			} );
+
+			tracks.recordEvent( 'jetpack_ai_feedback', {
+				type: feature,
+				rating: aiRating,
+			} );
+		}
 	};
 
 	return (

--- a/projects/js-packages/ai-client/src/components/ai-feedback/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-feedback/index.tsx
@@ -56,11 +56,11 @@ export default function AiFeedbackThumbs( {
 		return null;
 	}
 
-	const [ itemsRated, setItemsRated ] = useState( savedRatings );
+	const [ itemsRated, setItemsRated ] = useState( {} );
 	const { tracks } = useAnalytics();
 
 	useEffect( () => {
-		setItemsRated( savedRatings );
+		setItemsRated( { ...savedRatings, ...itemsRated } );
 	}, [ savedRatings ] );
 
 	const checkThumb = ( thumbValue: string ) => {

--- a/projects/js-packages/ai-client/src/components/ai-feedback/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-feedback/index.tsx
@@ -1,24 +1,57 @@
-import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
+/**
+ * External dependencies
+ */
+import {
+	useAnalytics,
+	getJetpackExtensionAvailability,
+} from '@automattic/jetpack-shared-extension-utils';
 import { Button, Tooltip } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { thumbsUp, thumbsDown } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useState } from 'react';
-import { getFeatureAvailability } from '../../../../blocks/ai-assistant/lib/utils/get-feature-availability';
-
+/*
+ * Internal dependencies
+ */
 import './style.scss';
+/**
+ * Types
+ */
+import type React from 'react';
 
+type AiFeedbackThumbsProps = {
+	disabled?: boolean;
+	iconSize?: number;
+	ratedItem?: string;
+	feature?: string;
+};
+
+/**
+ * Get the availability of a feature.
+ *
+ * @param {string} feature - The feature to check availability for.
+ * @return {boolean}       - Whether the feature is available.
+ */
+function getFeatureAvailability( feature: string ): boolean {
+	return getJetpackExtensionAvailability( feature ).available === true;
+}
+
+/**
+ * AiFeedbackThumbs component.
+ *
+ * @param {AiFeedbackThumbsProps} props - component props.
+ * @return {React.ReactElement} - rendered component.
+ */
 export default function AiFeedbackThumbs( {
 	disabled = false,
 	iconSize = 24,
 	ratedItem = '',
 	feature = '',
-}: {
-	disabled: boolean;
-	iconSize?: number;
-	ratedItem: string;
-	feature: string;
-} ) {
+}: AiFeedbackThumbsProps ): React.ReactElement {
+	if ( ! getFeatureAvailability( 'ai-response-feedback' ) ) {
+		return null;
+	}
+
 	const [ itemsRated, setItemsRated ] = useState( {} );
 	const { tracks } = useAnalytics();
 
@@ -44,9 +77,9 @@ export default function AiFeedbackThumbs( {
 		return itemsRated[ ratedItem ] === thumbValue;
 	};
 
-	return getFeatureAvailability( 'ai-response-feedback' ) ? (
+	return (
 		<div className="ai-assistant-feedback__selection">
-			<Tooltip text={ __( 'I like this', 'jetpack' ) }>
+			<Tooltip text={ __( 'I like this', 'jetpack-ai-client' ) }>
 				<Button
 					disabled={ disabled }
 					icon={ thumbsUp }
@@ -58,7 +91,7 @@ export default function AiFeedbackThumbs( {
 					} ) }
 				/>
 			</Tooltip>
-			<Tooltip text={ __( "I don't find this useful", 'jetpack' ) }>
+			<Tooltip text={ __( "I don't find this useful", 'jetpack-ai-client' ) }>
 				<Button
 					disabled={ disabled }
 					icon={ thumbsDown }
@@ -71,7 +104,5 @@ export default function AiFeedbackThumbs( {
 				/>
 			</Tooltip>
 		</div>
-	) : (
-		<></>
 	);
 }

--- a/projects/js-packages/ai-client/src/components/ai-feedback/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-feedback/index.tsx
@@ -6,7 +6,7 @@ import {
 	getJetpackExtensionAvailability,
 } from '@automattic/jetpack-shared-extension-utils';
 import { Button, Tooltip } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { thumbsUp, thumbsDown } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -24,6 +24,8 @@ type AiFeedbackThumbsProps = {
 	iconSize?: number;
 	ratedItem?: string;
 	feature?: string;
+	savedRatings?: Record< string, string >;
+	onRate?: ( rating: string ) => void;
 };
 
 /**
@@ -47,13 +49,19 @@ export default function AiFeedbackThumbs( {
 	iconSize = 24,
 	ratedItem = '',
 	feature = '',
+	savedRatings = {},
+	onRate,
 }: AiFeedbackThumbsProps ): React.ReactElement {
 	if ( ! getFeatureAvailability( 'ai-response-feedback' ) ) {
 		return null;
 	}
 
-	const [ itemsRated, setItemsRated ] = useState( {} );
+	const [ itemsRated, setItemsRated ] = useState( savedRatings );
 	const { tracks } = useAnalytics();
+
+	useEffect( () => {
+		setItemsRated( savedRatings );
+	}, [ savedRatings ] );
 
 	const checkThumb = ( thumbValue: string ) => {
 		if ( ! itemsRated[ ratedItem ] ) {
@@ -71,6 +79,8 @@ export default function AiFeedbackThumbs( {
 				...itemsRated,
 				[ ratedItem ]: aiRating,
 			} );
+
+			onRate?.( aiRating );
 
 			tracks.recordEvent( 'jetpack_ai_feedback', {
 				type: feature,

--- a/projects/js-packages/ai-client/src/components/ai-feedback/style.scss
+++ b/projects/js-packages/ai-client/src/components/ai-feedback/style.scss
@@ -11,6 +11,6 @@
 	}
 
 	&__thumb-selected {
-		color: var(--wp-components-color-accent,var(--wp-admin-theme-color,#3858e9));
+		color: var( --wp-components-color-accent, var( --wp-admin-theme-color, #3858e9 ) );
 	}
 }

--- a/projects/js-packages/ai-client/src/components/index.ts
+++ b/projects/js-packages/ai-client/src/components/index.ts
@@ -1,4 +1,5 @@
 export { AIControl, BlockAIControl, ExtensionAIControl } from './ai-control/index.js';
+export { default as AiFeedbackThumbs } from './ai-feedback/index.js';
 export { default as AiStatusIndicator } from './ai-status-indicator/index.js';
 export { default as AudioDurationDisplay } from './audio-duration-display/index.js';
 export { default as AiModalFooter } from './ai-modal-footer/index.js';

--- a/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
@@ -158,7 +158,7 @@ const RateLogo: React.FC< {
 	ratedItem: string;
 	onRate: ( rating: string ) => void;
 } > = ( { disabled, ratedItem, onRate } ) => {
-	const { logos } = useLogoGenerator();
+	const { logos, selectedLogo } = useLogoGenerator();
 	const savedRatings = logos
 		.filter( logo => logo.rating )
 		.reduce( ( acc, logo ) => {
@@ -172,6 +172,10 @@ const RateLogo: React.FC< {
 			ratedItem={ ratedItem }
 			feature="logo-generator"
 			savedRatings={ savedRatings }
+			options={ {
+				mediaLibraryId: selectedLogo.mediaId,
+				prompt: selectedLogo.description,
+			} }
 			onRate={ onRate }
 		/>
 	);

--- a/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
@@ -9,7 +9,7 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import AiFeedbackThumbs from '../../../../../plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-feedback';
+import { default as AiFeedbackThumbs } from '../../../../../plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-feedback/index.js';
 import CheckIcon from '../assets/icons/check.js';
 import LogoIcon from '../assets/icons/logo.js';
 import MediaIcon from '../assets/icons/media.js';
@@ -153,7 +153,10 @@ const LogoEmpty: React.FC = () => {
 	);
 };
 
-const RateLogo: React.FC = ( { disabled, ratedItem } ) => {
+const RateLogo: React.FC< { disabled: boolean; ratedItem: string } > = ( {
+	disabled,
+	ratedItem,
+} ) => {
 	return (
 		<>
 			<AiFeedbackThumbs disabled={ disabled } ratedItem={ ratedItem } feature="logo-generator" />

--- a/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
@@ -9,6 +9,7 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
+import AiFeedbackThumbs from '../../../../../plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-feedback';
 import CheckIcon from '../assets/icons/check.js';
 import LogoIcon from '../assets/icons/logo.js';
 import MediaIcon from '../assets/icons/media.js';
@@ -152,6 +153,14 @@ const LogoEmpty: React.FC = () => {
 	);
 };
 
+const RateLogo: React.FC = ( { disabled, ratedItem } ) => {
+	return (
+		<>
+			<AiFeedbackThumbs disabled={ disabled } ratedItem={ ratedItem } feature="logo-generator" />
+		</>
+	);
+};
+
 const LogoReady: React.FC< {
 	siteId: string;
 	logo: Logo;
@@ -171,6 +180,7 @@ const LogoReady: React.FC< {
 				<div className="jetpack-ai-logo-generator-modal-presenter__actions">
 					<SaveInLibraryButton siteId={ siteId } />
 					<UseOnSiteButton onApplyLogo={ onApplyLogo } />
+					<RateLogo ratedItem={ logo.url } disabled={ false } />
 				</div>
 			</div>
 		</>

--- a/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
@@ -9,7 +9,7 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import { default as AiFeedbackThumbs } from '../../../../../plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-feedback/index.js';
+import AiFeedbackThumbs from '../../components/ai-feedback/index.js';
 import CheckIcon from '../assets/icons/check.js';
 import LogoIcon from '../assets/icons/logo.js';
 import MediaIcon from '../assets/icons/media.js';

--- a/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
@@ -159,10 +159,12 @@ const RateLogo: React.FC< {
 	onRate: ( rating: string ) => void;
 } > = ( { disabled, ratedItem, onRate } ) => {
 	const { logos } = useLogoGenerator();
-	const savedRatings = logos.reduce( ( acc, logo ) => {
-		acc[ logo.url ] = logo.rating;
-		return acc;
-	}, {} );
+	const savedRatings = logos
+		.filter( logo => logo.rating )
+		.reduce( ( acc, logo ) => {
+			acc[ logo.url ] = logo.rating;
+			return acc;
+		}, {} );
 
 	return (
 		<AiFeedbackThumbs

--- a/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
@@ -153,14 +153,25 @@ const LogoEmpty: React.FC = () => {
 	);
 };
 
-const RateLogo: React.FC< { disabled: boolean; ratedItem: string } > = ( {
-	disabled,
-	ratedItem,
-} ) => {
+const RateLogo: React.FC< {
+	disabled: boolean;
+	ratedItem: string;
+	onRate: ( rating: string ) => void;
+} > = ( { disabled, ratedItem, onRate } ) => {
+	const { logos } = useLogoGenerator();
+	const savedRatings = logos.reduce( ( acc, logo ) => {
+		acc[ logo.url ] = logo.rating;
+		return acc;
+	}, {} );
+
 	return (
-		<>
-			<AiFeedbackThumbs disabled={ disabled } ratedItem={ ratedItem } feature="logo-generator" />
-		</>
+		<AiFeedbackThumbs
+			disabled={ disabled }
+			ratedItem={ ratedItem }
+			feature="logo-generator"
+			savedRatings={ savedRatings }
+			onRate={ onRate }
+		/>
 	);
 };
 
@@ -169,6 +180,17 @@ const LogoReady: React.FC< {
 	logo: Logo;
 	onApplyLogo: ( mediaId: number ) => void;
 } > = ( { siteId, logo, onApplyLogo } ) => {
+	const handleRateLogo = ( rating: string ) => {
+		// Update localStorage
+		updateLogo( {
+			siteId,
+			url: logo.url,
+			newUrl: logo.url,
+			mediaId: logo.mediaId,
+			rating,
+		} );
+	};
+
 	return (
 		<>
 			<img
@@ -183,7 +205,7 @@ const LogoReady: React.FC< {
 				<div className="jetpack-ai-logo-generator-modal-presenter__actions">
 					<SaveInLibraryButton siteId={ siteId } />
 					<UseOnSiteButton onApplyLogo={ onApplyLogo } />
-					<RateLogo ratedItem={ logo.url } disabled={ false } />
+					<RateLogo ratedItem={ logo.url } disabled={ false } onRate={ handleRateLogo } />
 				</div>
 			</div>
 		</>

--- a/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
@@ -412,10 +412,13 @@ User request:${ prompt }`;
 					throw error;
 				}
 
+				const revisedPrompt = image.data[ 0 ].revised_prompt || null;
+
 				// response_format=url returns object with url, otherwise b64_json
 				const logo: Logo = {
 					url: 'data:image/png;base64,' + image.data[ 0 ].b64_json,
 					description: prompt,
+					revisedPrompt,
 				};
 
 				try {
@@ -424,6 +427,7 @@ User request:${ prompt }`;
 						url: savedLogo.mediaURL,
 						description: prompt,
 						mediaId: savedLogo.mediaId,
+						revisedPrompt,
 					} );
 				} catch ( error ) {
 					storeLogo( logo );

--- a/projects/js-packages/ai-client/src/logo-generator/lib/logo-storage.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/lib/logo-storage.ts
@@ -45,9 +45,10 @@ export function stashLogo( { siteId, url, description, mediaId }: SaveToStorageP
  * @param {UpdateInStorageProps.url}     updateInStorageProps.url     - The URL of the logo to update
  * @param {UpdateInStorageProps.newUrl}  updateInStorageProps.newUrl  - The new URL of the logo
  * @param {UpdateInStorageProps.mediaId} updateInStorageProps.mediaId - The new media ID of the logo
+ * @param {UpdateInStorageProps.rating}  updateInStorageProps.rating  - The new rating of the logo
  * @return {Logo} The logo that was updated
  */
-export function updateLogo( { siteId, url, newUrl, mediaId }: UpdateInStorageProps ) {
+export function updateLogo( { siteId, url, newUrl, mediaId, rating }: UpdateInStorageProps ) {
 	const storedContent = getSiteLogoHistory( siteId );
 
 	const index = storedContent.findIndex( logo => logo.url === url );
@@ -55,6 +56,7 @@ export function updateLogo( { siteId, url, newUrl, mediaId }: UpdateInStoragePro
 	if ( index > -1 ) {
 		storedContent[ index ].url = newUrl;
 		storedContent[ index ].mediaId = mediaId;
+		storedContent[ index ].rating = rating;
 	}
 
 	localStorage.setItem(
@@ -96,6 +98,7 @@ export function getSiteLogoHistory( siteId: string ) {
 			url: logo.url,
 			description: logo.description,
 			mediaId: logo.mediaId,
+			rating: logo.rating,
 		} ) );
 
 	return storedContent;

--- a/projects/js-packages/ai-client/src/logo-generator/lib/logo-storage.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/lib/logo-storage.ts
@@ -10,21 +10,28 @@ const MAX_LOGOS = 10;
 /**
  * Add an entry to the site's logo history.
  *
- * @param {SaveToStorageProps}             saveToStorageProps             - The properties to save to storage
- * @param {SaveToStorageProps.siteId}      saveToStorageProps.siteId      - The site ID
- * @param {SaveToStorageProps.url}         saveToStorageProps.url         - The URL of the logo
- * @param {SaveToStorageProps.description} saveToStorageProps.description - The description of the logo, based on the prompt used to generate it
- * @param {SaveToStorageProps.mediaId}     saveToStorageProps.mediaId     - The media ID of the logo on the backend
- *
+ * @param {SaveToStorageProps}               saveToStorageProps               - The properties to save to storage
+ * @param {SaveToStorageProps.siteId}        saveToStorageProps.siteId        - The site ID
+ * @param {SaveToStorageProps.url}           saveToStorageProps.url           - The URL of the logo
+ * @param {SaveToStorageProps.description}   saveToStorageProps.description   - The description of the logo, based on the prompt used to generate it
+ * @param {SaveToStorageProps.mediaId}       saveToStorageProps.mediaId       - The media ID of the logo on the backend
+ * @param {SaveToStorageProps.revisedPrompt} saveToStorageProps.revisedPrompt - The revised prompt of the logo
  * @return {Logo} The logo that was saved
  */
-export function stashLogo( { siteId, url, description, mediaId }: SaveToStorageProps ) {
+export function stashLogo( {
+	siteId,
+	url,
+	description,
+	mediaId,
+	revisedPrompt,
+}: SaveToStorageProps ) {
 	const storedContent = getSiteLogoHistory( siteId );
 
 	const logo: Logo = {
 		url,
 		description,
 		mediaId,
+		revisedPrompt,
 	};
 
 	storedContent.push( logo );

--- a/projects/js-packages/ai-client/src/logo-generator/store/types.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/store/types.ts
@@ -141,6 +141,7 @@ export type Logo = {
 	description: string;
 	mediaId?: number;
 	rating?: string;
+	revisedPrompt?: string;
 };
 
 export type RequestError = string | Error | null;

--- a/projects/js-packages/ai-client/src/logo-generator/store/types.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/store/types.ts
@@ -140,6 +140,7 @@ export type Logo = {
 	url: string;
 	description: string;
 	mediaId?: number;
+	rating?: string;
 };
 
 export type RequestError = string | Error | null;

--- a/projects/js-packages/ai-client/src/logo-generator/types.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/types.ts
@@ -92,6 +92,7 @@ export type UpdateInStorageProps = {
 	url: Logo[ 'url' ];
 	newUrl: Logo[ 'url' ];
 	mediaId: Logo[ 'mediaId' ];
+	rating?: Logo[ 'rating' ];
 };
 
 export type RemoveFromStorageProps = {

--- a/projects/plugins/jetpack/changelog/change-jetpack-ai-rate-logo-generator
+++ b/projects/plugins/jetpack/changelog/change-jetpack-ai-rate-logo-generator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Add thumbs up/down component to AI logo generator

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/get-feature-availability.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/get-feature-availability.ts
@@ -3,6 +3,7 @@
  */
 import { getJetpackExtensionAvailability } from '@automattic/jetpack-shared-extension-utils';
 
+// TODO: Move to the AI Client js-package
 export function getFeatureAvailability( feature: string ): boolean {
 	return getJetpackExtensionAvailability( feature ).available === true;
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-feedback/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-feedback/index.tsx
@@ -11,8 +11,13 @@ import './style.scss';
 export default function AiFeedbackThumbs( {
 	disabled = false,
 	iconSize = 24,
-	ratedItem,
-	feature,
+	ratedItem = '',
+	feature = '',
+}: {
+	disabled: boolean;
+	iconSize?: number;
+	ratedItem: string;
+	feature: string;
 } ) {
 	const [ itemsRated, setItemsRated ] = useState( {} );
 	const { tracks } = useAnalytics();

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { AiFeedbackThumbs } from '@automattic/jetpack-ai-client';
 import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
@@ -8,7 +9,6 @@ import clsx from 'clsx';
 /**
  * Internal dependencies
  */
-import AiFeedbackThumbs from '../../ai-feedback';
 import AiIcon from '../../ai-icon';
 import './carrousel.scss';
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.tsx
@@ -15,6 +15,8 @@ import './carrousel.scss';
 export type CarrouselImageData = {
 	image?: string;
 	libraryId?: number | string;
+	prompt?: string;
+	revisedPrompt?: string;
 	libraryUrl?: string;
 	generating?: boolean;
 	error?: {
@@ -108,7 +110,7 @@ export default function Carrousel( {
 		<div className="ai-assistant-image__carrousel">
 			<div className="ai-assistant-image__carrousel-images">
 				{ images.length > 1 && prevButton }
-				{ images.map( ( { image, generating, error }, index ) => (
+				{ images.map( ( { image, generating, error, revisedPrompt }, index ) => (
 					<div
 						key={ `image:` + index }
 						className={ clsx( 'ai-assistant-image__carrousel-image-container', {
@@ -149,7 +151,11 @@ export default function Carrousel( {
 												<AiIcon />
 											</BlankImage>
 										) : (
-											<img className="ai-assistant-image__carrousel-image" src={ image } alt="" />
+											<img
+												className="ai-assistant-image__carrousel-image"
+												src={ image }
+												alt={ revisedPrompt }
+											/>
 										) }
 									</>
 								) }
@@ -171,6 +177,11 @@ export default function Carrousel( {
 						disabled={ aiFeedbackDisabled( images[ current ] ) }
 						ratedItem={ images[ current ].libraryUrl || '' }
 						iconSize={ 20 }
+						options={ {
+							mediaLibraryId: Number( images[ current ].libraryId ),
+							prompt: images[ current ].prompt,
+							revisedPrompt: images[ current ].revisedPrompt,
+						} }
 						feature="image-generator"
 					/>
 				</div>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
@@ -167,7 +167,9 @@ export default function useAiImage( {
 					.then( result => {
 						if ( result.data.length > 0 ) {
 							const image = 'data:image/png;base64,' + result.data[ 0 ].b64_json;
-							updateImages( { image }, pointer.current );
+							const prompt = userPrompt || null;
+							const revisedPrompt = result.data[ 0 ].revised_prompt || null;
+							updateImages( { image, prompt, revisedPrompt }, pointer.current );
 							updateRequestsCount();
 							saveToMediaLibrary( image, name )
 								.then( savedImage => {
@@ -181,7 +183,7 @@ export default function useAiImage( {
 										image,
 										libraryId: savedImage?.id,
 										libraryUrl: savedImage?.url,
-										revisedPrompt: result.data[ 0 ].revised_prompt || '',
+										revisedPrompt,
 									} );
 								} )
 								.catch( () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #40572
Fixes #40611

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the thumbs up/thumbs down rating component to the logo generator

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Slack thread about some limitations: p1734103605310639-slack-C054LN8RNVA
PS with designs: p1HpG7-uzm-p2

## Does this pull request change what data or activity we track or use?

Nope

## Testing instructions:
* Check out the branch and rebuild as usual
* Create a new post, insert a logo block, and use the AI logo generator to generate a new logo or browse your existing logos
* Verify that there are no thumbs next to the "Use on block" button
* Enable the feature: 

```php
define( 'JETPACK_BLOCKS_VARIATION', 'beta' );
add_filter( 'ai_response_feedback_enabled', '__return_true' );
```

* Reload your post and open the logo generator again
* Verify that a thumbs up/down appears next to the "Use on block" button
* You should be able to click on the thumbs up or down and observe that the thumb changes color
* Viewing other logos you have should show their rating (which will likely be no rating), and if you go back to a logo you already rated the same rating should be present.
* Additionally: when you click the thumbs up or down you should be able to observe Tracks events that submit the rating, blog ID, and a `type` parameter that should be `logo-generator`
* You can enter `localStorage.setItem('debug', '*')` in the console to see the above events
* Check that ratings are persisted after reload

## Screenshot

![Screenshot 2024-12-13 at 1 56 31 PM](https://github.com/user-attachments/assets/78b97798-f1dc-4751-83f0-0c86818fe172)
