### PR TITLE
Forms: add number input

### DIFF
--- a/projects/packages/forms/changelog/add-forms-number-input
+++ b/projects/packages/forms/changelog/add-forms-number-input
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms block: add number input

--- a/projects/packages/forms/src/blocks/README.md
+++ b/projects/packages/forms/src/blocks/README.md
@@ -8,6 +8,7 @@
 - `jetpack/field-date`
 - `jetpack/field-email`
 - `jetpack/field-name`
+- `jetpack/field-number`
 - `jetpack/field-option-checkbox`
 - `jetpack/field-option-radio`
 - `jetpack/field-radio`

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -404,10 +404,6 @@ export const childBlocks = [
 					type: 'string',
 					default: __( 'Number', 'jetpack-forms' ),
 				},
-				defaultValue: {
-					type: 'number',
-					default: '',
-				},
 			},
 		},
 	},

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -116,6 +116,11 @@ const FieldDefaults = {
 		to: [
 			{
 				type: 'block',
+				blocks: [ 'jetpack/field-number' ],
+				transform: attributes => createBlock( 'jetpack/field-number', attributes ),
+			},
+			{
+				type: 'block',
 				blocks: [ 'jetpack/field-text' ],
 				transform: attributes => createBlock( 'jetpack/field-text', attributes ),
 			},
@@ -392,20 +397,16 @@ export const childBlocks = [
 					d="M12 7H4V8.5H12V7ZM19.75 17.25V10.75H4.25V17.25H19.75ZM5.75 15.75V12.25H18.25V15.75H5.75Z"
 				/>
 			),
-			edit: editField( 'text' ),
+			edit: editField( 'number' ),
 			attributes: {
 				...FieldDefaults.attributes,
 				label: {
-					type: 'number',
-					default: 0,
+					type: 'string',
+					default: __( 'Number', 'jetpack-forms' ),
 				},
 				defaultValue: {
 					type: 'number',
-					default: 0,
-				},
-				placeholder: {
-					type: 'number',
-					default: 0,
+					default: '',
 				},
 			},
 		},

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -381,6 +381,36 @@ export const childBlocks = [
 		},
 	},
 	{
+		name: 'field-number',
+		settings: {
+			...FieldDefaults,
+			title: __( 'Number Input Field', 'jetpack-forms' ),
+			description: __( 'Collect numbers from site visitors.', 'jetpack-forms' ),
+			icon: renderMaterialIcon(
+				<Path
+					fill={ getIconColor() }
+					d="M12 7H4V8.5H12V7ZM19.75 17.25V10.75H4.25V17.25H19.75ZM5.75 15.75V12.25H18.25V15.75H5.75Z"
+				/>
+			),
+			edit: editField( 'text' ),
+			attributes: {
+				...FieldDefaults.attributes,
+				label: {
+					type: 'number',
+					default: 0,
+				},
+				defaultValue: {
+					type: 'number',
+					default: 0,
+				},
+				placeholder: {
+					type: 'number',
+					default: 0,
+				},
+			},
+		},
+	},
+	{
 		name: 'field-name',
 		settings: {
 			...FieldDefaults,

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -161,6 +161,13 @@ class Contact_Form_Block {
 			)
 		);
 
+		Blocks::jetpack_register_block(
+			'jetpack/field-number',
+			array(
+				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_number' ),
+			)
+		);
+
 		$blocks_variation = apply_filters( 'jetpack_blocks_variation', \Automattic\Jetpack\Constants::get_constant( 'JETPACK_BLOCKS_VARIATION' ) );
 		if ( 'beta' === $blocks_variation ) {
 			self::register_beta_blocks();
@@ -175,13 +182,6 @@ class Contact_Form_Block {
 			'jetpack/field-file',
 			array(
 				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_file' ),
-			)
-		);
-
-		Blocks::jetpack_register_block(
-			'jetpack/field-number',
-			array(
-				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_number' ),
 			)
 		);
 	}

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -177,6 +177,13 @@ class Contact_Form_Block {
 				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_file' ),
 			)
 		);
