### PR TITLE
Post list: Add track events for quick links and stats

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-tracking-for-posts-list
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-tracking-for-posts-list
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Adds tracking for post list quick links and post stats for WPCOM
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -144,6 +144,7 @@ class Jetpack_Mu_Wpcom {
 			require_once __DIR__ . '/features/help-center/class-help-center.php';
 		}
 		require_once __DIR__ . '/features/pages/pages.php';
+		require_once __DIR__ . '/features/posts/posts.php';
 		require_once __DIR__ . '/features/replace-site-visibility/replace-site-visibility.php';
 		require_once __DIR__ . '/features/wpcom-admin-bar/wpcom-admin-bar.php';
 		require_once __DIR__ . '/features/wpcom-admin-interface/wpcom-admin-interface.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/posts/post-list-tracking.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/posts/post-list-tracking.php
@@ -52,7 +52,7 @@ add_action( 'admin_print_footer_scripts-edit.php', 'wpcom_add_tracking_for_posts
 function wpcom_post_list_add_stats_tracking() {
 	global $post_type;
 
-	if ( ! in_array( $post_type, array('post', 'page') ) ) {
+	if ( ! in_array( $post_type, array( 'post', 'page' ), true ) ) {
 		return;
 	}
 	?>

--- a/projects/packages/jetpack-mu-wpcom/src/features/posts/post-list-tracking.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/posts/post-list-tracking.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Post list tracking.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Add tracking for the post list quick links.
+ *
+ * @return void
+ */
+function wpcom_add_tracking_for_posts_lists() {
+	global $post_type;
+
+	?>
+	<script>
+		document.querySelectorAll( '.column-primary .row-actions span' ).forEach( ( span ) => {
+			span.addEventListener( 'click', (event) => {
+				let name = event.currentTarget.className;
+
+				// Classic editor sets the class to "0".
+				if ( '0' === name ) {
+					name = 'classic-editor';
+				}
+
+				// Handle Quick inline edit.
+				if ( 'inline hide-if-no-js' === name ) {
+					name = 'quick-edit';
+				}
+
+				const props = {
+					post_type: '<?php echo esc_html( $post_type ); ?>',
+					section: name,
+				}
+
+				window._tkq.push( [ 'recordEvent', 'wpcom_post_list_quick_links_clicked', props ] );
+			} );
+		} );
+	</script>
+
+	<?php
+}
+
+add_action( 'admin_print_footer_scripts-edit.php', 'wpcom_add_tracking_for_posts_lists' );
+
+/**
+ * Adds event for stats clicks in the post list (for pages and post types).
+ *
+ * @return void
+ */
+function wpcom_post_list_add_stats_tracking() {
+	global $post_type;
+
+	if ( ! in_array( $post_type, array('post', 'page') ) ) {
+		return;
+	}
+	?>
+	<script>
+		document.querySelectorAll( '#the-list .stats a' ).forEach( ( link ) => {
+			link.addEventListener( 'click', () => {
+				const props = {
+					post_type: '<?php echo esc_html( $post_type ); ?>',
+				}
+
+				window._tkq.push( [ 'recordEvent', 'wpcom_post_list_stats_clicked', props ] );
+			} );
+		} );
+	</script>
+	<?php
+}
+
+add_action( 'admin_print_footer_scripts-edit.php', 'wpcom_post_list_add_stats_tracking' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/posts/posts.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/posts/posts.php
@@ -1,8 +1,4 @@
-<?php
-/**
- * Load various customizations for post lists.
- *
- * @package automattic/jetpack-mu-wpcom
- */
+<?php // phpcs:ignore Squiz.Commenting.FileComment.Missing
+
 
 require_once __DIR__ . '/post-list-tracking.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/posts/posts.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/posts/posts.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Load various customizations for post lists.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+require_once __DIR__ . '/post-list-tracking.php';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/95621
Fixes DOTCOM-12958

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add tracking events for Post list quick links and post list stats

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test the PR on both AT and Simple
* Go to Posts/Pages and make sure that when you click on the quick links you have a `wpcom_post_list_quick_links_clicked` triggered
* Go to Posts/Posts and make sure that when you click on the Stats in the post list a `wpcom_post_list_stats_clicked` event is triggered

