### PR TITLE
Social: Replace can_disconnect with a store data selector

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-connections-remove-can_disconnect-prop
+++ b/projects/js-packages/publicize-components/changelog/update-social-connections-remove-can_disconnect-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social: Replaced can_disconnect with a store data selector

--- a/projects/js-packages/publicize-components/src/components/connection-management/disconnect.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/disconnect.tsx
@@ -30,15 +30,16 @@ export function Disconnect( {
 
 	const { deleteConnectionById } = useDispatch( socialStore );
 
-	const { isDisconnecting } = useSelect(
+	const { isDisconnecting, canManageConnection } = useSelect(
 		select => {
-			const { getDeletingConnections } = select( socialStore );
+			const { getDeletingConnections, canUserManageConnection } = select( socialStore );
 
 			return {
 				isDisconnecting: getDeletingConnections().includes( connection.connection_id ),
+				canManageConnection: canUserManageConnection( connection ),
 			};
 		},
-		[ connection.connection_id ]
+		[ connection ]
 	);
 
 	const onClickDisconnect = useCallback( async () => {
@@ -49,7 +50,7 @@ export function Disconnect( {
 		} );
 	}, [ connection.connection_id, deleteConnectionById ] );
 
-	if ( ! connection.can_disconnect ) {
+	if ( ! canManageConnection ) {
 		return null;
 	}
 

--- a/projects/js-packages/publicize-components/src/components/connection-management/reconnect.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/reconnect.tsx
@@ -24,15 +24,16 @@ export function Reconnect( { connection, service, variant = 'link' }: ReconnectP
 	const { deleteConnectionById, setKeyringResult, openConnectionsModal, setReconnectingAccount } =
 		useDispatch( socialStore );
 
-	const { isDisconnecting } = useSelect(
+	const { isDisconnecting, canManageConnection } = useSelect(
 		select => {
-			const { getDeletingConnections } = select( socialStore );
+			const { getDeletingConnections, canUserManageConnection } = select( socialStore );
 
 			return {
 				isDisconnecting: getDeletingConnections().includes( connection.connection_id ),
+				canManageConnection: canUserManageConnection( connection ),
 			};
 		},
-		[ connection.connection_id ]
+		[ connection ]
 	);
 
 	const onConfirm = useCallback(
@@ -80,7 +81,7 @@ export function Reconnect( { connection, service, variant = 'link' }: ReconnectP
 		setReconnectingAccount,
 	] );
 
-	if ( ! connection.can_disconnect ) {
+	if ( ! canManageConnection ) {
 		return null;
 	}
 

--- a/projects/js-packages/publicize-components/src/components/connection-management/tests/specs/disconnect.test.js
+++ b/projects/js-packages/publicize-components/src/components/connection-management/tests/specs/disconnect.test.js
@@ -38,7 +38,6 @@ describe( 'Disconnecting a connection', () => {
 					service_name: 'facebook',
 					connection_id: '2',
 					display_name: 'Facebook',
-					can_disconnect: true,
 				} }
 			/>
 		);

--- a/projects/js-packages/publicize-components/src/components/connection-management/tests/specs/mark-as-shared.test.js
+++ b/projects/js-packages/publicize-components/src/components/connection-management/tests/specs/mark-as-shared.test.js
@@ -27,7 +27,6 @@ describe( 'Marking a connection as shared', () => {
 					service_name: 'facebook',
 					connection_id: '2',
 					display_name: 'Facebook',
-					can_disconnect: true,
 				} }
 			/>
 		);

--- a/projects/js-packages/publicize-components/src/components/connection-management/tests/specs/reconnect.test.js
+++ b/projects/js-packages/publicize-components/src/components/connection-management/tests/specs/reconnect.test.js
@@ -17,8 +17,7 @@ describe( 'Reconnect', () => {
 
 	const mockConnection = {
 		connection_id: '123',
-		can_disconnect: true,
-		external_display: 'mockDisplay',
+		display_name: 'mockDisplay',
 	};
 
 	beforeEach( () => {
@@ -58,12 +57,8 @@ describe( 'Reconnect', () => {
 	} );
 
 	test( 'does not render the button if connection cannot be disconnected', () => {
-		const nonDisconnectableConnection = {
-			...mockConnection,
-			can_disconnect: false,
-		};
-
-		render( <Reconnect connection={ nonDisconnectableConnection } service={ mockService } /> );
+		setup( { canUserManageConnection: false } );
+		render( <Reconnect connection={ mockConnection } service={ mockService } /> );
 
 		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
 	} );

--- a/projects/js-packages/publicize-components/src/components/services/service-connection-info.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/service-connection-info.tsx
@@ -1,5 +1,7 @@
 import { IconTooltip, Text } from '@automattic/jetpack-components';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as socialStore } from '../../social-store';
 import { Connection } from '../../social-store/types';
 import { ConnectionName } from '../connection-management/connection-name';
 import { ConnectionStatus } from '../connection-management/connection-status';
@@ -19,6 +21,11 @@ export const ServiceConnectionInfo = ( {
 	service,
 	isAdmin,
 }: ServiceConnectionInfoProps ) => {
+	const canManageConnection = useSelect(
+		select => select( socialStore ).canUserManageConnection( connection ),
+		[ connection ]
+	);
+
 	return (
 		<div className={ styles[ 'service-connection' ] }>
 			<div>
@@ -40,7 +47,7 @@ export const ServiceConnectionInfo = ( {
 					 * if the user can disconnect the connection.
 					 * Otherwise, non-admin authors will see only the status without any further context.
 					 */
-					if ( conn.status === 'broken' && conn.can_disconnect ) {
+					if ( conn.status === 'broken' && canManageConnection ) {
 						return <ConnectionStatus connection={ conn } service={ service } />;
 					}
 
@@ -63,7 +70,7 @@ export const ServiceConnectionInfo = ( {
 					 * Now if the user is not an admin, we tell them that the connection
 					 * was added by an admin and show the connection status if it's broken.
 					 */
-					return ! conn.can_disconnect ? (
+					return ! canManageConnection ? (
 						<>
 							<Text className={ styles.description }>
 								{ __(

--- a/projects/js-packages/publicize-components/src/components/services/service-item.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/service-item.tsx
@@ -1,8 +1,10 @@
 import { Button, useBreakpointMatch } from '@automattic/jetpack-components';
 import { Panel, PanelBody } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { useEffect, useReducer, useRef } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
+import { store as socialStore } from '../../social-store';
 import { ConnectForm } from './connect-form';
 import { ServiceItemDetails, ServicesItemDetailsProps } from './service-item-details';
 import { ServiceStatus } from './service-status';
@@ -40,9 +42,11 @@ export function ServiceItem( {
 
 	const brokenConnections = serviceConnections.filter( ( { status } ) => status === 'broken' );
 
-	const hasOwnBrokenConnections = brokenConnections.some(
-		( { can_disconnect } ) => can_disconnect
-	);
+	const hasOwnBrokenConnections = useSelect( select => {
+		const { canUserManageConnection, getBrokenConnections } = select( socialStore );
+
+		return getBrokenConnections().some( canUserManageConnection );
+	}, [] );
 
 	const hideInitialConnectForm =
 		// For services with custom inputs, the initial Connect button opens the panel,

--- a/projects/js-packages/publicize-components/src/components/services/service-status.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/service-status.tsx
@@ -1,5 +1,7 @@
 import { Alert } from '@automattic/jetpack-components';
+import { useSelect } from '@wordpress/data';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { store as socialStore } from '../../social-store';
 import { Connection } from '../../social-store/types';
 import styles from './style.module.scss';
 
@@ -16,13 +18,16 @@ export type ServiceStatusProps = {
  * @return {import('react').ReactNode} Service status component
  */
 export function ServiceStatus( { serviceConnections, brokenConnections }: ServiceStatusProps ) {
+	const canFix = useSelect(
+		select => brokenConnections.some( select( socialStore ).canUserManageConnection ),
+		[ brokenConnections ]
+	);
+
 	if ( ! serviceConnections.length ) {
 		return null;
 	}
 
 	if ( brokenConnections.length > 0 ) {
-		const canFix = brokenConnections.some( ( { can_disconnect } ) => can_disconnect );
-
 		return (
 			<Alert
 				level={ canFix ? 'error' : 'warning' }

--- a/projects/js-packages/publicize-components/src/components/services/tests/service-connection-info.test.js
+++ b/projects/js-packages/publicize-components/src/components/services/tests/service-connection-info.test.js
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { setup } from '../../../utils/test-factory';
 import { ServiceConnectionInfo } from '../service-connection-info';
 
 jest.mock( '../../connection-management/connection-name', () => ( {
@@ -19,7 +20,6 @@ describe( 'ServiceConnectionInfo', () => {
 		profile_picture: 'https://example.com/profile.jpg',
 		display_name: 'Example User',
 		status: 'connected',
-		can_disconnect: true,
 	};
 
 	const service = {
@@ -35,6 +35,10 @@ describe( 'ServiceConnectionInfo', () => {
 			/>
 		);
 	};
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
 
 	test( 'renders profile picture if available', () => {
 		renderComponent();
@@ -70,7 +74,9 @@ describe( 'ServiceConnectionInfo', () => {
 	} );
 
 	test( 'displays description if connection cannot be disconnected', () => {
-		renderComponent( { can_disconnect: false } );
+		setup( { canUserManageConnection: false } );
+		renderComponent();
+
 		expect(
 			screen.getByText( 'This connection is added by a site administrator.' )
 		).toBeInTheDocument();

--- a/projects/js-packages/publicize-components/src/components/services/tests/service-connection-info.test.js
+++ b/projects/js-packages/publicize-components/src/components/services/tests/service-connection-info.test.js
@@ -26,6 +26,16 @@ describe( 'ServiceConnectionInfo', () => {
 		icon: () => <svg aria-label="test-svg"></svg>,
 	};
 
+	beforeAll( () => {
+		global.JetpackScriptData = {
+			user: {
+				current_user: {
+					id: 123,
+				},
+			},
+		};
+	} );
+
 	const renderComponent = ( connOverrides = {}, serviceOverrides = {}, props = {} ) => {
 		render(
 			<ServiceConnectionInfo

--- a/projects/js-packages/publicize-components/src/social-store/actions/connection-data.ts
+++ b/projects/js-packages/publicize-components/src/social-store/actions/connection-data.ts
@@ -362,7 +362,6 @@ export function createConnection( data, optimisticData = {} ) {
 					// Updating the connection will also override the connection_id.
 					updateConnection( tempId, {
 						...connection,
-						can_disconnect: true,
 						// For editor, we always enable the connection by default.
 						enabled: true,
 					} )

--- a/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.ts
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.ts
@@ -1,5 +1,8 @@
+import { getScriptData } from '@automattic/jetpack-script-data';
+import { store as coreStore } from '@wordpress/core-data';
+import { createRegistrySelector } from '@wordpress/data';
 import { REQUEST_TYPE_DEFAULT } from '../actions/constants';
-import { SocialStoreState } from '../types';
+import { Connection, SocialStoreState } from '../types';
 
 /**
  * Returns the connections list from the store.
@@ -227,3 +230,32 @@ export function getKeyringResult( state ) {
 export function isConnectionsModalOpen( state ) {
 	return state.connectionData?.isConnectionsModalOpen ?? false;
 }
+
+/**
+ * Whether the current user can manage the connection.
+ */
+export const canUserManageConnection = createRegistrySelector(
+	select =>
+		( state: SocialStoreState, connectionOrId: Connection | string ): boolean => {
+			const connection =
+				typeof connectionOrId === 'string'
+					? getConnectionById( state, connectionOrId )
+					: connectionOrId;
+
+			const { current_user } = getScriptData().user;
+
+			// If the current user is the connection owner.
+			if ( current_user.wpcom?.ID === connection.user_id ) {
+				return true;
+			}
+
+			const {
+				// @ts-expect-error getUser exists but `core-data` entities are not typed properly.
+				// Should work fine after https://github.com/WordPress/gutenberg/pull/67668 is released to npm.
+				getUser,
+			} = select( coreStore );
+
+			// The user has to be at least an editor to manage the connection.
+			return getUser( current_user.id )?.capabilities?.edit_others_posts ?? false;
+		}
+);

--- a/projects/js-packages/publicize-components/src/social-store/selectors/index.ts
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/index.ts
@@ -8,8 +8,6 @@ import * as utmSelectors from './utm-settings';
 
 /**
  * Returns whether the site settings are being saved.
- *
- * @type {() => boolean} Whether the site settings are being saved.
  */
 export const isSavingSiteSettings = createRegistrySelector( select => () => {
 	return select( coreStore ).isSavingEntityRecord( 'root', 'site', undefined );

--- a/projects/js-packages/publicize-components/src/social-store/types.ts
+++ b/projects/js-packages/publicize-components/src/social-store/types.ts
@@ -18,10 +18,6 @@ export type Connection = {
 	/**
 	 * @deprecated
 	 */
-	can_disconnect?: boolean;
-	/**
-	 * @deprecated
-	 */
 	done?: boolean;
 	/**
 	 * @deprecated Use `status` instead.

--- a/projects/js-packages/publicize-components/src/utils/test-factory.js
+++ b/projects/js-packages/publicize-components/src/utils/test-factory.js
@@ -13,16 +13,16 @@ jest.mock( '../hooks/use-social-media-connections', () => ( {
 
 export const setup = ( {
 	connections = [
-		{ service_name: 'twitter', connection_id: '1', display_name: 'Twitter', can_disconnect: true },
+		{ service_name: 'twitter', connection_id: '1', display_name: 'Twitter' },
 		{
 			service_name: 'facebook',
 			connection_id: '2',
 			display_name: 'Facebook',
-			can_disconnect: true,
 		},
 	],
 	getDeletingConnections = [],
 	getUpdatingConnections = [],
+	canUserManageConnection = true,
 } = {} ) => {
 	let storeSelect;
 	renderHook( () => useSelect( select => ( storeSelect = select( store ) ) ) );
@@ -36,6 +36,10 @@ export const setup = ( {
 		.mockReset()
 		.mockReturnValue( getUpdatingConnections );
 	const stubGetKeyringResult = jest.spyOn( storeSelect, 'getKeyringResult' ).mockReset();
+	jest
+		.spyOn( storeSelect, 'canUserManageConnection' )
+		.mockReset()
+		.mockReturnValue( canUserManageConnection );
 
 	const { result: dispatch } = renderHook( () => useDispatch( store ) );
 	const stubDeleteConnectionById = jest

--- a/projects/js-packages/script-data/changelog/add-wpcom-data-for-current-user
+++ b/projects/js-packages/script-data/changelog/add-wpcom-data-for-current-user
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added wpcom data for current user

--- a/projects/js-packages/script-data/src/types.ts
+++ b/projects/js-packages/script-data/src/types.ts
@@ -32,6 +32,11 @@ export interface SiteData extends PublicSiteData, Partial< AdminSiteData > {}
 export interface CurrentUserData {
 	id: number;
 	display_name: string;
+	wpcom?: {
+		ID: number;
+		email: string;
+		login: string;
+	};
 }
 
 export interface UserData {

--- a/projects/js-packages/script-data/src/types.ts
+++ b/projects/js-packages/script-data/src/types.ts
@@ -34,7 +34,6 @@ export interface CurrentUserData {
 	display_name: string;
 	wpcom?: {
 		ID: number;
-		email: string;
 		login: string;
 	};
 }

--- a/projects/packages/publicize/changelog/update-social-connections-remove-can_disconnect-prop
+++ b/projects/packages/publicize/changelog/update-social-connections-remove-can_disconnect-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social: Replaced can_disconnect with a store data selector

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -70,14 +70,30 @@ class Publicize_Script_Data {
 		$data['site']['wpcom']['blog_id'] = Manager::get_site_id( true );
 		$data['site']['suffix']           = ( new Status() )->get_site_suffix();
 
-		$wpcom_user_data = ( new Manager() )->get_connected_user_data();
-
-		$data['user']['current_user']['wpcom'] = array_merge(
-			$data['user']['current_user']['wpcom'] ?? array(),
-			$wpcom_user_data ? $wpcom_user_data : array()
-		);
+		self::set_wpcom_user_data( $data['user']['current_user'] );
 
 		return $data;
+	}
+
+	/**
+	 * Set wpcom user data.
+	 *
+	 * @param array $user_data The user data.
+	 */
+	private static function set_wpcom_user_data( &$user_data ) {
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			$wpcom_user_data = array(
+				'ID'    => get_current_user_id(),
+				'login' => wp_get_current_user()->user_login,
+			);
+		} else {
+			$wpcom_user_data = ( new Manager() )->get_connected_user_data();
+		}
+
+		$user_data['wpcom'] = array_merge(
+			$user_data['wpcom'] ?? array(),
+			$wpcom_user_data ? $wpcom_user_data : array()
+		);
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -70,6 +70,13 @@ class Publicize_Script_Data {
 		$data['site']['wpcom']['blog_id'] = Manager::get_site_id( true );
 		$data['site']['suffix']           = ( new Status() )->get_site_suffix();
 
+		$wpcom_user_data = ( new Manager() )->get_connected_user_data();
+
+		$data['user']['current_user']['wpcom'] = array_merge(
+			$data['user']['current_user']['wpcom'] ?? array(),
+			$wpcom_user_data ? $wpcom_user_data : array()
+		);
+
 		return $data;
 	}
 


### PR DESCRIPTION
As discussed in the linked issue, we need to have better control over who can disconnect a connection. This PR uses the WP Data store approach as mentioned in the linked issue to create a data selector for that.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Create `canUserManageConnection` to check if the current user can manage a connection.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox this PR and your site
* As an admin, goto connections management and add some connections if not added already
* Confirm that you are able to see the "Disconnect" button.
* Mark a few connections as shared
* Login as an author and add a few connections
* Confirm that the author sees the "Disconnect" button for their own connections but not for shared connection.