+
+		Blocks::jetpack_register_block(
+			'jetpack/field-number',
+			array(
+				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_number' ),
+			)
+		);
 	}
 
 	/**

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
@@ -52,8 +52,7 @@ const JetpackField = props => {
 					onChange={ e => setAttributes( { placeholder: e.target.value } ) }
 					style={ fieldStyle }
 					type={ type }
-					value=""
-					placeholder={ placeholder }
+					value={ placeholder }
 					onClick={ event => type === 'file' && event.preventDefault() }
 					onKeyDown={ event => {
 						if ( event.defaultPrevented || event.key !== 'Enter' ) {
@@ -71,6 +70,7 @@ const JetpackField = props => {
 				setAttributes={ setAttributes }
 				placeholder={ placeholder }
 				attributes={ attributes }
+				hidePlaceholder={ type === 'number' }
 			/>
 		</>
 	);

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
@@ -52,7 +52,8 @@ const JetpackField = props => {
 					onChange={ e => setAttributes( { placeholder: e.target.value } ) }
 					style={ fieldStyle }
 					type={ type }
-					value={ placeholder }
+					value=""
+					placeholder={ placeholder }
 					onClick={ event => type === 'file' && event.preventDefault() }
 					onKeyDown={ event => {
 						if ( event.defaultPrevented || event.key !== 'Enter' ) {

--- a/projects/packages/forms/src/blocks/contact-form/transforms.js
+++ b/projects/packages/forms/src/blocks/contact-form/transforms.js
@@ -34,6 +34,7 @@ const getContactFieldBlockName = type => {
 		select: `${ prefix }/field-select`,
 		email: `${ prefix }/field-email`,
 		name: `${ prefix }/field-name`,
+		number: `${ prefix }/field-number`,
 		default: `${ prefix }/field-text`,
 	};
 	return fieldTypes[ type ] ? fieldTypes[ type ] : fieldTypes.default;

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -249,6 +249,13 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					$this->add_error( sprintf( __( '%s requires at least one selection', 'jetpack-forms' ), $field_label ) );
 				}
 				break;
+			case 'number':
+				// Make sure the number address is valid
+				if ( ! is_numeric( $field_value ) ) {
+					/* translators: %s is the name of a form field */
+					$this->add_error( sprintf( __( '%s requires a number', 'jetpack-forms' ), $field_label ) );
+				}
+				break;
 			default:
 				// Just check for presence of any text
 				if ( ! is_string( $field_value ) || ! strlen( trim( $field_value ) ) ) {
@@ -911,6 +918,25 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	}
 
 	/**
+	 * Return the HTML for the number field.
+	 *
+	 * @param int    $id - the ID.
+	 * @param string $label - the label.
+	 * @param string $value - the value of the field.
+	 * @param string $class - the field class.
+	 * @param bool   $required - if the field is marked as required.
+	 * @param string $required_field_text - the text in the required text field.
+	 * @param string $placeholder - the field placeholder content.
+	 *
+	 * @return string HTML
+	 */
+	public function render_number_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
+		$field  = $this->render_label( 'number', $id, $label, $required, $required_field_text );
+		$field .= $this->render_input_field( 'number', $id, $value, $class, $placeholder, $required );
+		return $field;
+	}
+
+	/**
 	 * Return the HTML for the default field.
 	 *
 	 * @param int    $id - the ID.
@@ -1101,6 +1127,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				break;
 			case 'consent':
 				$field .= $this->render_consent_field( $id, $field_class );
+				break;
+			case 'number':
+				$field .= $this->render_number_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder );
 				break;
 			default: // text field
 				$field .= $this->render_default_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder, $type );

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -521,6 +521,19 @@ class Contact_Form_Plugin {
 	}
 
 	/**
+	 * Render the number field.
+	 *
+	 * @param array  $atts - the block attributes.
+	 * @param string $content - html content.
+	 *
+	 * @return string HTML for the file upload field.
+	 */
+	public static function gutenblock_render_field_number( $atts, $content ) {
+		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'number' );
+		return Contact_Form::parse_contact_field( $atts, $content );
+	}
+
+	/**
 	 * Add the 'Form Responses' menu item as a submenu of Feedback.
 	 */
 	public function admin_menu() {

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -715,6 +715,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return string
 	 */
 	public static function escape_and_sanitize_field_value( $value ) {
+		if ( $value === null ) {
+			return '';
+		}
+
 		$value = str_replace( array( '[', ']' ), array( '&#91;', '&#93;' ), $value );
 		return nl2br( wp_kses( $value, array() ) );
 	}
@@ -980,7 +984,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 			switch ( $type ) {
 				case 'email':
 				case 'name':
-				case 'number':
 				case 'url':
 				case 'subject':
 				case 'textarea':

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -868,6 +868,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 			case 'name':
 				$str = __( 'Name', 'jetpack-forms' );
 				break;
+			case 'number':
+				$str = __( 'Number', 'jetpack-forms' );
+				break;
 			case 'email':
 				$str = __( 'Email', 'jetpack-forms' );
 				break;
@@ -977,6 +980,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			switch ( $type ) {
 				case 'email':
 				case 'name':
+				case 'number':
 				case 'url':
 				case 'subject':
 				case 'textarea':

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -33,6 +33,7 @@
 	.contact-form input[type='email'],
 	.contact-form input[type='tel'],
 	.contact-form input[type='url'],
+	.contact-form input[type='number'],
 	.contact-form textarea
 ) {
 	box-sizing: border-box;
@@ -203,11 +204,13 @@
 .textwidget .contact-form input[type='email'],
 .textwidget .contact-form input[type='tel'],
 .textwidget .contact-form input[type='url'],
+.textwidget .contact-form input[type='number'],
 .textwidget .contact-form textarea,
 .wp-block-column .contact-form input[type='text'],
 .wp-block-column .contact-form input[type='email'],
 .wp-block-column .contact-form input[type='tel'],
 .wp-block-column .contact-form input[type='url'],
+.wp-block-column .contact-form input[type='number'],
 .wp-block-column .contact-form textarea {
 	width: 100%;
 }
@@ -309,7 +312,8 @@
 	.contact-form input[type='text'],
 	.contact-form input[type='email'],
 	.contact-form input[type='tel'],
-	.contact-form input[type='url'] {
+	.contact-form input[type='url'],
+	.contact-form input[type='number'] {
 		width: 50%;
 	}
 
@@ -321,7 +325,8 @@
 	.wp-block-jetpack-contact-form input[type='text'],
 	.wp-block-jetpack-contact-form input[type='email'],
 	.wp-block-jetpack-contact-form input[type='tel'],
-	.wp-block-jetpack-contact-form input[type='url'] {
+	.wp-block-jetpack-contact-form input[type='url'],
+	.wp-block-jetpack-contact-form input[type='number'] {
 		width: 100%;
 	}
 }

--- a/projects/plugins/jetpack/changelog/add-forms-number-input
+++ b/projects/plugins/jetpack/changelog/add-forms-number-input
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms block: add number input

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/constants.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/constants.ts
@@ -1,6 +1,7 @@
 // All Jetpack Form blocks to extend
 export const JETPACK_FORM_CHILDREN_BLOCKS = [
 	'jetpack/field-name',
+	'jetpack/field-number',
 	'jetpack/field-email',
 	'jetpack/field-text',
 	'jetpack/field-textarea',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Issue https://github.com/Automattic/jetpack/issues/40961

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds simple number field
* No min/max/step attributes for now as those can be added in follow-up PR.
* Input is quite wide in editor, but how forms layout/CSS is done doesn't make it straightforward to correct. Good for follow-up PR.

<img width="449" alt="Screenshot 2025-02-11 at 12 18 10" src="https://github.com/user-attachments/assets/50f1b5c1-cef8-4a9b-9aa6-d351c60f07d6" />

<img width="405" alt="Screenshot 2025-02-11 at 13 02 09" src="https://github.com/user-attachments/assets/d0b8a748-4f81-49ba-b476-8c4008164800" />

Disables setting placeholders via sidebar, allowing setting them only in the editor (and thus only be number values for now) — PR for general improvement for all fields in https://github.com/Automattic/jetpack/pull/41712

<img width="1060" alt="Screenshot 2025-02-13 at 12 57 43" src="https://github.com/user-attachments/assets/556c5c37-825e-48b7-a326-8267a66dcd93" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In forms, add number input. 
* Try different default values; can be only numberic
* Try setting placeholder in the editor
* Try submit the input with correct and incorrect information
* Try hack the values, should accept only numeric values
* Try export values

Number needs to appear in several places after submitting:

Confirmation message
<img width="750" alt="Screenshot 2025-02-11 at 14 15 41" src="https://github.com/user-attachments/assets/ba5fbe1d-4cb0-4826-91fb-85410d811fd1" />

Email
<img width="447" alt="Screenshot 2025-02-11 at 13 55 36" src="https://github.com/user-attachments/assets/82e80a06-8d98-4008-957d-cd1be7832908" />

Inbox
<img width="1125" alt="Screenshot 2025-02-11 at 13 54 42" src="https://github.com/user-attachments/assets/8bb779c1-6240-4d90-ab5a-3421ca0db7fe" />

Export
<img width="503" alt="Screenshot 2025-02-11 at 14 04 39" src="https://github.com/user-attachments/assets/80ac7069-e340-4608-b64f-69424d107be1" />
