### PR TITLE
Fix/connection status inconsistencies

### DIFF
--- a/projects/packages/my-jetpack/_inc/admin.jsx
+++ b/projects/packages/my-jetpack/_inc/admin.jsx
@@ -1,8 +1,6 @@
 /**
  * External dependencies
  */
-import { ThemeProvider } from '@automattic/jetpack-components';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createRoot } from '@wordpress/element';
 import { useEffect } from 'react';
 import { HashRouter, Navigate, Routes, Route, useLocation } from 'react-router-dom';
@@ -32,10 +30,9 @@ import {
 import JetpackAiProductPage from './components/product-interstitial/jetpack-ai/product-page';
 import RedeemTokenScreen from './components/redeem-token-screen';
 import { MyJetpackRoutes } from './constants';
-import NoticeContextProvider from './context/notices/noticeContext';
-import ValueStoreContextProvider from './context/value-store/valueStoreContext';
 import { getMyJetpackWindowInitialState } from './data/utils/get-my-jetpack-window-state';
 import './style.module.scss';
+import Providers from './providers';
 
 /**
  * Component to scroll window to top on route change.
@@ -50,57 +47,44 @@ function ScrollToTop() {
 }
 
 const MyJetpack = () => {
-	const queryClient = new QueryClient();
 	const { loadAddLicenseScreen } = getMyJetpackWindowInitialState();
 
 	return (
-		<ThemeProvider>
-			<NoticeContextProvider>
-				<ValueStoreContextProvider>
-					<QueryClientProvider client={ queryClient }>
-						<HashRouter>
-							<ScrollToTop />
-							<Routes>
-								<Route path={ MyJetpackRoutes.Home } element={ <MyJetpackScreen /> } />
-								<Route path={ MyJetpackRoutes.Connection } element={ <ConnectionScreen /> } />
-								<Route path={ MyJetpackRoutes.AddAkismet } element={ <AntiSpamInterstitial /> } />
-								{ /* Redirect the old route for Anti Spam */ }
-								<Route
-									path={ MyJetpackRoutes.AddAntiSpam }
-									element={ <Navigate replace to={ MyJetpackRoutes.AddAkismet } /> }
-								/>
-								<Route path={ MyJetpackRoutes.AddBackup } element={ <BackupInterstitial /> } />
-								<Route path={ MyJetpackRoutes.AddBoost } element={ <BoostInterstitial /> } />
-								<Route path={ MyJetpackRoutes.AddCRM } element={ <CRMInterstitial /> } />
-								<Route
-									path={ MyJetpackRoutes.AddJetpackAI }
-									element={ <JetpackAiInterstitial /> }
-								/>
-								<Route path={ MyJetpackRoutes.AddExtras } element={ <ExtrasInterstitial /> } />
-								<Route path={ MyJetpackRoutes.AddProtect } element={ <ProtectInterstitial /> } />
-								<Route path={ MyJetpackRoutes.AddScan } element={ <ScanInterstitial /> } />
-								<Route path={ MyJetpackRoutes.AddSocial } element={ <SocialInterstitial /> } />
-								<Route path={ MyJetpackRoutes.AddSearch } element={ <SearchInterstitial /> } />
-								<Route
-									path={ MyJetpackRoutes.AddVideoPress }
-									element={ <VideoPressInterstitial /> }
-								/>
-								<Route path={ MyJetpackRoutes.AddStats } element={ <StatsInterstitial /> } />
-								{ loadAddLicenseScreen && (
-									<Route path={ MyJetpackRoutes.AddLicense } element={ <AddLicenseScreen /> } />
-								) }
-								<Route path={ MyJetpackRoutes.RedeemToken } element={ <RedeemTokenScreen /> } />
-								<Route path={ MyJetpackRoutes.RedeemToken } element={ <RedeemTokenScreen /> } />
-								<Route path={ MyJetpackRoutes.JetpackAi } element={ <JetpackAiProductPage /> } />
-								<Route path={ MyJetpackRoutes.AddSecurity } element={ <SecurityInterstitial /> } />
-								<Route path={ MyJetpackRoutes.AddGrowth } element={ <GrowthInterstitial /> } />
-								<Route path={ MyJetpackRoutes.AddComplete } element={ <CompleteInterstitial /> } />
-							</Routes>
-						</HashRouter>
-					</QueryClientProvider>
-				</ValueStoreContextProvider>
-			</NoticeContextProvider>
-		</ThemeProvider>
+		<Providers>
+			<HashRouter>
+				<ScrollToTop />
+				<Routes>
+					<Route path={ MyJetpackRoutes.Home } element={ <MyJetpackScreen /> } />
+					<Route path={ MyJetpackRoutes.Connection } element={ <ConnectionScreen /> } />
+					<Route path={ MyJetpackRoutes.AddAkismet } element={ <AntiSpamInterstitial /> } />
+					{ /* Redirect the old route for Anti Spam */ }
+					<Route
+						path={ MyJetpackRoutes.AddAntiSpam }
+						element={ <Navigate replace to={ MyJetpackRoutes.AddAkismet } /> }
+					/>
+					<Route path={ MyJetpackRoutes.AddBackup } element={ <BackupInterstitial /> } />
+					<Route path={ MyJetpackRoutes.AddBoost } element={ <BoostInterstitial /> } />
+					<Route path={ MyJetpackRoutes.AddCRM } element={ <CRMInterstitial /> } />
+					<Route path={ MyJetpackRoutes.AddJetpackAI } element={ <JetpackAiInterstitial /> } />
+					<Route path={ MyJetpackRoutes.AddExtras } element={ <ExtrasInterstitial /> } />
+					<Route path={ MyJetpackRoutes.AddProtect } element={ <ProtectInterstitial /> } />
+					<Route path={ MyJetpackRoutes.AddScan } element={ <ScanInterstitial /> } />
+					<Route path={ MyJetpackRoutes.AddSocial } element={ <SocialInterstitial /> } />
+					<Route path={ MyJetpackRoutes.AddSearch } element={ <SearchInterstitial /> } />
+					<Route path={ MyJetpackRoutes.AddVideoPress } element={ <VideoPressInterstitial /> } />
+					<Route path={ MyJetpackRoutes.AddStats } element={ <StatsInterstitial /> } />
+					{ loadAddLicenseScreen && (
+						<Route path={ MyJetpackRoutes.AddLicense } element={ <AddLicenseScreen /> } />
+					) }
+					<Route path={ MyJetpackRoutes.RedeemToken } element={ <RedeemTokenScreen /> } />
+					<Route path={ MyJetpackRoutes.RedeemToken } element={ <RedeemTokenScreen /> } />
+					<Route path={ MyJetpackRoutes.JetpackAi } element={ <JetpackAiProductPage /> } />
+					<Route path={ MyJetpackRoutes.AddSecurity } element={ <SecurityInterstitial /> } />
+					<Route path={ MyJetpackRoutes.AddGrowth } element={ <GrowthInterstitial /> } />
+					<Route path={ MyJetpackRoutes.AddComplete } element={ <CompleteInterstitial /> } />
+				</Routes>
+			</HashRouter>
+		</Providers>
 	);
 };
 

