### PR TITLE
Image CDN: Prevent URLs from being double encoded

### DIFF
--- a/projects/packages/image-cdn/changelog/fix-double-encoding
+++ b/projects/packages/image-cdn/changelog/fix-double-encoding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+General: Ensure that double encoding doesn't happen.

--- a/projects/packages/image-cdn/src/class-image-cdn-core.php
+++ b/projects/packages/image-cdn/src/class-image-cdn-core.php
@@ -273,6 +273,7 @@ class Image_CDN_Core {
 	 */
 	private static function escape_path( $path ) {
 		$parts = explode( '/', $path );
+		$parts = array_map( 'rawurldecode', $parts );
 		$parts = array_map( 'rawurlencode', $parts );
 		return implode( '/', $parts );
 	}

--- a/projects/packages/image-cdn/tests/php/test_class.image_cdn_core.php
+++ b/projects/packages/image-cdn/tests/php/test_class.image_cdn_core.php
@@ -296,6 +296,16 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 	}
 
 	/**
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
+	 * @since  $$next-version$$
+	 * @group  jetpack_photon_filter_url_encoding
+	 */
+	public function test_photon_url_filter_encoded_url_should_not_be_encoded_again() {
+		$url = Image_CDN_Core::cdn_url( '//example.com/image%20with%20spaces.jpg', array(), 'https' );
+		$this->assertEquals( 'https://i0.wp.com/example.com/image%20with%20spaces.jpg', $url );
+	}
+
+	/**
 	 * @author aduth
 	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url_scheme
 	 * @since  4.5.0

--- a/projects/plugins/boost/changelog/fix-image-cdn-double-encoding
+++ b/projects/plugins/boost/changelog/fix-image-cdn-double-encoding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Image CDN: Ensure that double encoding doesn't happen.

--- a/projects/plugins/jetpack/changelog/fix-image-cdn-double-encoding
+++ b/projects/plugins/jetpack/changelog/fix-image-cdn-double-encoding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Photon: Fix double encoding image urls.


### PR DESCRIPTION
Fixes #40290.

## Proposed changes:

* Decode path parts before encoding;
* Add unit test to make sure no double encoding happens.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Follow the instructions in the issue and make sure you can reproduce the problem before trying out this patch.
- A note on the instructions - WordPress will properly handle an image with spaces in the name when uploading it via the media manager. Upload it manually via FTP to your uploads folder and then manually add the URL to the page to avoid WP escaping it.