### PR TITLE
Publicize: Adjust how the Connections Post Field is initialised

### DIFF
--- a/projects/packages/publicize/changelog/update-post-connections-field-config
+++ b/projects/packages/publicize/changelog/update-post-connections-field-config
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Adjusted the initialisation logic for the connections field.

--- a/projects/packages/publicize/src/class-connections-post-field.php
+++ b/projects/packages/publicize/src/class-connections-post-field.php
@@ -34,6 +34,15 @@ class Connections_Post_Field {
 	public $memoized_updates = array();
 
 	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		// Adding on a higher priority to make sure we're the first field registered.
+		// The priority parameter can be removed once we deprecate WPCOM_REST_API_V2_Post_Publicize_Connections_Field
+		add_action( 'rest_api_init', array( $this, 'register_fields' ), 5 );
+	}
+
+	/**
 	 * Registers the jetpack_publicize_connections field. Called
 	 * automatically on `rest_api_init()`.
 	 */
@@ -489,4 +498,8 @@ class Connections_Post_Field {
 	private function is_valid_for_context( $schema, $context ) {
 		return empty( $schema['context'] ) || in_array( $context, $schema['context'], true );
 	}
+}
+
+if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+	wpcom_rest_api_v2_load_plugin( 'Automattic\Jetpack\Publicize\Connections_Post_Field' );
 }

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -34,12 +34,9 @@ class Publicize_Setup {
 
 		if ( ! isset( $publicize_ui ) ) {
 			$publicize_ui = new Publicize_UI();
-
 		}
 
-		// Adding on a higher priority to make sure we're the first field registered.
-		// The priority parameter can be removed once we deprecate WPCOM_REST_API_V2_Post_Publicize_Connections_Field
-		add_action( 'rest_api_init', array( new Connections_Post_Field(), 'register_fields' ), 5 );
+		new Connections_Post_Field();
 		add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
 		add_action( 'current_screen', array( static::class, 'init_sharing_limits' ) );
 


### PR DESCRIPTION
In order to make it compatible with use on WPCOM we need to adjust how the Connections Post Field is initialised. This adds a constructor to handle registering the `rest_init` hook, and adds the WPCOM specific logic.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/jetpack-reach#720


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

We need to check that the behaviour is the same as it is currently.

* On a site with Publicize set up and at least one active social connection
* Apply this branch/PR
* In the block editor for a new post, ensure that the connections are displayed as soon as you open the Jetpack sidebar
* Toggle one or more of the social connections to disable it, and add a custom message
* Save the post and reload the editor.
* Your changes should have been saved.

