### PR TITLE
Jetpack AI: trim title and content before triggering featured image generation

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-featured-image-trigger-emtpy
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-featured-image-trigger-emtpy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: do not trigger featured image generation if title or content are just empty spaces

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -339,7 +339,7 @@ export default function FeaturedImage( {
 	const generateAgainText = __( 'Generate another image', 'jetpack' );
 	const generateText = __( 'Generate', 'jetpack' );
 
-	const hasContent = postContent || postTitle ? true : false;
+	const hasContent = postContent.trim?.() || postTitle.trim?.() ? true : false;
 	const hasPrompt = hasContent ? prompt.length >= 0 : prompt.length >= 3;
 	const disableInput = notEnoughRequests || currentPointer?.generating || requireUpgrade;
 	const disableAction = disableInput || ( ! hasContent && ! hasPrompt );


### PR DESCRIPTION

## Proposed changes:
Make sure content and title are not just empty spaces to decide on triggering featured image generation


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p8oabR-1Bq-p2#comment-8338

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Open the editor and use post sidebar's "Set featured image" -> "Generate with AI". As title and post are empty, it should not trigger an image generation. Close the modal, add spaces either on title or some paragraph and open the Featured Image modal again. It should still not trigger any generation. Close it again and now add some title  to the post. Open the modal once more and see that it has now triggered an image generation based on the title.