### PR TITLE
Allow the site owner to run extra code before the cache loads

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
@@ -81,6 +81,13 @@ class Boost_Cache {
 		add_action( 'wp_trash_post', array( $this, 'delete_on_post_trash' ), 10, 2 );
 		add_filter( 'wp_php_error_message', array( $this, 'disable_caching_on_error' ) );
 		add_filter( 'init', array( $this, 'init_do_cache' ) );
+		$this->load_extra();
+	}
+
+	private function load_extra() {
+		if ( file_exists( WP_CONTENT_DIR . '/boost-cache-extra.php' ) ) {
+				include_once WP_CONTENT_DIR . '/boost-cache-extra.php';
+		}
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
@@ -86,7 +86,7 @@ class Boost_Cache {
 
 	private function load_extra() {
 		if ( file_exists( WP_CONTENT_DIR . '/boost-cache-extra.php' ) ) {
-				include_once WP_CONTENT_DIR . '/boost-cache-extra.php';
+			include_once WP_CONTENT_DIR . '/boost-cache-extra.php';
 		}
 	}
 

--- a/projects/plugins/boost/changelog/add-boost-extra-code-loader
+++ b/projects/plugins/boost/changelog/add-boost-extra-code-loader
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Cache: added extra PHP file the site owner can use to modify how the cache works.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We want technical site owners to be able to interact with the cache in Boost before it's served. This means loading and executing code before the plugin runs. This allows the site owner to modify the conditions of the site, such as cookies or even the URL before the cache is checked.
This code runs before WordPress loads.


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* In Boost_Cache, load the file wp-content/boost-cache-extra.php if it exists.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply PR
* Create a file called wp-content/boost-cache-extra.php and add this code:
```
<?php
error_log( 'Extra! Extra!' );
```
* Load the page and check your PHP error log and you should see the 'Extra! Extra' message.

