### PR TITLE
Search: Fix activity log for added widget.

### DIFF
--- a/projects/packages/search/changelog/fix-search-widget-init-log
+++ b/projects/packages/search/changelog/fix-search-widget-init-log
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+

--- a/projects/packages/search/src/instant-search/class-instant-search.php
+++ b/projects/packages/search/src/instant-search/class-instant-search.php
@@ -366,6 +366,7 @@ class Instant_Search extends Classic_Search {
 
 		// Init overlay sidebar if it doesn't exists.
 		if ( ! isset( $sidebars[ self::INSTANT_SEARCH_SIDEBAR ] ) ) {
+			$this->register_jetpack_instant_sidebar();
 			$sidebars[ self::INSTANT_SEARCH_SIDEBAR ] = array();
 		}
 
@@ -380,6 +381,9 @@ class Instant_Search extends Classic_Search {
 			$widget_options[ $next_id ] = $widget_options[ $sidebar_jp_searchbox_wiget_id ];
 		} else {
 			// If JP Search widget doesn't exist in the theme sidebar, we have nothing to copy from, so we create a new one within the overlay sidebar.
+			$search_widget = new Search_Widget();
+			$search_widget->_set( $next_id );
+			$search_widget->_register_one( $next_id );
 			$widget_options[ $next_id ] = $this->get_preconfig_widget_options();
 		}
 		array_unshift( $sidebars[ self::INSTANT_SEARCH_SIDEBAR ], Helper::build_widget_id( $next_id ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #https://github.com/Automattic/wp-calypso/issues/63745

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes activity log when search widget and sidebar are configured during plan activation.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync branch using Jetpack Beta Plugin for `Jetpack Search`
* Get the free Search plan to activate Jetpack Search
* Review Activity Log that it contains a `Search (Jetpack) in Jetpack Search Sidebar` record

