### PR TITLE
Fix/issue description not showing up on backup card

### DIFF
--- a/projects/packages/my-jetpack/_inc/data/constants.ts
+++ b/projects/packages/my-jetpack/_inc/data/constants.ts
@@ -4,7 +4,6 @@ const ODYSSEY_STATS_API_NAMESPACE = 'jetpack/v4/stats-app';
 
 export const REST_API_SITE_PURCHASES_ENDPOINT = `${ REST_API_NAMESPACE }/site/purchases`;
 export const REST_API_REWINDABLE_BACKUP_EVENTS_ENDPOINT = `${ REST_API_NAMESPACE }/site/backup/undo-event`;
-export const REST_API_COUNT_BACKUP_ITEMS_ENDPOINT = `${ REST_API_NAMESPACE }/site/backup/count-items`;
 export const REST_API_CHAT_AVAILABILITY_ENDPOINT = `${ REST_API_NAMESPACE }/chat/availability`;
 export const REST_API_CHAT_AUTHENTICATION_ENDPOINT = `${ REST_API_NAMESPACE }/chat/authentication`;
 export const REST_API_SITE_PRODUCTS_ENDPOINT = `${ REST_API_NAMESPACE }/site/products`;
@@ -27,7 +26,6 @@ export const QUERY_LICENSES_KEY = 'available licenses';
 export const QUERY_CHAT_AVAILABILITY_KEY = 'chat availability';
 export const QUERY_CHAT_AUTHENTICATION_KEY = 'chat authentication';
 export const QUERY_BACKUP_HISTORY_KEY = 'backup history';
-export const QUERY_BACKUP_STATS_KEY = 'backup stats';
 export const QUERY_STATS_COUNTS_KEY = 'stats counts';
 export const QUERY_DISMISS_WELCOME_BANNER_KEY = 'dismiss welcome banner';
 export const QUERY_PURCHASES_KEY = 'purchases';

--- a/projects/packages/my-jetpack/changelog/fix-issue-description-not-showing-up-on-backup-card
+++ b/projects/packages/my-jetpack/changelog/fix-issue-description-not-showing-up-on-backup-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix bug where description doesn't show up on backup card in specific scenarios

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -47,7 +47,8 @@ type JetpackModule =
 	| 'complete'
 	| 'site-accelerator'
 	| 'newsletter'
-	| 'related-posts';
+	| 'related-posts'
+	| 'brute-force';
 
 type ThreatItem = {
 	// Protect API properties (free plan)

--- a/projects/packages/my-jetpack/src/class-rest-product-data.php
+++ b/projects/packages/my-jetpack/src/class-rest-product-data.php
@@ -28,16 +28,6 @@ class REST_Product_Data {
 				'permission_callback' => __CLASS__ . '::permissions_callback',
 			)
 		);
-
-		register_rest_route(
-			'my-jetpack/v1',
-			'/site/backup/count-items',
-			array(
-				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => __CLASS__ . '::count_things_that_can_be_backed_up',
-				'permission_callback' => __CLASS__ . '::permissions_callback',
-			)
-		);
 	}
 
 	/**
@@ -108,40 +98,5 @@ class REST_Product_Data {
 		}
 
 		return rest_ensure_response( $undo_event );
-	}
-
-	/**
-	 * This will collect a count of all the items that could be backed up
-	 * This is used to show what backup could be doing if it is not enabled
-	 *
-	 * @return WP_Error|\WP_REST_Response
-	 */
-	public static function count_things_that_can_be_backed_up() {
-		$image_mime_type = 'image';
-		$video_mime_type = 'video';
-		$audio_mime_type = 'audio';
-
-		$data = array();
-
-		// Add all post types together to get the total post count
-		$data['total_post_count'] = array_sum( (array) wp_count_posts( 'post' ) );
-
-		// Add all page types together to get the total page count
-		$data['total_page_count'] = array_sum( (array) wp_count_posts( 'page' ) );
-
-		// Add all comments together to get the total comment count
-		$comments                    = (array) wp_count_comments();
-		$data['total_comment_count'] = $comments ? $comments['total_comments'] : 0;
-
-		// Add all image attachments together to get the total image count
-		$data['total_image_count'] = array_sum( (array) wp_count_attachments( $image_mime_type ) );
-
-		// Add all video attachments together to get the total video count
-		$data['total_video_count'] = array_sum( (array) wp_count_attachments( $video_mime_type ) );
-
-		// Add all audio attachments together to get the total audio count
-		$data['total_audio_count'] = array_sum( (array) wp_count_attachments( $audio_mime_type ) );
-
-		return rest_ensure_response( $data );
 	}
 }


### PR DESCRIPTION
## Proposed changes:

* Fix issue where backup description doesn't show up when card is not active and there is no error
* Remove deprecated code having to do with the backup inactive state

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Issue: https://github.com/Automattic/jetpack/issues/35801

## Does this pull request change what data or activity we track or use?

N/A

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Connect your site and user account
3. Go to My Jetpack and ensure the backup card has a description
![image](https://github.com/user-attachments/assets/c670b077-ea56-4345-b560-1999690e60dc)
4. Install the Jetpack Backup standalone plugin
5. Make sure the description shows up on the card
![image](https://github.com/user-attachments/assets/b88bb03b-7504-4aef-877d-9edbb0cd5b9f)
