### PR TITLE
Forms: Fix success message color inside a dark Cover block

### DIFF
--- a/projects/packages/forms/changelog/fix-form-go-back-color-success-message
+++ b/projects/packages/forms/changelog/fix-form-go-back-color-success-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix success message color inside a dark Cover block

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -183,7 +183,7 @@
 
 .contact-form-submission .go-back-message .link {
 	font-weight: 200;
-	color: #000;
+	color: inherit;
 }
 
 .contact-form-submission .field-name {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes: https://github.com/Automattic/jetpack/issues/29121

Currently if you have a form block inside a Cover block with a dark background and submit the form, the `Go back` link stays black, making hard to read and impossible to read if the color is black.

This PR updates the styles of that link to `inherit` the color. Other fields I tried seemed render properly.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
1. Insert a Cover block and add a dark background (ex. black)
2. Insert inside the Cover block a Contact form
3. In front-end submit the form 
4. Observe that the `Go back` link is properly colored.

