### PR TITLE
wpcom-block-editor-nux: avoid using useLocation which throws exception outside Site Editor in GB 19.9.0

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-uselocation-exception
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-uselocation-exception
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+wpcom-block-editor-nux: avoid using useLocation which now throws exception outside Site Editor in Gutenberg 19.9.0

--- a/projects/packages/jetpack-mu-wpcom/src/common/hooks/use-canvas-mode.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/common/hooks/use-canvas-mode.ts
@@ -17,7 +17,7 @@ const useCanvasMode = () => {
 		} );
 
 		return () => unsubscribe();
-	} );
+	}, [ isSiteEditor ] );
 
 	return canvasMode;
 };

--- a/projects/packages/jetpack-mu-wpcom/src/common/hooks/use-canvas-mode.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/common/hooks/use-canvas-mode.ts
@@ -1,20 +1,25 @@
-import { useSelect } from '@wordpress/data';
-import useLocation from './use-location';
+import { subscribe, useSelect } from '@wordpress/data';
+import { useEffect, useState } from 'react';
 
 const useCanvasMode = () => {
-	const location = useLocation();
+	const [ canvasMode, setCanvasMode ] = useState< string | null >( null );
+	const isSiteEditor = useSelect( select => !! select( 'core/edit-site' ), [] );
 
-	return useSelect(
-		select => {
-			// The canvas mode is limited to the site editor.
-			if ( ! select( 'core/edit-site' ) ) {
-				return null;
-			}
+	useEffect( () => {
+		// The canvas mode is limited to the site editor.
+		if ( ! isSiteEditor ) {
+			return;
+		}
 
-			return new URLSearchParams( location?.search ).get( 'canvas' ) || 'view';
-		},
-		[ location?.search ]
-	);
+		const unsubscribe = subscribe( () => {
+			const mode = new URLSearchParams( window.location?.search ).get( 'canvas' ) || 'view';
+			setCanvasMode( mode );
+		} );
+
+		return () => unsubscribe();
+	} );
+
+	return canvasMode;
 };
 
 export default useCanvasMode;


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/97317

## Proposed changes:

After https://github.com/WordPress/gutenberg/pull/67199/files#diff-aaaf969c8c446a8f428b54b2d5482767b6d92c7ab4771e68b14145cdbe6a9dddR88, the `@wordpress/router`'s private `useLocation()` hook now throws an error when called outside the Site Editor.

This PR proposes to subscribe to the store directly to listen for updates (including the current window location). See also the discussion: p1734451746748589/1734451069.855289-slack-CBTN58FTJand a prior art https://github.com/Automattic/jetpack/blob/trunk/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/use-canvas.js#L15-L31. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

Follow the exact same instructions as https://github.com/Automattic/jetpack/pull/40045.

