### PR TITLE
Resolves #40765 - Prevent SoundCloud shortcode conflict

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-40765-prevent_soundcloud_shortcode_conflict
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-40765-prevent_soundcloud_shortcode_conflict
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Shortcodes: Prevent conflict with third-party SoundCloud shortcodes.

--- a/projects/plugins/jetpack/modules/shortcodes.php
+++ b/projects/plugins/jetpack/modules/shortcodes.php
@@ -46,12 +46,20 @@ function shortcode_new_to_old_params( $params, $old_format_support = false ) {
  * Load all available Jetpack shortcode files.
  */
 function jetpack_load_shortcodes() {
+	// Prevent third-party shortcode plugins when loading shortcode files.
+	// shortcode => condition_when_to_skip
+	$shortcode_skips = array(
+		'soundcloud' => function_exists( 'soundcloud_shortcode' ), // SoundCloud Shortcodes
+	);
+
 	$shortcode_includes = array();
 
 	foreach ( Jetpack::glob_php( __DIR__ . '/shortcodes' ) as $file ) {
 		$filename = substr( basename( $file ), 0, -4 );
 
-		$shortcode_includes[ $filename ] = $file;
+		if ( empty( $shortcode_skips[ $filename ] ) ) {
+			$shortcode_includes[ $filename ] = $file;
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/shortcodes.php
+++ b/projects/plugins/jetpack/modules/shortcodes.php
@@ -47,9 +47,9 @@ function shortcode_new_to_old_params( $params, $old_format_support = false ) {
  */
 function jetpack_load_shortcodes() {
 	// Prevent third-party shortcode plugins when loading shortcode files.
-	// shortcode => condition_when_to_skip
+	// Format: shortcode => condition_when_to_skip
 	$shortcode_skips = array(
-		'soundcloud' => function_exists( 'soundcloud_shortcode' ), // SoundCloud Shortcodes
+		'soundcloud' => function_exists( 'soundcloud_shortcode' ), // SoundCloud Shortcodes plugin
 	);
 
 	$shortcode_includes = array();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves #40765 - Prevent SoundCloud shortcode conflict

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When the SoundCloud Shortcode plugin is installed, it declares the same function as Jetpack does in the shortcodes module. This PR adds the ability to skip shortcodes based on a specified condition.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Install SoundCloud Shortcode plugin: https://wordpress.org/plugins/soundcloud-shortcode/
2. Enable the shortcodes module in Jetpack: /wp-admin/admin.php?page=jetpack#/settings?term=shortcodes

In `trunk` this gives a fatal:
```
PHP Fatal error:  Cannot redeclare soundcloud_shortcode() (previously declared in /srv/htdocs/wp-content/plugins/soundcloud-shortcode/soundcloud-shortcode.php:63) in /srv/htdocs/wp-content/plugins/jetpack/modules/shortcodes/soundcloud.php on line 32
```

In the `fix/jetpack/40765-prevent_soundcloud_shortcode_conflict` branch the Jetpack shortcode file is not loaded in deference to the third-party plugin.
