### PR TITLE
My Jetpack: Fix - Update getting raw post type count

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-update-raw-post-type-count
+++ b/projects/packages/my-jetpack/changelog/fix-update-raw-post-type-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix an issue where high posts counts would cause backend issues for the get_raw_post_type_breakdown function used in My Jetpack. Sites with over a million posts can now have this query managed remotely. 

--- a/projects/packages/my-jetpack/changelog/fix-update-raw-post-type-count
+++ b/projects/packages/my-jetpack/changelog/fix-update-raw-post-type-count
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix an issue where high posts counts would cause backend issues for the get_raw_post_type_breakdown function used in My Jetpack. Sites with over a million posts can now have this query managed remotely. 
+Fix an issue where high posts counts would cause backend issues for the get_raw_post_type_breakdown function used in My Jetpack. Sites with over 100,000 posts can now have this query managed remotely.

--- a/projects/packages/my-jetpack/src/products/class-search-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-search-stats.php
@@ -167,11 +167,10 @@ class Search_Stats {
 
 		// Get post type breakdown from a remote request if the post count is high
 		if ( $total_posts_count > self::POST_COUNT_QUERY_LIMIT ) {
-			$search_stats                  = new Search_Stats();
-			$wpcom_stats                   = json_decode( wp_remote_retrieve_body( $search_stats->get_stats_from_wpcom() ), true );
-			$wpcom_raw_post_type_breakdown = $wpcom_stats['raw_post_type_breakdown'];
-			if ( $wpcom_raw_post_type_breakdown ) {
-				$results = $wpcom_raw_post_type_breakdown;
+			$search_stats = new Search_Stats();
+			$wpcom_stats  = json_decode( wp_remote_retrieve_body( $search_stats->get_stats_from_wpcom() ), true );
+			if ( ! empty( $wpcom_stats['raw_post_type_breakdown'] ) ) {
+				$results = $wpcom_stats['raw_post_type_breakdown'];
 				wp_cache_set( self::POST_TYPE_BREAKDOWN_CACHE_KEY, $results, self::CACHE_GROUP, self::CACHE_EXPIRY );
 				return $results;
 			} else {

--- a/projects/packages/my-jetpack/src/products/class-search-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-search-stats.php
@@ -36,6 +36,8 @@ class Search_Stats {
 	const CACHE_EXPIRY                  = 1 * MINUTE_IN_SECONDS;
 	const CACHE_GROUP                   = 'jetpack_search';
 	const POST_TYPE_BREAKDOWN_CACHE_KEY = 'post_type_break_down';
+	const TOTAL_POSTS_COUNT_CACHE_KEY   = 'total-post-count';
+	const POST_COUNT_QUERY_LIMIT        = 1e6;
 
 	/**
 	 * Get stats from the WordPress.com API for the current blog ID.
@@ -56,6 +58,25 @@ class Search_Stats {
 		);
 
 		return $response;
+	}
+
+	/**
+	 * Queue querying the post type breakdown from WordPress.com API for the current blog ID.
+	 */
+	public function queue_post_count_query_from_wpcom() {
+		$blog_id = Jetpack_Options::get_option( 'id' );
+
+		if ( ! is_numeric( $blog_id ) ) {
+			return null;
+		}
+
+		Client::wpcom_json_api_request_as_blog(
+			'/sites/' . (int) $blog_id . '/jetpack-search/queue-post-count',
+			'2',
+			array(),
+			null,
+			'wpcom'
+		);
 	}
 
 	/**
@@ -127,7 +148,7 @@ class Search_Stats {
 	}
 
 	/**
-	 * Get raw post type breakdown from the database.
+	 * Get raw post type breakdown from the database or a remote request if posts count is high.
 	 */
 	protected static function get_raw_post_type_breakdown() {
 		global $wpdb;
@@ -135,6 +156,28 @@ class Search_Stats {
 		$results = wp_cache_get( self::POST_TYPE_BREAKDOWN_CACHE_KEY, self::CACHE_GROUP );
 		if ( false !== $results ) {
 			return $results;
+		}
+
+		$total_posts_count = wp_cache_get( self::TOTAL_POSTS_COUNT_CACHE_KEY, self::CACHE_GROUP );
+		if ( false === $total_posts_count ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery */
+			$total_posts_counts = $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->posts}" );
+			wp_cache_set( self::TOTAL_POSTS_COUNT_CACHE_KEY, $total_posts_counts, self::CACHE_GROUP, self::CACHE_EXPIRY );
+		}
+
+		// Get post type breakdown from a remote request if the post count is high
+		if ( $total_posts_count > self::POST_COUNT_QUERY_LIMIT ) {
+			$search_stats                  = new Search_Stats();
+			$wpcom_stats                   = json_decode( wp_remote_retrieve_body( $search_stats->get_stats_from_wpcom() ), true );
+			$wpcom_raw_post_type_breakdown = $wpcom_stats['raw_post_type_breakdown'];
+			if ( $wpcom_raw_post_type_breakdown ) {
+				$results = $wpcom_raw_post_type_breakdown;
+				wp_cache_set( self::POST_TYPE_BREAKDOWN_CACHE_KEY, $results, self::CACHE_GROUP, self::CACHE_EXPIRY );
+				return $results;
+			} else {
+				$search_stats->queue_post_count_query_from_wpcom();
+				return array();
+			}
 		}
 
 		$query = "SELECT post_type, post_status, COUNT( * ) AS num_posts

--- a/projects/packages/my-jetpack/src/products/class-search-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-search-stats.php
@@ -168,13 +168,13 @@ class Search_Stats {
 		// Get post type breakdown from a remote request if the post count is high
 		if ( $total_posts_count > self::POST_COUNT_QUERY_LIMIT ) {
 			$search_stats = new Search_Stats();
-			$wpcom_stats  = json_decode( wp_remote_retrieve_body( $search_stats->get_stats_from_wpcom() ), true );
+			$search_stats->queue_post_count_query_from_wpcom();
+			$wpcom_stats = json_decode( wp_remote_retrieve_body( $search_stats->get_stats_from_wpcom() ), true );
 			if ( ! empty( $wpcom_stats['raw_post_type_breakdown'] ) ) {
 				$results = $wpcom_stats['raw_post_type_breakdown'];
 				wp_cache_set( self::POST_TYPE_BREAKDOWN_CACHE_KEY, $results, self::CACHE_GROUP, self::CACHE_EXPIRY );
 				return $results;
 			} else {
-				$search_stats->queue_post_count_query_from_wpcom();
 				return array();
 			}
 		}

--- a/projects/packages/my-jetpack/src/products/class-search-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-search-stats.php
@@ -37,7 +37,7 @@ class Search_Stats {
 	const CACHE_GROUP                   = 'jetpack_search';
 	const POST_TYPE_BREAKDOWN_CACHE_KEY = 'post_type_break_down';
 	const TOTAL_POSTS_COUNT_CACHE_KEY   = 'total-post-count';
-	const POST_COUNT_QUERY_LIMIT        = 1e6;
+	const POST_COUNT_QUERY_LIMIT        = 1e5;
 
 	/**
 	 * Get stats from the WordPress.com API for the current blog ID.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes # https://github.com/Automattic/jetpack/issues/38130

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* For sites with a high post count (over 1 million posts) a remote request will now be used instead of the local query found in get_raw_post_type_breakdown which has been identified as potentially causing backend issues.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* This test will require a site with over a million post to test that the remote call is triggered correctly. Alternatively this can be tested by updating the `POST_COUNT_QUERY_LIMIT` constant in the PR to a low number for testing purposes and to trigger the remote query.
* Visit My Jetpack and ensure that the remote call is made. You can verify this by confirming the option `raw_post_type_breakdown` is set on the remote site. 
* Ensure that My Jetpack loads as expected. 
* Verify the pricing page when clicking on `Get Search` loads as expected.

