### PR TITLE
Protect Status: Combine multiple vulnerabilities for the same extension into single threat objects

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14609,8 +14609,8 @@ packages:
   third-party-web@0.26.2:
     resolution: {integrity: sha512-taJ0Us0lKoYBqcbccMuDElSUPOxmBfwlHe1OkHQ3KFf+RwovvBHdXhbFk9XJVQE2vHzxbTwvwg5GFsT9hbDokQ==}
 
-  third-party-web@0.26.4:
-    resolution: {integrity: sha512-cH8Y2deNWtUan3u7DM8Z9aPIMll3ATwFBpuYFo7IXfz58X/hwz3Re+nUEpu6stViCeDvgkuR7RjeyNr495cULA==}
+  third-party-web@0.26.5:
+    resolution: {integrity: sha512-tDuKQJUTfjvi9Fcrs1s6YAQAB9mzhTSbBZMfNgtWNmJlHuoFeXO6dzBFdGeCWRvYL50jQGK0jPsBZYxqZQJ2SA==}
 
   thread-loader@3.0.4:
     resolution: {integrity: sha512-ByaL2TPb+m6yArpqQUZvP+5S1mZtXsEP7nWKKlAUTm7fCml8kB5s1uI3+eHRP2bk5mVYfRSBI7FFf+tWEyLZwA==}
@@ -17342,7 +17342,7 @@ snapshots:
 
   '@paulirish/trace_engine@0.0.39':
     dependencies:
-      third-party-web: 0.26.4
+      third-party-web: 0.26.5
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -29268,7 +29268,7 @@ snapshots:
 
   third-party-web@0.26.2: {}
 
-  third-party-web@0.26.4: {}
+  third-party-web@0.26.5: {}
 
   thread-loader@3.0.4(webpack@5.94.0):
     dependencies:

--- a/projects/packages/protect-models/changelog/protect-status-combine-vulns-into-extension-threat
+++ b/projects/packages/protect-models/changelog/protect-status-combine-vulns-into-extension-threat
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Combine vulnerabilities for the same extension into single vulnerable extension threats.

--- a/projects/packages/protect-models/composer.json
+++ b/projects/packages/protect-models/composer.json
@@ -4,7 +4,8 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"php": ">=7.2"
+		"php": ">=7.2",
+		"automattic/jetpack-redirect": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^1.1.1",

