### PR TITLE
Forms: Fixes checkbox checked state for admins

### DIFF
--- a/projects/packages/forms/changelog/fix-checkbox-checked-state
+++ b/projects/packages/forms/changelog/fix-checkbox-checked-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Form: fix the default checkstate for admins

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -386,7 +386,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @param string $field_type The field type.
 	 * @param string $field_id The field id.
 	 *
-	 * @return string;
+	 * @return string
 	 */
 	public function get_computed_field_value( $field_type, $field_id ) {
 		global $current_user, $user_identity;

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -280,7 +280,6 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render() {
-		global $current_user, $user_identity;
 
 		$field_id            = $this->get_attribute( 'id' );
 		$field_type          = $this->maybe_override_type();
@@ -359,46 +358,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		 */
 		$field_class = apply_filters( 'jetpack_contact_form_input_class', $class );
 
-		if ( isset( $_POST[ $field_id ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- no site changes.
-			if ( is_array( $_POST[ $field_id ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- no site changes.
-				$this->value = array_map( 'sanitize_textarea_field', wp_unslash( $_POST[ $field_id ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- no site changes.
-			} else {
-				$this->value = sanitize_textarea_field( wp_unslash( $_POST[ $field_id ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- no site changes.
-			}
-		} elseif ( isset( $_GET[ $field_id ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no site changes.
-			$this->value = sanitize_textarea_field( wp_unslash( $_GET[ $field_id ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no site changes.
-		} elseif (
-			is_user_logged_in() &&
-			( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ||
-			/**
-			 * Allow third-party tools to prefill the contact form with the user's details when they're logged in.
-			 *
-			 * @module contact-form
-			 *
-			 * @since 3.2.0
-			 *
-			 * @param bool false Should the Contact Form be prefilled with your details when you're logged in. Default to false.
-			 */
-			true === apply_filters( 'jetpack_auto_fill_logged_in_user', false )
-			)
-		) {
-			// Special defaults for logged-in users
-			switch ( $field_type ) {
-				case 'email':
-					$this->value = $current_user->data->user_email;
-					break;
-				case 'name':
-					$this->value = $user_identity;
-					break;
-				case 'url':
-					$this->value = $current_user->data->user_url;
-					break;
-				default:
-					$this->value = $this->get_attribute( 'default' );
-			}
-		} else {
-			$this->value = $this->get_attribute( 'default' );
-		}
+		$this->value = $this->get_computed_field_value( $field_type, $field_id );
 
 		$field_value = Contact_Form_Plugin::strip_tags( $this->value );
 		$field_label = Contact_Form_Plugin::strip_tags( $field_label );
@@ -417,6 +377,65 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		 * @param int|null $id Post ID.
 		 */
 		return apply_filters( 'grunion_contact_form_field_html', $rendered_field, $field_label, ( in_the_loop() ? get_the_ID() : null ) );
+	}
+	/**
+	 * Returns the computed field value for a field. It uses the POST, GET, Logged in data.
+	 *
+	 * @module contact-form
+	 *
+	 * @param string $field_type The field type.
+	 * @param string $field_id The field id.
+	 *
+	 * @return string;
+	 */
+	public function get_computed_field_value( $field_type, $field_id ) {
+		global $current_user, $user_identity;
+		// Use the POST Field if it is available.
+		if ( isset( $_POST[ $field_id ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- no site changes.
+			if ( is_array( $_POST[ $field_id ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- no site changes.
+				return array_map( 'sanitize_textarea_field', wp_unslash( $_POST[ $field_id ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- no site changes.
+			}
+
+			return sanitize_textarea_field( wp_unslash( $_POST[ $field_id ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- no site changes.
+		}
+
+		// Use the GET Field if it is available.
+		if ( isset( $_GET[ $field_id ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no site changes.
+			if ( is_array( $_GET[ $field_id ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no site changes.
+				return array_map( 'sanitize_textarea_field', wp_unslash( $_GET[ $field_id ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no site changes.
+			}
+
+			return sanitize_textarea_field( wp_unslash( $_GET[ $field_id ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no site changes.
+		}
+
+		if ( ! is_user_logged_in() ) {
+			return $this->get_attribute( 'default' );
+		}
+
+		/**
+		 * Allow third-party tools to prefill the contact form with the user's details when they're logged in.
+		 *
+		 * @module contact-form
+		 *
+		* @since 3.2.0
+		*
+		* @param bool false Should the Contact Form be prefilled with your details when you're logged in. Default to false.
+		*/
+		$filter_value = apply_filters( 'jetpack_auto_fill_logged_in_user', false );
+		if ( ( ! current_user_can( 'manage_options' ) && ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) || $filter_value ) {
+			switch ( $field_type ) {
+				case 'email':
+					return $current_user->data->user_email;
+
+				case 'name':
+					return ! empty( $user_identity ) ? $user_identity : $current_user->data->display_name;
+
+				case 'url':
+					return $current_user->data->user_url;
+			}
+		}
+
+		return $this->get_attribute( 'default' );
 	}
 
 	/**
@@ -1031,11 +1050,6 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		}
 
 		$field .= "\n<div {$block_style} {$shell_field_class} >\n"; // new in Jetpack 6.8.0
-
-		// If they are logged in, and this is their site, don't pre-populate fields
-		if ( current_user_can( 'manage_options' ) && isset( $type ) && $type !== 'checkbox' ) {
-			$value = '';
-		}
 
 		switch ( $type ) {
 			case 'email':

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1033,7 +1033,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$field .= "\n<div {$block_style} {$shell_field_class} >\n"; // new in Jetpack 6.8.0
 
 		// If they are logged in, and this is their site, don't pre-populate fields
-		if ( current_user_can( 'manage_options' ) ) {
+		if ( current_user_can( 'manage_options' ) && isset( $type ) && $type !== 'checkbox' ) {
 			$value = '';
 		}
 

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form-field.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form-field.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Unit Tests for Automattic\Jetpack\Forms\Contact_Form.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Test class for Contact_Form
+ *
+ * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form
+ */
+class WP_Test_Contact_Form_Field extends BaseTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Mock global variables
+		global $user_identity;
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'admin',
+				'user_pass'  => 'pass',
+				'user_email' => 'admin@admin.com',
+				'role'       => 'reader',
+				'user_url'   => 'https://example.com',
+			)
+		);
+
+		// Simulate a logged-in user
+		wp_set_current_user( $user_id );
+		$user_identity = 'Test User';
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+		global $current_user, $user_identity;
+
+		// Clean up globals
+		unset( $_POST, $_GET, $current_user, $user_identity );
+	}
+
+	/**
+	 * Helper function to invoke the function from the class.
+	 */
+	private function invoke_get_computed_field_value( $field_type, $field_id ) {
+		$field = $this->get_new_field_instance(
+			array(
+				'type' => $field_type,
+				'id'   => $field_id,
+			)
+		);
+		return $field->get_computed_field_value( $field_type, $field_id );
+	}
+
+	private function get_new_field_instance( $attributes ) {
+		$defaults = array(
+			'type'    => 'text',
+			'id'      => 'id',
+			'default' => 'default',
+		);
+
+		return new Contact_Form_Field( wp_parse_args( $attributes, $defaults ) );
+	}
+
+	/**
+	 * Test handling $_POST single value
+	 */
+	public function test_handles_post_single_value() {
+		$_POST['test_field'] = 'Post Value';
+
+		$result = $this->invoke_get_computed_field_value( 'text', 'test_field' );
+
+		$this->assertEquals( 'Post Value', $result );
+	}
+
+	/**
+	 * Test handling $_POST array value
+	 */
+	public function test_handles_post_array_value() {
+		$_POST['test_field'] = array( 'value1', 'value2' );
+
+		$result = $this->invoke_get_computed_field_value( 'text', 'test_field' );
+
+		$this->assertEquals( array( 'value1', 'value2' ), $result );
+	}
+
+	/**
+	 * Test handling $_GET single value
+	 */
+	public function test_handles_get_single_value() {
+		$_GET['test_field'] = 'Get Value';
+
+		$result = $this->invoke_get_computed_field_value( 'text', 'test_field' );
+
+		$this->assertEquals( 'Get Value', $result );
+	}
+
+	/**
+	 * Test handling $_GET array value
+	 */
+	public function test_handles_get_array_value() {
+		$_GET['test_field'] = array( 'value1', 'value2' );
+
+		$result = $this->invoke_get_computed_field_value( 'text', 'test_field' );
+
+		$this->assertEquals( array( 'value1', 'value2' ), $result );
+	}
+
+	/**
+	 * Test logged-in user email return
+	 */
+	public function test_returns_logged_in_user_email() {
+		add_filter( 'jetpack_auto_fill_logged_in_user', '__return_true' );
+		$result = $this->invoke_get_computed_field_value( 'email', 'test_field' );
+		remove_filter( 'jetpack_auto_fill_logged_in_user', '__return_true' );
+
+		$this->assertEquals( 'admin@admin.com', $result );
+	}
+
+	/**
+	 * Test logged-in user name return
+	 */
+	public function test_returns_logged_in_user_name() {
+		add_filter( 'jetpack_auto_fill_logged_in_user', '__return_true' );
+		$result = $this->invoke_get_computed_field_value( 'name', 'test_field' );
+		remove_filter( 'jetpack_auto_fill_logged_in_user', '__return_true' );
+
+		$this->assertEquals( 'Test User', $result );
+	}
+
+	/**
+	 * Test logged-in user URL return
+	 */
+	public function test_returns_logged_in_user_url() {
+		add_filter( 'jetpack_auto_fill_logged_in_user', '__return_true' );
+		$result = $this->invoke_get_computed_field_value( 'url', 'test_field' );
+		remove_filter( 'jetpack_auto_fill_logged_in_user', '__return_true' );
+
+		$this->assertEquals( 'https://example.com', $result );
+	}
+
+	/**
+	 * Test logged-in user URL return
+	 */
+	public function test_returns_logged_out_user_url() {
+		global $current_user;
+		unset( $current_user );
+		wp_set_current_user( 0 );
+
+		add_filter( 'jetpack_auto_fill_logged_in_user', '__return_true' );
+		$result = $this->invoke_get_computed_field_value( 'url', 'test_field' );
+		remove_filter( 'jetpack_auto_fill_logged_in_user', '__return_true' );
+
+		$this->assertEquals( 'default', $result );
+	}
+} // end class


### PR DESCRIPTION
Fixes #14912

Currently when a user adds a checkbox and sets the default state to be "checked" the admin user doesn't see the checked state when logged in when they see the form.

This was done because we didn't want to pre-fill any of the user info fields for admins. (this includes super admins) 

This PR fixes this by making sure that we only setting the user value for a specific set of fields (name, email and url) and only if they are admins. 

THis PR also fixes an issues where we were not able to pre fill form fields for admin users if they are passed in via the POST or get parameters. 

A number of tests were added to show that things still work as before. 

Before (Logged in admin user)
<img width="410" alt="Screenshot 2025-01-17 at 12 47 49 PM" src="https://github.com/user-attachments/assets/3af075f6-e132-463c-9daf-debf55a7d495" />


After ( Logged in user)
<img width="410" alt="Screenshot 2025-01-17 at 12 47 49 PM" src="https://github.com/user-attachments/assets/ccf675aa-f3b4-4ba7-880d-096f0382e16d" />

Logged in admin user
<img width="410" alt="Screenshot 2025-01-17 at 12 47 49 PM" src="https://github.com/user-attachments/assets/59aa9ab2-571e-42c6-a7f3-224cfac58406" />

Logged out user
<img width="410" alt="Screenshot 2025-01-17 at 12 47 49 PM" src="https://github.com/user-attachments/assets/c0727602-b7aa-49e2-95d5-9cb560af3a21" />

## Proposed changes:
Fix the checked default setting for logged in users. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Load this PR on a jetpack site and .com simple ( `bin/jetpack-downloader test jetpack fix/checkbox-checked-state` )
1. Create a new page. 
2. Add the form block and then add the checkbox block. 
3. In the setting for the checkbox block set the default value as checked. 
4. Notice now when you preview the form that the checkbox is checked as expected. 
5. Notice on .com we prefill the user data if they are not an admin of the site. For email, url and name fields. 
6. Notice that you can pass in the value for the form using the $_GET query parameter. 

