### PR TITLE
Boost: Update CSS minification library

### DIFF
--- a/projects/plugins/boost/.gitattributes
+++ b/projects/plugins/boost/.gitattributes
@@ -13,7 +13,6 @@ vendor/automattic/**                            production-include
 vendor/composer/**                              production-include
 vendor/jetpack-autoloader/**                    production-include
 vendor/tedivm/**                                production-include
-vendor/tubalmartin/**                           production-include
 vendor/matthiasmullie/**                        production-include
 vendor/wikimedia/aho-corasick/**                production-include
 

--- a/projects/plugins/boost/app/lib/class-minify.php
+++ b/projects/plugins/boost/app/lib/class-minify.php
@@ -9,18 +9,13 @@
 
 namespace Automattic\Jetpack_Boost\Lib;
 
+use MatthiasMullie\Minify\CSS as CSSMinifier;
 use MatthiasMullie\Minify\JS as JSMinifier;
-use tubalmartin\CssMin\Minifier as CSSMinifier;
 
 /**
  * Class Minify
  */
 class Minify {
-
-	/**
-	 * @var CSSMinifier - Holds the CssMin\Minifier instance, for reuse on subsequent calls.
-	 */
-	private static $css_minifier;
 
 	/**
 	 * Strips whitespace from JavaScript scripts.
@@ -44,10 +39,13 @@ class Minify {
 	 * Minifies the supplied CSS code, returning its minified form.
 	 */
 	public static function css( $css ) {
-		if ( ! self::$css_minifier ) {
-			self::$css_minifier = new CSSMinifier();
+		try {
+			$minifier     = new CSSMinifier( $css );
+			$minified_css = $minifier->minify();
+		} catch ( \Exception $e ) {
+			return $css;
 		}
 
-		return self::$css_minifier->run( $css );
+		return $minified_css;
 	}
 }

--- a/projects/plugins/boost/changelog/update-boost-minify-css-library
+++ b/projects/plugins/boost/changelog/update-boost-minify-css-library
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Concatenate CSS: Fixed cases where minification might cause a file to load slower.

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -30,8 +30,7 @@
 		"automattic/jetpack-status": "@dev",
 		"automattic/jetpack-sync": "@dev",
 		"automattic/jetpack-wp-js-data-sync": "@dev",
-		"matthiasmullie/minify": "^1.3",
-		"tubalmartin/cssmin": "^4.1"
+		"matthiasmullie/minify": "^1.3"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b52098ae2e5a4e594034ec41fb2636e6",
+    "content-hash": "0ad50993accd8a26f9fd344099d8a588",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -2142,63 +2142,6 @@
                 "source": "https://github.com/matthiasmullie/path-converter/tree/1.1.3"
             },
             "time": "2019-02-05T23:41:09+00:00"
-        },
-        {
-            "name": "tubalmartin/cssmin",
-            "version": "v4.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/tubalmartin/YUI-CSS-compressor-PHP-port.git",
-                "reference": "3cbf557f4079d83a06f9c3ff9b957c022d7805cf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/tubalmartin/YUI-CSS-compressor-PHP-port/zipball/3cbf557f4079d83a06f9c3ff9b957c022d7805cf",
-                "reference": "3cbf557f4079d83a06f9c3ff9b957c022d7805cf",
-                "shasum": ""
-            },
-            "require": {
-                "ext-pcre": "*",
-                "php": ">=5.3.2"
-            },
-            "require-dev": {
-                "cogpowered/finediff": "0.3.*",
-                "phpunit/phpunit": "4.8.*"
-            },
-            "bin": [
-                "cssmin"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "tubalmartin\\CssMin\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Túbal Martín",
-                    "homepage": "http://tubalmartin.me/"
-                }
-            ],
-            "description": "A PHP port of the YUI CSS compressor",
-            "homepage": "https://github.com/tubalmartin/YUI-CSS-compressor-PHP-port",
-            "keywords": [
-                "compress",
-                "compressor",
-                "css",
-                "cssmin",
-                "minify",
-                "yui"
-            ],
-            "support": {
-                "issues": "https://github.com/tubalmartin/YUI-CSS-compressor-PHP-port/issues",
-                "source": "https://github.com/tubalmartin/YUI-CSS-compressor-PHP-port"
-            },
-            "time": "2018-01-15T15:26:51+00:00"
         }
     ],
     "packages-dev": [

--- a/projects/plugins/boost/serve-minified-content.php
+++ b/projects/plugins/boost/serve-minified-content.php
@@ -3,10 +3,14 @@
 if ( ! defined( 'JETPACK_BOOST_CONCAT_USE_WP' ) ) {
 	define( 'JETPACK_BOOST_CONCAT_USE_WP', false );
 
-	// Load CSSmin.
-	require_once __DIR__ . '/vendor/tubalmartin/cssmin/src/Colors.php';
-	require_once __DIR__ . '/vendor/tubalmartin/cssmin/src/Utils.php';
-	require_once __DIR__ . '/vendor/tubalmartin/cssmin/src/Minifier.php';
+	// Load minification library.
+	require_once __DIR__ . '/vendor/matthiasmullie/minify/src/Exception.php';
+	require_once __DIR__ . '/vendor/matthiasmullie/minify/src/Minify.php';
+	require_once __DIR__ . '/vendor/matthiasmullie/minify/src/CSS.php';
+	require_once __DIR__ . '/vendor/matthiasmullie/minify/src/JS.php';
+	require_once __DIR__ . '/vendor/matthiasmullie/minify/src/Exceptions/BasicException.php';
+	require_once __DIR__ . '/vendor/matthiasmullie/minify/src/Exceptions/FileImportException.php';
+	require_once __DIR__ . '/vendor/matthiasmullie/minify/src/Exceptions/IOException.php';
 }
 
 // Load minify library code.


### PR DESCRIPTION
There was a bug in the old minification library, which caused a concatenated CSS file to be loaded very slowly.

This only happened when a website was running on a server with Brotli encoding, Jetpack Boost with Concatenate CSS enabled and the `Responsive Blocks - WordPress Gutenberg Blocks` plugin.

Related p1736444901637029-slack-C7YPW6K40

## Proposed changes:

- Replace CSS minification library. We already had the library minifying JS, it's now also minifying CSS;
- Remove old minification library.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1736444901637029-slack-C7YPW6K40

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

**Pre-requisites**

- A website on a server with Brotli encoding (atomic sites are great for this);
- The `Responsive Blocks - WordPress Gutenberg Blocks` plugin running on the website;

### Test that it breaks

- Setup Jetpack Boost production;
- Enable Concatenate CSS;
- Load the home page and observe the network requests. There should be one request (that contains `_jb_static`) that takes too long (around 40 seconds).

### Test that it works

- Setup Jetpack Boost from this branch;
- Enable Concatenate CSS;
- Load the home page and observe the network requests. There should be no `_jb_static` requests that take too long.