### PR TITLE
Fix premium content button CSS in editor and display

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-premium-content-button-css
+++ b/projects/plugins/jetpack/changelog/fix-premium-content-button-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fixes editor and display CSS for Premium Content buttons.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/editor.scss
@@ -61,6 +61,20 @@
 	margin: 0;
 }
 
+%button-outline-style {
+	background-color: unset;
+	color: #32373c;
+}
+
+.wp-block-premium-content-login-button,
+.wp-block-jetpack-button {
+	&.is-style-outline {
+		.wp-block-button__link {
+			@extend %button-outline-style;
+		}
+	}
+}
+
 /* Hide Stripe nudge from Jetpack payments block */
 /* https://github.com/Automattic/wp-calypso/issues/44332 */
 .wp-block-premium-content-container .premium-content-wrapper .jetpack-block-nudge {

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/editor.scss
@@ -63,7 +63,7 @@
 
 %button-outline-style {
 	background-color: unset;
-	color: #32373c;
+	color: $gray-800;
 }
 
 .wp-block-premium-content-login-button,

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/view.scss
@@ -26,6 +26,20 @@
 	float: right;
 }
 
+%button-outline-style {
+	background-color: unset;
+	color: #32373c;
+}
+
+.wp-block-premium-content-login-button,
+.wp-block-jetpack-button {
+	&.is-style-outline {
+		.wp-block-button__link {
+			@extend %button-outline-style;
+		}
+	}
+}
+
 /* Legacy Subscribe/Login buttons */
 
 .wp-block-premium-content-logged-out-view__buttons {

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/view.scss
@@ -28,7 +28,7 @@
 
 %button-outline-style {
 	background-color: unset;
-	color: #32373c;
+	color: $gray-800;
 }
 
 .wp-block-premium-content-login-button,

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/view.scss
@@ -1,3 +1,5 @@
+@import '@automattic/jetpack-base-styles/gutenberg-base-styles';
+
 /**
  * The following styles get applied both on the front of your site
  * and in the editor.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/40292

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This adds a missing CSS state for the filled/outline states in the editor, for the Premium Content block's Subscribe and Login buttons. The missing CSS is only evident in some themes (like Illustratr).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a test site, activate the Illustratr theme, and place a Premium Content block on a post or page.
* In the editor, select one of the buttons, and click the Filled/Outlined style selections. It should not change the visual appearance of the button to be outlined only. In an incognito window, you should observe the same behavior on the published page/post.
* Patch this diff.
* Refresh the editor; you should see the Subscribe and Login buttons change as expected now. Additionally, the visual changes should be reflected on the live page/post.

