### PR TITLE
Fix/bug color palettes

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-color-palette
+++ b/projects/plugins/wpcomsh/changelog/fix-color-palette
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixe the color palette now showing up.

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -389,7 +389,7 @@ class Colors_Manager_Common {
 		// register scripts
 		wp_register_script( 'Color.js', plugins_url( 'js/color.js', __FILE__ ), array(), '20121210', true );
 		wp_register_script( 'colors-instapreview', plugins_url( 'js/colors-theme-preview.js', __FILE__ ), array( 'customize-preview', 'jquery', 'Color.js' ), '20121210', true );
-		wp_register_script( 'colors-tool', plugins_url( 'js/colors-control.js', __FILE__ ), array( 'customize-controls', 'iris' ), '20160726', true );
+		wp_register_script( 'colors-tool', plugins_url( 'js/colors-control.js', __FILE__ ), array( 'customize-controls', 'iris' ), '20250102', true );
 		wp_register_script( 'spin', plugins_url( 'js/spin.js', __FILE__ ), array(), '1.3', true );
 		wp_register_script( 'jquery.spin', plugins_url( 'js/jquery.spin.js', __FILE__ ), array( 'spin' ), '20210111', true );
 	}

--- a/projects/plugins/wpcomsh/custom-colors/js/colors-control.js
+++ b/projects/plugins/wpcomsh/custom-colors/js/colors-control.js
@@ -308,7 +308,8 @@
 			const morePaletteClickHandler = function () {
 				// Load palettes into a client-side cache 40 at a time
 				// and refresh that cache one page before it's necessary.
-				if ( ct.paletteIndex <= ct.palettes.length - ct.palettesAtATime ) {
+				const lastIndex = Math.max( ct.palettes.length, ct.palettes.length - ct.palettesAtATime );
+				if ( lastIndex > ct.paletteIndex ) {
 					ct.showPalettes( ct.paletteIndex );
 				}
 
@@ -766,6 +767,9 @@
 
 			// Construct the color palettes
 			for ( let i = paletteIndex, _len = paletteIndex + 6; i < _len; i++ ) {
+				if ( undefined === ct.palettes[ i ] ) {
+					continue;
+				}
 				const new_palette = $( '<ul/>' ).addClass( 'color-grid colour-lovers' );
 
 				for ( const color_key in ct.palettes[ i ].colors ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes https://github.com/Automattic/themes/issues/8553

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We got a report that the color palettes were not showing up for the user. Upon visiting the code, I noticed that a condition would not work if only three palettes were returned from the endpoint, as the code only worked for six or more palettes. 
* I updated the conditions to accept three palettes.

Before:

![Captura de Tela 2025-01-02 às 13 15 15](https://github.com/user-attachments/assets/63a52566-c5aa-44a6-993c-646384766903)

After:

![399749995-6ebc4c91-de83-4145-9380-df4b6172d914](https://github.com/user-attachments/assets/eafbad2c-4431-4ec6-94ef-46da8b2cbb80)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


1. Create a new Business site, mark it as a WoA Dev site, and take it Atomic.
2. Apply this change to your Atomic site
3. Apply the Rockfield theme to your site.
4. Go to Appearance -> Customize -> Colors & Background.
5. You should now see the color palettes.
