### PR TITLE
Social | Consolidate proxy request logic for REST endpoints

### DIFF
--- a/projects/packages/publicize/.phan/baseline.php
+++ b/projects/packages/publicize/.phan/baseline.php
@@ -9,7 +9,7 @@
  */
 return [
     // # Issue statistics:
-    // PhanPluginDuplicateConditionalNullCoalescing : 6 occurrences
+    // PhanPluginDuplicateConditionalNullCoalescing : 8 occurrences
     // PhanTypeMismatchArgument : 6 occurrences
     // PhanTypeMismatchArgumentNullable : 3 occurrences
     // PhanDeprecatedFunction : 2 occurrences
@@ -29,6 +29,7 @@ return [
     // PhanTypeMismatchDefault : 1 occurrence
     // PhanTypeMismatchDimFetch : 1 occurrence
     // PhanTypeMismatchReturn : 1 occurrence
+    // PhanTypeSuspiciousNonTraversableForeach : 1 occurrence
     // PhanUndeclaredFunction : 1 occurrence
     // PhanUndeclaredMethod : 1 occurrence
 
@@ -40,8 +41,8 @@ return [
         'src/class-publicize-ui.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-publicize.php' => ['PhanParamSignatureMismatch', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMissingReturn'],
         'src/class-rest-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
-        'src/rest-api/class-base-controller.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
-        'src/rest-api/class-connections-controller.php' => ['PhanPluginMixedKeyNoKey', 'PhanUndeclaredMethod'],
+        'src/rest-api/class-base-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
+        'src/rest-api/class-connections-controller.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanUndeclaredMethod'],
         'src/rest-api/class-connections-post-field.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/social-image-generator/class-post-settings.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/social-image-generator/class-rest-settings-controller.php' => ['PhanPluginMixedKeyNoKey'],

--- a/projects/packages/publicize/changelog/update-social-consolidate-proxy-request-logic
+++ b/projects/packages/publicize/changelog/update-social-consolidate-proxy-request-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Consolidate the proxy request logic for REST endpoints

--- a/projects/packages/publicize/src/rest-api/class-base-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-base-controller.php
@@ -7,7 +7,10 @@
 
 namespace Automattic\Jetpack\Publicize\REST_API;
 
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Status\Host;
+use Automattic\Jetpack\Status\Visitor;
 use WP_Error;
 use WP_REST_Controller;
 use WP_REST_Request;
@@ -55,6 +58,86 @@ abstract class Base_Controller extends WP_REST_Controller {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Copied from WPCOM_REST_API_Proxy_Request_Trait. See the @todo below.
+	 *
+	 * Proxy request to wpcom servers on behalf of a user or using the Site-level Connection (blog token).
+	 *
+	 * @todo Swap this with the trait when it's available 🔗👇
+	 * @link https://github.com/Automattic/jetpack/issues/40947
+	 *
+	 * @param WP_Rest_Request $request Request to proxy.
+	 * @param string          $path Path to append to the rest base.
+	 * @param string          $context Can be Either 'user' or 'blog'. Defaults to 'user'.
+	 *
+	 * @return mixed|WP_Error           Response from wpcom servers or an error.
+	 */
+	protected function proxy_request_to_wpcom( $request, $path = '', $context = 'user' ) {
+		$blog_id      = \Jetpack_Options::get_option( 'id' );
+		$path         = '/sites/' . rawurldecode( $blog_id ) . '/' . rawurldecode( ltrim( $this->rest_base, '/' ) ) . ( $path ? '/' . rawurldecode( ltrim( $path, '/' ) ) : '' );
+		$query_params = $request->get_query_params();
+		$manager      = new Manager();
+
+		/*
+		 * A rest_route parameter can be added when using plain permalinks.
+		 * It is not necessary to pass them to WordPress.com,
+		 * and may even cause issues with some endpoints.
+		 * Let's remove it.
+		 */
+		if ( isset( $query_params['rest_route'] ) ) {
+			unset( $query_params['rest_route'] );
+		}
+		$api_url = add_query_arg( $query_params, $path );
+
+		$request_options = array(
+			'headers' => array(
+				'Content-Type'    => 'application/json',
+				'X-Forwarded-For' => ( new Visitor() )->get_ip( true ),
+			),
+			'method'  => $request->get_method(),
+		);
+
+		// If no body is present, passing it as $request->get_body() will cause an error.
+		$body = $request->get_body() ? $request->get_body() : null;
+
+		$response = new WP_Error(
+			'rest_unauthorized',
+			__( 'Please connect your user account to WordPress.com', 'jetpack-publicize-pkg' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+
+		if ( 'user' === $context ) {
+			if ( ! $manager->is_user_connected() ) {
+				return $response;
+			}
+			$response = Client::wpcom_json_api_request_as_user( $api_url, $this->version, $request_options, $body, $this->base_api_path );
+		}
+
+		if ( 'blog' === $context ) {
+			if ( ! $manager->is_connected() ) {
+				return $response;
+			}
+
+			$response = Client::wpcom_json_api_request_as_blog( $api_url, $this->version, $request_options, $body, $this->base_api_path );
+		}
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$response_status = wp_remote_retrieve_response_code( $response );
+		$response_body   = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( $response_status >= 400 ) {
+			$code    = isset( $response_body['code'] ) ? $response_body['code'] : 'unknown_error';
+			$message = isset( $response_body['message'] ) ? $response_body['message'] : __( 'An unknown error occurred.', 'jetpack-publicize-pkg' );
+
+			return new WP_Error( $code, $message, array( 'status' => $response_status ) );
+		}
+
+		return $response_body;
 	}
 
 	/**

--- a/projects/packages/publicize/src/rest-api/class-connections-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-controller.php
@@ -7,8 +7,6 @@
 
 namespace Automattic\Jetpack\Publicize\REST_API;
 
-use Automattic\Jetpack\Connection\Client;
-use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Publicize\Publicize;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -20,11 +18,25 @@ use WP_REST_Server;
 class Connections_Controller extends Base_Controller {
 
 	/**
+	 * The API version.
+	 *
+	 * @var string
+	 */
+	protected $version = 'v2';
+
+	/**
+	 * The base API path.
+	 *
+	 * @var string
+	 */
+	protected $base_api_path = 'wpcom';
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		parent::__construct();
-		$this->namespace = 'wpcom/v2';
+		$this->namespace = "{$this->base_api_path}/{$this->version}";
 		$this->rest_base = 'publicize/connections';
 
 		$this->allow_requests_as_blog = true;
@@ -182,7 +194,7 @@ class Connections_Controller extends Base_Controller {
 	 *
 	 * @return array
 	 */
-	protected static function get_all_connections( $args = array() ) {
+	private static function wpcom_get_connections( $args = array() ) {
 		/**
 		 * Publicize instance.
 		 */
@@ -247,37 +259,26 @@ class Connections_Controller extends Base_Controller {
 	 */
 	public static function get_connections( $args = array() ) {
 		if ( self::is_wpcom() ) {
-			return self::get_all_connections( $args );
+			return self::wpcom_get_connections( $args );
 		}
 
-		$site_id = Manager::get_site_id( true );
-		if ( ! $site_id ) {
-			return array();
+		// Since we are inside a static method, we can't use $this->proxy_request_to_wpcom().
+		// So, lets us so an internal REST request.
+		$request = new WP_REST_Request( 'GET', '/wpcom/v2/publicize/connections' );
+		$request->set_param( 'test_connections', $args['test_connections'] ?? false );
+
+		$context = ( $args['scope'] ?? '' ) === 'site' ? 'blog' : 'user';
+		if ( ! defined( 'JETPACK_SOCIAL_REST_REQUEST_CONTEXT' ) ) {
+			define( 'JETPACK_SOCIAL_REST_REQUEST_CONTEXT', $context );
 		}
+		$response = rest_do_request( $request );
 
-		$path = add_query_arg(
-			array(
-				'test_connections' => $args['test_connections'] ?? false,
-			),
-			sprintf( '/sites/%d/publicize/connections', $site_id )
-		);
-
-		$blog_or_user = ( $args['scope'] ?? '' ) === 'site' ? 'blog' : 'user';
-
-		$callback = array( Client::class, "wpcom_json_api_request_as_{$blog_or_user}" );
-
-		$response = call_user_func( $callback, $path, 'v2', array( 'method' => 'GET' ), null, 'wpcom' );
-
-		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		if ( $response->is_error() || is_wp_error( $response ) ) {
 			// TODO log error.
 			return array();
 		}
 
-		$body = wp_remote_retrieve_body( $response );
-
-		$items = json_decode( $body, true );
-
-		return $items ? $items : array();
+		return $response->get_data();
 	}
 
 	/**
@@ -288,14 +289,24 @@ class Connections_Controller extends Base_Controller {
 	 * @return WP_REST_Response suitable for 1-page collection
 	 */
 	public function get_items( $request ) {
+		if ( self::is_wpcom() ) {
+			$args = array( 'test_connections' => $request->get_param( 'test_connections' ) );
+
+			$connections = self::wpcom_get_connections( $args );
+		} else {
+			// If this request was fired internally, we should have the constant defined.
+			$context = defined( 'JETPACK_SOCIAL_REST_REQUEST_CONTEXT' ) ? JETPACK_SOCIAL_REST_REQUEST_CONTEXT : 'user';
+
+			$connections = $this->proxy_request_to_wpcom( $request, '', $context );
+		}
+
+		if ( is_wp_error( $connections ) ) {
+			return $connections;
+		}
+
 		$items = array();
 
-		// On Jetpack, we don't want to pass the 'scope' param to get_connections().
-		$args = array(
-			'test_connections' => $request->get_param( 'test_connections' ),
-		);
-
-		foreach ( self::get_connections( $args ) as $item ) {
+		foreach ( $connections as $item ) {
 			$data = $this->prepare_item_for_response( $item, $request );
 
 			$items[] = $this->prepare_response_for_collection( $data );


### PR DESCRIPTION
for our CRUD operations, we are going to make a few proxy calls to WPCOM and thus we want to have a single function to handle that. There is a trait in Jetpack to use in such endpoints but it’s in Jetpack plugin. There is now a task (#40947) to move it to the connection package.

So, for now, we can copy the implementation and add a todo comment to swap it when the trait is available.
Thus, this PR does it for the connections list request and then we can use the same in CRUD operations.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Copy `proxy_request_to_wpcom` method from [`WPCOM_REST_API_Proxy_Request_Trait`](https://github.com/Automattic/jetpack/blob/3374c193b10fdffe70fa68fc81a76208a1172730/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/trait-wpcom-rest-api-proxy-request-trait.php) trait
* Use that `proxy_request_to_wpcom` for connection list request.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the instructions given in #40704

