### PR TITLE
Forms: Fix select field height

### DIFF
--- a/projects/packages/forms/changelog/fix-select-field-height
+++ b/projects/packages/forms/changelog/fix-select-field-height
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fixed select control height

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -60,6 +60,7 @@
 .contact-form select {
 	padding: 14px 7px;
 	min-width: 150px;
+	height: auto;
 }
 
 .contact-form input[type='radio'],


### PR DESCRIPTION
## Proposed changes:

I found this bug while working on a related issue. It is theme dependent. For contact form fields, we allow the theme to determine most field styling. When using Astra theme, I noticed the Select dropdown has a fixed height that cuts off the content. See before/after pictures below. 

This is not an issue with other theme I checked (Twenty-series, including 2023, 2024, 2025). Astra imposes a field height of 40px on form fields, which is not high enough. 

One fix is to put height:auto on the select field. That's what this PR does. But this requires a bit of discussion. Add this CSS will mean that the field is no longer directly inheriting theme styles, so there may be inconsistency in the form field sizes on the form. 

Welcome thoughts and feedback.

**Before (with Astra Theme):**
<img width="1243" alt="contact-form-select-before" src="https://github.com/user-attachments/assets/6d72615e-577b-4c3f-bb53-a1732530d460" />


**After (with Astra Theme):**
<img width="1204" alt="select-control-after" src="https://github.com/user-attachments/assets/353f65f9-dd81-48d9-a42a-de7807700755" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Update your WordPress instance to the free Astra theme.
* Go to page and insert a form with a select dropdown field. 
* Go the frontend and confirm that the field is not cut off as in the above photos.

