### PR TITLE
Social | Fix connect button for broken connections

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-broken-connections-button
+++ b/projects/js-packages/publicize-components/changelog/fix-social-broken-connections-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed fix connection button label for broken connections

--- a/projects/js-packages/publicize-components/src/components/services/service-item.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/service-item.tsx
@@ -42,11 +42,14 @@ export function ServiceItem( {
 
 	const brokenConnections = serviceConnections.filter( ( { status } ) => status === 'broken' );
 
-	const hasOwnBrokenConnections = useSelect( select => {
-		const { canUserManageConnection, getBrokenConnections } = select( socialStore );
+	const hasOwnBrokenConnections = useSelect(
+		select => {
+			const { canUserManageConnection } = select( socialStore );
 
-		return getBrokenConnections().some( canUserManageConnection );
-	}, [] );
+			return brokenConnections.some( canUserManageConnection );
+		},
+		[ brokenConnections ]
+	);
 
 	const hideInitialConnectForm =
 		// For services with custom inputs, the initial Connect button opens the panel,


### PR DESCRIPTION
#40888 introduced a slight regression of using broken connections list directly from store instead of the broken connections for the current service in the connections management modal, which caused the issue that if any connection was broken, all the service Connect buttons say "Fix connection"

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix the "Fix connection" label for healthy connections

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Break a connection
    - For Mastodon, remove Jetpack [here](https://mastodon.social/oauth/authorized_applications).
    - For Facebook, remove Jetpack [here](https://www.facebook.com/settings/?tab=business_tools).
* Goto connections management modal
* Confirm that the broken connection's connect button says "Fix connection"
* Confirm that the healthy connection's connect button says "Connect" instead of "Fix connection"
* I am not sure how to test the `must_reauth` status.


| BEFORE | AFTER |
|--------|--------|
| <img width="1046" alt="Screenshot 2025-01-13 at 6 02 12 PM" src="https://github.com/user-attachments/assets/6790709d-a2be-49d4-8e31-dba5845e6c74" /> | <img width="1046" alt="Screenshot 2025-01-13 at 6 02 12 PM" src="https://github.com/user-attachments/assets/2af8fdbf-05ae-4fbc-9298-22eea4b3e2ed" /> | 