### PR TITLE
Fix connection test API path for WoA sites to fix broken connection notices not showing up

### DIFF
--- a/projects/packages/publicize/changelog/fix-connection-tests-for-woa
+++ b/projects/packages/publicize/changelog/fix-connection-tests-for-woa
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Ensure that broken connection notices work fine on WoA sites

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -236,9 +236,9 @@ class Publicize_Script_Data {
 	 */
 	public static function get_api_paths() {
 
-		$is_simple_site = ( new Host() )->is_wpcom_simple();
+		$is_wpcom = ( new Host() )->is_wpcom_platform();
 
-		if ( $is_simple_site ) {
+		if ( $is_wpcom ) {
 			return array(
 				'refreshConnections' => '/wpcom/v2/publicize/connection-test-results',
 				'resharePost'        => '/wpcom/v2/posts/{postId}/publicize',


### PR DESCRIPTION
Currently, the broken connection notices are not shown on WoA sites because the connection test result uses the wrong endpoint which returns the data in an incorrect format.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the endpoint used for connection test results

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Using Jetpack Beta Tester plugin, activate this branch on your WoA site
* Add at least one social connection like Facebook or Mastodon
* Edit a post in Block Editor
* Open Jetpack sidebar
* Select at least one connection and click on "Share post"
* Confirm that the post is shared successfully
* Now break the connection by removing "Jetpack" from [Facebook](https://www.facebook.com/settings/?tab=business_tools) or [Mastodon](https://mastodon.social/oauth/authorized_applications)
* Goto the editor again
* Now verify that that you see the notice about the broken connection


<img width="291" alt="Screenshot 2024-12-26 at 10 20 32 AM" src="https://github.com/user-attachments/assets/36e9f1cb-8fff-4eed-a45d-8298fa770c4b" />
