### PR TITLE
Social | Fix connected accounts not marked as such on confirmation screen

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-connected-accounts-not-marked-as-such
+++ b/projects/packages/publicize/changelog/fix-social-connected-accounts-not-marked-as-such
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social | Fixed connected accounts not marked as such on confirmation screen

--- a/projects/packages/publicize/src/class-connections.php
+++ b/projects/packages/publicize/src/class-connections.php
@@ -188,11 +188,9 @@ class Connections {
 
 		$test_results = $run_tests ? self::get_test_status() : array();
 
-		if ( isset( $args['context'] ) && 'blog' === $args['context'] ) {
-			$service_connections = $publicize->get_all_connections_for_blog_id( get_current_blog_id() );
-		} else {
-			$service_connections = (array) $publicize->get_services( 'connected' );
-		}
+		$service_connections = $publicize->get_all_connections_for_blog_id( get_current_blog_id() );
+
+		$context = $args['context'] ?? 'user';
 
 		foreach ( $service_connections as $service_name => $connections ) {
 			foreach ( $connections as $connection ) {
@@ -202,7 +200,9 @@ class Connections {
 
 				$item['status'] = $test_results[ $connection_id ] ?? null;
 
-				$items[] = $item;
+				if ( 'blog' === $context || $item['shared'] || self::user_owns_connection( $item ) ) {
+					$items[] = $item;
+				}
 			}
 		}
 

--- a/projects/packages/publicize/src/class-connections.php
+++ b/projects/packages/publicize/src/class-connections.php
@@ -200,6 +200,8 @@ class Connections {
 
 				$item['status'] = $test_results[ $connection_id ] ?? null;
 
+				// For blog context, return all connections.
+				// Otherwise, return only connections owned by the user and the shared ones.
 				if ( 'blog' === $context || $item['shared'] || self::user_owns_connection( $item ) ) {
 					$items[] = $item;
 				}


### PR DESCRIPTION
**Problem**: `get_all_connections_for_blog_id()` and `get_services()` [here](https://github.com/Automattic/jetpack/blob/a85f4d4aa321bd3d003dc008cabde8d1fa8562d8/projects/packages/publicize/src/class-connections.php#L191-L195) return connections in different formats, while the former internally using `populate_keyring_tokens_for_connections()` which correctly sets the `external_ID` but the later does not.

**Manifestation**: Already connected accounts (e.g. Facebook) are not marked as such on the confirmation screen.

**Reason**: The connection test results API call uses that `get_services` which returns the user external ID, not the facebook page ID and then it overrides the data in the store.

So, initial state will have the correct external_id but not the connection test results.

**Solution**: Always use `get_all_connections_for_blog_id` to get the connections and then filter based on the site context or user context.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use `get_all_connections_for_blog_id` to get the connections and then filter based on the site context or user context.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect a Facebook page
* Now click on Connect for Facebook again
* Confirm that the connection is now marked as already connected
* Verify that admin sees their own connections
* Verify that an author sees their own and shared connections

