### PR TITLE
Fix backup card not updating when site is connectd

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.tsx
@@ -98,11 +98,7 @@ const ConnectedProductCard: FC< ConnectedProductCardProps > = ( {
 	};
 
 	useEffect( () => {
-		if (
-			isRegistered &&
-			( status === PRODUCT_STATUSES.SITE_CONNECTION_ERROR ||
-				status === PRODUCT_STATUSES.NEEDS_FIRST_SITE_CONNECTION )
-		) {
+		if ( isRegistered ) {
 			refetch();
 		}
 	}, [ isRegistered, status, refetch ] );

--- a/projects/packages/my-jetpack/changelog/fix-backup-card-not-updating-when-site-is-connectd
+++ b/projects/packages/my-jetpack/changelog/fix-backup-card-not-updating-when-site-is-connectd
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix issue where backup card was not updating after site connection in some situations


### PR DESCRIPTION
## Proposed changes:

* Update all cards after site connection to ensure every card is in the correct state after async connection

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Connect your site and user
3. Purchase a Jetpack Security plan
4. Go to My Jetpack and disconnect your site
5. Dismiss the welcome banner so you can see the site connection notice that does not send you to the pricing page
![image](https://github.com/user-attachments/assets/46b6c680-fd79-4c5b-a3c8-b4e0a38d6513)
6. Connect your site via this banner, and ensure that the Backup card shows as needing user connection after the async connection
![image](https://github.com/user-attachments/assets/c916464d-ad6d-4b8f-ba31-a904b80b633c)
