### PR TITLE
Social: Use connections REST endpoint for initial state

### DIFF
--- a/projects/packages/publicize/changelog/update-unify-social-connections-schema
+++ b/projects/packages/publicize/changelog/update-unify-social-connections-schema
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Social: Use connections REST endpoint for initial state

--- a/projects/packages/publicize/src/class-connections.php
+++ b/projects/packages/publicize/src/class-connections.php
@@ -33,22 +33,9 @@ class Connections {
 		$is_wpcom = ( new Host() )->is_wpcom_simple();
 
 		if ( $is_wpcom ) {
-			// We don't need to cache connections for simple sites.
 			$connections = Connections_Controller::get_connections( $run_tests );
 		} else {
-
-			$clear_cache = $args['clear_cache'] ?? false;
-
-			if ( $clear_cache || $run_tests ) {
-				self::clear_transient();
-			}
-
-			$connections = get_transient( self::CONNECTIONS_TRANSIENT );
-
-			// This can be an empty array, so we need to check for false.
-			if ( false === $connections ) {
-				$connections = self::fetch_and_cache_connections( $run_tests );
-			}
+			$connections = self::fetch_and_cache_connections( $run_tests );
 		}
 
 		// Let us add the deprecated fields for now.
@@ -103,12 +90,5 @@ class Connections {
 		// TODO Implement caching here.
 
 		return $connections;
-	}
-
-	/**
-	 * Delete the transient.
-	 */
-	public static function clear_transient() {
-		delete_transient( self::CONNECTIONS_TRANSIENT );
 	}
 }

--- a/projects/packages/publicize/src/class-connections.php
+++ b/projects/packages/publicize/src/class-connections.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Publicize;
 
+use Automattic\Jetpack\Connection;
 use Automattic\Jetpack\Publicize\REST_API\Connections_Controller;
 use Automattic\Jetpack\Status\Host;
 
