### PR TITLE
Jetpack AI: Enable ratings feedback thumbs for all

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-enable-feedback
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-enable-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Enable ratings feedback thumbs for all

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -219,7 +219,7 @@ add_action(
 	'jetpack_register_gutenberg_extensions',
 	function () {
 		if ( apply_filters( 'jetpack_ai_enabled', true ) &&
-			apply_filters( 'ai_response_feedback_enabled', false )
+			apply_filters( 'ai_response_feedback_enabled', true )
 		) {
 			\Jetpack_Gutenberg::set_extension_available( 'ai-response-feedback' );
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #[40769](https://github.com/Automattic/jetpack/issues/40769)

## Proposed changes:
* Enables the `ai-response-feedback` feature flag.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Check out this branch and verify that the snippet used for previous tests of this feature is not enabled
* Use Jetpack AI and observe the thumbs up/down are available and function as expected
