### PR TITLE
Tests: Fix 31 December bug

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-tests-31_dec_coupon_price_bug
+++ b/projects/packages/my-jetpack/changelog/fix-tests-31_dec_coupon_price_bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tests: Fix failure on 31 December.

--- a/projects/packages/my-jetpack/tests/php/test-wpcom-products.php
+++ b/projects/packages/my-jetpack/tests/php/test-wpcom-products.php
@@ -108,8 +108,9 @@ class Test_Wpcom_Products extends TestCase {
 				'currency_code'          => 'BRL',
 				'product_term'           => 'month',
 				'sale_coupon'            => (object) array(
-					'start_date' => gmdate( 'Y' ) . '-01-01',
-					'expires'    => gmdate( 'Y' ) . '-12-31',
+					// Random dates (or are they?) so we always get the sale price.
+					'start_date' => '2003-05-27',
+					'expires'    => '2063-04-05',
 					'discount'   => 50,
 				),
 			),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

A coupon test was failing today (31 December) because the expiration of the coupon was set to "31 December of current year" (which would mean `0:00`). I changed the dates of the coupon so it should be valid longer than the test's lifespan.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

In `projects/packages/my-jetpack`, run the following:

```
composer test-php
```

In `trunk` this will fail. In the `fix/tests/31_dec_coupon_price_bug` branch all is well.

