### PR TITLE
Jetpack AI: Switch tracking data to snake_case to maintain Tracks' required property format

### DIFF
--- a/projects/js-packages/ai-client/changelog/change-jetpack-ai-fix-tracks-fields
+++ b/projects/js-packages/ai-client/changelog/change-jetpack-ai-fix-tracks-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack AI: Switch tracking data to camel_case to maintain Tracks' required property format

--- a/projects/js-packages/ai-client/src/components/ai-feedback/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-feedback/index.tsx
@@ -96,9 +96,9 @@ export default function AiFeedbackThumbs( {
 			tracks.recordEvent( 'jetpack_ai_feedback', {
 				type: feature,
 				rating: aiRating,
-				mediaLibraryId: options.mediaLibraryId || null,
+				media_library_id: options.mediaLibraryId || null,
 				prompt: options.prompt || null,
-				revisedPrompt: options.revisedPrompt || null,
+				revised_prompt: options.revisedPrompt || null,
 				block: options.block || null,
 			} );
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changing camelCase properties to snake_case as required by Tracks

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With the thumbs up/down component enabled, go to any AI generated item (or generate your own)
* Open the developer console and click a thumb. Verify that the data sent contains properties named `media_library_id` and `revised_prompt` and not their previous camelCase versions.

