### PR TITLE
Jetpack AI: show current featured image on modal

### DIFF
--- a/projects/plugins/jetpack/changelog/change-jetpack-ai-featured-image-show-current
+++ b/projects/plugins/jetpack/changelog/change-jetpack-ai-featured-image-show-current
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI: featured image generator modal noww shows current featured image if present

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.tsx
@@ -166,6 +166,7 @@ export default function AiImageModal( {
 		}
 	}, [ imageStyles, initialStyle ] );
 
+	debug( 'images', images );
 	return (
 		<>
 			{ open && (

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.tsx
@@ -166,7 +166,6 @@ export default function AiImageModal( {
 		}
 	}, [ imageStyles, initialStyle ] );
 
-	debug( 'images', images );
 	return (
 		<>
 			{ open && (

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.scss
@@ -100,7 +100,6 @@ $scale-factor: 0.55;
 
 		&-footer-left {
 			display: flex;
-			// width: 25%;
 			flex-grow: 1;
 		}
 
@@ -110,7 +109,6 @@ $scale-factor: 0.55;
 			align-items: center;
 			font-size: 13px;
 			padding: 6px 0;
-			// width: 50%;
 
 			.ai-carrousel {
 				&__prev,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.scss
@@ -100,7 +100,8 @@ $scale-factor: 0.55;
 
 		&-footer-left {
 			display: flex;
-			width: 25%;
+			// width: 25%;
+			flex-grow: 1;
 		}
 
 		&-counter {
@@ -109,7 +110,7 @@ $scale-factor: 0.55;
 			align-items: center;
 			font-size: 13px;
 			padding: 6px 0;
-			width: 50%;
+			// width: 50%;
 
 			.ai-carrousel {
 				&__prev,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.scss
@@ -1,3 +1,5 @@
+$scale-factor: 0.55;
+
 .ai-assistant-image {
 	&__blank {
 		display: flex;
@@ -47,6 +49,7 @@
 			display: flex;
 			align-items: center;
 			overflow: hidden;
+			height: calc( 768px * $scale-factor );
 
 			.ai-carrousel {
 				&__prev {
@@ -129,14 +132,17 @@
 		}
 
 		&-image {
-			width: 78%;
+			max-height: calc( 768px * $scale-factor );
+			max-width: calc( 1024px * $scale-factor );
+			width: auto;
 			height: auto;
+			margin: auto 0;
 		}
 
 		&-image-container {
 			display: flex;
 			width: 100%;
-			height: auto;
+			height: 100%;
 			position: absolute;
 			left: 8px;
 			transform: translateX( 100% );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.tsx
@@ -7,7 +7,6 @@ import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
-import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
@@ -51,7 +50,6 @@ function BlankImage( { children, isDotted = false, contentClassName = '' } ) {
 	);
 }
 
-const debug = debugFactory( 'jetpack-ai:carrousel' );
 export default function Carrousel( {
 	images,
 	current,
@@ -91,7 +89,7 @@ export default function Carrousel( {
 	const total = images?.filter?.(
 		item => item?.generating || Object.hasOwn( item, 'image' ) || Object.hasOwn( item, 'libraryId' )
 	)?.length;
-	debug( 'total', total );
+
 	const actual = current === 0 && total === 0 ? 0 : current + 1;
 
 	useEffect( () => {
@@ -114,7 +112,6 @@ export default function Carrousel( {
 		setImageFeedbackDisabled( false );
 	}, [ current, images ] );
 
-	debug( 'current', current, images[ current ] );
 	return (
 		<div className="ai-assistant-image__carrousel">
 			<div className="ai-assistant-image__carrousel-images">

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/carrousel.tsx
@@ -3,9 +3,11 @@
  */
 import { AiFeedbackThumbs } from '@automattic/jetpack-ai-client';
 import { Spinner } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
+import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
@@ -49,6 +51,7 @@ function BlankImage( { children, isDotted = false, contentClassName = '' } ) {
 	);
 }
 
+const debug = debugFactory( 'jetpack-ai:carrousel' );
 export default function Carrousel( {
 	images,
 	current,
@@ -62,6 +65,7 @@ export default function Carrousel( {
 	handleNextImage: () => void;
 	actions?: React.JSX.Element;
 } ) {
+	const [ imageFeedbackDisabled, setImageFeedbackDisabled ] = useState( false );
 	const prevButton = (
 		<button className="ai-carrousel__prev" onClick={ handlePreviousImage }>
 			<Icon
@@ -84,33 +88,38 @@ export default function Carrousel( {
 		</button>
 	);
 
-	const total = images?.filter?.( item => item?.generating || Object.hasOwn( item, 'image' ) )
-		?.length;
-
+	const total = images?.filter?.(
+		item => item?.generating || Object.hasOwn( item, 'image' ) || Object.hasOwn( item, 'libraryId' )
+	)?.length;
+	debug( 'total', total );
 	const actual = current === 0 && total === 0 ? 0 : current + 1;
 
-	const aiFeedbackDisabled = imageData => {
-		const { image, generating, error } = imageData;
+	useEffect( () => {
+		const imageData = images[ current ];
+		if ( ! imageData ) {
+			setImageFeedbackDisabled( true );
+		}
+
+		const { image, generating, error } = imageData || {};
 
 		// disable if there's an empty modal
 		if ( ! image && ! generating && ! error ) {
-			return true;
+			return setImageFeedbackDisabled( true );
 		}
-
 		// also disable if we're generating or have an error
 		if ( generating || error ) {
-			return true;
+			return setImageFeedbackDisabled( true );
 		}
 
-		// otherwise we're fine
-		return false;
-	};
+		setImageFeedbackDisabled( false );
+	}, [ current, images ] );
 
+	debug( 'current', current, images[ current ] );
 	return (
 		<div className="ai-assistant-image__carrousel">
 			<div className="ai-assistant-image__carrousel-images">
 				{ images.length > 1 && prevButton }
-				{ images.map( ( { image, generating, error, revisedPrompt }, index ) => (
+				{ images.map( ( { image, generating, error, revisedPrompt, libraryUrl }, index ) => (
 					<div
 						key={ `image:` + index }
 						className={ clsx( 'ai-assistant-image__carrousel-image-container', {
@@ -146,14 +155,14 @@ export default function Carrousel( {
 									</BlankImage>
 								) : (
 									<>
-										{ ! generating && ! image ? (
+										{ ! generating && ! image && ! libraryUrl ? (
 											<BlankImage>
 												<AiIcon />
 											</BlankImage>
 										) : (
 											<img
 												className="ai-assistant-image__carrousel-image"
-												src={ image }
+												src={ image || libraryUrl }
 												alt={ revisedPrompt }
 											/>
 										) }
@@ -174,8 +183,8 @@ export default function Carrousel( {
 					</div>
 
 					<AiFeedbackThumbs
-						disabled={ aiFeedbackDisabled( images[ current ] ) }
-						ratedItem={ images[ current ].libraryUrl || '' }
+						disabled={ imageFeedbackDisabled }
+						ratedItem={ images[ current ]?.libraryUrl || '' }
 						iconSize={ 20 }
 						options={ {
 							mediaLibraryId: Number( images[ current ].libraryId ),

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -51,11 +51,10 @@ export default function FeaturedImage( {
 	);
 	const siteType = useSiteType();
 	const postContent = usePostContent();
-	const { postTitle, postFeaturedMedia, isEditorPanelOpened } = useSelect( select => {
-		const featuredMediaId = select( editorStore ).getEditedPostAttribute( 'featured_media' );
+	const { postTitle, postFeaturedMediaId, isEditorPanelOpened } = useSelect( select => {
 		return {
 			postTitle: select( editorStore ).getEditedPostAttribute( 'title' ),
-			postFeaturedMedia: featuredMediaId,
+			postFeaturedMediaId: select( editorStore ).getEditedPostAttribute( 'featured_media' ),
 			isEditorPanelOpened:
 				select( editorStore ).isEditorPanelOpened ??
 				( select( 'core/edit-post' ) as EditorSelectors ).isEditorPanelOpened,
@@ -93,7 +92,7 @@ export default function FeaturedImage( {
 	const toggleEditorPanelOpened =
 		toggleEditorPanelOpenedFromEditor ?? toggleEditorPanelOpenedFromEditPost;
 
-	debug( 'postFeatureMedia', postFeaturedMedia );
+	debug( 'postFeaturedMediaId', postFeaturedMediaId );
 
 	const {
 		pointer,
@@ -112,7 +111,7 @@ export default function FeaturedImage( {
 		cost: featuredImageCost,
 		type: 'featured-image-generation',
 		feature: FEATURED_IMAGE_FEATURE_NAME,
-		previousMediaId: postFeaturedMedia,
+		previousMediaId: postFeaturedMediaId,
 	} );
 
 	const handleModalClose = useCallback( () => {
@@ -364,7 +363,7 @@ export default function FeaturedImage( {
 			disabled={
 				! currentImage?.image ||
 				currentImage?.generating ||
-				currentImage?.libraryId === postFeaturedMedia
+				currentImage?.libraryId === postFeaturedMediaId
 			}
 		>
 			{ __( 'Set as featured image', 'jetpack' ) }
@@ -389,7 +388,7 @@ export default function FeaturedImage( {
 			) }
 			<AiImageModal
 				postContent={ hasContent }
-				autoStart={ hasContent && ! postFeaturedMedia }
+				autoStart={ hasContent && ! postFeaturedMediaId }
 				autoStartAction={ handleFirstGenerate }
 				images={ images }
 				currentIndex={ current }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -51,21 +51,27 @@ export default function FeaturedImage( {
 	);
 	const siteType = useSiteType();
 	const postContent = usePostContent();
-	const { postTitle, postFeaturedMedia, currentFeaturedMedia, isEditorPanelOpened } = useSelect(
-		( select: ( store ) => EditorSelectors & CoreSelectors ) => {
+	const { postTitle, postFeaturedMedia, isEditorPanelOpened } = useSelect(
+		( select: ( store ) => EditorSelectors ) => {
 			const featuredMediaId = select( editorStore ).getEditedPostAttribute( 'featured_media' );
 			return {
 				postTitle: select( editorStore ).getEditedPostAttribute( 'title' ),
 				postFeaturedMedia: featuredMediaId,
-				currentFeaturedMedia: featuredMediaId
-					? select( 'core' )?.getMedia?.( featuredMediaId as number )
-					: null,
 				isEditorPanelOpened:
 					select( editorStore ).isEditorPanelOpened ??
 					select( 'core/edit-post' ).isEditorPanelOpened,
 			};
 		},
 		[]
+	);
+	const currentFeaturedMedia = useSelect(
+		( select: ( store ) => CoreSelectors ) => {
+			if ( postFeaturedMedia ) {
+				return select( 'core' )?.getMedia?.( postFeaturedMedia );
+			}
+			return null;
+		},
+		[ postFeaturedMedia ]
 	);
 	const { saveToMediaLibrary } = useSaveToMediaLibrary();
 	const { tracks } = useAnalytics();

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -51,12 +51,22 @@ export default function FeaturedImage( {
 	);
 	const siteType = useSiteType();
 	const postContent = usePostContent();
-	const { postTitle, postFeaturedMedia } = useSelect( select => {
-		return {
-			postTitle: select( editorStore ).getEditedPostAttribute( 'title' ),
-			postFeaturedMedia: select( editorStore ).getEditedPostAttribute( 'featured_media' ),
-		};
-	}, [] );
+	const { postTitle, postFeaturedMedia, currentFeaturedMedia, isEditorPanelOpened } = useSelect(
+		( select: ( store ) => EditorSelectors & CoreSelectors ) => {
+			const featuredMediaId = select( editorStore ).getEditedPostAttribute( 'featured_media' );
+			return {
+				postTitle: select( editorStore ).getEditedPostAttribute( 'title' ),
+				postFeaturedMedia: featuredMediaId,
+				currentFeaturedMedia: featuredMediaId
+					? select( 'core' )?.getMedia?.( featuredMediaId as number )
+					: null,
+				isEditorPanelOpened:
+					select( editorStore ).isEditorPanelOpened ??
+					select( 'core/edit-post' ).isEditorPanelOpened,
+			};
+		},
+		[]
+	);
 	const { saveToMediaLibrary } = useSaveToMediaLibrary();
 	const { tracks } = useAnalytics();
 	const { recordEvent } = tracks;
@@ -87,19 +97,6 @@ export default function FeaturedImage( {
 	// https://github.com/WordPress/gutenberg/blob/fe4d8cb936df52945c01c1863f7b87b58b7cc69f/packages/edit-post/CHANGELOG.md?plain=1#L19
 	const toggleEditorPanelOpened =
 		toggleEditorPanelOpenedFromEditor ?? toggleEditorPanelOpenedFromEditPost;
-	const isEditorPanelOpened = useSelect( ( select: ( store ) => EditorSelectors ) => {
-		const isOpened =
-			select( editorStore ).isEditorPanelOpened ?? select( 'core/edit-post' ).isEditorPanelOpened;
-		return isOpened;
-	}, [] );
-
-	const currentFeaturedMedia = useSelect(
-		( select: ( store ) => EditorSelectors & CoreSelectors ) => {
-			const mediaId = select( editorStore )?.getEditedPostAttribute?.( 'featured_media' );
-			return mediaId ? select( 'core' )?.getMedia?.( mediaId as number ) : null;
-		},
-		[]
-	);
 
 	const {
 		pointer,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -5,6 +5,7 @@ import { ImageStyle } from '@automattic/jetpack-ai-client';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import debugFactory from 'debug';
@@ -50,15 +51,12 @@ export default function FeaturedImage( {
 	);
 	const siteType = useSiteType();
 	const postContent = usePostContent();
-	const { postTitle, postFeaturedMedia } = useSelect(
-		( select: ( store: keyof SelectState ) => EditorSelectors ) => {
-			return {
-				postTitle: select( 'core/editor' ).getEditedPostAttribute( 'title' ),
-				postFeaturedMedia: select( 'core/editor' ).getEditedPostAttribute( 'featured_media' ),
-			};
-		},
-		[]
-	);
+	const { postTitle, postFeaturedMedia } = useSelect( select => {
+		return {
+			postTitle: select( editorStore ).getEditedPostAttribute( 'title' ),
+			postFeaturedMedia: select( editorStore ).getEditedPostAttribute( 'featured_media' ),
+		};
+	}, [] );
 	const { saveToMediaLibrary } = useSaveToMediaLibrary();
 	const { tracks } = useAnalytics();
 	const { recordEvent } = tracks;
@@ -71,7 +69,7 @@ export default function FeaturedImage( {
 	const { toggleEditorPanelOpened: toggleEditorPanelOpenedFromEditPost } =
 		useDispatch( 'core/edit-post' );
 	const { editPost, toggleEditorPanelOpened: toggleEditorPanelOpenedFromEditor } =
-		useDispatch( 'core/editor' );
+		useDispatch( editorStore );
 
 	// Get feature data
 	const { requireUpgrade, requestsCount, requestsLimit, currentTier, costs } = useAiFeature();

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -92,8 +92,6 @@ export default function FeaturedImage( {
 	const toggleEditorPanelOpened =
 		toggleEditorPanelOpenedFromEditor ?? toggleEditorPanelOpenedFromEditPost;
 
-	debug( 'postFeaturedMediaId', postFeaturedMediaId );
-
 	const {
 		pointer,
 		current,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -31,7 +31,7 @@ import {
 	PLACEMENT_MEDIA_SOURCE_DROPDOWN,
 } from './types';
 import type { ImageResponse } from './hooks/use-ai-image';
-import type { EditorSelectors } from './types';
+import type { CoreEditPostSelectors } from './types';
 
 const debug = debugFactory( 'jetpack-ai:featured-image' );
 
@@ -52,7 +52,7 @@ export default function FeaturedImage( {
 	const siteType = useSiteType();
 	const postContent = usePostContent();
 	const { postTitle, postFeaturedMediaURL, postFeaturedMediaId, isEditorPanelOpened } = useSelect(
-		( select: ( store ) => EditorSelectors ) => {
+		select => {
 			const editorStoreSelect = select( editorStore );
 			const featuredMediaURL = editorStoreSelect.getEditedPostAttribute(
 				'jetpack_featured_media_url'
@@ -67,7 +67,7 @@ export default function FeaturedImage( {
 				postFeaturedMediaId: featuredMediaId,
 				isEditorPanelOpened:
 					select( editorStore ).isEditorPanelOpened ??
-					select( 'core/edit-post' ).isEditorPanelOpened,
+					( select( 'core/edit-post' ) as CoreEditPostSelectors ).isEditorPanelOpened,
 			};
 		},
 		[]

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -201,7 +201,7 @@ export default function FeaturedImage( {
 				style: style,
 			} );
 
-			setCurrent( crrt => crrt + 1 );
+			setCurrent( () => images.length );
 			processImageGeneration( {
 				userPrompt,
 				postContent: postTitle + '\n\n' + postContent,
@@ -228,6 +228,7 @@ export default function FeaturedImage( {
 			postTitle,
 			postContent,
 			notEnoughRequests,
+			images,
 		]
 	);
 
@@ -398,7 +399,9 @@ export default function FeaturedImage( {
 				placement={ placement }
 				onClose={ handleModalClose }
 				onTryAgain={ handleTryAgain }
-				onGenerate={ pointer?.current > 0 ? handleRegenerate : handleGenerate }
+				onGenerate={
+					pointer?.current > 0 || postFeaturedMediaId ? handleRegenerate : handleGenerate
+				}
 				generating={ currentPointer?.generating }
 				notEnoughRequests={ notEnoughRequests }
 				requireUpgrade={ requireUpgrade }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -101,6 +101,8 @@ export default function FeaturedImage( {
 	const toggleEditorPanelOpened =
 		toggleEditorPanelOpenedFromEditor ?? toggleEditorPanelOpenedFromEditPost;
 
+	debug( 'postFeatureMedia', postFeaturedMedia );
+	debug( 'currentFeaturedMedia', currentFeaturedMedia );
 	const {
 		pointer,
 		current,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -30,6 +30,7 @@ import {
 	PLACEMENT_MEDIA_SOURCE_DROPDOWN,
 } from './types';
 import type { ImageResponse } from './hooks/use-ai-image';
+import type { SelectState, EditorSelectors, CoreSelectors } from './types';
 
 const debug = debugFactory( 'jetpack-ai:featured-image' );
 
@@ -49,14 +50,15 @@ export default function FeaturedImage( {
 	);
 	const siteType = useSiteType();
 	const postContent = usePostContent();
-	const { postTitle, postFeaturedMedia } = useSelect( select => {
-		return {
-			// @ts-expect-error - getEditedPostAttribute is not defined in the useSelect type
-			postTitle: select( 'core/editor' ).getEditedPostAttribute( 'title' ),
-			// @ts-expect-error - getEditedPostAttribute is not defined in the useSelect type
-			postFeaturedMedia: select( 'core/editor' ).getEditedPostAttribute( 'featured_media' ),
-		};
-	}, [] );
+	const { postTitle, postFeaturedMedia } = useSelect(
+		( select: ( store: keyof SelectState ) => EditorSelectors ) => {
+			return {
+				postTitle: select( 'core/editor' ).getEditedPostAttribute( 'title' ),
+				postFeaturedMedia: select( 'core/editor' ).getEditedPostAttribute( 'featured_media' ),
+			};
+		},
+		[]
+	);
 	const { saveToMediaLibrary } = useSaveToMediaLibrary();
 	const { tracks } = useAnalytics();
 	const { recordEvent } = tracks;
@@ -87,14 +89,23 @@ export default function FeaturedImage( {
 	// https://github.com/WordPress/gutenberg/blob/fe4d8cb936df52945c01c1863f7b87b58b7cc69f/packages/edit-post/CHANGELOG.md?plain=1#L19
 	const toggleEditorPanelOpened =
 		toggleEditorPanelOpenedFromEditor ?? toggleEditorPanelOpenedFromEditPost;
-	const isEditorPanelOpened = useSelect( select => {
-		const isOpened =
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			( select( 'core/editor' ) as any ).isEditorPanelOpened ??
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			( select( 'core/edit-post' ) as any ).isEditorPanelOpened;
-		return isOpened;
-	}, [] );
+	const isEditorPanelOpened = useSelect(
+		( select: ( store: keyof SelectState ) => EditorSelectors ) => {
+			const isOpened =
+				select( 'core/editor' ).isEditorPanelOpened ??
+				select( 'core/edit-post' ).isEditorPanelOpened;
+			return isOpened;
+		},
+		[]
+	);
+
+	const currentFeaturedMedia = useSelect(
+		( select: ( store: keyof SelectState ) => EditorSelectors & CoreSelectors ) => {
+			const mediaId = select( 'core/editor' )?.getEditedPostAttribute?.( 'featured_media' );
+			return mediaId ? select( 'core' )?.getMedia?.( mediaId as number ) : null;
+		},
+		[]
+	);
 
 	const {
 		pointer,
@@ -113,6 +124,16 @@ export default function FeaturedImage( {
 		cost: featuredImageCost,
 		type: 'featured-image-generation',
 		feature: FEATURED_IMAGE_FEATURE_NAME,
+		previousImages: currentFeaturedMedia
+			? [
+					{
+						image: currentFeaturedMedia.source_url,
+						libraryId: currentFeaturedMedia.id,
+						libraryUrl: currentFeaturedMedia.source_url,
+						generating: false,
+					},
+			  ]
+			: null,
 	} );
 
 	const handleModalClose = useCallback( () => {
@@ -341,7 +362,7 @@ export default function FeaturedImage( {
 	const generateAgainText = __( 'Generate another image', 'jetpack' );
 	const generateText = __( 'Generate', 'jetpack' );
 
-	const hasContent = postContent || postTitle;
+	const hasContent = postContent || postTitle ? true : false;
 	const hasPrompt = hasContent ? prompt.length >= 0 : prompt.length >= 3;
 	const disableInput = notEnoughRequests || currentPointer?.generating || requireUpgrade;
 	const disableAction = disableInput || ( ! hasContent && ! hasPrompt );
@@ -361,7 +382,11 @@ export default function FeaturedImage( {
 		<Button
 			onClick={ handleAccept }
 			variant="primary"
-			disabled={ ! currentImage?.image || currentImage?.generating }
+			disabled={
+				! currentImage?.image ||
+				currentImage?.generating ||
+				currentImage?.image === currentFeaturedMedia?.source_url
+			}
 		>
 			{ __( 'Set as featured image', 'jetpack' ) }
 		</Button>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -31,7 +31,7 @@ import {
 	PLACEMENT_MEDIA_SOURCE_DROPDOWN,
 } from './types';
 import type { ImageResponse } from './hooks/use-ai-image';
-import type { SelectState, EditorSelectors, CoreSelectors } from './types';
+import type { EditorSelectors, CoreSelectors } from './types';
 
 const debug = debugFactory( 'jetpack-ai:featured-image' );
 
@@ -87,19 +87,15 @@ export default function FeaturedImage( {
 	// https://github.com/WordPress/gutenberg/blob/fe4d8cb936df52945c01c1863f7b87b58b7cc69f/packages/edit-post/CHANGELOG.md?plain=1#L19
 	const toggleEditorPanelOpened =
 		toggleEditorPanelOpenedFromEditor ?? toggleEditorPanelOpenedFromEditPost;
-	const isEditorPanelOpened = useSelect(
-		( select: ( store: keyof SelectState ) => EditorSelectors ) => {
-			const isOpened =
-				select( 'core/editor' ).isEditorPanelOpened ??
-				select( 'core/edit-post' ).isEditorPanelOpened;
-			return isOpened;
-		},
-		[]
-	);
+	const isEditorPanelOpened = useSelect( ( select: ( store ) => EditorSelectors ) => {
+		const isOpened =
+			select( editorStore ).isEditorPanelOpened ?? select( 'core/edit-post' ).isEditorPanelOpened;
+		return isOpened;
+	}, [] );
 
 	const currentFeaturedMedia = useSelect(
-		( select: ( store: keyof SelectState ) => EditorSelectors & CoreSelectors ) => {
-			const mediaId = select( 'core/editor' )?.getEditedPostAttribute?.( 'featured_media' );
+		( select: ( store ) => EditorSelectors & CoreSelectors ) => {
+			const mediaId = select( editorStore )?.getEditedPostAttribute?.( 'featured_media' );
 			return mediaId ? select( 'core' )?.getMedia?.( mediaId as number ) : null;
 		},
 		[]

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -31,7 +31,7 @@ import {
 	PLACEMENT_MEDIA_SOURCE_DROPDOWN,
 } from './types';
 import type { ImageResponse } from './hooks/use-ai-image';
-import type { EditorSelectors, CoreSelectors } from './types';
+import type { EditorSelectors } from './types';
 
 const debug = debugFactory( 'jetpack-ai:featured-image' );
 
@@ -51,12 +51,20 @@ export default function FeaturedImage( {
 	);
 	const siteType = useSiteType();
 	const postContent = usePostContent();
-	const { postTitle, postFeaturedMedia, isEditorPanelOpened } = useSelect(
+	const { postTitle, postFeaturedMediaURL, postFeaturedMediaId, isEditorPanelOpened } = useSelect(
 		( select: ( store ) => EditorSelectors ) => {
-			const featuredMediaId = select( editorStore ).getEditedPostAttribute( 'featured_media' );
+			const editorStoreSelect = select( editorStore );
+			const featuredMediaURL = editorStoreSelect.getEditedPostAttribute(
+				'jetpack_featured_media_url'
+			) as string;
+			const featuredMediaId = editorStoreSelect.getEditedPostAttribute(
+				'featured_media'
+			) as number;
+
 			return {
 				postTitle: select( editorStore ).getEditedPostAttribute( 'title' ),
-				postFeaturedMedia: featuredMediaId,
+				postFeaturedMediaURL: featuredMediaURL,
+				postFeaturedMediaId: featuredMediaId,
 				isEditorPanelOpened:
 					select( editorStore ).isEditorPanelOpened ??
 					select( 'core/edit-post' ).isEditorPanelOpened,
@@ -64,15 +72,7 @@ export default function FeaturedImage( {
 		},
 		[]
 	);
-	const currentFeaturedMedia = useSelect(
-		( select: ( store ) => CoreSelectors ) => {
-			if ( postFeaturedMedia ) {
-				return select( 'core' )?.getMedia?.( postFeaturedMedia );
-			}
-			return null;
-		},
-		[ postFeaturedMedia ]
-	);
+
 	const { saveToMediaLibrary } = useSaveToMediaLibrary();
 	const { tracks } = useAnalytics();
 	const { recordEvent } = tracks;
@@ -121,12 +121,12 @@ export default function FeaturedImage( {
 		cost: featuredImageCost,
 		type: 'featured-image-generation',
 		feature: FEATURED_IMAGE_FEATURE_NAME,
-		previousImages: currentFeaturedMedia
+		previousImages: postFeaturedMediaURL
 			? [
 					{
-						image: currentFeaturedMedia.source_url,
-						libraryId: currentFeaturedMedia.id,
-						libraryUrl: currentFeaturedMedia.source_url,
+						image: postFeaturedMediaURL,
+						libraryId: postFeaturedMediaId,
+						libraryUrl: postFeaturedMediaURL,
 						generating: false,
 					},
 			  ]
@@ -382,7 +382,7 @@ export default function FeaturedImage( {
 			disabled={
 				! currentImage?.image ||
 				currentImage?.generating ||
-				currentImage?.image === currentFeaturedMedia?.source_url
+				currentImage?.image === postFeaturedMediaURL
 			}
 		>
 			{ __( 'Set as featured image', 'jetpack' ) }
@@ -407,7 +407,7 @@ export default function FeaturedImage( {
 			) }
 			<AiImageModal
 				postContent={ hasContent }
-				autoStart={ hasContent && ! postFeaturedMedia }
+				autoStart={ hasContent && ! postFeaturedMediaURL }
 				autoStartAction={ handleFirstGenerate }
 				images={ images }
 				currentIndex={ current }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -31,7 +31,7 @@ import {
 	PLACEMENT_MEDIA_SOURCE_DROPDOWN,
 } from './types';
 import type { ImageResponse } from './hooks/use-ai-image';
-import type { CoreEditPostSelectors } from './types';
+import type { EditorSelectors, CoreSelectors } from './types';
 
 const debug = debugFactory( 'jetpack-ai:featured-image' );
 
@@ -51,28 +51,25 @@ export default function FeaturedImage( {
 	);
 	const siteType = useSiteType();
 	const postContent = usePostContent();
-	const { postTitle, postFeaturedMediaURL, postFeaturedMediaId, isEditorPanelOpened } = useSelect(
-		select => {
-			const editorStoreSelect = select( editorStore );
-			const featuredMediaURL = editorStoreSelect.getEditedPostAttribute(
-				'jetpack_featured_media_url'
-			) as string;
-			const featuredMediaId = editorStoreSelect.getEditedPostAttribute(
-				'featured_media'
-			) as number;
-
-			return {
-				postTitle: select( editorStore ).getEditedPostAttribute( 'title' ),
-				postFeaturedMediaURL: featuredMediaURL,
-				postFeaturedMediaId: featuredMediaId,
-				isEditorPanelOpened:
-					select( editorStore ).isEditorPanelOpened ??
-					( select( 'core/edit-post' ) as CoreEditPostSelectors ).isEditorPanelOpened,
-			};
+	const { postTitle, postFeaturedMedia, isEditorPanelOpened } = useSelect( select => {
+		const featuredMediaId = select( editorStore ).getEditedPostAttribute( 'featured_media' );
+		return {
+			postTitle: select( editorStore ).getEditedPostAttribute( 'title' ),
+			postFeaturedMedia: featuredMediaId,
+			isEditorPanelOpened:
+				select( editorStore ).isEditorPanelOpened ??
+				( select( 'core/edit-post' ) as EditorSelectors ).isEditorPanelOpened,
+		};
+	}, [] );
+	const currentFeaturedMedia = useSelect(
+		( select: ( store ) => CoreSelectors ) => {
+			if ( postFeaturedMedia ) {
+				return select( 'core' )?.getMedia?.( postFeaturedMedia );
+			}
+			return null;
 		},
-		[]
+		[ postFeaturedMedia ]
 	);
-
 	const { saveToMediaLibrary } = useSaveToMediaLibrary();
 	const { tracks } = useAnalytics();
 	const { recordEvent } = tracks;
@@ -121,12 +118,12 @@ export default function FeaturedImage( {
 		cost: featuredImageCost,
 		type: 'featured-image-generation',
 		feature: FEATURED_IMAGE_FEATURE_NAME,
-		previousImages: postFeaturedMediaURL
+		previousImages: currentFeaturedMedia
 			? [
 					{
-						image: postFeaturedMediaURL,
-						libraryId: postFeaturedMediaId,
-						libraryUrl: postFeaturedMediaURL,
+						image: currentFeaturedMedia.source_url,
+						libraryId: currentFeaturedMedia.id,
+						libraryUrl: currentFeaturedMedia.source_url,
 						generating: false,
 					},
 			  ]
@@ -382,7 +379,7 @@ export default function FeaturedImage( {
 			disabled={
 				! currentImage?.image ||
 				currentImage?.generating ||
-				currentImage?.image === postFeaturedMediaURL
+				currentImage?.image === currentFeaturedMedia?.source_url
 			}
 		>
 			{ __( 'Set as featured image', 'jetpack' ) }
@@ -407,7 +404,7 @@ export default function FeaturedImage( {
 			) }
 			<AiImageModal
 				postContent={ hasContent }
-				autoStart={ hasContent && ! postFeaturedMediaURL }
+				autoStart={ hasContent && ! postFeaturedMedia }
 				autoStartAction={ handleFirstGenerate }
 				images={ images }
 				currentIndex={ current }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -31,7 +31,7 @@ import {
 	PLACEMENT_MEDIA_SOURCE_DROPDOWN,
 } from './types';
 import type { ImageResponse } from './hooks/use-ai-image';
-import type { EditorSelectors, CoreSelectors } from './types';
+import type { EditorSelectors } from './types';
 
 const debug = debugFactory( 'jetpack-ai:featured-image' );
 
@@ -61,15 +61,7 @@ export default function FeaturedImage( {
 				( select( 'core/edit-post' ) as EditorSelectors ).isEditorPanelOpened,
 		};
 	}, [] );
-	const currentFeaturedMedia = useSelect(
-		( select: ( store ) => CoreSelectors ) => {
-			if ( postFeaturedMedia ) {
-				return select( 'core' )?.getMedia?.( postFeaturedMedia );
-			}
-			return null;
-		},
-		[ postFeaturedMedia ]
-	);
+
 	const { saveToMediaLibrary } = useSaveToMediaLibrary();
 	const { tracks } = useAnalytics();
 	const { recordEvent } = tracks;
@@ -102,7 +94,7 @@ export default function FeaturedImage( {
 		toggleEditorPanelOpenedFromEditor ?? toggleEditorPanelOpenedFromEditPost;
 
 	debug( 'postFeatureMedia', postFeaturedMedia );
-	debug( 'currentFeaturedMedia', currentFeaturedMedia );
+
 	const {
 		pointer,
 		current,
@@ -120,16 +112,7 @@ export default function FeaturedImage( {
 		cost: featuredImageCost,
 		type: 'featured-image-generation',
 		feature: FEATURED_IMAGE_FEATURE_NAME,
-		previousImages: currentFeaturedMedia
-			? [
-					{
-						image: currentFeaturedMedia.source_url,
-						libraryId: currentFeaturedMedia.id,
-						libraryUrl: currentFeaturedMedia.source_url,
-						generating: false,
-					},
-			  ]
-			: null,
+		previousMediaId: postFeaturedMedia,
 	} );
 
 	const handleModalClose = useCallback( () => {
@@ -381,7 +364,7 @@ export default function FeaturedImage( {
 			disabled={
 				! currentImage?.image ||
 				currentImage?.generating ||
-				currentImage?.image === currentFeaturedMedia?.source_url
+				currentImage?.libraryId === postFeaturedMedia
 			}
 		>
 			{ __( 'Set as featured image', 'jetpack' ) }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
@@ -11,7 +11,6 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { cleanForSlug } from '@wordpress/url';
-import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
@@ -38,8 +37,6 @@ export type ImageResponse = {
 	revisedPrompt?: string;
 };
 
-const debug = debugFactory( 'jetpack-ai:use-ai-image' );
-
 export default function useAiImage( {
 	feature,
 	type,
@@ -53,7 +50,6 @@ export default function useAiImage( {
 	autoStart?: boolean;
 	previousMediaId?: number;
 } ) {
-	debug( 'previousImages', previousMediaId );
 	const { generateImageWithParameters } = useImageGenerator();
 	const { increaseRequestsCount, featuresControl } = useAiFeature();
 	const { saveToMediaLibrary } = useSaveToMediaLibrary();
@@ -66,7 +62,7 @@ export default function useAiImage( {
 	// TODO: should current be any relevant here? It's just modal/carrousel logic after all
 	const [ current, setCurrent ] = useState( 0 );
 	const [ images, setImages ] = useState< CarrouselImages >( [ { generating: autoStart } ] );
-	debug( 'images', images );
+
 	// map feature-to-control prop, if this goes over 2 options, make a hook for it
 	const featureControl = feature === FEATURED_IMAGE_FEATURE_NAME ? 'featured-image' : 'image';
 	const imageFeatureControl = featuresControl?.[ featureControl ] as ImageFeatureControl;
@@ -291,7 +287,7 @@ export default function useAiImage( {
 		},
 		[ imageStyles ]
 	);
-	debug( pointer.current, current );
+
 	return {
 		current,
 		setCurrent,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
@@ -11,6 +11,7 @@ import { useDispatch } from '@wordpress/data';
 import { useCallback, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { cleanForSlug } from '@wordpress/url';
+import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
@@ -37,6 +38,8 @@ export type ImageResponse = {
 	revisedPrompt?: string;
 };
 
+const debug = debugFactory( 'jetpack-ai:use-ai-image' );
+
 export default function useAiImage( {
 	feature,
 	type,
@@ -50,6 +53,7 @@ export default function useAiImage( {
 	autoStart?: boolean;
 	previousImages?: CarrouselImages;
 } ) {
+	debug( 'previousImages', previousImages );
 	const { generateImageWithParameters } = useImageGenerator();
 	const { increaseRequestsCount, featuresControl } = useAiFeature();
 	const { saveToMediaLibrary } = useSaveToMediaLibrary();
@@ -61,7 +65,7 @@ export default function useAiImage( {
 	const [ images, setImages ] = useState< CarrouselImages >(
 		previousImages || [ { generating: autoStart } ]
 	);
-
+	debug( 'images', images );
 	// map feature-to-control prop, if this goes over 2 options, make a hook for it
 	const featureControl = feature === FEATURED_IMAGE_FEATURE_NAME ? 'featured-image' : 'image';
 	const imageFeatureControl = featuresControl?.[ featureControl ] as ImageFeatureControl;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
@@ -56,7 +56,7 @@ export default function useAiImage( {
 	const { createNotice } = useDispatch( 'core/notices' );
 
 	/* Images Control */
-	const pointer = useRef( previousImages ? 1 : 0 );
+	const pointer = useRef( previousImages ? previousImages.length : 0 );
 	const [ current, setCurrent ] = useState( 0 );
 	const [ images, setImages ] = useState< CarrouselImages >(
 		previousImages || [ { generating: autoStart } ]

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
@@ -60,7 +60,10 @@ export default function useAiImage( {
 	const { createNotice } = useDispatch( 'core/notices' );
 
 	/* Images Control */
+	// pointer keeps track of request/generation iteration
 	const pointer = useRef( 0 );
+	// and current keeps track of what is the image exposed at the moment
+	// TODO: should current be any relevant here? It's just modal/carrousel logic after all
 	const [ current, setCurrent ] = useState( 0 );
 	const [ images, setImages ] = useState< CarrouselImages >( [ { generating: autoStart } ] );
 	debug( 'images', images );
@@ -148,6 +151,9 @@ export default function useAiImage( {
 			style?: string;
 		} ) => {
 			return new Promise< ImageResponse >( ( resolve, reject ) => {
+				if ( previousMediaId && pointer.current === 0 ) {
+					pointer.current++;
+				}
 				updateImages( { generating: true, error: null }, pointer.current );
 
 				// Ensure the site has enough requests to generate the image.
@@ -233,6 +239,7 @@ export default function useAiImage( {
 			saveToMediaLibrary,
 			showSnackbarNotice,
 			getImageNameSuggestion,
+			previousMediaId,
 		]
 	);
 
@@ -284,7 +291,7 @@ export default function useAiImage( {
 		},
 		[ imageStyles ]
 	);
-
+	debug( pointer.current, current );
 	return {
 		current,
 		setCurrent,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
@@ -42,11 +42,13 @@ export default function useAiImage( {
 	type,
 	cost,
 	autoStart = true,
+	previousImages,
 }: {
 	feature: AiImageFeature;
 	type: AiImageType;
 	cost: number;
 	autoStart?: boolean;
+	previousImages?: CarrouselImages;
 } ) {
 	const { generateImageWithParameters } = useImageGenerator();
 	const { increaseRequestsCount, featuresControl } = useAiFeature();
@@ -54,9 +56,11 @@ export default function useAiImage( {
 	const { createNotice } = useDispatch( 'core/notices' );
 
 	/* Images Control */
-	const pointer = useRef( 0 );
+	const pointer = useRef( previousImages ? 1 : 0 );
 	const [ current, setCurrent ] = useState( 0 );
-	const [ images, setImages ] = useState< CarrouselImages >( [ { generating: autoStart } ] );
+	const [ images, setImages ] = useState< CarrouselImages >(
+		previousImages || [ { generating: autoStart } ]
+	);
 
 	// map feature-to-control prop, if this goes over 2 options, make a hook for it
 	const featureControl = feature === FEATURED_IMAGE_FEATURE_NAME ? 'featured-image' : 'image';
@@ -213,7 +217,7 @@ export default function useAiImage( {
 
 	const handlePreviousImage = useCallback( () => {
 		setCurrent( Math.max( current - 1, 0 ) );
-	}, [ current, setCurrent ] );
+	}, [ current ] );
 
 	const handleNextImage = useCallback( () => {
 		setCurrent( Math.min( current + 1, images.length - 1 ) );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
@@ -82,23 +82,23 @@ export default function useAiImage( {
 	}, [] );
 
 	// the selec/useEffect combo...
-	const currentFeaturedMedia = useSelect(
+	const loadedMedia = useSelect(
 		( select: ( store ) => CoreSelectors ) => select( 'core' )?.getMedia?.( previousMediaId ),
 		[ previousMediaId ]
 	);
 	useEffect( () => {
-		if ( currentFeaturedMedia ) {
+		if ( loadedMedia ) {
 			updateImages(
 				{
-					image: currentFeaturedMedia.source_url,
-					libraryId: currentFeaturedMedia.id,
-					libraryUrl: currentFeaturedMedia.source_url,
+					image: loadedMedia.source_url,
+					libraryId: loadedMedia.id,
+					libraryUrl: loadedMedia.source_url,
 					generating: false,
 				},
 				pointer.current
 			);
 		}
-	}, [ currentFeaturedMedia, updateImages ] );
+	}, [ loadedMedia, updateImages ] );
 
 	/*
 	 * Function to show a snackbar notice on the editor.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
@@ -7,8 +7,8 @@ import {
 	ImageStyle,
 	askQuestionSync,
 } from '@automattic/jetpack-ai-client';
-import { useDispatch } from '@wordpress/data';
-import { useCallback, useRef, useState } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { cleanForSlug } from '@wordpress/url';
 import debugFactory from 'debug';
@@ -20,7 +20,7 @@ import useSaveToMediaLibrary from '../../../hooks/use-save-to-media-library';
 /**
  * Types
  */
-import { FEATURED_IMAGE_FEATURE_NAME, GENERAL_IMAGE_FEATURE_NAME } from '../types';
+import { CoreSelectors, FEATURED_IMAGE_FEATURE_NAME, GENERAL_IMAGE_FEATURE_NAME } from '../types';
 import type { CarrouselImageData, CarrouselImages } from '../components/carrousel';
 import type { RoleType } from '@automattic/jetpack-ai-client';
 import type { FeatureControl } from 'extensions/store/wordpress-com/types.js';
@@ -45,26 +45,24 @@ export default function useAiImage( {
 	type,
 	cost,
 	autoStart = true,
-	previousImages,
+	previousMediaId,
 }: {
 	feature: AiImageFeature;
 	type: AiImageType;
 	cost: number;
 	autoStart?: boolean;
-	previousImages?: CarrouselImages;
+	previousMediaId?: number;
 } ) {
-	debug( 'previousImages', previousImages );
+	debug( 'previousImages', previousMediaId );
 	const { generateImageWithParameters } = useImageGenerator();
 	const { increaseRequestsCount, featuresControl } = useAiFeature();
 	const { saveToMediaLibrary } = useSaveToMediaLibrary();
 	const { createNotice } = useDispatch( 'core/notices' );
 
 	/* Images Control */
-	const pointer = useRef( previousImages ? previousImages.length : 0 );
+	const pointer = useRef( 0 );
 	const [ current, setCurrent ] = useState( 0 );
-	const [ images, setImages ] = useState< CarrouselImages >(
-		previousImages || [ { generating: autoStart } ]
-	);
+	const [ images, setImages ] = useState< CarrouselImages >( [ { generating: autoStart } ] );
 	debug( 'images', images );
 	// map feature-to-control prop, if this goes over 2 options, make a hook for it
 	const featureControl = feature === FEATURED_IMAGE_FEATURE_NAME ? 'featured-image' : 'image';
@@ -82,6 +80,25 @@ export default function useAiImage( {
 			return newImages;
 		} );
 	}, [] );
+
+	// the selec/useEffect combo...
+	const currentFeaturedMedia = useSelect(
+		( select: ( store ) => CoreSelectors ) => select( 'core' )?.getMedia?.( previousMediaId ),
+		[ previousMediaId ]
+	);
+	useEffect( () => {
+		if ( currentFeaturedMedia ) {
+			updateImages(
+				{
+					image: currentFeaturedMedia.source_url,
+					libraryId: currentFeaturedMedia.id,
+					libraryUrl: currentFeaturedMedia.source_url,
+					generating: false,
+				},
+				pointer.current
+			);
+		}
+	}, [ currentFeaturedMedia, updateImages ] );
 
 	/*
 	 * Function to show a snackbar notice on the editor.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/types.ts
@@ -5,6 +5,15 @@ export const IMAGE_GENERATION_MODEL_DALL_E_3 = 'dall-e-3' as const;
 export const PLACEMENT_MEDIA_SOURCE_DROPDOWN = 'media-source-dropdown' as const;
 export const PLACEMENT_BLOCK_PLACEHOLDER_BUTTON = 'block-placeholder-button' as const;
 
-export interface CoreEditPostSelectors {
+export interface EditorSelectors {
+	// actually getEditedPostAttribute can bring different values, but for our current use, number is fine (media ID)
+	getEditedPostAttribute: ( attribute: string ) => number;
 	isEditorPanelOpened: ( panel: string ) => boolean;
+}
+
+export interface CoreSelectors {
+	getMedia: ( mediaId: number ) => {
+		id: number;
+		source_url: string;
+	} | null;
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/types.ts
@@ -17,9 +17,3 @@ export interface CoreSelectors {
 		source_url: string;
 	} | null;
 }
-
-export interface SelectState {
-	'core/editor': EditorSelectors;
-	'core/edit-post': EditorSelectors;
-	core: CoreSelectors;
-}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/types.ts
@@ -5,8 +5,6 @@ export const IMAGE_GENERATION_MODEL_DALL_E_3 = 'dall-e-3' as const;
 export const PLACEMENT_MEDIA_SOURCE_DROPDOWN = 'media-source-dropdown' as const;
 export const PLACEMENT_BLOCK_PLACEHOLDER_BUTTON = 'block-placeholder-button' as const;
 
-export interface EditorSelectors {
-	// actually getEditedPostAttribute can bring different values, but for our current use, number is fine (media ID)
-	getEditedPostAttribute: ( attribute: string ) => string | number;
+export interface CoreEditPostSelectors {
 	isEditorPanelOpened: ( panel: string ) => boolean;
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/types.ts
@@ -4,3 +4,22 @@ export const IMAGE_GENERATION_MODEL_STABLE_DIFFUSION = 'stable-diffusion' as con
 export const IMAGE_GENERATION_MODEL_DALL_E_3 = 'dall-e-3' as const;
 export const PLACEMENT_MEDIA_SOURCE_DROPDOWN = 'media-source-dropdown' as const;
 export const PLACEMENT_BLOCK_PLACEHOLDER_BUTTON = 'block-placeholder-button' as const;
+
+export interface EditorSelectors {
+	// actually getEditedPostAttribute can bring different values, but for our current use, number is fine (media ID)
+	getEditedPostAttribute: ( attribute: string ) => number;
+	isEditorPanelOpened: ( panel: string ) => boolean;
+}
+
+export interface CoreSelectors {
+	getMedia: ( mediaId: number ) => {
+		id: number;
+		source_url: string;
+	} | null;
+}
+
+export interface SelectState {
+	'core/editor': EditorSelectors;
+	'core/edit-post': EditorSelectors;
+	core: CoreSelectors;
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/types.ts
@@ -7,13 +7,6 @@ export const PLACEMENT_BLOCK_PLACEHOLDER_BUTTON = 'block-placeholder-button' as 
 
 export interface EditorSelectors {
 	// actually getEditedPostAttribute can bring different values, but for our current use, number is fine (media ID)
-	getEditedPostAttribute: ( attribute: string ) => number;
+	getEditedPostAttribute: ( attribute: string ) => string | number;
 	isEditorPanelOpened: ( panel: string ) => boolean;
-}
-
-export interface CoreSelectors {
-	getMedia: ( mediaId: number ) => {
-		id: number;
-		source_url: string;
-	} | null;
 }


### PR DESCRIPTION
## Proposed changes:
When  a featured image is already set, the Featured Image generator modal shows empty on open.
With this change, if a featured image is set, we load it on the modal for visibility.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1733840898030829-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Open the editor with a new post. Click on Sidebar's "Set featured image" and select "Generate with AI".
- [ ] opening the featured image generator modal with not context (no post content nor title) should open and do nothing
- [ ] close the modal, add a title or some content on the post and open the modal again, this time an image generation should trigger
- set the generated image as featured image and close the modal
- [ ] open the modal again, see the current featured image should show on the modal and no generation should be triggered

