### PR TITLE
Full sync: Send context for initial full sync action

### DIFF
--- a/projects/packages/sync/changelog/update-handle-context-in-full-sync
+++ b/projects/packages/sync/changelog/update-handle-context-in-full-sync
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Full Sync: Added context

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -608,7 +608,7 @@ class Actions {
 			'network_options' => true,
 		);
 
-		self::do_full_sync( $initial_sync_config );
+		self::do_full_sync( $initial_sync_config, 'initial_sync' );
 	}
 
 	/**
@@ -633,9 +633,10 @@ class Actions {
 	 * @static
 	 *
 	 * @param array $modules  The sync modules should be included in this full sync. All will be included if null.
+	 * @param mixed $context  The context where the full sync was initiated from.
 	 * @return bool           True if full sync was successfully started.
 	 */
-	public static function do_full_sync( $modules = null ) {
+	public static function do_full_sync( $modules = null, $context = null ) {
 		if ( ! self::sync_allowed() ) {
 			return false;
 		}
@@ -649,7 +650,7 @@ class Actions {
 
 		self::initialize_listener();
 
-		$full_sync_module->start( $modules );
+		$full_sync_module->start( $modules, $context );
 
 		return true;
 	}

--- a/projects/packages/sync/src/class-rest-endpoints.php
+++ b/projects/packages/sync/src/class-rest-endpoints.php
@@ -60,7 +60,7 @@ class REST_Endpoints {
 					),
 					'context'  => array(
 						'description' => __( 'Context for the Full Sync', 'jetpack-sync' ),
-						'type'        => 'array',
+						'type'        => 'string',
 						'required'    => false,
 					),
 				),

--- a/projects/packages/sync/src/class-rest-endpoints.php
+++ b/projects/packages/sync/src/class-rest-endpoints.php
@@ -58,6 +58,11 @@ class REST_Endpoints {
 						'type'        => 'array',
 						'required'    => false,
 					),
+					'context'  => array(
+						'description' => __( 'Context for the Full Sync', 'jetpack-sync' ),
+						'type'        => 'array',
+						'required'    => false,
+					),
 				),
 			)
 		);
@@ -363,9 +368,11 @@ class REST_Endpoints {
 			$modules = null;
 		}
 