--- a/projects/packages/protect-models/src/class-threat-model.php
+++ b/projects/packages/protect-models/src/class-threat-model.php
@@ -120,6 +120,15 @@ class Threat_Model {
 	public $extension;
 
 	/**
+	 * The threat's related vulnerabilities.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var null|Vulnerability_Model[]
+	 */
+	public $vulnerabilities;
+
+	/**
 	 * Threat Constructor
 	 *
 	 * @param array|object $threat Threat data to load into the class instance.
@@ -138,5 +147,119 @@ class Threat_Model {
 				$this->$property = $value;
 			}
 		}
+	}
+
+	/**
+	 * Get the ID value of the threat based on its related extension and vulnerabilities.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param Extension_Model $extension       The extension to get the ID from.
+	 *
+	 * @return string
+	 */
+	private static function get_id_from_vulnerable_extension( Extension_Model $extension ) {
+		return "$extension->type-$extension->slug-$extension->version";
+	}
+
+	/**
+	 * Get the title from a vulnerable extension.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param Extension_Model $extension The extension to get the title from.
+	 *
+	 * @return string|null
+	 */
+	private static function get_title_from_vulnerable_extension( Extension_Model $extension ) {
+		$titles = array(
+			'plugins' => sprintf(
+				/* translators: placeholders are the theme name and version number. Example: "Vulnerable theme: Jetpack (version 1.2.3)" */
+				__( 'Vulnerable plugin: %1$s (version %2$s)', 'jetpack-protect-models' ),
+				$extension->name,
+				$extension->version
+			),
+			'themes'  => sprintf(
+				/* translators: placeholders are the theme name and version number. Example: "Vulnerable theme: Jetpack (version 1.2.3)" */
+				__( 'Vulnerable theme: %1$s (version %2$s)', 'jetpack-protect-models' ),
+				$extension->name,
+				$extension->version
+			),
+			'core'    => sprintf(
+				/* translators: placeholder is the version number. Example: "Vulnerable WordPress (version 1.2.3)" */
+				__( 'Vulnerable WordPress (version %s)', 'jetpack-protect-models' ),
+				$extension->version
+			),
+		);
+
+		return $titles[ $extension->type ] ?? null;
+	}
+
+	/**
+	 * Get the description from a vulnerable extension.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param Extension_Model $extension The extension to get the description from.
+	 * @param array           $vulnerabilities The vulnerabilities to get the description from.
+	 *
+	 * @return string
+	 */
+	private static function get_description_from_vulnerable_extension( Extension_Model $extension, array $vulnerabilities ) {
+		return sprintf(
+				/* translators: placeholders are the theme name and version number. Example: "The installed version of Jetpack (1.2.3) has a known security vulnerability." */
+			_n( 'The installed version of %1$s (%2$s) has a known security vulnerability.', 'The installed version of %1$s (%2$s) has known security vulnerabilities.', count( $vulnerabilities ), 'jetpack-protect-models' ),
+			$extension->name,
+			$extension->version
+		);
+	}
+
+	/**
+	 * Get the latest fixed_in version from a list of vulnerabilities.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $vulnerabilities The vulnerabilities to get the fixed_in version from.
+	 *
+	 * @return string|bool|null The latest fixed_in version, or false if any of the vulnerabilities are not fixed.
+	 */
+	private static function get_fixed_in_from_vulnerabilities( array $vulnerabilities ) {
+		$fixed_in = null;
+
+		foreach ( $vulnerabilities as $vulnerability ) {
+			// If any of the vulnerabilities are not fixed, the threat is not fixed.
+			if ( ! $vulnerability->fixed_in ) {
+				break;
+			}
+
+			// Use the latest available fixed_in version.
+			if ( ! $fixed_in || ( $fixed_in && version_compare( $vulnerability->fixed_in, $fixed_in, '>' ) ) ) {
+				$fixed_in = $vulnerability->fixed_in;
+			}
+		}
+
+		return $fixed_in;
+	}
+
+	/**
+	 * Generate a threat from extension vulnerabilities.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param Extension_Model       $extension       The extension to generate the threat for.
+	 * @param Vulnerability_Model[] $vulnerabilities The vulnerabilities to generate the threat from.
+	 *
+	 * @return Threat_Model
+	 */
+	public static function generate_from_extension_vulnerabilities( Extension_Model $extension, array $vulnerabilities ) {
+		return new Threat_Model(
+			array(
+				'id'              => self::get_id_from_vulnerable_extension( $extension ),
+				'title'           => self::get_title_from_vulnerable_extension( $extension ),
+				'description'     => self::get_description_from_vulnerable_extension( $extension, $vulnerabilities ),
+				'fixed_in'        => self::get_fixed_in_from_vulnerabilities( $vulnerabilities ),
+				'vulnerabilities' => $vulnerabilities,
+			)
+		);
 	}
 }

