### PR TITLE
Resolves #40767 - Prevent error with http_request_timeout filter

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-40767-prevent_error_on_http_override_filter
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-40767-prevent_error_on_http_override_filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Filters: Prevent error when `http_request_timeout` filter is used incorrectly.

--- a/projects/plugins/jetpack/modules/shortcodes/others.php
+++ b/projects/plugins/jetpack/modules/shortcodes/others.php
@@ -26,7 +26,7 @@ wp_oembed_add_provider( '#https?://(www\.)?loom\.com/share/.*#i', 'https://www.l
  *
  * @return int The timeout value in seconds.
  */
-function jetpack_oembed_timeout_override( $timeout, $url ) {
+function jetpack_oembed_timeout_override( $timeout, $url = '' ) {
 	if (
 		is_string( $url )
 		&& str_contains( $url, 'iwmb.icloud.com' )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves #40767 - Prevent error on http_request_timeout filter

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If the `http_request_timeout` filter is applied without passing a `$url` param, it causes a PHP fatal. While we can't fix the call, we can prevent the error by setting `$url` to a blank string by default.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The two known reports involved the Kallyas theme, and in theory the issue was resolved over a year ago:

https://wordpress.org/support/topic/too-few-arguments-to-function-jetpack_oembed_timeout-others-php-line-29/#post-17128228

Likely someone didn't update their theme and it's not in the WP.org repo, so we can't test directly. However, if you add the following code snippet you should be able to confirm there's an error in `trunk` and no error in the `fix/jetpack/40767-prevent_error_on_http_override_filter` branch:

```
function timeout_filter_trigger() {
	$timeout = apply_filters( 'http_request_timeout', 5 );
	error_log(var_export($timeout, true));
}
add_action( 'wp_footer', 'timeout_filter_trigger', 10, 1 );
```