### PR TITLE
Forms: fix seperators not aligning consistently

### DIFF
--- a/projects/packages/forms/changelog/fix-25025-form-seperator
+++ b/projects/packages/forms/changelog/fix-25025-form-seperator
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Improves the styling options of the seperator block when places inside the form block
+Improves the styling options of the separator block when placed inside the form block

--- a/projects/packages/forms/changelog/fix-25025-form-seperator
+++ b/projects/packages/forms/changelog/fix-25025-form-seperator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improves the styling options of the seperator block when places inside the form block

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -94,7 +94,7 @@
 				align-self: center;
 			}
 
-			&:where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-default ){
+			&:where( .wp-block-jetpack-contact-form .wp-block-separator ){
 				max-width: var(--wp-preset--spacing--80, 150px);
 				margin-left: auto;
 				margin-right: auto;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -94,8 +94,8 @@
 				align-self: center;
 			}
 
-			&:where(.wp-block-separator:not(.is-style-wide):not(.is-style-dots):not(.alignwide):not(.alignfull)){
-				max-width: var(--wp--preset--spacing--60);
+			&:where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-default ){
+				max-width: var(--wp-preset--spacing--80, 150px);
 				margin-left: auto;
 				margin-right: auto;
 			}

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -95,7 +95,7 @@
 			}
 
 			&:where( .wp-block-jetpack-contact-form .wp-block-separator ){
-				max-width: var(--wp-preset--spacing--80, 150px);
+				max-width: var( --wp--preset--spacing--80, 100px );
 				margin-left: auto;
 				margin-right: auto;
 			}

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -99,8 +99,8 @@
 				margin-left: auto;
 				margin-right: auto;
 			}
-			:where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-wide ),
-			:where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-dots ) {
+			&:where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-wide ),
+			&:where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-dots ) {
 				max-width: inherit;
 			}
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -93,6 +93,12 @@
 			&[data-type='jetpack/field-consent'] {
 				align-self: center;
 			}
+
+			&:where(.wp-block-separator:not(.is-style-wide):not(.is-style-dots):not(.alignwide):not(.alignfull)){
+				max-width: var(--wp--preset--spacing--60);
+				margin-left: auto;
+				margin-right: auto;
+			}
 		}
 	}
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -99,6 +99,11 @@
 				margin-left: auto;
 				margin-right: auto;
 			}
+			:where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-wide ),
+			:where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-dots ) {
+				max-width: inherit;
+			}
+
 		}
 	}
 

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -236,7 +236,7 @@
 }
 
 :where( .wp-block-jetpack-contact-form .wp-block-separator ) {
-	max-width: var(--wp-preset--spacing--80, 150px );
+	max-width: var( --wp--preset--spacing--80, 100px );
 	margin-top: 0;
 	margin-bottom: 0;
 }

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -234,8 +234,9 @@
 	flex: 0 0 100%;
 	box-sizing: border-box;
 }
-.wp-block-jetpack-contact-form .wp-block-separator:not(.is-style-wide):not(.is-style-dots):not(.alignwide):not(.alignfull) {
-	max-width: var(--wp--preset--spacing--60);
+
+:where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-default ) {
+	max-width: var(--wp-preset--spacing--80, 150px );
 }
 
 /* Added circa Nov 2022: container class assigned to topmost block div */

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -234,6 +234,9 @@
 	flex: 0 0 100%;
 	box-sizing: border-box;
 }
+.wp-block-jetpack-contact-form .wp-block-separator:not(.is-style-wide):not(.is-style-dots):not(.alignwide):not(.alignfull) {
+	max-width: var(--wp--preset--spacing--60);
+}
 
 /* Added circa Nov 2022: container class assigned to topmost block div */
 .wp-block-jetpack-contact-form-container.alignfull .wp-block-jetpack-contact-form {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -229,10 +229,6 @@
 	flex-grow: 1;
 	gap: var(--wp--style--block-gap, 1.5rem);
 }
-:where( .wp-block-jetpack-contact-form .wp-block-separator ) {
-	margin-top: 0;
-	margin-bottom: 0;
-}
 
 .wp-block-jetpack-contact-form > *:not(.wp-block-jetpack-button) {
 	flex: 0 0 100%;
@@ -241,6 +237,8 @@
 
 :where( .wp-block-jetpack-contact-form .wp-block-separator ) {
 	max-width: var(--wp-preset--spacing--80, 150px );
+	margin-top: 0;
+	margin-bottom: 0;
 }
 :where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-wide ),
 :where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-dots ) {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -229,6 +229,10 @@
 	flex-grow: 1;
 	gap: var(--wp--style--block-gap, 1.5rem);
 }
+:where( .wp-block-jetpack-contact-form .wp-block-separator ) {
+	margin-top: 0;
+	margin-bottom: 0;
+}
 
 .wp-block-jetpack-contact-form > *:not(.wp-block-jetpack-button) {
 	flex: 0 0 100%;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -235,8 +235,12 @@
 	box-sizing: border-box;
 }
 
-:where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-default ) {
+:where( .wp-block-jetpack-contact-form .wp-block-separator ) {
 	max-width: var(--wp-preset--spacing--80, 150px );
+}
+:where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-wide ),
+:where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-dots ) {
+	max-width: inherit;
 }
 
 /* Added circa Nov 2022: container class assigned to topmost block div */

--- a/projects/plugins/jetpack/changelog/fix-25025-form-seperator
+++ b/projects/plugins/jetpack/changelog/fix-25025-form-seperator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Improve the styling of the sperator block when place inside the form block

--- a/projects/plugins/jetpack/changelog/fix-25025-form-seperator
+++ b/projects/plugins/jetpack/changelog/fix-25025-form-seperator
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Forms: Improve the styling of the sperator block when place inside the form block
+Forms: Improve the styling of the separator block when placed inside the form block


### PR DESCRIPTION
Fixes #25025

In my testing I wasn't able to identify the issues that were reported in the Issue. but I did notice that the default spectator doesn't match how the design looks when the seperator is not in the form and has the default styles applied to it. 

## Proposed changes:
* This PR Fixes how the default sperator appears in the contact form. 
* Now it is a fixes with that is centerd the width is overwritable by the theme if the theme does provide a max-with value. 

Before:
![image](https://github.com/user-attachments/assets/48e650a1-22ff-4b54-8e51-55673d176c42)

![image](https://github.com/user-attachments/assets/19bc2304-e866-4988-8e7a-78eb0eaeb9e2)


After:

![image](https://github.com/user-attachments/assets/b77713eb-766a-45db-bea8-0fcc2916e282)

![image](https://github.com/user-attachments/assets/74e378ed-94b2-4d37-9519-c612320578f6)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:


* Apply this PR
* Insert a form and add a seperator to it. 
* Notice that it looks as expected when you apply different styles to it. 
* Notice that it looks as expected on the front end as well. 
* Notice that it this works across many themes. 

