### PR TITLE
Tests: Use more recent theme when running PHPUnit tests

### DIFF
--- a/projects/plugins/jetpack/changelog/update-use_more_recent_theme_in_tests
+++ b/projects/plugins/jetpack/changelog/update-use_more_recent_theme_in_tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Tests: Use updated theme in tests.

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -250,8 +250,8 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_install_edit_delete_theme_sync() {
-		$theme_slug = 'itek';
-		$theme_name = 'iTek';
+		$theme_slug = 'astra';
+		$theme_name = 'Astra';
 
 		delete_theme( $theme_slug ); // Ensure theme is not lingering on file system
 		$this->server_event_storage->reset();
@@ -295,7 +295,7 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 
 		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_deleted_theme' );
 
-		$this->assertEquals( 'itek', $event_data->args[0] );
+		$this->assertEquals( $theme_slug, $event_data->args[0] );
 	}
 
 	public function test_update_themes_sync() {

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -250,6 +250,9 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_install_edit_delete_theme_sync() {
+		// This requires a theme that isn't directly available on WordPress.com:
+		// https://public-api.wordpress.com/rest/v1.2/themes/astra?http_envelope=1
+		// Any theme with the "Community" badge in the WordPress.com theme search would work here.
 		$theme_slug = 'astra';
 		$theme_name = 'Astra';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR proposes swapping out the defunct iTek theme with the Astra theme in PHPUnit tests (Jetpack + `wpcomsh`).

One caveat is that this may bump Astra's download stats a bit. Right now we're downloading iTek, though, so I don't see it being a big impact on such a common theme.

Note: I'm fine closing this with no change if preferred; I followed the rabbit hole to personal closure and am documenting how to update it should we want to here or in the future. :^)

---

A while back, I noticed our tests were installing a long-outdated theme, `itek`:

https://github.com/Automattic/jetpack/blob/5e270fb3d34bb3f35e6304392cbdf5d95681b4c1/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-themes.php#L253-L254

The theme hadn't been updated in almost 9 years, and I decided to swap it out with a more recent theme (`twentytwentyfour`). However, the tests inexplicably failed, so I abandoned the attempt at that time.

Today I finally went down that rabbit hole, which involved all the classic elements of an Agatha Christie novel: treachery, red herrings, twists and turns, and a vaguely satisfying ending. It required quite a bit of iterative debugging, with the difference in the two themes coming down to the `WPCom_Themes_Api::fetch_theme` method:

https://github.com/Automattic/jetpack/blob/5e270fb3d34bb3f35e6304392cbdf5d95681b4c1/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-api.php#L94

In essence, most themes return a bunch of data from the WordPress.com API:
https://public-api.wordpress.com/rest/v1.2/themes/twentytwentyfour?http_envelope=1

However, the API doesn't return data for iTek:

https://public-api.wordpress.com/rest/v1.2/themes/itek?http_envelope=1

This forces it to go down a different path of code, installing from WordPress.org, etc.

I'm not sure how to search for similar themes directly, but it seems any theme with the "Community" badge in the WordPress.com theme search would work:

https://github.com/Automattic/wp-calypso/blob/fee4511de222d5d040a708230887190c3ab58182/client/components/theme-tier/theme-tier-badge/index.js#L41-L43

In this PR I went with Astra:

https://public-api.wordpress.com/rest/v1.2/themes/astra?http_envelope=1

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Is the CI happy?

