### PR TITLE
Forms: Update default URL field label to match front-end

### DIFF
--- a/projects/packages/forms/changelog/forms-update-default-url-field-label-value
+++ b/projects/packages/forms/changelog/forms-update-default-url-field-label-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Update default URL field label to match front-end

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -410,7 +410,12 @@ export const childBlocks = [
 		settings: {
 			...FieldDefaults,
 			title: __( 'URL Field', 'jetpack-forms' ),
-			keywords: [ 'url', __( 'internet page', 'jetpack-forms' ), 'link' ],
+			keywords: [
+				'url',
+				__( 'internet page', 'jetpack-forms' ),
+				'link',
+				__( 'website', 'jetpack-forms' ),
+			],
 			description: __( 'Collect a website address from your site visitors.', 'jetpack-forms' ),
 			icon: renderMaterialIcon(
 				<>

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -411,9 +411,9 @@ export const childBlocks = [
 			...FieldDefaults,
 			title: __( 'URL Field', 'jetpack-forms' ),
 			keywords: [
-				'url',
+				__( 'url', 'jetpack-forms' ),
 				__( 'internet page', 'jetpack-forms' ),
-				'link',
+				__( 'link', 'jetpack-forms' ),
 				__( 'website', 'jetpack-forms' ),
 			],
 			description: __( 'Collect a website address from your site visitors.', 'jetpack-forms' ),
@@ -435,7 +435,7 @@ export const childBlocks = [
 				...FieldDefaults.attributes,
 				label: {
 					type: 'string',
-					default: 'Website',
+					default: __( 'Website', 'jetpack-forms' ),
 				},
 			},
 		},

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -430,7 +430,7 @@ export const childBlocks = [
 				...FieldDefaults.attributes,
 				label: {
 					type: 'string',
-					default: 'URL',
+					default: 'Website',
 				},
 			},
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/28224

## Proposed changes:
When adding a URL field in a Form block, in the editor the default label is `URL` whereas the default one in front-end is `Website`. These should be the same and we should update the editor one, since it would be a breaking change to update the front-end one.

I also added `website` in the block's keywords. I think it makes sense..

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Insert a URL field block.
2. Observe that the default is `Website` both in the editor and the front-end.

