### PR TITLE
RDV: Remove the wpcom_admin_interface hook for the admin_menu hook

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-wp-admin-rdv
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-wp-admin-rdv
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Exclude the wpcom_admin_interface from the admin_menu action

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -263,7 +263,7 @@ add_action( 'admin_bar_menu', 'wpcom_replace_edit_profile_menu_to_me', 9999 );
  * @return string Name of the admin bar class.
  */
 function wpcom_custom_wpcom_admin_bar_class( $wp_admin_bar_class ) {
-	if ( ! wpcom_is_using_default_admin_menu() ) {
+	if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
 		return $wp_admin_bar_class;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -193,6 +193,21 @@ function wpcom_admin_get_user_option_jetpack( $value ) {
 add_filter( 'get_user_option_jetpack_admin_menu_preferred_views', 'wpcom_admin_get_user_option_jetpack' );
 add_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option', 10 );
 
+add_action(
+	'admin_menu',
+	function () {
+		remove_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option' );
+	},
+	PHP_INT_MIN
+);
+
+add_action(
+	'admin_menu',
+	function () {
+		add_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option', 10 );
+	},
+	PHP_INT_MAX
+);
 /**
  * Hides the "View" switcher on WP Admin screens enforced by the "Remove duplicate views" experiment.
  */

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -39,11 +39,7 @@ function current_user_has_wpcom_account() {
  * @return bool
  */
 function wpcom_is_using_default_admin_menu() {
-	remove_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option' );
-	$option = get_option( 'wpcom_admin_interface' ) !== 'wp-admin';
-	add_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option', 10 );
-
-	return $option;
+	return get_option( 'wpcom_admin_interface' ) !== 'wp-admin';
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -34,19 +34,10 @@ function current_user_has_wpcom_account() {
 }
 
 /**
- * Check if the user has the default (Calypso) Admin menu.
- *
- * @return bool
- */
-function wpcom_is_using_default_admin_menu() {
-	return get_option( 'wpcom_admin_interface' ) !== 'wp-admin';
-}
-
-/**
  * Adds a Hosting menu.
  */
 function wpcom_add_hosting_menu() {
-	if ( wpcom_is_using_default_admin_menu() ) {
+	if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
 		return;
 	}
 
@@ -158,7 +149,7 @@ add_action( 'admin_menu', 'wpcom_add_hosting_menu' );
 function wpcom_add_jetpack_submenu() {
 	$is_simple_site          = defined( 'IS_WPCOM' ) && IS_WPCOM;
 	$is_atomic_site          = ! $is_simple_site;
-	$uses_wp_admin_interface = ! wpcom_is_using_default_admin_menu();
+	$uses_wp_admin_interface = get_option( 'wpcom_admin_interface' ) === 'wp-admin';
 
 	if ( ! $uses_wp_admin_interface ) {
 		return;
@@ -388,7 +379,7 @@ function wpcom_add_plugins_menu() {
 	global $menu;
 	$is_simple_site          = defined( 'IS_WPCOM' ) && IS_WPCOM;
 	$is_atomic_site          = ! $is_simple_site;
-	$uses_wp_admin_interface = ! wpcom_is_using_default_admin_menu();
+	$uses_wp_admin_interface = get_option( 'wpcom_admin_interface' ) === 'wp-admin';
 
 	if ( $is_simple_site ) {
 		$has_plugins_menu = false;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
@@ -10,7 +10,7 @@
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 
-if ( wpcom_is_using_default_admin_menu() ) {
+if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
 	return;
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
@@ -56,7 +56,7 @@ add_action( 'load-theme-install.php', 'wpcom_themes_show_banner' );
  * Registers an "Appearance > Theme Showcase" menu.
  */
 function wpcom_themes_add_theme_showcase_menu() {
-	if ( wpcom_is_using_default_admin_menu() ) {
+	if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
 		return;
 	}
 

--- a/projects/packages/masterbar/changelog/fix-wp-admin-rdv
+++ b/projects/packages/masterbar/changelog/fix-wp-admin-rdv
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Exclude the wpcom_admin_interface from the admin_menu action

--- a/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
@@ -356,7 +356,7 @@ class Admin_Menu extends Base_Admin_Menu {
 
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		add_submenu_page( 'tools.php', esc_attr__( 'Marketing', 'jetpack-masterbar' ), __( 'Marketing', 'jetpack-masterbar' ), 'publish_posts', 'https://wordpress.com/marketing/tools/' . $this->domain, null, 0 );
-		if ( $this->is_using_default_admin_menu() ) {
+		if ( ! $this->use_wp_admin_interface() ) {
 			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 			add_submenu_page( 'tools.php', esc_attr__( 'Monetize', 'jetpack-masterbar' ), __( 'Monetize', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain, null, 1 );
 		}

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -47,7 +47,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		);
 
 		// Add notices to the settings pages when there is a Calypso page available.
-		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+		if ( $this->use_wp_admin_interface() ) {
 			add_action( 'current_screen', array( $this, 'add_settings_page_notice' ) );
 		}
 	}
@@ -79,7 +79,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		$this->remove_gutenberg_menu();
 
 		// We don't need the `My Mailboxes` when the interface is set to wp-admin or the site is a staging site,
-		if ( $this->is_using_default_admin_menu() && ! get_option( 'wpcom_is_staging_site' ) ) {
+		if ( ! $this->use_wp_admin_interface() && ! get_option( 'wpcom_is_staging_site' ) ) {
 			$this->add_my_mailboxes_menu();
 		}
 
@@ -132,7 +132,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			$this->update_submenus( $slug, $submenus_to_update );
 		}
 
-		if ( $this->is_using_default_admin_menu() ) {
+		if ( ! $this->use_wp_admin_interface() ) {
 			// The 'Subscribers' menu exists in the Jetpack menu for Classic wp-admin interface, so only add it for non-wp-admin interfaces.
 			// // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 			add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack-masterbar' ), __( 'Subscribers', 'jetpack-masterbar' ), 'list_users', 'https://wordpress.com/subscribers/' . $this->domain, null );
@@ -322,7 +322,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 */
 	public function add_jetpack_menu() {
 		// This is supposed to be the same as class-admin-menu but with a different position specified for the Jetpack menu.
-		if ( ! $this->is_using_default_admin_menu() ) {
+		if ( $this->use_wp_admin_interface() ) {
 			parent::create_jetpack_menu( 2, false );
 		} else {
 			parent::add_jetpack_menu();
@@ -445,7 +445,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 
 		// Hide Settings > Performance when the interface is set to wp-admin.
 		// This is due to these settings are mostly also available in Jetpack > Settings, in the Performance tab.
-		if ( ! $this->is_using_default_admin_menu() ) {
+		if ( $this->use_wp_admin_interface() ) {
 			$this->hide_submenu_page( 'options-general.php', 'https://wordpress.com/settings/performance/' . $this->domain );
 		}
 	}
@@ -457,7 +457,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		parent::add_tools_menu();
 
 		// Link the Tools menu to Available Tools when the interface is set to wp-admin.
-		if ( ! $this->is_using_default_admin_menu() ) {
+		if ( $this->use_wp_admin_interface() ) {
 			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 			add_submenu_page( 'tools.php', esc_attr__( 'Available Tools', 'jetpack-masterbar' ), __( 'Available Tools', 'jetpack-masterbar' ), 'edit_posts', 'tools.php', null, 0 );
 		}

--- a/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
@@ -762,13 +762,7 @@ abstract class Base_Admin_Menu {
 	 * @return bool
 	 */
 	public function is_using_default_admin_menu() {
-		remove_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option' );
-		$option = get_option( 'wpcom_admin_interface' ) !== 'wp-admin';
-		if ( function_exists( 'wpcom_admin_interface_pre_get_option' ) ) {
-			add_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option', 10 );
-		}
-
-		return $option;
+		return get_option( 'wpcom_admin_interface' ) !== 'wp-admin';
 	}
 
 	/**

--- a/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
@@ -757,15 +757,6 @@ abstract class Base_Admin_Menu {
 	}
 
 	/**
-	 * Check if the user has the default (Calypso) Admin menu.
-	 *
-	 * @return bool
-	 */
-	public function is_using_default_admin_menu() {
-		return get_option( 'wpcom_admin_interface' ) !== 'wp-admin';
-	}
-
-	/**
 	 * Create the desired menu output.
 	 */
 	abstract public function reregister_menu_items();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Previously, we used a different approach to load the nav-unification (Calypso) admin menu items. This caused some unexpected behaviors where if a user visited a WP-Admin page (untangled), will get the rest of the admin menu items pointing to WP-Admin - instead of their corresponding Calypso screen.

Related https://github.com/Automattic/wp-calypso/issues/95478

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the wpcom_admin_interface de-register and re-register from nav-unification
* Exclude the hook before admin_menu is executed and re-add it afterwards

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to WP-Admin > Posts (edit.php)
* Make sure that Settings > General is linking to the Calypso screen
* Make sure that edit.php is untangled (there's no in-page dashboard switcher)

