### PR TITLE
[Analyzer] Fix fatal when trying to call toCodeString() in Node\Expr\Variable class

### DIFF
--- a/projects/packages/analyzer/changelog/fix-analyzer-expr-variable-exception
+++ b/projects/packages/analyzer/changelog/fix-analyzer-expr-variable-exception
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixes a bug in Analyzer tring to call toCodeString() in Variable class.

--- a/projects/packages/analyzer/src/class-utils.php
+++ b/projects/packages/analyzer/src/class-utils.php
@@ -152,6 +152,11 @@ class Utils {
 			if ( ! $stmt instanceof Node\Stmt\Expression || ! $stmt->expr instanceof Node\Expr\FuncCall ) {
 				continue;
 			}
+
+			if ( $stmt->expr->name instanceof Node\Expr\Variable ) {
+				continue;
+			}
+
 			if ( false !== strpos( $stmt->expr->name->toCodeString(), $name ) ) {
 				return true;
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:

* When using WooCommerce Compatibility Checker tool which uses JP Analyzer. Recently we have shown a fatal like this 

```
PHP Fatal error:  Uncaught Error: Call to undefined method PhpParser\Node\Expr\Variable::toCodeString() in /private/var/folders/v9/71vtqrxx5p50ww0t9r8rlsj00000gn/T/jetpack-analyzer/src/class-utils.php:155
Stack trace:
#0 /private/var/folders/v9/71vtqrxx5p50ww0t9r8rlsj00000gn/T/jetpack-analyzer/src/Declarations/class-visitor.php(50): Automattic\Jetpack\Analyzer\Utils::has_function_call(Object(PhpParser\Node\Stmt\ClassMethod), '_deprecated_fun...')
#1 /private/var/folders/v9/71vtqrxx5p50ww0t9r8rlsj00000gn/T/jetpack-analyzer/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(200): Automattic\Jetpack\Analyzer\Declarations\Visitor->enterNode(Object(PhpParser\Node\Stmt\ClassMethod))
#2 /private/var/folders/v9/71vtqrxx5p50ww0t9r8rlsj00000gn/T/jetpack-analyzer/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(114): PhpParser\NodeTraverser->traverseArray(Array)
#3 /private/var/folders/v9/71vtqrxx5p50ww0t9r8rlsj00000gn/T/jetpack-analyzer/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(223): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\Class_))
#4 /private/var/folders/v9/71vtqrxx5p50ww0t9r8rlsj00000gn/T/jetpack-analyzer/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(114): PhpParser\NodeTraverser->traverseArray(Array)
#5 /private/var/folders/v9/71vtqrxx5p50ww0t9r8rlsj00000gn/T/jetpack-analyzer/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(223): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\Namespace_))
#6 /private/var/folders/v9/71vtqrxx5p50ww0t9r8rlsj00000gn/T/jetpack-analyzer/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(91): PhpParser\NodeTraverser->traverseArray(Array)
#7 /private/var/folders/v9/71vtqrxx5p50ww0t9r8rlsj00000gn/T/jetpack-analyzer/src/class-declarations.php(95): PhpParser\NodeTraverser->traverse(Array)
#8 /private/var/folders/v9/71vtqrxx5p50ww0t9r8rlsj00000gn/T/jetpack-analyzer/src/class-declarations.php(62): Automattic\Jetpack\Analyzer\Declarations->scan_file('/var/folders/v9...', Object(SplFileInfo))
#9 /private/var/folders/v9/71vtqrxx5p50ww0t9r8rlsj00000gn/T/jetpack-analyzer/src/class-declarations.php(29): Automattic\Jetpack\Analyzer\Declarations->scan_dir('/var/folders/v9...', Array)
#10 /private/var/folders/v9/71vtqrxx5p50ww0t9r8rlsj00000gn/T/jetpack-analyzer/scripts/analyzer.php(18): Automattic\Jetpack\Analyzer\Declarations->scan('/var/folders/v9...', Array)
#11 /Users/miguelperezpellicer/Sites/woocommerce-extension-compat-checker/includes/utils.php(284): run()
#12 /Users/miguelperezpellicer/Sites/woocommerce-extension-compat-checker/wc-compat-checker.php(37): run_analyzer()
#13 /Users/miguelperezpellicer/Sites/woocommerce-extension-compat-checker/wc-compat-checker.php(15): wc_compat_checker(Array)
#14 {main}
  thrown in /private/var/folders/v9/71vtqrxx5p50ww0t9r8rlsj00000gn/T/jetpack-analyzer/src/class-utils.php on line 155
```

In order to mitigate this we need to fo thisnstep each time we perform a Compat Check, on every WC Release:

- Execute Compat Checker and get the Analyzer cloned
- Compat Checker fails
- Replace the code with the fix in the temporary Analyzer folder 
- Comment the code that overrides Analyzer directory
- Execute Compat Checker

The fix tho is very simple so I hope it gets merged in the repo itself.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Clone https://github.com/Automattic/woocommerce-extension-compat-checker
* Execute the compat checker for any extension
* See the fatal error mentioned above
* Apply this patch
* See the fatal error mentioned above not appearing anymore


