### PR TITLE
Gated styles: Redesign front end prompt to upgrade to paid styles

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-allow-reset-global-styles
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-allow-reset-global-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adds reset global styles functionality to the wpcom global styles view.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -384,6 +384,8 @@ function wpcom_global_styles_in_use() {
 	}
 
 	$user_cpt = WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( wp_get_theme() );
+	// This is the global styles stylesheet.
+	// var_dump( wp_get_global_stylesheet() );
 
 	$global_styles_in_use = wpcom_global_styles_in_use_by_wp_global_styles_post( $user_cpt );
 
@@ -419,7 +421,7 @@ function wpcom_premium_global_styles_is_site_exempt( $blog_id = 0 ) {
 	}
 
 	// If the current user cannot modify the `wp_global_styles` CPT, the exemption check is not needed;
-	// other conditions will determine whether they can use GS.
+	// other conditions will determine whether they can use GS.
 	if ( ! wpcom_global_styles_current_user_can_edit_wp_global_styles( $blog_id ) ) {
 		return false;
 	}
@@ -515,7 +517,11 @@ function wpcom_should_show_global_styles_launch_bar() {
  */
 function wpcom_display_global_styles_launch_bar() {
 	$blog_id          = get_current_blog_id();
-	$global_styles_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
+	$global_styles_id = null;
+
+	if ( class_exists( 'WP_Theme_JSON_Resolver' ) ) {
+		$global_styles_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
+	}
 
 	if ( method_exists( '\WPCOM_Masterbar', 'get_calypso_site_slug' ) ) {
 		$site_slug = WPCOM_Masterbar::get_calypso_site_slug( $blog_id );
@@ -537,7 +543,27 @@ function wpcom_display_global_styles_launch_bar() {
 	} else {
 		$preview_location = remove_query_arg( 'hide-global-styles' );
 	}
+	remove_filter( 'wp_theme_json_data_user', 'wpcom_block_global_styles_frontend' );
 
+	// Get base theme styles
+	$base_theme_json = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( 'theme' );
+	$base_theme_json_stylesheet = $base_theme_json->get_stylesheet();
+
+	// Get raw user global styles directly from the database
+	$user_custom_post_type_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
+	$global_styles_post = get_post( $user_custom_post_type_id );
+	$user_data = $global_styles_post ? json_decode( $global_styles_post->post_content, true ) : array();
+
+	// Create a new theme JSON object with user data
+	$user_theme_json = new WP_Theme_JSON( $user_data );
+
+	// Merge with theme data
+	$merged_data = new WP_Theme_JSON( array() );
+	$merged_data->merge( $base_theme_json );
+	$merged_data->merge( $user_theme_json );
+	$merged_stylesheet = $merged_data->get_stylesheet();
+
+	add_filter( 'wp_theme_json_data_user', 'wpcom_block_global_styles_frontend' );
 	?>
 
 	<div class="launch-banner" id="launch-banner" style="display:none;">
@@ -573,6 +599,9 @@ function wpcom_display_global_styles_launch_bar() {
 						<div class="launch-bar-global-styles-close">
 							<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 96 960 960" width="48"><path d="m249 849-42-42 231-231-231-231 42-42 231 231 231-231 42 42-231 231 231 231-42 42-231-231-231 231Z"/></svg>
 						</div>
+						<h2 class="launch-bar-global-styles-popover__title">
+							<?php echo esc_html_e( 'Unlock premium styles', 'jetpack-mu-wpcom' ); ?>
+						</h2>
 						<div class="launch-bar-global-styles-message">
 							<?php
 							$support_url = function_exists( 'localized_wpcom_url' )
@@ -602,29 +631,63 @@ function wpcom_display_global_styles_launch_bar() {
 							);
 							?>
 						</div>
-						<a
-							class="launch-bar-global-styles-upgrade"
-							href="<?php echo esc_url( $upgrade_url ); ?>"
-						>
-							<?php echo esc_html__( 'Upgrade now', 'jetpack-mu-wpcom' ); ?>
-						</a>
-						<a
-							class="launch-bar-global-styles-reset"
-							href="https://wordpress.com/support/using-styles/#reset-all-styles"
-							target="_blank"
-							data-blog-id="<?php echo esc_attr( (string) $blog_id ); ?>"
-							data-global-styles-id="<?php echo esc_attr( (string) $global_styles_id ); ?>"
-						>
-							<svg width="15" height="14" viewBox="0 0 15 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-								<path d="M5.8125 5.6875C5.8125 4.75552 6.56802 4 7.5 4C8.43198 4 9.1875 4.75552 9.1875 5.6875C9.1875 6.55621 8.53108 7.2716 7.6872 7.36473C7.58427 7.37609 7.5 7.45895 7.5 7.5625V8.5M7.5 9.25V10.375M13.5 7C13.5 10.3137 10.8137 13 7.5 13C4.18629 13 1.5 10.3137 1.5 7C1.5 3.68629 4.18629 1 7.5 1C10.8137 1 13.5 3.68629 13.5 7Z" stroke="#1E1E1E" stroke-width="1.5"/>
-							</svg>
-							<?php echo esc_html__( 'Remove premium styles', 'jetpack-mu-wpcom' ); ?>
-							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="15" height="15" aria-hidden="true" focusable="false"><path d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"></path></svg>
-						</a>
-						<a class="launch-bar-global-styles-preview" href="<?php echo esc_url( $preview_location ); ?>">
-							<label><input type="checkbox" <?php echo wpcom_is_previewing_global_styles() ? 'checked' : ''; ?>><span></span></label>
-							<?php echo esc_html__( 'Preview premium styles', 'jetpack-mu-wpcom' ); ?>
-						</a>
+						<div class="launch-bar-global-styles-actions">
+							<a 
+								class="launch-bar-global-styles-actions__preview <?php echo wpcom_is_previewing_global_styles() ? 'disabled' : ''; ?>"
+								href="<?php echo ! wpcom_is_previewing_global_styles() ? esc_url( $preview_location ) : 'javascript:void(0)'; ?>"
+							>
+								<iframe 
+									class="launch-bar-global-styles-actions__preview-frame"
+									data-content="<h2 style='display:inline;'>A</h2><p style='display:inline;'>a</p>"
+									data-styles="* {cursor: pointer;}<?php echo esc_attr( $merged_stylesheet ); ?>"
+									frameborder="0"
+									scrolling="no"
+									title="<?php echo esc_attr__( 'Style preview', 'jetpack-mu-wpcom' ); ?>"
+								></iframe>
+								<?php echo esc_html__( 'Use premium style', 'jetpack-mu-wpcom' ); ?>
+							</a>
+							<a
+								class="launch-bar-global-styles-actions__preview <?php echo ! wpcom_is_previewing_global_styles() ? 'disabled' : ''; ?>"
+								href="<?php echo wpcom_is_previewing_global_styles() ? esc_url( $preview_location ) : 'javascript:void(0)'; ?>"
+							>
+								<iframe 
+									class="launch-bar-global-styles-actions__preview-frame"
+									data-content="<h2 style='display:inline;'>A</h2><p style='display:inline;'>a</p>"
+									data-styles="* {cursor: pointer;}<?php echo esc_attr( $base_theme_json_stylesheet ); ?>"
+									frameborder="0"
+									scrolling="no"
+									title="<?php echo esc_attr__( 'Style preview', 'jetpack-mu-wpcom' ); ?>"
+								></iframe>
+								<?php echo esc_html__( 'Use default style', 'jetpack-mu-wpcom' ); ?>
+							</a>
+						</div>
+
+						<div class="launch-bar-global-styles-actions">
+						<?php
+						if ( wpcom_is_previewing_global_styles() ) {
+							?>
+							<a
+								class="launch-bar-global-styles__button--upgrade"
+								href="<?php echo esc_url( $upgrade_url ); ?>"
+							>
+								<?php echo esc_html__( 'Upgrade to Premium plan', 'jetpack-mu-wpcom' ); ?>
+							</a>
+								<?php
+							} else {
+							?>
+							<a
+								class="launch-bar-global-styles__button--reset"
+								href="https://wordpress.com/support/using-styles/#reset-all-styles"
+								target="_blank"
+								data-blog-id="<?php echo esc_attr( (string) $blog_id ); ?>"
+								data-global-styles-id="<?php echo esc_attr( (string) $global_styles_id ); ?>"
+							>
+								<?php echo esc_html__( 'Remove styles and keep free plan', 'jetpack-mu-wpcom' ); ?>
+							</a>
+								<?php
+						}
+						?>
+						</div>
 					</div>
 					<a class="launch-bar-global-styles-toggle" href="#">
 						<svg width="25" height="25" viewBox="0 96 960 960" xmlns="http://www.w3.org/2000/svg">

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -576,7 +576,7 @@ function wpcom_display_global_styles_launch_bar() {
 							<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 96 960 960" width="48"><path d="m249 849-42-42 231-231-231-231 42-42 231 231 231-231 42 42-231 231 231 231-42 42-231-231-231 231Z"/></svg>
 						</div>
 						<h2 class="launch-bar-global-styles-popover__title">
-							<?php echo esc_html_e( 'Unlock premium styles', 'jetpack-mu-wpcom' ); ?>
+							<?php esc_html_e( 'Unlock premium styles', 'jetpack-mu-wpcom' ); ?>
 						</h2>
 						<div class="launch-bar-global-styles-message">
 							<?php
@@ -623,10 +623,10 @@ function wpcom_display_global_styles_launch_bar() {
 										<input type="checkbox" id="launch-bar-global-styles-preview-checkbox" data-href="<?php echo esc_url( $preview_location ); ?>" <?php echo wpcom_is_previewing_global_styles() ? 'checked' : ''; ?>>
 										<span></span>
 									</span>
-									<span class="launch-bar-global-styles-preview__label-text"><?php echo esc_html__( 'Preview premium styles', 'jetpack-mu-wpcom' ); ?></span>
+									<span class="launch-bar-global-styles-preview__label-text"><?php esc_html_e( 'Preview premium styles', 'jetpack-mu-wpcom' ); ?></span>
 								</label>
 								<input type="hidden" name="<?php echo wpcom_is_previewing_global_styles() ? 'hide-global-styles' : ''; ?>" value="" />
-								<button type="submit" class="launch-bar-global-styles__button--preview"><?php echo esc_html__( 'Preview', 'jetpack-mu-wpcom' ); ?></button>
+								<button type="submit" class="launch-bar-global-styles__button--preview"><?php esc_html_e( 'Preview', 'jetpack-mu-wpcom' ); ?></button>
 							</form>
 						</div>
 						<div class="launch-bar-global-styles-actions">
@@ -637,7 +637,7 @@ function wpcom_display_global_styles_launch_bar() {
 								class="launch-bar-global-styles__button--upgrade"
 								href="<?php echo esc_url( $upgrade_url ); ?>"
 							>
-								<?php echo esc_html__( 'Upgrade and keep premium styles', 'jetpack-mu-wpcom' ); ?>
+								<?php esc_html_e( 'Upgrade and keep premium styles', 'jetpack-mu-wpcom' ); ?>
 							</a>
 							<?php
 						} else {
@@ -646,7 +646,7 @@ function wpcom_display_global_styles_launch_bar() {
 								class="launch-bar-global-styles__button--upgrade"
 								href="<?php echo esc_url( $upgrade_url ); ?>"
 							>
-								<?php echo esc_html__( 'Upgrade to unlock premium styles', 'jetpack-mu-wpcom' ); ?>
+								<?php esc_html_e( 'Upgrade to unlock premium styles', 'jetpack-mu-wpcom' ); ?>
 							</a>
 							<?php
 						}
@@ -659,7 +659,7 @@ function wpcom_display_global_styles_launch_bar() {
 								data-global-styles-id="<?php echo esc_attr( (string) $global_styles_id ); ?>"
 							>
 								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 5.5A2.25 2.25 0 0 0 9.878 7h4.244A2.251 2.251 0 0 0 12 5.5ZM12 4a3.751 3.751 0 0 0-3.675 3H5v1.5h1.27l.818 8.997a2.75 2.75 0 0 0 2.739 2.501h4.347a2.75 2.75 0 0 0 2.738-2.5L17.73 8.5H19V7h-3.325A3.751 3.751 0 0 0 12 4Zm4.224 4.5H7.776l.806 8.861a1.25 1.25 0 0 0 1.245 1.137h4.347a1.25 1.25 0 0 0 1.245-1.137l.805-8.861Z"></path></svg>
-								<?php echo esc_html__( 'Remove premium styles', 'jetpack-mu-wpcom' ); ?>
+								<?php esc_html_e( 'Remove premium styles', 'jetpack-mu-wpcom' ); ?>
 							</a>
 						</div>
 					</div>
@@ -668,10 +668,10 @@ function wpcom_display_global_styles_launch_bar() {
 							<path d="M479.982 776q14.018 0 23.518-9.482 9.5-9.483 9.5-23.5 0-14.018-9.482-23.518-9.483-9.5-23.5-9.5-14.018 0-23.518 9.482-9.5 9.483-9.5 23.5 0 14.018 9.482 23.518 9.483 9.5 23.5 9.5ZM453 623h60V370h-60v253Zm27.266 353q-82.734 0-155.5-31.5t-127.266-86q-54.5-54.5-86-127.341Q80 658.319 80 575.5q0-82.819 31.5-155.659Q143 347 197.5 293t127.341-85.5Q397.681 176 480.5 176q82.819 0 155.659 31.5Q709 239 763 293t85.5 127Q880 493 880 575.734q0 82.734-31.5 155.5T763 858.316q-54 54.316-127 86Q563 976 480.266 976Zm.234-60Q622 916 721 816.5t99-241Q820 434 721.188 335 622.375 236 480 236q-141 0-240.5 98.812Q140 433.625 140 576q0 141 99.5 240.5t241 99.5Zm-.5-340Z" style="fill: orange"/>
 						</svg>
 						<span class="is-mobile">
-							<?php echo esc_html__( 'Upgrade', 'jetpack-mu-wpcom' ); ?>
+							<?php esc_html_e( 'Upgrade', 'jetpack-mu-wpcom' ); ?>
 						</span>
 						<span class="is-desktop">
-							<?php echo esc_html__( 'Upgrade required', 'jetpack-mu-wpcom' ); ?>
+							<?php esc_html_e( 'Upgrade required', 'jetpack-mu-wpcom' ); ?>
 						</span>
 					</div>
 				</div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -543,27 +543,6 @@ function wpcom_display_global_styles_launch_bar() {
 	} else {
 		$preview_location = remove_query_arg( 'hide-global-styles' );
 	}
-	remove_filter( 'wp_theme_json_data_user', 'wpcom_block_global_styles_frontend' );
-
-	// Get base theme styles
-	$base_theme_json = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( 'theme' );
-	$base_theme_json_stylesheet = $base_theme_json->get_stylesheet();
-
-	// Get raw user global styles directly from the database
-	$user_custom_post_type_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
-	$global_styles_post = get_post( $user_custom_post_type_id );
-	$user_data = $global_styles_post ? json_decode( $global_styles_post->post_content, true ) : array();
-
-	// Create a new theme JSON object with user data
-	$user_theme_json = new WP_Theme_JSON( $user_data );
-
-	// Merge with theme data
-	$merged_data = new WP_Theme_JSON( array() );
-	$merged_data->merge( $base_theme_json );
-	$merged_data->merge( $user_theme_json );
-	$merged_stylesheet = $merged_data->get_stylesheet();
-
-	add_filter( 'wp_theme_json_data_user', 'wpcom_block_global_styles_frontend' );
 	?>
 
 	<div class="launch-banner" id="launch-banner" style="display:none;">
@@ -609,15 +588,24 @@ function wpcom_display_global_styles_launch_bar() {
 								// phpcs:ignore WPCOM.I18nRules.LocalizedUrl.UnlocalizedUrl
 								: 'https://wordpress.com/support/using-styles/';
 
-							$message = sprintf(
+							$message = wpcom_is_previewing_global_styles() ? sprintf(
 								/* translators: %1$s - documentation URL, %2$s - the name of the required plan */
 								__(
-									'Your site includes <a href="%1$s" target="_blank">premium styles</a> that are only visible to visitors after upgrading to the %2$s plan or higher.',
+									'With <a href="%1$s" target="_blank">premium styles</a>, this is how your site will appear to visitors after you upgrade to the %2$s plan or higher.',
 									'jetpack-mu-wpcom'
 								),
-								$support_url,
+								esc_url( $support_url ),
 								get_store_product( $gs_upgrade_plan )->product_name
+							) : sprintf(
+								/* translators: %1$s - plan upgrade URL, %2$s - documentation URL */
+								__(
+									'This is how your site will appear to visitors. To customize its colors, fonts, layout and more, <a href="%1$s" target="_blank">upgrade your plan</a> to activate <a href="%2$s" target="_blank">premium styles</a>.',
+									'jetpack-mu-wpcom'
+								),
+								esc_url( $upgrade_url ),
+								esc_url( $support_url )
 							);
+
 							printf(
 								wp_kses(
 									$message,
@@ -636,29 +624,19 @@ function wpcom_display_global_styles_launch_bar() {
 								class="launch-bar-global-styles-actions__preview <?php echo wpcom_is_previewing_global_styles() ? 'disabled' : ''; ?>"
 								href="<?php echo ! wpcom_is_previewing_global_styles() ? esc_url( $preview_location ) : 'javascript:void(0)'; ?>"
 							>
-								<iframe 
-									class="launch-bar-global-styles-actions__preview-frame"
-									data-content="<h2 style='display:inline;'>A</h2><p style='display:inline;'>a</p>"
-									data-styles="* {cursor: pointer;}<?php echo esc_attr( $merged_stylesheet ); ?>"
-									frameborder="0"
-									scrolling="no"
-									title="<?php echo esc_attr__( 'Style preview', 'jetpack-mu-wpcom' ); ?>"
-								></iframe>
-								<?php echo esc_html__( 'Use premium style', 'jetpack-mu-wpcom' ); ?>
+								<div class="launch-bar-global-styles-actions__preview-frame is-premium">
+									<h2>A</h2><p>a</p>
+								</div>
+								<?php echo esc_html__( 'Premium styles', 'jetpack-mu-wpcom' ); ?>
 							</a>
 							<a
 								class="launch-bar-global-styles-actions__preview <?php echo ! wpcom_is_previewing_global_styles() ? 'disabled' : ''; ?>"
 								href="<?php echo wpcom_is_previewing_global_styles() ? esc_url( $preview_location ) : 'javascript:void(0)'; ?>"
 							>
-								<iframe 
-									class="launch-bar-global-styles-actions__preview-frame"
-									data-content="<h2 style='display:inline;'>A</h2><p style='display:inline;'>a</p>"
-									data-styles="* {cursor: pointer;}<?php echo esc_attr( $base_theme_json_stylesheet ); ?>"
-									frameborder="0"
-									scrolling="no"
-									title="<?php echo esc_attr__( 'Style preview', 'jetpack-mu-wpcom' ); ?>"
-								></iframe>
-								<?php echo esc_html__( 'Use default style', 'jetpack-mu-wpcom' ); ?>
+								<div class="launch-bar-global-styles-actions__preview-frame">
+									<h2>A</h2><p>a</p>
+								</div>
+								<?php echo esc_html__( 'Default styles', 'jetpack-mu-wpcom' ); ?>
 							</a>
 						</div>
 
@@ -670,10 +648,10 @@ function wpcom_display_global_styles_launch_bar() {
 								class="launch-bar-global-styles__button--upgrade"
 								href="<?php echo esc_url( $upgrade_url ); ?>"
 							>
-								<?php echo esc_html__( 'Upgrade to Premium plan', 'jetpack-mu-wpcom' ); ?>
+								<?php echo esc_html__( 'Upgrade and keep premium styles', 'jetpack-mu-wpcom' ); ?>
 							</a>
 								<?php
-							} else {
+						} else {
 							?>
 							<a
 								class="launch-bar-global-styles__button--reset"
@@ -682,7 +660,7 @@ function wpcom_display_global_styles_launch_bar() {
 								data-blog-id="<?php echo esc_attr( (string) $blog_id ); ?>"
 								data-global-styles-id="<?php echo esc_attr( (string) $global_styles_id ); ?>"
 							>
-								<?php echo esc_html__( 'Remove styles and keep free plan', 'jetpack-mu-wpcom' ); ?>
+								<?php echo esc_html__( 'Remove premium styles', 'jetpack-mu-wpcom' ); ?>
 							</a>
 								<?php
 						}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -516,7 +516,7 @@ function wpcom_display_global_styles_launch_bar() {
 	$blog_id          = get_current_blog_id();
 	$global_styles_id = null;
 
-	if ( class_exists( 'WP_Theme_JSON_Resolver' ) ) {
+	if ( class_exists( 'WP_Theme_JSON_Resolver' ) && wpcom_global_styles_current_user_can_edit_wp_global_styles( $blog_id ) ) {
 		$global_styles_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
 	}
 
@@ -588,15 +588,15 @@ function wpcom_display_global_styles_launch_bar() {
 							$message = wpcom_is_previewing_global_styles() ? sprintf(
 								/* translators: %1$s - documentation URL, %2$s - the name of the required plan */
 								__(
-									'With <a href="%1$s" target="_blank">premium styles</a>, this is how your site will appear to visitors after you upgrade to the %2$s plan or higher.',
+									'You are viewing <a href="%1$s" target="_blank">premium styles</a>. This is how your site will appear to visitors after you upgrade to the %2$s plan or higher.',
 									'jetpack-mu-wpcom'
 								),
 								esc_url( $support_url ),
 								get_store_product( $gs_upgrade_plan )->product_name
 							) : sprintf(
-								/* translators: %1$s - plan upgrade URL, %2$s - documentation URL */
+								/* translators: %1$s - plan upgrade URL */
 								__(
-									'With the Free plan, this is how your site will appear to visitors. To customize colors, fonts, layout and more, <a href="%1$s" target="_blank">upgrade your plan</a> to activate <a href="%2$s" target="_blank">premium styles</a>.',
+									'You are viewing default styles. This is how your site will appear to visitors. To customize colors, fonts, layout and more, <a href="%1$s" target="_blank">upgrade your plan</a>.',
 									'jetpack-mu-wpcom'
 								),
 								esc_url( $upgrade_url ),

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -599,7 +599,7 @@ function wpcom_display_global_styles_launch_bar() {
 							) : sprintf(
 								/* translators: %1$s - plan upgrade URL, %2$s - documentation URL */
 								__(
-									'This is how your site will appear to visitors. To customize its colors, fonts, layout and more, <a href="%1$s" target="_blank">upgrade your plan</a> to activate <a href="%2$s" target="_blank">premium styles</a>.',
+									'With the Free plan, this is how your site will appear to visitors. To customize colors, fonts, layout and more, <a href="%1$s" target="_blank">upgrade your plan</a> to activate <a href="%2$s" target="_blank">premium styles</a>.',
 									'jetpack-mu-wpcom'
 								),
 								esc_url( $upgrade_url ),
@@ -620,26 +620,18 @@ function wpcom_display_global_styles_launch_bar() {
 							?>
 						</div>
 						<div class="launch-bar-global-styles-actions">
-							<a 
-								class="launch-bar-global-styles-actions__preview <?php echo wpcom_is_previewing_global_styles() ? 'disabled' : ''; ?>"
-								href="<?php echo ! wpcom_is_previewing_global_styles() ? esc_url( $preview_location ) : 'javascript:void(0)'; ?>"
-							>
-								<div class="launch-bar-global-styles-actions__preview-frame is-premium">
-									<h2>A</h2><p>a</p>
-								</div>
-								<?php echo esc_html__( 'Premium styles', 'jetpack-mu-wpcom' ); ?>
-							</a>
-							<a
-								class="launch-bar-global-styles-actions__preview <?php echo ! wpcom_is_previewing_global_styles() ? 'disabled' : ''; ?>"
-								href="<?php echo wpcom_is_previewing_global_styles() ? esc_url( $preview_location ) : 'javascript:void(0)'; ?>"
-							>
-								<div class="launch-bar-global-styles-actions__preview-frame">
-									<h2>A</h2><p>a</p>
-								</div>
-								<?php echo esc_html__( 'Default styles', 'jetpack-mu-wpcom' ); ?>
-							</a>
+							<form class="launch-bar-global-styles-preview" action="<?php echo esc_url( $preview_location ); ?>">
+								<label for="launch-bar-global-styles-preview-checkbox">
+									<span class="launch-bar-global-styles-preview__checkbox">
+										<input type="checkbox" id="launch-bar-global-styles-preview-checkbox" data-href="<?php echo esc_url( $preview_location ); ?>" <?php echo wpcom_is_previewing_global_styles() ? 'checked' : ''; ?>>
+										<span></span>
+									</span>
+									<span class="launch-bar-global-styles-preview__label-text"><?php echo esc_html__( 'Preview premium styles', 'jetpack-mu-wpcom' ); ?></span>
+								</label>
+								<input type="hidden" name="<?php echo wpcom_is_previewing_global_styles() ? 'hide-global-styles' : ''; ?>" value="" />
+								<button type="submit" class="launch-bar-global-styles__button--preview"><?php echo esc_html__( 'Preview', 'jetpack-mu-wpcom' ); ?></button>
+							</form>
 						</div>
-
 						<div class="launch-bar-global-styles-actions">
 						<?php
 						if ( wpcom_is_previewing_global_styles() ) {
@@ -654,12 +646,19 @@ function wpcom_display_global_styles_launch_bar() {
 						} else {
 							?>
 							<a
+								class="launch-bar-global-styles__button--upgrade"
+								href="<?php echo esc_url( $upgrade_url ); ?>"
+							>
+								<?php echo esc_html__( 'Upgrade and keep premium styles', 'jetpack-mu-wpcom' ); ?>
+							</a>
+							<a
 								class="launch-bar-global-styles__button--reset"
 								href="https://wordpress.com/support/using-styles/#reset-all-styles"
 								target="_blank"
 								data-blog-id="<?php echo esc_attr( (string) $blog_id ); ?>"
 								data-global-styles-id="<?php echo esc_attr( (string) $global_styles_id ); ?>"
 							>
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 5.5A2.25 2.25 0 0 0 9.878 7h4.244A2.251 2.251 0 0 0 12 5.5ZM12 4a3.751 3.751 0 0 0-3.675 3H5v1.5h1.27l.818 8.997a2.75 2.75 0 0 0 2.739 2.501h4.347a2.75 2.75 0 0 0 2.738-2.5L17.73 8.5H19V7h-3.325A3.751 3.751 0 0 0 12 4Zm4.224 4.5H7.776l.806 8.861a1.25 1.25 0 0 0 1.245 1.137h4.347a1.25 1.25 0 0 0 1.245-1.137l.805-8.861Z"></path></svg>
 								<?php echo esc_html__( 'Remove premium styles', 'jetpack-mu-wpcom' ); ?>
 							</a>
 								<?php
@@ -667,8 +666,8 @@ function wpcom_display_global_styles_launch_bar() {
 						?>
 						</div>
 					</div>
-					<a class="launch-bar-global-styles-toggle" href="#">
-						<svg width="25" height="25" viewBox="0 96 960 960" xmlns="http://www.w3.org/2000/svg">
+					<div class="launch-bar-global-styles-toggle">
+						<svg width="24" height="24" viewBox="0 96 960 960" xmlns="http://www.w3.org/2000/svg">
 							<path d="M479.982 776q14.018 0 23.518-9.482 9.5-9.483 9.5-23.5 0-14.018-9.482-23.518-9.483-9.5-23.5-9.5-14.018 0-23.518 9.482-9.5 9.483-9.5 23.5 0 14.018 9.482 23.518 9.483 9.5 23.5 9.5ZM453 623h60V370h-60v253Zm27.266 353q-82.734 0-155.5-31.5t-127.266-86q-54.5-54.5-86-127.341Q80 658.319 80 575.5q0-82.819 31.5-155.659Q143 347 197.5 293t127.341-85.5Q397.681 176 480.5 176q82.819 0 155.659 31.5Q709 239 763 293t85.5 127Q880 493 880 575.734q0 82.734-31.5 155.5T763 858.316q-54 54.316-127 86Q563 976 480.266 976Zm.234-60Q622 916 721 816.5t99-241Q820 434 721.188 335 622.375 236 480 236q-141 0-240.5 98.812Q140 433.625 140 576q0 141 99.5 240.5t241 99.5Zm-.5-340Z" style="fill: orange"/>
 						</svg>
 						<span class="is-mobile">
@@ -677,7 +676,7 @@ function wpcom_display_global_styles_launch_bar() {
 						<span class="is-desktop">
 							<?php echo esc_html__( 'Upgrade required', 'jetpack-mu-wpcom' ); ?>
 						</span>
-					</a>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -383,10 +383,7 @@ function wpcom_global_styles_in_use() {
 		return false;
 	}
 
-	$user_cpt = WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( wp_get_theme() );
-	// This is the global styles stylesheet.
-	// var_dump( wp_get_global_stylesheet() );
-
+	$user_cpt             = WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( wp_get_theme() );
 	$global_styles_in_use = wpcom_global_styles_in_use_by_wp_global_styles_post( $user_cpt );
 
 	if ( $global_styles_in_use ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -642,17 +642,20 @@ function wpcom_display_global_styles_launch_bar() {
 							>
 								<?php echo esc_html__( 'Upgrade and keep premium styles', 'jetpack-mu-wpcom' ); ?>
 							</a>
-								<?php
+							<?php
 						} else {
 							?>
 							<a
 								class="launch-bar-global-styles__button--upgrade"
 								href="<?php echo esc_url( $upgrade_url ); ?>"
 							>
-								<?php echo esc_html__( 'Upgrade and keep premium styles', 'jetpack-mu-wpcom' ); ?>
+								<?php echo esc_html__( 'Upgrade to unlock premium styles', 'jetpack-mu-wpcom' ); ?>
 							</a>
-							<a
-								class="launch-bar-global-styles__button--reset"
+							<?php
+						}
+						?>
+						<a
+							class="launch-bar-global-styles__button--reset"
 								href="https://wordpress.com/support/using-styles/#reset-all-styles"
 								target="_blank"
 								data-blog-id="<?php echo esc_attr( (string) $blog_id ); ?>"
@@ -661,9 +664,6 @@ function wpcom_display_global_styles_launch_bar() {
 								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 5.5A2.25 2.25 0 0 0 9.878 7h4.244A2.251 2.251 0 0 0 12 5.5ZM12 4a3.751 3.751 0 0 0-3.675 3H5v1.5h1.27l.818 8.997a2.75 2.75 0 0 0 2.739 2.501h4.347a2.75 2.75 0 0 0 2.738-2.5L17.73 8.5H19V7h-3.325A3.751 3.751 0 0 0 12 4Zm4.224 4.5H7.776l.806 8.861a1.25 1.25 0 0 0 1.245 1.137h4.347a1.25 1.25 0 0 0 1.245-1.137l.805-8.861Z"></path></svg>
 								<?php echo esc_html__( 'Remove premium styles', 'jetpack-mu-wpcom' ); ?>
 							</a>
-								<?php
-						}
-						?>
 						</div>
 					</div>
 					<div class="launch-bar-global-styles-toggle">

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -514,8 +514,11 @@ function wpcom_should_show_global_styles_launch_bar() {
  * Renders the global style notice banner to the launch bar.
  */
 function wpcom_display_global_styles_launch_bar() {
+	$blog_id          = get_current_blog_id();
+	$global_styles_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
+
 	if ( method_exists( '\WPCOM_Masterbar', 'get_calypso_site_slug' ) ) {
-		$site_slug = WPCOM_Masterbar::get_calypso_site_slug( get_current_blog_id() );
+		$site_slug = WPCOM_Masterbar::get_calypso_site_slug( $blog_id );
 	} else {
 		$home_url  = home_url( '/' );
 		$site_slug = wp_parse_url( $home_url, PHP_URL_HOST );
@@ -609,6 +612,8 @@ function wpcom_display_global_styles_launch_bar() {
 							class="launch-bar-global-styles-reset"
 							href="https://wordpress.com/support/using-styles/#reset-all-styles"
 							target="_blank"
+							data-blog-id="<?php echo esc_attr( (string) $blog_id ); ?>"
+							data-global-styles-id="<?php echo esc_attr( (string) $global_styles_id ); ?>"
 						>
 							<svg width="15" height="14" viewBox="0 0 15 14" fill="none" xmlns="http://www.w3.org/2000/svg">
 								<path d="M5.8125 5.6875C5.8125 4.75552 6.56802 4 7.5 4C8.43198 4 9.1875 4.75552 9.1875 5.6875C9.1875 6.55621 8.53108 7.2716 7.6872 7.36473C7.58427 7.37609 7.5 7.45895 7.5 7.5625V8.5M7.5 9.25V10.375M13.5 7C13.5 10.3137 10.8137 13 7.5 13C4.18629 13 1.5 10.3137 1.5 7C1.5 3.68629 4.18629 1 7.5 1C10.8137 1 13.5 3.68629 13.5 7Z" stroke="#1E1E1E" stroke-width="1.5"/>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.js
@@ -63,7 +63,9 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	const popoverToggle = container.querySelector( '.launch-bar-global-styles-toggle' );
 	const popover = container.querySelector( '.launch-bar-global-styles-popover' );
 	const upgradeButton = container.querySelector( '.launch-bar-global-styles-upgrade' );
-	//const previewButton = container.querySelector( '.launch-bar-global-styles-preview' );
+	const previewButtonCheckbox = container.querySelector(
+		'.launch-bar-global-styles-preview input[type="checkbox"]'
+	);
 	const closeButton = container.querySelector( '.launch-bar-global-styles-close' );
 	const resetButton = container.querySelector( '.launch-bar-global-styles__button--reset' );
 
@@ -95,18 +97,13 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		window.location = upgradeButton.href;
 	} );
 
-	// TODO: Add tracking back for preview buttons.
-	// previewButton?.addEventListener( 'click', event => {
-	// 	event.preventDefault();
-	// 	const checkbox = previewButton.querySelector( 'input[type="checkbox"]' );
-	// 	if ( checkbox ) {
-	// 		checkbox.checked = ! checkbox.checked;
-	// 	}
-	// 	recordEvent( 'wpcom_global_styles_gating_notice_preview', {
-	// 		action: checkbox.checked ? 'show' : 'hide',
-	// 	} );
-	// 	window.location = previewButton.href;
-	// } );
+	previewButtonCheckbox?.addEventListener( 'change', event => {
+		event.preventDefault();
+		recordEvent( 'wpcom_global_styles_gating_notice_preview', {
+			action: previewButtonCheckbox.checked ? 'show' : 'hide',
+		} );
+		window.location = previewButtonCheckbox.dataset.href;
+	} );
 
 	resetButton?.addEventListener( 'click', async event => {
 		event.preventDefault();

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.js
@@ -63,9 +63,9 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	const popoverToggle = container.querySelector( '.launch-bar-global-styles-toggle' );
 	const popover = container.querySelector( '.launch-bar-global-styles-popover' );
 	const upgradeButton = container.querySelector( '.launch-bar-global-styles-upgrade' );
-	const previewButton = container.querySelector( '.launch-bar-global-styles-preview' );
+	//const previewButton = container.querySelector( '.launch-bar-global-styles-preview' );
 	const closeButton = container.querySelector( '.launch-bar-global-styles-close' );
-	const resetButton = container.querySelector( '.launch-bar-global-styles-reset' );
+	const resetButton = container.querySelector( '.launch-bar-global-styles__button--reset' );
 
 	const limitedGlobalStylesNoticeAction =
 		localStorage.getItem( 'limitedGlobalStylesNoticeAction' ) ?? 'show';
@@ -95,17 +95,18 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		window.location = upgradeButton.href;
 	} );
 
-	previewButton?.addEventListener( 'click', event => {
-		event.preventDefault();
-		const checkbox = previewButton.querySelector( 'input[type="checkbox"]' );
-		if ( checkbox ) {
-			checkbox.checked = ! checkbox.checked;
-		}
-		recordEvent( 'wpcom_global_styles_gating_notice_preview', {
-			action: checkbox.checked ? 'show' : 'hide',
-		} );
-		window.location = previewButton.href;
-	} );
+	// TODO: Add tracking back for preview buttons.
+	// previewButton?.addEventListener( 'click', event => {
+	// 	event.preventDefault();
+	// 	const checkbox = previewButton.querySelector( 'input[type="checkbox"]' );
+	// 	if ( checkbox ) {
+	// 		checkbox.checked = ! checkbox.checked;
+	// 	}
+	// 	recordEvent( 'wpcom_global_styles_gating_notice_preview', {
+	// 		action: checkbox.checked ? 'show' : 'hide',
+	// 	} );
+	// 	window.location = previewButton.href;
+	// } );
 
 	resetButton?.addEventListener( 'click', async event => {
 		event.preventDefault();
@@ -124,4 +125,24 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			window.open( resetButton.href, '_blank' ).focus();
 		}
 	} );
+
+	// Function to inject content into iframes
+	const injectIframeContent = () => {
+		const iframes = document.querySelectorAll( '.launch-bar-global-styles-actions__preview-frame' );
+		iframes.forEach( iframe => {
+			const content = iframe.getAttribute( 'data-content' );
+			const styles = iframe.getAttribute( 'data-styles' );
+			if ( content && styles ) {
+				const doc = iframe.contentDocument || iframe.contentWindow.document;
+				doc.open();
+				doc.write(
+					`<!DOCTYPE html><html><head><style>${ styles }</style></head><body>${ content }</body></html>`
+				);
+				doc.close();
+			}
+		} );
+	};
+
+	// Call it once DOM is loaded
+	injectIframeContent();
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.js
@@ -108,13 +108,13 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		const globalStylesId = resetButton.dataset.globalStylesId;
 		const siteId = resetButton.dataset.blogId;
 		if ( globalStylesId && siteId ) {
-			resetButton?.classList.add( 'is-resetting' );
+			popover?.classList.add( 'is-resetting' );
 			const result = await resetGlobalStyles( globalStylesId, siteId );
 			if ( result ) {
 				recordEvent( 'wpcom_global_styles_gating_notice_reset_styles', { action: 'reset' } );
 				window.location.reload();
 			} else {
-				resetButton?.classList.remove( 'is-resetting' );
+				popover?.classList.remove( 'is-resetting' );
 			}
 		} else {
 			recordEvent( 'wpcom_global_styles_gating_notice_reset_support' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.js
@@ -5,18 +5,16 @@ import { wpcomTrackEvent } from '../../common/tracks';
 import './wpcom-global-styles-view.scss';
 
 /**
- * REST API endpoint to update global styles.
+ * REST API endpoint call to reset global styles.
  *
  * @param {string} globalStylesId - The ID of the global styles.
  * @param {string} siteIdOrSlug   - The ID or slug of the site.
  * @return {Promise}                The response from the REST API.
  */
-const restGlobalStyles = async ( globalStylesId, siteIdOrSlug ) => {
+const resetGlobalStyles = async ( globalStylesId, siteIdOrSlug ) => {
 	if ( ! globalStylesId || ! siteIdOrSlug ) {
 		return false;
 	}
-
-	// TODO find a way to PUT from the frontend preview.
 
 	return await wpcomRequest( {
 		path: `/sites/${ encodeURIComponent( siteIdOrSlug ) }/global-styles/${ globalStylesId }`,
@@ -107,18 +105,19 @@ document.addEventListener( 'DOMContentLoaded', () => {
 
 	resetButton?.addEventListener( 'click', async event => {
 		event.preventDefault();
-		recordEvent( 'wpcom_global_styles_gating_notice_reset_support' );
 		const globalStylesId = resetButton.dataset.globalStylesId;
 		const siteId = resetButton.dataset.blogId;
 		if ( globalStylesId && siteId ) {
 			resetButton?.classList.add( 'is-resetting' );
-			const result = await restGlobalStyles( globalStylesId, siteId );
+			const result = await resetGlobalStyles( globalStylesId, siteId );
 			if ( result ) {
+				recordEvent( 'wpcom_global_styles_gating_notice_reset_styles', { action: 'reset' } );
 				window.location.reload();
 			} else {
 				resetButton?.classList.remove( 'is-resetting' );
 			}
 		} else {
+			recordEvent( 'wpcom_global_styles_gating_notice_reset_support' );
 			window.open( resetButton.href, '_blank' ).focus();
 		}
 	} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.js
@@ -125,24 +125,4 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			window.open( resetButton.href, '_blank' ).focus();
 		}
 	} );
-
-	// Function to inject content into iframes
-	const injectIframeContent = () => {
-		const iframes = document.querySelectorAll( '.launch-bar-global-styles-actions__preview-frame' );
-		iframes.forEach( iframe => {
-			const content = iframe.getAttribute( 'data-content' );
-			const styles = iframe.getAttribute( 'data-styles' );
-			if ( content && styles ) {
-				const doc = iframe.contentDocument || iframe.contentWindow.document;
-				doc.open();
-				doc.write(
-					`<!DOCTYPE html><html><head><style>${ styles }</style></head><body>${ content }</body></html>`
-				);
-				doc.close();
-			}
-		} );
-	};
-
-	// Call it once DOM is loaded
-	injectIframeContent();
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.js
@@ -1,7 +1,34 @@
 /* global launchBarUserData */
+import wpcomRequest from 'wpcom-proxy-request';
 import { wpcomTrackEvent } from '../../common/tracks';
 
 import './wpcom-global-styles-view.scss';
+
+/**
+ * REST API endpoint to update global styles.
+ *
+ * @param {string} globalStylesId - The ID of the global styles.
+ * @param {string} siteIdOrSlug   - The ID or slug of the site.
+ * @return {Promise}                The response from the REST API.
+ */
+const restGlobalStyles = async ( globalStylesId, siteIdOrSlug ) => {
+	if ( ! globalStylesId || ! siteIdOrSlug ) {
+		return false;
+	}
+
+	// TODO find a way to PUT from the frontend preview.
+
+	return await wpcomRequest( {
+		path: `/sites/${ encodeURIComponent( siteIdOrSlug ) }/global-styles/${ globalStylesId }`,
+		apiNamespace: 'wp/v2',
+		method: 'POST',
+		body: {
+			id: globalStylesId,
+			settings: {},
+			styles: {},
+		},
+	} );
+};
 
 /**
  * Records a Tracks click event.
@@ -80,9 +107,21 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		window.location = previewButton.href;
 	} );
 
-	resetButton?.addEventListener( 'click', event => {
+	resetButton?.addEventListener( 'click', async event => {
 		event.preventDefault();
 		recordEvent( 'wpcom_global_styles_gating_notice_reset_support' );
-		window.open( resetButton.href, '_blank' ).focus();
+		const globalStylesId = resetButton.dataset.globalStylesId;
+		const siteId = resetButton.dataset.blogId;
+		if ( globalStylesId && siteId ) {
+			resetButton?.classList.add( 'is-resetting' );
+			const result = await restGlobalStyles( globalStylesId, siteId );
+			if ( result ) {
+				window.location.reload();
+			} else {
+				resetButton?.classList.remove( 'is-resetting' );
+			}
+		} else {
+			window.open( resetButton.href, '_blank' ).focus();
+		}
 	} );
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -67,6 +67,7 @@
 
 	.launch-bar-global-styles-toggle span {
 		font-size: 13px;
+		font-weight: 500;
 	}
 
 	.launch-bar-global-styles-toggle svg {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -205,6 +205,12 @@
 			background: transparent;
 			color: #676767;
 		}
+
+		&.is-resetting {
+			opacity: 0.5;
+			pointer-events: none;
+  			cursor: default;
+		}
 	}
 
 	&.hidden {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -42,8 +42,9 @@
 	color: #fff;
 }
 
-.launch-banner-content .launch-banner-section a,
-.launch-banner-content .launch-banner-section button {
+.launch-banner-content .launch-bar-global-styles-toggle,
+.launch-banner-content .launch-bar-global-styles__button--reset,
+.launch-banner-content .launch-bar-global-styles__button--upgrade {
 	border: none;
 	align-items: center;
 	color: #fff;
@@ -201,6 +202,11 @@
 		background: #fff !important;
 		color: #0675c4 !important;
 		border: 1px solid #0675c4 !important;
+		padding: 0;
+		svg {
+			fill: #0675c4 !important;
+			margin-right: 6px;
+		}
 	}
 
 	&.hidden {
@@ -267,62 +273,79 @@
 	width: 100%;
 	gap: 10px;
 	box-sizing: border-box;
-	&__preview {
-		justify-content: center;
-		flex-grow: 1;
-		min-height: 110px !important;
-		box-sizing: border-box;
-		width: 100%;
-		border-radius: 4px;
-		background: #f4f6f7;
-		font-size: 13px;
-		line-height: 17px;
-		flex-direction: column;
-		padding: 10px !important;
-		flex: 1;
-		min-width: 0;
-		overflow: hidden;
-		color: #24282D !important;
-		&:hover {
-			box-shadow: inset 0 0 0 1px #0675c4;
-			color: #fff !important;
-		}
-		&.disabled {
-			pointer-events: none;
-			cursor: default;
-			box-shadow: inset 0 0 0 1px #0675c4;
-		}
+	flex-direction: column;
+}
+
+.launch-banner-content .launch-bar-global-styles-preview {
+	display: flex;
+	align-items: center;
+	justify-content: space-evenly;
+
+	button {
+		opacity: 0;
+		height: 0;
+		width: 0;
+		pointer-events: none;
 	}
-	&__preview-frame {
-		border: 1px solid #ccc;
-		background-color: #fff;
-		margin-bottom: 10px;
-		box-sizing: border-box;
-		padding: 10px;
-		max-height: 90px;
-		width: 100%;
-		overflow: hidden;
+	label {
 		cursor: pointer;
-
-		// Ensure iframe content is visible
-		height: 100%;
-		min-height: 70px; // Adjust based on your content
-		display: block;
-		&.is-premium {
-			background-color: #0675c4;
-			color: #fff;
-		}
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+	.launch-bar-global-styles-preview__label-text {
+		font-size: 13px !important;
+		line-height: 1.5;
 	}
 
-	&__preview-frame h2,
-	&__preview-frame p {
-		margin: 0;
-		display:inline;
-		color: #24282D !important;
-		&:hover {
-			color: #24282D !important;
+	.launch-bar-global-styles-preview__checkbox {
+		position: relative;
+		display: inline-block;
+		width: 36px;
+		height: 18px;
+
+		span {
+			position: absolute;
+			cursor: pointer;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			background-color: #ccc;
+			transition: 0.4s;
+			/* stylelint-disable-next-line scales/radii */
+			border-radius: 18px;
+
+			&::before {
+				position: absolute;
+				content: "";
+				height: 12px;
+				width: 12px;
+				left: 3px;
+				bottom: 3px;
+				background-color: #fff;
+				transition: 0.4s;
+				border-radius: 50%;
+			}
+		}
+
+		input {
+			opacity: 0;
+			width: 0;
+			height: 0;
+
+			&:checked + span {
+				background-color: #0675c4;
+
+				&::before {
+					transform: translateX(18px);
+				}
+			}
+
+			&:focus + span {
+				box-shadow: 0 0 1px #2196f3;
+			}
 		}
 	}
 }
-
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -35,32 +35,32 @@
 	color: #fff;
 }
 
-.launch-banner-content a,
-.launch-banner-content button {
-	border: none;
-	align-items: center;
-	color: #fff;
-	cursor: pointer;
-	display: flex;
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 13px;
-	font-style: normal;
-	min-height: 48px;
-	outline: none;
-	padding: 0 20px;
-	text-decoration: none !important;
-}
+// .launch-banner-content a,
+// .launch-banner-content button {
+// 	border: none;
+// 	align-items: center;
+// 	color: #fff;
+// 	cursor: pointer;
+// 	display: flex;
+// 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+// 	font-size: 13px;
+// 	font-style: normal;
+// 	min-height: 48px;
+// 	outline: none;
+// 	padding: 0 20px;
+// 	text-decoration: none !important;
+// }
 
-.launch-banner-content a:hover,
-.launch-banner-content button:hover {
-	background: #34383D;
-	cursor: pointer;
-}
+// .launch-banner-content a:hover,
+// .launch-banner-content button:hover {
+// 	background: #34383D;
+// 	cursor: pointer;
+// }
 
-.launch-banner-content a:hover span,
-.launch-banner-content button:hover span {
-	color: #fff;
-}
+// .launch-banner-content a:hover span,
+// .launch-banner-content button:hover span {
+// 	color: #fff;
+// }
 
 .launch-banner-section.bar-controls {
 	display: flex;
@@ -140,19 +140,20 @@
 	position: absolute;
 	width: 320px;
 	top: 48px;
-	font-size: 14px;
+	font-size: 13px;
 	left: 50%;
 	transform: translateX(-50%);
 	background-color: #fff;
-	padding: 24px 24px 0;
+	padding: 28px;
 	line-height: 20px;
-	color: #2c3338;
+	color: #121517;
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 	border: 1px solid #c3c4c7;
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
-	gap: 12px;
+	gap: 16px;
+	border-radius: 8px;
 
 	&::before {
 		content: "";
@@ -167,120 +168,37 @@
 		transform: translateX(-50%);
 	}
 
-	.launch-bar-global-styles-upgrade,
-	.launch-bar-global-styles-reset {
+	.launch-bar-global-styles-popover__title {
+		font-size: 18px;
+		font-weight: 600;
+		margin: 0;
+	}
+
+	.launch-bar-global-styles__button--upgrade,
+	.launch-bar-global-styles__button--reset {
 		min-height: 28px;
 		box-sizing: border-box;
 		width: 100%;
 		justify-content: center;
 		height: auto;
-	}
-
-	.launch-bar-global-styles-upgrade {
+		display: flex;
 		border: 1px solid #0675c4;
 		background: #0675c4;
 		color: #fff;
 		border-radius: 2px;
-
-		&:hover {
-			background: #006ba1;
-		}
+		text-decoration: none;
+		align-items: center;
+		padding: 10px;
 	}
 
-	.launch-bar-global-styles-reset {
-		color: inherit;
-		font-weight: 400 !important;
-
-		svg:first-child {
-			margin-right: 4px;
-		}
-
-		svg:last-child {
-			margin-left: 4px;
-			position: relative;
-			top: 1px;
-		}
-
-		&:hover {
-			background: transparent;
-			color: #676767;
-		}
-
-		&.is-resetting {
-			opacity: 0.5;
-			pointer-events: none;
-  			cursor: default;
-		}
+	.launch-bar-global-styles__button--reset {
+		background: #fff;
+		color: #0675c4;
+		border: 1px solid #0675c4;
 	}
 
 	&.hidden {
 		display: none;
-	}
-}
-
-.launch-banner-content .launch-bar-global-styles-preview {
-	border-top: 1px solid #c3c4c7;
-	width: calc(100% + 48px);
-	margin: 0 -24px;
-	box-sizing: border-box;
-	padding: 12px 24px;
-	font-size: 13px;
-	line-height: 17px;
-	color: inherit;
-
-	&:hover {
-		background: none;
-	}
-
-	label {
-		position: relative;
-		display: inline-block;
-		width: 36px;
-		height: 18px;
-		margin-right: 8px;
-
-		span {
-			position: absolute;
-			cursor: pointer;
-			top: 0;
-			left: 0;
-			right: 0;
-			bottom: 0;
-			background-color: #ccc;
-			transition: 0.4s;
-			/* stylelint-disable-next-line scales/radii */
-			border-radius: 18px;
-
-			&::before {
-				position: absolute;
-				content: "";
-				height: 12px;
-				width: 12px;
-				left: 3px;
-				bottom: 3px;
-				background-color: #fff;
-				transition: 0.4s;
-				border-radius: 50%;
-			}
-		}
-
-		input {
-			opacity: 0;
-			width: 0;
-			height: 0;
-
-			&:checked + span {
-				background-color: #0675c4;
-
-				&::before {
-					transform: translateX(18px);
-				}
-			}
-
-			&:focus + span {
-				box-shadow: 0 0 1px #2196f3;
-			}
-		}
 	}
 }
 
@@ -300,10 +218,10 @@
 
 .launch-bar-global-styles-close {
 	position: absolute;
-	top: 4px;
-	right: 4px;
-	width: 24px;
-	height: 24px;
+	top: 20px;
+    right: 20px;
+    width: 32px;
+    height: 32px;
 	cursor: pointer;
 	display: flex;
 	justify-content: center;
@@ -311,8 +229,8 @@
 
 	svg {
 		fill: #1e1e1e;
-		width: 18px;
-		height: 18px;
+		width: 24px;
+		height: 24px;
 	}
 }
 
@@ -329,3 +247,61 @@
 		transform: none;
 	}
 }
+
+.launch-bar-global-styles-actions {
+	display: flex;
+	width: 100%;
+	gap: 10px;
+	box-sizing: border-box;
+	&__preview {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-grow: 1;
+		min-height: 110px;
+		box-sizing: border-box;
+		width: 100%;
+		border-radius: 4px;
+		background: #f4f6f7;
+		font-size: 13px;
+		line-height: 17px;
+		flex-direction: column;
+		padding: 10px;
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-decoration: none;
+		box-sizing: border-box;
+		&:hover {
+			box-shadow: inset 0 0 0 1px #0675c4;
+		}
+		&.disabled {
+			pointer-events: none;
+			cursor: default;
+			box-shadow: inset 0 0 0 1px #0675c4;
+		}
+	}
+	&__preview-frame {
+		border: 1px solid #ccc;
+		background-color: #fff;
+		margin-bottom: 10px;
+		box-sizing: border-box;
+		padding: 10px;
+		max-height: 90px;
+		width: 100%;
+		overflow: hidden;
+		cursor: pointer;
+
+		// Ensure iframe content is visible
+		height: 100%;
+		min-height: 70px; // Adjust based on your content
+		display: block;
+	}
+
+	&__preview-frame h2,
+	&__preview-frame p {
+		margin: 0;
+	}
+}
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -1,21 +1,28 @@
 /* stylelint-disable declaration-property-unit-allowed-list */
 .launch-banner {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 16px;
-	font-style: normal;
 	height: 48px;
-	line-height: normal;
 	background: #24282D;
 	position: fixed;
 	top: 0;
 	left: 0;
 	width: 100%;
 	z-index: 99998;
-
-
+	text-decoration: none;
 	.is-mobile {
 		display: none;
 	}
+}
+
+.launch-banner * {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+	font-size: 16px;
+	font-style: normal;
+	line-height: normal;
+    border-radius: 0;
+    box-sizing: content-box;
+	text-shadow: none;
+    text-transform: none;
+    letter-spacing: normal;
 }
 
 .admin-bar #launch-banner.launch-banner {
@@ -35,32 +42,29 @@
 	color: #fff;
 }
 
-// .launch-banner-content a,
-// .launch-banner-content button {
-// 	border: none;
-// 	align-items: center;
-// 	color: #fff;
-// 	cursor: pointer;
-// 	display: flex;
-// 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
-// 	font-size: 13px;
-// 	font-style: normal;
-// 	min-height: 48px;
-// 	outline: none;
-// 	padding: 0 20px;
-// 	text-decoration: none !important;
-// }
+.launch-banner-content .launch-banner-section a,
+.launch-banner-content .launch-banner-section button {
+	border: none;
+	align-items: center;
+	color: #fff;
+	cursor: pointer;
+	display: flex;
+	min-height: 48px;
+	outline: none;
+	padding: 0 20px;
+	text-decoration: none !important;
+}
 
-// .launch-banner-content a:hover,
-// .launch-banner-content button:hover {
-// 	background: #34383D;
-// 	cursor: pointer;
-// }
+.launch-banner-content a:hover,
+.launch-banner-content button:hover {
+	background: #34383D;
+	cursor: pointer;
+}
 
-// .launch-banner-content a:hover span,
-// .launch-banner-content button:hover span {
-// 	color: #fff;
-// }
+.launch-banner-content a:hover span,
+.launch-banner-content button:hover span {
+	color: #fff;
+}
 
 .launch-banner-section.bar-controls {
 	display: flex;
@@ -96,7 +100,6 @@
 	.admin-bar #launch-banner.launch-banner {
 		top: 46px;
 	}
-
 	.launch-banner {
 		position: absolute;
 	}
@@ -138,6 +141,7 @@
 
 .launch-bar-global-styles-popover {
 	position: absolute;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
 	width: 320px;
 	top: 48px;
 	font-size: 13px;
@@ -182,38 +186,48 @@
 		justify-content: center;
 		height: auto;
 		display: flex;
-		border: 1px solid #0675c4;
-		background: #0675c4;
-		color: #fff;
+		border: 1px solid #0675c4 !important;
+		background: #0675c4 !important;
+		color: #fff !important;
 		border-radius: 2px;
 		text-decoration: none;
 		align-items: center;
 		padding: 10px;
+		font-size: 13px !important;
+		min-height: 36px !important;
 	}
 
 	.launch-bar-global-styles__button--reset {
-		background: #fff;
-		color: #0675c4;
-		border: 1px solid #0675c4;
+		background: #fff !important;
+		color: #0675c4 !important;
+		border: 1px solid #0675c4 !important;
 	}
 
 	&.hidden {
 		display: none;
 	}
 }
+.launch-bar-global-styles-message a,
+.launch-bar-global-styles-message {
+	font-size: 13px !important;
+	line-height: 1.5;
+}
 
 .launch-banner-content .launch-bar-global-styles-popover .launch-bar-global-styles-message a {
 	display: inline;
 	color: inherit;
 	padding: 0;
-	font-weight: 400;
-	font-size: inherit;
 	text-decoration: underline !important;
 	background: none;
 }
 
+.launch-bar-global-styles-toggle span {
+	font-size: 13px;
+}
+
 .launch-bar-global-styles-toggle svg {
 	margin-right: 4px;
+	width: 18px;
 }
 
 .launch-bar-global-styles-close {
@@ -254,11 +268,9 @@
 	gap: 10px;
 	box-sizing: border-box;
 	&__preview {
-		display: flex;
-		align-items: center;
 		justify-content: center;
 		flex-grow: 1;
-		min-height: 110px;
+		min-height: 110px !important;
 		box-sizing: border-box;
 		width: 100%;
 		border-radius: 4px;
@@ -266,14 +278,14 @@
 		font-size: 13px;
 		line-height: 17px;
 		flex-direction: column;
-		padding: 10px;
+		padding: 10px !important;
 		flex: 1;
 		min-width: 0;
 		overflow: hidden;
-		text-decoration: none;
-		box-sizing: border-box;
+		color: #24282D !important;
 		&:hover {
 			box-shadow: inset 0 0 0 1px #0675c4;
+			color: #fff !important;
 		}
 		&.disabled {
 			pointer-events: none;
@@ -296,11 +308,20 @@
 		height: 100%;
 		min-height: 70px; // Adjust based on your content
 		display: block;
+		&.is-premium {
+			background-color: #0675c4;
+			color: #fff;
+		}
 	}
 
 	&__preview-frame h2,
 	&__preview-frame p {
 		margin: 0;
+		display:inline;
+		color: #24282D !important;
+		&:hover {
+			color: #24282D !important;
+		}
 	}
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -8,11 +8,13 @@
 	width: 100%;
 	z-index: 99998;
 	text-decoration: none;
+
 	.is-mobile {
 		display: none;
 	}
+
 	* {
-		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 		font-size: 16px;
 		font-style: normal;
 		line-height: normal;
@@ -110,7 +112,7 @@
 
 	.launch-bar-global-styles-popover {
 		position: absolute;
-		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 		width: 320px;
 		top: 48px;
 		font-size: 13px;
@@ -127,6 +129,7 @@
 		align-items: flex-start;
 		gap: 16px;
 		border-radius: 8px;
+
 		&::before {
 			content: "";
 			width: 0;
@@ -141,9 +144,11 @@
 		}
 
 		&.is-resetting {
+
 			button, a, form {
 				pointer-events: none;
 			}
+
 			form,
 			.launch-bar-global-styles__button--upgrade,
 			.launch-bar-global-styles__button--reset {
@@ -193,6 +198,7 @@
 			font-weight: 300;
 			justify-content: flex-end;
 			font-size: 12px;
+
 			svg {
 				fill: #0675c4;
 				margin-right: 6px;
@@ -246,12 +252,14 @@
 				width: 0;
 				pointer-events: none;
 			}
+
 			label {
 				cursor: pointer;
 				display: flex;
 				align-items: center;
 				gap: 8px;
 			}
+
 			.launch-bar-global-styles-preview__label-text {
 				font-size: 13px;
 				line-height: 1.5;
@@ -315,6 +323,7 @@
 	.admin-bar #launch-banner.launch-banner {
 		top: 46px;
 	}
+
 	.launch-banner {
 		position: absolute;
 	}
@@ -344,6 +353,7 @@
 }
 
 @media screen and (max-width: 460px) {
+
 	.launch-banner-section.bar-controls {
 		overflow-y: scroll;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -65,6 +65,15 @@
 		text-decoration: none;
 	}
 
+	.launch-bar-global-styles-toggle span {
+		font-size: 13px;
+	}
+
+	.launch-bar-global-styles-toggle svg {
+		margin-right: 4px;
+		width: 18px;
+	}
+
 	.launch-banner-section.bar-controls {
 		display: flex;
 		justify-content: center;
@@ -129,7 +138,18 @@
 			left: 50%;
 			transform: translateX(-50%);
 		}
-	
+
+		&.is-resetting {
+			button, a, form {
+				pointer-events: none;
+			}
+			form,
+			.launch-bar-global-styles__button--upgrade,
+			.launch-bar-global-styles__button--reset {
+				opacity: 0.5;
+			}
+		}
+
 		.launch-bar-global-styles-popover__title {
 			font-size: 18px;
 			font-weight: 600;
@@ -194,15 +214,6 @@
 			padding: 0;
 			text-decoration: underline;
 			background: none;
-		}
-	
-		.launch-bar-global-styles-toggle span {
-			font-size: 13px;
-		}
-	
-		.launch-bar-global-styles-toggle svg {
-			margin-right: 4px;
-			width: 18px;
 		}
 	
 		.launch-bar-global-styles-close {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -149,7 +149,7 @@
 	left: 50%;
 	transform: translateX(-50%);
 	background-color: #fff;
-	padding: 28px;
+	padding: 28px 28px 12px 28px;
 	line-height: 20px;
 	color: #121517;
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
@@ -159,7 +159,6 @@
 	align-items: flex-start;
 	gap: 16px;
 	border-radius: 8px;
-
 	&::before {
 		content: "";
 		width: 0;
@@ -201,8 +200,10 @@
 	.launch-bar-global-styles__button--reset {
 		background: #fff !important;
 		color: #0675c4 !important;
-		border: 1px solid #0675c4 !important;
+		border: none !important;
 		padding: 0;
+		min-height: auto !important;
+		font-weight: 300 !important;
 		svg {
 			fill: #0675c4 !important;
 			margin-right: 6px;
@@ -301,8 +302,8 @@
 	.launch-bar-global-styles-preview__checkbox {
 		position: relative;
 		display: inline-block;
-		width: 36px;
-		height: 18px;
+		width: 42px;
+		height: 24px;
 
 		span {
 			position: absolute;
@@ -319,8 +320,8 @@
 			&::before {
 				position: absolute;
 				content: "";
-				height: 12px;
-				width: 12px;
+				height: 18px;
+				width: 18px;
 				left: 3px;
 				bottom: 3px;
 				background-color: #fff;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -11,18 +11,17 @@
 	.is-mobile {
 		display: none;
 	}
-}
-
-.launch-banner * {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
-	font-size: 16px;
-	font-style: normal;
-	line-height: normal;
-    border-radius: 0;
-    box-sizing: content-box;
-	text-shadow: none;
-    text-transform: none;
-    letter-spacing: normal;
+	* {
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+		font-size: 16px;
+		font-style: normal;
+		line-height: normal;
+		border-radius: 0;
+		box-sizing: content-box;
+		text-shadow: none;
+		text-transform: none;
+		letter-spacing: normal;
+	}
 }
 
 .admin-bar #launch-banner.launch-banner {
@@ -34,66 +33,269 @@
 	margin-top: 49px;
 }
 
-.launch-banner-content {
+#launch-banner.launch-banner > .launch-banner-content {
 	width: 100%;
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	color: #fff;
-}
 
-.launch-banner-content .launch-bar-global-styles-toggle,
-.launch-banner-content .launch-bar-global-styles__button--reset,
-.launch-banner-content .launch-bar-global-styles__button--upgrade {
-	border: none;
-	align-items: center;
-	color: #fff;
-	cursor: pointer;
-	display: flex;
-	min-height: 48px;
-	outline: none;
-	padding: 0 20px;
-	text-decoration: none !important;
-}
+	a:hover,
+	button:hover {
+		background: #34383D;
+		cursor: pointer;
+	}
 
-.launch-banner-content a:hover,
-.launch-banner-content button:hover {
-	background: #34383D;
-	cursor: pointer;
-}
+	a:hover span,
+	button:hover span {
+		color: #fff;
+	}
 
-.launch-banner-content a:hover span,
-.launch-banner-content button:hover span {
-	color: #fff;
-}
+	.launch-bar-global-styles-toggle,
+	.launch-bar-global-styles__button--reset,
+	.launch-bar-global-styles__button--upgrade {
+		border: none;
+		align-items: center;
+		color: #fff;
+		cursor: pointer;
+		display: flex;
+		min-height: 48px;
+		outline: none;
+		padding: 0 20px;
+		text-decoration: none;
+	}
 
-.launch-banner-section.bar-controls {
-	display: flex;
-	justify-content: center;
-	flex-grow: 1;
-}
+	.launch-banner-section.bar-controls {
+		display: flex;
+		justify-content: center;
+		flex-grow: 1;
+	}
+	
+	.launch-banner-section.bar-controls > * {
+		border-left: 1px solid #424446;
+	}
+	
+	.launch-banner-section.bar-controls a,
+	.launch-banner-section.bar-controls button {
+		font-weight: 500;
+	}
+	
+	.launch-banner-section.bar-controls> :last-child {
+		border-right: 1px solid #424446;
+	}
+	
+	.launch-banner-section .icon {
+		margin-right: 5px;
+		fill: none;
+	}
+	
+	.launch-banner-section .icon path,
+	.launch-banner-section .icon rect {
+		stroke: #b0b2b3;
+	}
 
-.launch-banner-section.bar-controls>* {
-	border-left: 1px solid #424446;
-}
+	.launch-bar-global-styles-button {
+		position: relative;
+	}
 
-.launch-banner-section.bar-controls a,
-.launch-banner-section.bar-controls button {
-	font-weight: 500;
-}
+	.launch-bar-global-styles-popover {
+		position: absolute;
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+		width: 320px;
+		top: 48px;
+		font-size: 13px;
+		left: 50%;
+		transform: translateX(-50%);
+		background-color: #fff;
+		padding: 28px 28px 12px 28px;
+		line-height: 20px;
+		color: #121517;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+		border: 1px solid #c3c4c7;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 16px;
+		border-radius: 8px;
+		&::before {
+			content: "";
+			width: 0;
+			height: 0;
+			border-left: 8px solid transparent;
+			border-right: 8px solid transparent;
+			border-bottom: 8px solid #fff;
+			position: absolute;
+			top: -8px;
+			left: 50%;
+			transform: translateX(-50%);
+		}
+	
+		.launch-bar-global-styles-popover__title {
+			font-size: 18px;
+			font-weight: 600;
+			margin: 0;
+		}
+	
+		.launch-bar-global-styles-actions {
+			display: flex;
+			width: 100%;
+			gap: 10px;
+			box-sizing: border-box;
+			flex-direction: column;
+		}
 
-.launch-banner-section.bar-controls> :last-child {
-	border-right: 1px solid #424446;
-}
+		.launch-bar-global-styles-actions > .launch-bar-global-styles__button--upgrade,
+		.launch-bar-global-styles-actions > .launch-bar-global-styles__button--reset {
+			min-height: 28px;
+			box-sizing: border-box;
+			width: 100%;
+			justify-content: center;
+			height: auto;
+			display: flex;
+			border: 1px solid #0675c4;
+			background: #0675c4;
+			color: #fff;
+			border-radius: 2px;
+			text-decoration: none;
+			align-items: center;
+			padding: 10px;
+			font-size: 13px;
+			min-height: 36px;
+		}
+	
+		.launch-bar-global-styles-actions > .launch-bar-global-styles__button--reset {
+			background: #fff;
+			color: #0675c4;
+			border: none;
+			padding: 0;
+			min-height: auto;
+			font-weight: 300;
+			justify-content: flex-end;
+			font-size: 12px;
+			svg {
+				fill: #0675c4;
+				margin-right: 6px;
+			}
+		}
+	
+		&.hidden {
+			display: none;
+		}
 
-.launch-banner-section .icon {
-	margin-right: 5px;
-	fill: none;
-}
+		.launch-bar-global-styles-message a,
+		.launch-bar-global-styles-message {
+			font-size: 13px;
+			line-height: 1.5;
+		}
+	
+		.launch-bar-global-styles-message a {
+			display: inline;
+			color: inherit;
+			padding: 0;
+			text-decoration: underline;
+			background: none;
+		}
+	
+		.launch-bar-global-styles-toggle span {
+			font-size: 13px;
+		}
+	
+		.launch-bar-global-styles-toggle svg {
+			margin-right: 4px;
+			width: 18px;
+		}
+	
+		.launch-bar-global-styles-close {
+			position: absolute;
+			top: 20px;
+			right: 20px;
+			width: 32px;
+			height: 32px;
+			cursor: pointer;
+			display: flex;
+			justify-content: center;
+			align-items: center;
+	
+			svg {
+				fill: #1e1e1e;
+				width: 24px;
+				height: 24px;
+			}
+		}
 
-.launch-banner-section .icon path,
-.launch-banner-section .icon rect {
-	stroke: #b0b2b3;
+		.launch-bar-global-styles-preview {
+			display: flex;
+			align-items: center;
+			justify-content: space-evenly;
+		
+			button {
+				opacity: 0;
+				height: 0;
+				width: 0;
+				pointer-events: none;
+			}
+			label {
+				cursor: pointer;
+				display: flex;
+				align-items: center;
+				gap: 8px;
+			}
+			.launch-bar-global-styles-preview__label-text {
+				font-size: 13px;
+				line-height: 1.5;
+			}
+		
+			.launch-bar-global-styles-preview__checkbox {
+				position: relative;
+				display: inline-block;
+				width: 42px;
+				height: 24px;
+		
+				span {
+					position: absolute;
+					cursor: pointer;
+					top: 0;
+					left: 0;
+					right: 0;
+					bottom: 0;
+					background-color: #ccc;
+					transition: 0.4s;
+					/* stylelint-disable-next-line scales/radii */
+					border-radius: 18px;
+		
+					&::before {
+						position: absolute;
+						content: "";
+						height: 18px;
+						width: 18px;
+						left: 3px;
+						bottom: 3px;
+						background-color: #fff;
+						transition: 0.4s;
+						border-radius: 50%;
+					}
+				}
+		
+				input {
+					opacity: 0;
+					width: 0;
+					height: 0;
+		
+					&:checked + span {
+						background-color: #0675c4;
+		
+						&::before {
+							transform: translateX(18px);
+						}
+					}
+		
+					&:focus + span {
+						box-shadow: 0 0 1px #2196f3;
+					}
+				}
+			}
+		}
+	}
 }
 
 @media screen and (max-width: 782px) {
@@ -116,7 +318,7 @@
 		display: block;
 	}
 
-	.launch-banner-content .bar-controls>* {
+	.launch-banner-content .bar-controls > * {
 		border-left: none;
 	}
 
@@ -130,128 +332,8 @@
 }
 
 @media screen and (max-width: 460px) {
-
 	.launch-banner-section.bar-controls {
 		overflow-y: scroll;
-	}
-}
-
-.launch-bar-global-styles-button {
-	position: relative;
-}
-
-.launch-bar-global-styles-popover {
-	position: absolute;
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
-	width: 320px;
-	top: 48px;
-	font-size: 13px;
-	left: 50%;
-	transform: translateX(-50%);
-	background-color: #fff;
-	padding: 28px 28px 12px 28px;
-	line-height: 20px;
-	color: #121517;
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-	border: 1px solid #c3c4c7;
-	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
-	gap: 16px;
-	border-radius: 8px;
-	&::before {
-		content: "";
-		width: 0;
-		height: 0;
-		border-left: 8px solid transparent;
-		border-right: 8px solid transparent;
-		border-bottom: 8px solid #fff;
-		position: absolute;
-		top: -8px;
-		left: 50%;
-		transform: translateX(-50%);
-	}
-
-	.launch-bar-global-styles-popover__title {
-		font-size: 18px;
-		font-weight: 600;
-		margin: 0;
-	}
-
-	.launch-bar-global-styles__button--upgrade,
-	.launch-bar-global-styles__button--reset {
-		min-height: 28px;
-		box-sizing: border-box;
-		width: 100%;
-		justify-content: center;
-		height: auto;
-		display: flex;
-		border: 1px solid #0675c4 !important;
-		background: #0675c4 !important;
-		color: #fff !important;
-		border-radius: 2px;
-		text-decoration: none;
-		align-items: center;
-		padding: 10px;
-		font-size: 13px !important;
-		min-height: 36px !important;
-	}
-
-	.launch-bar-global-styles__button--reset {
-		background: #fff !important;
-		color: #0675c4 !important;
-		border: none !important;
-		padding: 0;
-		min-height: auto !important;
-		font-weight: 300 !important;
-		svg {
-			fill: #0675c4 !important;
-			margin-right: 6px;
-		}
-	}
-
-	&.hidden {
-		display: none;
-	}
-}
-.launch-bar-global-styles-message a,
-.launch-bar-global-styles-message {
-	font-size: 13px !important;
-	line-height: 1.5;
-}
-
-.launch-banner-content .launch-bar-global-styles-popover .launch-bar-global-styles-message a {
-	display: inline;
-	color: inherit;
-	padding: 0;
-	text-decoration: underline !important;
-	background: none;
-}
-
-.launch-bar-global-styles-toggle span {
-	font-size: 13px;
-}
-
-.launch-bar-global-styles-toggle svg {
-	margin-right: 4px;
-	width: 18px;
-}
-
-.launch-bar-global-styles-close {
-	position: absolute;
-	top: 20px;
-    right: 20px;
-    width: 32px;
-    height: 32px;
-	cursor: pointer;
-	display: flex;
-	justify-content: center;
-	align-items: center;
-
-	svg {
-		fill: #1e1e1e;
-		width: 24px;
-		height: 24px;
 	}
 }
 
@@ -269,84 +351,4 @@
 	}
 }
 
-.launch-bar-global-styles-actions {
-	display: flex;
-	width: 100%;
-	gap: 10px;
-	box-sizing: border-box;
-	flex-direction: column;
-}
-
-.launch-banner-content .launch-bar-global-styles-preview {
-	display: flex;
-	align-items: center;
-	justify-content: space-evenly;
-
-	button {
-		opacity: 0;
-		height: 0;
-		width: 0;
-		pointer-events: none;
-	}
-	label {
-		cursor: pointer;
-		display: flex;
-		align-items: center;
-		gap: 8px;
-	}
-	.launch-bar-global-styles-preview__label-text {
-		font-size: 13px !important;
-		line-height: 1.5;
-	}
-
-	.launch-bar-global-styles-preview__checkbox {
-		position: relative;
-		display: inline-block;
-		width: 42px;
-		height: 24px;
-
-		span {
-			position: absolute;
-			cursor: pointer;
-			top: 0;
-			left: 0;
-			right: 0;
-			bottom: 0;
-			background-color: #ccc;
-			transition: 0.4s;
-			/* stylelint-disable-next-line scales/radii */
-			border-radius: 18px;
-
-			&::before {
-				position: absolute;
-				content: "";
-				height: 18px;
-				width: 18px;
-				left: 3px;
-				bottom: 3px;
-				background-color: #fff;
-				transition: 0.4s;
-				border-radius: 50%;
-			}
-		}
-
-		input {
-			opacity: 0;
-			width: 0;
-			height: 0;
-
-			&:checked + span {
-				background-color: #0675c4;
-
-				&::before {
-					transform: translateX(18px);
-				}
-			}
-
-			&:focus + span {
-				box-shadow: 0 0 1px #2196f3;
-			}
-		}
-	}
-}
 


### PR DESCRIPTION
Resolves:

- https://github.com/Automattic/wp-calypso/issues/97730
- https://github.com/Automattic/wp-calypso/issues/98039

This is a first pass at redesigning the upgrade global styles drop down.

It also updates the "Remove premium styles" action to remove premium styles, rather than a link to the docs.

### Before

 Remove premium styles links off to a support page and does nothing else

<img width="457" alt="Screenshot 2025-03-11 at 2 28 06 pm" src="https://github.com/user-attachments/assets/9262d369-92f2-4d9f-b7e5-96f48438072e" />


### After


https://github.com/user-attachments/assets/29197754-3cf2-4337-9372-16a627d79771









## Product discussion

https://github.com/Automattic/wp-calypso/issues/98039

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

To sync with sandbox:

First build:
```
jetpack build packages/jetpack-mu-wpcom
```

Then sync

```
jetpack rsync jetpack [YOUR_SANDBOX_HOST]:~/[PATH_TO_PLUGIN]/dev
```

Fire up a free site and change and save any global styles in the site editor over at `/wp-admin/site-editor.php?p=%2Fstyles`

Then visit your site's frontend logged in. 

In the global styles upgrade popover, check that the buttons work:

- upgrade links to plan
- premium styles documentation
- toggle between styles views
- reset global styles

