### PR TITLE
Gutenberg 19.8.0 hotfix: don't show the template-locked rendering mode for pages

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/hotfix-template-locked-bug
+++ b/projects/packages/jetpack-mu-wpcom/changelog/hotfix-template-locked-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Gutenberg 19.8.0 hotfix: don't show the template-locked rendering mode for pages

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -125,6 +125,20 @@ class Jetpack_Mu_Wpcom {
 		if ( class_exists( 'Automattic\Jetpack\Scheduled_Updates' ) ) {
 			Scheduled_Updates::init();
 		}
+
+		/**
+		 * Hotfix for a Gutenberg 19.8.0 bug preventing lower-capability users from editing pages.
+		 * See: p1734525664059729-slack-C02FMH4G8
+		 * See: https://github.com/WordPress/gutenberg/issues/68053#issuecomment-2550730705
+		 */
+		add_filter(
+			'register_post_type_args',
+			function ( $args ) {
+				unset( $args['default_rendering_mode'] );
+				return $args;
+			},
+			20
+		);
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -111,6 +111,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-admin-dashboard/wpcom-admin-dashboard.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/class-jetpack-wpcom-block-editor.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/functions.editor-type.php';
+		require_once __DIR__ . '/features/wpcom-hotfixes/wpcom-hotfixes.php';
 		require_once __DIR__ . '/features/wpcom-logout/wpcom-logout.php';
 		require_once __DIR__ . '/features/wpcom-themes/wpcom-theme-fixes.php';
 
@@ -125,20 +126,6 @@ class Jetpack_Mu_Wpcom {
 		if ( class_exists( 'Automattic\Jetpack\Scheduled_Updates' ) ) {
 			Scheduled_Updates::init();
 		}
-
-		/**
-		 * Hotfix for a Gutenberg 19.8.0 bug preventing lower-capability users from editing pages.
-		 * See: p1734525664059729-slack-C02FMH4G8
-		 * See: https://github.com/WordPress/gutenberg/issues/68053#issuecomment-2550730705
-		 */
-		add_filter(
-			'register_post_type_args',
-			function ( $args ) {
-				unset( $args['default_rendering_mode'] );
-				return $args;
-			},
-			20
-		);
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-hotfixes/wpcom-hotfixes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-hotfixes/wpcom-hotfixes.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Various hotfixes to WordPress.com
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Hotfix for a Gutenberg 19.8.0 bug preventing lower-capability users from editing pages.
+ * See: p1734525664059729-slack-C02FMH4G8
+ * See: https://github.com/WordPress/gutenberg/issues/68053#issuecomment-2550730705
+ */
+add_action(
+	'admin_init',
+	function () {
+		add_filter(
+			'register_post_type_args',
+			function ( $args ) {
+				unset( $args['default_rendering_mode'] );
+				return $args;
+			},
+			20
+		);
+	}
+);

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-hotfixes/wpcom-hotfixes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-hotfixes/wpcom-hotfixes.php
@@ -10,16 +10,11 @@
  * See: p1734525664059729-slack-C02FMH4G8
  * See: https://github.com/WordPress/gutenberg/issues/68053#issuecomment-2550730705
  */
-add_action(
-	'admin_init',
-	function () {
-		add_filter(
-			'register_post_type_args',
-			function ( $args ) {
-				unset( $args['default_rendering_mode'] );
-				return $args;
-			},
-			20
-		);
-	}
+add_filter(
+	'register_post_type_args',
+	function ( $args ) {
+		unset( $args['default_rendering_mode'] );
+		return $args;
+	},
+	20
 );


### PR DESCRIPTION
Fixes p1734525664059729-slack-C02FMH4G8

## Proposed changes:

This PR applies the hotfix proposed in https://github.com/WordPress/gutenberg/issues/68053#issuecomment-2550730705.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Patch this PR
1. Add your user as an Editor to a Simple site
1. Switch your user language to non-English (in /me/account)
1. Try creating a new page
1. Verify you can edit the page