### PR TITLE
Fix/33301 form checkbox field

### DIFF
--- a/projects/packages/forms/changelog/fix-33301-form-checkbox-field
+++ b/projects/packages/forms/changelog/fix-33301-form-checkbox-field
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Minor fix
+
+

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -348,14 +348,14 @@
 		color: var(--jetpack--contact-form--text-color);
 		display: flex;
 		border: none;
-		font-size: var(--jetpack--contact-form--font-size);
+		font-size: var(--jetpack--contact-form--font-size, 16px );
 		font-family: var(--jetpack--contact-form--font-family);
-		height: var(--jetpack--contact-form--font-size);
+		height: var(--jetpack--contact-form--font-size, 16px );
 		justify-content: center;
 		margin: 0 10px 0 0;
 		outline: none;
 		position: relative;
-		width: var(--jetpack--contact-form--font-size);
+		width: var(--jetpack--contact-form--font-size, 16px);
 		pointer-events: none;
 
 		&::after, &::before {
@@ -375,9 +375,9 @@
 			content: ' ';
 			display: flex;
 			font-weight: bold;
-			height: var(--jetpack--contact-form--font-size);
+			height: var(--jetpack--contact-form--font-size, 16px);
 			justify-content: center;
-			width: var(--jetpack--contact-form--font-size);
+			width: var(--jetpack--contact-form--font-size, 16px);
 		}
 
 		&[type="radio"]::before {
@@ -458,7 +458,7 @@
 			margin: 0 5px 0 0;
 		}
 	}
-	
+
 	.jetpack-field-option.field-option-checkbox,
 	.jetpack-field-option.field-option-radio,
 	.wp-block-jetpack-field-option-checkbox,
@@ -661,7 +661,7 @@
 		border-radius: var(--jetpack--contact-form--border-radius);
 		background-color: var(--jetpack--contact-form--input-background);
 		color: var(--jetpack--contact-form--text-color);
-		font-size: var(--jetpack--contact-form--font-size);
+		font-size: var(--jetpack--contact-form--font-size, 16px);
 		line-height: var(--jetpack--contact-form--line-height);
 		padding: var(--jetpack--contact-form--input-padding);
 		display: flex;
@@ -702,7 +702,7 @@
 		border-radius: var(--jetpack--contact-form--border-radius);
 		background-color: var(--jetpack--contact-form--input-background);
 		color: var(--jetpack--contact-form--text-color);
-		font-size: var(--jetpack--contact-form--font-size);
+		font-size: var(--jetpack--contact-form--font-size, 16px);
 		max-height: 165px;
 		overflow: auto;
 		padding: 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #33301 

Currently when a user is editing the radio buttons or the multi line checkbox and they switch between the different 
previews ( mobile, tablet) they end us seeing dots instead of checkboxes or radio buttons. 

This is due to the rendering of the styles variables not being set yet. 





## Proposed changes:
* This PR fixes the issue by setting assigning a default height and width for the checkbox sizes.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Load up this PR. 
2. Add page with a form. 
3. Add multi select input ( radio or checkbox or both) 
4. Notice that when you toggle between previews ( mobile, tablet ) that the form still looks like expected.



