### PR TITLE
Social: Update sig description block editor

### DIFF
--- a/projects/plugins/jetpack/_inc/client/sharing/features/social-image-generator-section.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/features/social-image-generator-section.jsx
@@ -16,7 +16,7 @@ const SocialImageGeneratorSection = () => {
 						<strong>{ __( 'Enable Social Image Generator', 'jetpack' ) }</strong>
 					</Text>
 					{ __(
-						'With Social Image Generator enabled you can automatically generate social images for your posts. You can use the button below to choose a default template for new posts.',
+						'With Social Image Generator enabled you can automatically generate social images for your posts. You can use the button below to choose a default template for new posts. This feature is only supported in the block editor.',
 						'jetpack'
 					) }
 				</div>

--- a/projects/plugins/jetpack/changelog/update-social-sig-description-block-editor
+++ b/projects/plugins/jetpack/changelog/update-social-sig-description-block-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+SIG: Changed description for togle

--- a/projects/plugins/social/changelog/update-social-sig-description-block-editor
+++ b/projects/plugins/social/changelog/update-social-sig-description-block-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+SIG: Changed description for toggle

--- a/projects/plugins/social/src/js/components/social-image-generator-toggle/index.tsx
+++ b/projects/plugins/social/src/js/components/social-image-generator-toggle/index.tsx
@@ -72,7 +72,7 @@ const SocialImageGeneratorToggle: React.FC< SocialImageGeneratorToggleProps > = 
 		>
 			<Text className={ styles.text }>
 				{ __(
-					'When enabled, Social Image Generator will automatically generate social images for your posts. You can use the button below to choose a default template for new posts.',
+					'When enabled, Social Image Generator will automatically generate social images for your posts. You can use the button below to choose a default template for new posts. This feature is only supported in the block editor.',
 					'jetpack-social'
 				) }
 			</Text>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/40518

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changed text

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/jetpack/issues/40518

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test this on the admin page and in Jetpack settings

![CleanShot 2025-01-13 at 12 01 37 png](https://github.com/user-attachments/assets/43e3a0d6-e66d-4ec2-ac28-f5ef32945e30)
![CleanShot 2025-01-13 at 12 01 24 png](https://github.com/user-attachments/assets/9abbe1df-2ac4-4994-ad7b-ef09d0f4d1b4)


