### PR TITLE
Instagram shortcodes: support reels and videos in AMP views

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-instagram-shortcode-amp-reel
+++ b/projects/plugins/jetpack/changelog/fix-instagram-shortcode-amp-reel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Shortcode embeds: ensure Instagram reels are properly displayed in AMP views.

--- a/projects/plugins/jetpack/modules/shortcodes/instagram.php
+++ b/projects/plugins/jetpack/modules/shortcodes/instagram.php
@@ -309,7 +309,7 @@ function jetpack_shortcode_instagram( $atts ) {
 	}
 
 	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
-		$url_pattern = '#http(s?)://(www\.)?instagr(\.am|am\.com)/p/([^/?]+)#i';
+		$url_pattern = '#http(s?)://(www\.)?instagr(\.am|am\.com)/(p|tv|reel)/([^/?]+)#i';
 		preg_match( $url_pattern, $atts['url'], $matches );
 		if ( ! $matches ) {
 			return sprintf(


### PR DESCRIPTION
Fixes #40680

## Proposed changes:

Follow-up to #19735

Let's grab instagram IDs from reels in AMP views too.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > Settings > Writing
* Enable Shortcodes
* Go to Plugins > Add New
* Install and activate the AMP plugin
* Open the AMP onboarding wizard, and enable "Reader" mode
* Go to Posts > Add New
* Add a shortcode block
* Add the following in the block: `[instagram url="https://instagram.com/reel/COWmlFLB_7P/"]`
* Publish your post
* View the post on the frontend
* You should see the embed work in regular view
* Click on the AMP option in the admin bar
* You should see the embed work in the AMP view too.
