### PR TITLE
Fix/form block submit button styles when errors

### DIFF
--- a/projects/packages/forms/changelog/fix-form-block-submit-button-styles-when-errors
+++ b/projects/packages/forms/changelog/fix-form-block-submit-button-styles-when-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Form block: Fix submit button styles when there are errors

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -321,16 +321,16 @@
 .contact-form .contact-form__select-wrapper::after {
 	position: absolute;
 	inset-inline-end: calc(var(--jetpack--contact-form--input-padding-left) + 4px);
-	top: calc(var(--jetpack--contact-form--input-padding-top) + var(--jetpack--contact-form--line-height) / 2);  
+	top: calc(var(--jetpack--contact-form--input-padding-top) + var(--jetpack--contact-form--line-height) / 2);
 
   content: "";
   display: block;
 	width: 8px;
 	height: 8px;
-  
+
 	border-bottom: 2px solid;
   border-right: 2px solid;
-  
+
 	transform: translateY(-50%) rotate(45deg);
 	transform-origin: center center;
 
@@ -594,7 +594,7 @@ on production builds, the attributes are being reordered, causing side-effects
 
 .contact-form .grunion-field-wrap input.checkbox-multiple:checked::before {
 	content: "\2713";
-	
+
 	position: absolute;
 	top: calc(var(--jetpack--contact-form--font-size) / 2);
 	left: calc(var(--jetpack--contact-form--font-size) / 2);
@@ -603,7 +603,7 @@ on production builds, the attributes are being reordered, causing side-effects
 
 	font-size: var(--jetpack--contact-form--font-size);
 	line-height: 1;
-	
+
   transform: translate(-50%, -50%);
 }
 
@@ -714,7 +714,6 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .contact-form__error {
-	margin-bottom: var(--wp--style--block-gap, 1.5rem);
 	padding: 1em;
 	gap: var(--warning-icon-margin);
 

--- a/projects/packages/forms/src/contact-form/js/accessible-form.js
+++ b/projects/packages/forms/src/contact-form/js/accessible-form.js
@@ -897,7 +897,7 @@ const setFormError = ( form, invalidFields, opts = {} ) => {
 		const submitBtn = getFormSubmitBtn( form );
 
 		if ( submitBtn ) {
-			submitBtn.parentNode.insertBefore( error, submitBtn );
+			submitBtn.parentNode.parentNode.insertBefore( error, submitBtn.parentNode );
 		} else {
 			form.appendChild( error );
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes: https://github.com/Automattic/jetpack/issues/40753

## Proposed changes:
After this [GB change](https://github.com/WordPress/gutenberg/pull/64770) button block styles were affected to stretch properly in flex containers. This resulted in the linked issue, where when we have required fields in a form and submit the form with expecting errors, the `submit` button has 'broken' styles.

A css solution could also be explored here, but I thought it makes more sense semantically to append the errors element outside the `wp-block-jetpack-button wp-block-button` container. 

I'm new to Jetpack codebase so I might be missing context for the original decision to add the errors inside that container, but I'm not sure if it affects other things. I think not though by my testing, as if I understand correctly we always have `wp-block-jetpack-button wp-block-button` container, if we have a submit button. I'd love some testing/input from experienced Jetpack contributors.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:

In order to see the 'broken' styles you need to have Gutenberg activated.

- Insert a `Form block` with required fields and a submit button. The `contact form` should be enough.
- In front-end submit the form with errors - for example empty
- Observe that the styles are not broken
- Test the same without Gutenberg activated and you should see no visual changes or errors. It's just that `errors` are rendered in a different position.

Before     | After
:-------------------------:|:-------------------------:
<img width="636" alt="Screenshot 2024-12-30 at 9 55 49 AM" src="https://github.com/user-attachments/assets/3608fe04-79cf-4310-90c6-61dd4dec2464" /> | <img width="636" alt="after" src="https://github.com/user-attachments/assets/35611f86-921f-4dd1-a375-611fb40fa209" />



