### PR TITLE
Use WPAdmin view for Posts Listing

### DIFF
--- a/projects/packages/masterbar/changelog/try-use-wp-admin-for-posts-listing
+++ b/projects/packages/masterbar/changelog/try-use-wp-admin-for-posts-listing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use WPAdmin view for Posts listing 

--- a/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
@@ -22,6 +22,7 @@ class Admin_Menu extends Base_Admin_Menu {
 	 * Create the desired menu output.
 	 */
 	public function reregister_menu_items() {
+
 		// Remove separators.
 		remove_menu_page( 'separator1' );
 		$this->add_stats_menu();
@@ -181,7 +182,6 @@ class Admin_Menu extends Base_Admin_Menu {
 		$submenus_to_update = array();
 
 		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'edit.php' ) ) {
-			$submenus_to_update['edit.php']     = 'https://wordpress.com/posts/' . $this->domain;
 			$submenus_to_update['post-new.php'] = 'https://wordpress.com/post/' . $this->domain;
 			$this->update_submenus( 'edit.php', $submenus_to_update );
 		}

--- a/projects/plugins/jetpack/changelog/try-use-wp-admin-for-posts-listing
+++ b/projects/plugins/jetpack/changelog/try-use-wp-admin-for-posts-listing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Use WPAdmin view for Posts listing

--- a/projects/plugins/mu-wpcom-plugin/changelog/try-use-wp-admin-for-posts-listing
+++ b/projects/plugins/mu-wpcom-plugin/changelog/try-use-wp-admin-for-posts-listing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use WPAdmin view for Posts listing

--- a/projects/plugins/wpcomsh/changelog/try-use-wp-admin-for-posts-listing
+++ b/projects/plugins/wpcomsh/changelog/try-use-wp-admin-for-posts-listing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use WPAdmin view for Posts listing


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/95621

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replaces Calypso Post listing view with the WP Admin equivalent

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Click `Posts`.
* You should see the WPAdmin view for Posts as opposed to the Calypso version.


## Screenshots

<img width="2444" alt="Screen Shot 2025-01-09 at 10 31 23" src="https://github.com/user-attachments/assets/bc3e38f8-d647-4cdf-bfed-081c28ce9136" />

