### PR TITLE
Forms: Add unique IDs when multiple instances.

### DIFF
--- a/projects/packages/forms/changelog/update-forms-unique-id
+++ b/projects/packages/forms/changelog/update-forms-unique-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Add unique ids to each form

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -119,6 +119,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		if ( ! empty( self::$forms ) ) {
+			// Ensure 'id' exists in $attributes before trying to modify it
+			if ( ! isset( $attributes['id'] ) ) {
+				$attributes['id'] = '';
+			}
 			$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 );
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -118,6 +118,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$default_to      .= $post_author->user_email;
 		}
 
+		if ( ! empty( self::$forms ) ) {
+			$attributes['id'] = $attributes['id'] . '-' . count( self::$forms ) + 1;
+		}
+
 		$this->hash                 = sha1( wp_json_encode( $attributes ) );
 		self::$forms[ $this->hash ] = $this;
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -119,7 +119,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		if ( ! empty( self::$forms ) ) {
-			$attributes['id'] = $attributes['id'] . '-' . count( self::$forms ) + 1;
+			$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 );
 		}
 
 		$this->hash                 = sha1( wp_json_encode( $attributes ) );

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -43,14 +43,14 @@ class Contact_Form extends Contact_Form_Shortcode {
 	/**
 	 * The most recent (inclusive) contact-form shortcode processed.
 	 *
-	 * @var Contact_Form
+	 * @var Contact_Form|null
 	 */
 	public static $last;
 
 	/**
 	 * Form we are currently looking at. If processed, will become $last
 	 *
-	 * @var Contact_Form
+	 * @var Contact_Form|null
 	 */
 	public static $current_form;
 

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -58,7 +58,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	public function set_up_test_case() {
 		// Avoid actually trying to send any mail.
 		add_filter( 'pre_wp_mail', '__return_true', PHP_INT_MAX );
-
+		$this->track_feedback_inserted = array();
 		$this->set_globals();
 
 		$author_id = wp_insert_user(
@@ -2095,7 +2095,6 @@ EOT;
 	public function test_multiple_form_instances_with_unique_ids() {
 		global $post;
 
-		$this->track_feedback_inserted = array();
 		add_action( 'grunion_after_feedback_post_inserted', array( $this, 'track_feedback_inserted' ), 10, 1 );
 
 		$this->add_field_values(
@@ -2128,13 +2127,19 @@ EOT;
 		// Verify that the forms have different IDs
 		$this->assertNotEquals( $form1->get_attribute( 'id' ), $form2->get_attribute( 'id' ), 'Forms should have unique IDs' );
 
-		remove_action( 'grunion_after_feedback_post_inserted', array( $this, 'track_feedback_inserted' ), 10, 1 );
+		remove_action( 'grunion_after_feedback_post_inserted', array( $this, 'track_feedback_inserted' ), 10 );
 
-		$this->assertTrue( count( $this->track_feedback_inserted ) === 2 );
+		$this->assertCount( 2, $this->track_feedback_inserted, 'The number of feedback forms that were inserted does not match! Expected 2.' );
 
+		// Add assertion to ensure array is not empty
+		$this->assertNotEmpty( $this->track_feedback_inserted, 'No feedback forms were inserted' );
+
+		$count = 1;
 		foreach ( $this->track_feedback_inserted as $feedback_id ) {
 			$feedback = get_post( $feedback_id );
-			$this->assertStringContainsString( 'First form name', $feedback->post_content );
+			$this->assertStringContainsString( 'First form name ' . $count, $feedback->post_content );
+			$this->assertStringContainsString( 'First form message ' . $count, $feedback->post_content );
+			++$count;
 		}
 	}
 } // end class

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -98,6 +98,11 @@ class WP_Test_Contact_Form extends BaseTestCase {
 		remove_all_filters( 'wp_mail' );
 		remove_all_filters( 'grunion_still_email_spam' );
 		remove_all_filters( 'jetpack_contact_form_is_spam' );
+
+		// Reset the forms array
+		Contact_Form::$forms        = array();
+		Contact_Form::$last         = null;
+		Contact_Form::$current_form = null;
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -2,6 +2,8 @@
 /**
  * Unit Tests for Automattic\Jetpack\Forms\Contact_Form.
  *
+ * To run the test visit the packages/forms directory and run composer test-php
+ *
  * @package automattic/jetpack-forms
  */
 
@@ -20,6 +22,8 @@ use WorDBless\Posts;
 class WP_Test_Contact_Form extends BaseTestCase {
 
 	private $post;
+
+	private $track_feedback_inserted;
 
 	private $plugin;
 
@@ -113,6 +117,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	 */
 	private function add_field_values( $values, $form_id = null ) {
 		$prefix = $form_id ? $form_id : 'g' . $this->post->ID;
+		$_POST  = array();
 		foreach ( $values as $key => $val ) {
 			if ( strpos( $key, 'contact-form' ) === 0 || strpos( $key, 'action' ) === 0 ) {
 				$_POST[ $key ] = $val;
@@ -2078,28 +2083,58 @@ EOT;
 			Util::grunion_contact_form_apply_block_attribute( $original, array( 'foo' => 'bar' ) )
 		);
 	}
-
+	/**
+	 * Helper function that tracks the ids of the feedbacks that got created.
+	 */
+	public function track_feedback_inserted( $post_id ) {
+		$this->track_feedback_inserted[] = $post_id;
+	}
 	/**
 	 * Tests that multiple instances of the same form work correctly with unique IDs.
 	 */
 	public function test_multiple_form_instances_with_unique_ids() {
-		// Create two instances of the same form
+		global $post;
+
+		$this->track_feedback_inserted = array();
+		add_action( 'grunion_after_feedback_post_inserted', array( $this, 'track_feedback_inserted' ), 10, 1 );
+
+		$this->add_field_values(
+			array(
+				'name'    => 'First form name 1',
+				'message' => 'First form message 1',
+			),
+			'g' . $post->ID
+		);
+
 		$form1 = new Contact_Form( array(), "[contact-field label='Name' type='name' required='1'/][contact-field label='Message' type='textarea' required='1'/]" );
-		$form2 = new Contact_Form( array(), "[contact-field label='Name' type='name' required='1'/][contact-field label='Message' type='textarea' required='1'/]" );
+		// Submit first form
+		$result1 = $form1->process_submission();
+
+		$this->assertTrue( is_string( $result1 ), 'First form submission should be successful' );
+
+		$this->add_field_values(
+			array(
+				'name'    => 'First form name 2',
+				'message' => 'First form message 2',
+			),
+			'g' . $post->ID . '-2'
+		);
+
+		$form2   = new Contact_Form( array(), "[contact-field label='Name' type='name' required='1'/][contact-field label='Message' type='textarea' required='1'/]" );
+		$result2 = $form2->process_submission();
+
+		$this->assertTrue( is_string( $result2 ), 'First form submission should be successful' );
 
 		// Verify that the forms have different IDs
 		$this->assertNotEquals( $form1->get_attribute( 'id' ), $form2->get_attribute( 'id' ), 'Forms should have unique IDs' );
 
-		// Submit first form
-		$this->add_field_values(
-			array(
-				'name'    => 'First form name',
-				'message' => 'First form message',
-			),
-			$form1->get_attribute( 'id' )
-		);
-		$result1 = $form1->process_submission();
-		$this->assertTrue( is_string( $result1 ), 'First form submission should be successful' );
-		// TODO: Test that the both froms submissions are saved with the correct information.
+		remove_action( 'grunion_after_feedback_post_inserted', array( $this, 'track_feedback_inserted' ), 10, 1 );
+
+		$this->assertTrue( count( $this->track_feedback_inserted ) === 2 );
+
+		foreach ( $this->track_feedback_inserted as $feedback_id ) {
+			$feedback = get_post( $feedback_id );
+			$this->assertStringContainsString( 'First form name', $feedback->post_content );
+		}
 	}
 } // end class

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -108,11 +108,17 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	/**
 	 * Adds the field values to the global $_POST value.
 	 *
-	 * @param array $values Array of field key value pairs.
+	 * @param array  $values Array of form fields and values.
+	 * @param string $form_id Optional form ID. If not provided, will use $this->post->ID.
 	 */
-	private function add_field_values( $values ) {
+	private function add_field_values( $values, $form_id = null ) {
+		$prefix = $form_id ? $form_id : 'g' . $this->post->ID;
 		foreach ( $values as $key => $val ) {
-			$_POST[ 'g' . $this->post->ID . '-' . $key ] = $val;
+			if ( strpos( $key, 'contact-form' ) === 0 || strpos( $key, 'action' ) === 0 ) {
+				$_POST[ $key ] = $val;
+			} else {
+				$_POST[ $prefix . '-' . $key ] = $val;
+			}
 		}
 	}
 
@@ -2071,5 +2077,29 @@ EOT;
 			$expected,
 			Util::grunion_contact_form_apply_block_attribute( $original, array( 'foo' => 'bar' ) )
 		);
+	}
+
+	/**
+	 * Tests that multiple instances of the same form work correctly with unique IDs.
+	 */
+	public function test_multiple_form_instances_with_unique_ids() {
+		// Create two instances of the same form
+		$form1 = new Contact_Form( array(), "[contact-field label='Name' type='name' required='1'/][contact-field label='Message' type='textarea' required='1'/]" );
+		$form2 = new Contact_Form( array(), "[contact-field label='Name' type='name' required='1'/][contact-field label='Message' type='textarea' required='1'/]" );
+
+		// Verify that the forms have different IDs
+		$this->assertNotEquals( $form1->get_attribute( 'id' ), $form2->get_attribute( 'id' ), 'Forms should have unique IDs' );
+
+		// Submit first form
+		$this->add_field_values(
+			array(
+				'name'    => 'First form name',
+				'message' => 'First form message',
+			),
+			$form1->get_attribute( 'id' )
+		);
+		$result1 = $form1->process_submission();
+		$this->assertTrue( is_string( $result1 ), 'First form submission should be successful' );
+		// TODO: Test that the both froms submissions are saved with the correct information.
 	}
 } // end class

--- a/projects/plugins/jetpack/changelog/update-forms-unique-id
+++ b/projects/plugins/jetpack/changelog/update-forms-unique-id
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Forms: Add unique ids to each form
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes: https://github.com/Automattic/jetpack/issues/33009 https://github.com/Automattic/jetpack/issues/39788


Currently, when forms are used multiple times on a single page, all instances share the same ID. This can cause issues with:
- Form submission handling
- Success message display targeting
- Accessibility (duplicate IDs violate HTML spec)


Before:

<img width="797" alt="Screenshot 2025-01-13 at 10 51 00 AM" src="https://github.com/user-attachments/assets/cae21b15-ab7a-422a-b8e4-3129077c2d8a" />


After:

<img width="573" alt="Screenshot 2025-01-13 at 10 52 55 AM" src="https://github.com/user-attachments/assets/d4fefd9f-0fea-44d8-b4ae-027d73d219d3" />


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a unique identifier suffix to form IDs when multiple instances of the same form exist on a page by:
* Tracking the number of form instances via `self::$forms` count
* Appending a numeric suffix to the form ID (e.g., `form-123-1`, `form-123-2`)
* Using this unique ID in the form HTML output and submission handling
* First form will keep the existing id


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a page with multiple instances of the same contact form
2. Verify each form instance has a unique ID in the HTML output
3. Submit each form instance and verify:
   - Success messages appear correctly for the submitted form
   - Form submissions are tracked properly


