### PR TITLE
Jetpack: Fix authors widget 'all' checkbox

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-author-widget-all-checkbox
+++ b/projects/plugins/jetpack/changelog/fix-author-widget-all-checkbox
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Authors widget: Fix saving of unchecked "Display all authors" checkbox in the legacy widget editor.

--- a/projects/plugins/jetpack/modules/widgets/authors.php
+++ b/projects/plugins/jetpack/modules/widgets/authors.php
@@ -289,7 +289,7 @@ class Jetpack_Widget_Authors extends WP_Widget {
 	 */
 	public function update( $new_instance, $old_instance ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$new_instance['title']       = wp_strip_all_tags( $new_instance['title'] );
-		$new_instance['all']         = isset( $new_instance['all'] );
+		$new_instance['all']         = isset( $new_instance['all'] ) ? (bool) $new_instance['all'] : false;
 		$new_instance['number']      = (int) $new_instance['number'];
 		$new_instance['avatar_size'] = (int) $new_instance['avatar_size'];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The block-based legacy widget editor sends the instance data through the `update()` function multiple times, for preview and again on save. This widget doing `isset( $new_instance['all'] )` was therefore going from unset to `false` on preview and then from `false` to `true` on save.

Instead let's do like other widgets with checkboxes do, and cast the value to boolean when set.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes https://github.com/Automattic/jpop-issues/issues/9458

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a test site. Use a theme such as Twenty Ten that has Appearance → Widgets. Disable edge caching if necessary.
* Enable Jetpack's widgets module.
* Make sure there's at least one user with a post. Add an additional author-user, with no posts.
* Use the legacy Appearance → Widgets editor to add the widget. Check the "Display all" checkbox.
* Verify the widget displays both users on the frontend.
* Use the legacy Appearance → Widgets editor to edit the widget, unchecking the "Display all" checkbox.
* Verify the widget no longer displays the postless user.
