### PR TITLE
Social: Fix license activation message showing for paid users

### DIFF
--- a/projects/plugins/social/changelog/fix-social-show-pricing-page-default-value
+++ b/projects/plugins/social/changelog/fix-social-show-pricing-page-default-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed an issue where we showed the license message even with a plan

--- a/projects/plugins/social/src/js/components/admin-page/header/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/header/index.jsx
@@ -1,17 +1,11 @@
-import { store as socialStore } from '@automattic/jetpack-publicize-components';
+import { hasSocialPaidFeatures } from '@automattic/jetpack-publicize-components';
 import { getMyJetpackUrl } from '@automattic/jetpack-script-data';
-import { useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import Logo from './../../logo';
 import styles from './styles.module.scss';
 
 const AdminPageHeader = () => {
-	const { showPricingPage } = useSelect( select => {
-		return {
-			showPricingPage: select( socialStore ).getSocialPluginSettings().show_pricing_page,
-		};
-	} );
 	const activateLicenseUrl = getMyJetpackUrl( '#/add-license' );
 
 	return (
@@ -20,7 +14,7 @@ const AdminPageHeader = () => {
 				<Logo />
 			</span>
 
-			{ showPricingPage && (
+			{ ! hasSocialPaidFeatures() && (
 				<p>
 					{ createInterpolateElement(
 						__(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/639

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changed the logic so we show the notice based on the value of `hasPaidFeatures`

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new site
* You should see the license activation notice on top of the Social admin page
* buy the social plan
* The message should dissapear

