### PR TITLE
Scan Report: Align Status Icon

### DIFF
--- a/projects/js-packages/components/components/scan-report/index.tsx
+++ b/projects/js-packages/components/components/scan-report/index.tsx
@@ -216,7 +216,10 @@ export default function ScanReport( { dataSource, data, onChangeSelection } ): J
 	 *
 	 * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dataviews/#getitemid-function
 	 */
-	const getItemId = useCallback( ( item: ScanReportExtension ) => item.id.toString(), [] );
+	const getItemId = useCallback(
+		( item: ScanReportExtension ) => `${ item.type }_${ item.slug }_${ item.version }`,
+		[]
+	);
 
 	return (
 		<DataViews

--- a/projects/js-packages/components/components/scan-report/styles.module.scss
+++ b/projects/js-packages/components/components/scan-report/styles.module.scss
@@ -19,3 +19,9 @@
 	border-radius: 4px;
 	text-align: left;
 }
+
+.icon {
+	min-width: 32px;
+	display: flex;
+	justify-content: center;
+}

--- a/projects/plugins/protect/src/js/routes/home/index.jsx
+++ b/projects/plugins/protect/src/js/routes/home/index.jsx
@@ -27,7 +27,6 @@ const HomePage = () => {
 							checked: !! status.lastChecked,
 							threats: status.files,
 							type: 'files',
-							name: __( 'Files', 'jetpack-protect' ),
 						},
 				  ]
 				: [] ),

--- a/projects/plugins/protect/src/js/routes/home/index.jsx
+++ b/projects/plugins/protect/src/js/routes/home/index.jsx
@@ -1,5 +1,4 @@
 import { AdminSection, Container, Col, ScanReport } from '@automattic/jetpack-components';
-import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import AdminPage from '../../components/admin-page';
 import useScanStatusQuery from '../../data/scan/use-scan-status-query';

--- a/projects/plugins/protect/src/js/routes/home/index.jsx
+++ b/projects/plugins/protect/src/js/routes/home/index.jsx
@@ -1,4 +1,6 @@
 import { AdminSection, Container, Col, ScanReport } from '@automattic/jetpack-components';
+import { __ } from '@wordpress/i18n';
+import { useMemo } from 'react';
 import AdminPage from '../../components/admin-page';
 import useScanStatusQuery from '../../data/scan/use-scan-status-query';
 import HomeAdminSectionHero from './home-admin-section-hero';
@@ -13,16 +15,25 @@ import styles from './styles.module.scss';
  */
 const HomePage = () => {
 	const { data: status } = useScanStatusQuery( { usePolling: true } );
-	const { core, plugins, themes, files } = status;
 
-	const data = [
-		core,
-		...plugins,
-		...themes,
-		{ checked: true, threats: files, type: 'files' },
-	].map( ( item, index ) => {
-		return { id: index + 1, ...item };
-	} );
+	const data = useMemo(
+		() => [
+			...( Object.keys( status.core ).length ? [ status.core ] : [] ),
+			...status.plugins,
+			...status.themes,
+			...( status.dataSource === 'scan_api'
+				? [
+						{
+							checked: !! status.lastChecked,
+							threats: status.files,
+							type: 'files',
+							name: __( 'Files', 'jetpack-protect' ),
+						},
+				  ]
+				: [] ),
+		],
+		[ status ]
+	);
 
 	return (
 		<AdminPage>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Applies a `min-width` to the status icon, in order to visually align the column.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Review the Scan Report storybook or Protect implementation, verify the shield status icon is centered with the column label.

<img width="1288" alt="Screenshot 2024-12-15 at 12 00 42 PM" src="https://github.com/user-attachments/assets/48b4f68c-a454-4cb5-87f4-ec712e38cd29" />