@@ -33,23 +34,60 @@ class Connections {
 
 		if ( $is_wpcom ) {
 			// We don't need to cache connections for simple sites.
-			return Connections_Controller::get_connections( $run_tests );
+			$connections = Connections_Controller::get_connections( $run_tests );
+		} else {
+
+			$clear_cache = $args['clear_cache'] ?? false;
+
+			if ( $clear_cache || $run_tests ) {
+				self::clear_transient();
+			}
+
+			$connections = get_transient( self::CONNECTIONS_TRANSIENT );
+
+			// This can be an empty array, so we need to check for false.
+			if ( false === $connections ) {
+				$connections = self::fetch_and_cache_connections( $run_tests );
+			}
 		}
 
-		$clear_cache = $args['clear_cache'] ?? false;
-
-		if ( $clear_cache || $run_tests ) {
-			self::clear_transient();
-		}
-
-		$connections = get_transient( self::CONNECTIONS_TRANSIENT );
-
-		// This can be an empty array, so we need to check for false.
-		if ( false === $connections ) {
-			$connections = self::fetch_and_cache_connections( $run_tests );
-		}
+		// Let us add the deprecated fields for now.
+		// TODO: Remove this after https://github.com/Automattic/jetpack/pull/40539 is merged.
+		$connections = self::retain_deprecated_fields( $connections );
 
 		return $connections;
+	}
+
+	/**
+	 * Retain deprecated fields.
+	 *
+	 * @param array $connections Connections.
+	 * @return array
+	 */
+	private static function retain_deprecated_fields( $connections ) {
+		return array_map(
+			function ( $connection ) {
+				$wpcom_user_data = ( new Connection\Manager() )->get_connected_user_data();
+
+				$owns_connection = ! empty( $wpcom_user_data['ID'] ) && $wpcom_user_data['ID'] === $connection['user_id'];
+
+				$connection = array_merge(
+					$connection,
+					array(
+						'external_display' => $connection['display_name'],
+						'can_disconnect'   => current_user_can( 'edit_others_posts' ) || $owns_connection,
+						'label'            => $connection['service_label'],
+					)
+				);
+
+				if ( 'bluesky' === $connection['service_name'] ) {
+					$connection['external_name'] = $connection['external_handle'];
+				}
+
+				return $connection;
+			},
+			$connections
+		);
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-connections.php
+++ b/projects/packages/publicize/src/class-connections.php
@@ -100,9 +100,7 @@ class Connections {
 	public static function fetch_and_cache_connections( $run_tests = false ) {
 		$connections = Connections_Controller::get_connections( $run_tests );
 
-		if ( is_array( $connections ) ) {
-			set_transient( self::CONNECTIONS_TRANSIENT, $connections, HOUR_IN_SECONDS * 4 );
-		}
+		// TODO Implement caching here.
 
 		return $connections;
 	}

--- a/projects/packages/publicize/src/class-connections.php
+++ b/projects/packages/publicize/src/class-connections.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Publicize Connections class.
+ *
+ * @package automattic/jetpack-publicize
+ */
+
+namespace Automattic\Jetpack\Publicize;
+
+use Automattic\Jetpack\Publicize\REST_API\Connections_Controller;
+use Automattic\Jetpack\Status\Host;
+
+/**
+ * Publicize Connections class.
+ */
+class Connections {
+
+	const CONNECTIONS_TRANSIENT = 'jetpack_social_connections_list';
+
+	/**
+	 * Get all connections.
+	 *
+	 * @param array $args Arguments
+	 *                - 'clear_cache': bool Whether to clear the cache.
+	 *                - 'test_connections': bool Whether to run connection tests.
+	 * @return array
+	 */
+	public static function get_all( $args = array() ) {
+
+		$run_tests = $args['test_connections'] ?? false;
+
+		$is_wpcom = ( new Host() )->is_wpcom_simple();
+
+		if ( $is_wpcom ) {
+			// We don't need to cache connections for simple sites.
+			return Connections_Controller::get_connections( $run_tests );
+		}
+
+		$clear_cache = $args['clear_cache'] ?? false;
+
+		if ( $clear_cache || $run_tests ) {
+			self::clear_transient();
+		}
+
+		$connections = get_transient( self::CONNECTIONS_TRANSIENT );
+
+		// This can be an empty array, so we need to check for false.
+		if ( false === $connections ) {
+			$connections = self::fetch_and_cache_connections( $run_tests );
+		}
+
+		return $connections;
+	}
+
+	/**
+	 * Fetch connections from the REST API and cache them.
+	 *
+	 * @param bool $run_tests Whether to run connection tests.
+	 *
+	 * @return array
+	 */
+	public static function fetch_and_cache_connections( $run_tests = false ) {
+		$connections = Connections_Controller::get_connections( $run_tests );
+
+		if ( is_array( $connections ) ) {
+			set_transient( self::CONNECTIONS_TRANSIENT, $connections, HOUR_IN_SECONDS * 4 );
+		}
+
+		return $connections;
+	}
+
+	/**
+	 * Delete the transient.
+	 */
+	public static function clear_transient() {
+		delete_transient( self::CONNECTIONS_TRANSIENT );
+	}
+}

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -556,8 +556,8 @@ abstract class Publicize_Base {
 	public function get_display_name( $service_name, $connection ) {
 		$cmeta = $this->get_connection_meta( $connection );
 
-		if ( 'mastodon' === $service_name && isset( $cmeta['external_name'] ) ) {
-			return $cmeta['external_name'];
+		if ( 'mastodon' === $service_name && isset( $cmeta['external_display'] ) ) {
+			return $cmeta['external_display'];
 		}
 
 		if ( isset( $cmeta['connection_data']['meta']['display_name'] ) ) {

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -21,8 +21,6 @@ use Jetpack_Options;
  */
 class Publicize_Script_Data {
 
-	const SERVICES_TRANSIENT = 'jetpack_social_services_list';
-
 	/**
 	 * Get the publicize instance - properly typed
 	 *
@@ -160,8 +158,7 @@ class Publicize_Script_Data {
 
 		return array(
 			'connectionData' => array(
-				// We do not have this method on WPCOM Publicize class yet.
-				'connections' => ! $is_wpcom ? self::publicize()->get_all_connections_for_user() : array(),
+				'connections' => Connections::get_all(),
 			),
 			'shareStatus'    => $share_status,
 		);
@@ -238,17 +235,24 @@ class Publicize_Script_Data {
 
 		$is_simple_site = ( new Host() )->is_wpcom_simple();
 
+		$commom_paths = array(
+			'refreshConnections' => '/wpcom/v2/publicize/connections?test_connections=1',
+		);
+
+		$specific_paths = array();
+
 		if ( $is_simple_site ) {
-			return array(
-				'refreshConnections' => '/wpcom/v2/publicize/connection-test-results',
-				'resharePost'        => '/wpcom/v2/posts/{postId}/publicize',
+
+			$specific_paths = array(
+				'resharePost' => '/wpcom/v2/posts/{postId}/publicize',
+			);
+		} else {
+			$specific_paths = array(
+				'resharePost' => '/jetpack/v4/publicize/{postId}',
 			);
 		}
 
-		return array(
-			'refreshConnections' => '/jetpack/v4/publicize/connections?test_connections=1',
-			'resharePost'        => '/jetpack/v4/publicize/{postId}',
-		);
+		return array_merge( $commom_paths, $specific_paths );
 	}
 
 	/**


### PR DESCRIPTION
Supercedes #40589

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Create `Automattic\Jetpack\Publicize\Connections` class to handle caching for connections
* Update script data to use the cached call for connections initial state

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Goto connections management on a Jetpack site and verify that everything works same as before like adding, removing and updating connections.
* Apply this PR to your sandbox
*  Point the public API and your simple site to your sandbox
* On that Simple site, goto the editor and open the Jetpack sidebar
* Verify that the connections management links still point to Calypso connections management
* Reset your sandbox - `jetpack-downloader reset jetpack`
* Checkout the enterprise git PR `Automattic/wpcom/pull/168243` (`git checkout arcpatch-D168243`) in your sandbox
* Apply this PR again on top `arcpatch-D168243` branch
* Reload and goto the editor again and open the Jetpack sidebar
* Verify that Connections management now opens the modal, instead of pointing to Calypso
* In the modal, confirm that the connections show up fine.
* Note that adding/removing connections is not yet implemented for simple sites

