### PR TITLE
Stop showing limited global styles notice in editor distraction free mode

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-global-styles-notice-distraction-free
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-global-styles-notice-distraction-free
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Global Styles: Stop showing the limited global styles notice in distraction free mode.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/notices.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/notices.js
@@ -245,11 +245,11 @@ function GlobalStylesEditNotice() {
 	);
 
 	useEffect( () => {
-		if ( ( ! isSiteEditor && ! isPostEditor ) || isDistractionFree ) {
+		if ( ! isSiteEditor && ! isPostEditor ) {
 			return;
 		}
 
-		if ( globalStylesInUse ) {
+		if ( globalStylesInUse && ! isDistractionFree ) {
 			showNotice();
 		} else {
 			removeNotice( NOTICE_ID );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/notices.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/notices.js
@@ -1,5 +1,6 @@
 /* global wpcomGlobalStyles */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { ExternalLink, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -238,8 +239,13 @@ function GlobalStylesEditNotice() {
 		upgradePlan,
 	] );
 
+	const isDistractionFree = useSelect(
+		select => select( blockEditorStore ).getSettings().isDistractionFree,
+		[]
+	);
+
 	useEffect( () => {
-		if ( ! isSiteEditor && ! isPostEditor ) {
+		if ( ( ! isSiteEditor && ! isPostEditor ) || isDistractionFree ) {
 			return;
 		}
 
@@ -250,7 +256,14 @@ function GlobalStylesEditNotice() {
 		}
 
 		return () => removeNotice( NOTICE_ID );
-	}, [ globalStylesInUse, isSiteEditor, isPostEditor, removeNotice, showNotice ] );
+	}, [
+		globalStylesInUse,
+		isDistractionFree,
+		isSiteEditor,
+		isPostEditor,
+		removeNotice,
+		showNotice,
+	] );
 
 	return null;
 }

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-global-styles-notice-distraction-free
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-global-styles-notice-distraction-free
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Global Styles: Stop showing the limited global styles notice in distraction free mode.

--- a/projects/plugins/wpcomsh/changelog/fix-global-styles-notice-distraction-free
+++ b/projects/plugins/wpcomsh/changelog/fix-global-styles-notice-distraction-free
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Global Styles: Stop showing the limited global styles notice in distraction free mode.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #40906

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the non-dismissable limited global styles notice from the top of the post editor when distraction free mode is enabled. This clears the editor window as expected, and also uncovers the UI for exiting distraction free mode.

| Before | After |
|--------|--------|
| ![Screenshot 2025-01-09 at 2 42 52 PM](https://github.com/user-attachments/assets/ca9998ba-772d-42b3-ac20-b87aa3ccc2b2) | ![Screenshot 2025-01-09 at 2 41 21 PM](https://github.com/user-attachments/assets/cfe4009a-d754-4986-9a81-f12976e63028) | 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open the site editor on a Free WP.com site
* Make some style changes and save them
* Open the post editor
* Observe the limited Global Styles notice
* In the Options menu, enable the distraction free mode
* Observe the limited Global Styles notice disappears
* In the Options menu, disable the distraction free mode
* Observe the limited Global Styles notice reappears