+		$context = $request->get_param( 'context' );
+
 		return rest_ensure_response(
 			array(
-				'scheduled' => Actions::do_full_sync( $modules ),
+				'scheduled' => Actions::do_full_sync( $modules, $context ),
 			)
 		);
 	}

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -60,10 +60,11 @@ class Full_Sync_Immediately extends Module {
 	 * @access public
 	 *
 	 * @param array $full_sync_config Full sync configuration.
+	 * @param mixed $context The context where the full sync was initiated from.
 	 *
 	 * @return bool Always returns true at success.
 	 */
-	public function start( $full_sync_config = null ) {
+	public function start( $full_sync_config = null, $context = null ) {
 		// There was a full sync in progress.
 		if ( $this->is_started() && ! $this->is_finished() ) {
 			/**
@@ -119,10 +120,10 @@ class Full_Sync_Immediately extends Module {
 		 * @since 1.6.3
 		 * @since-jetpack 4.2.0
 		 * @since-jetpack 7.3.0 Added $range arg.
-		 * @since-jetpack 7.4.0 Added $empty arg.
+		 * @since-jetpack $$next-version$$ Added $context arg.
 		 */
 		do_action( 'jetpack_full_sync_start', $full_sync_config, $range );
-		$this->send_action( 'jetpack_full_sync_start', array( $full_sync_config, $range ) );
+		$this->send_action( 'jetpack_full_sync_start', array( $full_sync_config, $range, $context ) );
 
 		return true;
 	}

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -120,7 +120,7 @@ class Full_Sync_Immediately extends Module {
 		 * @since 1.6.3
 		 * @since-jetpack 4.2.0
 		 * @since-jetpack 7.3.0 Added $range arg.
-		 * @since-jetpack $$next-version$$ Added $context arg.
+		 * @since $$next-version$$ Added $context arg.
 		 */
 		do_action( 'jetpack_full_sync_start', $full_sync_config, $range );
 		$this->send_action( 'jetpack_full_sync_start', array( $full_sync_config, $range, $context ) );

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -115,7 +115,7 @@ class Full_Sync_Immediately extends Module {
 		 *
 		 * @param array $full_sync_config Sync configuration for all sync modules.
 		 * @param array $range Range of the sync items, containing min and max IDs for some item types.
-		 * @param array $empty The modules with no items to sync during a full sync.
+		 * @param mixed $context The context where the full sync was initiated from.
 		 *
 		 * @since 1.6.3
 		 * @since-jetpack 4.2.0

--- a/projects/packages/sync/src/modules/class-full-sync.php
+++ b/projects/packages/sync/src/modules/class-full-sync.php
@@ -80,9 +80,10 @@ class Full_Sync extends Module {
 	 * @access public
 	 *
 	 * @param array $module_configs Full sync configuration for all sync modules.
+	 * @param mixed $context        Context for the full sync.
 	 * @return bool Always returns true at success.
 	 */
-	public function start( $module_configs = null ) {
+	public function start( $module_configs = null, $context = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$was_already_running = $this->is_started() && ! $this->is_finished();
 
 		// Remove all evidence of previous full sync items and status.

--- a/projects/plugins/jetpack/_inc/class.jetpack-provision.php
+++ b/projects/plugins/jetpack/_inc/class.jetpack-provision.php
@@ -46,7 +46,7 @@ class Jetpack_Provision {
 		// If Jetpack is currently connected, and is not in Safe Mode already, kick off a sync of the current
 		// functions/callables so that we can test if this site is in IDC.
 		if ( Jetpack::is_connection_ready() && ! Identity_Crisis::validate_sync_error_idc_option() && Actions::sync_allowed() ) {
-			Actions::do_full_sync( array( 'functions' => true ) );
+			Actions::do_full_sync( array( 'functions' => true ), 'provision' );
 			Actions::$sender->do_full_sync();
 		}
 

--- a/projects/plugins/jetpack/changelog/update-handle-context-in-full-sync
+++ b/projects/plugins/jetpack/changelog/update-handle-context-in-full-sync
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Full Sync: Added context

--- a/projects/plugins/jetpack/class.jetpack-cli.php
+++ b/projects/plugins/jetpack/class.jetpack-cli.php
@@ -1036,7 +1036,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				}
 
 				// Kick off a full sync.
-				if ( Actions::do_full_sync( $modules ) ) {
+				if ( Actions::do_full_sync( $modules, 'jetpack_cli' ) ) {
 					if ( $modules ) {
 						/* translators: %s is a comma separated list of Jetpack modules */
 						WP_CLI::log( sprintf( __( 'Initialized a new full sync with modules: %s', 'jetpack' ), implode( ', ', array_keys( $modules ) ) ) );

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -68,7 +68,7 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 		if ( empty( $modules ) ) {
 			$modules = null;
 		}
-		return array( 'scheduled' => Actions::do_full_sync( $modules ) );
+		return array( 'scheduled' => Actions::do_full_sync( $modules, 'jetpack_json_api_sync_endpoint' ) );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/vulcan/issues/590 will help track the number of full syncs run and differentiate them by the flow that initiates them e.g initial_full_sync, custom_tables_creation, checksum_fix_failure.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Send the context from where a full sync was initiated with the `jetpack_full_sync_start` action.
* Updated usages of full sync action to set the context. Both for the ones initiated directly from the package as well as the ones triggered from wpcom (See 169718-ghe-Automattic/wpcom)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
For a more complete approach, check testing instructions in 169718-ghe-Automattic/wpcom