### PR TITLE
Update social-logos imports from default to named

### DIFF
--- a/projects/js-packages/components/changelog/update-social-logo-usage
+++ b/projects/js-packages/components/changelog/update-social-logo-usage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated social-logos import from default to named

--- a/projects/js-packages/components/components/icons/index.tsx
+++ b/projects/js-packages/components/components/icons/index.tsx
@@ -1,6 +1,6 @@
 import { Path, SVG, G, Polygon } from '@wordpress/components';
 import clsx from 'clsx';
-import SocialLogo from 'social-logos';
+import { SocialLogo } from 'social-logos';
 import styles from './style.module.scss';
 import { BaseIconProps } from './types';
 import type React from 'react';

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import SocialLogo from 'social-logos';
+import { SocialLogo } from 'social-logos';
 import ConnectionBanner from 'components/connection-banner';
 import NoticesList from 'components/global-notices';
 import SimpleNotice from 'components/notice';

--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -8,7 +8,7 @@ import { __, _x, _n, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import SocialLogo from 'social-logos';
+import { SocialLogo } from 'social-logos';
 import Button from 'components/button';
 import FoldableCard from 'components/foldable-card';
 import { FormLabel, FormTextarea } from 'components/forms';

--- a/projects/plugins/jetpack/changelog/update-social-logo-usage
+++ b/projects/plugins/jetpack/changelog/update-social-logo-usage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated social-logos import from default to named

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/edit.js
@@ -1,7 +1,7 @@
 import { useBlockProps } from '@wordpress/block-editor';
 import { Button } from '@wordpress/components';
 import clsx from 'clsx';
-import SocialIcon from 'social-logos';
+import { SocialLogo } from 'social-logos';
 import { getNameBySite } from './utils';
 import './style.scss';
 
@@ -31,7 +31,7 @@ const SharingButtonEdit = ( { attributes, context } ) => {
 		<>
 			<li { ...blockProps }>
 				<Button className={ sharingButtonClass } style={ buttonStyle }>
-					<SocialIcon icon={ service } size={ 24 } />
+					<SocialLogo icon={ service } size={ 24 } />
 					<span className={ 'jetpack-sharing-button__service-label' }>{ socialLinkLabel }</span>
 				</Button>
 			</li>

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/variations.js
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/variations.js
@@ -1,12 +1,12 @@
 import { __ } from '@wordpress/i18n';
-import SocialIcon from 'social-logos';
+import { SocialLogo } from 'social-logos';
 
 export const variations = [
 	{
 		name: 'bluesky',
 		attributes: { service: 'bluesky', label: 'Bluesky' },
 		title: 'Bluesky',
-		icon: <SocialIcon icon={ 'bluesky' } size={ 24 } />,
+		icon: <SocialLogo icon={ 'bluesky' } size={ 24 } />,
 	},
 	{
 		name: 'print',
@@ -17,20 +17,20 @@ export const variations = [
 		},
 		// translators: option to print the content - a verb labelling a button.
 		title: __( 'Print', 'jetpack' ),
-		icon: <SocialIcon icon={ 'print' } size={ 24 } />,
+		icon: <SocialLogo icon={ 'print' } size={ 24 } />,
 	},
 	{
 		name: 'facebook',
 		attributes: { service: 'facebook', label: 'Facebook' },
 		title: 'Facebook',
-		icon: <SocialIcon icon={ 'facebook' } size={ 24 } />,
+		icon: <SocialLogo icon={ 'facebook' } size={ 24 } />,
 	},
 	{
 		name: 'linkedin',
 		attributes: { service: 'linkedin', label: 'LinkedIn' },
 		title: 'LinkedIn',
 		isDefault: true,
-		icon: <SocialIcon icon={ 'linkedin' } size={ 24 } />,
+		icon: <SocialLogo icon={ 'linkedin' } size={ 24 } />,
 	},
 	{
 		name: 'mail',
@@ -42,75 +42,75 @@ export const variations = [
 		// translators: option to share the content by email - a verb labelling a button.
 		title: __( 'Mail', 'jetpack' ),
 		keywords: [ 'email', 'e-mail' ],
-		icon: <SocialIcon icon={ 'mail' } size={ 24 } />,
+		icon: <SocialLogo icon={ 'mail' } size={ 24 } />,
 	},
 	{
 		name: 'mastodon',
 		attributes: { service: 'mastodon', label: 'Mastodon' },
 		title: 'Mastodon',
-		icon: <SocialIcon icon={ 'mastodon' } size={ 24 } />,
+		icon: <SocialLogo icon={ 'mastodon' } size={ 24 } />,
 	},
 	{
 		name: 'pinterest',
 		attributes: { service: 'pinterest', label: 'Pinterest' },
 		title: 'Pinterest',
-		icon: <SocialIcon icon={ 'pinterest' } size={ 24 } />,
+		icon: <SocialLogo icon={ 'pinterest' } size={ 24 } />,
 	},
 	{
 		name: 'pocket',
 		attributes: { service: 'pocket', label: 'Pocket' },
 		title: 'Pocket',
-		icon: <SocialIcon icon={ 'pocket' } size={ 24 } />,
+		icon: <SocialLogo icon={ 'pocket' } size={ 24 } />,
 	},
 	{
 		name: 'reddit',
 		attributes: { service: 'reddit', label: 'Reddit' },
 		title: 'Reddit',
-		icon: <SocialIcon icon={ 'reddit' } size={ 24 } />,
+		icon: <SocialLogo icon={ 'reddit' } size={ 24 } />,
 	},
 	{
 		name: 'telegram',
 		attributes: { service: 'telegram', label: 'Telegram' },
 		title: 'Telegram',
-		icon: <SocialIcon icon={ 'telegram' } size={ 24 } />,
+		icon: <SocialLogo icon={ 'telegram' } size={ 24 } />,
 	},
 	{
 		name: 'threads',
 		attributes: { service: 'threads', label: 'Threads' },
 		title: 'Threads',
-		icon: <SocialIcon icon={ 'threads' } size={ 24 } />,
+		icon: <SocialLogo icon={ 'threads' } size={ 24 } />,
 	},
 	{
 		name: 'tumblr',
 		attributes: { service: 'tumblr', label: 'Tumblr' },
 		title: 'Tumblr',
-		icon: <SocialIcon icon={ 'tumblr' } size={ 24 } />,
+		icon: <SocialLogo icon={ 'tumblr' } size={ 24 } />,
 	},
 	{
 		name: 'whatsapp',
 		attributes: { service: 'whatsapp', label: 'WhatsApp' },
 		title: 'WhatsApp',
-		icon: <SocialIcon icon={ 'whatsapp' } size={ 24 } />,
+		icon: <SocialLogo icon={ 'whatsapp' } size={ 24 } />,
 	},
 	{
 		name: 'x',
 		attributes: { service: 'x', label: 'X' },
 		keywords: [ 'twitter', 'x' ],
 		title: 'X',
-		icon: <SocialIcon icon={ 'x' } size={ 24 } />,
+		icon: <SocialLogo icon={ 'x' } size={ 24 } />,
 	},
 	{
 		name: 'twitter',
 		attributes: { service: 'twitter', label: 'Twitter' },
 		keywords: [ 'twitter' ],
 		title: 'Twitter',
-		icon: <SocialIcon icon={ 'twitter' } size={ 24 } />,
+		icon: <SocialLogo icon={ 'twitter' } size={ 24 } />,
 	},
 	{
 		name: 'nextdoor',
 		attributes: { service: 'nextdoor', label: 'Nextdoor' },
 		title: 'Nextdoor',
-		icon: <SocialIcon icon={ 'nextdoor' } size={ 24 } />,
+		icon: <SocialLogo icon={ 'nextdoor' } size={ 24 } />,
 	},
 	{
 		name: 'native-share',
@@ -121,7 +121,7 @@ export const variations = [
 		},
 		// translators: option to share the content - a verb labelling a button.
 		title: __( 'Native Share', 'jetpack' ),
-		icon: <SocialIcon icon={ 'share' } size={ 24 } />,
+		icon: <SocialLogo icon={ 'share' } size={ 24 } />,
 		//TODO: we can add link in the future to proper documentation
 		description: __(
 			'Share with native tools on users device or copy to clipboard otherwise',
@@ -163,17 +163,17 @@ export default variations;
 // 	name: 'twitch',
 // 	attributes: { service: 'twitch' },
 // 	title: 'Twitch',
-// 	icon: <SocialIcon icon={ 'twitch' } size={ 24 } />,
+// 	icon: <SocialLogo icon={ 'twitch' } size={ 24 } />,
 // },
 // {
 // 	name: 'patreon',
 // 	attributes: { service: 'patreon' },
 // 	title: 'Patreon',
-// 	icon: <SocialIcon icon={ 'patreon' } size={ 24 } />,
+// 	icon: <SocialLogo icon={ 'patreon' } size={ 24 } />,
 // },
 // {
 // 	name: 'skype',
 // 	attributes: { service: 'skype' },
 // 	title: 'Skype',
-// 	icon: <SocialIcon icon={ 'skype' } size={ 24 } />,
+// 	icon: <SocialLogo icon={ 'skype' } size={ 24 } />,
 // },


### PR DESCRIPTION
In #40801, we deprecated the default import from `social-logos` package and this PR makes the relevant change in our own consumer components

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update social-logos import from default to named in the consumer components

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack > Settings > Traffic
* Enable "Search engine optimization" if it's disabled
* Click on `"Expand to preview how the SEO settings will look for your homepage on Google, Facebook, and Twitter."`
* Confirm that the social logos for Google, Facebook and Twitter/X work fine
* Goto block editor
* Add "Sharing Buttons" block
* Verify that the social icons look fine

<img width="932" alt="Screenshot 2025-01-02 at 8 56 56 AM" src="https://github.com/user-attachments/assets/2fba19c8-eda9-447f-92f5-954709fd8170" />
<img width="847" alt="Screenshot 2025-01-02 at 9 16 05 AM" src="https://github.com/user-attachments/assets/01b2e10b-8f9f-4a11-b682-f087e2c143e7" />


