### PR TITLE
Resolves #40969 - Allow three-letter language code translations in notifications pane

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-40969-notifications_pane_language_bug
+++ b/projects/plugins/jetpack/changelog/fix-40969-notifications_pane_language_bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Notifications: Support three-letter language code translations.

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -192,12 +192,18 @@ class Jetpack_Notifications {
 		$third_party_cookie_check_iframe = '<span style="display:none;"><iframe class="jetpack-notes-cookie-check" src="https://widgets.wp.com/3rd-party-cookie-check/index.html"></iframe></span>';
 
 		$title = self::get_notes_markup();
+
+		// The default fallback is `en_US`. Remove underscore if present, noting that lang codes can be more than three chars.
+		if ( str_contains( '_' ) ) {
+			$user_locale = strtolower( explode( '_', $user_locale, 2 )[0] );
+		}
+
 		$wp_admin_bar->add_menu(
 			array(
 				'id'     => 'notes',
 				'title'  => $title,
 				'meta'   => array(
-					'html'  => '<div id="wpnt-notes-panel2" class="intrinsic-ignore" style="display:none" lang="' . esc_attr( strtolower( substr( $user_locale, 0, 2 ) ) ) . '" dir="' . ( is_rtl() ? 'rtl' : 'ltr' ) . '"><div class="wpnt-notes-panel-header"><span class="wpnt-notes-header">' . __( 'Notifications', 'jetpack' ) . '</span><span class="wpnt-notes-panel-link"></span></div></div>' . $third_party_cookie_check_iframe,
+					'html'  => '<div id="wpnt-notes-panel2" class="intrinsic-ignore" style="display:none" lang="' . esc_attr( $user_locale ) . '" dir="' . ( is_rtl() ? 'rtl' : 'ltr' ) . '"><div class="wpnt-notes-panel-header"><span class="wpnt-notes-header">' . __( 'Notifications', 'jetpack' ) . '</span><span class="wpnt-notes-panel-link"></span></div></div>' . $third_party_cookie_check_iframe,
 					'class' => 'menupop',
 				),
 				'parent' => 'top-secondary',

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -194,9 +194,7 @@ class Jetpack_Notifications {
 		$title = self::get_notes_markup();
 
 		// The default fallback is `en_US`. Remove underscore if present, noting that lang codes can be more than three chars.
-		if ( str_contains( '_' ) ) {
-			$user_locale = strtolower( explode( '_', $user_locale, 2 )[0] );
-		}
+		$user_locale = strtolower( explode( '_', $user_locale, 2 )[0] );
 
 		$wp_admin_bar->add_menu(
 			array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves #40969 - Allow three-letter language code translations in notifications pane

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
As of #38871 we truncate the language code in the Notifications panel, but some language codes are three letters long.

This PR corrects this issue by using `explode()` on `_` rather than using `substr()`.

Note that I looked for similar instances of code but this was the only one I saw.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Set locale to `roh` (Romansh) in WordPress.
2. Connect to WordPress.com.
3. Open Notifications widget.

In `trunk`, the notification panel is in Romanian (`ro`). In the `fix/40969/notifications_pane_language_bug` branch, it's in Romansh (`roh`).
