### PR TITLE
Add a watch script  for jetpack-mu-wpcom package

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-jetpack-mu-wpcom-watch
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-jetpack-mu-wpcom-watch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a watch command for this package in composer.json

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -45,7 +45,11 @@
 		"build-production": "pnpm run build-production-js",
 		"build-development": "pnpm run build-js",
 		"post-install-cmd": "WorDBless\\Composer\\InstallDropin::copy",
-		"post-update-cmd": "WorDBless\\Composer\\InstallDropin::copy"
+		"post-update-cmd": "WorDBless\\Composer\\InstallDropin::copy",
+		"watch": [
+			"Composer\\Config::disableProcessTimeout",
+			"pnpm run watch"
+		]
 	},
 	"repositories": [
 		{

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-jetpack-mu-wpcom-watch
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-jetpack-mu-wpcom-watch
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: update composer.lock file
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1060,7 +1060,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "63f823f3817e4c126abd96fc971ad6c39c8f1f01"
+                "reference": "ed55315319c331275f4f0c715294d5a9350ed7ea"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1127,6 +1127,10 @@
                 ],
                 "post-update-cmd": [
                     "WorDBless\\Composer\\InstallDropin::copy"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [
@@ -4391,16 +4395,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "e9c8413de4c8ae03d2923a44f17d0d7dad1b96be"
+                "reference": "0b31ce834facf03b8b44b6587e65b3cf1d7cfb94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/e9c8413de4c8ae03d2923a44f17d0d7dad1b96be",
-                "reference": "e9c8413de4c8ae03d2923a44f17d0d7dad1b96be",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/0b31ce834facf03b8b44b6587e65b3cf1d7cfb94",
+                "reference": "0b31ce834facf03b8b44b6587e65b3cf1d7cfb94",
                 "shasum": ""
             },
             "require": {
@@ -4450,7 +4454,7 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2024-09-06T22:03:10+00:00"
+            "time": "2025-01-08T16:58:34+00:00"
         }
     ],
     "aliases": [],

--- a/projects/plugins/wpcomsh/changelog/add-jetpack-mu-wpcom-watch
+++ b/projects/plugins/wpcomsh/changelog/add-jetpack-mu-wpcom-watch
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1197,7 +1197,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "63f823f3817e4c126abd96fc971ad6c39c8f1f01"
+                "reference": "ed55315319c331275f4f0c715294d5a9350ed7ea"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1264,6 +1264,10 @@
                 ],
                 "post-update-cmd": [
                     "WorDBless\\Composer\\InstallDropin::copy"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [


### PR DESCRIPTION
## Proposed changes:

Add a `watch` script in the `composer.json` file to be able to watch build this package.

Without this change you get this message when trying to watch changes in this package:

```
✔ Please choose which project · jetpack-mu-wpcom
This project does not have a watch step defined in composer.json.
```


### Other information:
No functional changes added in this PR only improving the dev workflow a bit.
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No product related changes.


## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Run the command `jetpack watch`
2. Select `packages`
3. Select `jetpack-mu-wpcom`


### Before:
https://github.com/user-attachments/assets/be32d7ff-8791-4b51-9942-31b0b1e6ca85


### After:
https://github.com/user-attachments/assets/82666b66-618c-4372-8b42-1f5b7e888a05







