### PR TITLE
Gutenberg 19.9: don't show launch banner when the site is previewed in Appearance -> Design

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-launch-banner-in-iframe
+++ b/projects/plugins/wpcomsh/changelog/fix-launch-banner-in-iframe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Gutenberg 19.9: don't show launch banner when the site is previewed in Appearance -> Design

--- a/projects/plugins/wpcomsh/private-site/logged-in-banner.php
+++ b/projects/plugins/wpcomsh/private-site/logged-in-banner.php
@@ -199,6 +199,11 @@ function show_logged_in_banner() {
 
 			el.style.display = 'none';
 			document.addEventListener( 'DOMContentLoaded', function() {
+				// Don't show the banner if the site is previewed via an iframe.
+				if ( window.top !== window.self ) {
+					return;
+				}
+
 				var el = document.querySelector( '#wpcom-launch-banner-wrapper' );
 				if ( el ) {
 					el.style.display = null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/97648

## Proposed changes:

A recent PR for Gutenberg 19.9 allows previewing a site using a Classic theme on Appearance -> Design via an [iframe](https://github.com/WordPress/gutenberg/pull/66851/files#diff-3a7b1bf98dd04a82203aa5440220ba2353d07e2d8ba0cbc80451208f21668848R30-R56). We need to account for this case when deciding whether to show our dotcom launch banner.

I tried to prevent showing the banner in the backend side. However, the iframe just plainly renders the site frontend, and there is no way to detect that in PHP code (CMIIW). So, I am checking that in the JS file.

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/1bd477d0-4880-446d-8193-f3461046202e)|![image](https://github.com/user-attachments/assets/7a00f9a9-6d65-4952-a697-2157de770087)|


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Prepare a WoA DEV site.
2. Build this PR and sync to the site

```
git checkout BRANCH
composer install
WPCOMSH_DEVMODE=1 make clean build
rsync -avze ssh --delete build/wpcomsh USERNAME@sftp.wp.com:htdocs/wp-content/mu-plugins
```

3. Switch to a classic theme (e.g. Alves).
4. Go to the site frontend; verify you see the launch banner.
5. Now Install Gutenberg 19.9.0: https://github.com/WordPress/gutenberg/releases/download/v19.9.0/gutenberg.zip
6. Go to the site frontend; verify you see the launch banner.
7. Go to Appearance -> Design; verify you DON'T see the launch banner as per the above screenshot.
