### PR TITLE
Fix form submission with no name but mail

### DIFF
--- a/projects/packages/forms/changelog/try-fix-form-submission-with-no-name-but-mail
+++ b/projects/packages/forms/changelog/try-fix-form-submission-with-no-name-but-mail
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix form submission view if name field kept empty, email entry shows in name field

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2046,10 +2046,7 @@ class Contact_Form_Plugin {
 			if ( str_contains( $content, 'JSON_DATA' ) ) {
 				$chunks     = explode( "\nJSON_DATA", $content );
 				$all_values = json_decode( $chunks[1], true );
-				if ( is_array( $all_values ) ) {
-					$fields_array = array_keys( $all_values );
-				}
-				$lines = array_filter( explode( "\n", $chunks[0] ) );
+				$lines      = array_filter( explode( "\n", $chunks[0] ) );
 			} else {
 				$fields_array = preg_replace( '/.*Array\s\( (.*)\)/msx', '$1', $content );
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -508,6 +508,14 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 				if ( $meta_key ) {
 					if ( isset( $content_fields[ "_feedback_{$meta_key}" ] ) ) {
+						if ( 'name' === $type ) {
+							// If a form contains both email and name fields but the user doesn't provide a name, we don't need to show the name field
+							// in the success message after submision. We have this specific check because in the above case the `author` field gets
+							// a fallback value of the provided email and is used in the backend in various places.
+							if ( isset( $content_fields['_feedback_author_email'] ) && $content_fields['_feedback_author'] === $content_fields['_feedback_author_email'] ) {
+								continue;
+							}
+						}
 						$value = $content_fields[ "_feedback_{$meta_key}" ];
 					}
 				} else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/30456

## Proposed changes:
Currently if we have a form with a `name` field and an `email` field where the `name` is not required, when we submit the form with an empty name, the success messages shows the `name` with the `email` value.

This happens because during submission there [is code](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/forms/src/contact-form/class-contact-form.php#L1228) that sets the email as a fallback. That `$comment_author` is later on used in more places (like headers, entity title, etc..) so I didn't make any update there.

Instead in the time of rendering the success message I added a check whether name and email have the same values. In that case, we don't render the `name`.

Ideally we should check if the original `name` value was provided or not, but I couldn't find a way to get that value and I think it's not stored anywhere else, without having the fallback applied during submission.

My check though introduces a new edge case where in a form like the one described here, if a user submits an `email` to both `name and email` fields, we will not render the `name` in the success message.

I'd consider edge cases both the linked issue and my approach and I'm not sure if it's even worth it to handle this.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
1. In a post add a contact form
2. make the `name` field **not** required
3. submit the form in the front end without providing a `name`
4. Observe that the `name` is not part of the success message
5. Test the form with different combinations of input (ex. provide both `email and name`, only `email`, etc..).
 