### PR TITLE
RDV: Use the tour only on a subset of the pages

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-tour-on-subset-of-rdv
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-tour-on-subset-of-rdv
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Enable the tour only on a subset of the Removed duplicate views screens.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -125,7 +125,7 @@ const WPCOM_DUPLICATE_VIEW_WITH_TOUR = array(
 	'edit-tags.php?taxonomy=post_tag',
 );
 const WPCOM_DUPLICATED_VIEW = array(
-	...WPCOM_DUPLICATED_VIEW,
+	...WPCOM_DUPLICATE_VIEW_WITH_TOUR,
 	'admin.php?page=stats',
 	'tools.php?page=advertising',
 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -125,7 +125,12 @@ const WPCOM_DUPLICATE_VIEW_WITH_TOUR = array(
 	'edit-tags.php?taxonomy=post_tag',
 );
 const WPCOM_DUPLICATED_VIEW = array(
-	...WPCOM_DUPLICATE_VIEW_WITH_TOUR,
+	'edit.php',
+	'edit.php?post_type=jetpack-portfolio',
+	'edit.php?post_type=jetpack-testimonial',
+	'edit-comments.php',
+	'edit-tags.php?taxonomy=category',
+	'edit-tags.php?taxonomy=post_tag',
 	'admin.php?page=stats',
 	'tools.php?page=advertising',
 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -116,15 +116,18 @@ function wpcom_admin_interface_pre_update_option( $new_value, $old_value ) {
 }
 add_filter( 'pre_update_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_update_option', 10, 2 );
 
-const WPCOM_DUPLICATED_VIEW = array(
+const WPCOM_DUPLICATE_VIEW_WITH_TOUR = array(
 	'edit.php',
-	'admin.php?page=stats',
-	'tools.php?page=advertising',
 	'edit.php?post_type=jetpack-portfolio',
 	'edit.php?post_type=jetpack-testimonial',
 	'edit-comments.php',
 	'edit-tags.php?taxonomy=category',
 	'edit-tags.php?taxonomy=post_tag',
+);
+const WPCOM_DUPLICATED_VIEW = array(
+	...WPCOM_DUPLICATED_VIEW,
+	'admin.php?page=stats',
+	'tools.php?page=advertising',
 );
 
 /**
@@ -462,7 +465,7 @@ function wpcom_show_removed_calypso_screen_notice() {
 
 	$current_screen = wpcom_admin_get_current_screen();
 
-	if ( ! in_array( $current_screen, WPCOM_DUPLICATED_VIEW, true ) ) {
+	if ( ! in_array( $current_screen, WPCOM_DUPLICATE_VIEW_WITH_TOUR, true ) ) {
 		return;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Before this change, all pages marked as duplicate view would have been presented with a tour explaining the switch to Core.

However, there were pages like Stats and Advertising that shouldn't receive this tour. Furthermore, when a user visited these pages, a gray overlay was displayed without a tour (since the page didn't had one).

This PR removes this behavior and loads the tour only on a subset of the pages that have a tour.

Related to https://github.com/Automattic/wp-calypso/issues/97400

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Load the tour only on a subset of the pages; Advertising and Stats should be excluded.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR on your site
* Go to WP-Admin > Posts  and Click on the stats icon we display for a post
* Go to WP-Admin > Settings > Advertising
* Notice that there's no gray overlay displayed anymore

