### PR TITLE
AI Assistant: Enhance thumbs feedback on AI Assistant and extensions

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-thumbs-prompt
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-thumbs-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Client: Move prompt types and update thumbs feedback event

--- a/projects/js-packages/ai-client/src/components/ai-control/block-ai-control.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/block-ai-control.tsx
@@ -46,6 +46,7 @@ type BlockAIControlProps = {
 	showRemove?: boolean;
 	banner?: ReactElement;
 	error?: ReactElement;
+	lastAction?: string;
 };
 
 const debug = debugFactory( 'jetpack-ai-client:block-ai-control' );
@@ -77,6 +78,7 @@ export function BlockAIControl(
 		showRemove = false,
 		banner = null,
 		error = null,
+		lastAction,
 	}: BlockAIControlProps,
 	ref: React.MutableRefObject< HTMLInputElement >
 ): ReactElement {
@@ -263,7 +265,7 @@ export function BlockAIControl(
 			<GuidelineMessage
 				showAIFeedbackThumbs={ true }
 				ratedItem={ 'ai-assistant' }
-				prompt={ value }
+				prompt={ lastAction }
 			/>
 		) );
 

--- a/projects/js-packages/ai-client/src/components/ai-control/block-ai-control.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/block-ai-control.tsx
@@ -263,9 +263,12 @@ export function BlockAIControl(
 		! editRequest &&
 		( customFooter || (
 			<GuidelineMessage
-				showAIFeedbackThumbs={ true }
-				ratedItem={ 'ai-assistant' }
-				prompt={ lastAction }
+				aiFeedbackThumbsOptions={ {
+					showAIFeedbackThumbs: true,
+					ratedItem: 'ai-assistant',
+					prompt: lastAction,
+					block: 'ai-assistant',
+				} }
 			/>
 		) );
 

--- a/projects/js-packages/ai-client/src/components/ai-control/extension-ai-control.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/extension-ai-control.tsx
@@ -46,6 +46,7 @@ type ExtensionAIControlProps = {
 	onUndo?: () => void;
 	onUpgrade?: ( event: MouseEvent< HTMLButtonElement > ) => void;
 	onTryAgain?: () => void;
+	lastAction?: string;
 };
 
 /**
@@ -78,6 +79,7 @@ export function ExtensionAIControl(
 		onUndo,
 		onUpgrade,
 		onTryAgain,
+		lastAction,
 	}: ExtensionAIControlProps,
 	ref: React.MutableRefObject< HTMLInputElement >
 ): ReactElement {
@@ -86,8 +88,6 @@ export function ExtensionAIControl(
 	const [ lastValue, setLastValue ] = useState( value || null );
 	const promptUserInputRef = useRef( null );
 	const isDone = value?.length <= 0 && state === 'done';
-	const [ initialPlaceholder ] = useState( placeholder );
-	const [ prompt, setPrompt ] = useState( null );
 
 	// Pass the ref to forwardRef.
 	useImperativeHandle( ref, () => promptUserInputRef.current );
@@ -98,16 +98,8 @@ export function ExtensionAIControl(
 		}
 	}, [ editRequest ] );
 
-	useEffect( () => {
-		if ( placeholder !== initialPlaceholder ) {
-			// The prompt is used to determine if there was a toolbar action
-			setPrompt( placeholder );
-		}
-	}, [ placeholder ] );
-
 	const sendHandler = useCallback( () => {
 		setLastValue( value );
-		setPrompt( value );
 		setEditRequest( false );
 		onSend?.( value );
 	}, [ onSend, value ] );
@@ -248,7 +240,7 @@ export function ExtensionAIControl(
 			<GuidelineMessage
 				showAIFeedbackThumbs={ true }
 				ratedItem={ 'ai-assistant' }
-				prompt={ prompt }
+				prompt={ lastAction }
 			/>
 		) : (
 			<GuidelineMessage />

--- a/projects/js-packages/ai-client/src/components/ai-control/extension-ai-control.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/extension-ai-control.tsx
@@ -47,6 +47,7 @@ type ExtensionAIControlProps = {
 	onUpgrade?: ( event: MouseEvent< HTMLButtonElement > ) => void;
 	onTryAgain?: () => void;
 	lastAction?: string;
+	blockType: string;
 };
 
 /**
@@ -80,6 +81,7 @@ export function ExtensionAIControl(
 		onUpgrade,
 		onTryAgain,
 		lastAction,
+		blockType,
 	}: ExtensionAIControlProps,
 	ref: React.MutableRefObject< HTMLInputElement >
 ): ReactElement {
@@ -238,9 +240,12 @@ export function ExtensionAIControl(
 	} else if ( showGuideLine ) {
 		message = isDone ? (
 			<GuidelineMessage
-				showAIFeedbackThumbs={ true }
-				ratedItem={ 'ai-assistant' }
-				prompt={ lastAction }
+				aiFeedbackThumbsOptions={ {
+					showAIFeedbackThumbs: true,
+					ratedItem: 'ai-assistant',
+					prompt: lastAction,
+					block: blockType,
+				} }
 			/>
 		) : (
 			<GuidelineMessage />

--- a/projects/js-packages/ai-client/src/components/ai-feedback/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-feedback/index.tsx
@@ -29,6 +29,7 @@ type AiFeedbackThumbsProps = {
 		mediaLibraryId?: number;
 		prompt?: string;
 		revisedPrompt?: string;
+		block?: string | null;
 	};
 	onRate?: ( rating: string ) => void;
 };
@@ -98,6 +99,7 @@ export default function AiFeedbackThumbs( {
 				mediaLibraryId: options.mediaLibraryId || null,
 				prompt: options.prompt || null,
 				revisedPrompt: options.revisedPrompt || null,
+				block: options.block || null,
 			} );
 		}
 	};

--- a/projects/js-packages/ai-client/src/components/message/index.tsx
+++ b/projects/js-packages/ai-client/src/components/message/index.tsx
@@ -31,22 +31,24 @@ export type MessageSeverityProp =
 	| typeof MESSAGE_SEVERITY_INFO
 	| null;
 
-type RateProps = {
+type AiFeedbackThumbsOptions = {
+	showAIFeedbackThumbs?: boolean;
 	ratedItem?: string;
 	prompt?: string;
+	block?: string | null;
 	onRate?: ( rating: string ) => void;
 };
 
 export type MessageProps = {
 	icon?: React.ReactNode;
 	severity?: MessageSeverityProp;
-	showAIFeedbackThumbs?: boolean;
+	aiFeedbackThumbsOptions?: AiFeedbackThumbsOptions;
 	children: React.ReactNode;
-} & RateProps;
+};
 
 export type GuidelineMessageProps = {
-	showAIFeedbackThumbs?: boolean;
-} & RateProps;
+	aiFeedbackThumbsOptions?: AiFeedbackThumbsOptions;
+};
 
 export type OnUpgradeClick = ( event?: React.MouseEvent< HTMLButtonElement > ) => void;
 
@@ -81,10 +83,13 @@ const messageIconsMap = {
 export default function Message( {
 	severity = MESSAGE_SEVERITY_INFO,
 	icon = null,
-	showAIFeedbackThumbs = false,
-	ratedItem = '',
-	prompt = '',
-	onRate = () => {},
+	aiFeedbackThumbsOptions = {
+		showAIFeedbackThumbs: false,
+		ratedItem: '',
+		prompt: '',
+		block: null,
+		onRate: () => {},
+	},
 	children,
 }: MessageProps ): React.ReactElement {
 	return (
@@ -98,15 +103,16 @@ export default function Message( {
 				<Icon icon={ messageIconsMap[ severity ] || icon } />
 			) }
 			{ <div className="jetpack-ai-assistant__message-content">{ children }</div> }
-			{ showAIFeedbackThumbs && prompt && (
+			{ aiFeedbackThumbsOptions.showAIFeedbackThumbs && aiFeedbackThumbsOptions.prompt && (
 				<AiFeedbackThumbs
 					disabled={ false }
-					ratedItem={ ratedItem }
+					ratedItem={ aiFeedbackThumbsOptions.ratedItem }
 					feature="ai-assistant"
 					options={ {
-						prompt,
+						prompt: aiFeedbackThumbsOptions.prompt,
+						block: aiFeedbackThumbsOptions.block,
 					} }
-					onRate={ onRate }
+					onRate={ aiFeedbackThumbsOptions.onRate }
 				/>
 			) }
 		</div>
@@ -133,11 +139,16 @@ function LearnMoreLink(): React.ReactElement {
  * @return {React.ReactElement} - Message component.
  */
 export function GuidelineMessage( {
-	showAIFeedbackThumbs = false,
-	...props
+	aiFeedbackThumbsOptions = {
+		showAIFeedbackThumbs: false,
+		ratedItem: '',
+		prompt: '',
+		block: null,
+		onRate: () => {},
+	},
 }: GuidelineMessageProps ): React.ReactElement {
 	return (
-		<Message showAIFeedbackThumbs={ showAIFeedbackThumbs } { ...props }>
+		<Message aiFeedbackThumbsOptions={ aiFeedbackThumbsOptions }>
 			<span>
 				{ __( 'AI-generated content could be inaccurate or biased.', 'jetpack-ai-client' ) }
 			</span>

--- a/projects/js-packages/ai-client/src/components/message/index.tsx
+++ b/projects/js-packages/ai-client/src/components/message/index.tsx
@@ -98,7 +98,7 @@ export default function Message( {
 				<Icon icon={ messageIconsMap[ severity ] || icon } />
 			) }
 			{ <div className="jetpack-ai-assistant__message-content">{ children }</div> }
-			{ showAIFeedbackThumbs && (
+			{ showAIFeedbackThumbs && prompt && (
 				<AiFeedbackThumbs
 					disabled={ false }
 					ratedItem={ ratedItem }

--- a/projects/js-packages/ai-client/src/constants.ts
+++ b/projects/js-packages/ai-client/src/constants.ts
@@ -1,0 +1,116 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+// Mappings
+export const LANGUAGE_MAP = {
+	en: {
+		label: __( 'English', 'jetpack-ai-client' ),
+	},
+	es: {
+		label: __( 'Spanish', 'jetpack-ai-client' ),
+	},
+	fr: {
+		label: __( 'French', 'jetpack-ai-client' ),
+	},
+	de: {
+		label: __( 'German', 'jetpack-ai-client' ),
+	},
+	it: {
+		label: __( 'Italian', 'jetpack-ai-client' ),
+	},
+	pt: {
+		label: __( 'Portuguese', 'jetpack-ai-client' ),
+	},
+	ru: {
+		label: __( 'Russian', 'jetpack-ai-client' ),
+	},
+	zh: {
+		label: __( 'Chinese', 'jetpack-ai-client' ),
+	},
+	ja: {
+		label: __( 'Japanese', 'jetpack-ai-client' ),
+	},
+	ar: {
+		label: __( 'Arabic', 'jetpack-ai-client' ),
+	},
+	hi: {
+		label: __( 'Hindi', 'jetpack-ai-client' ),
+	},
+	ko: {
+		label: __( 'Korean', 'jetpack-ai-client' ),
+	},
+};
+export const PROMPT_TONES_MAP = {
+	formal: {
+		label: __( 'Formal', 'jetpack-ai-client' ),
+		emoji: '🎩',
+	},
+	informal: {
+		label: __( 'Informal', 'jetpack-ai-client' ),
+		emoji: '😊',
+	},
+	optimistic: {
+		label: __( 'Optimistic', 'jetpack-ai-client' ),
+		emoji: '😃',
+	},
+	humorous: {
+		label: __( 'Humorous', 'jetpack-ai-client' ),
+		emoji: '😂',
+	},
+	serious: {
+		label: __( 'Serious', 'jetpack-ai-client' ),
+		emoji: '😐',
+	},
+	skeptical: {
+		label: __( 'Skeptical', 'jetpack-ai-client' ),
+		emoji: '🤨',
+	},
+	empathetic: {
+		label: __( 'Empathetic', 'jetpack-ai-client' ),
+		emoji: '💗',
+	},
+	confident: {
+		label: __( 'Confident', 'jetpack-ai-client' ),
+		emoji: '😎',
+	},
+	passionate: {
+		label: __( 'Passionate', 'jetpack-ai-client' ),
+		emoji: '❤️',
+	},
+	provocative: {
+		label: __( 'Provocative', 'jetpack-ai-client' ),
+		emoji: '🔥',
+	},
+};
+
+// Prompt types
+export const PROMPT_TYPE_SUMMARY_BY_TITLE = 'titleSummary' as const;
+export const PROMPT_TYPE_CONTINUE = 'continue' as const;
+export const PROMPT_TYPE_SIMPLIFY = 'simplify' as const;
+export const PROMPT_TYPE_CORRECT_SPELLING = 'correctSpelling' as const;
+export const PROMPT_TYPE_GENERATE_TITLE = 'generateTitle' as const;
+export const PROMPT_TYPE_MAKE_LONGER = 'makeLonger' as const;
+export const PROMPT_TYPE_MAKE_SHORTER = 'makeShorter' as const;
+export const PROMPT_TYPE_CHANGE_TONE = 'changeTone' as const;
+export const PROMPT_TYPE_SUMMARIZE = 'summarize' as const;
+export const PROMPT_TYPE_CHANGE_LANGUAGE = 'changeLanguage' as const;
+export const PROMPT_TYPE_USER_PROMPT = 'userPrompt' as const;
+export const PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT = 'jetpackFormCustomPrompt' as const;
+export const PROMPT_TYPE_TRANSFORM_LIST_TO_TABLE = 'transformListToTable' as const;
+export const PROMPT_TYPE_WRITE_POST_FROM_LIST = 'writePostFromList' as const;
+
+// Human-readable labels
+export const TRANSLATE_LABEL = __( 'Translate', 'jetpack-ai-client' );
+export const TONE_LABEL = __( 'Change tone', 'jetpack-ai-client' );
+export const CORRECT_SPELLING_LABEL = __( 'Correct spelling and grammar', 'jetpack-ai-client' );
+export const SIMPLIFY_LABEL = __( 'Simplify', 'jetpack-ai-client' );
+export const SUMMARIZE_LABEL = __( 'Summarize', 'jetpack-ai-client' );
+export const MAKE_SHORTER_LABEL = __( 'Make shorter', 'jetpack-ai-client' );
+export const MAKE_LONGER_LABEL = __( 'Expand', 'jetpack-ai-client' );
+export const TURN_LIST_INTO_TABLE_LABEL = __( 'Turn list into a table', 'jetpack-ai-client' );
+export const WRITE_POST_FROM_LIST_LABEL = __( 'Write a post from this list', 'jetpack-ai-client' );
+export const GENERATE_TITLE_LABEL = __( 'Generate a post title', 'jetpack-ai-client' );
+export const SUMMARY_BASED_ON_TITLE_LABEL = __( 'Summary based on title', 'jetpack-ai-client' );
+export const CONTINUE_LABEL = __( 'Continue writing', 'jetpack-ai-client' );

--- a/projects/js-packages/ai-client/src/index.ts
+++ b/projects/js-packages/ai-client/src/index.ts
@@ -44,6 +44,11 @@ export * from './types.js';
 export * from './libs/index.js';
 
 /*
+ * Constants
+ */
+export * from './constants.js';
+
+/*
  * Logo Generator
  */
 export * from './logo-generator/index.js';

--- a/projects/js-packages/ai-client/src/libs/index.ts
+++ b/projects/js-packages/ai-client/src/libs/index.ts
@@ -7,3 +7,5 @@ export {
 } from './markdown/index.js';
 
 export type { RenderHTMLRules } from './markdown/index.js';
+
+export { mapActionToHumanText } from './map-action-to-human-text.js';

--- a/projects/js-packages/ai-client/src/libs/map-action-to-human-text.ts
+++ b/projects/js-packages/ai-client/src/libs/map-action-to-human-text.ts
@@ -1,0 +1,77 @@
+import {
+	LANGUAGE_MAP,
+	PROMPT_TONES_MAP,
+	PROMPT_TYPE_CHANGE_LANGUAGE,
+	PROMPT_TYPE_CHANGE_TONE,
+	PROMPT_TYPE_CONTINUE,
+	PROMPT_TYPE_CORRECT_SPELLING,
+	PROMPT_TYPE_GENERATE_TITLE,
+	PROMPT_TYPE_MAKE_LONGER,
+	PROMPT_TYPE_MAKE_SHORTER,
+	PROMPT_TYPE_SIMPLIFY,
+	PROMPT_TYPE_SUMMARIZE,
+	PROMPT_TYPE_SUMMARY_BY_TITLE,
+	PROMPT_TYPE_TRANSFORM_LIST_TO_TABLE,
+	PROMPT_TYPE_WRITE_POST_FROM_LIST,
+	CONTINUE_LABEL,
+	CORRECT_SPELLING_LABEL,
+	GENERATE_TITLE_LABEL,
+	MAKE_LONGER_LABEL,
+	MAKE_SHORTER_LABEL,
+	SIMPLIFY_LABEL,
+	SUMMARIZE_LABEL,
+	SUMMARY_BASED_ON_TITLE_LABEL,
+	TONE_LABEL,
+	TRANSLATE_LABEL,
+	TURN_LIST_INTO_TABLE_LABEL,
+	WRITE_POST_FROM_LIST_LABEL,
+} from '../constants.js';
+
+type MapActionToHumanTextOptions = {
+	language?: string;
+	tone?: string;
+};
+
+/**
+ * Maps an action to a human-readable text.
+ *
+ * @param  action  - The action to map.
+ * @param  options - The options for the mapping.
+ * @return {string} The human-readable text.
+ */
+export function mapActionToHumanText(
+	action: string,
+	options: MapActionToHumanTextOptions
+): string {
+	const { language, tone } = options;
+	const languageCode = language?.split( ' (' )[ 0 ];
+
+	switch ( action ) {
+		case PROMPT_TYPE_CHANGE_LANGUAGE:
+			return `${ TRANSLATE_LABEL }: ${ LANGUAGE_MAP[ languageCode ].label }`;
+		case PROMPT_TYPE_CHANGE_TONE:
+			return `${ TONE_LABEL }: ${ PROMPT_TONES_MAP[ tone ].label }`;
+		case PROMPT_TYPE_CORRECT_SPELLING:
+			return CORRECT_SPELLING_LABEL;
+		case PROMPT_TYPE_SIMPLIFY:
+			return SIMPLIFY_LABEL;
+		case PROMPT_TYPE_SUMMARIZE:
+			return SUMMARIZE_LABEL;
+		case PROMPT_TYPE_MAKE_LONGER:
+			return MAKE_LONGER_LABEL;
+		case PROMPT_TYPE_MAKE_SHORTER:
+			return MAKE_SHORTER_LABEL;
+		case PROMPT_TYPE_TRANSFORM_LIST_TO_TABLE:
+			return TURN_LIST_INTO_TABLE_LABEL;
+		case PROMPT_TYPE_WRITE_POST_FROM_LIST:
+			return WRITE_POST_FROM_LIST_LABEL;
+		case PROMPT_TYPE_GENERATE_TITLE:
+			return GENERATE_TITLE_LABEL;
+		case PROMPT_TYPE_SUMMARY_BY_TITLE:
+			return SUMMARY_BASED_ON_TITLE_LABEL;
+		case PROMPT_TYPE_CONTINUE:
+			return CONTINUE_LABEL;
+		default:
+			return action;
+	}
+}

--- a/projects/js-packages/ai-client/src/libs/map-action-to-human-text.ts
+++ b/projects/js-packages/ai-client/src/libs/map-action-to-human-text.ts
@@ -42,7 +42,7 @@ type MapActionToHumanTextOptions = {
 export function mapActionToHumanText(
 	action: string,
 	options: MapActionToHumanTextOptions
-): string {
+): string | null {
 	const { language, tone } = options;
 	const languageCode = language?.split( ' (' )[ 0 ];
 
@@ -72,6 +72,6 @@ export function mapActionToHumanText(
 		case PROMPT_TYPE_CONTINUE:
 			return CONTINUE_LABEL;
 		default:
-			return action;
+			return null;
 	}
 }

--- a/projects/js-packages/ai-client/src/libs/map-action-to-human-text.ts
+++ b/projects/js-packages/ai-client/src/libs/map-action-to-human-text.ts
@@ -41,7 +41,7 @@ type MapActionToHumanTextOptions = {
  */
 export function mapActionToHumanText(
 	action: string,
-	options: MapActionToHumanTextOptions
+	options: MapActionToHumanTextOptions = {}
 ): string | null {
 	const { language, tone } = options;
 	const languageCode = language?.split( ' (' )[ 0 ];

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-thumbs-prompt
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-thumbs-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Enhance thumbs feedback on AI Assistant and extensions

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/dropdown-content.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/dropdown-content.tsx
@@ -1,17 +1,8 @@
 /*
  * External dependencies
  */
-import { aiAssistantIcon } from '@automattic/jetpack-ai-client';
-import { MenuItem, MenuGroup, Notice } from '@wordpress/components';
-import { select } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
-import { post, postContent, postExcerpt, termDescription, blockTable } from '@wordpress/icons';
-import React from 'react';
-/**
- * Internal dependencies
- */
-import { EXTENDED_BLOCKS } from '../../extensions/constants';
 import {
+	aiAssistantIcon,
 	PROMPT_TYPE_CHANGE_TONE,
 	PROMPT_TYPE_CORRECT_SPELLING,
 	PROMPT_TYPE_MAKE_LONGER,
@@ -21,10 +12,26 @@ import {
 	PROMPT_TYPE_CHANGE_LANGUAGE,
 	PROMPT_TYPE_USER_PROMPT,
 	PROMPT_TYPE_TRANSFORM_LIST_TO_TABLE,
-} from '../../lib/prompt';
-import { capitalize } from '../../lib/utils/capitalize';
-import { I18nMenuDropdown, TRANSLATE_LABEL } from '../i18n-dropdown-control';
-import { TONE_LABEL, ToneDropdownMenu } from '../tone-dropdown-control';
+	mapActionToHumanText,
+	CORRECT_SPELLING_LABEL,
+	SIMPLIFY_LABEL,
+	SUMMARIZE_LABEL,
+	MAKE_LONGER_LABEL,
+	MAKE_SHORTER_LABEL,
+	TURN_LIST_INTO_TABLE_LABEL,
+	WRITE_POST_FROM_LIST_LABEL,
+} from '@automattic/jetpack-ai-client';
+import { MenuItem, MenuGroup, Notice } from '@wordpress/components';
+import { select } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { post, postContent, postExcerpt, termDescription, blockTable } from '@wordpress/icons';
+import React from 'react';
+/**
+ * Internal dependencies
+ */
+import { EXTENDED_BLOCKS } from '../../extensions/constants';
+import { I18nMenuDropdown } from '../i18n-dropdown-control';
+import { ToneDropdownMenu } from '../tone-dropdown-control';
 import './style.scss';
 /**
  * Types and constants
@@ -52,6 +59,12 @@ export const QUICK_EDIT_KEY_MAKE_SHORTER = 'make-shorter' as const;
 // Ask AI Assistant option
 export const KEY_ASK_AI_ASSISTANT = 'ask-ai-assistant' as const;
 
+// Quick edits option: "Turn list into a table"
+export const QUICK_EDIT_KEY_TURN_LIST_INTO_TABLE = 'turn-list-into-table' as const;
+
+// Quick edits option: "Write a post from this list"
+export const QUICK_EDIT_KEY_WRITE_POST_FROM_LIST = 'write-post-from-list' as const;
+
 const quickActionsList: {
 	[ key: string ]: {
 		name: string;
@@ -63,7 +76,7 @@ const quickActionsList: {
 } = {
 	default: [
 		{
-			name: __( 'Correct spelling and grammar', 'jetpack' ),
+			name: CORRECT_SPELLING_LABEL,
 			key: QUICK_EDIT_KEY_CORRECT_SPELLING,
 			aiSuggestion: PROMPT_TYPE_CORRECT_SPELLING,
 			icon: termDescription,
@@ -71,25 +84,25 @@ const quickActionsList: {
 	],
 	'core/paragraph': [
 		{
-			name: __( 'Simplify', 'jetpack' ),
+			name: SIMPLIFY_LABEL,
 			key: QUICK_EDIT_KEY_SIMPLIFY,
 			aiSuggestion: PROMPT_TYPE_SIMPLIFY,
 			icon: post,
 		},
 		{
-			name: __( 'Summarize', 'jetpack' ),
+			name: SUMMARIZE_LABEL,
 			key: QUICK_EDIT_KEY_SUMMARIZE,
 			aiSuggestion: PROMPT_TYPE_SUMMARIZE,
 			icon: postExcerpt,
 		},
 		{
-			name: __( 'Expand', 'jetpack' ),
+			name: MAKE_LONGER_LABEL,
 			key: QUICK_EDIT_KEY_MAKE_LONGER,
 			aiSuggestion: PROMPT_TYPE_MAKE_LONGER,
 			icon: postContent,
 		},
 		{
-			name: __( 'Make shorter', 'jetpack' ),
+			name: MAKE_SHORTER_LABEL,
 			key: QUICK_EDIT_KEY_MAKE_SHORTER,
 			aiSuggestion: PROMPT_TYPE_MAKE_SHORTER,
 			icon: postContent,
@@ -97,19 +110,19 @@ const quickActionsList: {
 	],
 	'core/list-item': [
 		{
-			name: __( 'Simplify', 'jetpack' ),
+			name: SIMPLIFY_LABEL,
 			key: QUICK_EDIT_KEY_SIMPLIFY,
 			aiSuggestion: PROMPT_TYPE_SIMPLIFY,
 			icon: post,
 		},
 		{
-			name: __( 'Expand', 'jetpack' ),
+			name: MAKE_LONGER_LABEL,
 			key: QUICK_EDIT_KEY_MAKE_LONGER,
 			aiSuggestion: PROMPT_TYPE_MAKE_LONGER,
 			icon: postContent,
 		},
 		{
-			name: __( 'Make shorter', 'jetpack' ),
+			name: MAKE_SHORTER_LABEL,
 			key: QUICK_EDIT_KEY_MAKE_SHORTER,
 			aiSuggestion: PROMPT_TYPE_MAKE_SHORTER,
 			icon: postContent,
@@ -118,26 +131,26 @@ const quickActionsList: {
 	'core/list': EXTENDED_BLOCKS.includes( 'core/list' )
 		? [
 				{
-					name: __( 'Simplify', 'jetpack' ),
+					name: SIMPLIFY_LABEL,
 					key: QUICK_EDIT_KEY_SIMPLIFY,
 					aiSuggestion: PROMPT_TYPE_SIMPLIFY,
 					icon: post,
 				},
 				{
-					name: __( 'Expand', 'jetpack' ),
+					name: MAKE_LONGER_LABEL,
 					key: QUICK_EDIT_KEY_MAKE_LONGER,
 					aiSuggestion: PROMPT_TYPE_MAKE_LONGER,
 					icon: postContent,
 				},
 				{
-					name: __( 'Make shorter', 'jetpack' ),
+					name: MAKE_SHORTER_LABEL,
 					key: QUICK_EDIT_KEY_MAKE_SHORTER,
 					aiSuggestion: PROMPT_TYPE_MAKE_SHORTER,
 					icon: postContent,
 				},
 				{
-					name: __( 'Turn list into a table', 'jetpack' ),
-					key: 'turn-into-table',
+					name: TURN_LIST_INTO_TABLE_LABEL,
+					key: QUICK_EDIT_KEY_TURN_LIST_INTO_TABLE,
 					aiSuggestion: PROMPT_TYPE_TRANSFORM_LIST_TO_TABLE,
 					icon: blockTable,
 					options: {
@@ -150,8 +163,8 @@ const quickActionsList: {
 				// Those actions are transformative in nature and are better suited for the AI Assistant block.
 				// TODO: Keep the action, but transforming the block.
 				{
-					name: __( 'Write a post from this list', 'jetpack' ),
-					key: 'write-post-from-list',
+					name: WRITE_POST_FROM_LIST_LABEL,
+					key: QUICK_EDIT_KEY_WRITE_POST_FROM_LIST,
 					aiSuggestion: PROMPT_TYPE_USER_PROMPT,
 					icon: post,
 					options: {
@@ -253,18 +266,18 @@ export default function AiAssistantToolbarDropdownContent( {
 						onRequestSuggestion(
 							PROMPT_TYPE_CHANGE_TONE,
 							{ tone },
-							`${ TONE_LABEL }: ${ capitalize( tone ) }`
+							mapActionToHumanText( PROMPT_TYPE_CHANGE_TONE, { tone } )
 						);
 					} }
 					disabled={ disabled }
 				/>
 
 				<I18nMenuDropdown
-					onChange={ ( language, name ) => {
+					onChange={ language => {
 						onRequestSuggestion(
 							PROMPT_TYPE_CHANGE_LANGUAGE,
 							{ language },
-							`${ TRANSLATE_LABEL }: ${ name }`
+							mapActionToHumanText( PROMPT_TYPE_CHANGE_LANGUAGE, { language } )
 						);
 					} }
 					disabled={ disabled }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/dropdown-content.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/dropdown-content.tsx
@@ -12,7 +12,6 @@ import {
 	PROMPT_TYPE_CHANGE_LANGUAGE,
 	PROMPT_TYPE_USER_PROMPT,
 	PROMPT_TYPE_TRANSFORM_LIST_TO_TABLE,
-	mapActionToHumanText,
 	CORRECT_SPELLING_LABEL,
 	SIMPLIFY_LABEL,
 	SUMMARIZE_LABEL,
@@ -185,8 +184,7 @@ export type AiAssistantDropdownOnChangeOptionsArgProps = {
 
 export type OnRequestSuggestion = (
 	promptType: PromptTypeProp,
-	options?: AiAssistantDropdownOnChangeOptionsArgProps,
-	humanText?: string
+	options?: AiAssistantDropdownOnChangeOptionsArgProps
 ) => void;
 
 type AiAssistantToolbarDropdownContentProps = {
@@ -248,11 +246,9 @@ export default function AiAssistantToolbarDropdownContent( {
 								iconPosition="left"
 								key={ `key-${ quickAction.key }` }
 								onClick={ () => {
-									onRequestSuggestion(
-										quickAction.aiSuggestion,
-										{ ...( quickAction.options ?? {} ) },
-										quickAction.name
-									);
+									onRequestSuggestion( quickAction.aiSuggestion, {
+										...( quickAction.options ?? {} ),
+									} );
 								} }
 								disabled={ disabled }
 							>
@@ -263,22 +259,14 @@ export default function AiAssistantToolbarDropdownContent( {
 
 				<ToneDropdownMenu
 					onChange={ tone => {
-						onRequestSuggestion(
-							PROMPT_TYPE_CHANGE_TONE,
-							{ tone },
-							mapActionToHumanText( PROMPT_TYPE_CHANGE_TONE, { tone } )
-						);
+						onRequestSuggestion( PROMPT_TYPE_CHANGE_TONE, { tone } );
 					} }
 					disabled={ disabled }
 				/>
 
 				<I18nMenuDropdown
 					onChange={ language => {
-						onRequestSuggestion(
-							PROMPT_TYPE_CHANGE_LANGUAGE,
-							{ language },
-							mapActionToHumanText( PROMPT_TYPE_CHANGE_LANGUAGE, { language } )
-						);
+						onRequestSuggestion( PROMPT_TYPE_CHANGE_LANGUAGE, { language } );
 					} }
 					disabled={ disabled }
 				/>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/i18n-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/i18n-dropdown-control/index.tsx
@@ -1,6 +1,7 @@
 /*
  * External dependencies
  */
+import { LANGUAGE_MAP, TRANSLATE_LABEL } from '@automattic/jetpack-ai-client';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import {
 	MenuItem,
@@ -46,50 +47,9 @@ type LanguageDropdownControlProps = {
 const defaultLanguageLocale =
 	window?.Jetpack_Editor_Initial_State?.siteLocale || navigator?.language;
 
-export const TRANSLATE_LABEL = __( 'Translate', 'jetpack' );
-
 export const defaultLanguage = ( defaultLanguageLocale?.split( '-' )[ 0 ] || 'en' ) as LanguageProp;
 
 export const defaultLocale = defaultLanguageLocale?.split( '-' )?.[ 1 ] || null;
-
-export const LANGUAGE_MAP = {
-	en: {
-		label: __( 'English', 'jetpack' ),
-	},
-	es: {
-		label: __( 'Spanish', 'jetpack' ),
-	},
-	fr: {
-		label: __( 'French', 'jetpack' ),
-	},
-	de: {
-		label: __( 'German', 'jetpack' ),
-	},
-	it: {
-		label: __( 'Italian', 'jetpack' ),
-	},
-	pt: {
-		label: __( 'Portuguese', 'jetpack' ),
-	},
-	ru: {
-		label: __( 'Russian', 'jetpack' ),
-	},
-	zh: {
-		label: __( 'Chinese', 'jetpack' ),
-	},
-	ja: {
-		label: __( 'Japanese', 'jetpack' ),
-	},
-	ar: {
-		label: __( 'Arabic', 'jetpack' ),
-	},
-	hi: {
-		label: __( 'Hindi', 'jetpack' ),
-	},
-	ko: {
-		label: __( 'Korean', 'jetpack' ),
-	},
-};
 
 export const I18nMenuGroup = ( {
 	value,
@@ -107,12 +67,7 @@ export const I18nMenuGroup = ( {
 				return (
 					<MenuItem
 						key={ `key-${ language }` }
-						onClick={ () =>
-							onChange(
-								language + ' (' + LANGUAGE_MAP[ language ].label + ')',
-								LANGUAGE_MAP[ language ].label
-							)
-						}
+						onClick={ () => onChange( language + ' (' + LANGUAGE_MAP[ language ].label + ')' ) }
 						isSelected={ value === language }
 					>
 						{ LANGUAGE_MAP[ language ].label }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/improve-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/improve-dropdown-control/index.tsx
@@ -1,6 +1,11 @@
 /*
  * External dependencies
  */
+import {
+	PROMPT_TYPE_MAKE_LONGER,
+	PROMPT_TYPE_MAKE_SHORTER,
+	PROMPT_TYPE_SUMMARIZE,
+} from '@automattic/jetpack-ai-client';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import {
 	MenuItem,
@@ -14,38 +19,33 @@ import { __ } from '@wordpress/i18n';
 import { pencil } from '@wordpress/icons';
 
 export const IMPROVE_KEY_MAKE_LONGER = 'make-longer' as const;
-const IMPROVE_SUGGESTION_MAKE_LONGER = 'makeLonger' as const;
-
 export const IMPROVE_KEY_MAKE_SHORTER = 'make-shorter' as const;
-const IMPROVE_SUGGESTION_MAKE_SHORTER = 'makeShorter' as const;
-
 export const IMPROVE_KEY_SUMMARIZE = 'summarize' as const;
-const IMPROVE_SUGGESTION_SUMMARIZE = 'summarize' as const;
 
 type ImproveKeyProp =
 	| typeof IMPROVE_KEY_SUMMARIZE
 	| typeof IMPROVE_KEY_MAKE_LONGER
 	| typeof IMPROVE_KEY_MAKE_SHORTER;
 type ImproveSuggestionProp =
-	| typeof IMPROVE_SUGGESTION_SUMMARIZE
-	| typeof IMPROVE_SUGGESTION_MAKE_LONGER
-	| typeof IMPROVE_SUGGESTION_MAKE_SHORTER;
+	| typeof PROMPT_TYPE_SUMMARIZE
+	| typeof PROMPT_TYPE_MAKE_LONGER
+	| typeof PROMPT_TYPE_MAKE_SHORTER;
 
 const quickActionsList = [
 	{
 		name: __( 'Summarize', 'jetpack' ),
 		key: IMPROVE_KEY_SUMMARIZE,
-		aiSuggestion: IMPROVE_SUGGESTION_SUMMARIZE,
+		aiSuggestion: PROMPT_TYPE_SUMMARIZE,
 	},
 	{
 		name: __( 'Make longer', 'jetpack' ),
 		key: IMPROVE_KEY_MAKE_LONGER,
-		aiSuggestion: IMPROVE_SUGGESTION_MAKE_LONGER,
+		aiSuggestion: PROMPT_TYPE_MAKE_LONGER,
 	},
 	{
 		name: __( 'Make shorter', 'jetpack' ),
 		key: IMPROVE_KEY_MAKE_SHORTER,
-		aiSuggestion: IMPROVE_SUGGESTION_MAKE_SHORTER,
+		aiSuggestion: PROMPT_TYPE_MAKE_SHORTER,
 	},
 ];
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/prompt-templates-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/prompt-templates-control/index.tsx
@@ -1,6 +1,20 @@
 /*
  * External dependencies
  */
+import {
+	CORRECT_SPELLING_LABEL,
+	GENERATE_TITLE_LABEL,
+	PROMPT_TYPE_CONTINUE,
+	PROMPT_TYPE_GENERATE_TITLE,
+	PROMPT_TYPE_SUMMARY_BY_TITLE,
+	SIMPLIFY_LABEL,
+	SUMMARIZE_LABEL,
+	SUMMARY_BASED_ON_TITLE_LABEL,
+	CONTINUE_LABEL,
+	PROMPT_TYPE_SUMMARIZE,
+	PROMPT_TYPE_SIMPLIFY,
+	PROMPT_TYPE_CORRECT_SPELLING,
+} from '@automattic/jetpack-ai-client';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { MenuItem, MenuGroup, ToolbarDropdownMenu } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -134,23 +148,23 @@ export default function PromptTemplatesControl( {
 								<MenuItem
 									icon={ postContent }
 									iconPosition="left"
-									onClick={ () => onSuggestionSelect( 'continue' ) }
+									onClick={ () => onSuggestionSelect( PROMPT_TYPE_CONTINUE ) }
 								>
-									{ __( 'Continue writing', 'jetpack' ) }
+									{ CONTINUE_LABEL }
 								</MenuItem>
 								<MenuItem
 									icon={ termDescription }
 									iconPosition="left"
-									onClick={ () => onSuggestionSelect( 'correctSpelling' ) }
+									onClick={ () => onSuggestionSelect( PROMPT_TYPE_CORRECT_SPELLING ) }
 								>
-									{ __( 'Correct spelling and grammar', 'jetpack' ) }
+									{ CORRECT_SPELLING_LABEL }
 								</MenuItem>
 								<MenuItem
 									icon={ post }
 									iconPosition="left"
-									onClick={ () => onSuggestionSelect( 'simplify' ) }
+									onClick={ () => onSuggestionSelect( PROMPT_TYPE_SIMPLIFY ) }
 								>
-									{ __( 'Simplify', 'jetpack' ) }
+									{ SIMPLIFY_LABEL }
 								</MenuItem>
 							</MenuGroup>
 						) }
@@ -160,18 +174,18 @@ export default function PromptTemplatesControl( {
 									<MenuItem
 										icon={ postExcerpt }
 										iconPosition="left"
-										onClick={ () => onSuggestionSelect( 'summarize' ) }
+										onClick={ () => onSuggestionSelect( PROMPT_TYPE_SUMMARIZE ) }
 									>
-										{ __( 'Summarize', 'jetpack' ) }
+										{ SUMMARIZE_LABEL }
 									</MenuItem>
 								) }
 								{ hasContent && (
 									<MenuItem
 										icon={ title }
 										iconPosition="left"
-										onClick={ () => onSuggestionSelect( 'generateTitle' ) }
+										onClick={ () => onSuggestionSelect( PROMPT_TYPE_GENERATE_TITLE ) }
 									>
-										{ __( 'Generate a post title', 'jetpack' ) }
+										{ GENERATE_TITLE_LABEL }
 									</MenuItem>
 								) }
 							</MenuGroup>
@@ -181,9 +195,9 @@ export default function PromptTemplatesControl( {
 								<MenuItem
 									icon={ pencil }
 									iconPosition="left"
-									onClick={ () => onSuggestionSelect( 'titleSummary' ) }
+									onClick={ () => onSuggestionSelect( PROMPT_TYPE_SUMMARY_BY_TITLE ) }
 								>
-									{ __( 'Summary based on title', 'jetpack' ) }
+									{ SUMMARY_BASED_ON_TITLE_LABEL }
 								</MenuItem>
 							) }
 							{ promptTemplates.map( ( prompt: PromptTemplateProps, i: number ) => (

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
@@ -1,7 +1,7 @@
 /*
  * External dependencies
  */
-import { speakToneIcon } from '@automattic/jetpack-ai-client';
+import { PROMPT_TONES_MAP, speakToneIcon, TONE_LABEL } from '@automattic/jetpack-ai-client';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import {
 	MenuItem,
@@ -34,51 +34,6 @@ const PROMPT_TONES_LIST = [
 ] as const;
 
 export const DEFAULT_PROMPT_TONE = 'formal';
-
-export const TONE_LABEL = __( 'Change tone', 'jetpack' );
-
-export const PROMPT_TONES_MAP = {
-	formal: {
-		label: __( 'Formal', 'jetpack' ),
-		emoji: '🎩',
-	},
-	informal: {
-		label: __( 'Informal', 'jetpack' ),
-		emoji: '😊',
-	},
-	optimistic: {
-		label: __( 'Optimistic', 'jetpack' ),
-		emoji: '😃',
-	},
-	humorous: {
-		label: __( 'Humorous', 'jetpack' ),
-		emoji: '😂',
-	},
-	serious: {
-		label: __( 'Serious', 'jetpack' ),
-		emoji: '😐',
-	},
-	skeptical: {
-		label: __( 'Skeptical', 'jetpack' ),
-		emoji: '🤨',
-	},
-	empathetic: {
-		label: __( 'Empathetic', 'jetpack' ),
-		emoji: '💗',
-	},
-	confident: {
-		label: __( 'Confident', 'jetpack' ),
-		emoji: '😎',
-	},
-	passionate: {
-		label: __( 'Passionate', 'jetpack' ),
-		emoji: '❤️',
-	},
-	provocative: {
-		label: __( 'Provocative', 'jetpack' ),
-		emoji: '🔥',
-	},
-};
 
 export type ToneProp = ( typeof PROMPT_TONES_LIST )[ number ];
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/toolbar-controls/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/toolbar-controls/index.js
@@ -1,6 +1,10 @@
 /**
  * External dependencies
  */
+import {
+	PROMPT_TYPE_CHANGE_TONE,
+	PROMPT_TYPE_CHANGE_LANGUAGE,
+} from '@automattic/jetpack-ai-client';
 import { BlockControls } from '@wordpress/block-editor';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -8,7 +12,6 @@ import { update, check } from '@wordpress/icons';
 /*
  * Internal dependencies
  */
-import { PROMPT_TYPE_CHANGE_TONE, PROMPT_TYPE_CHANGE_LANGUAGE } from '../../lib/prompt';
 import I18nDropdownControl from '../i18n-dropdown-control';
 import ImproveToolbarDropdownMenu from '../improve-dropdown-control';
 import PromptTemplatesControl from '../prompt-templates-control';

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -6,6 +6,7 @@ import {
 	UpgradeMessage,
 	renderHTMLFromMarkdown,
 	PROMPT_TYPE_GENERATE_TITLE,
+	mapActionToHumanText,
 } from '@automattic/jetpack-ai-client';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
@@ -53,6 +54,8 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 
 	const { replaceBlocks, removeBlock } = useDispatch( 'core/block-editor' );
 	const { editPost } = useDispatch( 'core/editor' );
+
+	const [ lastAction, setLastAction ] = useState( null );
 
 	const {
 		isOverLimit,
@@ -217,6 +220,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 	};
 
 	const handleSend = () => {
+		setLastAction( attributes.userPrompt );
 		handleGetSuggestion( 'userPrompt' );
 		tracks.recordEvent( 'jetpack_ai_assistant_block_generate', { feature: 'ai-assistant' } );
 	};
@@ -293,6 +297,12 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 		stopSuggestion();
 		focusOnPrompt();
 		tracks.recordEvent( 'jetpack_ai_assistant_block_stop', { feature: 'ai-assistant' } );
+	};
+
+	const handleGetSuggestionFromToolbar = ( type, options ) => {
+		const humanText = mapActionToHumanText( type, options );
+		setLastAction( humanText );
+		getSuggestionFromOpenAI( type, options );
 	};
 
 	const blockProps = useBlockProps( {
@@ -390,7 +400,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 					<ToolbarControls
 						isWaitingState={ isLoadingCompletion }
 						contentIsLoaded={ contentIsLoaded }
-						getSuggestionFromOpenAI={ getSuggestionFromOpenAI }
+						getSuggestionFromOpenAI={ handleGetSuggestionFromToolbar }
 						retryRequest={ retryRequest }
 						handleAcceptContent={ handleAcceptContent }
 						handleAcceptTitle={ handleAcceptTitle }
@@ -446,6 +456,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 							/>
 						) : null
 					}
+					lastAction={ lastAction }
 				/>
 			</div>
 		</KeyboardShortcuts>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -5,6 +5,7 @@ import {
 	BlockAIControl,
 	UpgradeMessage,
 	renderHTMLFromMarkdown,
+	PROMPT_TYPE_GENERATE_TITLE,
 } from '@automattic/jetpack-ai-client';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
@@ -192,7 +193,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 		return lastEditableElement;
 	};
 
-	const isGeneratingTitle = attributes.promptType === 'generateTitle';
+	const isGeneratingTitle = attributes.promptType === PROMPT_TYPE_GENERATE_TITLE;
 
 	const acceptContentLabel = __( 'Accept', 'jetpack' );
 	const acceptTitleLabel = __( 'Accept title', 'jetpack' );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/components/ai-assistant-input/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/components/ai-assistant-input/index.tsx
@@ -35,6 +35,7 @@ export type AiAssistantInputProps = {
 	close?: () => void;
 	undo?: () => void;
 	tryAgain?: () => void;
+	lastAction?: string;
 };
 
 const defaultClassNames = clsx(
@@ -57,6 +58,7 @@ export default function AiAssistantInput( {
 	close,
 	undo,
 	tryAgain,
+	lastAction,
 }: AiAssistantInputProps ): ReactElement {
 	const defaultPlaceholder = customPlaceholder
 		? customPlaceholder
@@ -102,8 +104,11 @@ export default function AiAssistantInput( {
 			block_type: blockType,
 		} );
 
+		// Reset the placeholder to the default placeholder.
+		setPlaceholder( defaultPlaceholder );
+
 		stopSuggestion?.();
-	}, [ blockType, stopSuggestion, tracks ] );
+	}, [ blockType, defaultPlaceholder, stopSuggestion, tracks ] );
 
 	function handleClose(): void {
 		close?.();
@@ -188,6 +193,7 @@ export default function AiAssistantInput( {
 			onTryAgain={ handleTryAgain }
 			wrapperRef={ wrapperRef }
 			ref={ inputRef }
+			lastAction={ lastAction }
 		/>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/components/ai-assistant-input/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/components/ai-assistant-input/index.tsx
@@ -194,6 +194,7 @@ export default function AiAssistantInput( {
 			wrapperRef={ wrapperRef }
 			ref={ inputRef }
 			lastAction={ lastAction }
+			blockType={ blockType }
 		/>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/components/ai-assistant-toolbar-dropdown/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/components/ai-assistant-toolbar-dropdown/index.tsx
@@ -49,7 +49,6 @@ function AiAssistantExtensionToolbarDropdownContent( {
 		( request?: {
 			promptType: PromptTypeProp;
 			options?: AiAssistantDropdownOnChangeOptionsArgProps;
-			humanText?: string;
 		} ) => {
 			const selectedBlockIds = getSelectedBlockClientIds();
 			const [ clientId ] = selectedBlockIds;
@@ -62,7 +61,7 @@ function AiAssistantExtensionToolbarDropdownContent( {
 			) {
 				// If there is only one selected block or the block cannot be transformed, proceed to open the extension input.
 				if ( request ) {
-					onRequestSuggestion?.( request.promptType, request.options, request.humanText );
+					onRequestSuggestion?.( request.promptType, request.options );
 				} else {
 					onAskAiAssistant?.();
 				}
@@ -83,8 +82,8 @@ function AiAssistantExtensionToolbarDropdownContent( {
 		]
 	);
 
-	const handleRequestSuggestion: OnRequestSuggestion = ( promptType, options, humanText ) => {
-		handleToolbarButtonClick( { promptType, options, humanText } );
+	const handleRequestSuggestion: OnRequestSuggestion = ( promptType, options ) => {
+		handleToolbarButtonClick( { promptType, options } );
 	};
 
 	const handleAskAiAssistant = async () => {
@@ -142,13 +141,13 @@ export default function AiAssistantExtensionToolbarDropdown( {
 	}, [ blockType, onAskAiAssistant, tracks ] );
 
 	const handleRequestSuggestion = useCallback< OnRequestSuggestion >(
-		( promptType, options, humanText ) => {
+		( promptType, options ) => {
 			tracks.recordEvent( 'jetpack_editor_ai_assistant_extension_toolbar_button_click', {
 				suggestion: promptType,
 				block_type: blockType,
 			} );
 
-			onRequestSuggestion?.( promptType, options, humanText );
+			onRequestSuggestion?.( promptType, options );
 		},
 		[ blockType, onRequestSuggestion, tracks ]
 	);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
@@ -87,6 +87,8 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		const chatHistory = useRef< PromptMessagesProp >( [] );
 		// A human-readable action to be displayed in the input when a toolbar suggestion is requested, like "Translate: Japanese".
 		const [ action, setAction ] = useState< string >( '' );
+		// The last human-readable action performed by the user, to be used by the thumbs up/down buttons.
+		const [ lastAction, setLastAction ] = useState< string | null >( null );
 		// The last request made by the user, to be used when the user clicks the "Try Again" button.
 		const lastRequest = useRef< RequestOptions | null >( null );
 		// Ref to the requesting state to use it in the hideOnBlockFocus effect.
@@ -320,6 +322,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 
 				if ( humanText ) {
 					setAction( humanText );
+					setLastAction( humanText );
 				}
 
 				const messages = getRequestMessages( { promptType, options } );
@@ -348,6 +351,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			( userPrompt: string ) => {
 				const promptType = 'userPrompt';
 				const options = { userPrompt };
+				setLastAction( userPrompt );
 
 				enableAutoScroll();
 				handleRequestSuggestion( promptType, options );
@@ -515,6 +519,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 						close={ handleClose }
 						undo={ handleUndo }
 						tryAgain={ handleTryAgain }
+						lastAction={ lastAction }
 					/>
 				) }
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
@@ -4,6 +4,7 @@
 import {
 	ERROR_NETWORK,
 	ERROR_QUOTA_EXCEEDED,
+	mapActionToHumanText,
 	useAiSuggestions,
 } from '@automattic/jetpack-ai-client';
 import { BlockControls, useBlockProps } from '@wordpress/block-editor';
@@ -307,13 +308,15 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 
 		// Called when a suggestion from the toolbar is requested, like "Change tone".
 		const handleRequestSuggestion = useCallback< OnRequestSuggestion >(
-			( promptType, options, humanText ) => {
+			( promptType, options ) => {
 				setShowAiControl( true );
 
 				// If the user needs to upgrade, don't make the request, but show the input with the upgrade message.
 				if ( requireUpgrade ) {
 					return;
 				}
+
+				const humanText = mapActionToHumanText( promptType, options );
 
 				if ( humanText ) {
 					setAction( humanText );
@@ -363,11 +366,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		// Called when the user clicks the "Try Again" button in the input error message.
 		const handleTryAgain = useCallback( () => {
 			if ( lastRequest.current ) {
-				handleRequestSuggestion(
-					lastRequest.current.promptType,
-					lastRequest.current.options,
-					lastRequest.current.humanText
-				);
+				handleRequestSuggestion( lastRequest.current.promptType, lastRequest.current.options );
 			}
 		}, [ lastRequest, handleRequestSuggestion ] );
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-assistant/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-assistant/index.js
@@ -9,6 +9,7 @@ import {
 	ERROR_QUOTA_EXCEEDED,
 	ERROR_SERVICE_UNAVAILABLE,
 	ERROR_UNCLEAR_PROMPT,
+	PROMPT_TYPE_GENERATE_TITLE,
 } from '@automattic/jetpack-ai-client';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useRef } from '@wordpress/element';
@@ -207,7 +208,7 @@ const useAIAssistant = ( {
 				options,
 				userPrompt: options?.userPrompt || userPrompt,
 				type,
-				isGeneratingTitle: attributes.promptType === 'generateTitle',
+				isGeneratingTitle: attributes.promptType === PROMPT_TYPE_GENERATE_TITLE,
 			} );
 
 			/*
@@ -226,7 +227,7 @@ const useAIAssistant = ( {
 			setLastPrompt( prompt );
 
 			// If it is a title generation, keep the prompt type in subsequent changes.
-			if ( attributes.promptType !== 'generateTitle' ) {
+			if ( attributes.promptType !== PROMPT_TYPE_GENERATE_TITLE ) {
 				updateBlockAttributes( clientId, { promptType: type } );
 			}
 		} else {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/backend-prompt.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/backend-prompt.ts
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
 import {
 	PROMPT_TYPE_SUMMARY_BY_TITLE,
@@ -14,10 +14,11 @@ import {
 	PROMPT_TYPE_CHANGE_LANGUAGE,
 	PROMPT_TYPE_USER_PROMPT,
 	PROMPT_TYPE_TRANSFORM_LIST_TO_TABLE,
-	PromptTypeProp,
-	PromptItemProps,
-	BuildPromptProps,
-} from './index';
+} from '@automattic/jetpack-ai-client';
+/**
+ * Internal dependencies
+ */
+import { PromptTypeProp, PromptItemProps, BuildPromptProps } from './index';
 
 /**
  * Constants

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -1,6 +1,21 @@
 /**
  * Internal dependencies
  */
+import {
+	PROMPT_TYPE_SUMMARIZE,
+	PROMPT_TYPE_CORRECT_SPELLING,
+	PROMPT_TYPE_USER_PROMPT,
+	PROMPT_TYPE_GENERATE_TITLE,
+	PROMPT_TYPE_MAKE_SHORTER,
+	PROMPT_TYPE_SUMMARY_BY_TITLE,
+	PROMPT_TYPE_TRANSFORM_LIST_TO_TABLE,
+	PROMPT_TYPE_CONTINUE,
+	PROMPT_TYPE_SIMPLIFY,
+	PROMPT_TYPE_MAKE_LONGER,
+	PROMPT_TYPE_CHANGE_TONE,
+	PROMPT_TYPE_CHANGE_LANGUAGE,
+	PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT,
+} from '@automattic/jetpack-ai-client';
 import { ToneProp } from '../../components/tone-dropdown-control';
 import {
 	buildInitialMessageForBackendPrompt,
@@ -9,20 +24,6 @@ import {
 /**
  * Types & consts
  */
-export const PROMPT_TYPE_SUMMARY_BY_TITLE = 'titleSummary' as const;
-export const PROMPT_TYPE_CONTINUE = 'continue' as const;
-export const PROMPT_TYPE_SIMPLIFY = 'simplify' as const;
-export const PROMPT_TYPE_CORRECT_SPELLING = 'correctSpelling' as const;
-export const PROMPT_TYPE_GENERATE_TITLE = 'generateTitle' as const;
-export const PROMPT_TYPE_MAKE_LONGER = 'makeLonger' as const;
-export const PROMPT_TYPE_MAKE_SHORTER = 'makeShorter' as const;
-export const PROMPT_TYPE_CHANGE_TONE = 'changeTone' as const;
-export const PROMPT_TYPE_SUMMARIZE = 'summarize' as const;
-export const PROMPT_TYPE_CHANGE_LANGUAGE = 'changeLanguage' as const;
-export const PROMPT_TYPE_USER_PROMPT = 'userPrompt' as const;
-export const PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT = 'jetpackFormCustomPrompt' as const;
-export const PROMPT_TYPE_TRANSFORM_LIST_TO_TABLE = 'transformListToTable' as const;
-
 export const PROMPT_TYPE_LIST = [
 	PROMPT_TYPE_SUMMARY_BY_TITLE,
 	PROMPT_TYPE_CONTINUE,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/capitalize.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/capitalize.ts
@@ -1,7 +1,0 @@
-export function capitalize( text: string ) {
-	if ( ! text || typeof text !== 'string' ) {
-		return '';
-	}
-
-	return text.charAt( 0 ).toUpperCase() + text.slice( 1 );
-}

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/index.tsx
@@ -1,21 +1,15 @@
 /*
  * External dependencies
  */
-import { aiAssistantIcon } from '@automattic/jetpack-ai-client';
+import { aiAssistantIcon, LANGUAGE_MAP, PROMPT_TONES_MAP } from '@automattic/jetpack-ai-client';
 import { RangeControl, Button, BaseControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import React from 'react';
 /**
  * Internal dependencies
  */
-import {
-	I18nMenuDropdown,
-	LANGUAGE_MAP,
-} from '../../../../blocks/ai-assistant/components/i18n-dropdown-control';
-import {
-	PROMPT_TONES_MAP,
-	ToneDropdownMenu,
-} from '../../../../blocks/ai-assistant/components/tone-dropdown-control';
+import { I18nMenuDropdown } from '../../../../blocks/ai-assistant/components/i18n-dropdown-control';
+import { ToneDropdownMenu } from '../../../../blocks/ai-assistant/components/tone-dropdown-control';
 /**
  * Types and constants
  */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #40734 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves the prompt types to AI Client
* Changes thumbs prompt implementation on extensions away from relying on the placeholder
* Adds a `lastAction` state to the block and the extensions to track the prompt on the thumbs event
* Adds the block type to the event parameters

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor with the thumbs feedback feature enabled
* Use the AI Assistant block and its extensions
* After a request, open the deveoper console and click on a feedback icon
* Check that the event has the block type and the prompt, which is either a user prompt or a mapping of the toolbar action used, like "Translate: Korean"
* Since some data was moved around, check that the AI Assistant and the extensions work as expected.

**Known issue**: The feedback is not displayed when using the list to table feature yet