### PR TITLE
Tooling: Add support for bundled `jq` version in dev environment check

### DIFF
--- a/tools/check-development-environment.sh
+++ b/tools/check-development-environment.sh
@@ -177,6 +177,10 @@ else
 	elif version_compare "$VER" "1.6"; then
 		success "ok (version $VER)"
 		JQOK=true
+	elif version_compare "$VER" "1.6-159-apple-gcff5336-dirty"; then
+		# As of macOS 10.15, Apple bundles a random version that should be good enough.
+		success "ok (version $VER)"
+		JQOK=true
 	else
 		failure "too old" '' "jq at $BIN is version $VER. Version 1.6 or later is required."
 	fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

As of macOS 10.15, `jq` is included. The version is `1.6-159-apple-gcff5336-dirty`, which would be parsed as being less than `1.6`, and thus fails dev environment checks. That said, the referenced commit is from 2022, so in reality it's newer than `1.6`:

https://github.com/jqlang/jq/commit/cff5336

I'm not even sure why the check requires `1.6` (it might be arbitrary), but this PR should at least let people proceed with the version they have.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

On a Mac without `jq` installed manually (or at least added in the path), run `tools/check-development-environment.sh`.