### PR TITLE
Protect: Show loading indicator as status icon when scan in progress

### DIFF
--- a/projects/js-packages/components/components/scan-report/index.tsx
+++ b/projects/js-packages/components/components/scan-report/index.tsx
@@ -1,5 +1,5 @@
 import { type ScanReportExtension } from '@automattic/jetpack-scan';
-import { Tooltip } from '@wordpress/components';
+import { Spinner, Tooltip } from '@wordpress/components';
 import {
 	type SupportedLayouts,
 	type View,
@@ -30,10 +30,16 @@ import styles from './styles.module.scss';
  * @param {string}   props.dataSource        - Data source.
  * @param {Array}    props.data              - Scan report data.
  * @param {Function} props.onChangeSelection - Callback function run when an item is selected.
+ * @param {boolean}  props.scanInProgress    - Whether a scan is in progress.
  *
  * @return {JSX.Element} The ScanReport component.
  */
-export default function ScanReport( { dataSource, data, onChangeSelection } ): JSX.Element {
+export default function ScanReport( {
+	dataSource,
+	data,
+	onChangeSelection,
+	scanInProgress = false,
+} ): JSX.Element {
 	const baseView = {
 		search: '',
 		filters: [],
@@ -140,7 +146,11 @@ export default function ScanReport( { dataSource, data, onChangeSelection } ): J
 					return (
 						<Tooltip className={ styles.tooltip } text={ text }>
 							<div className={ styles.icon }>
-								<ShieldIcon variant={ variant } height={ iconHeight } />
+								{ scanInProgress ? (
+									<Spinner />
+								) : (
+									<ShieldIcon variant={ variant } height={ iconHeight } />
+								) }
 							</div>
 						</Tooltip>
 					);
@@ -191,7 +201,7 @@ export default function ScanReport( { dataSource, data, onChangeSelection } ): J
 		];
 
 		return result;
-	}, [ view, dataSource ] );
+	}, [ view.type, dataSource, scanInProgress ] );
 
 	/**
 	 * Apply the view settings (i.e. filters, sorting, pagination) to the dataset.

--- a/projects/js-packages/components/components/scan-report/styles.module.scss
+++ b/projects/js-packages/components/components/scan-report/styles.module.scss
@@ -24,4 +24,8 @@
 	min-width: 32px;
 	display: flex;
 	justify-content: center;
+
+	> svg {
+		margin: 0;
+	}
 }

--- a/projects/plugins/protect/src/js/routes/home/index.jsx
+++ b/projects/plugins/protect/src/js/routes/home/index.jsx
@@ -2,7 +2,7 @@ import { AdminSection, Container, Col, ScanReport } from '@automattic/jetpack-co
 import { useMemo } from 'react';
 import AdminPage from '../../components/admin-page';
 import { SCAN_IN_PROGRESS_STATUSES } from '../../constants';
-import useScanStatusQuery from '../../data/scan/use-scan-status-query';
+import useScanStatusQuery, { isScanInProgress } from '../../data/scan/use-scan-status-query';
 import HomeAdminSectionHero from './home-admin-section-hero';
 import styles from './styles.module.scss';
 
@@ -47,7 +47,11 @@ const HomePage = () => {
 						horizontalGap={ 4 }
 					>
 						<Col>
-							<ScanReport dataSource={ status.dataSource } data={ data } />
+							<ScanReport
+								dataSource={ status.dataSource }
+								data={ data }
+								scanInProgress={ isScanInProgress( status ) }
+							/>
 						</Col>
 					</Container>
 				</AdminSection>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the `ScanReport` component to accept a `scanInProgress: boolean` prop, which displays a `Spinner` instead of a `ShieldIcon` in the "status" column when a scan is currently in progress.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test the home page in Protect while a scan is running and then complete.

<img width="1213" alt="Screenshot 2024-12-15 at 1 33 27 PM" src="https://github.com/user-attachments/assets/fc525841-af48-4ce2-b96b-dfd3e7c2165f" />

