### PR TITLE
Social | Update support link on admin page to jetpack support instead of WPCOM support

### DIFF
--- a/projects/plugins/social/changelog/update-social-support-link
+++ b/projects/plugins/social/changelog/update-social-support-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social admin page: Ensure the support link points to Jetpack support

--- a/projects/plugins/social/src/js/components/support-section/index.js
+++ b/projects/plugins/social/src/js/components/support-section/index.js
@@ -38,7 +38,7 @@ const SupportSection = () => {
 					) }
 				</Text>
 				<Text className={ styles.link }>
-					<ExternalLink href={ getRedirectUrl( 'https://wordpress.com/support' ) }>
+					<ExternalLink href={ getRedirectUrl( 'jetpack-contact-support' ) }>
 						{ __( 'Contact Support', 'jetpack-social' ) }
 					</ExternalLink>
 				</Text>


### PR DESCRIPTION
The support link on the social admin page wrongly points to WPCOM support instead of Jetpack support.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update support link on Social admin page to jetpack support instead of WPCOM support

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Get a paid Social plan for the site if not already active
* Go to Social admin page
* Confirm that the "Contact Support" link goes to Jetpack support instead of WPCOM support

<img width="832" alt="image" src="https://github.com/user-attachments/assets/81d45dab-6798-4563-9412-19c263a09e43" />


