### PR TITLE
Added a safeguard for invalid uploads causing fatals in API endpoints.

### DIFF
--- a/projects/plugins/jetpack/changelog/add-safeguard-for-invalid-uploads
+++ b/projects/plugins/jetpack/changelog/add-safeguard-for-invalid-uploads
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack API: Fixed a bug where invalid upload input caused a fatal error.

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -2254,6 +2254,11 @@ abstract class WPCOM_JSON_API_Endpoint {
 
 				if ( ! $user_can_upload_files ) {
 					$media_id = new WP_Error( 'unauthorized', 'User cannot upload media.', 403 );
+				} elseif ( ! is_array( $media_item ) ) {
+					$media_id   = new WP_Error( 'invalid_input', 'Unable to process request.', 400 );
+					$media_item = array(
+						'name' => 'invalid_file',
+					);
 				} elseif ( $this->media_item_is_free_video_mobile_upload_and_too_long( $media_item ) ) {
 					$media_id = new WP_Error( 'upload_video_length', 'Video uploads longer than 5 minutes require a paid plan.', 400 );
 				} else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes fatal errors occurring when an upload for some reason contains a string instead of an array when it comes to file processing.

```
Fatal error: Uncaught TypeError: Cannot access offset of type string on string in /jetpack-plugin/sun/class.json-api-endpoints.php:2180
Stack trace:
#0 /jetpack-plugin/sun/class.json-api-endpoints.php(2257): WPCOM_JSON_API_Endpoint->media_item_is_free_video_mobile_upload_and_too_long('string')
#1 /jetpack-plugin/sun/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php(150): WPCOM_JSON_API_Endpoint->handle_media_creation_v1_1(Array, Array, Array)
#2 /jetpack-plugin/sun/class.json-api.php(609): WPCOM_JSON_API_Upload_Media_v1_1_Endpoint->callback('/sites/...', 99999999)
```

## Proposed changes:
* Adds an `is_array` check for input file processing data.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

