### PR TITLE
Forms: Properly support formatting options for labels and required text

### DIFF
--- a/projects/packages/forms/changelog/forms-remove-formatting-options-from-labels
+++ b/projects/packages/forms/changelog/forms-remove-formatting-options-from-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: remove formatting options from labels

--- a/projects/packages/forms/changelog/forms-remove-formatting-options-from-labels
+++ b/projects/packages/forms/changelog/forms-remove-formatting-options-from-labels
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: remove formatting options from labels
+Forms: Properly support formatting options for labels and required text

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-label.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-label.js
@@ -33,8 +33,7 @@ const FieldLabel = ( {
 					setAttributes( { label: value } );
 				} }
 				placeholder={ placeholder ?? __( 'Add label…', 'jetpack-forms' ) }
-				withoutInteractiveFormatting
-				allowedFormats={ [ 'core/bold', 'core/italic' ] }
+				__unstableDisableFormats
 			/>
 			{ suffix && <span className="jetpack-field-label__suffix">{ suffix }</span> }
 			{ required && (
@@ -45,8 +44,7 @@ const FieldLabel = ( {
 					onChange={ value => {
 						setAttributes( { requiredText: value } );
 					} }
-					withoutInteractiveFormatting
-					allowedFormats={ [ 'core/bold', 'core/italic' ] }
+					__unstableDisableFormats
 				/>
 			) }
 		</div>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-label.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-label.js
@@ -33,7 +33,8 @@ const FieldLabel = ( {
 					setAttributes( { label: value } );
 				} }
 				placeholder={ placeholder ?? __( 'Add label…', 'jetpack-forms' ) }
-				__unstableDisableFormats
+				withoutInteractiveFormatting
+				allowedFormats={ [ 'core/italic' ] }
 			/>
 			{ suffix && <span className="jetpack-field-label__suffix">{ suffix }</span> }
 			{ required && (
@@ -44,7 +45,8 @@ const FieldLabel = ( {
 					onChange={ value => {
 						setAttributes( { requiredText: value } );
 					} }
-					__unstableDisableFormats
+					withoutInteractiveFormatting
+					allowedFormats={ [ 'core/bold', 'core/italic' ] }
 				/>
 			) }
 		</div>

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -455,7 +455,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				class='grunion-field-label{$type_class}" . ( $this->is_error() ? ' form-error' : '' ) . "'"
 				. $extra_attrs_string
 				. '>'
-				. esc_html( $label )
+				. wp_kses_post( $label )
 				. ( $required ? '<span class="grunion-label-required" aria-hidden="true">' . $required_field_text . '</span>' : '' )
 				. "</label>\n";
 	}
@@ -1012,7 +1012,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		 *
 		 * @param string $var Required field text. Default is "(required)".
 		 */
-		$required_field_text = esc_html( apply_filters( 'jetpack_required_field_text', $required_field_text ) );
+		$required_field_text = wp_kses_post( apply_filters( 'jetpack_required_field_text', $required_field_text ) );
 
 		$block_style = 'style="' . $this->block_styles . '"';
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -117,13 +117,13 @@ class Contact_Form_Plugin {
 		if ( is_array( $data_with_tags ) ) {
 			foreach ( $data_with_tags as $index => $value ) {
 				$index = sanitize_text_field( (string) $index );
-				$value = wp_kses_post( (string) $value, array() );
+				$value = wp_kses_post( (string) $value );
 				$value = str_replace( '&amp;', '&', $value ); // undo damage done by wp_kses_normalize_entities()
 
 				$data_without_tags[ $index ] = $value;
 			}
 		} else {
-			$data_without_tags = wp_kses_post( (string) $data_with_tags, array() );
+			$data_without_tags = wp_kses_post( (string) $data_with_tags );
 			$data_without_tags = str_replace( '&amp;', '&', $data_without_tags ); // undo damage done by wp_kses_normalize_entities()
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -117,13 +117,13 @@ class Contact_Form_Plugin {
 		if ( is_array( $data_with_tags ) ) {
 			foreach ( $data_with_tags as $index => $value ) {
 				$index = sanitize_text_field( (string) $index );
-				$value = wp_kses( (string) $value, array() );
+				$value = wp_kses_post( (string) $value, array() );
 				$value = str_replace( '&amp;', '&', $value ); // undo damage done by wp_kses_normalize_entities()
 
 				$data_without_tags[ $index ] = $value;
 			}
 		} else {
-			$data_without_tags = wp_kses( (string) $data_with_tags, array() );
+			$data_without_tags = wp_kses_post( (string) $data_with_tags, array() );
 			$data_without_tags = str_replace( '&amp;', '&', $data_without_tags ); // undo damage done by wp_kses_normalize_entities()
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/29125

## Proposed changes:

By investigating a bit it seems that label styles (including `font-weight:bold`) have been there for at least a couple of years. This means that the `bold and italic` options provided in the editor to format the labels doesn't work for a while - if it worked at all in the past.

The approach I'm suggesting here (after the provided feedback) is to remove the formatting `bold` option in the editor for labels, as it seems it's being handled by css and maybe it makes more sense to be a bit more opinionated like this here.

This PR also fixes the formatting for `italic` in labels and both `bold and italic` for required text by updating `strip_tags` to use `wp_kses_post`. I search for a while a better place to use `wp_kses_post` specifically for labels and required text, because `strip_tags` is used in other places too. I couldn't find a good fit though since this function and it's caller ([unesc_attr](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/forms/src/contact-form/class-contact-form-shortcode.php#L161))  is called in various places.

I wouldn't expect any issues to be honest, but more experienced Jetpack devs could help here with feedback.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
1. Add some form fields and update some of them with `bold and italic`
2. observe that the labels and the `required text` renders in the front end the changes there.

