### PR TITLE
Fix Verbum comments in Query Loop

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/allow-multiple-verbum-instances-on-one-page
+++ b/projects/packages/jetpack-mu-wpcom/changelog/allow-multiple-verbum-instances-on-one-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+To support adding a comment form inside a query loop

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
@@ -96,7 +96,7 @@ class Verbum_Comments {
 			$color_scheme = 'transparent';
 		}
 
-		$verbum = '<div id="comment-form__verbum" class="' . $color_scheme . '"></div>' . $this->hidden_fields();
+		$verbum = '<div class="comment-form__verbum ' . $color_scheme . '"></div>' . $this->hidden_fields();
 
 		// If the blog requires login, Verbum need to be wrapped in a <form> to work.
 		// Verbum is given `mustLogIn` to handle the login flow.
@@ -180,7 +180,8 @@ class Verbum_Comments {
 		$comment_registration_enabled = boolval( get_blog_option( $this->blog_id, 'comment_registration' ) );
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$post_id = isset( $_GET['postid'] ) ? intval( $_GET['postid'] ) : get_queried_object_id();
-		$locale  = get_locale();
+		l( 'verbum-comments', $post_id );
+		$locale = get_locale();
 
 		$css_mtime        = filemtime( ABSPATH . '/widgets.wp.com/verbum-block-editor/block-editor.css' );
 		$js_mtime         = filemtime( ABSPATH . '/widgets.wp.com/verbum-block-editor/block-editor.min.js' );
@@ -535,12 +536,17 @@ HTML;
 	 * Get the hidden fields for the comment form.
 	 */
 	public function hidden_fields() {
+		// Ironically, get_queried_post_id doesn't work inside query loop.
+		// See: https://github.com/Automattic/wp-calypso/issues/98136
+		$queried_post    = get_post();
+		$queried_post_id = $queried_post ? $queried_post->ID : 0;
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$post_id = isset( $_GET['postid'] ) ? intval( $_GET['postid'] ) : get_queried_object_id();
+		$post_id = isset( $_GET['postid'] ) ? intval( $_GET['postid'] ) : $queried_post_id;
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$is_current_user_subscribed = isset( $_GET['is_current_user_subscribed'] ) ? intval( $_GET['is_current_user_subscribed'] ) : 0;
 		$nonce                      = wp_create_nonce( 'highlander_comment' );
-		$hidden_fields              = get_comment_id_fields( $post_id ) . '
+		l( 'verbum-comments2', $post_id );
+		$hidden_fields = get_comment_id_fields( $post_id ) . '
 			<input type="hidden" name="highlander_comment_nonce" id="highlander_comment_nonce" value="' . esc_attr( $nonce ) . '" />
 			<input type="hidden" name="verbum_show_subscription_modal" value="' . $this->subscription_modal_status() . '" />';
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
@@ -180,8 +180,7 @@ class Verbum_Comments {
 		$comment_registration_enabled = boolval( get_blog_option( $this->blog_id, 'comment_registration' ) );
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$post_id = isset( $_GET['postid'] ) ? intval( $_GET['postid'] ) : get_queried_object_id();
-		l( 'verbum-comments', $post_id );
-		$locale = get_locale();
+		$locale  = get_locale();
 
 		$css_mtime        = filemtime( ABSPATH . '/widgets.wp.com/verbum-block-editor/block-editor.css' );
 		$js_mtime         = filemtime( ABSPATH . '/widgets.wp.com/verbum-block-editor/block-editor.min.js' );
@@ -545,8 +544,7 @@ HTML;
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$is_current_user_subscribed = isset( $_GET['is_current_user_subscribed'] ) ? intval( $_GET['is_current_user_subscribed'] ) : 0;
 		$nonce                      = wp_create_nonce( 'highlander_comment' );
-		l( 'verbum-comments2', $post_id );
-		$hidden_fields = get_comment_id_fields( $post_id ) . '
+		$hidden_fields              = get_comment_id_fields( $post_id ) . '
 			<input type="hidden" name="highlander_comment_nonce" id="highlander_comment_nonce" value="' . esc_attr( $nonce ) . '" />
 			<input type="hidden" name="verbum_show_subscription_modal" value="' . $this->subscription_modal_status() . '" />';
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/EmailForm/email-form-cookie-consent.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/EmailForm/email-form-cookie-consent.tsx
@@ -1,12 +1,18 @@
+import { useContext, useCallback } from 'preact/hooks';
 import { translate } from '../../i18n';
-import { shouldStoreEmailData } from '../../state';
+import { VerbumSignals } from '../../state';
 import { ToggleControl } from '../ToggleControl';
 
-const handleChange = ( e: boolean ) => {
-	shouldStoreEmailData.value = e;
-};
-
 export const EmailFormCookieConsent = () => {
+	const { shouldStoreEmailData } = useContext( VerbumSignals );
+
+	const handleChange = useCallback(
+		( e: boolean ) => {
+			shouldStoreEmailData.value = e;
+		},
+		[ shouldStoreEmailData ]
+	);
+
 	const label = (
 		<div className="verbum-toggle-control__label">
 			<p className="primary">

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/EmailForm/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/EmailForm/style.scss
@@ -1,4 +1,4 @@
-#comment-form__verbum .verbum-subscriptions .verbum-form
+.comment-form__verbum .verbum-subscriptions .verbum-form
 {
 	.verbum-form__content {
 		// protect the button from style leaks from the site; reset all.

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/SimpleSubscribeModal/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/SimpleSubscribeModal/index.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
-import { useEffect, useState, useRef } from 'preact/hooks';
+import { useEffect, useState, useRef, useContext } from 'preact/hooks';
 import { translate } from '../../i18n';
-import { userInfo, userLoggedIn, commentUrl, subscribeModalStatus } from '../../state';
+import { VerbumSignals } from '../../state';
 import { SimpleSubscribeModalProps } from '../../types';
 import {
 	getSubscriptionModalViewCount,
@@ -13,6 +13,7 @@ import { SimpleSubscribeModalLoggedOut } from './logged-out';
 import './style.scss';
 
 export const SimpleSubscribeModal = ( { closeModalHandler, email }: SimpleSubscribeModalProps ) => {
+	const { userInfo, userLoggedIn, commentUrl, subscribeModalStatus } = useContext( VerbumSignals );
 	const [ subscribeState, setSubscribeState ] = useState<
 		'SUBSCRIBING' | 'LOADING' | 'SUBSCRIBED'
 	>();
@@ -51,6 +52,13 @@ export const SimpleSubscribeModal = ( { closeModalHandler, email }: SimpleSubscr
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
+	// This is used to track how many times the modal was shown to the user.
+	useEffect( () => {
+		const userId = userInfo.value?.uid || 0;
+		const currentViewCount = getSubscriptionModalViewCount( userId );
+		setSubscriptionModalViewCount( currentViewCount + 1, userId );
+	}, [ userInfo ] );
+
 	if ( ! commentUrl.value ) {
 		// When not showing the modal, we check for modal conditions to show it.
 		// This is done to avoid subscriptionApi calls for logged out users.
@@ -68,14 +76,6 @@ export const SimpleSubscribeModal = ( { closeModalHandler, email }: SimpleSubscr
 		closeModalHandler();
 		return null;
 	}
-
-	// This is used to track how many times the modal was shown to the user.
-	// eslint-disable-next-line react-hooks/rules-of-hooks
-	useEffect( () => {
-		const userId = userInfo.value?.uid || 0;
-		const currentViewCount = getSubscriptionModalViewCount( userId );
-		setSubscriptionModalViewCount( currentViewCount + 1, userId );
-	}, [] );
 
 	if ( subscribeState === 'LOADING' ) {
 		return (

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/SimpleSubscribeModal/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/SimpleSubscribeModal/index.tsx
@@ -9,7 +9,7 @@ import {
 	shouldShowSubscriptionModal,
 } from '../../utils';
 import { SimpleSubscribeModalLoggedIn, SimpleSubscribeSetModalShowLoggedIn } from './logged-in';
-import SimpleSubscribeModalLoggedOut from './logged-out';
+import { SimpleSubscribeModalLoggedOut } from './logged-out';
 import './style.scss';
 
 export const SimpleSubscribeModal = ( { closeModalHandler, email }: SimpleSubscribeModalProps ) => {

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/SimpleSubscribeModal/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/SimpleSubscribeModal/index.tsx
@@ -9,7 +9,7 @@ import {
 	shouldShowSubscriptionModal,
 } from '../../utils';
 import { SimpleSubscribeModalLoggedIn, SimpleSubscribeSetModalShowLoggedIn } from './logged-in';
-import { SimpleSubscribeModalLoggedOut } from './logged-out';
+import SimpleSubscribeModalLoggedOut from './logged-out';
 import './style.scss';
 
 export const SimpleSubscribeModal = ( { closeModalHandler, email }: SimpleSubscribeModalProps ) => {

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/SimpleSubscribeModal/logged-in.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/SimpleSubscribeModal/logged-in.tsx
@@ -1,6 +1,7 @@
+import { useContext } from 'preact/hooks';
 import useSubscriptionApi from '../../hooks/useSubscriptionApi';
 import { translate } from '../../i18n';
-import { subscriptionSettings, userInfo, commentUrl, subscribeModalStatus } from '../../state';
+import { VerbumSignals } from '../../state';
 import { SimpleSubscribeModalProps } from '../../types';
 import { shouldShowSubscriptionModal } from '../../utils';
 import SubscriptionModal from './subscription-modal';
@@ -8,6 +9,7 @@ import SubscriptionModal from './subscription-modal';
 // This determines if the modal should be shown to the user.
 // It's called before the modal is rendered.
 export const SimpleSubscribeSetModalShowLoggedIn = () => {
+	const { subscriptionSettings, userInfo, subscribeModalStatus } = useContext( VerbumSignals );
 	const { email } = subscriptionSettings.value ?? {
 		email: {
 			send_posts: false,
@@ -27,6 +29,7 @@ export const SimpleSubscribeModalLoggedIn = ( {
 	closeModalHandler,
 }: SimpleSubscribeModalProps ) => {
 	const { setEmailPostsSubscription } = useSubscriptionApi();
+	const { userInfo, commentUrl } = useContext( VerbumSignals );
 
 	/**
 	 * Handle the subscribe button click.

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/SimpleSubscribeModal/logged-out.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/SimpleSubscribeModal/logged-out.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'preact/hooks';
+import { useContext, useEffect, useState } from 'preact/hooks';
 import { translate } from '../../i18n';
-import { commentUrl } from '../../state';
+import { VerbumSignals } from '../../state';
 import { SimpleSubscribeModalProps } from '../../types';
 import SubscriptionModal from './subscription-modal';
 import type { ChangeEvent } from 'preact/compat';
@@ -16,6 +16,7 @@ export const SimpleSubscribeModalLoggedOut = ( {
 	const [ userEmail, setUserEmail ] = useState( '' );
 	const [ iframeUrl, setIframeUrl ] = useState( '' );
 	const [ subscribeDisabled, setSubscribeDisabled ] = useState( false );
+	const { commentUrl } = useContext( VerbumSignals );
 
 	// Only want this to run once, when email is set for the first time
 	useEffect( () => {

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/comment-footer.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/comment-footer.tsx
@@ -1,12 +1,7 @@
 import clsx from 'clsx';
+import { useContext } from 'preact/hooks';
 import { translate } from '../i18n';
-import {
-	commentParent,
-	isReplyDisabled,
-	isSavingComment,
-	isTrayOpen,
-	userLoggedIn,
-} from '../state';
+import { VerbumSignals } from '../state';
 import { SettingsButton } from './settings-button';
 
 interface CommentFooterProps {
@@ -14,6 +9,8 @@ interface CommentFooterProps {
 }
 
 export const CommentFooter = ( { toggleTray }: CommentFooterProps ) => {
+	const { commentParent, isReplyDisabled, isSavingComment, isTrayOpen, userLoggedIn } =
+		useContext( VerbumSignals );
 	return (
 		<div
 			className={ clsx( 'verbum-footer', {

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/comment-input-field.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/comment-input-field.tsx
@@ -1,8 +1,9 @@
+/* global verbumBlockEditor */
 import clsx from 'clsx';
 import { forwardRef, type TargetedEvent } from 'preact/compat';
-import { useEffect, useState } from 'preact/hooks';
+import { useContext, useEffect, useState } from 'preact/hooks';
 import { translate } from '../i18n';
-import { commentParent, commentValue } from '../state';
+import { VerbumSignals } from '../state';
 import { isFastConnection } from '../utils';
 import { EditorPlaceholder } from './editor-placeholder';
 
@@ -35,6 +36,7 @@ export const CommentInputField = forwardRef(
 		{ handleOnKeyUp }: CommentInputFieldProps,
 		ref: React.MutableRefObject< HTMLTextAreaElement | null >
 	) => {
+		const { commentParent, commentValue } = useContext( VerbumSignals );
 		const [ editorState, setEditorState ] = useState< 'LOADING' | 'LOADED' | 'ERROR' >( null );
 		const [ isGBEditorEnabled, setIsGBEditorEnabled ] = useState( false );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/editor-placeholder.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/editor-placeholder.tsx
@@ -1,9 +1,11 @@
 import clsx from 'clsx';
+import { useContext } from 'preact/hooks';
 import { translate } from '../i18n';
-import { commentParent } from '../state';
+import { VerbumSignals } from '../state';
 import { CustomLoadingSpinner } from './custom-loading-spinner';
 
 export const EditorPlaceholder = ( { onClick, loading } ) => {
+	const { commentParent } = useContext( VerbumSignals );
 	return (
 		<div
 			className="verbum-editor-wrapper"

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/logged-in.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/logged-in.tsx
@@ -1,8 +1,9 @@
 import clsx from 'clsx';
+import { useContext } from 'preact/hooks';
 import useSubscriptionApi from '../hooks/useSubscriptionApi';
 import { translate } from '../i18n';
 import { Close } from '../images';
-import { isTrayOpen, subscriptionSettings, userInfo } from '../state';
+import { VerbumSignals } from '../state';
 import { serviceData, isFastConnection } from '../utils';
 import { NewCommentEmail } from './new-comment-email';
 import { NewPostsEmail } from './new-posts-email';
@@ -25,6 +26,7 @@ interface LoggedInProps {
 }
 
 export const LoggedIn = ( { toggleTray, logout }: LoggedInProps ) => {
+	const { isTrayOpen, subscriptionSettings, userInfo } = useContext( VerbumSignals );
 	const { setEmailPostsSubscription, setCommentSubscription, setNotificationSubscription } =
 		useSubscriptionApi();
 	const { subscribeToComment, subscribeToBlog } = VerbumComments;

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/logged-out.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/logged-out.tsx
@@ -1,7 +1,8 @@
+import { Signal } from '@preact/signals';
 import clsx from 'clsx';
-import { useEffect, useState } from 'preact/hooks';
+import { useContext, useEffect, useState } from 'preact/hooks';
 import { translate } from '../i18n';
-import { commentParent } from '../state';
+import { VerbumSignals } from '../state';
 import { serviceData } from '../utils';
 import { EmailForm } from './EmailForm';
 
@@ -12,7 +13,7 @@ interface LoggedOutProps {
 	loginWindow: Window | null;
 }
 
-const getLoginCommentText = () => {
+const getLoginCommentText = ( commentParent: Signal ) => {
 	let defaultText = translate( 'Log in to leave a comment.' );
 	let optionalText = translate( 'Leave a comment. (log in optional)' );
 	let nameAndEmailRequired = translate(
@@ -80,13 +81,17 @@ export const LoggedOut = ( { login, canWeAccessCookies, loginWindow }: LoggedOut
 		setActiveService( service );
 	};
 
+	const { commentParent } = useContext( VerbumSignals );
+
 	return (
 		<div className="verbum-subscriptions logged-out">
 			<div className="verbum-subscriptions__wrapper">
 				<div className="verbum-subscriptions__login">
 					{ canWeAccessCookies && (
 						<>
-							<div className="verbum-subscriptions__login-header">{ getLoginCommentText() }</div>
+							<div className="verbum-subscriptions__login-header">
+								{ getLoginCommentText( commentParent ) }
+							</div>
 							<div
 								className={ clsx( 'verbum-logins', {
 									'logging-in': activeService,

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/settings-button.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/settings-button.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
-import { userInfo } from '../state';
+import { useContext } from 'preact/hooks';
+import { VerbumSignals } from '../state';
 import { hasSubscriptionOptionsVisible } from '../utils';
 
 interface SettingsButtonProps {
@@ -8,6 +9,7 @@ interface SettingsButtonProps {
 }
 
 export const SettingsButton = ( { expanded, toggleSubscriptionTray }: SettingsButtonProps ) => {
+	const { userInfo } = useContext( VerbumSignals );
 	const subscriptionOptionsVisible = hasSubscriptionOptionsVisible();
 
 	const handleOnClick = ( event: MouseEvent ) => {

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/types.d.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/types.d.ts
@@ -6,6 +6,14 @@ type ScriptLoader = {
 
 declare global {
 	const VerbumComments: VerbumCommentsType;
+	const verbumBlockEditor: {
+		attachGutenberg: (
+			textarea: HTMLTextAreaElement,
+			content: ( embedUrl: string ) => void,
+			isRtl: boolean,
+			onEmbedContent: ( embedUrl: string ) => void
+		) => void;
+	};
 	const vbeCacheBuster: string;
 	const WP_Enqueue_Dynamic_Script: ScriptLoader;
 	const wp: Record< string, unknown >;

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/hooks/useFormMutations.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/hooks/useFormMutations.tsx
@@ -1,12 +1,15 @@
-import { useEffect } from 'preact/hooks';
-import { commentParent } from '../state';
+import { useEffect, useContext } from 'preact/hooks';
+import { VerbumSignals } from '../state';
 
 /**
  * Hook to observe comment form changes and update state according to comment_parent changes.
+ *
+ * @param formElement - The form element to observe.
  */
-export default function useFormMutations() {
+export default function useFormMutations( formElement: HTMLFormElement ) {
+	const { commentParent } = useContext( VerbumSignals );
+
 	useEffect( () => {
-		const formElement = document.querySelector( '#commentform' ) as HTMLFormElement;
 		const commentParentInput = formElement.querySelector( '#comment_parent' );
 
 		if ( ! formElement || ! commentParentInput ) {
@@ -28,5 +31,5 @@ export default function useFormMutations() {
 		return () => {
 			mutationObserver.disconnect();
 		};
-	}, [] );
+	}, [ formElement, commentParent ] );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/hooks/useSocialLogin.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/hooks/useSocialLogin.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'preact/hooks';
+import { useState, useEffect, useContext } from 'preact/hooks';
 import wpcomRequest from 'wpcom-proxy-request';
-import { userInfo } from '../state';
+import { VerbumSignals } from '../state';
 import { UserInfo } from '../types';
 import { serviceData, setUserInfoCookie } from '../utils';
 
@@ -30,6 +30,7 @@ const addWordPressDomain = window.location.hostname.endsWith( '.wordpress.com' )
  */
 export default function useSocialLogin() {
 	const [ loginWindowRef, setLoginWindowRef ] = useState< Window >();
+	const { userInfo } = useContext( VerbumSignals );
 
 	useEffect( () => {
 		wpcomRequest< UserInfo >( {
@@ -42,6 +43,7 @@ export default function useSocialLogin() {
 			.catch( () => {
 				// User may not be logged in.
 			} );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
 	if ( VerbumComments.isJetpackCommentsLoggedIn ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/hooks/useSubscriptionApi.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/hooks/useSubscriptionApi.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'preact/hooks';
+import { useState, useEffect, useContext } from 'preact/hooks';
 import wpcomRequest from 'wpcom-proxy-request';
-import { subscriptionSettings } from '../state';
+import { VerbumSignals } from '../state';
 import { SubscriptionDetails, EmailPostsChange, EmailSubscriptionResponse } from '../types';
 
 const getSubscriptionDetails = async () => {
@@ -24,7 +24,8 @@ const getSubscriptionDetails = async () => {
  *
  * @return {object} Object containing functions to manage subscriptions.
  */
-export default function useSubscriptionApi(): object {
+export default function useSubscriptionApi() {
+	const { subscriptionSettings } = useContext( VerbumSignals );
 	const { siteId } = VerbumComments;
 	const [ subscriptionSettingsIsLoading, setSubscriptionSettingsIsLoading ] = useState( true );
 
@@ -61,6 +62,7 @@ export default function useSubscriptionApi(): object {
 			.finally( () => {
 				setSubscriptionSettingsIsLoading( false );
 			} );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
 	const setEmailPostsSubscription = async function ( change: EmailPostsChange ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/state.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/state.tsx
@@ -1,110 +1,139 @@
 import { signal, computed } from '@preact/signals';
+import { createContext } from 'preact';
 import { canWeAccessCookies, getUserInfoCookie, isAuthRequired, isEmptyEditor } from './utils';
 import type { UserInfo, SubscriptionDetails } from './types';
 import type { Signal } from '@preact/signals';
 
-/*
- * In userInfo we store the user data for logged-in users.
+/**
+ * Creates an instance of the app state.
+ *
+ * @return An object containing all the signals used in the app.
  */
-export const userInfo: Signal< UserInfo > = signal( getUserInfoCookie() );
+export function createSignals() {
+	/*
+	 * In userInfo we store the user data for logged-in users.
+	 */
+	const userInfo: Signal< UserInfo > = signal( getUserInfoCookie() );
 
-/*
- * Calculate if user is logged in. For self-hosted sites this check is based only on VerbumComments.isJetpackCommentsLoggedIn.
- * Here we also check if cookies are accessible, userInfo is set and the service is different from 'guest' or 'jetpack'.
- */
-export const userLoggedIn = computed( () => {
-	return (
-		VerbumComments.isJetpackCommentsLoggedIn ||
-		( canWeAccessCookies() &&
-			userInfo.value &&
-			userInfo.value?.service !== 'guest' &&
-			userInfo.value?.service !== 'jetpack' )
-	);
-} );
+	/*
+	 * Calculate if user is logged in. For self-hosted sites this check is based only on VerbumComments.isJetpackCommentsLoggedIn.
+	 * Here we also check if cookies are accessible, userInfo is set and the service is different from 'guest' or 'jetpack'.
+	 */
+	const userLoggedIn = computed( () => {
+		return (
+			VerbumComments.isJetpackCommentsLoggedIn ||
+			( canWeAccessCookies() &&
+				userInfo.value &&
+				userInfo.value?.service !== 'guest' &&
+				userInfo.value?.service !== 'jetpack' )
+		);
+	} );
 
-/*
- * Store user input: email, author and url from email form.
- */
-export const mailLoginData = signal( {
-	email: '',
-	author: '',
-	url: '',
-} );
+	/*
+	 * Store user input: email, author and url from email form.
+	 */
+	const mailLoginData = signal( {
+		email: '',
+		author: '',
+		url: '',
+	} );
 
-/*
- * Indicate whether the tray showing the subscription options is open.
- */
-export const isTrayOpen = signal( false );
+	/*
+	 * Indicate whether the tray showing the subscription options is open.
+	 */
+	const isTrayOpen = signal( false );
 
-/*
- * Indicate whether the subscription option tray has been opened once.
- */
-export const hasOpenedTrayOnce = signal( false );
+	/*
+	 * Indicate whether the subscription option tray has been opened once.
+	 */
+	const hasOpenedTrayOnce = signal( false );
 
-/*
- * Store the value of the comment input field.
- */
-export const commentValue = signal( '' );
+	/*
+	 * Store the value of the comment input field.
+	 */
+	const commentValue = signal( '' );
 
-/*
- * Calculate if the comment value is empty.
- */
-export const isEmptyComment = computed( () => {
-	return isEmptyEditor( commentValue.value );
-} );
+	/*
+	 * Calculate if the comment value is empty.
+	 */
+	const isEmptyComment = computed( () => {
+		return isEmptyEditor( commentValue.value );
+	} );
 
-/*
- * Indicate whether we are saving the comment.
- */
-export const isSavingComment = signal( false );
+	/*
+	 * Indicate whether we are saving the comment.
+	 */
+	const isSavingComment = signal( false );
 
-/*
- * isMailFormInvalid is used to if the required email form data was not properly filled.
- */
-export const isMailFormInvalid = signal( false );
+	/*
+	 * isMailFormInvalid is used to if the required email form data was not properly filled.
+	 */
+	const isMailFormInvalid = signal( false );
 
-/*
- * isMailFormMissingInput is used to determine if the mail input is not set.
- */
-const isMailFormMissingInput = computed( () => {
-	return ! mailLoginData.value.email || ! mailLoginData.value.author;
-} );
+	/*
+	 * isMailFormMissingInput is used to determine if the mail input is not set.
+	 */
+	const isMailFormMissingInput = computed( () => {
+		return ! mailLoginData.value.email || ! mailLoginData.value.author;
+	} );
 
-/*
- * Calculate if the reply button should be disabled. When we have no user data we check the shouldDisableReply value,
- * otherwise we check if the comment is empty or saving.
- */
-export const isReplyDisabled = computed( () => {
-	return (
-		( isAuthRequired() &&
-			! userLoggedIn.value &&
-			( isMailFormMissingInput.value || isMailFormInvalid.value ) ) ||
-		isEmptyComment.value ||
-		isSavingComment.value
-	);
-} );
+	/*
+	 * Calculate if the reply button should be disabled. When we have no user data we check the shouldDisableReply value,
+	 * otherwise we check if the comment is empty or saving.
+	 */
+	const isReplyDisabled = computed( () => {
+		return (
+			( isAuthRequired() &&
+				! userLoggedIn.value &&
+				( isMailFormMissingInput.value || isMailFormInvalid.value ) ) ||
+			isEmptyComment.value ||
+			isSavingComment.value
+		);
+	} );
 
-/*
- * commentUrl is used to store the url of the comment page.
- * This is used to redirect the user to the comment page after the comment is saved.
- */
-export const commentUrl = signal( '' );
+	/*
+	 * commentUrl is used to store the url of the comment page.
+	 * This is used to redirect the user to the comment page after the comment is saved.
+	 */
+	const commentUrl = signal( '' );
 
-/*
- * Indicate whether we need to store the email data. If set we use this to store the user info cookie.
- */
-export const shouldStoreEmailData = signal( false );
+	/*
+	 * Indicate whether we need to store the email data. If set we use this to store the user info cookie.
+	 */
+	const shouldStoreEmailData = signal( false );
 
-//
-export const subscriptionSettings: Signal< SubscriptionDetails > = signal( undefined );
+	//
+	const subscriptionSettings: Signal< SubscriptionDetails > = signal( undefined );
 
-/*
- * Store the comment parent which is updated by external scripts
- */
-export const commentParent = signal( 0 );
+	/*
+	 * Store the comment parent which is updated by external scripts
+	 */
+	const commentParent = signal( 0 );
 
-/*
- * Store the subscription modal status calculated for the user.
- * Can be one of these values: 'showed', 'hidden_cookies_disabled', 'hidden_subscribe_not_enabled', 'hidden_views_limit' and 'hidden_already_subscribed'.
- */
-export const subscribeModalStatus = signal( undefined );
+	/*
+	 * Store the subscription modal status calculated for the user.
+	 * Can be one of these values: 'showed', 'hidden_cookies_disabled', 'hidden_subscribe_not_enabled', 'hidden_views_limit' and 'hidden_already_subscribed'.
+	 */
+	const subscribeModalStatus = signal( undefined );
+
+	return {
+		userInfo,
+		userLoggedIn,
+		mailLoginData,
+		isTrayOpen,
+		hasOpenedTrayOnce,
+		commentValue,
+		isEmptyComment,
+		isSavingComment,
+		isMailFormInvalid,
+		isMailFormMissingInput,
+		isReplyDisabled,
+		commentUrl,
+		shouldStoreEmailData,
+		subscriptionSettings,
+		commentParent,
+		subscribeModalStatus,
+	} as const;
+}
+
+export const VerbumSignals = createContext( createSignals() );

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/style.scss
@@ -89,7 +89,7 @@
 			display: none;
 		}
 
-		#comment-form__verbum {
+		.comment-form__verbum {
 			@include color-schemes;
 
 			&.dark {

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/types.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/types.tsx
@@ -36,6 +36,10 @@ export type EmailPostsChange =
 			trackSource: 'verbum-subscription-modal' | 'verbum-toggle';
 	  };
 
+export type VerbumAppProps = {
+	parentForm: HTMLFormElement;
+	siteId?: number;
+};
 export interface VerbumComments {
 	loginPostMessage?: UserInfo;
 	siteId?: number;
@@ -67,6 +71,7 @@ export interface VerbumComments {
 	 * Contains the time we started loading Highlander.
 	 */
 	fullyLoadedTime: number;
+	vbeCacheBuster: string;
 }
 
 export type EmailSubscriptionResponse = {

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/utils.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/utils.ts
@@ -1,6 +1,6 @@
 import { translate } from './i18n';
 import { Facebook, Mail, WordPress } from './images';
-import type { UserInfo, VerbumComments } from './types';
+import type { UserInfo } from './types';
 
 export const serviceData = {
 	wordpress: {

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/tests/simple/open_comments_for_everyone.test.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/tests/simple/open_comments_for_everyone.test.ts
@@ -21,7 +21,7 @@ test( 'Simple: open_comments_for_everyone - Anonymous', async ( { page } ) => {
 	await page.getByPlaceholder( 'Write a comment...' ).click();
 	await page.getByPlaceholder( 'Write a comment...' ).pressSequentially( randomComment );
 	await expect( page.getByRole( 'button', { name: 'Comment' } ) ).toBeVisible();
-	await expect( page.locator( '#comment-form__verbum' ) ).toContainText(
+	await expect( page.locator( '.comment-form__verbum' ) ).toContainText(
 		'Leave a comment. (log in optional)'
 	);
 	await page.getByRole( 'button', { name: 'Comment' } ).click();

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/tests/simple/user_must_be_registered_and_logged_in_to_comment.test.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/tests/simple/user_must_be_registered_and_logged_in_to_comment.test.ts
@@ -25,7 +25,7 @@ test( 'Simple: user_must_be_registered_and_logged_in_to_comment - Anonymous', as
 		.locator( 'p[contenteditable="true"]' )
 		.pressSequentially( randomComment );
 
-	await expect( page.locator( '#comment-form__verbum' ) ).toContainText(
+	await expect( page.locator( '.comment-form__verbum' ) ).toContainText(
 		'Log in to leave a comment.'
 	);
 	// Reply button should be disabled before log in.
@@ -41,7 +41,7 @@ test( 'Simple: user_must_be_registered_and_logged_in_to_comment - Anonymous', as
 	await loginPopupPage.getByRole( 'button', { name: 'Log In' } ).click();
 	// <!---- end login ----->
 
-	await expect( page.locator( '#comment-form__verbum' ) ).toContainText(
+	await expect( page.locator( '.comment-form__verbum' ) ).toContainText(
 		`${ testingUser.username } - Logged in via WordPress.com`
 	);
 	await page.getByRole( 'button', { name: 'Comment' } ).click();


### PR DESCRIPTION
Requires https://github.com/Automattic/wp-calypso/pull/98155

Fixes https://github.com/Automattic/wp-calypso/issues/98136

## Proposed changes:
This changes the Verbum app state from global to one-per-instance. This allows running multiple instances on the same page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Checkout this branch.
2. In `projects/packages/jetpack-mu-wpcom` run `pnpm run build-production-js && jetpack rsync mu-wpcom-plugin wpcom-sandbox:~/public_html/wp-content/mu-plugins/jetpack-mu-wpcom-plugin/sun`
3. You can use https://dsfsfdsfdsfdsfdsf.wordpress.com/2025/01/09/umbrella-post/ to test.
4. Make sure to sandbox dsfsfdsfdsfdsfdsf.wordpress.com.
5. Comment on First nested post. The comment should appear on that post.
6. Comment on Second nested post. The comment should appear on that post.
7. Comment on the main post (i.e scroll to the bottom). The comment should appear there.

