### PR TITLE
Forms: add border options to select, radio, and checkbox blocks

### DIFF
--- a/projects/packages/forms/changelog/add-border-styling-radio
+++ b/projects/packages/forms/changelog/add-border-styling-radio
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixes the styling options for multi select options

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -98,6 +98,11 @@ function JetpackFieldCheckbox( props ) {
 								onChange: value => setAttributes( { labelColor: value } ),
 								label: __( 'Label Text', 'jetpack-forms' ),
 							},
+							{
+								value: attributes.borderColor,
+								onChange: value => setAttributes( { borderColor: value } ),
+								label: __( 'Border', 'jetpack-forms' ),
+							},
 						] }
 					/>
 					<PanelBody

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-choice/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-choice/edit.js
@@ -23,6 +23,7 @@ const JetpackFieldChoiceEdit = props => {
 	const classes = clsx( className, 'jetpack-field jetpack-field-multiple', {
 		'is-selected': isSelected,
 		'has-placeholder': ( options && options.length ) || innerBlocks.length,
+		'has-colors': attributes.inputColor || attributes.labelColor,
 	} );
 	const formStyle = useFormStyle( clientId );
 	const { blockStyle } = useJetpackFieldStyles( attributes );

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
@@ -6,6 +6,7 @@ import { withSharedFieldAttributes } from '../util/with-shared-field-attributes'
 import JetpackFieldLabel from './jetpack-field-label';
 import JetpackFieldWidth from './jetpack-field-width';
 import JetpackManageResponsesSettings from './jetpack-manage-responses-settings';
+import { useJetpackFieldStyles } from './use-jetpack-field-styles';
 
 const JetpackFieldConsent = ( {
 	instanceId,
@@ -16,9 +17,11 @@ const JetpackFieldConsent = ( {
 	setAttributes,
 	attributes,
 } ) => {
+	const { blockStyle } = useJetpackFieldStyles( attributes );
 	const blockProps = useBlockProps( {
 		id: `jetpack-field-consent-${ instanceId }`,
 		className: 'jetpack-field jetpack-field-consent',
+		style: blockStyle,
 	} );
 
 	return (
@@ -65,6 +68,11 @@ const JetpackFieldConsent = ( {
 							value: attributes.labelColor,
 							onChange: value => setAttributes( { labelColor: value } ),
 							label: __( 'Label Text', 'jetpack-forms' ),
+						},
+						{
+							value: attributes.borderColor,
+							onChange: value => setAttributes( { borderColor: value } ),
+							label: __( 'Border', 'jetpack-forms' ),
 						},
 					] }
 				/>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -35,8 +35,14 @@ const JetpackFieldControls = ( {
 	extraFieldSettings = [],
 } ) => {
 	const formStyle = useFormStyle( clientId );
-	const blockStyle = getBlockStyle( blockClassNames );
+
+	const blockStyle =
+		getBlockStyle( blockClassNames ) !== ''
+			? getBlockStyle( blockClassNames )
+			: attributes?.className && getBlockStyle( attributes.className );
+
 	const isChoicesBlock = [ 'radio', 'checkbox' ].includes( type );
+	const isRadioButton = type === 'radio' && blockStyle === 'button';
 
 	const setNumberAttribute =
 		( key, parse = parseInt ) =>
@@ -78,14 +84,7 @@ const JetpackFieldControls = ( {
 		},
 	];
 
-	if ( isChoicesBlock ) {
-		colorSettings.push( {
-			value: attributes.borderColor,
-			onChange: value => setAttributes( { borderColor: value } ),
-			label: __( 'Border', 'jetpack-forms' ),
-		} );
-	}
-	if ( isChoicesBlock && blockStyle === 'button' ) {
+	if ( blockStyle === 'button' ) {
 		colorSettings.push( {
 			value: attributes.buttonBackgroundColor,
 			onChange: value => setAttributes( { buttonBackgroundColor: value } ),
@@ -93,13 +92,15 @@ const JetpackFieldControls = ( {
 		} );
 	}
 
-	if ( ! isChoicesBlock || formStyle === FORM_STYLE.OUTLINED ) {
+	if ( formStyle === FORM_STYLE.OUTLINED ) {
 		colorSettings.push( {
 			value: attributes.fieldBackgroundColor,
 			onChange: value => setAttributes( { fieldBackgroundColor: value } ),
 			label: backgroundColorLabel,
 		} );
+	}
 
+	if ( ! isRadioButton ) {
 		colorSettings.push( {
 			value: attributes.borderColor,
 			onChange: value => setAttributes( { borderColor: value } ),

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -78,6 +78,13 @@ const JetpackFieldControls = ( {
 		},
 	];
 
+	if ( isChoicesBlock ) {
+		colorSettings.push( {
+			value: attributes.borderColor,
+			onChange: value => setAttributes( { borderColor: value } ),
+			label: __( 'Border', 'jetpack-forms' ),
+		} );
+	}
 	if ( isChoicesBlock && blockStyle === 'button' ) {
 		colorSettings.push( {
 			value: attributes.buttonBackgroundColor,

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -335,6 +335,44 @@
 		opacity: 1;
 	}
 
+	&.jetpack-field-checkbox .jetpack-field-checkbox__checkbox {
+		align-items: center;
+		all: initial;
+		appearance: none;
+		color: var(--jetpack--contact-form--border-color);
+
+		border: none;
+		font-size: var(--jetpack--contact-form--font-size);
+		font-family: var(--jetpack--contact-form--font-family);
+		height: var(--jetpack--contact-form--font-size);
+		justify-content: center;
+		margin: 0 10px 0 0;
+		outline: none;
+		position: relative;
+		width: var(--jetpack--contact-form--font-size);
+		pointer-events: none;
+		display: flex;
+
+		&::before {
+			all: initial;
+			color: inherit;
+			font-size: inherit;
+			font-family: inherit;
+			align-items: center;
+			border-color: currentColor;
+			border-radius: min(var(--jetpack--contact-form--button-outline--border-radius, 0px), 4px);
+			border-style: solid;
+			border-width: 1px;
+			box-sizing: border-box;
+			content: ' ';
+
+			font-weight: bold;
+			height: var(--jetpack--contact-form--font-size);
+			justify-content: center;
+			width: var(--jetpack--contact-form--font-size);
+		}
+	}
+
 	.jetpack-option__type.jetpack-option__type {
 		align-items: center;
 		all: initial;
@@ -461,6 +499,7 @@
 		align-items: baseline; /* Align input with first label line */
 
 		.jetpack-option__type:before {
+			color: var(--jetpack--contact-form--border-color);
 			display: block; /* display: flex causes baselines to not align */
 		}
 	}

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -328,66 +328,26 @@
 		margin-bottom: 0;
 	}
 
+	&.jetpack-field-consent .jetpack-field-consent__checkbox,
 	&.jetpack-field-checkbox .jetpack-field-checkbox__checkbox,
-	&.jetpack-field-consent .jetpack-field-consent__checkbox {
-		margin: 0 0.75rem 0 0;
-		border-color: currentColor;
-		opacity: 1;
-	}
-
-	&.jetpack-field-checkbox .jetpack-field-checkbox__checkbox {
-		align-items: center;
-		all: initial;
-		appearance: none;
-		color: var(--jetpack--contact-form--border-color);
-
-		border: none;
-		font-size: var(--jetpack--contact-form--font-size);
-		font-family: var(--jetpack--contact-form--font-family);
-		height: var(--jetpack--contact-form--font-size);
-		justify-content: center;
-		margin: 0 10px 0 0;
-		outline: none;
-		position: relative;
-		width: var(--jetpack--contact-form--font-size);
-		pointer-events: none;
-		display: flex;
-
-		&::before {
-			all: initial;
-			color: inherit;
-			font-size: inherit;
-			font-family: inherit;
-			align-items: center;
-			border-color: currentColor;
-			border-radius: min(var(--jetpack--contact-form--button-outline--border-radius, 0px), 4px);
-			border-style: solid;
-			border-width: 1px;
-			box-sizing: border-box;
-			content: ' ';
-
-			font-weight: bold;
-			height: var(--jetpack--contact-form--font-size);
-			justify-content: center;
-			width: var(--jetpack--contact-form--font-size);
-		}
-	}
-
 	.jetpack-option__type.jetpack-option__type {
 		align-items: center;
 		all: initial;
 		appearance: none;
-		color: var(--jetpack--contact-form--text-color);
+		color: var(--jetpack--contact-form--border-color);
 		display: flex;
 		border: none;
 		font-size: var(--jetpack--contact-form--font-size, 16px );
 		font-family: var(--jetpack--contact-form--font-family);
 		height: var(--jetpack--contact-form--font-size, 16px );
+		opacity: 1;
 		justify-content: center;
 		margin: 0 10px 0 0;
 		outline: none;
 		position: relative;
 		width: var(--jetpack--contact-form--font-size, 16px);
+		min-width: var(--jetpack--contact-form--font-size, 16px);
+		flex-shrink: inherit;
 		pointer-events: none;
 
 		&::after, &::before {
@@ -399,7 +359,7 @@
 
 		&::before {
 			align-items: center;
-			border-color: currentColor;
+			border-color: var(--jetpack--contact-form--border-color);
 			border-radius: min(var(--jetpack--contact-form--button-outline--border-radius, 0px), 4px);
 			border-style: solid;
 			border-width: 1px;
@@ -407,14 +367,33 @@
 			content: ' ';
 			display: flex;
 			font-weight: bold;
-			height: var(--jetpack--contact-form--font-size, 16px);
 			justify-content: center;
+			height: var(--jetpack--contact-form--font-size, 16px);
 			width: var(--jetpack--contact-form--font-size, 16px);
+			min-width: var(--jetpack--contact-form--font-size, 16px);
+			background:var( --jetpack--contact-form--input-background );
 		}
 
 		&[type="radio"]::before {
 			border-radius: 50%;
 		}
+	}
+
+	&.jetpack-field-checkbox .jetpack-field-checkbox__checkbox:checked::before {
+		position: absolute;
+		content: "\2713";
+
+		top: calc(var(--jetpack--contact-form--font-size) / 2);
+		left: calc(var(--jetpack--contact-form--font-size) / 2);
+
+		display: flex;
+
+		font-size: var(--jetpack--contact-form--font-size);
+		line-height: 1;
+
+		transform: translate(-50%, -50%);
+		color: var(--jetpack--contact-form--text-color);
+		opacity: 1;
 	}
 
 	&.jetpack-field-multiple {
@@ -475,10 +454,6 @@
 				margin-right: 12px;
 			}
 		}
-	}
-
-	.jetpack-field-consent__checkbox + .jetpack-field-label {
-		line-height: normal;
 	}
 
 	.jetpack-field-option {
@@ -597,15 +572,13 @@
 }
 
 .jetpack-field-checkbox {
-	align-items: baseline;
 
 	.jetpack-field-label {
-		display: block;
+		line-height: 1;
 	}
 }
 
 .jetpack-field-consent {
-	align-items: center;
 
 	.jetpack-field-label {
 		flex-grow: 1;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -87,6 +87,7 @@
 			&[data-type='jetpack/field-checkbox'],
 			&[data-type='jetpack/field-consent'] {
 				align-self: center;
+				align-items: center;
 			}
 		}
 	}

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -497,6 +497,7 @@
 	.wp-block-jetpack-field-option-radio {
 		display: flex;
 		align-items: baseline; /* Align input with first label line */
+		color: var(--jetpack--contact-form--text-color);
 
 		.jetpack-option__type:before {
 			color: var(--jetpack--contact-form--border-color);

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -473,10 +473,8 @@
 	.wp-block-jetpack-field-option-radio {
 		display: flex;
 		align-items: baseline; /* Align input with first label line */
-		color: var(--jetpack--contact-form--text-color);
 
 		.jetpack-option__type:before {
-			color: var(--jetpack--contact-form--border-color);
 			display: block; /* display: flex causes baselines to not align */
 		}
 	}
@@ -485,6 +483,19 @@
 	.wp-block-jetpack-field-option-radio {
 		.jetpack-option__type {
 			transform: translateY(15%); /* Small offset to compensate the slightly odd perceived alignment that's due to the circular shape */
+		}
+	}
+}
+
+.jetpack-field.has-colors {
+	.jetpack-field-option.field-option-checkbox,
+	.jetpack-field-option.field-option-radio,
+	.wp-block-jetpack-field-option-checkbox,
+	.wp-block-jetpack-field-option-radio {
+		color: var(--jetpack--contact-form--text-color);
+
+		.jetpack-option__type:before {
+			color: var(--jetpack--contact-form--border-color);
 		}
 	}
 }

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -596,6 +596,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	background-color: var(--jetpack--contact-form--input-background);
 	font-family: var( --jetpack--contact-form--font-family );
 	flex-basis: content;
+	text-align: left;
 }
 
 .contact-form .grunion-field-wrap input.radio {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -143,9 +143,11 @@
 .contact-form .grunion-checkbox-multiple-options .contact-form-field,
 .contact-form .grunion-radio-options .contact-form-field {
 	display: flex;
-	align-items: baseline;
-
+	align-items: center;
 	margin: 0;
+}
+.contact-form .grunion-radio-options .contact-form-field {
+	align-items: baseline;
 }
 
 .contact-form label span.required,
@@ -570,6 +572,8 @@ on production builds, the attributes are being reordered, causing side-effects
 	padding-top: 8px;
 }
 
+.contact-form .grunion-field-wrap input.consent,
+.contact-form .grunion-field-wrap input.checkbox,
 .contact-form .grunion-field-wrap input.checkbox-multiple,
 .contact-form .grunion-field-wrap input.radio {
 	position: relative;
@@ -589,10 +593,11 @@ on production builds, the attributes are being reordered, causing side-effects
 
 .contact-form .grunion-field-wrap input.radio {
 	border-radius: 50%;
-
 	transform: translateY(15%); /* Small offset to compensate the slightly odd perceived alignment that's due to the circular shape */
 }
 
+.contact-form .grunion-field-wrap input.consent:checked::before,
+.contact-form .grunion-field-wrap input.checkbox:checked::before,
 .contact-form .grunion-field-wrap input.checkbox-multiple:checked::before {
 	content: "\2713";
 
@@ -785,10 +790,8 @@ on production builds, the attributes are being reordered, causing side-effects
 	font-style: normal;
 	font-weight: bold;
 }
-
-.contact-form__checkbox-wrap {
+.contact-form .contact-form__checkbox-wrap {
 	display: inline-flex;
-	align-items: baseline;
 }
 
 .contact-form :is([type="submit"],button:not([type="reset"])) {
@@ -807,7 +810,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	display: block;
 }
 
-.visually-hidden {
+.contact-form .visually-hidden {
   clip: rect(0 0 0 0);
   clip-path: inset(50%);
   height: 1px;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -588,7 +588,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	padding: 0;
 
 	appearance: none;
-	opacity: 100;
+	opacity: 1;
 	border: solid 1px currentColor;
 
 	outline-offset: 4px;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -584,6 +584,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	border: solid 1px currentColor;
 
 	outline-offset: 4px;
+	color: var( --jetpack--contact-form--border-color );
 }
 
 .contact-form .grunion-field-wrap input.radio {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -96,6 +96,8 @@
 
 .contact-form label.checkbox {
 	font-weight: normal;
+	margin-bottom: 0;
+	line-height: 1;
 }
 
 .contact-form label.checkbox-multiple,
@@ -580,6 +582,7 @@ on production builds, the attributes are being reordered, causing side-effects
 
 	box-sizing: border-box;
 	width: var(--jetpack--contact-form--font-size);
+	min-width: var(--jetpack--contact-form--font-size);
 	height: var(--jetpack--contact-form--font-size);
 	margin-inline-end: calc(var(--jetpack--contact-form--font-size) / 2);
 	padding: 0;
@@ -590,6 +593,9 @@ on production builds, the attributes are being reordered, causing side-effects
 
 	outline-offset: 4px;
 	color: var( --jetpack--contact-form--border-color );
+	background-color: var(--jetpack--contact-form--input-background);
+	font-family: var( --jetpack--contact-form--font-family );
+	flex-basis: content;
 }
 
 .contact-form .grunion-field-wrap input.radio {
@@ -612,6 +618,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	line-height: 1;
 
 	transform: translate(-50%, -50%);
+	color: var(--jetpack--contact-form--text-color);
 }
 
 .contact-form .grunion-field-wrap input.radio:checked::before {
@@ -624,6 +631,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	position: absolute;
 	transform: translate(-50%, -50%);
 	width: calc(var(--jetpack--contact-form--font-size) / 2);
+	color: var(--jetpack--contact-form--text-color);
 }
 
 .contact-form .grunion-field-wrap.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .contact-form-field,

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -585,6 +585,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	padding: 0;
 
 	appearance: none;
+	opacity: 100;
 	border: solid 1px currentColor;
 
 	outline-offset: 4px;
@@ -610,7 +611,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	font-size: var(--jetpack--contact-form--font-size);
 	line-height: 1;
 
-  transform: translate(-50%, -50%);
+	transform: translate(-50%, -50%);
 }
 
 .contact-form .grunion-field-wrap input.radio:checked::before {

--- a/projects/plugins/jetpack/changelog/add-border-styling-radio
+++ b/projects/plugins/jetpack/changelog/add-border-styling-radio
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Form: fixes the colour styling options of multiselect inputs


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/39675

## Proposed changes:
* Add border options to the multi select, radio and checkbox blocks ( simple and consent ).
* This makes it possible to set different colours for checkbox borders and options and label colour contorl work more like you would expect. 
* Also the _different types of checkboxes now have the same styling implemented_. Before the single checkbox and the consent control has the just the default checkbox styling. This make it so that the styling is now constant across all the different form. 
* This PR also adds the background colour to checkbox and radio buttons to come from the background colour that can be set on fields. But this is currently not something that can be controlled on the fields. 

## Editor:
<table >
<tr>
<td>Before:</td>
<td>After:</td>
</tr>

<tr>
<td>
<img width="1157" alt="Screenshot 2025-01-09 at 3 41 04 PM" src="https://github.com/user-attachments/assets/89e691a2-41c8-4305-9b79-2d0de3f968d4" />
</td>
<td>
<img width="1122" alt="Screenshot 2025-01-09 at 3 32 11 PM" src="https://github.com/user-attachments/assets/23f61750-fc8f-4175-b19f-6facf509828c" />
</td>
</tr>

<tr>
<td>
<img width="1091" alt="Screenshot 2025-01-09 at 3 38 10 PM" src="https://github.com/user-attachments/assets/c2438b9f-31fd-4011-8dff-cffd6b1a1d7e" />

</td>
<td>
<img width="1115" alt="Screenshot 2025-01-09 at 3 31 48 PM" src="https://github.com/user-attachments/assets/e4098373-3e76-4663-b0b3-ab0136295638" />
</td>
</tr>


</table>

## Frontend

<table >
<tr>
<td>Before:</td>
<td>After:</td>
</tr>


<tr>
<td>
<img width="872" alt="Screenshot 2025-01-09 at 3 55 14 PM" src="https://github.com/user-attachments/assets/11aa0aef-c917-465e-85d7-c29acc80c913" />
</td>
<td>
<img width="872" alt="Screenshot 2025-01-09 at 3 51 17 PM" src="https://github.com/user-attachments/assets/7bcf25fb-49c9-4e56-9e1b-9727a02494d2" />

</td>
</tr>

</table>


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Load this PR. 
* In the Gutenberg editor add a form
* Insert radio select, multi select and checkboxes and consent fields. 
* Update the consent field to show the checkbox. by setting the dropdown in the sidebar to be "Add Privacy Checkbox"
* Play around with the different colour settings in the sidebar. Does the form look like you would expect? 
* Notice that the form displays the same in the Block editor as in the front end of the site. 
