### PR TITLE
Jetpack AI: introduce seo extension availability

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-introduce-seo-extension-availability
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-introduce-seo-extension-availability
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI: introduce new beta feature ai-seo-assistant

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -225,3 +225,17 @@ add_action(
 		}
 	}
 );
+
+/**
+ * Register the `ai-seo-assistant` extension.
+ */
+add_action(
+	'jetpack_register_gutenberg_extensions',
+	function () {
+		if ( apply_filters( 'jetpack_ai_enabled', true ) &&
+			apply_filters( 'ai_seo_assistant_enabled', false )
+		) {
+			\Jetpack_Gutenberg::set_extension_available( 'ai-seo-assistant' );
+		}
+	}
+);

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -80,7 +80,8 @@
 		"videopress/video-chapters",
 		"ai-assistant-backend-prompts",
 		"ai-list-to-table-transform",
-		"ai-response-feedback"
+		"ai-response-feedback",
+		"ai-seo-assistant"
 	],
 	"experimental": [],
 	"no-post-editor": [

--- a/projects/plugins/jetpack/extensions/index.scss
+++ b/projects/plugins/jetpack/extensions/index.scss
@@ -2,7 +2,7 @@
 
 .is-beta-extension {
 	position: relative;
-	box-shadow: 0 0 3px var( --jp-green-30 );
+	box-shadow: 0 0 0px 15px white, 0 0 0px 16px var( --jp-green-30 );
 	transition: 0.5s box-shadow linear;
 
 	&.inset-shadow {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -9,7 +9,6 @@ import { PluginPrePublishPanel, PluginDocumentSettingPanel } from '@wordpress/ed
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
-import React from 'react';
 /**
  * Internal dependencies
  */
@@ -18,12 +17,14 @@ import useAICheckout from '../../../../blocks/ai-assistant/hooks/use-ai-checkout
 import useAiFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
 import useAiProductPage from '../../../../blocks/ai-assistant/hooks/use-ai-product-page';
 import { getFeatureAvailability } from '../../../../blocks/ai-assistant/lib/utils/get-feature-availability';
+import { isBetaExtension } from '../../../../editor';
 import JetpackPluginSidebar from '../../../../shared/jetpack-plugin-sidebar';
 import { PLAN_TYPE_FREE, PLAN_TYPE_UNLIMITED, usePlanType } from '../../../../shared/use-plan-type';
 import { FeaturedImage } from '../ai-image';
 import { Breve, registerBreveHighlights, Highlight } from '../breve';
 import { getBreveAvailability, canWriteBriefBeEnabled } from '../breve/utils/get-availability';
 import Feedback from '../feedback';
+import SeoAssistant from '../seo-assistant';
 import TitleOptimization from '../title-optimization';
 import UsagePanel from '../usage-panel';
 import {
@@ -59,6 +60,8 @@ const isAITitleOptimizationKeywordsFeatureAvailable = getFeatureAvailability(
 	'ai-title-optimization-keywords-support'
 );
 
+const isSeoAssistantEnabled = getFeatureAvailability( 'ai-seo-assistant' );
+
 const JetpackAndSettingsContent = ( {
 	placement,
 	requireUpgrade,
@@ -82,6 +85,19 @@ const JetpackAndSettingsContent = ( {
 				<PanelRow className="jetpack-ai-sidebar__feature-section">
 					<BaseControl __nextHasNoMarginBottom={ true }>
 						<FairUsageNotice variant="muted" />
+					</BaseControl>
+				</PanelRow>
+			) }
+
+			{ isSeoAssistantEnabled && (
+				<PanelRow
+					className={ `jetpack-ai-sidebar__feature-section ${
+						isBetaExtension( 'ai-seo-assistant' ) ? 'is-beta-extension' : ''
+					}` }
+				>
+					<BaseControl __nextHasNoMarginBottom={ true }>
+						<BaseControl.VisualLabel>{ __( 'SEO', 'jetpack' ) }</BaseControl.VisualLabel>
+						<SeoAssistant busy={ false } disabled={ false } />
 					</BaseControl>
 				</PanelRow>
 			) }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/index.tsx
@@ -1,0 +1,21 @@
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import debugFactory from 'debug';
+
+const debug = debugFactory( 'jetpack-ai:seo-assistant' );
+
+export default function SeoAssistant( { busy, disabled } ) {
+	return (
+		<div>
+			<p>{ __( 'Improve post engagement.', 'jetpack' ) }</p>
+			<Button
+				onClick={ () => debug( 'click' ) }
+				variant="secondary"
+				disabled={ disabled }
+				isBusy={ busy }
+			>
+				{ __( 'SEO Assistant', 'jetpack' ) }
+			</Button>
+		</div>
+	);
+}


### PR DESCRIPTION


## Proposed changes:
Introduce new `ai-seo-assistant` as a beta feature. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Block variation `production`:
- [ ] open the console while in the editor and check `Jetpack_Editor_Initial_State.available_blocks['ai-seo-assistant']` value should be `undefined`
- [ ] add the filter `add_filter( 'ai_seo_assistant_enabled', '__return_true' );` and try again, as long as block variation is `production` the feature/block should not be available

Block variation `beta`:
- [ ] open the console while in the editor and check `Jetpack_Editor_Initial_State.available_blocks['ai-seo-assistant'].available` value, should be `true` (since you enabled the filter on the step above)
- [ ] On the Post sidebar, in the AI panel, there should now be a new panel row titled SEO and a CTA button
- [ ] remove the filter `add_filter( 'ai_seo_assistant_enabled', '__return_true' );` (or turn it to `__return_false`) and try again, the feature/block availability should now`false`
- [ ] Check that the SEO sidebar panel is no longer available
