### PR TITLE
E2E Tests: Only install Chromium and its deps for Playwright

### DIFF
--- a/projects/plugins/automattic-for-agencies-client/changelog/fix-playwright_install_tweaks
+++ b/projects/plugins/automattic-for-agencies-client/changelog/fix-playwright_install_tweaks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+E2E Tests: Only install single browser used by Playwright.

--- a/projects/plugins/automattic-for-agencies-client/tests/e2e/package.json
+++ b/projects/plugins/automattic-for-agencies-client/tests/e2e/package.json
@@ -25,7 +25,7 @@
 		"tunnel:reset": "tunnel reset",
 		"tunnel:down": "tunnel down",
 		"pretest:run": "pnpm run clean",
-		"test:run": ". ./node_modules/jetpack-e2e-commons/bin/app-password.sh && playwright install && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
+		"test:run": ". ./node_modules/jetpack-e2e-commons/bin/app-password.sh && playwright install --with-deps chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
 	},
 	"devDependencies": {
 		"@playwright/test": "1.48.2",

--- a/projects/plugins/boost/changelog/fix-playwright_install_tweaks
+++ b/projects/plugins/boost/changelog/fix-playwright_install_tweaks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+E2E Tests: Only install single browser used by Playwright.

--- a/projects/plugins/boost/tests/e2e/package.json
+++ b/projects/plugins/boost/tests/e2e/package.json
@@ -24,7 +24,7 @@
 		"tunnel:reset": "tunnel reset",
 		"tunnel:down": "tunnel down",
 		"pretest:run": "pnpm run clean",
-		"test:run": ". ./node_modules/jetpack-e2e-commons/bin/app-password.sh && playwright install && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs",
+		"test:run": ". ./node_modules/jetpack-e2e-commons/bin/app-password.sh && playwright install --with-deps chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs",
 		"prepare:e2e": "pnpm jetpack docker --type e2e --name t1 exec-silent -- chown -R www-data .htaccess wp-config.php wp-content"
 	},
 	"devDependencies": {

--- a/projects/plugins/classic-theme-helper-plugin/changelog/fix-playwright_install_tweaks
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/fix-playwright_install_tweaks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+E2E Tests: Only install single browser used by Playwright.

--- a/projects/plugins/classic-theme-helper-plugin/tests/e2e/package.json
+++ b/projects/plugins/classic-theme-helper-plugin/tests/e2e/package.json
@@ -25,7 +25,7 @@
 		"tunnel:reset": "tunnel reset",
 		"tunnel:down": "tunnel down",
 		"pretest:run": "pnpm run clean",
-		"test:run": ". ./node_modules/jetpack-e2e-commons/bin/app-password.sh && playwright install && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
+		"test:run": ". ./node_modules/jetpack-e2e-commons/bin/app-password.sh && playwright install --with-deps chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
 	},
 	"devDependencies": {
 		"@playwright/test": "1.48.2",

--- a/projects/plugins/jetpack/changelog/fix-playwright_install_tweaks
+++ b/projects/plugins/jetpack/changelog/fix-playwright_install_tweaks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+E2E Tests: Only install single browser used by Playwright.

--- a/projects/plugins/jetpack/tests/e2e/package.json
+++ b/projects/plugins/jetpack/tests/e2e/package.json
@@ -26,7 +26,7 @@
 		"tunnel:reset": "tunnel reset",
 		"tunnel:down": "tunnel down",
 		"pretest:run": "pnpm run clean",
-		"test:run": ". ./node_modules/jetpack-e2e-commons/bin/app-password.sh && playwright install && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=playwright.config.mjs",
+		"test:run": ". ./node_modules/jetpack-e2e-commons/bin/app-password.sh && playwright install --with-deps chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=playwright.config.mjs",
 		"test-decrypt-default-config": "openssl enc -md sha1 -aes-256-cbc -d -pass env:CONFIG_KEY -in ./node_modules/jetpack-e2e-commons/config/encrypted.enc -out ./node_modules/jetpack-e2e-commons/config/local.cjs",
 		"test-decrypt-config": "openssl enc -md sha1 -aes-256-cbc -d -pass env:CONFIG_KEY -in ./config/encrypted.enc -out config/local.cjs",
 		"test-decrypt-all-config": "pnpm test-decrypt-default-config && pnpm test-decrypt-config",

--- a/projects/plugins/search/changelog/fix-playwright_install_tweaks
+++ b/projects/plugins/search/changelog/fix-playwright_install_tweaks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+E2E Tests: Only install single browser used by Playwright.

--- a/projects/plugins/search/tests/e2e/package.json
+++ b/projects/plugins/search/tests/e2e/package.json
@@ -23,7 +23,7 @@
 		"tunnel:reset": "tunnel reset",
 		"tunnel:down": "tunnel down",
 		"pretest:run": "pnpm run clean",
-		"test:run": ". ./node_modules/jetpack-e2e-commons/bin/app-password.sh && playwright install && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=playwright.config.mjs"
+		"test:run": ". ./node_modules/jetpack-e2e-commons/bin/app-password.sh && playwright install --with-deps chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=playwright.config.mjs"
 	},
 	"devDependencies": {
 		"@playwright/test": "1.48.2",

--- a/projects/plugins/social/changelog/fix-playwright_install_tweaks
+++ b/projects/plugins/social/changelog/fix-playwright_install_tweaks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+E2E Tests: Only install single browser used by Playwright.

--- a/projects/plugins/social/tests/e2e/package.json
+++ b/projects/plugins/social/tests/e2e/package.json
@@ -27,7 +27,7 @@
 		"tunnel:reset": "tunnel reset",
 		"tunnel:down": "tunnel down",
 		"pretest:run": "pnpm run clean",
-		"test:run": ". ./node_modules/jetpack-e2e-commons/bin/app-password.sh && playwright install && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
+		"test:run": ". ./node_modules/jetpack-e2e-commons/bin/app-password.sh && playwright install --with-deps chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
 	},
 	"devDependencies": {
 		"@playwright/test": "1.48.2",

--- a/projects/plugins/starter-plugin/changelog/fix-playwright_install_tweaks
+++ b/projects/plugins/starter-plugin/changelog/fix-playwright_install_tweaks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+E2E Tests: Only install single browser used by Playwright.

--- a/projects/plugins/starter-plugin/tests/e2e/package.json
+++ b/projects/plugins/starter-plugin/tests/e2e/package.json
@@ -25,7 +25,7 @@
 		"tunnel:reset": "tunnel reset",
 		"tunnel:down": "tunnel down",
 		"pretest:run": "pnpm run clean",
-		"test:run": ". ./node_modules/jetpack-e2e-commons/bin/app-password.sh && playwright install && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
+		"test:run": ". ./node_modules/jetpack-e2e-commons/bin/app-password.sh && playwright install --with-deps chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
 	},
 	"devDependencies": {
 		"@playwright/test": "1.48.2",

--- a/projects/plugins/videopress/changelog/fix-playwright_install_tweaks
+++ b/projects/plugins/videopress/changelog/fix-playwright_install_tweaks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+E2E Tests: Only install single browser used by Playwright.

--- a/projects/plugins/videopress/tests/e2e/package.json
+++ b/projects/plugins/videopress/tests/e2e/package.json
@@ -25,7 +25,7 @@
 		"tunnel:reset": "tunnel reset",
 		"tunnel:down": "tunnel down",
 		"pretest:run": "pnpm run clean",
-		"test:run": ". ./node_modules/jetpack-e2e-commons/bin/app-password.sh && playwright install && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
+		"test:run": ". ./node_modules/jetpack-e2e-commons/bin/app-password.sh && playwright install --with-deps chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
 	},
 	"devDependencies": {
 		"@playwright/test": "1.48.2",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Right now we use default settings to install Chromium, Firefox, and Webkit for Playwright prior to running E2E tests, but we only use Chromium in our config. GH Actions also shows missing dependencies. This PR fixes both of those by switching from this:

`playwright install`

to this:

`playwright install --with-deps chromium`

It trades about 10 seconds of unneeded installs for about 15 seconds of dependencies, which means this is technically slower by a few seconds. We could remove the `--with-deps` if we prefer since tests run fine anyway, though I don't see a way to suppress those dependency warnings.

I considered `--only-shell`, but this would force headless on local installs, which isn't ideal.
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
* Is only Chromium (and FFMPEG) downloading)?
* Is the dependency warning gone?
* In particular, are E2E tests passing (as well as they did before)?

Here's an old run with multiple browsers downloaded and the dependency warning:
https://github.com/Automattic/jetpack/actions/runs/12585666388/job/35077965663