### PR TITLE
Stats: Remove legacy widget loader from WP Admin

### DIFF
--- a/projects/plugins/jetpack/changelog/update-stats_remove_legacy_widget_loader
+++ b/projects/plugins/jetpack/changelog/update-stats_remove_legacy_widget_loader
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Remove legacy Stats widget loader

--- a/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
@@ -5,7 +5,6 @@
  * @package jetpack
  */
 
-use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Stats\Options as Stats_Options;
@@ -74,23 +73,6 @@ class Jetpack_Stats_Dashboard_Widget {
 				);
 				// Only load scripts when the widget is not hidden
 				$stats_widget->maybe_load_admin_scripts();
-			} else {
-				// Legacy widget.
-				wp_add_dashboard_widget(
-					Dashboard_Stats_Widget::DASHBOARD_WIDGET_ID,
-					$widget_title,
-					array( __CLASS__, 'render_widget' )
-				);
-				wp_enqueue_style(
-					'jetpack-dashboard-widget',
-					Assets::get_file_url_for_environment(
-						'css/dashboard-widget.min.css',
-						'css/dashboard-widget.css'
-					),
-					array(),
-					JETPACK__VERSION
-				);
-				wp_style_add_data( 'jetpack-dashboard-widget', 'rtl', 'replace' );
 			}
 		}
 	}

--- a/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
@@ -7,7 +7,6 @@
 
 use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
 use Automattic\Jetpack\Redirect;
-use Automattic\Jetpack\Stats\Options as Stats_Options;
 use Automattic\Jetpack\Stats_Admin\WP_Dashboard_Odyssey_Widget as Dashboard_Stats_Widget;
 use Automattic\Jetpack\Status;
 
@@ -63,17 +62,15 @@ class Jetpack_Stats_Dashboard_Widget {
 				__( 'Jetpack Stats', 'jetpack' )
 			);
 
-			if ( Stats_Options::get_option( 'enable_odyssey_stats' ) ) {
-				// New widget implemented in Odyssey Stats.
-				$stats_widget = new Dashboard_Stats_Widget();
-				wp_add_dashboard_widget(
-					Dashboard_Stats_Widget::DASHBOARD_WIDGET_ID,
-					$widget_title,
-					array( $stats_widget, 'render' )
-				);
-				// Only load scripts when the widget is not hidden
-				$stats_widget->maybe_load_admin_scripts();
-			}
+			// New widget implemented in Odyssey Stats.
+			$stats_widget = new Dashboard_Stats_Widget();
+			wp_add_dashboard_widget(
+				Dashboard_Stats_Widget::DASHBOARD_WIDGET_ID,
+				$widget_title,
+				array( $stats_widget, 'render' )
+			);
+			// Only load scripts when the widget is not hidden
+			$stats_widget->maybe_load_admin_scripts();
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/40412

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the legacy Stats widget loader to prevent seeing the outdated Stats widget when visiting `/wp-admin` of Simple sites with the Default Admin interface style.
* Ignore the `enable_odyssey_stats` option for the WPAdmin Dashboard widget completely.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Launch a Simple site and go to the WPCOM Settings page: `https://wordpress.com/settings/general/{site-slug}`.
* Ensure the Admin interface style is set to `Default style`.
* Visit the Simple site WPAdmin Dashboard: `https://{site-slug}/wp-admin`.
* Ensure the legacy Stats widget is not shown anymore.

<img width="490" alt="截圖 2025-01-03 晚上11 30 51" src="https://github.com/user-attachments/assets/c5d80028-090c-427e-95bc-a2493b1c6c5f" />

