### PR TITLE
Stats: Fix stats setting role toggles not sticking

### DIFF
--- a/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
@@ -43,8 +43,23 @@ class SiteStatsComponent extends React.Component {
 		};
 
 		if ( roles ) {
-			this.addCustomCountRolesState( countRoles );
-			this.addCustomRolesState( roles );
+			roles.forEach( role => {
+				if (
+					! [ 'administrator', 'editor', 'author', 'subscriber', 'contributor' ].includes( role )
+				) {
+					this.state[ `roles_${ role }` ] = includes( roles, role, false );
+				}
+			} );
+		}
+
+		if ( countRoles ) {
+			countRoles.forEach( role => {
+				if (
+					! [ 'administrator', 'editor', 'author', 'subscriber', 'contributor' ].includes( role )
+				) {
+					this.state[ `count_roles_${ role }` ] = includes( countRoles, role, false );
+				}
+			} );
 		}
 	}
 
@@ -106,38 +121,6 @@ class SiteStatsComponent extends React.Component {
 	handleRoleToggleChange = ( role, setting ) => {
 		return () => this.updateOptions( role, setting );
 	};
-
-	/**
-	 * Allows for custom roles 'count logged in page views' stats settings to be added to the current state.
-	 *
-	 * @param {Array} countRoles - All roles (including custom) that have 'count logged in page views' enabled.
-	 */
-	addCustomCountRolesState( countRoles ) {
-		countRoles.forEach( role => {
-			if (
-				! [ 'administrator', 'editor', 'author', 'subscriber', 'contributor' ].includes(
-					countRoles
-				)
-			) {
-				this.setState( { [ `count_roles_${ role }` ]: includes( countRoles, role, false ) } );
-			}
-		} );
-	}
-
-	/**
-	 * Allows for custom roles 'allow stats reports' stats settings to be added to the current state.
-	 *
-	 * @param {Array} roles - All roles (including custom) that have 'allow stats reports' enabled.
-	 */
-	addCustomRolesState( roles ) {
-		roles.forEach( role => {
-			if (
-				! [ 'administrator', 'editor', 'author', 'subscriber', 'contributor' ].includes( role )
-			) {
-				this.setState( { [ `roles_${ role }` ]: includes( roles, role, false ) } );
-			}
-		} );
-	}
 
 	handleStatsOptionToggle( option_slug ) {
 		return () => this.props.updateFormStateModuleOption( 'stats', option_slug );

--- a/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
@@ -47,7 +47,7 @@ class SiteStatsComponent extends React.Component {
 				if (
 					! [ 'administrator', 'editor', 'author', 'subscriber', 'contributor' ].includes( role )
 				) {
-					this.state[ `roles_${ role }` ] = includes( roles, role, false );
+					this.state[ `roles_${ role }` ] = true;
 				}
 			} );
 		}
@@ -57,7 +57,7 @@ class SiteStatsComponent extends React.Component {
 				if (
 					! [ 'administrator', 'editor', 'author', 'subscriber', 'contributor' ].includes( role )
 				) {
-					this.state[ `count_roles_${ role }` ] = includes( countRoles, role, false );
+					this.state[ `count_roles_${ role }` ] = true;
 				}
 			} );
 		}

--- a/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
@@ -42,11 +42,11 @@ class SiteStatsComponent extends React.Component {
 			wpcom_reader_views_enabled: props.getOptionValue( 'wpcom_reader_views_enabled' ),
 		};
 
+		const defaultRoles = [ 'administrator', 'editor', 'author', 'contributor', 'subscriber' ];
+
 		if ( roles?.length > 0 ) {
 			roles.forEach( role => {
-				if (
-					! [ 'administrator', 'editor', 'author', 'subscriber', 'contributor' ].includes( role )
-				) {
+				if ( ! defaultRoles.includes( role ) ) {
 					this.state[ `roles_${ role }` ] = true;
 				}
 			} );
@@ -54,9 +54,7 @@ class SiteStatsComponent extends React.Component {
 
 		if ( countRoles?.length > 0 ) {
 			countRoles.forEach( role => {
-				if (
-					! [ 'administrator', 'editor', 'author', 'subscriber', 'contributor' ].includes( role )
-				) {
+				if ( ! defaultRoles.includes( role ) ) {
 					this.state[ `count_roles_${ role }` ] = true;
 				}
 			} );

--- a/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
@@ -42,7 +42,7 @@ class SiteStatsComponent extends React.Component {
 			wpcom_reader_views_enabled: props.getOptionValue( 'wpcom_reader_views_enabled' ),
 		};
 
-		if ( roles ) {
+		if ( roles?.length > 0 ) {
 			roles.forEach( role => {
 				if (
 					! [ 'administrator', 'editor', 'author', 'subscriber', 'contributor' ].includes( role )
@@ -52,7 +52,7 @@ class SiteStatsComponent extends React.Component {
 			} );
 		}
 
-		if ( countRoles ) {
+		if ( countRoles?.length > 0 ) {
 			countRoles.forEach( role => {
 				if (
 					! [ 'administrator', 'editor', 'author', 'subscriber', 'contributor' ].includes( role )

--- a/projects/plugins/jetpack/changelog/fix-stats-setting-role-toggles
+++ b/projects/plugins/jetpack/changelog/fix-stats-setting-role-toggles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix custom roles settings are not sticking for Jetpack Stats


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jpop-issues/issues/9445

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Calling setState in the constructor of a React class component does not work because the component is not yet mounted, and React explicitly prevents the use of setState during this phase. Instead, we should directly assign values to this.state in the constructor.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create custom roles with code running in a mu plugin
```PHP
function add_custom_user_role() {
    add_role(
        'content_manager',
        'Content Manager',
        array(
            'read' => true,
            'edit_posts' => true,
            'delete_posts' => true,
            'publish_posts' => true,
            'upload_files' => true,
        )
    );
}
add_action('init', 'add_custom_user_role');
```

* Open `/wp-admin/admin.php?page=jetpack#/traffic`
* Expand Jetpack Stats section
* Toggle `Content Manager` for `Count logged in page views from` and `Allow Jetpack Stats to be viewed by`
* Refresh page
* Ensure the option sticks
* Toggle off
* Refresh page
* Ensure the option sticks

<img width="747" alt="image" src="https://github.com/user-attachments/assets/23d88f60-5472-4894-864d-a42771aca298" />
