### PR TITLE
Sharing Block > Native sharing: use relevant link for popup

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharing-dialog-location
+++ b/projects/plugins/jetpack/changelog/fix-sharing-dialog-location
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sharing: Fix the location of the sharing dialog, so it is not always the first sharing element on the page

--- a/projects/plugins/jetpack/extensions/blocks/sharing-buttons/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-buttons/view.js
@@ -39,7 +39,7 @@ if ( typeof window !== 'undefined' ) {
 					if ( link?.href && isWebShareAPIEnabled( { url: link.href } ) ) {
 						navigator.share( { url: link.href } );
 					} else {
-						const [ tooltip ] = document.getElementsByClassName( 'tooltiptext' );
+						const [ tooltip ] = link.getElementsByClassName( 'tooltiptext' );
 						if ( tooltip && tooltip.style ) {
 							tooltip.style.display = 'initial';
 							setTimeout( () => {


### PR DESCRIPTION
Fixes #39060.

## Proposed changes:
This switches the tooltip to use the associated link, rather than any element containing the `tooltiptext` class within the page.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Install and activate Jetpack
2. go to Appearance> Editor
3. Edit a template that displays a list of posts.
4. Add a sharing buttons block
5. Add a native share sharing service 
6. Save your changes
7. On the frontend, view that list of posts
8. Click on the native share button next to a post down on the page. 

-> On desktop, a "coped to clipboard" popup should appear next to the button