--- a/projects/packages/protect-models/src/class-vulnerability-model.php
+++ b/projects/packages/protect-models/src/class-vulnerability-model.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Model class for vulnerability data.
+ *
+ * @package automattic/jetpack-protect-models
+ */
+
+namespace Automattic\Jetpack\Protect_Models;
+
+use Automattic\Jetpack\Redirect;
+
+/**
+ * Model class for vulnerability data.
+ */
+class Vulnerability_Model {
+	/**
+	 * Threat ID.
+	 *
+	 * @var null|string
+	 */
+	public $id;
+
+	/**
+	 * Threat Title.
+	 *
+	 * @var null|string
+	 */
+	public $title;
+
+	/**
+	 * Threat Description.
+	 *
+	 * @var null|string
+	 */
+	public $description;
+
+	/**
+	 * The version the threat is fixed in.
+	 *
+	 * @var null|string
+	 */
+	public $fixed_in;
+
+	/**
+	 * The version the threat was introduced.
+	 *
+	 * @var null|string
+	 */
+	public $introduced_in;
+
+	/**
+	 * The type of threat.
+	 *
+	 * @var null|string
+	 */
+	public $type;
+
+	/**
+	 * The source URL for the threat.
+	 *
+	 * @var null|string
+	 */
+	public $source;
+
+	/**
+	 * Threat Constructor
+	 *
+	 * @param array|object $threat Threat data to load into the class instance.
+	 */
+	public function __construct( $threat ) {
+		// Initialize the threat data.
+		foreach ( $threat as $property => $value ) {
+			if ( property_exists( $this, $property ) ) {
+				$this->$property = $value;
+			}
+		}
+
+		// Ensure the source URL is set.
+		$this->get_source();
+	}
+
+	/**
+	 * Get the source URL for the threat.
+	 *
+	 * @return string
+	 */
+	public function get_source() {
+		if ( empty( $this->source ) && $this->id ) {
+			$this->source = Redirect::get_url( 'jetpack-protect-vul-info', array( 'path' => $this->id ) );
+		}
+
+		return $this->source;
+	}
+}

