### PR TITLE
AI Assistant: Add thumbs feedback for list-to-table feature

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-thumbs-prompt-list-to-table
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-thumbs-prompt-list-to-table
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Add thumbs feedback for list-to-table feature

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/block.json
@@ -45,6 +45,11 @@
 		"requestingState": {
 			"type": "string",
 			"default": "init"
+		},
+
+		"preTransformAction": {
+			"type": "string",
+			"default": null
 		}
 	},
 	"example": {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -55,7 +55,9 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 	const { replaceBlocks, removeBlock } = useDispatch( 'core/block-editor' );
 	const { editPost } = useDispatch( 'core/editor' );
 
-	const [ lastAction, setLastAction ] = useState( null );
+	const [ lastAction, setLastAction ] = useState(
+		mapActionToHumanText( attributes.preTransformAction )
+	);
 
 	const {
 		isOverLimit,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-transform-to-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-transform-to-assistant/index.ts
@@ -96,6 +96,7 @@ const useTransformToAssistant = () => {
 			const extendedBlockAttributes = {
 				...( firstBlock?.attributes || {} ), // firstBlock.attributes should never be undefined, but still add a fallback
 				content,
+				preTransformAction: request?.promptType,
 			};
 
 			const newAIAssistantBlock = transformToAIAssistantBlock(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes an issue from https://github.com/Automattic/jetpack/pull/40746 where the "Transform list to table" feature did not have the thumbs feedback

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `preTransformAction` attribute to AI Assistant block
* Populate it when transforming

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor with the thumbs feedback feature enabled
* Create a list
* Use the Transform List to Table toolbar action
* Check that the thumbs feedback icons are there
* Give a feedback
* Check that the event was sent with "Turn list into a table" as its prompt
