### PR TITLE
Add explanation firewall inactive when not supported

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/use-protect-tooltip-copy.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/use-protect-tooltip-copy.ts
@@ -247,7 +247,7 @@ export function useProtectTooltipCopy(): TooltipContent {
 						),
 				  },
 		autoFirewallTooltip:
-			hasProtectPaidPlan && ! isAutoFirewallEnabled
+			( hasProtectPaidPlan && ! isAutoFirewallEnabled ) || ! wafSupported
 				? {
 						title: __( 'Auto-Firewall: Inactive', 'jetpack-my-jetpack' ),
 						text: wafSupported

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/use-protect-tooltip-copy.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/use-protect-tooltip-copy.ts
@@ -49,6 +49,7 @@ export function useProtectTooltipCopy(): TooltipContent {
 		jetpack_waf_automatic_rules: isAutoFirewallEnabled,
 		blocked_logins: blockedLoginsCount,
 		brute_force_protection: hasBruteForceProtection,
+		waf_supported: wafSupported,
 	} = wafData || {};
 
 	const pluginsCount = fromScanPlugins.length || Object.keys( plugins ).length;
@@ -249,18 +250,23 @@ export function useProtectTooltipCopy(): TooltipContent {
 			hasProtectPaidPlan && ! isAutoFirewallEnabled
 				? {
 						title: __( 'Auto-Firewall: Inactive', 'jetpack-my-jetpack' ),
-						text: createInterpolateElement(
-							__(
-								'You have Auto-Firewall disabled, visit your Protect <a>firewall settings</a> to activate.',
-								'jetpack-my-jetpack'
-							),
-							{
-								a: createElement( 'a', {
-									href: settingsLink,
-									onClick: trackFirewallSettingsLinkClick,
-								} ),
-							}
-						),
+						text: wafSupported
+							? createInterpolateElement(
+									__(
+										'You have Auto-Firewall disabled, visit your Protect <a>firewall settings</a> to activate.',
+										'jetpack-my-jetpack'
+									),
+									{
+										a: createElement( 'a', {
+											href: settingsLink,
+											onClick: trackFirewallSettingsLinkClick,
+										} ),
+									}
+							  )
+							: __(
+									'Auto-Firewall is disabled as your hosting provider already includes a built-in firewall with similar rules for your site.',
+									'jetpack-my-jetpack'
+							  ),
 				  }
 				: {
 						title: __( 'Auto-Firewall: Inactive', 'jetpack-my-jetpack' ),

--- a/projects/packages/my-jetpack/changelog/add-explanation-firewall-inactive-when-not-supported
+++ b/projects/packages/my-jetpack/changelog/add-explanation-firewall-inactive-when-not-supported
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add new WAF status on Protect card for when WAF is unsupported

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -286,6 +286,7 @@ interface Window {
 				jetpack_waf_share_data: '1' | '';
 				jetpack_waf_share_debug_data: boolean;
 				standalone_mode: boolean;
+				waf_supported: boolean;
 			};
 		};
 		videopress: {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -236,9 +236,12 @@ class Initializer {
 		$scan_data                      = Products\Protect::get_protect_data();
 		self::update_historically_active_jetpack_modules();
 
-		$waf_config = array();
+		$waf_config    = array();
+		$waf_supported = false;
+
 		if ( class_exists( 'Automattic\Jetpack\Waf\Waf_Runner' ) ) {
-			$waf_config = Waf_Runner::get_config();
+			$waf_config    = Waf_Runner::get_config();
+			$waf_supported = Waf_Runner::is_supported_environment();
 		}
 
 		wp_localize_script(
@@ -297,6 +300,9 @@ class Initializer {
 					'scanData'  => $scan_data,
 					'wafConfig' => array_merge(
 						$waf_config,
+						array(
+							'waf_supported' => $waf_supported,
+						),
 						array( 'blocked_logins' => (int) get_site_option( 'jetpack_protect_blocked_attempts', 0 ) )
 					),
 				),


### PR DESCRIPTION
## Proposed changes:

* Add new tooltip on Protect card in My Jetpack for when WAF is unsupported

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: https://github.com/Automattic/jetpack/issues/38970

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

### Testing on Pressable

1. Create a Pressable site: PCYsg-9TF-p2
2. Download the Jetpack Beta plugin [here](https://jetpack.com/download-jetpack-beta/) (or wherever you want)
3. Install the Jetpack Beta plugin on your pressable site
4. Checkout this branch via the beta plugin

### Testing locally

1. Checkout this branch locally
2. Go to `projects/packages/my-jetpack/src/class-initializer.php` and update line 304 to
```php
'waf_supported' => false,
```

### Continue here for both options

1. Go to `/wp-admin/admin.php?page=my-jetpack`
2. Confirm you see the following tooltip letting the user know that the WAF is unsupported for their site
![image](https://github.com/user-attachments/assets/686c4e88-bbc3-4afb-9321-218822c2e19e)
3. You can test with or without a plan, or any other instances but it should always show this tooltip