### PR TITLE
Posts APIs: always return internal '_jetpack_dont_email_post_to_subs' meta

### DIFF
--- a/projects/plugins/jetpack/changelog/update-metadata-api-dont-email
+++ b/projects/plugins/jetpack/changelog/update-metadata-api-dont-email
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Metadata: always return internal '_jetpack_dont_email_post_to_subs' meta

--- a/projects/plugins/jetpack/sal/class.json-api-metadata.php
+++ b/projects/plugins/jetpack/sal/class.json-api-metadata.php
@@ -59,6 +59,7 @@ class WPCOM_JSON_API_Metadata {
 		$whitelist = array(
 			'_jetpack_newsletter_access',
 			'_jetpack_newsletter_tier_id',
+			'_jetpack_dont_email_post_to_subs',
 		);
 
 		if ( in_array( $key, $whitelist, true ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of https://github.com/Automattic/jetpack/issues/40724

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Return "do not send to subs" metadata as part of posts object, so that it can be used in Calypso UIs to indicate if email was sent to subscribers or not:

- https://github.com/Automattic/wp-calypso/pull/97739

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply PR at your sandbox
* Create a new post and set "post only" from "newsletter" sidebar (icon in the header)
* Open stats individual posts view in Calypso at `/stats/post/[POST ID]/[SITE ID]`
* See API request to `/rest/v1.1/sites/[SITE ID]/posts/[ POST ID]` from networks tab, and see raw data contain new meta
    <img width="466" alt="image" src="https://github.com/user-attachments/assets/95013e15-3e90-405b-bac6-3f10d20539d1" />
