### PR TITLE
[WC Analytics] Fix fatal error when cart is null

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/fix-analytics-error-cart-null
+++ b/projects/packages/woocommerce-analytics/changelog/fix-analytics-error-cart-null
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix fatal when WC()->cart returns null

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -585,6 +585,9 @@ trait Woo_Analytics_Trait {
 	 */
 	public function get_cart_total() {
 		$cart = WC()->cart;
+		if ( $cart === null ) {
+			return 0;
+		}
 		return $cart->get_total( 'tracking' );
 	}
 
@@ -595,6 +598,9 @@ trait Woo_Analytics_Trait {
 	 */
 	public function get_cart_subtotal() {
 		$cart = WC()->cart;
+		if ( $cart === null ) {
+			return 0;
+		}
 		return $cart->get_subtotal();
 	}
 
@@ -605,6 +611,9 @@ trait Woo_Analytics_Trait {
 	 */
 	public function get_cart_shipping_total() {
 		$cart = WC()->cart;
+		if ( $cart === null ) {
+			return 0;
+		}
 		return $cart->get_shipping_total();
 	}
 
@@ -615,6 +624,9 @@ trait Woo_Analytics_Trait {
 	 */
 	public function get_cart_taxes() {
 		$cart = WC()->cart;
+		if ( $cart === null ) {
+			return 0;
+		}
 		return $cart->get_taxes_total();
 	}
 
@@ -625,6 +637,9 @@ trait Woo_Analytics_Trait {
 	 */
 	public function get_total_discounts() {
 		$cart = WC()->cart;
+		if ( $cart === null ) {
+			return 0;
+		}
 		return $cart->get_discount_total();
 	}
 
@@ -635,6 +650,9 @@ trait Woo_Analytics_Trait {
 	 */
 	public function get_cart_items_count() {
 		$cart = WC()->cart;
+		if ( $cart === null ) {
+			return 0;
+		}
 		return $cart->get_cart_contents_count();
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://a8c.slack.com/archives/C01U2KGS2PQ/p1735038171598949?thread_ts=1734981348.766769&cid=C01U2KGS2PQ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes a fatal when WC()->cart returns null when tracking the session_statted event when sending headers

```
PHP Fatal error:  Uncaught Error: Call to a member function get_subtotal() on null in /wordpress/plugins/jetpack/14.2-a.5/jetpack_vendor/automattic/woocommerce-analytics/src/class-woo-analytics-trait.php:598
Stack trace:
#0 /wordpress/plugins/jetpack/14.2-a.5/jetpack_vendor/automattic/woocommerce-analytics/src/class-woo-analytics-trait.php(275): Automattic\Woocommerce_Analytics\Universal->get_cart_subtotal()
#1 /wordpress/plugins/jetpack/14.2-a.5/jetpack_vendor/automattic/woocommerce-analytics/src/class-woo-analytics-trait.php(394): Automattic\Woocommerce_Analytics\Universal->get_common_properties()
#2 /wordpress/plugins/jetpack/14.2-a.5/jetpack_vendor/automattic/woocommerce-analytics/src/class-woo-analytics-trait.php(314): Automattic\Woocommerce_Analytics\Universal->process_event_properties('woocommerceanal...', Array, NULL)
#3 /wordpress/plugins/jetpack/14.2-a.5/jetpack_vendor/automattic/woocommerce-analytics/src/class-universal.php(69): Automattic\Woocommerce_Analytics\Universal->record_event('woocommerceanal...')
#4 /wordpress/core/6.7.1/wp-includes/class-wp-hook.php(324): Automattic\Woocommerce_Analytics\Universal->initialize_woocommerceanalytics_session(Object(WP))
#5 /wordpress/core/6.7.1/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#6 /wordpress/core/6.7.1/wp-includes/plugin.php(565): WP_Hook->do_action(Array)
#7 /wordpress/core/6.7.1/wp-includes/class-wp.php(590): do_action_ref_array('send_headers', Array)
#8 /wordpress/core/6.7.1/wp-includes/class-wp.php(821): WP->send_headers()
#9 /wordpress/core/6.7.1/wp-includes/functions.php(1336): WP->main('')
#10 /wordpress/core/6.7.1/wp-blog-header.php(16): wp()
#11 /wordpress/core/6.7.1/index.php(17): require('/wordpress/core...')
#12 {main}
  thrown in /wordpress/plugins/jetpack/14.2-a.5/jetpack_vendor/automattic/woocommerce-analytics/src/class-woo-analytics-trait.php on line 598
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I wasn't able to reproduce the error. BUt I forced it to check that is not happening when cart is null by adding

`WC()->cart = null;` in https://github.com/Automattic/jetpack/blob/trunk/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php#L259

Then visit the shop or any page and check that there is no fatals.

