### PR TITLE
My Jetpack: Improve `Products::get_products()`. Allow to get displayed products only.

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-get-product-classes
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-get-product-classes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Enhanced `get_products()` to optionally accept parameter whether to return all or visible_only products. Non user-facing enhancement.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -984,25 +984,11 @@ class Initializer {
 		if ( ! $connection->is_connected() ) {
 			return $red_bubble_slugs;
 		}
-		$product_classes    = Products::get_products_classes();
-		$not_shown_products = array(
-			'scan',
-			'extras',
-			'ai',
-			'newsletter',
-			'site-accelerator',
-			'related-posts',
-		);
+		// Passing `true` argument in order to only get visible products that are displayed as product cards on the My Jetpack page.
+		$displayed_products_classes = Products::get_products_classes( true );
 
 		$products_included_in_expiring_plan = array();
-		foreach ( $product_classes as $key => $product ) {
-			// Skip these- we don't show them in My Jetpack.
-			// ('ai' is a duplicate class of 'jetpack-ai', and therefore not needed).
-			// See `get_product_classes() in projects/packages/my-jetpack/src/class-products.php for more info.
-			if ( in_array( $key, $not_shown_products, true ) ) {
-				continue;
-			}
-
+		foreach ( $displayed_products_classes as $product ) {
 			if ( $product::has_paid_plan_for_product() ) {
 				$purchase = $product::get_paid_plan_purchase_for_product();
 				if ( $purchase ) {

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -200,11 +200,13 @@ class Products {
 	/**
 	 * Product data
 	 *
+	 * @param bool $visible_products_only If true, only products that are visible product cards on the My Jetpack page are returned.
+	 *
 	 * @return array Jetpack products on the site and their availability.
 	 */
-	public static function get_products() {
+	public static function get_products( $visible_products_only = false ) {
 		$products = array();
-		foreach ( self::get_products_classes() as $class ) {
+		foreach ( self::get_products_classes( $visible_products_only ) as $class ) {
 			$product_slug              = $class::$slug;
 			$products[ $product_slug ] = $class::get_info();
 		}

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -114,13 +114,14 @@ class Products {
 
 	/**
 	 * Get the list of Products classes
-	 *
 	 * Here's where all the existing Products are registered
+	 *
+	 * @param bool $visible_products_only If true, only products that are visible product cards on the My Jetpack page are returned.
 	 *
 	 * @throws \Exception If the result of a filter has invalid classes.
 	 * @return array List of class names
 	 */
-	public static function get_products_classes() {
+	public static function get_products_classes( $visible_products_only = false ) {
 		$classes = array(
 			'anti-spam'        => Products\Anti_Spam::class,
 			'backup'           => Products\Backup::class,
@@ -130,7 +131,8 @@ class Products {
 			'extras'           => Products\Extras::class,
 			'jetpack-ai'       => Products\Jetpack_Ai::class,
 			// TODO: Remove this duplicate class ('ai')? See: https://github.com/Automattic/jetpack/pull/35910#pullrequestreview-2456462227
-			'ai'               => Products\Jetpack_Ai::class,
+			// Jan 2, 2025 - Removing this 'ai' slug now.  But only commenting it out for now for debugging purposes, just in case it causes an error somewhere.
+			// 'ai'               => Products\Jetpack_Ai::class,
 			'scan'             => Products\Scan::class,
 			'search'           => Products\Search::class,
 			'social'           => Products\Social::class,
@@ -170,7 +172,29 @@ class Products {
 			}
 		}
 
+		if ( $visible_products_only ) {
+			// Filter out products that are not shown as visible product cards on the main My Jetpack page.
+			return array_filter(
+				$final_classes,
+				function ( $class ) {
+					return $class::$is_visible_product_card;
+				}
+			);
+		}
+
 		return $final_classes;
+	}
+
+	/**
+	 * Get the list of product slugs that are NOT shown on the main My Jetpack screen.
+	 *
+	 * @return array An array of product slugs that do not get displayed as product cards on the My Jetpack screen.
+	 */
+	public static function get_products_not_shown_in_ui() {
+		$all_products     = self::get_products_classes();
+		$visible_products = self::get_products_classes( true );
+
+		return array_keys( array_diff( $all_products, $visible_products ) );
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/class-rest-products.php
+++ b/projects/packages/my-jetpack/src/class-rest-products.php
@@ -25,6 +25,12 @@ class REST_Products {
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => __CLASS__ . '::get_products',
 					'permission_callback' => __CLASS__ . '::permissions_callback',
+					'args'                => array(
+						'visible_only' => array(
+							'required' => false,
+							'type'     => 'boolean',
+						),
+					),
 				),
 				'schema' => array( $this, 'get_products_schema' ),
 			)
@@ -144,10 +150,12 @@ class REST_Products {
 	/**
 	 * Site products endpoint.
 	 *
+	 * @param \WP_REST_Request $request The request object.
 	 * @return array of site products list.
 	 */
-	public static function get_products() {
-		$response = Products::get_products();
+	public static function get_products( $request ) {
+		$visible_products_only = $request->get_param( 'visible_only' ) ?? false;
+		$response              = Products::get_products( $visible_products_only );
 		return rest_ensure_response( $response, 200 );
 	}
 

--- a/projects/packages/my-jetpack/src/products/class-anti-spam.php
+++ b/projects/packages/my-jetpack/src/products/class-anti-spam.php
@@ -65,6 +65,13 @@ class Anti_Spam extends Product {
 	public static $has_standalone_plugin = true;
 
 	/**
+	 * Whether the Product is a visible product card shown on the main My Jetpack screen
+	 *
+	 * @var bool
+	 */
+	public static $is_visible_product_card = true;
+
+	/**
 	 * Get the product name
 	 *
 	 * @return string

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -72,6 +72,13 @@ class Backup extends Hybrid_Product {
 	public static $feature_identifying_paid_plan = 'backups';
 
 	/**
+	 * Whether the Product is a visible product card shown on the main My Jetpack screen
+	 *
+	 * @var bool
+	 */
+	public static $is_visible_product_card = true;
+
+	/**
 	 * Get the product name
 	 *
 	 * @return string

--- a/projects/packages/my-jetpack/src/products/class-boost.php
+++ b/projects/packages/my-jetpack/src/products/class-boost.php
@@ -73,6 +73,13 @@ class Boost extends Product {
 	public static $feature_identifying_paid_plan = 'cloud-critical-css';
 
 	/**
+	 * Whether the Product is a visible product card shown on the main My Jetpack screen
+	 *
+	 * @var bool
+	 */
+	public static $is_visible_product_card = true;
+
+	/**
 	 * Get the product name
 	 *
 	 * @return string

--- a/projects/packages/my-jetpack/src/products/class-crm.php
+++ b/projects/packages/my-jetpack/src/products/class-crm.php
@@ -61,6 +61,13 @@ class Crm extends Product {
 	public static $has_standalone_plugin = true;
 
 	/**
+	 * Whether the Product is a visible product card shown on the main My Jetpack screen
+	 *
+	 * @var bool
+	 */
+	public static $is_visible_product_card = true;
+
+	/**
 	 * Get the product name
 	 *
 	 * @return string

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -43,6 +43,13 @@ class Jetpack_Ai extends Product {
 	public static $feature_identifying_paid_plan = 'ai-assistant';
 
 	/**
+	 * Whether the Product is a visible product card shown on the main My Jetpack screen
+	 *
+	 * @var bool
+	 */
+	public static $is_visible_product_card = true;
+
+	/**
 	 * Get the Product info for the API
 	 *
 	 * @throws \Exception If required attribute is not declared in the child class.

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -117,6 +117,13 @@ abstract class Product {
 	public static $feature_identifying_paid_plan = '';
 
 	/**
+	 * Whether the Product is a visible product card shown on the main My Jetpack screen
+	 *
+	 * @var bool
+	 */
+	public static $is_visible_product_card = false;
+
+	/**
 	 * Get the plugin slug
 	 *
 	 * @return ?string

--- a/projects/packages/my-jetpack/src/products/class-protect.php
+++ b/projects/packages/my-jetpack/src/products/class-protect.php
@@ -80,6 +80,13 @@ class Protect extends Hybrid_Product {
 	public static $feature_identifying_paid_plan = 'scan';
 
 	/**
+	 * Whether the Product is a visible product card shown on the main My Jetpack screen
+	 *
+	 * @var bool
+	 */
+	public static $is_visible_product_card = true;
+
+	/**
 	 * Get the product name
 	 *
 	 * @return string

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -88,6 +88,13 @@ class Search extends Hybrid_Product {
 	public static $feature_identifying_paid_plan = 'search';
 
 	/**
+	 * Whether the Product is a visible product card shown on the main My Jetpack screen
+	 *
+	 * @var bool
+	 */
+	public static $is_visible_product_card = true;
+
+	/**
 	 * Get the product name
 	 *
 	 * @return string

--- a/projects/packages/my-jetpack/src/products/class-social.php
+++ b/projects/packages/my-jetpack/src/products/class-social.php
@@ -71,6 +71,13 @@ class Social extends Hybrid_Product {
 	public static $feature_identifying_paid_plan = 'social-enhanced-publishing';
 
 	/**
+	 * Whether the Product is a visible product card shown on the main My Jetpack screen
+	 *
+	 * @var bool
+	 */
+	public static $is_visible_product_card = true;
+
+	/**
 	 * Get the product name
 	 *
 	 * @return string

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -75,6 +75,13 @@ class Stats extends Module_Product {
 	public static $feature_identifying_paid_plan = 'stats-paid';
 
 	/**
+	 * Whether the Product is a visible product card shown on the main My Jetpack screen
+	 *
+	 * @var bool
+	 */
+	public static $is_visible_product_card = true;
+
+	/**
 	 * Get the product name
 	 *
 	 * @return string

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -76,6 +76,13 @@ class Videopress extends Hybrid_Product {
 	public static $feature_identifying_paid_plan = 'videopress';
 
 	/**
+	 * Whether the Product is a visible product card shown on the main My Jetpack screen
+	 *
+	 * @var bool
+	 */
+	public static $is_visible_product_card = true;
+
+	/**
 	 * Get the product name
 	 *
 	 * @return string


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* TBD..  Coming soon...
*

