### PR TITLE
Map block: UI updates to inspector controls

### DIFF
--- a/projects/plugins/jetpack/changelog/map-block-ui-updates
+++ b/projects/plugins/jetpack/changelog/map-block-ui-updates
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Map block: Inspector controls UI improvements

--- a/projects/plugins/jetpack/extensions/blocks/map/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/controls.js
@@ -9,11 +9,12 @@ import {
 	ToolbarButton,
 	ToolbarGroup,
 	RangeControl,
-	BaseControl,
 	SVG,
 	G,
 	Polygon,
 	Path,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalNumberControl as NumberControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import Locations from './locations';
@@ -44,7 +45,6 @@ export default ( {
 	onKeyChange,
 	context,
 	mapRef,
-	instanceId,
 	minHeight,
 	removeAPIKey,
 	updateAPIKey,
@@ -56,38 +56,6 @@ export default ( {
 
 		// Allow one cycle for alignment change to take effect
 		if ( mapRef.current?.sizeMap ) {
-			setTimeout( mapRef.current.sizeMap, 0 );
-		}
-	};
-
-	/**
-	 * Change event handler for the map height sidebar control. Ensures the height is valid,
-	 * and updates both the height attribute, and the map component's height in the DOM.
-	 *
-	 * @param {Event} event - The change event object.
-	 */
-	const onHeightChange = event => {
-		const { mapHeight } = attributes;
-
-		let height = parseInt( event.target.value, 10 );
-
-		if ( isNaN( height ) ) {
-			// Set map height to default size and input box to empty string
-			height = null;
-		} else if ( null == mapHeight ) {
-			// There was previously no height defined, so set the default.
-			const ref = mapRef?.current?.mapRef ?? mapRef;
-			height = ref?.current.offsetHeight;
-		} else if ( height < minHeight ) {
-			// Set map height to minimum size
-			height = minHeight;
-		}
-
-		setAttributes( {
-			mapHeight: height,
-		} );
-
-		if ( mapRef.current.sizeMap ) {
 			setTimeout( mapRef.current.sizeMap, 0 );
 		}
 	};
@@ -120,36 +88,21 @@ export default ( {
 					{
 						value: attributes.markerColor,
 						onChange: value => setAttributes( { markerColor: value } ),
-						label: __( 'Marker Color', 'jetpack' ),
+						label: __( 'Marker', 'jetpack' ),
 					},
 				] }
 			/>
-			<PanelBody title={ __( 'Map Settings', 'jetpack' ) }>
-				<BaseControl
-					__nextHasNoMarginBottom={ true }
+			<PanelBody title={ __( 'Settings', 'jetpack' ) }>
+				<NumberControl
 					label={ __( 'Height in pixels', 'jetpack' ) }
-					id={ `block-jetpack-map-height-input-${ instanceId }` }
-				>
-					<input
-						type="number"
-						id={ `block-jetpack-map-height-input-${ instanceId }` }
-						className="wp-block-jetpack-map__height_input"
-						onChange={ event => {
-							setAttributes( { mapHeight: event.target.value } );
-							// If this input isn't focussed, the onBlur handler won't be triggered
-							// to commit the map size, so we need to check for that.
-							if ( event.target !== event.target.ownerDocument.activeElement ) {
-								if ( mapRef.current ) {
-									setTimeout( mapRef.current.sizeMap, 0 );
-								}
-							}
-						} }
-						onBlur={ onHeightChange }
-						value={ attributes.mapHeight || '' }
-						min={ minHeight }
-						step="10"
-					/>
-				</BaseControl>
+					value={ attributes.mapHeight || '' }
+					min={ minHeight }
+					onChange={ newValue => {
+						setAttributes( { mapHeight: newValue } );
+					} }
+					size="__unstable-large"
+					step={ 10 }
+				/>
 				<RangeControl
 					__nextHasNoMarginBottom={ true }
 					__next40pxDefaultSize
@@ -175,7 +128,7 @@ export default ( {
 				{ mapProvider === 'mapbox' ? (
 					<ToggleControl
 						__nextHasNoMarginBottom={ true }
-						label={ __( 'Show street names', 'jetpack' ) }
+						label={ __( 'Show labels', 'jetpack' ) }
 						checked={ attributes.mapDetails }
 						onChange={ value => setAttributes( { mapDetails: value } ) }
 					/>

--- a/projects/plugins/jetpack/extensions/blocks/map/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/edit.js
@@ -15,7 +15,7 @@ import {
 	ResizableBox,
 } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
-import { withDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getActiveStyleName } from '../../shared/block-styles';
@@ -55,9 +55,6 @@ const MapEdit = ( {
 	noticeUI,
 	notices,
 	isSelected,
-	instanceId,
-	onResizeStart,
-	onResizeStop,
 	noticeOperations,
 } ) => {
 	const {
@@ -70,6 +67,8 @@ const MapEdit = ( {
 		mapHeight,
 		showFullscreenButton,
 	} = attributes;
+
+	const { toggleSelection } = useDispatch( 'core/block-editor' );
 
 	const { isPreviewMode } = useSelect( select => {
 		const { getSettings } = select( blockEditorStore );
@@ -195,8 +194,7 @@ const MapEdit = ( {
 	 * @param {object}      delta     - Information about how far the element was resized.
 	 */
 	const onMapResize = ( event, direction, elt, delta ) => {
-		onResizeStop();
-
+		toggleSelection( true );
 		const ref = mapRef?.current?.mapRef ?? mapRef;
 
 		if ( ref ) {
@@ -322,7 +320,6 @@ const MapEdit = ( {
 						apiKeyControl={ apiKeyControl }
 						onKeyChange={ onKeyChange }
 						mapRef={ mapRef }
-						instanceId={ instanceId }
 						minHeight={ MIN_HEIGHT }
 						removeAPIKey={ removeAPIKey }
 						updateAPIKey={ updateAPIKey }
@@ -339,7 +336,7 @@ const MapEdit = ( {
 					showHandle={ isSelected }
 					minHeight={ MIN_HEIGHT }
 					enable={ RESIZABLE_BOX_ENABLE_OPTION }
-					onResizeStart={ onResizeStart }
+					onResizeStart={ () => toggleSelection( false ) }
 					onResizeStop={ onMapResize }
 				>
 					<div className="wp-block-jetpack-map__map_wrapper">
@@ -392,14 +389,4 @@ const MapEdit = ( {
 	);
 };
 
-export default compose( [
-	withNotices,
-	withDispatch( dispatch => {
-		const { toggleSelection } = dispatch( 'core/block-editor' );
-
-		return {
-			onResizeStart: () => toggleSelection( false ),
-			onResizeStop: () => toggleSelection( true ),
-		};
-	} ),
-] )( MapEdit );
+export default compose( withNotices )( MapEdit );

--- a/projects/plugins/jetpack/extensions/blocks/map/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/map/editor.scss
@@ -58,10 +58,6 @@
 	}
 }
 
-.wp-block-jetpack-map__height_input {
-	display: block;
-}
-
 .component__add-point__popover {
 	.components-popover__content {
 		width: 250px;

--- a/projects/plugins/jetpack/extensions/blocks/map/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/test/controls.js
@@ -63,11 +63,11 @@ describe( 'Inspector controls', () => {
 		test( 'displays marker colors correctly', () => {
 			render( <MapControls { ...defaultProps } /> );
 
-			expect( screen.getByText( 'Marker Color' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Marker' ) ).toBeInTheDocument();
 		} );
 	} );
 
-	describe( 'Map settings panel', () => {
+	describe( 'Settings panel', () => {
 		test( 'height input shows correctly', () => {
 			render( <MapControls { ...defaultProps } /> );
 
@@ -83,7 +83,7 @@ describe( 'Inspector controls', () => {
 		test( 'street names toggle shows correctly when mapProvider is mapbox', () => {
 			render( <MapControls { ...defaultProps } /> );
 
-			expect( screen.getByText( 'Show street names' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Show labels' ) ).toBeInTheDocument();
 		} );
 
 		test( "street names toggle shows doesn't show when mapProvider is mapkit", () => {
@@ -91,7 +91,7 @@ describe( 'Inspector controls', () => {
 
 			render( <MapControls { ...props } /> );
 
-			expect( screen.queryByText( 'Show street names' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Show labels' ) ).not.toBeInTheDocument();
 		} );
 
 		test( 'scroll to zoom toggle shows correctly when mapProvider is mapbox', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of: https://github.com/Automattic/jetpack/issues/40718

Some minor UI Improvements to the Map block inspector controls.
The issue suggests using the `HeightControl`, but for now I've updated to use the `NumberControl`.
 `HeightControl` would require some upstream changes to probably allow defining the available units, as it's currently using the theme's available units and it seemed to me that we specifically only want to define this in pixels. We can do that in follow ups.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Testing instructions:
1. insert a `map` block, open the inspector controls and observe the following
2. "Map Settings" changed to "Settings"
3. "Show street names" changed to "Show labels"
4. "Marker Color" changed to "Marker"
5. height in pixels uses `HeightControl`
6. No regressions are introduced

Before     | After
:-------------------------:|:-------------------------:
<img width="814" alt="bef" src="https://github.com/user-attachments/assets/0d9fcddd-cea6-45a9-a24a-81ed377bcdf5" /> | <img width="814" alt="after" src="https://github.com/user-attachments/assets/e6a020e4-3c89-4715-b37d-4ae55e704303" />

