### PR TITLE
Social | Clean up connections controller to use connections class

### DIFF
--- a/projects/packages/publicize/.phan/baseline.php
+++ b/projects/packages/publicize/.phan/baseline.php
@@ -9,7 +9,7 @@
  */
 return [
     // # Issue statistics:
-    // PhanPluginDuplicateConditionalNullCoalescing : 6 occurrences
+    // PhanPluginDuplicateConditionalNullCoalescing : 8 occurrences
     // PhanTypeMismatchArgument : 6 occurrences
     // PhanTypeMismatchArgumentNullable : 3 occurrences
     // PhanDeprecatedFunction : 2 occurrences
@@ -29,11 +29,13 @@ return [
     // PhanTypeMismatchDefault : 1 occurrence
     // PhanTypeMismatchDimFetch : 1 occurrence
     // PhanTypeMismatchReturn : 1 occurrence
+    // PhanTypeSuspiciousNonTraversableForeach : 1 occurrence
     // PhanUndeclaredFunction : 1 occurrence
     // PhanUndeclaredMethod : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
+        'src/class-connections.php' => ['PhanUndeclaredMethod'],
         'src/class-keyring-helper.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault'],
         'src/class-publicize-base.php' => ['PhanImpossibleCondition', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanSuspiciousMagicConstant', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchDimFetch', 'PhanTypeMismatchReturn'],
         'src/class-publicize-setup.php' => ['PhanNoopNew', 'PhanTypeMismatchArgument'],
@@ -41,8 +43,9 @@ return [
         'src/class-publicize.php' => ['PhanParamSignatureMismatch', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMissingReturn'],
         'src/class-rest-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
         'src/rest-api/class-base-controller.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
-        'src/rest-api/class-connections-controller.php' => ['PhanPluginMixedKeyNoKey', 'PhanUndeclaredMethod'],
+        'src/rest-api/class-connections-controller.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeSuspiciousNonTraversableForeach'],
         'src/rest-api/class-connections-post-field.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
+        'src/rest-api/class-proxy-requests.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/social-image-generator/class-post-settings.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/social-image-generator/class-rest-settings-controller.php' => ['PhanPluginMixedKeyNoKey'],
         'src/social-image-generator/class-settings.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],

--- a/projects/packages/publicize/changelog/update-social-clean-up-connections-controller
+++ b/projects/packages/publicize/changelog/update-social-clean-up-connections-controller
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Moved the connections specific logic from controller to the connections class

--- a/projects/packages/publicize/src/class-connections.php
+++ b/projects/packages/publicize/src/class-connections.php
@@ -8,8 +8,8 @@
 namespace Automattic\Jetpack\Publicize;
 
 use Automattic\Jetpack\Connection;
-use Automattic\Jetpack\Publicize\REST_API\Connections_Controller;
-use Automattic\Jetpack\Status\Host;
+use Automattic\Jetpack\Publicize\REST_API\Proxy_Requests;
+use WP_REST_Request;
 
 /**
  * Publicize Connections class.
@@ -27,10 +27,8 @@ class Connections {
 	 */
 	public static function get_all( $args = array() ) {
 
-		$is_wpcom = ( new Host() )->is_wpcom_simple();
-
-		if ( $is_wpcom ) {
-			$connections = Connections_Controller::get_connections();
+		if ( Publicize_Utils::is_wpcom() ) {
+			$connections = self::wpcom_get_connections( array( 'context' => 'site' ) );
 		} else {
 
 			$ignore_cache = $args['ignore_cache'] ?? false;
@@ -82,7 +80,7 @@ class Connections {
 	 * @return bool
 	 */
 	public static function user_owns_connection( $connection, $user_id = null ) {
-		if ( ( new Host() )->is_wpcom_simple() ) {
+		if ( Publicize_Utils::is_wpcom() ) {
 			$wpcom_user_id = get_current_user_id();
 		} else {
 
@@ -131,12 +129,7 @@ class Connections {
 	 * @return array
 	 */
 	public static function fetch_and_cache_connections() {
-		$args = array(
-			// Request all connections.
-			'scope' => 'site',
-		);
-
-		$connections = Connections_Controller::get_connections( $args );
+		$connections = self::fetch_site_connections();
 
 		if ( is_array( $connections ) ) {
 			if ( ! set_transient( self::CONNECTIONS_TRANSIENT, $connections, HOUR_IN_SECONDS * 4 ) ) {
@@ -149,6 +142,143 @@ class Connections {
 		}
 
 		return $connections;
+	}
+
+	/**
+	 * Fetch connections for the site from WPCOM REST API.
+	 *
+	 * @return array
+	 */
+	public static function fetch_site_connections() {
+		$proxy = new Proxy_Requests( 'publicize/connections' );
+
+		$request = new WP_REST_Request( 'GET', '/wpcom/v2/publicize/connections' );
+
+		$connections = $proxy->proxy_request_to_wpcom( $request, '', 'blog' );
+
+		if ( is_wp_error( $connections ) ) {
+			// @todo log error.
+			return array();
+		}
+
+		return $connections;
+	}
+
+	/**
+	 * Get all connections. Meant to be called directly only on WPCOM.
+	 *
+	 * @param array $args Arguments
+	 *                    - 'test_connections': bool Whether to run connection tests.
+	 *                    - 'context': enum('blog', 'user') Whether to include connections for the current blog or user.
+	 *
+	 * @return array
+	 */
+	public static function wpcom_get_connections( $args = array() ) {
+		// Ensure that we are on WPCOM.
+		Publicize_Utils::assert_is_wpcom( __METHOD__ );
+
+		/**
+		 * Publicize instance.
+		 */
+		global $publicize;
+
+		$items = array();
+
+		$run_tests = $args['test_connections'] ?? false;
+
+		$test_results = $run_tests ? self::get_test_status() : array();
+
+		if ( isset( $args['context'] ) && 'blog' === $args['context'] ) {
+			$service_connections = $publicize->get_all_connections_for_blog_id( get_current_blog_id() );
+		} else {
+			$service_connections = (array) $publicize->get_services( 'connected' );
+		}
+
+		foreach ( $service_connections as $service_name => $connections ) {
+			foreach ( $connections as $connection ) {
+				$connection_id = $publicize->get_connection_id( $connection );
+
+				$item = self::wpcom_prepare_connection_data( $connection, $service_name );
+
+				$item['status'] = $test_results[ $connection_id ] ?? null;
+
+				$items[] = $item;
+			}
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Filters out data based on ?_fields= request parameter
+	 *
+	 * @param mixed  $connection   Connection to prepare.
+	 * @param string $service_name Service name.
+	 *
+	 * @return array
+	 */
+	private static function wpcom_prepare_connection_data( $connection, $service_name ) {
+		// Ensure that we are on WPCOM.
+		Publicize_Utils::assert_is_wpcom( __METHOD__ );
+
+		/**
+		 * Publicize instance.
+		 */
+		global $publicize;
+
+		$connection_id = $publicize->get_connection_id( $connection );
+
+		$connection_meta = $publicize->get_connection_meta( $connection );
+		$connection_data = $connection_meta['connection_data'];
+
+		return array(
+			'connection_id'        => $connection_id,
+			'display_name'         => $publicize->get_display_name( $service_name, $connection ),
+			'external_handle'      => $publicize->get_external_handle( $service_name, $connection ),
+			'external_id'          => $connection_meta['external_id'] ?? '',
+			'profile_link'         => $publicize->get_profile_link( $service_name, $connection ),
+			'profile_picture'      => $publicize->get_profile_picture( $connection ),
+			'service_label'        => Publicize::get_service_label( $service_name ),
+			'service_name'         => $service_name,
+			'shared'               => ! $connection_data['user_id'],
+			'user_id'              => (int) $connection_data['user_id'],
+
+			// Deprecated fields.
+			'id'                   => (string) $publicize->get_connection_unique_id( $connection ),
+			'username'             => $publicize->get_username( $service_name, $connection ),
+			'profile_display_name' => ! empty( $connection_meta['profile_display_name'] ) ? $connection_meta['profile_display_name'] : '',
+			// phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual -- We expect an integer, but do loose comparison below in case some other type is stored.
+			'global'               => 0 == $connection_data['user_id'],
+
+		);
+	}
+
+	/**
+	 * Get the connections test status.
+	 *
+	 * @return array
+	 */
+	public static function get_test_status() {
+		/**
+		 * Publicize instance.
+		 *
+		 * @var \Automattic\Jetpack\Publicize\Publicize $publicize
+		 */
+		global $publicize;
+
+		$test_results = $publicize->get_publicize_conns_test_results();
+
+		$test_results_map = array();
+
+		foreach ( $test_results as $test_result ) {
+			$result = $test_result['connectionTestPassed'];
+			if ( 'must_reauth' !== $result ) {
+				$result = $test_result['connectionTestPassed'] ? 'ok' : 'broken';
+			}
+			$test_results_map[ $test_result['connectionID'] ] = $result;
+		}
+
+		return $test_results_map;
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-publicize-utils.php
+++ b/projects/packages/publicize/src/class-publicize-utils.php
@@ -97,4 +97,16 @@ class Publicize_Utils {
 		return ( new Host() )->is_wpcom_simple();
 	}
 
+	/**
+	 * Assert that the method is only called on WPCOM.
+	 *
+	 * @param string $method The method name.
+	 *
+	 * @throws \Exception If the method is not called on WPCOM.
+	 */
+	public static function assert_is_wpcom( $method ) {
+		if ( ! self::is_wpcom() ) {
+			throw new \Exception( esc_html( "Method $method can only be called on WordPress.com." ) );
+		}
+	}
 }

--- a/projects/packages/publicize/src/class-publicize-utils.php
+++ b/projects/packages/publicize/src/class-publicize-utils.php
@@ -87,4 +87,14 @@ class Publicize_Utils {
 	public static function is_publicize_active() {
 		return ( new Modules() )->is_active( 'publicize' );
 	}
+
+	/**
+	 * Check if we are on WPCOM.
+	 *
+	 * @return bool
+	 */
+	public static function is_wpcom() {
+		return ( new Host() )->is_wpcom_simple();
+	}
+
 }

--- a/projects/packages/publicize/src/rest-api/class-base-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-base-controller.php
@@ -77,6 +77,15 @@ abstract class Base_Controller extends WP_REST_Controller {
 	 * @return true|WP_Error
 	 */
 	public function get_items_permissions_check( $request ) {// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return $this->publicize_permissions_check();
+	}
+
+	/**
+	 * Verify that user can access Publicize data
+	 *
+	 * @return true|WP_Error
+	 */
+	protected function publicize_permissions_check() {
 
 		global $publicize;
 

--- a/projects/packages/publicize/src/rest-api/class-base-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-base-controller.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack\Publicize\REST_API;
 
-use Automattic\Jetpack\Status\Host;
+use Automattic\Jetpack\Publicize\Publicize_Utils;
 use WP_Error;
 use WP_REST_Controller;
 use WP_REST_Request;
@@ -33,21 +33,12 @@ abstract class Base_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Check if we are on WPCOM.
-	 *
-	 * @return bool
-	 */
-	public static function is_wpcom() {
-		return ( new Host() )->is_wpcom_simple();
-	}
-
-	/**
 	 * Check if the request is authorized for the blog.
 	 *
 	 * @return bool
 	 */
 	protected static function is_authorized_blog_request() {
-		if ( self::is_wpcom() && is_jetpack_site( get_current_blog_id() ) ) {
+		if ( Publicize_Utils::is_wpcom() && is_jetpack_site( get_current_blog_id() ) ) {
 
 			$jp_auth_endpoint = new \WPCOM_REST_API_V2_Endpoint_Jetpack_Auth();
 

--- a/projects/packages/publicize/src/rest-api/class-connections-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-controller.php
@@ -7,9 +7,8 @@
 
 namespace Automattic\Jetpack\Publicize\REST_API;
 
-use Automattic\Jetpack\Connection\Client;
-use Automattic\Jetpack\Connection\Manager;
-use Automattic\Jetpack\Publicize\Publicize;
+use Automattic\Jetpack\Publicize\Connections;
+use Automattic\Jetpack\Publicize\Publicize_Utils;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
@@ -20,11 +19,25 @@ use WP_REST_Server;
 class Connections_Controller extends Base_Controller {
 
 	/**
+	 * The API version.
+	 *
+	 * @var string
+	 */
+	protected $version = 'v2';
+
+	/**
+	 * The base API path.
+	 *
+	 * @var string
+	 */
+	protected $base_api_path = 'wpcom';
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		parent::__construct();
-		$this->namespace = 'wpcom/v2';
+		$this->namespace = "{$this->base_api_path}/{$this->version}";
 		$this->rest_base = 'publicize/connections';
 
 		$this->allow_requests_as_blog = true;
@@ -175,113 +188,6 @@ class Connections_Controller extends Base_Controller {
 	}
 
 	/**
-	 * Get all connections. Meant to be called directly only on WPCOM.
-	 *
-	 * @param array $args Arguments
-	 *                    - 'test_connections': bool Whether to run connection tests.
-	 *                    - 'scope': enum('site', 'user') Which connections to include.
-	 *
-	 * @return array
-	 */
-	protected static function get_all_connections( $args = array() ) {
-		/**
-		 * Publicize instance.
-		 */
-		global $publicize;
-
-		$items = array();
-
-		$run_tests = $args['test_connections'] ?? false;
-
-		$test_results = $run_tests ? self::get_connections_test_status() : array();
-
-		// If a (Jetpack) blog request, return all the connections for that site.
-		if ( self::is_authorized_blog_request() ) {
-			$service_connections = $publicize->get_all_connections_for_blog_id( get_current_blog_id() );
-		} else {
-			$service_connections = (array) $publicize->get_services( 'connected' );
-		}
-
-		foreach ( $service_connections as $service_name => $connections ) {
-			foreach ( $connections as $connection ) {
-
-				$connection_id = $publicize->get_connection_id( $connection );
-
-				$connection_meta = $publicize->get_connection_meta( $connection );
-				$connection_data = $connection_meta['connection_data'];
-
-				$items[] = array(
-					'connection_id'        => $connection_id,
-					'display_name'         => $publicize->get_display_name( $service_name, $connection ),
-					'external_handle'      => $publicize->get_external_handle( $service_name, $connection ),
-					'external_id'          => $connection_meta['external_id'] ?? '',
-					'profile_link'         => $publicize->get_profile_link( $service_name, $connection ),
-					'profile_picture'      => $publicize->get_profile_picture( $connection ),
-					'service_label'        => Publicize::get_service_label( $service_name ),
-					'service_name'         => $service_name,
-					'shared'               => ! $connection_data['user_id'],
-					'status'               => $test_results[ $connection_id ] ?? null,
-					'user_id'              => (int) $connection_data['user_id'],
-
-					// Deprecated fields.
-					'id'                   => (string) $publicize->get_connection_unique_id( $connection ),
-					'username'             => $publicize->get_username( $service_name, $connection ),
-					'profile_display_name' => ! empty( $connection_meta['profile_display_name'] ) ? $connection_meta['profile_display_name'] : '',
-					// phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual -- We expect an integer, but do loose comparison below in case some other type is stored.
-					'global'               => 0 == $connection_data['user_id'],
-
-				);
-			}
-		}
-
-		return $items;
-	}
-
-	/**
-	 * Get a list of publicize connections.
-	 *
-	 * @param array $args Arguments.
-	 *
-	 * @see Automattic\Jetpack\Publicize\REST_API\Connections_Controller::get_all_connections()
-	 *
-	 * @return array
-	 */
-	public static function get_connections( $args = array() ) {
-		if ( self::is_wpcom() ) {
-			return self::get_all_connections( $args );
-		}
-
-		$site_id = Manager::get_site_id( true );
-		if ( ! $site_id ) {
-			return array();
-		}
-
-		$path = add_query_arg(
-			array(
-				'test_connections' => $args['test_connections'] ?? false,
-			),
-			sprintf( '/sites/%d/publicize/connections', $site_id )
-		);
-
-		$blog_or_user = ( $args['scope'] ?? '' ) === 'site' ? 'blog' : 'user';
-
-		$callback = array( Client::class, "wpcom_json_api_request_as_{$blog_or_user}" );
-
-		$response = call_user_func( $callback, $path, 'v2', array( 'method' => 'GET' ), null, 'wpcom' );
-
-		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			// TODO log error.
-			return array();
-		}
-
-		$body = wp_remote_retrieve_body( $response );
-
-		$items = json_decode( $body, true );
-
-		return $items ? $items : array();
-	}
-
-	/**
 	 * Get list of connected Publicize connections.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
@@ -289,14 +195,26 @@ class Connections_Controller extends Base_Controller {
 	 * @return WP_REST_Response suitable for 1-page collection
 	 */
 	public function get_items( $request ) {
+		if ( Publicize_Utils::is_wpcom() ) {
+			$args = array(
+				'context'          => self::is_authorized_blog_request() ? 'blog' : 'user',
+				'test_connections' => $request->get_param( 'test_connections' ),
+			);
+
+			$connections = Connections::wpcom_get_connections( $args );
+		} else {
+			$proxy = new Proxy_Requests( $this->rest_base );
+
+			$connections = $proxy->proxy_request_to_wpcom( $request );
+		}
+
+		if ( is_wp_error( $connections ) ) {
+			return $connections;
+		}
+
 		$items = array();
 
-		// On Jetpack, we don't want to pass the 'scope' param to get_connections().
-		$args = array(
-			'test_connections' => $request->get_param( 'test_connections' ),
-		);
-
-		foreach ( self::get_connections( $args ) as $item ) {
+		foreach ( $connections as $item ) {
 			$data = $this->prepare_item_for_response( $item, $request );
 
 			$items[] = $this->prepare_response_for_collection( $data );
@@ -307,33 +225,5 @@ class Connections_Controller extends Base_Controller {
 		$response->header( 'X-WP-TotalPages', '1' );
 
 		return $response;
-	}
-
-	/**
-	 * Get the connections test status.
-	 *
-	 * @return array
-	 */
-	protected static function get_connections_test_status() {
-		/**
-		 * Publicize instance.
-		 *
-		 * @var \Automattic\Jetpack\Publicize\Publicize $publicize
-		 */
-		global $publicize;
-
-		$test_results = $publicize->get_publicize_conns_test_results();
-
-		$test_results_map = array();
-
-		foreach ( $test_results as $test_result ) {
-			$result = $test_result['connectionTestPassed'];
-			if ( 'must_reauth' !== $result ) {
-				$result = $test_result['connectionTestPassed'] ? 'ok' : 'broken';
-			}
-			$test_results_map[ $test_result['connectionID'] ] = $result;
-		}
-
-		return $test_results_map;
 	}
 }

--- a/projects/packages/publicize/src/rest-api/class-proxy-requests.php
+++ b/projects/packages/publicize/src/rest-api/class-proxy-requests.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Helper class to make proxy requests to wpcom.
+ *
+ * @package automattic/jetpack-publicize
+ */
+
+namespace Automattic\Jetpack\Publicize\REST_API;
+
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager;
+use Automattic\Jetpack\Status\Visitor;
+use WP_Error;
+use WP_REST_Request;
+
+/**
+ * Helper class to make proxy requests to wpcom.
+ */
+class Proxy_Requests {
+
+	/**
+	 * The rest base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base;
+
+	/**
+	 * The base API path.
+	 *
+	 * @var string
+	 */
+	protected $base_api_path;
+
+	/**
+	 * The API version.
+	 *
+	 * @var string
+	 */
+	protected $version;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $rest_base The rest base.
+	 * @param string $base_api_path The base API path.
+	 * @param string $version The API version.
+	 */
+	public function __construct( $rest_base, $base_api_path = 'wpcom', $version = 'v2' ) {
+		$this->rest_base     = $rest_base;
+		$this->base_api_path = $base_api_path;
+		$this->version       = $version;
+	}
+
+	/**
+	 * Copied from WPCOM_REST_API_Proxy_Request_Trait. See the @todo below.
+	 *
+	 * Proxy request to wpcom servers on behalf of a user or using the Site-level Connection (blog token).
+	 *
+	 * @todo Swap this with the trait when it's available 🔗👇
+	 * @link https://github.com/Automattic/jetpack/issues/40947
+	 *
+	 * @param WP_Rest_Request $request Request to proxy.
+	 * @param string          $path Path to append to the rest base.
+	 * @param string          $context Can be Either 'user' or 'blog'. Defaults to 'user'.
+	 *
+	 * @return mixed|WP_Error           Response from wpcom servers or an error.
+	 */
+	public function proxy_request_to_wpcom( $request, $path = '', $context = 'user' ) {
+		$blog_id      = \Jetpack_Options::get_option( 'id' );
+		$path         = '/sites/' . rawurldecode( $blog_id ) . '/' . rawurldecode( ltrim( $this->rest_base, '/' ) ) . ( $path ? '/' . rawurldecode( ltrim( $path, '/' ) ) : '' );
+		$query_params = $request->get_query_params();
+		$manager      = new Manager();
+
+		/*
+		 * A rest_route parameter can be added when using plain permalinks.
+		 * It is not necessary to pass them to WordPress.com,
+		 * and may even cause issues with some endpoints.
+		 * Let's remove it.
+		 */
+		if ( isset( $query_params['rest_route'] ) ) {
+			unset( $query_params['rest_route'] );
+		}
+		$api_url = add_query_arg( $query_params, $path );
+
+		$request_options = array(
+			'headers' => array(
+				'Content-Type'    => 'application/json',
+				'X-Forwarded-For' => ( new Visitor() )->get_ip( true ),
+			),
+			'method'  => $request->get_method(),
+		);
+
+		// If no body is present, passing it as $request->get_body() will cause an error.
+		$body = $request->get_body() ? $request->get_body() : null;
+
+		$response = new WP_Error(
+			'rest_unauthorized',
+			__( 'Please connect your user account to WordPress.com', 'jetpack-publicize-pkg' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+
+		if ( 'user' === $context ) {
+			if ( ! $manager->is_user_connected() ) {
+				return $response;
+			}
+			$response = Client::wpcom_json_api_request_as_user( $api_url, $this->version, $request_options, $body, $this->base_api_path );
+		}
+
+		if ( 'blog' === $context ) {
+			if ( ! $manager->is_connected() ) {
+				return $response;
+			}
+
+			$response = Client::wpcom_json_api_request_as_blog( $api_url, $this->version, $request_options, $body, $this->base_api_path );
+		}
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$response_status = wp_remote_retrieve_response_code( $response );
+		$response_body   = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( $response_status >= 400 ) {
+			$code    = isset( $response_body['code'] ) ? $response_body['code'] : 'unknown_error';
+			$message = isset( $response_body['message'] ) ? $response_body['message'] : __( 'An unknown error occurred.', 'jetpack-publicize-pkg' );
+
+			return new WP_Error( $code, $message, array( 'status' => $response_status ) );
+		}
+
+		return $response_body;
+	}
+}


### PR DESCRIPTION
This PR supersedes #40950 to have better separation of concern and to clean up controller to move the connections logic to the connections specific class.

> For our CRUD operations, we are going to make a few proxy calls to WPCOM and thus we want to have a single function to handle that. There is a trait in Jetpack to use in such endpoints but it’s in Jetpack plugin. There is now a task (#40947) to move it to the connection package.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move the connections specific logic from controller to the connections class
* Copy `proxy_request_to_wpcom` method from [`WPCOM_REST_API_Proxy_Request_Trait`](https://github.com/Automattic/jetpack/blob/3374c193b10fdffe70fa68fc81a76208a1172730/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/trait-wpcom-rest-api-proxy-request-trait.php) trait to a `Proxy_Requests` class. We can swap that method with the trait when #40947 is completed.
* Add guards for calls to functions on WPCOM to ensure that they aren't called accidentally on Jetpack

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox this PR and point your site and public API to the sandbox
* Load the editor and watch for the sandboxed requests to `publicize/connections` endpoint in the debug log
* Follow the instructions given in #40892
* If you wish to force fetch the connections, pass `['ignore_cache' => true]` to `Connections::get_all_for_user()` in `publicize/src/class-publicize-script-data.php` on [line 184](https://github.com/Automattic/jetpack/blob/57b4364c5b4e4cee251964bccdc81b65d8e34798/projects/packages/publicize/src/class-publicize-script-data.php#L184).
* Login as an author to see the connections in the editor load fine.
* Run this in the browser console for both admin and author
```ts
await wp.apiFetch({
    path: '/wpcom/v2/publicize/connections'
});
```
* Confirm that the connections list is as expected, i.e. it includes user's and shared connections
* Verify the same data from [developer console](https://developer.wordpress.com/docs/api/console/).