### PR TITLE
Inject "Add New Theme" button on Theme screen for simple sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-themes-add-new-button
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-themes-add-new-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Themes: Inject "Add New Theme" button on simple sites.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/js/theme-actions.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/js/theme-actions.js
@@ -1,3 +1,5 @@
+/* global wpcomThemesActions */
+
 const wpcomThemesRemoveWpcomActions = () => {
 	const themeOverlay = document.querySelector( '.theme-overlay' );
 	const themeBrowser = document.querySelector( '.theme-browser' );
@@ -19,6 +21,16 @@ const wpcomThemesRemoveWpcomActions = () => {
 	} );
 	observer.observe( themeOverlay, { childList: true } );
 	observer.observe( themeBrowser, { childList: true, subtree: true } );
+
+	// Add the "Add new theme" action to the page header, if there isn't one already.
+	const pageTitle = document.querySelector( '.wp-heading-inline' );
+	const addButton = document.querySelector( '.page-title-action' );
+	if ( pageTitle && ! addButton ) {
+		pageTitle.insertAdjacentHTML(
+			'afterend',
+			`<a href="${ wpcomThemesActions.addNewUrl }" class="page-title-action">${ wpcomThemesActions.addNewLabel }</a>`
+		);
+	}
 };
 
 document.addEventListener( 'DOMContentLoaded', wpcomThemesRemoveWpcomActions );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-theme-fixes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-theme-fixes.php
@@ -27,5 +27,16 @@ function wpcom_themes_remove_wpcom_actions() {
 			'in_footer' => true,
 		)
 	);
+
+	$site_slug = wp_parse_url( home_url(), PHP_URL_HOST );
+
+	wp_localize_script(
+		'wpcom-theme-actions',
+		'wpcomThemesActions',
+		array(
+			'addNewLabel' => esc_html__( 'Add New Theme', 'jetpack-mu-wpcom' ),
+			'addNewUrl'   => esc_url( "https://wordpress.com/themes/$site_slug?ref=wpcom-themes-add" ),
+		)
+	);
 }
 add_action( 'load-themes.php', 'wpcom_themes_remove_wpcom_actions' );

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-themes-add-new-button
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-themes-add-new-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Themes: Inject "Add New Theme" button on simple sites.

--- a/projects/plugins/wpcomsh/changelog/add-themes-add-new-button
+++ b/projects/plugins/wpcomsh/changelog/add-themes-add-new-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Themes: Inject "Add New Theme" button on simple sites.


### PR DESCRIPTION
This PR adds the same "Add New Theme" button that appears on core WordPress sites to simple wpcom sites. Currently, I have it directing to the Calypso Theme Showcase, as `https://yoursite.wordpress.com/wp-admin/theme-install.php` does not work for simple sites. If/when the theme showcase is moved to a wp-admin page, this can be replaced with the core URL.

Fixes https://github.com/Automattic/wp-calypso/issues/96393

**Screenshots**

Note that when a site has the "classic" dashboard mode selected, this banner appears on the theme screen with the "Explore" button, which also leads to the Theme Showcase.

| Before | After |
|---|---|
| ![](https://github.com/user-attachments/assets/6d228f38-bcba-431a-b23c-a0a920a2a7ca) | ![](https://github.com/user-attachments/assets/007464af-9669-4463-b2c3-0d765536e0bd) |

On simple sites the calypso dashboard mode, if you go directly to the wp-admin/themes.php page, you don't get the banner. But this still adds the button.

| Before | After |
|---|---|
| ![](https://github.com/user-attachments/assets/c4779454-75c1-4c0f-9447-84702dd5b867) | ![](https://github.com/user-attachments/assets/05d0c906-cc86-4251-892d-5a71a7deb1db) |

Atomic sites already have the button, no change needed here.

<img alt="" src="https://github.com/user-attachments/assets/65f68029-0e25-4b39-be08-86ad8d6587c2" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

I don't think this applies, but I did tweak the URL target for the button, to `https://wordpress.com/themes/$site_slug?ref=wpcom-themes-add` — same format as the banner, but a new `ref`. I'm not familiar with whatever we use to track now to know if that needs to be set up somewhere else.

## Testing instructions:

1. Use a simple site with the "Classic" dashboard mode; or go directly to `site.wordpress.com/wp-admin/themes.php`
2. Go to Appearance > Themes
3. You should see the page title Themes, and next to that is the "Add New Theme" button
4. Clicking that will take you to the theme showcase, allowing you to select a new theme