### PR TITLE
Forms: rename "URL" field to "Website" and update icon

### DIFF
--- a/projects/packages/forms/changelog/update-forms-url-field-rename
+++ b/projects/packages/forms/changelog/update-forms-url-field-rename
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: rename "URL" field to "Website"

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -409,7 +409,7 @@ export const childBlocks = [
 		name: 'field-url',
 		settings: {
 			...FieldDefaults,
-			title: __( 'URL Field', 'jetpack-forms' ),
+			title: __( 'Website Field', 'jetpack-forms' ),
 			keywords: [
 				__( 'url', 'jetpack-forms' ),
 				__( 'internet page', 'jetpack-forms' ),

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -1,7 +1,7 @@
 import { createBlock } from '@wordpress/blocks';
 import { Path, Icon } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
-import { link } from '@wordpress/icons';
+import { globe } from '@wordpress/icons';
 import { filter, isEmpty, map, startsWith, trim } from 'lodash';
 import JetpackField from './components/jetpack-field';
 import JetpackFieldCheckbox from './components/jetpack-field-checkbox';
@@ -419,7 +419,7 @@ export const childBlocks = [
 			description: __( 'Collect a website address from your site visitors.', 'jetpack-forms' ),
 			icon: (
 				<Icon
-					icon={ link }
+					icon={ globe }
 					style={ {
 						fill: getIconColor(),
 					} }

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -1,6 +1,5 @@
 import { createBlock } from '@wordpress/blocks';
 import { Path } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { filter, isEmpty, map, startsWith, trim } from 'lodash';
 import JetpackField from './components/jetpack-field';
@@ -418,17 +417,11 @@ export const childBlocks = [
 			],
 			description: __( 'Collect a website address from your site visitors.', 'jetpack-forms' ),
 			icon: renderMaterialIcon(
-				<>
-					<Path
-						fill={ getIconColor() }
-						d="M4.47118 8.5H3V12.9489C3 14.4653 4.14479 15.5 5.94723 15.5C7.74479 15.5 8.88958 14.4653 8.88958 12.9489V8.5H7.4184V12.8059C7.4184 13.688 6.88742 14.265 5.94723 14.265C5.00216 14.265 4.47118 13.688 4.47118 12.8059V8.5Z"
-					/>
-					<Path
-						fill={ getIconColor() }
-						d="M11.5348 9.62534H12.7867C13.5175 9.62534 13.9754 10.0545 13.9754 10.7221C13.9754 11.404 13.5418 11.8188 12.8014 11.8188H11.5348V9.62534ZM11.5348 12.8631H12.7137L14.0241 15.3808H15.6901L14.2092 12.6485C15.0179 12.3386 15.4855 11.5756 15.4855 10.6935C15.4855 9.33447 14.5599 8.5 12.9426 8.5H10.0636V15.3808H11.5348V12.8631Z"
-					/>
-					<Path fill={ getIconColor() } d="M21 14.1887H17.9261V8.5H16.4549V15.3808H21V14.1887Z" />
-				</>
+				// `link` from `@wordpress/icons`
+				<Path
+					fill={ getIconColor() }
+					d="M10 17.389H8.444A5.194 5.194 0 1 1 8.444 7H10v1.5H8.444a3.694 3.694 0 0 0 0 7.389H10v1.5ZM14 7h1.556a5.194 5.194 0 0 1 0 10.39H14v-1.5h1.556a3.694 3.694 0 0 0 0-7.39H14V7Zm-4.5 6h5v-1.5h-5V13Z"
+				/>
 			),
 			edit: editField( 'url' ),
 			attributes: {

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -1,6 +1,7 @@
 import { createBlock } from '@wordpress/blocks';
-import { Path } from '@wordpress/components';
+import { Path, Icon } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
+import { link } from '@wordpress/icons';
 import { filter, isEmpty, map, startsWith, trim } from 'lodash';
 import JetpackField from './components/jetpack-field';
 import JetpackFieldCheckbox from './components/jetpack-field-checkbox';
@@ -416,11 +417,12 @@ export const childBlocks = [
 				__( 'website', 'jetpack-forms' ),
 			],
 			description: __( 'Collect a website address from your site visitors.', 'jetpack-forms' ),
-			icon: renderMaterialIcon(
-				// `link` from `@wordpress/icons`
-				<Path
-					fill={ getIconColor() }
-					d="M10 17.389H8.444A5.194 5.194 0 1 1 8.444 7H10v1.5H8.444a3.694 3.694 0 0 0 0 7.389H10v1.5ZM14 7h1.556a5.194 5.194 0 0 1 0 10.39H14v-1.5h1.556a3.694 3.694 0 0 0 0-7.39H14V7Zm-4.5 6h5v-1.5h-5V13Z"
+			icon: (
+				<Icon
+					icon={ link }
+					style={ {
+						fill: getIconColor(),
+					} }
 				/>
 			),
 			edit: editField( 'url' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow up to https://github.com/Automattic/jetpack/pull/40921

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* For consistency, call the field "Website" just like the label in the block. URL is commonly understood term, but "Website" feels more user friendly/human language.
* Update icon to `globe` from [WP Icons library](https://wordpress.github.io/gutenberg/?path=/story/icons-icon--library).  Regocniceable symbol felt better than tiny text "URL" that can be hard to read since it's so small.

**Before**

<img width="1242" alt="Screenshot 2025-01-13 at 13 44 13" src="https://github.com/user-attachments/assets/d71ae479-dcf0-4361-8292-50f517f5ecff" />


**After**

<img width="1387" alt="Screenshot 2025-01-13 at 13 52 04" src="https://github.com/user-attachments/assets/7aa0a1cf-2b08-47e1-9f1a-7fd19878240a" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert form, see URL field before/after

