### PR TITLE
Jetpack AI: Adding AI feedback to Write Brief features

### DIFF
--- a/projects/plugins/jetpack/changelog/change-jetpack-ai-write-brief-ai-feedback
+++ b/projects/plugins/jetpack/changelog/change-jetpack-ai-write-brief-ai-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Adding AI feedback to Write Brief features

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/index.tsx
@@ -349,7 +349,7 @@ export default function Highlight() {
 							<div className="jetpack-ai-breve__helper-inner">
 								<AiFeedbackThumbs
 									disabled={ ! hasSuggestions }
-									ratedItem={ suggestions?.id }
+									ratedItem={ id }
 									iconSize={ 18 }
 									feature="write-brief"
 									options={ {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fixes } from '@automattic/jetpack-ai-client';
+import { fixes, Block, AiFeedbackThumbs } from '@automattic/jetpack-ai-client';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { rawHandler, serialize } from '@wordpress/blocks';
 import { Button, Popover, Spinner } from '@wordpress/components';
@@ -31,7 +31,6 @@ import './style.scss';
  * Types
  */
 import type { BreveDispatch, BreveSelect } from '../types';
-import type { Block } from '@automattic/jetpack-ai-client';
 
 type CoreBlockEditorSelect = {
 	getBlock: ( clientId: string ) => Block;
@@ -347,10 +346,22 @@ export default function Highlight() {
 									? __( 'Click on the suggestion to insert it.', 'jetpack' )
 									: description ) }
 
-							<div className="jetpack-ai-breve__helper-buttons-wrapper">
-								<Button variant="link" onClick={ handleIgnoreSuggestion }>
-									{ __( 'Ignore', 'jetpack' ) }
-								</Button>
+							<div className="jetpack-ai-breve__helper-inner">
+								<AiFeedbackThumbs
+									disabled={ ! hasSuggestions }
+									ratedItem={ suggestions?.id }
+									iconSize={ 18 }
+									feature="write-brief"
+									options={ {
+										prompt: feature,
+									} }
+								/>
+
+								<div className="jetpack-ai-breve__helper-buttons-wrapper">
+									<Button variant="link" onClick={ handleIgnoreSuggestion }>
+										{ __( 'Ignore', 'jetpack' ) }
+									</Button>
+								</div>
 							</div>
 						</div>
 					</div>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/style.scss
@@ -149,9 +149,26 @@
 				gap: 16px;
 			}
 
+			.jetpack-ai-breve__helper-inner {
+				display: flex;
+				gap: 8px;
+			}
+
 			.components-button {
 				padding: 0px;
 				color: #646970;
+			}
+
+			.ai-assistant-feedback {
+				&__selection {
+					.components-button:not(:disabled):hover {
+						color: var( --wp-components-color-accent, var( --wp-admin-theme-color, #3858e9 ) );
+					}
+				}
+
+				&__thumb-selected {
+					color: var( --wp-components-color-accent, var( --wp-admin-theme-color, #3858e9 ) );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #[40573](https://github.com/Automattic/jetpack/issues/40573)

## Proposed changes:
* Adds AI feedback (thumbs up/down) to Write Brief

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Go to the block editor with the AI feedback feature turned on
* Ensure Write Brief features are turned on
* Write something that will cause spelling mistakes / complex words / long sentences / unconfident words to trigger (it's important to test all of them just to verify that the layout looks correct).
* Upon hovering over the underlined text, the thumbs up/down should be present but disabled (clicking or hovering over them should cause no changes). Note that in the case of spelling errors, the spelling suggestions will auto-populate so the thumbs should be active.
* After clicking the "Suggest" button and getting a suggestion, the thumbs should not be active. Hovering over them should change their color, and clicking should do the same as well as make a request.

## Limitations
* Currently the ratings do not persist once the popover has been destroyed. I will create an issue to fix this and it can be prioritized later.
