### PR TITLE
Resolves #40766 - Prevent TypeError in VideoPress shortcode

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-40766-catch_typeerror
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-40766-catch_typeerror
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+VideoPress: Catch TypeError when theme specifies $content_width as a string.

--- a/projects/plugins/jetpack/modules/videopress/shortcode.php
+++ b/projects/plugins/jetpack/modules/videopress/shortcode.php
@@ -127,7 +127,7 @@ class VideoPress_Shortcode {
 		 * If there was an invalid or unspecified width, set the width equal to the theme's `$content_width`.
 		 */
 		if ( 0 === $attr['width'] && isset( $content_width ) && $content_width >= VIDEOPRESS_MIN_WIDTH ) {
-			$attr['width'] = $content_width;
+			$attr['width'] = (int) $content_width;
 		}
 
 		/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves #40766 - Prevent TypeError in VideoPress shortcode

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If `$attr['width']` was a string, and the modulus operator was attempted on it, it gave a TypeError in PHP 8.x.

There was only one place in the code where the value could be set as a string: the `$content_width`. This is set in one's theme. This PR casts that value to an `int`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Per the provided log, it seems the `alchemists` theme is a third-party one that is not available in WP.org, so I wasn't able to install/confirm with that. That said, I'm pretty confident in the fix.