### PR TITLE
Gardening: Fix errant dependency update (compare-versions)

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-gardening-self_inflicted_failure
+++ b/projects/github-actions/repo-gardening/changelog/fix-gardening-self_inflicted_failure
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure use of named export for compare-versions.

--- a/projects/github-actions/repo-gardening/src/utils/get-next-valid-milestone.js
+++ b/projects/github-actions/repo-gardening/src/utils/get-next-valid-milestone.js
@@ -1,4 +1,4 @@
-const compareVersions = require( 'compare-versions' );
+const { compareVersions } = require( 'compare-versions' );
 const moment = require( 'moment' );
 
 /* global GitHub, OktokitIssuesListMilestonesForRepoResponseItem */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In #40787 I updated `compare-versions`, but missed that it switched to named exports, which was causing intermittent errors when running repo gardening tasks. This updates the script in question.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Gardening milestone tasks should complete without error, I guess.