### PR TITLE
WPCOMSH: Use WP_CLI to activate wordads module post-transfer

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wordads-wpcomsh-post-transfer
+++ b/projects/plugins/wpcomsh/changelog/update-wordads-wpcomsh-post-transfer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+woa: Enable wordads module via WP_CLI post transfer

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -250,18 +250,22 @@ function wpcomsh_woa_post_process_maybe_enable_wordads( $args, $assoc_args ) {
 		return;
 	}
 
+	// Set WordAds options.
 	foreach ( $options_decoded as $option => $value ) {
 		// Convert boolean options to string first to work around update_option not setting the option if the value is false.
 		// This sets the option to either '1' if true or '' if false.
 		update_option( $option, is_bool( $value ) ? (string) $value : $value );
 	}
 
-	if ( ! defined( 'JETPACK__VERSION' ) || ! class_exists( 'Jetpack' ) ) {
-		return;
-	}
+	// Activate the WordAds module.
+	WP_CLI::runcommand(
+		'jetpack module activate wordads',
+		array(
+			'launch'     => false,
+			'exit_error' => false,
+		)
+	);
 
-	if ( ! Jetpack::is_module_active( 'wordads' ) ) {
-		Jetpack::activate_module( 'wordads', false, false );
-	}
+	WP_CLI::success( 'WordAds options transferred and module activated' );
 }
 add_action( 'wpcomsh_woa_post_transfer', 'wpcomsh_woa_post_process_maybe_enable_wordads', 10, 2 );


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use WP_CLI to activate the wordads module if necessary during post-transfer

## Testing instructions:
* Initiate a transfer for a site enrolled in WordAds
* After transfer, verify that the WordAds Jetpack module is activated

## Does this pull request change what data or activity we track or use?

* No

