### PR TITLE
Add/api sandboxed tag to my jetpack

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,6 +416,9 @@ importers:
       '@automattic/format-currency':
         specifier: 1.0.1
         version: 1.0.1
+      '@automattic/jetpack-api':
+        specifier: workspace:*
+        version: link:../api
       '@automattic/jetpack-boost-score-api':
         specifier: workspace:*
         version: link:../boost-score-api

--- a/projects/js-packages/components/changelog/add-optional-api-sandboxed-tag-to-admin-page-component
+++ b/projects/js-packages/components/changelog/add-optional-api-sandboxed-tag-to-admin-page-component
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add an optional sandboxed tag to show if the current user is sandboxing their API. This is mostly for devs

--- a/projects/js-packages/components/components/admin-page/index.tsx
+++ b/projects/js-packages/components/components/admin-page/index.tsx
@@ -61,11 +61,11 @@ const AdminPage: React.FC< AdminPageProps > = ( {
 		<div className={ rootClassName }>
 			{ showHeader && (
 				<Container horizontalSpacing={ 5 }>
-					<Col>{ header ? header : <JetpackLogo /> }</Col>
-					{ sandboxedDomain && (
-						<Col>
+					<Col className={ styles[ 'admin-page-header' ] }>
+						{ header ? header : <JetpackLogo /> }
+						{ sandboxedDomain && (
 							<code
-								id="sandbox-domain-badge"
+								className={ styles[ 'sandbox-domain-badge' ] }
 								onClick={ testConnection }
 								onKeyDown={ testConnection }
 								// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
@@ -75,8 +75,8 @@ const AdminPage: React.FC< AdminPageProps > = ( {
 							>
 								API Sandboxed
 							</code>
-						</Col>
-					) }
+						) }
+					</Col>
 				</Container>
 			) }
 			<Container fluid horizontalSpacing={ 0 }>

--- a/projects/js-packages/components/components/admin-page/index.tsx
+++ b/projects/js-packages/components/components/admin-page/index.tsx
@@ -31,8 +31,8 @@ const AdminPage: React.FC< AdminPageProps > = ( {
 	header,
 } ) => {
 	useEffect( () => {
-		restApi.setRoot( apiRoot );
-		restApi.setNonce( apiNonce );
+		restApi.setApiRoot( apiRoot );
+		restApi.setApiNonce( apiNonce );
 	}, [ apiRoot, apiNonce ] );
 
 	const rootClassName = clsx( styles[ 'admin-page' ], {

--- a/projects/js-packages/components/components/admin-page/index.tsx
+++ b/projects/js-packages/components/components/admin-page/index.tsx
@@ -1,5 +1,7 @@
-import { __ } from '@wordpress/i18n';
+import restApi from '@automattic/jetpack-api';
+import { __, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
+import { useEffect, useCallback } from 'react';
 import JetpackFooter from '../jetpack-footer';
 import JetpackLogo from '../jetpack-logo';
 import Col from '../layout/col';
@@ -23,17 +25,58 @@ const AdminPage: React.FC< AdminPageProps > = ( {
 	showHeader = true,
 	showFooter = true,
 	showBackground = true,
+	sandboxedDomain = '',
+	apiRoot = '',
+	apiNonce = '',
 	header,
 } ) => {
+	useEffect( () => {
+		restApi.setRoot( apiRoot );
+		restApi.setNonce( apiNonce );
+	}, [ apiRoot, apiNonce ] );
+
 	const rootClassName = clsx( styles[ 'admin-page' ], {
 		[ styles.background ]: showBackground,
 	} );
+
+	const testConnection = useCallback( async () => {
+		try {
+			const connectionTest = await restApi.fetchSiteConnectionTest();
+
+			// eslint-disable-next-line no-alert
+			window.alert( connectionTest.message );
+		} catch ( error ) {
+			// eslint-disable-next-line no-alert
+			window.alert(
+				sprintf(
+					/* translators: placeholder is an error message. */
+					__( 'There was an error testing Jetpack. Error: %s', 'jetpack-components' ),
+					error.message
+				)
+			);
+		}
+	}, [] );
 
 	return (
 		<div className={ rootClassName }>
 			{ showHeader && (
 				<Container horizontalSpacing={ 5 }>
 					<Col>{ header ? header : <JetpackLogo /> }</Col>
+					{ sandboxedDomain && (
+						<Col>
+							<code
+								id="sandbox-domain-badge"
+								onClick={ testConnection }
+								onKeyDown={ testConnection }
+								// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
+								role="button"
+								tabIndex={ 0 }
+								title={ `Sandboxing via ${ sandboxedDomain }. Click to test connection.` }
+							>
+								API Sandboxed
+							</code>
+						</Col>
+					) }
 				</Container>
 			) }
 			<Container fluid horizontalSpacing={ 0 }>

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -8,15 +8,21 @@
 	&.background {
 		background-color: var(--jp-white);
 	}
-}
 
-#sandbox-domain-badge {
-	background: #d63638;
-	text-transform: uppercase;
-	letter-spacing: 0.2em;
-	text-shadow: none;
-	font-size: 9px;
-	font-weight: bold;
-	cursor: pointer;
-	color: #ffffff;
+	.admin-page-header {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.sandbox-domain-badge {
+		background: #d63638;
+		text-transform: uppercase;
+		letter-spacing: 0.2em;
+		text-shadow: none;
+		font-size: 9px;
+		font-weight: bold;
+		cursor: pointer;
+		color: #ffffff;
+	}
 }

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -9,3 +9,14 @@
 		background-color: var(--jp-white);
 	}
 }
+
+#sandbox-domain-badge {
+	background: #d63638;
+	text-transform: uppercase;
+	letter-spacing: 0.2em;
+	text-shadow: none;
+	font-size: 9px;
+	font-weight: bold;
+	cursor: pointer;
+	color: #ffffff;
+}

--- a/projects/js-packages/components/components/admin-page/types.ts
+++ b/projects/js-packages/components/components/admin-page/types.ts
@@ -38,4 +38,19 @@ export type AdminPageProps = {
 	 * URL of the site WP Admin.
 	 */
 	siteAdminUrl?: string;
+
+	/**
+	 * The domain of the sanboxed API.
+	 */
+	sandboxedDomain?: string;
+
+	/**
+	 * The root URL of the API.
+	 */
+	apiRoot?: string;
+
+	/**
+	 * The nonce of the API.
+	 */
+	apiNonce?: string;
 };

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -16,6 +16,7 @@
 	"dependencies": {
 		"@automattic/format-currency": "1.0.1",
 		"@automattic/jetpack-boost-score-api": "workspace:*",
+		"@automattic/jetpack-api": "workspace:*",
 		"@automattic/jetpack-scan": "workspace:*",
 		"@babel/runtime": "^7",
 		"@wordpress/browserslist-config": "6.14.0",

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -85,7 +85,12 @@ export default function MyJetpackScreen() {
 	} );
 	useNotificationWatcher();
 	const { redBubbleAlerts } = getMyJetpackWindowInitialState();
-	const { isAtomic = false, jetpackManage = {}, adminUrl } = getMyJetpackWindowInitialState();
+	const {
+		isAtomic = false,
+		jetpackManage = {},
+		adminUrl,
+		sandboxedDomain,
+	} = getMyJetpackWindowInitialState();
 
 	const { isWelcomeBannerVisible } = useWelcomeBanner();
 	const { isSectionVisible } = useEvaluationRecommendations();
@@ -136,7 +141,7 @@ export default function MyJetpackScreen() {
 	}
 
 	return (
-		<AdminPage siteAdminUrl={ adminUrl }>
+		<AdminPage siteAdminUrl={ adminUrl } sandboxedDomain={ sandboxedDomain }>
 			<hr className={ styles.separator } />
 
 			<IDCModal />

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -94,7 +94,7 @@ export default function MyJetpackScreen() {
 
 	const { isWelcomeBannerVisible } = useWelcomeBanner();
 	const { isSectionVisible } = useEvaluationRecommendations();
-	const { siteIsRegistered } = useMyJetpackConnection();
+	const { siteIsRegistered, apiRoot, apiNonce } = useMyJetpackConnection();
 	const { currentNotice } = useContext( NoticeContext );
 	const {
 		message: noticeMessage,
@@ -141,7 +141,12 @@ export default function MyJetpackScreen() {
 	}
 
 	return (
-		<AdminPage siteAdminUrl={ adminUrl } sandboxedDomain={ sandboxedDomain }>
+		<AdminPage
+			siteAdminUrl={ adminUrl }
+			sandboxedDomain={ sandboxedDomain }
+			apiRoot={ apiRoot }
+			apiNonce={ apiNonce }
+		>
 			<hr className={ styles.separator } />
 
 			<IDCModal />

--- a/projects/packages/my-jetpack/changelog/add-api-sandboxed-tag-to-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/add-api-sandboxed-tag-to-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add sandboxed tag to My Jetpack

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -448,6 +448,7 @@ interface Window {
 		};
 		topJetpackMenuItemUrl: string;
 		isAtomic: boolean;
+		sandboxedDomain: string;
 		userIsAdmin: string;
 		userIsNewToJetpack: string;
 	};

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -290,6 +290,7 @@ class Initializer {
 				'isStatsModuleActive'    => $modules->is_active( 'stats' ),
 				'isUserFromKnownHost'    => self::is_user_from_known_host(),
 				'isCommercial'           => self::is_commercial_site(),
+				'sandboxedDomain'        => defined( JETPACK__SANDBOX_DOMAIN ) ?? '',
 				'isAtomic'               => ( new Status_Host() )->is_woa_site(),
 				'jetpackManage'          => array(
 					'isEnabled'       => Jetpack_Manage::could_use_jp_manage(),

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -290,7 +290,7 @@ class Initializer {
 				'isStatsModuleActive'    => $modules->is_active( 'stats' ),
 				'isUserFromKnownHost'    => self::is_user_from_known_host(),
 				'isCommercial'           => self::is_commercial_site(),
-				'sandboxedDomain'        => defined( JETPACK__SANDBOX_DOMAIN ) ?? '',
+				'sandboxedDomain'        => defined( JETPACK__SANDBOX_DOMAIN ) ? JETPACK__SANDBOX_DOMAIN : '',
 				'isAtomic'               => ( new Status_Host() )->is_woa_site(),
 				'jetpackManage'          => array(
 					'isEnabled'       => Jetpack_Manage::could_use_jp_manage(),

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -290,7 +290,7 @@ class Initializer {
 				'isStatsModuleActive'    => $modules->is_active( 'stats' ),
 				'isUserFromKnownHost'    => self::is_user_from_known_host(),
 				'isCommercial'           => self::is_commercial_site(),
-				'sandboxedDomain'        => defined( JETPACK__SANDBOX_DOMAIN ) ? JETPACK__SANDBOX_DOMAIN : '',
+				'sandboxedDomain'        => JETPACK__SANDBOX_DOMAIN,
 				'isAtomic'               => ( new Status_Host() )->is_woa_site(),
 				'jetpackManage'          => array(
 					'isEnabled'       => Jetpack_Manage::could_use_jp_manage(),


### PR DESCRIPTION
## Proposed changes:

* Update the Admin Page component to allow an option prop that shows the "API Sandboxed" tag in the header of the page if applicable

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

NOTE:
* If creating a JN site, make sure to select `Enable Sandbox Access`. Once the site is created, go to `/wp-admin/options-general.php?page=companion_settings` and set the constant to your sandbox domain
* If using your local environment, ensure you have the `JETPACK__SANDBOX_DOMAIN` set in your wp-config.php file

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Go to My Jetpack and ensure that you can see the `API SANDBOXED` tag
![image](https://github.com/user-attachments/assets/0e145c41-61a5-4e5c-bfac-f7c0b0c87785)
3. Click on it and make sure it checks the connection for you
![image](https://github.com/user-attachments/assets/0885be29-8f5a-43b4-9d62-ec50541e5e85)
