### PR TITLE
ScanReport: Use error variant ShieldIcon for threats

### DIFF
--- a/projects/js-packages/components/components/scan-report/index.tsx
+++ b/projects/js-packages/components/components/scan-report/index.tsx
@@ -97,7 +97,7 @@ export default function ScanReport( { dataSource, data, onChangeSelection } ): J
 				},
 				render( { item }: { item: ScanReportExtension } ) {
 					const scanApi = 'scan_api' === dataSource;
-					let variant: 'info' | 'warning' | 'success' = 'info';
+					let variant: 'info' | 'error' | 'success' = 'info';
 					let text = __(
 						'This item was added to your site after the most recent scan. We will check for threats during the next scheduled one.',
 						'jetpack-components'
@@ -105,7 +105,7 @@ export default function ScanReport( { dataSource, data, onChangeSelection } ): J
 
 					if ( item.checked ) {
 						if ( item.threats.length > 0 ) {
-							variant = 'warning';
+							variant = 'error';
 							text = _n(
 								'Vulnerability detected.',
 								'Vulnerabilities detected.',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Description
Update the ScanReport to use the error variant over the warning variant for threat entries.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://github.com/Automattic/jetpack-scan-team/issues/1615

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* View ScanReport stories

## Screenshot
![Screen Shot on 2025-01-02 at 11-27-50](https://github.com/user-attachments/assets/1894d49b-6884-4b30-8cfe-75195c1608e7)

