### PR TITLE
Testimonials: Ensure we avoid a division by zero error if the columns attribute is set to 0

### DIFF
--- a/projects/packages/classic-theme-helper/changelog/fix-testimonials-module-by-zero-error
+++ b/projects/packages/classic-theme-helper/changelog/fix-testimonials-module-by-zero-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Testimonials: fix a shortcode related bug which ccurs if the column attribute is added and set to 0

--- a/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-testimonial.php
+++ b/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-testimonial.php
@@ -827,6 +827,11 @@ if ( ! class_exists( __NAMESPACE__ . '\Jetpack_Testimonial' ) ) {
 				}
 			}
 
+			// Add a guard clause to prevent division by zero below.
+			if ( $columns <= 0 ) {
+				$columns = 1;
+			}
+
 			// add first and last classes to first and last items in a row
 			if ( ( $testimonial_index_number % $columns ) === 0 ) {
 				$class[] = 'testimonial-entry-first-item-row';

--- a/projects/plugins/classic-theme-helper-plugin/changelog/fix-testimonials-module-by-zero-error
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/fix-testimonials-module-by-zero-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Testimonials: fix a shortcode related bug which ccurs if the column attribute is added and set to 0

--- a/projects/plugins/jetpack/changelog/fix-testimonials-module-by-zero-error
+++ b/projects/plugins/jetpack/changelog/fix-testimonials-module-by-zero-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Testimonials: fix a shortcode related bug which ccurs if the column attribute is added and set to 0

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-testimonials-module-by-zero-error
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-testimonials-module-by-zero-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Testimonials: fix a shortcode related bug which ccurs if the column attribute is added and set to 0

--- a/projects/plugins/wpcomsh/changelog/fix-testimonials-module-by-zero-error
+++ b/projects/plugins/wpcomsh/changelog/fix-testimonials-module-by-zero-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Testimonials: fix a shortcode related bug which ccurs if the column attribute is added and set to 0


### PR DESCRIPTION
## Proposed changes:

*  This PR adds a check to see if the columns attribute (which would be added manually via a shortcode) is set to 0. If so, it defaults to 1, to prevent issues updating the post / page, and prevent a broken post / page on the front-end.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See p1736348468089239-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

On self-hosted, WoA or Simple:

To replicate the issue:

* On trunk, enable testimonials on your test site (Jetpack > Settings > Writing on self-hosted and Atomic, or Settings > Writing on Simple (`wp-admin/options-writing.php`).
* Ensure you are checking the error log - if on Simple, tail with `tail -f /tmp/php-errors`
* Create a couple of testimonials
* Add a new post, and add the shortcode block. Add the following shortcode: `[testimonials columns=1]`. Save the post and view on the front-end. It should display just one column.
* Change the number to 2 - it should show two columns on the front-end.
* Change the number to 0 - on saving you should see `Updating failed. The response is not a valid JSON response.`. The post will also appear broken on the front-end as well.
* You should see the fatal error appearing in your logs.

To test the fix:
* Apply this PR locally, or using the beta tester plugin on a Jurassic Ninja site or WoA. On Simple, sandbox a test site and apply the PR using the commands in the generated comment below.
* Follow the same steps as above.
* When columns are set to 0, you should not see an error and the post should display with 1 column of testimonials.
* There should be no errors in logs.