### PR TITLE
Stats: Update stats bar lazy loading adminbar image

### DIFF
--- a/projects/plugins/jetpack/changelog/update-stats-lazy-loading-adminbar-image
+++ b/projects/plugins/jetpack/changelog/update-stats-lazy-loading-adminbar-image
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Load the adminbar stats graph lazily"

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -821,7 +821,7 @@ function stats_admin_bar_menu( &$wp_admin_bar ) {
 	$menu = array(
 		'id'    => 'stats',
 		'href'  => add_query_arg( 'page', 'stats', admin_url( 'admin.php' ) ), // no menu_page_url() blog-side.
-		'title' => "<div><img fetchPriority='low' loading='lazy' decoding='async' src='$img_src' srcset='$img_src 1x, $img_src_2x 2x' width='112' height='24' alt='$alt' title='$title'></div>",
+		'title' => "<div><img fetchpriority='low' loading='lazy' decoding='async' src='$img_src' srcset='$img_src 1x, $img_src_2x 2x' width='112' height='24' alt='$alt' title='$title'></div>",
 	);
 
 	$wp_admin_bar->add_menu( $menu );

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -821,7 +821,7 @@ function stats_admin_bar_menu( &$wp_admin_bar ) {
 	$menu = array(
 		'id'    => 'stats',
 		'href'  => add_query_arg( 'page', 'stats', admin_url( 'admin.php' ) ), // no menu_page_url() blog-side.
-		'title' => "<div><img src='$img_src' srcset='$img_src 1x, $img_src_2x 2x' width='112' height='24' alt='$alt' title='$title'></div>",
+		'title' => "<div><img fetchPriority='low' loading='lazy' decoding='async' src='$img_src' srcset='$img_src 1x, $img_src_2x 2x' width='112' height='24' alt='$alt' title='$title'></div>",
 	);
 
 	$wp_admin_bar->add_menu( $menu );


### PR DESCRIPTION
before:
<img width="1715" alt="Screenshot 2025-01-06 at 2 38 25 PM" src="https://github.com/user-attachments/assets/dd0c272a-e6db-490d-a67f-73e76499b3a2" />

after:
<img width="1666" alt="Screenshot 2025-01-06 at 2 45 49 PM" src="https://github.com/user-attachments/assets/2beb3839-956f-4418-841c-2aeaf3e8a00f" />


## Proposed changes:
* Loads the stats bar in a deferred way this way image which takes a bit of time to generate doesn't prevent other parts of the page to load. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Load this PR, Connect Jetpack and have the stats module enabled. 
* Notice that the loading of the page when logged in can produce less jank because other image assets will get proritized before the stats bar image. Such as contact form selection input fields. 

 

