### PR TITLE
Code coverage: Fix warnings in scheduled updates package

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-scheduled-updates-coverage_warnings
+++ b/projects/packages/scheduled-updates/changelog/fix-scheduled-updates-coverage_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Code: Fix @covers annotations.

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-admin-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-admin-test.php
@@ -10,7 +10,7 @@ namespace Automattic\Jetpack;
 /**
  * Test class for Scheduled_Updates_Admin.
  *
- * @coversDefaultClass Scheduled_Updates_Admin
+ * @coversDefaultClass Automattic\Jetpack\Scheduled_Updates_Admin
  */
 class Scheduled_Updates_Admin_Test extends \WorDBless\BaseTestCase {
 	/**

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-health-paths-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-health-paths-test.php
@@ -11,7 +11,7 @@ use Automattic\Jetpack\Scheduled_Updates_Health_Paths;
 /**
  * Test class for Scheduled_Updates_Health_Paths.
  *
- * @coversDefaultClass Scheduled_Updates_Health_Paths
+ * @coversDefaultClass Automattic\Jetpack\Scheduled_Updates_Health_Paths
  */
 class Scheduled_Updates_Health_Paths_Test extends \WorDBless\BaseTestCase {
 

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-logs-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-logs-test.php
@@ -10,7 +10,7 @@ namespace Automattic\Jetpack;
 /**
  * Test class for Scheduled_Updates_Logs.
  *
- * @coversDefaultClass Scheduled_Updates_Logs
+ * @coversDefaultClass Automattic\Jetpack\Scheduled_Updates_Logs
  */
 class Scheduled_Updates_Logs_Test extends \WorDBless\BaseTestCase {
 

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
@@ -10,7 +10,7 @@ namespace Automattic\Jetpack;
 /**
  * Test class for Scheduled_Updates.
  *
- * @coversDefaultClass Scheduled_Updates
+ * @coversDefaultClass Automattic\Jetpack\Scheduled_Updates
  */
 class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 
@@ -659,7 +659,7 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	/**
 	 * Test when all requested plugins are not installed.
 	 *
-	 * @covers ::verify_plugins
+	 * @covers WPCOM_REST_API_V2_Endpoint_Update_Schedules::validate_plugins_param
 	 */
 	public function test_verify_plugins_not_installed() {
 		$plugins = array( 'not-installed-plugin-1/not-installed-plugin-1.php', 'not-installed-plugin-2/not-installed-plugin-2.php' );
@@ -686,7 +686,7 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	/**
 	 * Test when all requested plugins are managed.
 	 *
-	 * @covers ::verify_plugins
+	 * @covers WPCOM_REST_API_V2_Endpoint_Update_Schedules::validate_plugins_param
 	 */
 	public function test_verify_plugins_all_managed() {
 		$plugins = array( 'managed-plugin-1/managed-plugin-1.php', 'managed-plugin-2/managed-plugin-2.php' );
@@ -713,7 +713,7 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	/**
 	 * Test when one requested plugin is installed and not managed, and another is installed but managed.
 	 *
-	 * @covers ::verify_plugins
+	 * @covers WPCOM_REST_API_V2_Endpoint_Update_Schedules::validate_plugins_param
 	 */
 	public function test_verify_plugins_installed_mixed() {
 		$plugins = array( 'managed-plugin/managed-plugin.php', 'installed-plugin/installed-plugin.php' );

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-active-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-active-test.php
@@ -91,7 +91,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test extends \WorDBless
 	/**
 	 * Test update_item.
 	 *
-	 * @covers update_item
+	 * @covers ::update_item
 	 */
 	public function test_active_is_true_by_default() {
 		$plugins   = array( 'gutenberg/gutenberg.php' );
@@ -124,7 +124,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test extends \WorDBless
 	/**
 	 * Test update_item.
 	 *
-	 * @covers update_item
+	 * @covers ::update_item
 	 */
 	public function test_set_active_false_update_active_flag() {
 		$plugins   = array(
@@ -179,7 +179,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test extends \WorDBless
 	/**
 	 * Test update_item.
 	 *
-	 * @covers update_item
+	 * @covers ::update_item
 	 */
 	public function test_run_inactive_schedule() {
 		$plugins   = array(
@@ -217,7 +217,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test extends \WorDBless
 	/**
 	 * Test update_item.
 	 *
-	 * @covers update_item
+	 * @covers ::update_item
 	 */
 	public function test_run_active_schedule() {
 		$plugins   = array( 'gutenberg/gutenberg.php' );
@@ -251,7 +251,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test extends \WorDBless
 	/**
 	 * Test update_item update cron.
 	 *
-	 * @covers update_item
+	 * @covers ::update_item
 	 */
 	public function test_set_active_false_update_sync_option() {
 		$plugins   = array(

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -385,7 +385,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	/**
 	 * Can't have more than two schedules.
 	 *
-	 * @covers ::create
+	 * @covers ::create_item
 	 */
 	public function test_empty_last_run() {
 		$plugins = array( 'gutenberg/gutenberg.php' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When running code coverage tests on `scheduled-updates`, we get 34 warnings due to errant `@covers` annotations. This PR corrects those.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Check the CI Tests → Code Coverage run. On `trunk` it looks like this:
https://github.com/Automattic/jetpack/actions/runs/12717372492/job/35453699359#step:10:8096

With this branch the warnings should be gone.