### PR TITLE
Sitemaps: ensure one item in a news sitemap to ensure validitiy

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-empty-news
+++ b/projects/plugins/jetpack/changelog/fix-empty-news
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sitemaps: ensures a valid news sitemap is present even if no posts are eligible.

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
@@ -1087,12 +1087,15 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 			);
 
 			$posts = $this->librarian->query_most_recent_posts( JP_NEWS_SITEMAP_MAX_ITEMS );
+			if ( empty( $posts ) ) {
+				$buffer->append( array( 'url' => array( 'loc' => home_url( '/' ) ) ) );
+			} else {
+				foreach ( $posts as $post ) {
+					$current_item = $this->post_to_news_sitemap_item( $post );
 
-			foreach ( $posts as $post ) {
-				$current_item = $this->post_to_news_sitemap_item( $post );
-
-				if ( false === $buffer->append( $current_item['xml'] ) ) {
-					break;
+					if ( false === $buffer->append( $current_item['xml'] ) ) {
+						break;
+					}
 				}
 			}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #9753

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the homepage as an item in a news sitemap when no posts are eligible.

This works for a news sitemap since Google excludes any entries without the `news` items, which wouldn't be present here. So, it is a valid sitemap and still empty for news, as desired.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Jetpack, connected, Sitemaps active.
* Without the patch, attempt to add a news sitemap to the Google Search Console.
* See the error.
* On a site with the patch, repeat.
* No error.

