### PR TITLE
[WordAds]: Clean-up the wordads shortcode class and restore the old behavior

### DIFF
--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -539,10 +539,7 @@ HTML;
 			return $content . $this->get_watl_ad_html_tag( $location );
 		}
 
-		return $content . sprintf(
-			'<div class="jetpack-wordad" itemscope itemtype="https://schema.org/WPAdBlock">%s</div>',
-			$this->get_ad( 'inline', $ad_type )
-		);
+		return $content . $this->get_ad( 'inline', $ad_type );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -532,13 +532,14 @@ HTML;
 
 		$ad_type  = $this->option( 'wordads_house' ) ? 'house' : 'iponweb';
 		$location = 'shortcode';
+
 		// Not house ad and WATL enabled.
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( 'house' !== $ad_type && ( isset( $_GET['wordads-logging'] ) && isset( $_GET[ $location ] ) && 'true' === $_GET[ $location ] ) ) {
 			return $content . $this->get_watl_ad_html_tag( $location );
 		}
 
-		return $content .= sprintf(
+		return $content . sprintf(
 			'<div class="jetpack-wordad" itemscope itemtype="https://schema.org/WPAdBlock">%s</div>',
 			$this->get_ad( 'inline', $ad_type )
 		);

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -532,7 +532,7 @@ HTML;
 
 		$ad_type  = $this->option( 'wordads_house' ) ? 'house' : 'iponweb';
 		$location = 'shortcode';
-		// not house ad and watl enabled
+		// Not house ad and WATL enabled.
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( 'house' !== $ad_type && ( isset( $_GET['wordads-logging'] ) && isset( $_GET[ $location ] ) && 'true' === $_GET[ $location ] ) ) {
 			return $content . $this->get_watl_ad_html_tag( $location );

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-shortcode.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-shortcode.php
@@ -38,28 +38,12 @@ class WordAds_Shortcode {
 	 * @return string HTML for WordAds shortcode.
 	 */
 	public static function handle_wordads_shortcode( $atts, $content = '' ) {
-		$atts = shortcode_atts( array(), $atts, 'wordads' );
-
-		return self::wordads_shortcode_html( $atts, $content );
-	}
-
-	/**
-	 * The shortcode output
-	 *
-	 * @param array  $atts    Array of shortcode attributes.
-	 * @param string $content Post content.
-	 *
-	 * @return string HTML output
-	 */
-	private static function wordads_shortcode_html( $atts, $content = '' ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		global $wordads;
 
 		if ( empty( $wordads ) ) {
 			return '<div>' . __( 'The WordAds module is not active', 'jetpack' ) . '</div>';
 		}
 
-		$html = $wordads->insert_inline_ad( '' );
-
-		return $html;
+		return $wordads->insert_inline_ad( $content );
 	}
 }

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-shortcode.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-shortcode.php
@@ -32,18 +32,17 @@ class WordAds_Shortcode {
 	 * Our [wordads] shortcode.
 	 * Prints a WordAds Ad.
 	 *
-	 * @param array  $atts    Array of shortcode attributes.
-	 * @param string $content Post content.
-	 *
 	 * @return string HTML for WordAds shortcode.
 	 */
-	public static function handle_wordads_shortcode( $atts, $content = '' ) {
+	public static function handle_wordads_shortcode() {
 		global $wordads;
 
 		if ( empty( $wordads ) ) {
 			return '<div>' . __( 'The WordAds module is not active', 'jetpack' ) . '</div>';
 		}
 
-		return $wordads->insert_inline_ad( $content );
+		$html = '<div class="jetpack-wordad" itemscope itemtype="https://schema.org/WPAdBlock"></div>';
+
+		return $wordads->insert_inline_ad( $html );
 	}
 }


### PR DESCRIPTION
## Proposed changes:
* Clean-up the `WordAds_Shortcode` class
* Restore the old behavior when printing the html for the shortcode

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to your Jetpack test blog
* Go to a post page with `[wordads]` shortcode inserted
* Ensure that the IPW calls are happening
* Append the query string `?wordads-logging=true&shortcode=true`, check if the Smart is shown
* Go to your blog /feed, check if the `<div class="jetpack-wordad" itemscope itemtype="https://schema.org/WPAdBlock"></div>` is printed

<img width="1261" alt="image" src="https://github.com/user-attachments/assets/ce226f6c-03e5-4cbb-9a0c-15c0d2ea641a" />


