### PR TITLE
Social: Implement connections caching with the updated endpoint

### DIFF
--- a/projects/packages/publicize/changelog/add-social-connections-caching
+++ b/projects/packages/publicize/changelog/add-social-connections-caching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Social: Add caching for connections using the updated endpoint

--- a/projects/packages/publicize/src/class-connections.php
+++ b/projects/packages/publicize/src/class-connections.php
@@ -23,19 +23,26 @@ class Connections {
 	 *
 	 * @param array $args Arguments
 	 *                - 'clear_cache': bool Whether to clear the cache.
-	 *                - 'test_connections': bool Whether to run connection tests.
 	 * @return array
 	 */
 	public static function get_all( $args = array() ) {
 
-		$run_tests = $args['test_connections'] ?? false;
-
 		$is_wpcom = ( new Host() )->is_wpcom_simple();
 
 		if ( $is_wpcom ) {
-			$connections = Connections_Controller::get_connections( $run_tests );
+			$connections = Connections_Controller::get_connections();
 		} else {
-			$connections = self::fetch_and_cache_connections( $run_tests );
+
+			if ( $args['clear_cache'] ?? false ) {
+				self::clear_cache();
+			}
+
+			$connections = get_transient( self::CONNECTIONS_TRANSIENT );
+
+			// This can be an empty array, so we need to check for false.
+			if ( false === $connections ) {
+				$connections = self::fetch_and_cache_connections();
+			}
 		}
 
 		// Let us add the deprecated fields for now.
@@ -80,15 +87,27 @@ class Connections {
 	/**
 	 * Fetch connections from the REST API and cache them.
 	 *
-	 * @param bool $run_tests Whether to run connection tests.
-	 *
 	 * @return array
 	 */
-	public static function fetch_and_cache_connections( $run_tests = false ) {
-		$connections = Connections_Controller::get_connections( $run_tests );
+	public static function fetch_and_cache_connections() {
+		$args = array(
+			// Request all connections.
+			'scope' => 'site',
+		);
 
-		// TODO Implement caching here.
+		$connections = Connections_Controller::get_connections( $args );
+
+		if ( is_array( $connections ) ) {
+			set_transient( self::CONNECTIONS_TRANSIENT, $connections, HOUR_IN_SECONDS * 4 );
+		}
 
 		return $connections;
+	}
+
+	/**
+	 * Clear the connections cache.
+	 */
+	public static function clear_cache() {
+		delete_transient( self::CONNECTIONS_TRANSIENT );
 	}
 }

--- a/projects/packages/publicize/src/class-connections.php
+++ b/projects/packages/publicize/src/class-connections.php
@@ -53,6 +53,51 @@ class Connections {
 	}
 
 	/**
+	 * Get all connections for the current user.
+	 *
+	 * @param array $args Arguments. Same as self::get_all().
+	 *
+	 * @see Automattic\Jetpack\Publicize\Connections::get_all()
+	 *
+	 * @return array
+	 */
+	public static function get_all_for_user( $args = array() ) {
+		$connections = self::get_all( $args );
+
+		$connections_for_user = array();
+
+		foreach ( $connections as $connection ) {
+
+			if ( $connection['shared'] || self::user_owns_connection( $connection ) ) {
+				$connections_for_user[] = $connection;
+			}
+		}
+
+		return $connections_for_user;
+	}
+
+	/**
+	 * Whether the current user owns a connection.
+	 *
+	 * @param array $connection The connection.
+	 * @param int   $user_id    The user ID. Defaults to the current user.
+	 *
+	 * @return bool
+	 */
+	public static function user_owns_connection( $connection, $user_id = null ) {
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			$wpcom_user_id = get_current_user_id();
+		} else {
+
+			$wpcom_user_data = ( new Connection\Manager() )->get_connected_user_data( $user_id );
+
+			$wpcom_user_id = ! empty( $wpcom_user_data['ID'] ) ? $wpcom_user_data['ID'] : null;
+		}
+
+		return $wpcom_user_id && $connection['user_id'] === $wpcom_user_id;
+	}
+
+	/**
 	 * Retain deprecated fields.
 	 *
 	 * @param array $connections Connections.
@@ -61,9 +106,8 @@ class Connections {
 	private static function retain_deprecated_fields( $connections ) {
 		return array_map(
 			function ( $connection ) {
-				$wpcom_user_data = ( new Connection\Manager() )->get_connected_user_data();
 
-				$owns_connection = ! empty( $wpcom_user_data['ID'] ) && $wpcom_user_data['ID'] === $connection['user_id'];
+				$owns_connection = self::user_owns_connection( $connection );
 
 				$connection = array_merge(
 					$connection,

--- a/projects/packages/publicize/src/class-connections.php
+++ b/projects/packages/publicize/src/class-connections.php
@@ -22,7 +22,7 @@ class Connections {
 	 * Get all connections.
 	 *
 	 * @param array $args Arguments
-	 *                - 'clear_cache': bool Whether to clear the cache.
+	 *                - 'ignore_cache': bool Whether to ignore the cache and fetch the connections from the API.
 	 * @return array
 	 */
 	public static function get_all( $args = array() ) {
@@ -33,14 +33,11 @@ class Connections {
 			$connections = Connections_Controller::get_connections();
 		} else {
 
-			if ( $args['clear_cache'] ?? false ) {
-				self::clear_cache();
-			}
+			$ignore_cache = $args['ignore_cache'] ?? false;
 
 			$connections = get_transient( self::CONNECTIONS_TRANSIENT );
 
-			// This can be an empty array, so we need to check for false.
-			if ( false === $connections ) {
+			if ( $ignore_cache || false === $connections ) {
 				$connections = self::fetch_and_cache_connections();
 			}
 		}
@@ -142,7 +139,13 @@ class Connections {
 		$connections = Connections_Controller::get_connections( $args );
 
 		if ( is_array( $connections ) ) {
-			set_transient( self::CONNECTIONS_TRANSIENT, $connections, HOUR_IN_SECONDS * 4 );
+			if ( ! set_transient( self::CONNECTIONS_TRANSIENT, $connections, HOUR_IN_SECONDS * 4 ) ) {
+				// If the transient has beeen set in another request, the call to set_transient can fail.
+				// If so, we can delete the transient and try again.
+				self::clear_cache();
+
+				set_transient( self::CONNECTIONS_TRANSIENT, $connections, HOUR_IN_SECONDS * 4 );
+			}
 		}
 
 		return $connections;

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -158,7 +158,7 @@ class Publicize_Script_Data {
 
 		return array(
 			'connectionData' => array(
-				'connections' => Connections::get_all(),
+				'connections' => Connections::get_all_for_user(),
 			),
 			'shareStatus'    => $share_status,
 		);

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -148,8 +148,6 @@ class Publicize extends Publicize_Base {
 
 		// Clear the cache.
 		Connections::clear_cache();
-		// Populate the cache with the new data.
-		Connections::get_all();
 
 		$expiry = 3600 * 4;
 		if ( ! set_transient( self::JETPACK_SOCIAL_CONNECTIONS_TRANSIENT, $publicize_connections, $expiry ) ) {

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -145,6 +145,12 @@ class Publicize extends Publicize_Base {
 	 * @return true
 	 */
 	public function receive_updated_publicize_connections( $publicize_connections ) {
+
+		// Clear the cache.
+		Connections::clear_cache();
+		// Populate the cache with the new data.
+		Connections::get_all();
+
 		$expiry = 3600 * 4;
 		if ( ! set_transient( self::JETPACK_SOCIAL_CONNECTIONS_TRANSIENT, $publicize_connections, $expiry ) ) {
 			// If the transient has beeen set in another request, the call to set_transient can fail. If so,

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -146,8 +146,8 @@ class Publicize extends Publicize_Base {
 	 */
 	public function receive_updated_publicize_connections( $publicize_connections ) {
 
-		// Clear the cache.
-		Connections::clear_cache();
+		// Populate the cache with the new data.
+		Connections::get_all( array( 'ignore_cache' => true ) );
 
 		$expiry = 3600 * 4;
 		if ( ! set_transient( self::JETPACK_SOCIAL_CONNECTIONS_TRANSIENT, $publicize_connections, $expiry ) ) {


### PR DESCRIPTION
This is dependent upon #40704 and implements caching for connections received from WPCOM.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update connections class to implement caching
* Hook into XMLRPC requests to invalidate cache

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox this PR and your site
* As an admin, goto connections management and add some connections if not added already
* Confirm in the debug log that the request to `/publicize/connections` endpoint (without `?test_connections=1`) happens only once even after multiple reloads
* Try to add/remove the connection from Jetpack and Calypso
* Confirm that the changes reflect in wp-admin, i.e. the cache is updated with request to `/publicize/connections`
* Mark a few connections as shared
* Login as an author and add a few connections
* Confirm that the author sees the only their own connections and the shared ones
* Confirm that author page load doesn't trigger a new request to `/publicize/connections`


