### PR TITLE
Add mask css rule to csstidy allow list

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/benz56-add-mask-css-rule-to-allowlist
+++ b/projects/packages/jetpack-mu-wpcom/changelog/benz56-add-mask-css-rule-to-allowlist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+CSS Tidy: add css rule mask to allowlist

--- a/projects/packages/jetpack-mu-wpcom/src/features/custom-css/csstidy/data.inc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/custom-css/csstidy/data.inc.php
@@ -549,6 +549,7 @@ $GLOBALS['csstidy']['all_properties']['marquee-loop']                = 'CSS3.0';
 $GLOBALS['csstidy']['all_properties']['marquee-play-count']          = 'CSS3.0';
 $GLOBALS['csstidy']['all_properties']['marquee-speed']               = 'CSS3.0';
 $GLOBALS['csstidy']['all_properties']['marquee-style']               = 'CSS3.0';
+$GLOBALS['csstidy']['all_properties']['mask']                        = 'CSS3.0';
 $GLOBALS['csstidy']['all_properties']['mask-clip']                   = 'CSS3.0';
 $GLOBALS['csstidy']['all_properties']['mask-composite']              = 'CSS3.0';
 $GLOBALS['csstidy']['all_properties']['mask-image']                  = 'CSS3.0';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `mask` CSS rule to the allow list given that all `mask-*` sub properties are allowed.

## Testing instructions:

* Go to Site editor, try edit global styles through Options -> Styles -> Additional CSS:
<img width="300" alt="Screenshot 2024-12-18 at 4 09 24 PM" src="https://github.com/user-attachments/assets/a75f0354-cb82-442b-94ff-0c523a9e1373" />

Then add a testing style using the `mask` rule. Then save.
* With this change, the `mask` rule should be preserved. Without the change, it will get stripped.

## Does this pull request change what data or activity we track or use?



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?