--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.tsx
@@ -66,7 +66,7 @@ const ConnectedProductCard: FC< ConnectedProductCardProps > = ( {
 		manageUrl,
 	} = detail;
 
-	const navigateToConnectionPage = useMyJetpackNavigate( MyJetpackRoutes.Connection );
+	const navigateToConnectionPage = useMyJetpackNavigate( MyJetpackRoutes.ConnectionSkipPricing );
 
 	/*
 	 * Redirect only if connected

--- a/projects/packages/my-jetpack/_inc/components/connection-screen/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-screen/index.tsx
@@ -1,5 +1,6 @@
 import { Container, Col, AdminPage } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
+import { useSearchParams } from 'react-router-dom';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import useMyJetpackReturnToPage from '../../hooks/use-my-jetpack-return-to-page';
 import CloseLink from '../close-link';
@@ -9,6 +10,8 @@ import styles from './styles.module.scss';
 import type { FC } from 'react';
 
 const ConnectionScreen: FC = () => {
+	const [ searchParams ] = useSearchParams();
+	const shouldSkipPricing = searchParams.get( 'skip_pricing' ) === 'true';
 	const returnToPage = useMyJetpackReturnToPage();
 	const { apiRoot, apiNonce, registrationNonce } = useMyJetpackConnection();
 
@@ -28,6 +31,7 @@ const ConnectionScreen: FC = () => {
 						apiRoot={ apiRoot }
 						apiNonce={ apiNonce }
 						registrationNonce={ registrationNonce }
+						skipPricingPage={ shouldSkipPricing }
 						footer={ <ConnectionScreenFooter /> }
 					/>
 				</Col>

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
@@ -294,7 +294,6 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 			event: 'jetpack_myjetpack_connection_connect_site',
 			properties: tracksEventData,
 		},
-		shouldScrollToTop: true,
 	} );
 
 	const getConnectionLineStyles = () => {

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
@@ -4,8 +4,11 @@ import { useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, info, check, lockOutline } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useContext } from 'react';
+import { NoticeContext } from '../../context/notices/noticeContext';
+import { NOTICE_SITE_CONNECTION_ERROR } from '../../context/notices/noticeTemplates';
 import { useAllProducts } from '../../data/products/use-product';
+import useProductsByOwnership from '../../data/products/use-products-by-ownership';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import getProductSlugsThatRequireUserConnection from '../../data/utils/get-product-slugs-that-require-user-connection';
 import useAnalytics from '../../hooks/use-analytics';
@@ -33,6 +36,11 @@ const ConnectionListItem: ConnectionListItemType = ( {
 	let icon = check;
 	let statusStyles = '';
 
+	if ( status === 'info' ) {
+		icon = null;
+		statusStyles = '';
+	}
+
 	if ( status === 'success' ) {
 		icon = check;
 		statusStyles = styles.success;
@@ -50,13 +58,13 @@ const ConnectionListItem: ConnectionListItemType = ( {
 
 	if ( status === 'unlock' ) {
 		icon = lockOutline;
-		statusStyles = styles.unlock;
+		statusStyles = '';
 	}
 
 	return (
 		<div className={ styles[ 'list-item' ] }>
 			<Text className={ clsx( styles[ 'list-item-text' ], statusStyles ) }>
-				<Icon icon={ icon } />
+				{ icon && <Icon icon={ icon } /> }
 				{ text }
 			</Text>
 			{ actionText && status !== 'success' && (
@@ -77,9 +85,17 @@ const ConnectionItemButton: ConnectionItemButtonType = ( { actionText, onClick }
 const getSiteConnectionLineData: getSiteConnectionLineDataType = ( {
 	isRegistered,
 	hasSiteConnectionBrokenModules,
-	handleConnectUser,
+	handleConnectSite,
+	siteIsRegistering,
 	openManageSiteConnectionDialog,
 } ) => {
+	if ( siteIsRegistering ) {
+		return {
+			text: __( 'Connecting your site…', 'jetpack-my-jetpack' ),
+			status: 'info',
+		};
+	}
+
 	if ( isRegistered ) {
 		return {
 			onClick: openManageSiteConnectionDialog,
@@ -91,7 +107,7 @@ const getSiteConnectionLineData: getSiteConnectionLineDataType = ( {
 
 	if ( hasSiteConnectionBrokenModules ) {
 		return {
-			onClick: handleConnectUser,
+			onClick: handleConnectSite,
 			text: __( 'Missing site connection to enable some features.', 'jetpack-my-jetpack' ),
 			actionText: __( 'Connect', 'jetpack-my-jetpack' ),
 			status: 'error',
@@ -99,7 +115,7 @@ const getSiteConnectionLineData: getSiteConnectionLineDataType = ( {
 	}
 
 	return {
-		onClick: handleConnectUser,
+		onClick: handleConnectSite,
 		text: __( 'Start with Jetpack.', 'jetpack-my-jetpack' ),
 		actionText: __( 'Connect your site with one click', 'jetpack-my-jetpack' ),
 		status: 'warning',
@@ -194,13 +210,23 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 	const { isRegistered, isUserConnected, userConnectionData } = useMyJetpackConnection( {
 		redirectUri,
 	} );
-
+	const { handleRegisterSite, siteIsRegistering } = useMyJetpackConnection( {
+		skipUserConnection: true,
+		redirectUri,
+	} );
+	const { setNotice, resetNotice } = useContext( NoticeContext );
+	const { lifecycleStats, siteSuffix, adminUrl } = getMyJetpackWindowInitialState();
+	const connectAfterCheckoutUrl = `?connect_after_checkout=true&admin_url=${ encodeURIComponent(
+		adminUrl
+	) }&from_site_slug=${ siteSuffix }&source=my-jetpack`;
+	const query = `${ connectAfterCheckoutUrl }${ redirectUri }&unlinked=1`;
+	const jetpackPlansPath = getRedirectUrl( 'jetpack-my-jetpack-site-only-plans', { query } );
+	const { refetch: refetchOwnershipData } = useProductsByOwnership();
 	const { recordEvent } = useAnalytics();
 	const [ isManageConnectionDialogOpen, setIsManageConnectionDialogOpen ] = useState( false );
 	const { setConnectionStatus, setUserIsConnecting } = useDispatch( CONNECTION_STORE_ID );
 	const connectUserFn = onConnectUser || setUserIsConnecting;
 	const avatar = userConnectionData.currentUser?.wpcomUser?.avatar;
-	const { lifecycleStats } = getMyJetpackWindowInitialState();
 	const { brokenModules } = lifecycleStats || {};
 	const products = useAllProducts();
 	const hasProductsThatRequireUserConnection =
@@ -272,6 +298,40 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 		[ connectUserFn, recordEvent, tracksEventData ]
 	);
 
+	const handleConnectSite = useCallback(
+		async ( e: MouseEvent< HTMLButtonElement > ) => {
+			e && e.preventDefault();
+			window.scrollTo( {
+				top: 0,
+				left: 0,
+				behavior: 'smooth',
+			} );
+			recordEvent( 'jetpack_myjetpack_connection_connect_site_click', tracksEventData );
+
+			try {
+				await handleRegisterSite();
+
+				recordEvent( 'jetpack_myjetpack_connection_connect_site_success', tracksEventData );
+
+				// Redirect user to the plans page after connection
+				window.location.href = jetpackPlansPath;
+			} catch {
+				setNotice( NOTICE_SITE_CONNECTION_ERROR, resetNotice );
+			} finally {
+				refetchOwnershipData();
+			}
+		},
+		[
+			handleRegisterSite,
+			jetpackPlansPath,
+			recordEvent,
+			refetchOwnershipData,
+			resetNotice,
+			setNotice,
+			tracksEventData,
+		]
+	);
+
 	const getConnectionLineStyles = () => {
 		if ( isRegistered ) {
 			return '';
@@ -283,7 +343,8 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 	const siteConnectionLineData = getSiteConnectionLineData( {
 		isRegistered,
 		hasSiteConnectionBrokenModules,
-		handleConnectUser,
+		handleConnectSite,
+		siteIsRegistering,
 		openManageSiteConnectionDialog,
 	} );
 

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
@@ -4,14 +4,12 @@ import { useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, info, check, lockOutline } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useState, useCallback, useMemo, useContext } from 'react';
-import { NoticeContext } from '../../context/notices/noticeContext';
-import { NOTICE_SITE_CONNECTION_ERROR } from '../../context/notices/noticeTemplates';
+import { useState, useCallback, useMemo } from 'react';
 import { useAllProducts } from '../../data/products/use-product';
-import useProductsByOwnership from '../../data/products/use-products-by-ownership';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import getProductSlugsThatRequireUserConnection from '../../data/utils/get-product-slugs-that-require-user-connection';
 import useAnalytics from '../../hooks/use-analytics';
+import useConnectSite from '../../hooks/use-connect-site';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import cloud from './cloud.svg';
 import emptyAvatar from './empty-avatar.svg';
@@ -210,18 +208,11 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 	const { isRegistered, isUserConnected, userConnectionData } = useMyJetpackConnection( {
 		redirectUri,
 	} );
-	const { handleRegisterSite, siteIsRegistering } = useMyJetpackConnection( {
+	const { siteIsRegistering } = useMyJetpackConnection( {
 		skipUserConnection: true,
 		redirectUri,
 	} );
-	const { setNotice, resetNotice } = useContext( NoticeContext );
-	const { lifecycleStats, siteSuffix, adminUrl } = getMyJetpackWindowInitialState();
-	const connectAfterCheckoutUrl = `?connect_after_checkout=true&admin_url=${ encodeURIComponent(
-		adminUrl
-	) }&from_site_slug=${ siteSuffix }&source=my-jetpack`;
-	const query = `${ connectAfterCheckoutUrl }${ redirectUri }&unlinked=1`;
-	const jetpackPlansPath = getRedirectUrl( 'jetpack-my-jetpack-site-only-plans', { query } );
-	const { refetch: refetchOwnershipData } = useProductsByOwnership();
+	const { lifecycleStats } = getMyJetpackWindowInitialState();
 	const { recordEvent } = useAnalytics();
 	const [ isManageConnectionDialogOpen, setIsManageConnectionDialogOpen ] = useState( false );
 	const { setConnectionStatus, setUserIsConnecting } = useDispatch( CONNECTION_STORE_ID );
@@ -298,39 +289,13 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 		[ connectUserFn, recordEvent, tracksEventData ]
 	);
 
-	const handleConnectSite = useCallback(
-		async ( e: MouseEvent< HTMLButtonElement > ) => {
-			e && e.preventDefault();
-			window.scrollTo( {
-				top: 0,
-				left: 0,
-				behavior: 'smooth',
-			} );
-			recordEvent( 'jetpack_myjetpack_connection_connect_site_click', tracksEventData );
-
-			try {
-				await handleRegisterSite();
-
-				recordEvent( 'jetpack_myjetpack_connection_connect_site_success', tracksEventData );
-
-				// Redirect user to the plans page after connection
-				window.location.href = jetpackPlansPath;
-			} catch {
-				setNotice( NOTICE_SITE_CONNECTION_ERROR, resetNotice );
-			} finally {
-				refetchOwnershipData();
-			}
+	const { connectSite: handleConnectSite } = useConnectSite( {
+		tracksInfo: {
+			event: 'jetpack_myjetpack_connection_connect_site',
+			properties: tracksEventData,
 		},
-		[
-			handleRegisterSite,
-			jetpackPlansPath,
-			recordEvent,
-			refetchOwnershipData,
-			resetNotice,
-			setNotice,
-			tracksEventData,
-		]
-	);
+		shouldScrollToTop: true,
+	} );
 
 	const getConnectionLineStyles = () => {
 		if ( isRegistered ) {

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
 import { render, renderHook, screen } from '@testing-library/react';
 import { useSelect } from '@wordpress/data';
+import Providers from '../../../providers';
 import ConnectionStatusCard from '../index';
 import type { StateProducts, MyJetpackInitialState } from '../../../data/types';
 
@@ -58,7 +59,9 @@ const setConnectionStore = ( {
 	hasConnectedOwner = false,
 } = {} ) => {
 	let storeSelect;
-	renderHook( () => useSelect( select => ( storeSelect = select( CONNECTION_STORE_ID ) ), [] ) );
+	renderHook( () => useSelect( select => ( storeSelect = select( CONNECTION_STORE_ID ) ), [] ), {
+		wrapper: Providers,
+	} );
 	jest
 		.spyOn( storeSelect, 'getConnectionStatus' )
 		.mockReset()
@@ -80,7 +83,11 @@ describe( 'ConnectionStatusCard', () => {
 
 	describe( 'When the site is not registered and has no broken modules', () => {
 		const setup = () => {
-			return render( <ConnectionStatusCard { ...testProps } /> );
+			return render(
+				<Providers>
+					<ConnectionStatusCard { ...testProps } />
+				</Providers>
+			);
 		};
 
 		it( 'renders the correct copy for the site connection line item', () => {
@@ -103,7 +110,11 @@ describe( 'ConnectionStatusCard', () => {
 			window.myJetpackInitialState.lifecycleStats.brokenModules.needs_site_connection = [
 				'anti-spam',
 			];
-			return render( <ConnectionStatusCard { ...testProps } /> );
+			return render(
+				<Providers>
+					<ConnectionStatusCard { ...testProps } />
+				</Providers>
+			);
 		};
 
 		it( 'renders the correct copy for the site connection line item', () => {
@@ -125,7 +136,11 @@ describe( 'ConnectionStatusCard', () => {
 		describe( 'There are no products that require user connection', () => {
 			const setup = () => {
 				setConnectionStore( { isRegistered: true } );
-				return render( <ConnectionStatusCard { ...testProps } /> );
+				return render(
+					<Providers>
+						<ConnectionStatusCard { ...testProps } />
+					</Providers>
+				);
 			};
 
 			it( 'renders the correct site connection line item', () => {
@@ -145,7 +160,11 @@ describe( 'ConnectionStatusCard', () => {
 			const setup = () => {
 				setConnectionStore( { isRegistered: true } );
 				window.myJetpackInitialState.products.items[ 'anti-spam' ].requires_user_connection = true;
-				return render( <ConnectionStatusCard { ...testProps } /> );
+				return render(
+					<Providers>
+						<ConnectionStatusCard { ...testProps } />
+					</Providers>
+				);
 			};
 
 			it( 'renders the correct site connection line item', () => {
@@ -168,7 +187,11 @@ describe( 'ConnectionStatusCard', () => {
 			window.myJetpackInitialState.lifecycleStats.brokenModules.needs_user_connection = [
 				'anti-spam',
 			];
-			return render( <ConnectionStatusCard { ...testProps } /> );
+			return render(
+				<Providers>
+					<ConnectionStatusCard { ...testProps } />
+				</Providers>
+			);
 		};
 
 		it( 'renders the correct site connection line item', () => {
@@ -189,7 +212,11 @@ describe( 'ConnectionStatusCard', () => {
 	describe( 'When the user has connected their WordPress.com account', () => {
 		const setup = () => {
 			setConnectionStore( { isRegistered: true, isUserConnected: true, hasConnectedOwner: true } );
-			return render( <ConnectionStatusCard { ...testProps } /> );
+			return render(
+				<Providers>
+					<ConnectionStatusCard { ...testProps } />
+				</Providers>
+			);
 		};
 
 		it( 'renders the correct site connection line item', () => {

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/types.ts
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/types.ts
@@ -1,6 +1,6 @@
 import type { FC, MouseEvent } from 'react';
 
-type StatusType = 'warning' | 'error' | 'unlock' | 'success';
+type StatusType = 'warning' | 'error' | 'unlock' | 'success' | 'info';
 
 interface ConnectionListItemProps {
 	text: string;
@@ -19,7 +19,8 @@ export type ConnectionItemButtonType = FC< {
 interface getSiteConnectionLineDataProps {
 	isRegistered: boolean;
 	hasSiteConnectionBrokenModules: boolean;
-	handleConnectUser: ( e: MouseEvent< HTMLButtonElement > ) => void;
+	siteIsRegistering: boolean;
+	handleConnectSite: ( e: MouseEvent< HTMLButtonElement > ) => void;
 	openManageSiteConnectionDialog: ( e: MouseEvent ) => void;
 }
 

--- a/projects/packages/my-jetpack/_inc/components/connections-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connections-section/index.jsx
@@ -12,7 +12,7 @@ import ConnectionStatusCard from '../connection-status-card';
  */
 export default function ConnectionsSection() {
 	const { apiRoot, apiNonce, topJetpackMenuItemUrl, connectedPlugins } = useMyJetpackConnection();
-	const navigate = useMyJetpackNavigate( MyJetpackRoutes.Connection );
+	const navigate = useMyJetpackNavigate( MyJetpackRoutes.ConnectionSkipPricing );
 	const products = useAllProducts();
 	const onDisconnected = () => document?.location?.reload( true ); // TODO: replace with a better experience.
 	const productsThatRequireUserConnection = getProductSlugsThatRequireUserConnection( products );

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.tsx
@@ -178,7 +178,7 @@ const PlanSectionFooter: FC< PlanSectionHeaderAndFooterProps > = ( { numberOfPur
 		recordEvent( 'jetpack_myjetpack_plans_purchase_click' );
 	}, [ recordEvent ] );
 
-	const navigateToConnectionPage = useMyJetpackNavigate( MyJetpackRoutes.Connection );
+	const navigateToConnectionPage = useMyJetpackNavigate( MyJetpackRoutes.ConnectionSkipPricing );
 	const activateLicenseClickHandler = useCallback( () => {
 		recordEvent( 'jetpack_myjetpack_activate_license_click' );
 		if ( ! isUserConnected ) {

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
@@ -135,6 +135,9 @@ const ProductCard: FC< ProductCardProps > = props => {
 		} );
 	}, [ slug, recordEvent ] );
 
+	/**
+	 * Calls the passed function onFixSiteConnection after firing Tracks event
+	 */
 	const fixSiteConnectionHandler = useCallback(
 		( { e }: { e: MouseEvent< HTMLButtonElement > } ) => {
 			connectSite( e );

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
@@ -4,6 +4,8 @@ import { useCallback, useEffect } from 'react';
 import { PRODUCT_STATUSES } from '../../constants';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import useAnalytics from '../../hooks/use-analytics';
+import useConnectSite from '../../hooks/use-connect-site';
+import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import Card from '../card';
 import ActionButton from './action-button';
 import PriceComponent from './pricing-component';
@@ -13,7 +15,7 @@ import Status from './status';
 import styles from './style.module.scss';
 import type { AdditionalAction, SecondaryAction } from './types';
 import type { MutateCallback } from '../../data/use-simple-mutation';
-import type { FC, MouseEventHandler, ReactNode } from 'react';
+import type { FC, MouseEvent, MouseEventHandler, ReactNode } from 'react';
 
 export type ProductCardProps = {
 	children?: ReactNode;
@@ -86,6 +88,15 @@ const ProductCard: FC< ProductCardProps > = props => {
 	} );
 
 	const { recordEvent } = useAnalytics();
+	const { siteIsRegistering } = useMyJetpackConnection();
+	const isLoading =
+		isFetching || ( siteIsRegistering && status === PRODUCT_STATUSES.SITE_CONNECTION_ERROR );
+	const { connectSite } = useConnectSite( {
+		tracksInfo: {
+			event: 'jetpack_myjetpack_product_card_fix_site_connection',
+			properties: {},
+		},
+	} );
 
 	/**
 	 * Calls the passed function onActivate after firing Tracks event
@@ -118,11 +129,18 @@ const ProductCard: FC< ProductCardProps > = props => {
 	/**
 	 * Calls the passed function onFixConnection after firing Tracks event
 	 */
-	const fixConnectionHandler = useCallback( () => {
+	const fixUserConnectionHandler = useCallback( () => {
 		recordEvent( 'jetpack_myjetpack_product_card_fixconnection_click', {
 			product: slug,
 		} );
 	}, [ slug, recordEvent ] );
+
+	const fixSiteConnectionHandler = useCallback(
+		( { e }: { e: MouseEvent< HTMLButtonElement > } ) => {
+			connectSite( e );
+		},
+		[ connectSite ]
+	);
 
 	/**
 	 * Calls when the "Learn more" button is clicked
@@ -182,7 +200,8 @@ const ProductCard: FC< ProductCardProps > = props => {
 						<ActionButton
 							{ ...ownProps }
 							onActivate={ activateHandler }
-							onFixConnection={ fixConnectionHandler }
+							onFixUserConnection={ fixUserConnectionHandler }
+							onFixSiteConnection={ fixSiteConnectionHandler }
 							onManage={ manageHandler }
 							onAdd={ addHandler }
 							onInstall={ installStandaloneHandler }
@@ -198,7 +217,7 @@ const ProductCard: FC< ProductCardProps > = props => {
 					</div>
 					<Status
 						status={ status }
-						isFetching={ isFetching }
+						isFetching={ isLoading }
 						isInstallingStandalone={ isInstallingStandalone }
 						isOwned={ isOwned }
 					/>

--- a/projects/packages/my-jetpack/_inc/components/product-card/secondary-button.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/secondary-button.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
-import type { FC, ReactNode } from 'react';
+import type { FC, ReactNode, MouseEvent } from 'react';
 
 export type SecondaryButtonProps = {
 	href?: string;
@@ -9,7 +9,7 @@ export type SecondaryButtonProps = {
 	weight?: 'bold' | 'regular';
 	label?: string;
 	shouldShowButton?: () => boolean;
-	onClick?: () => void;
+	onClick?: ( () => void ) | ( ( { e }: { e: MouseEvent< HTMLButtonElement > } ) => void );
 	isExternalLink?: boolean;
 	icon?: ReactNode;
 	iconSize?: number;

--- a/projects/packages/my-jetpack/_inc/components/welcome-flow/ConnectionStep.tsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-flow/ConnectionStep.tsx
@@ -1,69 +1,24 @@
-import { Col, Button, Text, TermsOfService, getRedirectUrl } from '@automattic/jetpack-components';
+import { Col, Button, Text, TermsOfService } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
-import { useCallback, useContext } from 'react';
-import { NoticeContext } from '../../context/notices/noticeContext';
-import { NOTICE_SITE_CONNECTION_ERROR } from '../../context/notices/noticeTemplates';
-import useProductsByOwnership from '../../data/products/use-products-by-ownership';
-import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
-import useAnalytics from '../../hooks/use-analytics';
+import useConnectSite from '../../hooks/use-connect-site';
 import styles from './style.module.scss';
 import { WelcomeFlowExperiment } from '.';
 import type { Dispatch, SetStateAction } from 'react';
 
 type ConnectionStepProps = {
-	onActivateSite: ( e?: Event ) => Promise< void >;
 	onUpdateWelcomeFlowExperiment?: Dispatch< SetStateAction< WelcomeFlowExperiment > >;
 	isActivating: boolean;
 };
 
-/**
- * Component that renders the Welcome banner on My Jetpack.
- *
- * @param {object}   props                - ConnectioStepProps
- * @param {Function} props.onActivateSite - Alias for handleRegisterSite
- * @param {boolean}  props.isActivating   - Alias for siteIsRegistering
- * @return {object} The ConnectionStep component.
- */
-const ConnectionStep = ( { onActivateSite, isActivating }: ConnectionStepProps ) => {
-	const { recordEvent } = useAnalytics();
-	const { setNotice, resetNotice } = useContext( NoticeContext );
-
-	const { siteSuffix, adminUrl } = getMyJetpackWindowInitialState();
-	const connectAfterCheckoutUrl = `?connect_after_checkout=true&admin_url=${ encodeURIComponent(
-		adminUrl
-	) }&from_site_slug=${ siteSuffix }&source=my-jetpack`;
-	const redirectUri = `&redirect_to=${ encodeURIComponent( window.location.href ) }`;
-	const query = `${ connectAfterCheckoutUrl }${ redirectUri }&unlinked=1`;
-	const jetpackPlansPath = getRedirectUrl( 'jetpack-my-jetpack-site-only-plans', { query } );
-
+const ConnectionStep = ( { isActivating }: ConnectionStepProps ) => {
 	const activationButtonLabel = __( 'Activate Jetpack in one click', 'jetpack-my-jetpack' );
-	const { refetch: refetchOwnershipData } = useProductsByOwnership();
 
-	const onConnectSiteClick = useCallback( async () => {
-		resetNotice();
-
-		recordEvent( 'jetpack_myjetpack_welcome_banner_connect_site_click' );
-
-		try {
-			await onActivateSite();
-
-			recordEvent( 'jetpack_myjetpack_welcome_banner_connect_site_success' );
-
-			// Redirect user to the plans page after connection
-			window.location.href = jetpackPlansPath;
-		} catch {
-			setNotice( NOTICE_SITE_CONNECTION_ERROR, resetNotice );
-		} finally {
-			refetchOwnershipData();
-		}
-	}, [
-		jetpackPlansPath,
-		onActivateSite,
-		recordEvent,
-		refetchOwnershipData,
-		resetNotice,
-		setNotice,
-	] );
+	const { connectSite: onConnectSiteClick } = useConnectSite( {
+		tracksInfo: {
+			event: 'jetpack_myjetpack_welcome_banner_connect_site',
+			properties: {},
+		},
+	} );
 
 	return (
 		<>

--- a/projects/packages/my-jetpack/_inc/components/welcome-flow/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-flow/index.tsx
@@ -34,15 +34,10 @@ const WelcomeFlow: FC< Props > = ( {
 	const { dismissWelcomeBanner } = useWelcomeBanner();
 	const { recommendedModules, submitEvaluation, saveEvaluationResult } =
 		useEvaluationRecommendations();
-	const {
-		siteIsRegistered,
-		siteIsRegistering,
-		isUserConnected,
-		isSiteConnected,
-		handleRegisterSite,
-	} = useMyJetpackConnection( {
-		skipUserConnection: true,
-	} );
+	const { siteIsRegistered, siteIsRegistering, isUserConnected, isSiteConnected } =
+		useMyJetpackConnection( {
+			skipUserConnection: true,
+		} );
 	const [ isProcessingEvaluation, setIsProcessingEvaluation ] = useState( false );
 	const [ prevStep, setPrevStep ] = useState( '' );
 
@@ -162,7 +157,6 @@ const WelcomeFlow: FC< Props > = ( {
 					>
 						{ 'connection' === currentStep && (
 							<ConnectionStep
-								onActivateSite={ handleRegisterSite }
 								onUpdateWelcomeFlowExperiment={ setWelcomeFlowExperiment }
 								isActivating={ siteIsRegistering || welcomeFlowExperiment.isLoading }
 							/>

--- a/projects/packages/my-jetpack/_inc/constants.ts
+++ b/projects/packages/my-jetpack/_inc/constants.ts
@@ -6,6 +6,7 @@ export const MY_JETPACK_PRODUCT_CHECKOUT = 'my-jetpack-product-checkout';
 export const MyJetpackRoutes = {
 	Home: '/',
 	Connection: '/connection',
+	ConnectionSkipPricing: '/connection?skip_pricing=true',
 	AddAkismet: '/add-akismet',
 	AddAntiSpam: '/add-anti-spam', // Old route for Anti Spam
 	AddBackup: '/add-backup',

--- a/projects/packages/my-jetpack/_inc/context/notices/noticeTemplates.ts
+++ b/projects/packages/my-jetpack/_inc/context/notices/noticeTemplates.ts
@@ -4,17 +4,6 @@ import { Notice } from './types';
 
 export const WELCOME_BANNER_NOTICE_IDS: string[] = [ 'site-connection-success-notice' ];
 
-export const NOTICE_SITE_CONNECTED: Notice = {
-	message: __( 'Your site has been successfully connected.', 'jetpack-my-jetpack' ),
-	options: {
-		id: 'site-connection-success-notice',
-		level: 'success',
-		actions: [],
-		priority: NOTICE_PRIORITY_HIGH,
-		hideCloseButton: false,
-	},
-};
-
 export const NOTICE_SITE_CONNECTION_ERROR: Notice = {
 	message: __( 'Site connection failed. Please try again.', 'jetpack-my-jetpack' ),
 	options: {

--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.ts
@@ -3,10 +3,10 @@ import { useCallback, useEffect } from 'react';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import useMyJetpackConnection from '../use-my-jetpack-connection';
 
-type TracksRecordEvent = (
-	event: `jetpack_${ string }`, // Enforces the event name to start with "jetpack_"
-	properties?: Record< Lowercase< string >, unknown >
-) => void;
+export type TracksEvent = `jetpack_${ string }`; // Enforces the event name to start with "jetpack_"
+export type TracksProperties = Record< Lowercase< string >, unknown >; // Defines the shape of the properties object
+
+type TracksRecordEvent = ( event: TracksEvent, properties?: TracksProperties ) => void;
 
 const useAnalytics = () => {
 	const {

--- a/projects/packages/my-jetpack/_inc/hooks/use-connect-site/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-connect-site/index.ts
@@ -41,11 +41,13 @@ const useConnectSite = ( { tracksInfo }: useConnectSiteProps ) => {
 		async ( e: MouseEvent< HTMLButtonElement > ) => {
 			e && e.preventDefault();
 
-			window.scrollTo( {
-				top: 0,
-				left: 0,
-				behavior: 'smooth',
-			} );
+			setTimeout( () => {
+				window.scrollTo( {
+					top: 0,
+					left: 0,
+					behavior: 'smooth',
+				} );
+			}, 100 );
 
 			recordEvent( `${ event }_click`, tracksEventData );
 

--- a/projects/packages/my-jetpack/_inc/hooks/use-connect-site/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-connect-site/index.ts
@@ -1,0 +1,83 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { useCallback, useContext } from 'react';
+import { NoticeContext } from '../../context/notices/noticeContext';
+import { NOTICE_SITE_CONNECTION_ERROR } from '../../context/notices/noticeTemplates';
+import useProductsByOwnership from '../../data/products/use-products-by-ownership';
+import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
+import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
+import useAnalytics from '../use-analytics';
+import type { TracksEvent, TracksProperties } from '../use-analytics';
+import type { MouseEvent } from 'react';
+
+interface useConnectSiteProps {
+	tracksInfo: {
+		event: TracksEvent;
+		properties: TracksProperties;
+	};
+	shouldScrollToTop?: boolean;
+}
+
+const useConnectSite = ( { tracksInfo, shouldScrollToTop = false }: useConnectSiteProps ) => {
+	const { event, properties: tracksEventData } = tracksInfo;
+
+	const { setNotice, resetNotice } = useContext( NoticeContext );
+
+	const { recordEvent } = useAnalytics();
+	const { refetch: refetchOwnershipData } = useProductsByOwnership();
+
+	const { siteSuffix, adminUrl, myJetpackCheckoutUri } = getMyJetpackWindowInitialState();
+	const redirectUri = `&redirect_to=${ myJetpackCheckoutUri }`;
+
+	const connectAfterCheckoutUrl = `?connect_after_checkout=true&admin_url=${ encodeURIComponent(
+		adminUrl
+	) }&from_site_slug=${ siteSuffix }&source=my-jetpack`;
+	const query = `${ connectAfterCheckoutUrl }${ redirectUri }&unlinked=1`;
+	const jetpackPlansPath = getRedirectUrl( 'jetpack-my-jetpack-site-only-plans', { query } );
+	const { handleRegisterSite } = useMyJetpackConnection( {
+		skipUserConnection: true,
+		redirectUri,
+	} );
+
+	const connectSite = useCallback(
+		async ( e: MouseEvent< HTMLButtonElement > ) => {
+			e && e.preventDefault();
+
+			if ( shouldScrollToTop ) {
+				window.scrollTo( {
+					top: 0,
+					left: 0,
+					behavior: 'smooth',
+				} );
+			}
+
+			recordEvent( `${ event }_click`, tracksEventData );
+
+			try {
+				await handleRegisterSite();
+
+				recordEvent( `${ event }_success`, tracksEventData );
+
+				window.location.href = jetpackPlansPath;
+			} catch {
+				setNotice( NOTICE_SITE_CONNECTION_ERROR, resetNotice );
+			} finally {
+				refetchOwnershipData();
+			}
+		},
+		[
+			handleRegisterSite,
+			jetpackPlansPath,
+			recordEvent,
+			refetchOwnershipData,
+			resetNotice,
+			setNotice,
+			tracksEventData,
+			event,
+			shouldScrollToTop,
+		]
+	);
+
+	return { connectSite };
+};
+
+export default useConnectSite;

--- a/projects/packages/my-jetpack/_inc/hooks/use-connect-site/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-connect-site/index.ts
@@ -14,10 +14,9 @@ interface useConnectSiteProps {
 		event: TracksEvent;
 		properties: TracksProperties;
 	};
-	shouldScrollToTop?: boolean;
 }
 
-const useConnectSite = ( { tracksInfo, shouldScrollToTop = false }: useConnectSiteProps ) => {
+const useConnectSite = ( { tracksInfo }: useConnectSiteProps ) => {
 	const { event, properties: tracksEventData } = tracksInfo;
 
 	const { setNotice, resetNotice } = useContext( NoticeContext );
@@ -42,13 +41,11 @@ const useConnectSite = ( { tracksInfo, shouldScrollToTop = false }: useConnectSi
 		async ( e: MouseEvent< HTMLButtonElement > ) => {
 			e && e.preventDefault();
 
-			if ( shouldScrollToTop ) {
-				window.scrollTo( {
-					top: 0,
-					left: 0,
-					behavior: 'smooth',
-				} );
-			}
+			window.scrollTo( {
+				top: 0,
+				left: 0,
+				behavior: 'smooth',
+			} );
 
 			recordEvent( `${ event }_click`, tracksEventData );
 
@@ -73,7 +70,6 @@ const useConnectSite = ( { tracksInfo, shouldScrollToTop = false }: useConnectSi
 			setNotice,
 			tracksEventData,
 			event,
-			shouldScrollToTop,
 		]
 	);
 

--- a/projects/packages/my-jetpack/_inc/hooks/use-my-jetpack-navigate/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-my-jetpack-navigate/index.ts
@@ -3,18 +3,14 @@ import { useNavigate } from 'react-router-dom';
 import { MyJetpackRoutes } from '../../constants';
 import type { NavigateOptions } from 'react-router-dom';
 
-/**
- * Custom My Jetpack navigator hook
- *
- * @param {string} route - route to navigate to
- * @return {Function} - navigate function
- */
-export default function useMyJetpackNavigate(
+const useMyJetpackNavigate = (
 	route: ( typeof MyJetpackRoutes )[ keyof typeof MyJetpackRoutes ]
-) {
+) => {
 	const navigate = useNavigate();
 	return useCallback(
 		( options?: NavigateOptions ) => navigate( route, options ),
 		[ navigate, route ]
 	);
-}
+};
+
+export default useMyJetpackNavigate;

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
@@ -19,11 +19,11 @@ type RedBubbleAlerts = Window[ 'myJetpackInitialState' ][ 'redBubbleAlerts' ];
 const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 	const { recordEvent } = useAnalytics();
 	const { setNotice, resetNotice } = useContext( NoticeContext );
-	const { siteIsRegistering } = useMyJetpackConnection( {
+	const { siteIsRegistering, isSiteConnected } = useMyJetpackConnection( {
 		skipUserConnection: true,
 	} );
 	const products = useAllProducts();
-	const navToConnection = useMyJetpackNavigate( MyJetpackRoutes.Connection );
+	const navToConnection = useMyJetpackNavigate( MyJetpackRoutes.ConnectionSkipPricing );
 	const redBubbleSlug = 'missing-connection';
 	const connectionError = redBubbleAlerts[ redBubbleSlug ];
 	const { connectSite } = useConnectSite( {
@@ -48,9 +48,9 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 			if ( requiresUserConnection ) {
 				recordEvent( 'jetpack_my_jetpack_user_connection_notice_cta_click' );
 				navToConnection();
+			} else {
+				connectSite( e );
 			}
-
-			connectSite( e );
 		};
 
 		const oneProductMessage = sprintf(
@@ -121,6 +121,7 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 			options: noticeOptions,
 		} );
 	}, [
+		isSiteConnected,
 		connectSite,
 		navToConnection,
 		products,

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
@@ -4,27 +4,34 @@ import { useContext, useEffect } from 'react';
 import { MyJetpackRoutes } from '../../constants';
 import { NOTICE_PRIORITY_HIGH } from '../../context/constants';
 import { NoticeContext } from '../../context/notices/noticeContext';
-import { NOTICE_SITE_CONNECTED } from '../../context/notices/noticeTemplates';
 import { useAllProducts } from '../../data/products/use-product';
 import useProductsByOwnership from '../../data/products/use-products-by-ownership';
 import getProductSlugsThatRequireUserConnection from '../../data/utils/get-product-slugs-that-require-user-connection';
 import useAnalytics from '../use-analytics';
+import useConnectSite from '../use-connect-site';
 import useMyJetpackConnection from '../use-my-jetpack-connection';
 import useMyJetpackNavigate from '../use-my-jetpack-navigate';
 import type { NoticeOptions } from '../../context/notices/types';
+import type { MouseEvent } from 'react';
 
 type RedBubbleAlerts = Window[ 'myJetpackInitialState' ][ 'redBubbleAlerts' ];
 
 const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 	const { recordEvent } = useAnalytics();
 	const { setNotice, resetNotice } = useContext( NoticeContext );
-	const { handleRegisterSite, siteIsRegistering } = useMyJetpackConnection( {
+	const { siteIsRegistering } = useMyJetpackConnection( {
 		skipUserConnection: true,
 	} );
 	const products = useAllProducts();
 	const navToConnection = useMyJetpackNavigate( MyJetpackRoutes.Connection );
 	const redBubbleSlug = 'missing-connection';
 	const connectionError = redBubbleAlerts[ redBubbleSlug ];
+	const { connectSite } = useConnectSite( {
+		tracksInfo: {
+			event: 'jetpack_my_jetpack_site_connection_notice_cta',
+			properties: {},
+		},
+	} );
 
 	const { refetch: refetchOwnershipData } = useProductsByOwnership();
 
@@ -37,20 +44,13 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 			getProductSlugsThatRequireUserConnection( products );
 		const requiresUserConnection = connectionError.type === 'user';
 
-		const onActionButtonClick = () => {
+		const onActionButtonClick = ( { e }: { e: MouseEvent< HTMLButtonElement > } ) => {
 			if ( requiresUserConnection ) {
 				recordEvent( 'jetpack_my_jetpack_user_connection_notice_cta_click' );
 				navToConnection();
 			}
 
-			recordEvent( 'jetpack_my_jetpack_site_connection_notice_cta_click' );
-			handleRegisterSite().then( () => {
-				setNotice( NOTICE_SITE_CONNECTED, resetNotice );
-				delete redBubbleAlerts[ redBubbleSlug ];
-				window.myJetpackInitialState.redBubbleAlerts = redBubbleAlerts;
-
-				refetchOwnershipData();
-			} );
+			connectSite( e );
 		};
 
 		const oneProductMessage = sprintf(
@@ -121,7 +121,7 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 			options: noticeOptions,
 		} );
 	}, [
-		handleRegisterSite,
+		connectSite,
 		navToConnection,
 		products,
 		recordEvent,

--- a/projects/packages/my-jetpack/_inc/providers.tsx
+++ b/projects/packages/my-jetpack/_inc/providers.tsx
@@ -1,0 +1,25 @@
+import { ThemeProvider } from '@automattic/jetpack-components';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import NoticeContextProvider from './context/notices/noticeContext';
+import ValueStoreContextProvider from './context/value-store/valueStoreContext';
+import type { ReactNode, FC } from 'react';
+
+interface ProvidersProps {
+	children: ReactNode;
+}
+
+const Providers: FC< ProvidersProps > = ( { children } ) => {
+	const queryClient = new QueryClient();
+
+	return (
+		<ThemeProvider>
+			<NoticeContextProvider>
+				<ValueStoreContextProvider>
+					<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+				</ValueStoreContextProvider>
+			</NoticeContextProvider>
+		</ThemeProvider>
+	);
+};
+
+export default Providers;

--- a/projects/packages/my-jetpack/changelog/fix-connection-status-inconsistencies
+++ b/projects/packages/my-jetpack/changelog/fix-connection-status-inconsistencies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Unify connection flows in My Jetpack


### PR DESCRIPTION
## Proposed changes:

The main purpose of this PR is to unify the connections states and flows in My Jetpack. It should now follow these rules
* If the site is not connected, all "Connection" CTAs should connect the site only, and then redirect users to the pricing page
* If the site is connected, but the user is not, it sends the user to the connection page, then to user connection, and back to My Jetpack, skipping the pricing page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

GH: 3687b-pb/

## Does this pull request change what data or activity we track or use?

Yes, there is going to be new events
* `jetpack_myjetpack_product_card_fix_site_connection_click`
* `jetpack_myjetpack_product_card_fix_site_connection_success`
For when a user connects their site via a product card

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment

3. Go to `/wp-admin/admin.php?page=my-jetpack` and scroll down to the bottom

4. Select `Connect your site with one click`. Ensure you are scrolled to the top of the page and that after connection, you are directed to the pricing page

https://github.com/user-attachments/assets/412a7cc6-5db8-4bc4-8de2-46546ecb3f8d

5. Disconnect your site and ensure you see a few product cards with the `Connect` CTA
![image](https://github.com/user-attachments/assets/b6adc6e0-5a56-454d-aeba-4a2333c5bd1e)

6. Select Connect and ensure a similar experience to the footer happens where you are connected, brought to the pricing page, and then back to My Jetpack
![image](https://github.com/user-attachments/assets/b8720d3d-cefd-4b82-b34b-06a1ef8398d5)

7. Scroll down to the bottom again and select `Sign In` in the connection footer. On the Connection page, select `Connect your user account`
![image](https://github.com/user-attachments/assets/d1090fc1-e4f3-4d04-92ae-3ee1606a6fe2)

8. Ensure you are led to the user connection flow, and after connecting, you go straight back to the plugin instead of the pricing page

9. Purchase a Jetpack Security plan for your site however you'd like (I used the Store Admin)

10. Go back to My Jetpack and disconnect your site

11. Confirm you see the site connection notice instead of the welcome banner

![image](https://github.com/user-attachments/assets/1f472a9a-8c5d-44d5-83d4-e26c7f64333a)

12. Scroll down to the connection footer and select `Connect`

13. Ensure you have a similar experience where the screen scrolls to the top and connects the site, then directs to the pricing page

14. Go back to My Jetpack and confirm you see the User connection banner now

![image](https://github.com/user-attachments/assets/592bfe0a-15a1-476e-8e2d-e46cdb1b2ff5)

15. Connect your user account any way you'd like (Connect footer, Connection banner, or product card) and ensure the connect flow skips the pricing page

Note: There are other ways to connect I didn't explicitly cover (Such as user connection from the `Activate a license` link), feel free to try out any connection flow you can think of to ensure all site connections and user connections act exactly the same.