### PR TITLE
AI Client: add first logo generation style

### DIFF
--- a/projects/js-packages/ai-client/changelog/fix-jetpack-ai-first-logo-generation-style
+++ b/projects/js-packages/ai-client/changelog/fix-jetpack-ai-first-logo-generation-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Client: add style parameter to first logo generator so it doesn't fall in a dall-e situation

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -91,7 +91,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 
 			// Then generate the logo based on the prompt.
 			setLoadingState( 'generating' );
-			await generateLogo( { prompt } );
+			await generateLogo( { prompt, style: 'none' } );
 			setLoadingState( null );
 		} catch ( error ) {
 			debug( 'Error generating first logo', error );


### PR DESCRIPTION
## Proposed changes:
Add `style` parameter as `none` of first logo generation (auto) so we use the new FLUX pipeline

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1735756215761019-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Use a site with title and description. Make sure you don't have a logo history for the site (clear logo-history-**** entry on localStorage).

Add a logo block and click on AI toolbar button. Upon first opening a logo generation should trigger. Check on the resulting image and verify it wasn't generated by Dall-e. You can check this logstash link (make sure you change the blog_id on the query to your site's): 740d510e2a0737a5a3202207dc48ddad-logstash