--- a/projects/packages/protect-models/src/class-vulnerability-model.php
+++ b/projects/packages/protect-models/src/class-vulnerability-model.php
@@ -14,62 +14,62 @@ use Automattic\Jetpack\Redirect;
  */
 class Vulnerability_Model {
 	/**
-	 * Threat ID.
+	 * Vulnerability ID.
 	 *
 	 * @var null|string
 	 */
 	public $id;
 
 	/**
-	 * Threat Title.
+	 * Vulnerability Title.
 	 *
 	 * @var null|string
 	 */
 	public $title;
 
 	/**
-	 * Threat Description.
+	 * Vulnerability Description.
 	 *
 	 * @var null|string
 	 */
 	public $description;
 
 	/**
-	 * The version the threat is fixed in.
+	 * The version the vulnerability is fixed in.
 	 *
 	 * @var null|string
 	 */
 	public $fixed_in;
 
 	/**
-	 * The version the threat was introduced.
+	 * The version the vulnerability was introduced.
 	 *
 	 * @var null|string
 	 */
 	public $introduced_in;
 
 	/**
-	 * The type of threat.
+	 * The type of vulnerability.
 	 *
 	 * @var null|string
 	 */
 	public $type;
 
 	/**
-	 * The source URL for the threat.
+	 * The source URL for the vulnerability.
 	 *
 	 * @var null|string
 	 */
 	public $source;
 
 	/**
-	 * Threat Constructor
+	 * Vulnerability Constructor
 	 *
-	 * @param array|object $threat Threat data to load into the class instance.
+	 * @param array|object $vulnerability Vulnerability data to load into the class instance.
 	 */
-	public function __construct( $threat ) {
-		// Initialize the threat data.
-		foreach ( $threat as $property => $value ) {
+	public function __construct( $vulnerability ) {
+		// Initialize the vulnerability data.
+		foreach ( $vulnerability as $property => $value ) {
 			if ( property_exists( $this, $property ) ) {
 				$this->$property = $value;
 			}
@@ -80,7 +80,7 @@ class Vulnerability_Model {
 	}
 
 	/**
-	 * Get the source URL for the threat.
+	 * Get the source URL for the vulnerability.
 	 *
 	 * @return string
 	 */

--- a/projects/packages/protect-status/changelog/combine-vulns-into-threat
+++ b/projects/packages/protect-status/changelog/combine-vulns-into-threat
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Combine multiple vulnerability results for the same extension into a single vulnerable extension threat result.

--- a/projects/packages/protect-status/src/class-protect-status.php
+++ b/projects/packages/protect-status/src/class-protect-status.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Plugins_Installer;
 use Automattic\Jetpack\Protect_Models\Extension_Model;
 use Automattic\Jetpack\Protect_Models\Status_Model;
 use Automattic\Jetpack\Protect_Models\Threat_Model;
-use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Protect_Models\Vulnerability_Model;
 use Automattic\Jetpack\Sync\Functions as Sync_Functions;
 use Jetpack_Options;
 use WP_Error;
@@ -223,21 +223,29 @@ class Protect_Status extends Status {
 				continue;
 			}
 
-			$extension->checked = true;
+			$extension->checked         = true;
+			$extension_threats[ $slug ] = $extension;
 
-			foreach ( $checked_extension->vulnerabilities as $vulnerability ) {
-				$threat         = new Threat_Model( $vulnerability );
-				$threat->source = isset( $vulnerability->id ) ? Redirect::get_url( 'jetpack-protect-vul-info', array( 'path' => $vulnerability->id ) ) : null;
+			if ( ! empty( $checked_extension->vulnerabilities ) ) {
+				// normalize the vulnerabilities data
+				$vulnerabilities = array_map(
+					function ( $vulnerability ) {
+						return new Vulnerability_Model( $vulnerability );
+					},
+					$checked_extension->vulnerabilities
+				);
 
-				$threat_extension            = clone $extension;
-				$extension_threat            = clone $threat;
-				$extension_threat->extension = null;
+				// convert the detected vulnerabilities into a vulnerable extension threat
+				$threat = Threat_Model::generate_from_extension_vulnerabilities( $extension, $vulnerabilities );
 
+				$threat_extension = clone $extension;
+				$extension_threat = clone $threat;
+
+				$extension_threat->extension           = null;
 				$extension_threats[ $slug ]->threats[] = $extension_threat;
 
 				$threat->extension = $threat_extension;
 				$status->threats[] = $threat;
-
 			}
 		}
 
@@ -284,27 +292,26 @@ class Protect_Status extends Status {
 		// If we've made it this far, the core version has been checked.
 		$core->checked = true;
 
-		// Extract threat data from the report.
-		if ( is_array( $report_data->core->vulnerabilities ) ) {
-			foreach ( $report_data->core->vulnerabilities as $vulnerability ) {
-				$threat = new Threat_Model(
-					array(
-						'id'          => $vulnerability->id,
-						'title'       => $vulnerability->title,
-						'fixed_in'    => $vulnerability->fixed_in,
-						'description' => isset( $vulnerability->description ) ? $vulnerability->description : null,
-						'source'      => isset( $vulnerability->id ) ? Redirect::get_url( 'jetpack-protect-vul-info', array( 'path' => $vulnerability->id ) ) : null,
-					)
-				);
+		// Generate a threat from core vulnerabilities.
+		if ( ! empty( $report_data->core->vulnerabilities ) ) {
+			// normalize the vulnerabilities data
+			$vulnerabilities = array_map(
+				function ( $vulnerability ) {
+					return new Vulnerability_Model( $vulnerability );
+				},
+				$report_data->core->vulnerabilities
+			);
 
-				$threat_extension = clone $core;
-				$extension_threat = clone $threat;
+			// convert the detected vulnerabilities into a vulnerable extension threat
+			$threat = Threat_Model::generate_from_extension_vulnerabilities( $core, $vulnerabilities );
 
-				$core->threats[]   = $extension_threat;
-				$threat->extension = $threat_extension;
+			$threat_extension = clone $core;
+			$extension_threat = clone $threat;
 
-				$status->threats[] = $threat;
-			}
+			$core->threats[]   = $extension_threat;
+			$threat->extension = $threat_extension;
+
+			$status->threats[] = $threat;
 		}
 
 		$status->core = $core;

--- a/projects/plugins/backup/changelog/update-lock-file
+++ b/projects/plugins/backup/changelog/update-lock-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated composer.lock

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1431,9 +1431,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-models",
-                "reference": "6b8a84b23ab688f32c77c37bf835ef2b9d3ef6b1"
+                "reference": "817a607f312421144a2acf0c4b65165d8125ec59"
             },
             "require": {
+                "automattic/jetpack-redirect": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {

--- a/projects/plugins/boost/changelog/update-lock-file
+++ b/projects/plugins/boost/changelog/update-lock-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated composer.lock

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1421,9 +1421,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-models",
-                "reference": "6b8a84b23ab688f32c77c37bf835ef2b9d3ef6b1"
+                "reference": "817a607f312421144a2acf0c4b65165d8125ec59"
             },
             "require": {
+                "automattic/jetpack-redirect": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {

--- a/projects/plugins/jetpack/changelog/update-lock-file
+++ b/projects/plugins/jetpack/changelog/update-lock-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update composer.lock

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2132,9 +2132,10 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/protect-models",
-				"reference": "6b8a84b23ab688f32c77c37bf835ef2b9d3ef6b1"
+				"reference": "817a607f312421144a2acf0c4b65165d8125ec59"
 			},
 			"require": {
+				"automattic/jetpack-redirect": "@dev",
 				"php": ">=7.2"
 			},
 			"require-dev": {

--- a/projects/plugins/protect/changelog/update-lock-file
+++ b/projects/plugins/protect/changelog/update-lock-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated composer.lock

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1347,9 +1347,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-models",
-                "reference": "6b8a84b23ab688f32c77c37bf835ef2b9d3ef6b1"
+                "reference": "817a607f312421144a2acf0c4b65165d8125ec59"
             },
             "require": {
+                "automattic/jetpack-redirect": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {

--- a/projects/plugins/search/changelog/update-lock-file
+++ b/projects/plugins/search/changelog/update-lock-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated composer.lock

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1293,9 +1293,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-models",
-                "reference": "6b8a84b23ab688f32c77c37bf835ef2b9d3ef6b1"
+                "reference": "817a607f312421144a2acf0c4b65165d8125ec59"
             },
             "require": {
+                "automattic/jetpack-redirect": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {

--- a/projects/plugins/social/changelog/update-lock-file
+++ b/projects/plugins/social/changelog/update-lock-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated composer.lock

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1358,9 +1358,10 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/protect-models",
-				"reference": "6b8a84b23ab688f32c77c37bf835ef2b9d3ef6b1"
+				"reference": "817a607f312421144a2acf0c4b65165d8125ec59"
 			},
 			"require": {
+				"automattic/jetpack-redirect": "@dev",
 				"php": ">=7.2"
 			},
 			"require-dev": {

--- a/projects/plugins/starter-plugin/changelog/update-lock-file
+++ b/projects/plugins/starter-plugin/changelog/update-lock-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated composer.lock

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1293,9 +1293,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-models",
-                "reference": "6b8a84b23ab688f32c77c37bf835ef2b9d3ef6b1"
+                "reference": "817a607f312421144a2acf0c4b65165d8125ec59"
             },
             "require": {
+                "automattic/jetpack-redirect": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {

--- a/projects/plugins/videopress/changelog/update-lock-file
+++ b/projects/plugins/videopress/changelog/update-lock-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated composer.lock

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1293,9 +1293,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-models",
-                "reference": "6b8a84b23ab688f32c77c37bf835ef2b9d3ef6b1"
+                "reference": "817a607f312421144a2acf0c4b65165d8125ec59"
             },
             "require": {
+                "automattic/jetpack-redirect": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Updates the `protect-status` package to group vulnerabilities by extension (i.e. one threat per vulnerable extension).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `Vulnerability_Model` class.
* Adds `Threat_Model::$vulnerabilities` property.
* Updates `Protect_Status` to generate a single `Threat_Model` per vulnerable extension, with the relevant vulnerabilities included as a property of the threat.
* Updates tests.
* Updates composer lock files.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

peb6dq-3ma-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Validate results from `jetpack-protect/v1/status` with a free plan:
  * Validate the deprecated `plugins`, `themes`, and `core` properties.
  * Validate the `threats` property.
  * Reference this value in Jetpack Protect using `window.jetpackProtectInitialState`, or the TanStack Query developer tools.

<img width="1222" alt="Screenshot 2025-01-06 at 3 11 05 PM" src="https://github.com/user-attachments/assets/ac2002a7-eaa4-4044-bd61-a149fe7391e2" />

<img width="1798" alt="Screenshot 2025-01-15 at 5 08 15 PM" src="https://github.com/user-attachments/assets/649b5603-e6ab-4de9-bc3a-2eef4b10d63f" />
