### PR TITLE
Stop Blaze & Copy quick links disappearing after using Quick Edit

### DIFF
--- a/projects/packages/blaze/changelog/fix-show-quicklinks-after-quickedit
+++ b/projects/packages/blaze/changelog/fix-show-quicklinks-after-quickedit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Blaze: ensure post list quick link is added after quick edit

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -45,6 +45,10 @@ class Blaze {
 	public static function init() {
 		// On the edit screen, add a row action to promote the post.
 		add_action( 'load-edit.php', array( __CLASS__, 'add_post_links_actions' ) );
+		// After the quick-edit screen is processed, ensure the blaze row action is still present
+		if ( 'admin-ajax.php' === $GLOBALS['pagenow'] && ! empty( $_POST['screen'] ) && 'edit-post' === $_POST['screen'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verification is not needed here, we're not saving anything.
+			self::add_post_links_actions();
+		}
 		// In the post editor, add a post-publish panel to allow promoting the post.
 		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_assets' ) );
 		// Add a Blaze Menu.

--- a/projects/plugins/jetpack/changelog/fix-show-quicklinks-after-quickedit
+++ b/projects/plugins/jetpack/changelog/fix-show-quicklinks-after-quickedit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Post list: Ensure copy quick link is added after quick edit

--- a/projects/plugins/jetpack/modules/copy-post.php
+++ b/projects/plugins/jetpack/modules/copy-post.php
@@ -29,7 +29,7 @@ class Jetpack_Copy_Post {
 	 * @return void
 	 */
 	public function __construct() {
-		if ( 'edit.php' === $GLOBALS['pagenow'] ) {
+		if ( 'edit.php' === $GLOBALS['pagenow'] || ( 'admin-ajax.php' === $GLOBALS['pagenow'] && ! empty( $_POST['screen'] ) && 'edit-post' === $_POST['screen'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- update_post_data() handles access check.
 			add_action( 'admin_head', array( $this, 'print_inline_styles' ) );
 			add_filter( 'post_row_actions', array( $this, 'add_row_action' ), 10, 2 );
 			add_filter( 'page_row_actions', array( $this, 'add_row_action' ), 10, 2 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes two thirds of https://github.com/Automattic/wp-calypso/issues/97995

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The post list has a number of quick links including 'Promote with Blaze', 'Copy' and Quick Edit. After using Quick Edit, the Blaze and Copy links go missing - they're not registered when the ajax response includes the new quick links.

This is solved by registering the `post_row_actions` hook on the admin-ajax.php page as well as the edit.php page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

 1. Apply the patch to your wpcom sandbox following the instructions in the comment below
 2. Sandbox your site
 3. Go to /wp-admin/edit.php
 4. You should see that your posts have various quick links including 'Copy' and 'Promote with Blaze'
 5. Press 'Quick Edit' and make a simple change, e.g. toggling the sticky setting
 6. Press the 'Update' button
 7. Look at the quick links again, you should see that 'Copy' and 'Promote with Blaze' are still there.

Before | After
-------|------
 <img width="818" alt="Screenshot 2025-01-08 at 13 10 41" src="https://github.com/user-attachments/assets/529bfab1-bda7-4d36-96c4-61c949323954" /> | <img width="818" alt="Screenshot 2025-01-08 at 13 08 49" src="https://github.com/user-attachments/assets/d11f52bc-4d66-40c7-b7ee-41fbdf099c1b" />




