### PR TITLE
Admin Menu / WooCommerce: Fix product redirect

### DIFF
--- a/projects/packages/masterbar/changelog/fix-self-hosted-product-redirect
+++ b/projects/packages/masterbar/changelog/fix-self-hosted-product-redirect
@@ -1,4 +1,4 @@
-Significance: fix
+Significance: patch
 Type: changed
 
 Fixes the self-hosted link when WooCommerce is installed alongside with the SSO.

--- a/projects/packages/masterbar/changelog/fix-self-hosted-product-redirect
+++ b/projects/packages/masterbar/changelog/fix-self-hosted-product-redirect
@@ -1,0 +1,4 @@
+Significance: fix
+Type: changed
+
+Fixes the self-hosted link when WooCommerce is installed alongside with the SSO.

--- a/projects/packages/masterbar/src/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-jetpack-admin-menu.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\Masterbar;
 use Automattic\Jetpack\Blaze;
 use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
 use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\Status\Host;
 
 require_once __DIR__ . '/class-admin-menu.php';
 

--- a/projects/packages/masterbar/src/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-jetpack-admin-menu.php
@@ -62,20 +62,6 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	}
 
 	/**
-	 * Check if the current site is a self-hosted site.
-	 *
-	 * @return bool Whether the site is a self-hosted site.
-	 */
-	private function is_self_hosted_site() {
-		if ( ! function_exists( 'is_jetpack_site' ) || ! function_exists( 'is_blog_atomic' ) ) {
-			return true;
-		}
-		$blog_id = get_current_blog_id();
-
-		return is_jetpack_site( $blog_id ) && ! is_blog_atomic( get_blog_details( $blog_id ) );
-	}
-
-	/**
 	 * Get the Calypso or wp-admin link to CPT page.
 	 *
 	 * @param object $ptype_obj The post type object.
@@ -85,7 +71,8 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	public function get_cpt_menu_link( $ptype_obj ) {
 
 		$post_type                          = $ptype_obj->name;
-		$is_woocommerce_product_self_hosted = $post_type === 'product' && class_exists( 'WooCommerce' ) && $this->is_self_hosted_site();
+		$is_self_hosted_site                = ! ( new Host() )->is_wpcom_platform();
+		$is_woocommerce_product_self_hosted = $post_type === 'product' && class_exists( 'WooCommerce' ) && $is_self_hosted_site;
 
 		if ( ! $is_woocommerce_product_self_hosted && ( new Modules() )->is_active( 'sso' ) && $ptype_obj->show_in_rest ) {
 			return 'https://wordpress.com/types/' . $post_type . '/' . $this->domain;

--- a/projects/packages/masterbar/src/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-jetpack-admin-menu.php
@@ -62,6 +62,20 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	}
 
 	/**
+	 * Check if the current site is a self-hosted site.
+	 *
+	 * @return bool Whether the site is a self-hosted site.
+	 */
+	private function is_self_hosted_site() {
+		if ( ! function_exists( 'is_jetpack_site' ) || ! function_exists( 'is_blog_atomic' ) ) {
+			return true;
+		}
+		$blog_id = get_current_blog_id();
+
+		return is_jetpack_site( $blog_id ) && ! is_blog_atomic( get_blog_details( $blog_id ) );
+	}
+
+	/**
 	 * Get the Calypso or wp-admin link to CPT page.
 	 *
 	 * @param object $ptype_obj The post type object.
@@ -70,9 +84,10 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	 */
 	public function get_cpt_menu_link( $ptype_obj ) {
 
-		$post_type = $ptype_obj->name;
+		$post_type                          = $ptype_obj->name;
+		$is_woocommerce_product_self_hosted = $post_type === 'product' && class_exists( 'WooCommerce' ) && $this->is_self_hosted_site();
 
-		if ( ( new Modules() )->is_active( 'sso' ) && $ptype_obj->show_in_rest ) {
+		if ( ! $is_woocommerce_product_self_hosted && ( new Modules() )->is_active( 'sso' ) && $ptype_obj->show_in_rest ) {
 			return 'https://wordpress.com/types/' . $post_type . '/' . $this->domain;
 		} else {
 			return 'edit.php?post_type=' . $post_type;

--- a/projects/packages/masterbar/src/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-jetpack-admin-menu.php
@@ -10,7 +10,6 @@ namespace Automattic\Jetpack\Masterbar;
 use Automattic\Jetpack\Blaze;
 use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
 use Automattic\Jetpack\Modules;
-use Automattic\Jetpack\Status\Host;
 
 require_once __DIR__ . '/class-admin-menu.php';
 
@@ -71,11 +70,10 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	 */
 	public function get_cpt_menu_link( $ptype_obj ) {
 
-		$post_type                          = $ptype_obj->name;
-		$is_self_hosted_site                = ! ( new Host() )->is_wpcom_platform();
-		$is_woocommerce_product_self_hosted = $post_type === 'product' && class_exists( 'WooCommerce' ) && $is_self_hosted_site;
+		$post_type              = $ptype_obj->name;
+		$is_woocommerce_product = $post_type === 'product' && class_exists( 'WooCommerce' );
 
-		if ( ! $is_woocommerce_product_self_hosted && ( new Modules() )->is_active( 'sso' ) && $ptype_obj->show_in_rest ) {
+		if ( ! $is_woocommerce_product && ( new Modules() )->is_active( 'sso' ) && $ptype_obj->show_in_rest ) {
 			return 'https://wordpress.com/types/' . $post_type . '/' . $this->domain;
 		} else {
 			return 'edit.php?post_type=' . $post_type;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/72429

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We noticed that the "Products" button was not working on self-hosted sites connected with Jetpack and had the SSO enabled. The problem was the user was being redirected to `https://wordpress.com/types/product/{site}` as opposed to `/wp-admin/edit.php?post_type=product`.
* I updated the check on the `class-jetpack-admin-menu.php` file, which is responsible for generating the link we use in Calypso.
* I'm not convinced that this is the best approach, but I believe we shouldn't disable the `show_in_rest` prop on the Product type.

For more context, please visit https://github.com/Automattic/wp-calypso/issues/72429

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* We need a self-hosted site to test this. I used a Jurassic Ninja site for that and applied the changes manually. 
* Install WooCommerce on your self-hosted site and connect Jetpack.
* Don't enable the SSO just yet.
* Now access your site on WordPress.com
* Click on the Products link, and you should be redirected to the WP Admin page of your site.
* Now enable the SSO, and go back to WordPress.com
* Click again on the Products link and you should be redirected to the WP Admin page again.
* You can also remove the changes and test the wrong behavior.
