### PR TITLE
Protect Meets Core: Fix "0" rendered by conditional render chain

### DIFF
--- a/projects/plugins/protect/src/js/routes/scan/index.jsx
+++ b/projects/plugins/protect/src/js/routes/scan/index.jsx
@@ -35,8 +35,8 @@ const ScanPage = () => {
 		currentScanStatus = 'active';
 	}
 
-	const hasActiveThreats = status && status.threats.length;
-	const hasHistory = history && history.threats.length;
+	const hasActiveThreats = status && !! status.threats.length;
+	const hasHistory = history && !! history.threats.length;
 	const showResults = hasActiveThreats || hasHistory;
 
 	// Track view for Protect admin page.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Casts `.length` values as strict booleans, to prevent the "0" value from being rendered.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a site with a paid plan and no threat history, verify that no zero is rendered above the footer.

<img width="682" alt="Screenshot 2025-01-07 at 7 19 30 PM" src="https://github.com/user-attachments/assets/91aeeff3-e360-455f-af6d-e1ee8a541c81" />
