### PR TITLE
WPAdmin always loads Odyssey Stats widget regardless of "wpcom_admin_interface"

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-wpadmin_always_loads_odyssey_stats_widget
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-wpadmin_always_loads_odyssey_stats_widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Always loads Odyssey Stats widget regardless of wpcom_admin_interface

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -453,9 +453,7 @@ class Jetpack_Mu_Wpcom {
 	 * Load Odyssey Stats in Simple sites.
 	 */
 	public static function load_wpcom_simple_odyssey_stats() {
-		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' || ( function_exists( 'wpcom_is_duplicate_views_experiment_enabled' ) && wpcom_is_duplicate_views_experiment_enabled() ) ) {
-			require_once __DIR__ . '/features/wpcom-simple-odyssey-stats/wpcom-simple-odyssey-stats.php';
-		}
+		require_once __DIR__ . '/features/wpcom-simple-odyssey-stats/wpcom-simple-odyssey-stats.php';
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/40412

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* After tackling [removing the legacy Stats widget on Jetpack](https://github.com/Automattic/jetpack/pull/40839), the legacy Stats widget on the WPAdmin Dashboard of Simple sites from the original issue still shows, which was actually loaded by wpcom admin plugins and should be removed as it's outdated: 169721-ghe-Automattic/wpcom.
* On the other hand, to have an alternative Stats widget even for the unexpected path, it seems fine to always load Jetpack_Stats_Dashboard_Widget regardless of the [wpcom_admin_interface](https://github.com/Automattic/jetpack/blob/f7f7c16abdb47b7e3303042b40b96e80f95c65ce/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php#L455) settings. Context: p1736405729895379/1734418687.010599-slack-C06DN6QQVAQ.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build changes with `jetpack build packages/jetpack-mu-wpcom plugins/mu-wpcom-plugin`.
* `cd projects/plugins/mu-wpcom-plugin/`.
* Check out the sandbox branch to 169721-ghe-Automattic/wpcom.
* Sync Jetpack build to sandbox: `jetpack rsync mu-wpcom-plugin {sandbox-user}@{sandbox-hostname}:/path-to/wp-content/mu-plugins/jetpack-mu-wpcom-plugin/production`.
* Sandbox a testing Simple site on the local hosts file.
* Navigate to the testing Simple site.
* Ensure the Settings > General > Admin interface style is set to `Default style`.

<img width="1081" alt="截圖 2025-01-13 晚上7 48 42" src="https://github.com/user-attachments/assets/90e1eee3-2a62-4edd-bfa8-d84a43bb8049" />

* Go to the WPAdmin Dashboard by directly typing on the URL: `https://{your-site}.wordpress.com/wp-admin`.
* Ensure the latest Odyssey Stats widget is loaded.

<img width="804" alt="截圖 2025-01-13 晚上7 56 53" src="https://github.com/user-attachments/assets/1bf4728e-b421-4ae0-ac73-09ec883e7855" />