### PR TITLE
AI Assistant: Add thumbs feedback on AI Assistant

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-thumbs-feedback-ai-assistant
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-thumbs-feedback-ai-assistant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+AI Client: Add thumbs feedback on AI Assistant

--- a/projects/js-packages/ai-client/src/components/ai-control/block-ai-control.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/block-ai-control.tsx
@@ -256,7 +256,16 @@ export function BlockAIControl(
 	);
 
 	const message =
-		showGuideLine && ! loading && ! editRequest && ( customFooter || <GuidelineMessage /> );
+		showGuideLine &&
+		! loading &&
+		! editRequest &&
+		( customFooter || (
+			<GuidelineMessage
+				showAIFeedbackThumbs={ true }
+				ratedItem={ 'ai-assistant' }
+				prompt={ value }
+			/>
+		) );
 
 	return (
 		<AIControl

--- a/projects/js-packages/ai-client/src/components/ai-control/extension-ai-control.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/extension-ai-control.tsx
@@ -85,6 +85,9 @@ export function ExtensionAIControl(
 	const [ editRequest, setEditRequest ] = useState( false );
 	const [ lastValue, setLastValue ] = useState( value || null );
 	const promptUserInputRef = useRef( null );
+	const isDone = value?.length <= 0 && state === 'done';
+	const [ initialPlaceholder ] = useState( placeholder );
+	const [ prompt, setPrompt ] = useState( null );
 
 	// Pass the ref to forwardRef.
 	useImperativeHandle( ref, () => promptUserInputRef.current );
@@ -95,8 +98,16 @@ export function ExtensionAIControl(
 		}
 	}, [ editRequest ] );
 
+	useEffect( () => {
+		if ( placeholder !== initialPlaceholder ) {
+			// The prompt is used to determine if there was a toolbar action
+			setPrompt( placeholder );
+		}
+	}, [ placeholder ] );
+
 	const sendHandler = useCallback( () => {
 		setLastValue( value );
+		setPrompt( value );
 		setEditRequest( false );
 		onSend?.( value );
 	}, [ onSend, value ] );
@@ -183,7 +194,7 @@ export function ExtensionAIControl(
 							</Button>
 						</div>
 					) }
-					{ value?.length <= 0 && state === 'done' && (
+					{ isDone && (
 						<div className="jetpack-components-ai-control__controls-prompt_button_wrapper">
 							<ButtonGroup>
 								<Button
@@ -233,7 +244,15 @@ export function ExtensionAIControl(
 			/>
 		);
 	} else if ( showGuideLine ) {
-		message = <GuidelineMessage />;
+		message = isDone ? (
+			<GuidelineMessage
+				showAIFeedbackThumbs={ true }
+				ratedItem={ 'ai-assistant' }
+				prompt={ prompt }
+			/>
+		) : (
+			<GuidelineMessage />
+		);
 	}
 
 	return (

--- a/projects/js-packages/ai-client/src/components/message/index.tsx
+++ b/projects/js-packages/ai-client/src/components/message/index.tsx
@@ -4,7 +4,7 @@
 import { ExternalLink, Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Icon, check, arrowRight } from '@wordpress/icons';
+import { Icon, check } from '@wordpress/icons';
 import clsx from 'clsx';
 /**
  * Internal dependencies
@@ -12,6 +12,7 @@ import clsx from 'clsx';
 import './style.scss';
 import errorExclamation from '../../icons/error-exclamation.js';
 import { ERROR_QUOTA_EXCEEDED } from '../../types.js';
+import AiFeedbackThumbs from '../ai-feedback/index.js';
 /**
  * Types
  */
@@ -30,13 +31,22 @@ export type MessageSeverityProp =
 	| typeof MESSAGE_SEVERITY_INFO
 	| null;
 
+type RateProps = {
+	ratedItem?: string;
+	prompt?: string;
+	onRate?: ( rating: string ) => void;
+};
+
 export type MessageProps = {
 	icon?: React.ReactNode;
 	severity?: MessageSeverityProp;
-	showSidebarIcon?: boolean;
-	onSidebarIconClick?: () => void;
+	showAIFeedbackThumbs?: boolean;
 	children: React.ReactNode;
-};
+} & RateProps;
+
+export type GuidelineMessageProps = {
+	showAIFeedbackThumbs?: boolean;
+} & RateProps;
 
 export type OnUpgradeClick = ( event?: React.MouseEvent< HTMLButtonElement > ) => void;
 
@@ -71,8 +81,10 @@ const messageIconsMap = {
 export default function Message( {
 	severity = MESSAGE_SEVERITY_INFO,
 	icon = null,
-	showSidebarIcon = false,
-	onSidebarIconClick = () => {},
+	showAIFeedbackThumbs = false,
+	ratedItem = '',
+	prompt = '',
+	onRate = () => {},
 	children,
 }: MessageProps ): React.ReactElement {
 	return (
@@ -85,11 +97,17 @@ export default function Message( {
 			{ ( messageIconsMap[ severity ] || icon ) && (
 				<Icon icon={ messageIconsMap[ severity ] || icon } />
 			) }
-			<div className="jetpack-ai-assistant__message-content">{ children }</div>
-			{ showSidebarIcon && (
-				<Button className="jetpack-ai-assistant__message-sidebar" onClick={ onSidebarIconClick }>
-					<Icon size={ 20 } icon={ arrowRight } />
-				</Button>
+			{ <div className="jetpack-ai-assistant__message-content">{ children }</div> }
+			{ showAIFeedbackThumbs && (
+				<AiFeedbackThumbs
+					disabled={ false }
+					ratedItem={ ratedItem }
+					feature="ai-assistant"
+					options={ {
+						prompt,
+					} }
+					onRate={ onRate }
+				/>
 			) }
 		</div>
 	);
@@ -111,11 +129,15 @@ function LearnMoreLink(): React.ReactElement {
 /**
  * React component to render a guideline message.
  *
+ * @param {GuidelineMessageProps} props - Component props.
  * @return {React.ReactElement} - Message component.
  */
-export function GuidelineMessage(): React.ReactElement {
+export function GuidelineMessage( {
+	showAIFeedbackThumbs = false,
+	...props
+}: GuidelineMessageProps ): React.ReactElement {
 	return (
-		<Message>
+		<Message showAIFeedbackThumbs={ showAIFeedbackThumbs } { ...props }>
 			<span>
 				{ __( 'AI-generated content could be inaccurate or biased.', 'jetpack-ai-client' ) }
 			</span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #40574

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the thumbs feedback to the Message component
* Displays it when appropriate

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor with the thumbs feedback feature enabled
* Use the AI Assistant to generate some text
* Check that you can rate it
* On an extended block, ask for some change
* Check that you can rate it
* Test the written change or a toolbar action

Known issues: The toolbar actions are correctly mapped for extensions, but not for the AI Assistant block. Some plumbing and/or refactoring is necessary to get the human readable toolbar action in the block. Let's leave it for a follow-up.

![Screenshot from 2024-12-23 20-14-39](https://github.com/user-attachments/assets/d1d18a91-c176-44fa-9150-1257bbc2e525)
