### PR TITLE
Update/always show upgrade button if one is available my jetpack

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/action-button.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-button.tsx
@@ -44,7 +44,6 @@ const ActionButton: FC< ActionButtonProps > = ( {
 	onAdd,
 	onInstall,
 	onLearnMore,
-	upgradeInInterstitial,
 	isOwned,
 } ) => {
 	const troubleshootBackupsUrl =
@@ -126,15 +125,11 @@ const ActionButton: FC< ActionButtonProps > = ( {
 				};
 			}
 			case PRODUCT_STATUSES.CAN_UPGRADE: {
-				const upgradeText = __( 'Upgrade', 'jetpack-my-jetpack' );
-				const purchaseText = __( 'Learn more', 'jetpack-my-jetpack' );
-				const buttonText = purchaseUrl || upgradeInInterstitial ? upgradeText : purchaseText;
-
 				return {
 					...buttonState,
 					href: purchaseUrl || `#/add-${ slug }`,
 					variant: 'primary',
-					label: buttonText,
+					label: __( 'Upgrade', 'jetpack-my-jetpack' ),
 					onClick: onAdd,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.CAN_UPGRADE ] ?? {} ),
 				};
@@ -256,7 +251,6 @@ const ActionButton: FC< ActionButtonProps > = ( {
 		onInstall,
 		onLearnMore,
 		purchaseUrl,
-		upgradeInInterstitial,
 		isManageDisabled,
 		manageUrl,
 		onManage,

--- a/projects/packages/my-jetpack/changelog/update-always-show-upgrade-button-if-one-is-available-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/update-always-show-upgrade-button-if-one-is-available-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Show an upgrade CTA anytime a product has an available upgrade

--- a/projects/packages/my-jetpack/src/products/class-anti-spam.php
+++ b/projects/packages/my-jetpack/src/products/class-anti-spam.php
@@ -128,20 +128,15 @@ class Anti_Spam extends Product {
 	}
 
 	/**
-	 * Determine if the site has an Akismet plan.
+	 * Check if the product has a free plan
+	 * In this case we are only checking for an API key. The has_paid_plan_for_product will check to see if the specific site has a paid plan
 	 *
-	 * @return bool - whether an API key was found
+	 * @return bool
 	 */
-	public static function has_paid_plan_for_product() {
-		if ( parent::has_paid_plan_for_product() ) {
-			return true;
-		}
-		// As a fallback, we're checking if the site has an API key for Akismet.
-		// Note that some Akismet Plans are free - we're just checking for an API key and don't have the perspective of the plan attached to it here
+	public static function has_free_plan_for_product() {
 		$akismet_api_key = apply_filters( 'akismet_get_api_key', defined( 'WPCOM_API_KEY' ) ? constant( 'WPCOM_API_KEY' ) : get_option( 'wordpress_api_key' ) );
 		if ( ! empty( $akismet_api_key ) ) {
 			return true;
-
 		}
 
 		return false;

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -643,7 +643,7 @@ abstract class Product {
 	 * @return boolean
 	 */
 	public static function is_upgradable() {
-		return false;
+		return ! static::has_paid_plan_for_product() && ! static::is_bundle_product();
 	}
 
 	/**

--- a/projects/packages/my-jetpack/tests/php/test-products-rest.php
+++ b/projects/packages/my-jetpack/tests/php/test-products-rest.php
@@ -201,7 +201,7 @@ class Test_Products_Rest extends TestCase {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 'active', $data['status'] );
+		$this->assertEquals( 'can_upgrade', $data['status'] );
 		$this->assertTrue( is_plugin_active( $this->boost_mock_filename ) );
 	}
 


### PR DESCRIPTION
## Proposed changes:

* Update Product class `is_upgradable` to check if the product is not a bundle and that the site does not already have a paid plan for it

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: pbNhbs-bjn-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

Note: Ignore the "troubleshoot" CTA on the backup card in the screenshots, that is from previous testing and I haven't re-run a backup yet to get rid of it

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Connect your site and user
3. Without any plans purchased, go to My Jetpack. Confirm that all active products also have an "upgrade" button, except for those that require a plan. Those will say "Get Plan"
(The following screenshot is on my local environment where all standalone plugins are installed and active)
![image](https://github.com/user-attachments/assets/fc26aafa-078b-4b13-adbd-ca7d1f47c321)
4. Try purchasing several products/bundles and ensure that the upgrade CTA goes away for the product (or products in a bundle). The following steps will be testing Complete, but you can try whatever bundle or product plan you'd like to ensure it always works well
5. Assign a Jetpack Complete license to your site via the store admin
![image](https://github.com/user-attachments/assets/7a3b884d-5ece-44e5-affd-f9044710f6b6)
