### PR TITLE
AI Assistant: Fix block inserter position for Form block with AI extension

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-extension-form-adjustment
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-extension-form-adjustment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Fix block inserter position for Form block with AI extension

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-form/index.tsx
@@ -22,7 +22,6 @@ export class JetpackFormHandler extends BlockHandler {
 		super( clientId, [] );
 		this.behavior = 'action';
 		this.feature = 'jetpack-form-ai-extension';
-		this.adjustPosition = false;
 		this.startOpen = true;
 		this.hideOnBlockFocus = false;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #40833 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the `adjustPosition` flag from the Form extension, as a Gutenberg update seems to have changed how that works for blocks with wrapper elements

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and add a Form block before some other block
* Check that, when the AI input is displayed, the block inserter is at the right place

| Before | After |
| - | - |
| ![Screenshot from 2025-01-02 17-07-22](https://github.com/user-attachments/assets/d9740030-b26d-44dd-b52d-ee4be76229b0) | ![Screenshot from 2025-01-02 17-04-42](https://github.com/user-attachments/assets/94102c3d-3f03-47c2-be60-db5c2814313f) |



