### PR TITLE
Social | Fix failure on post save with LinkedIn connection enabled

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-schema-validation-on-saving-post
+++ b/projects/packages/publicize/changelog/fix-social-schema-validation-on-saving-post
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social | Fix failure on post save with LinkedIn connection enabled

--- a/projects/packages/publicize/src/rest-api/class-connections-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-controller.php
@@ -210,13 +210,13 @@ class Connections_Controller extends Base_Controller {
 				$connection_data = $connection_meta['connection_data'];
 
 				$items[] = array(
-					'connection_id'        => $connection_id,
-					'display_name'         => $publicize->get_display_name( $service_name, $connection ),
-					'external_handle'      => $publicize->get_external_handle( $service_name, $connection ),
-					'external_id'          => $connection_meta['external_id'] ?? '',
-					'profile_link'         => $publicize->get_profile_link( $service_name, $connection ),
-					'profile_picture'      => $publicize->get_profile_picture( $connection ),
-					'service_label'        => Publicize::get_service_label( $service_name ),
+					'connection_id'        => (string) $connection_id,
+					'display_name'         => (string) $publicize->get_display_name( $service_name, $connection ),
+					'external_handle'      => (string) $publicize->get_external_handle( $service_name, $connection ),
+					'external_id'          => (string) $connection_meta['external_id'] ?? '',
+					'profile_link'         => (string) $publicize->get_profile_link( $service_name, $connection ),
+					'profile_picture'      => (string) $publicize->get_profile_picture( $connection ),
+					'service_label'        => (string) Publicize::get_service_label( $service_name ),
 					'service_name'         => $service_name,
 					'shared'               => ! $connection_data['user_id'],
 					'status'               => $test_results[ $connection_id ] ?? null,

--- a/projects/packages/publicize/src/rest-api/class-connections-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-controller.php
@@ -213,7 +213,7 @@ class Connections_Controller extends Base_Controller {
 					'connection_id'        => (string) $connection_id,
 					'display_name'         => (string) $publicize->get_display_name( $service_name, $connection ),
 					'external_handle'      => (string) $publicize->get_external_handle( $service_name, $connection ),
-					'external_id'          => (string) $connection_meta['external_id'] ?? '',
+					'external_id'          => $connection_meta['external_id'] ?? '',
 					'profile_link'         => (string) $publicize->get_profile_link( $service_name, $connection ),
 					'profile_picture'      => (string) $publicize->get_profile_picture( $connection ),
 					'service_label'        => (string) Publicize::get_service_label( $service_name ),


### PR DESCRIPTION
Currently, when saving a post with a LinkedIn connection enabled, it fails

<img width="1121" alt="Image" src="https://github.com/user-attachments/assets/7630eb4f-7229-4bf5-b19c-bb2396c7b099" />

Reason: Some string fields are set to `false` or `null`.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure that the connection string fields are such

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to post editor
* Enabled a LinkedIn connection
* Save the post
* Confirm that there is no failure

