### PR TITLE
Social | Restore must_reauth as connection status

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-add-back-must_reauth-as-connection-status
+++ b/projects/js-packages/publicize-components/changelog/update-social-add-back-must_reauth-as-connection-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Restored UI changes to support must_reauth status

--- a/projects/js-packages/publicize-components/src/components/connection/index.js
+++ b/projects/js-packages/publicize-components/src/components/connection/index.js
@@ -62,7 +62,7 @@ class PublicizeConnection extends Component {
 	}
 
 	isDisabled() {
-		return this.props.disabled || this.connectionIsFailing() || this.connectionNeedsReauth();
+		return this.props.disabled || this.connectionIsFailing();
 	}
 
 	render() {

--- a/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.ts
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.ts
@@ -71,7 +71,7 @@ export function getFailedConnections( state ) {
 
 /**
  * Returns a list of Publicize connection service names that require reauthentication from users.
- * iFor example, when LinkedIn switched its API from v1 to v2.
+ * For example, when LinkedIn switched its API from v1 to v2.
  *
  * @param {import("../types").SocialStoreState} state - State object.
  * @return {Array<import("../types").Connection>} List of service names that need reauthentication.
@@ -79,7 +79,7 @@ export function getFailedConnections( state ) {
 export function getMustReauthConnections( state ) {
 	const connections = getConnections( state );
 	return connections
-		.filter( connection => 'broken' === connection.status )
+		.filter( connection => 'must_reauth' === connection.status )
 		.map( connection => connection.service_name );
 }
 

--- a/projects/js-packages/publicize-components/src/social-store/selectors/test/connection-data.test.js
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/test/connection-data.test.js
@@ -36,7 +36,7 @@ const state = {
 				external_handle: '@somename@mastodon.social',
 				enabled: false,
 				connection_id: '219876543',
-				status: 'ok',
+				status: 'must_reauth',
 			},
 		],
 	},
@@ -90,7 +90,7 @@ describe( 'Social store selectors: connectionData', () => {
 		it( 'should return must reauth connections', () => {
 			const mustReauthConnections = getMustReauthConnections( state );
 			expect( mustReauthConnections ).toEqual( [
-				state.connectionData.connections[ 1 ].service_name,
+				state.connectionData.connections[ 2 ].service_name,
 			] );
 		} );
 	} );

--- a/projects/js-packages/publicize-components/src/social-store/types.ts
+++ b/projects/js-packages/publicize-components/src/social-store/types.ts
@@ -1,4 +1,4 @@
-export type ConnectionStatus = 'ok' | 'broken';
+export type ConnectionStatus = 'ok' | 'broken' | 'must_reauth';
 
 export type Connection = {
 	connection_id: string;

--- a/projects/packages/publicize/changelog/update-social-add-back-must_reauth-as-connection-status
+++ b/projects/packages/publicize/changelog/update-social-add-back-must_reauth-as-connection-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added must_reauth as status in connection REST schema

--- a/projects/packages/publicize/src/rest-api/class-connections-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-controller.php
@@ -164,6 +164,7 @@ class Connections_Controller extends Base_Controller {
 				'enum'        => array(
 					'ok',
 					'broken',
+					'must_reauth',
 				),
 			),
 			'user_id'         => array(
@@ -326,8 +327,11 @@ class Connections_Controller extends Base_Controller {
 		$test_results_map = array();
 
 		foreach ( $test_results as $test_result ) {
-			// Compare to `true` because the API returns a 'must_reauth' for LinkedIn.
-			$test_results_map[ $test_result['connectionID'] ] = true === $test_result['connectionTestPassed'] ? 'ok' : 'broken';
+			$result = $test_result['connectionTestPassed'];
+			if ( 'must_reauth' !== $result ) {
+				$result = $test_result['connectionTestPassed'] ? 'ok' : 'broken';
+			}
+			$test_results_map[ $test_result['connectionID'] ] = $result;
 		}
 
 		return $test_results_map;


### PR DESCRIPTION
When we brought connections management to wp-admin, we set the connection status only to `'ok'` or `'broken'`. Then, in #40539, we made changes to the front-end logic to remove the usage of `must_reauth` status.

It seems like we will still need that `must_reauth` status for LinkedIn connections.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `must_reauth` as status in the connections schema
* Revert UI changes made in #40539, related to `must_reauth`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Goto connections management
* Ensure that the connections are marked as healthy (not broken)
* Break a connection
    - For Mastodon, remove Jetpack [here](https://mastodon.social/oauth/authorized_applications).
    - For Facebook, remove Jetpack [here](https://www.facebook.com/settings/?tab=business_tools).
* Confirm that the broken connections in the editor are marked as such and the notices appear.
* I am not sure how to test the `must_reauth` status.

