### PR TITLE
Boost: Fix checkout page when running WC Shipping and Concat JS

### DIFF
--- a/projects/plugins/boost/changelog/fix-woocommerce-shipping-concat-js-conflict
+++ b/projects/plugins/boost/changelog/fix-woocommerce-shipping-concat-js-conflict
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Concatenate JS: Improve compatibility with WooCommerce shipping.

--- a/projects/plugins/boost/compatibility/js-concatenate.php
+++ b/projects/plugins/boost/compatibility/js-concatenate.php
@@ -10,6 +10,8 @@ function maybe_do_not_concat( $do_concat, $handle ) {
 		// Plugin: `event-tickets`
 		'tribe-tickets-block',
 		'tribe-tickets-provider',
+		// Plugin: `woocommerce-shipping`
+		'woocommerce-shipping-checkout-address-validation',
 	);
 
 	if ( in_array( $handle, $excluded_handles, true ) ) {


### PR DESCRIPTION
Fixes #40684

## Proposed changes:

* Exclude WC Shipping JS file to prevent the checkout page from being broken when Concat JS is enabled.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1734605309871569-slack-C7U3Y3VMY
p1734608265003869-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Make sure that you can reproduce the problem from the related issue first;
- After reproducing the problem, switch to PR branch and see if they persist.