### PR TITLE
Boost: Trigger a site health issue if cornerstone change is detected

### DIFF
--- a/projects/plugins/boost/app/lib/Environment_Change_Detector.php
+++ b/projects/plugins/boost/app/lib/Environment_Change_Detector.php
@@ -79,6 +79,8 @@ class Environment_Change_Detector {
 			self::ENV_CHANGE_POST_SAVED,
 			self::ENV_CHANGE_SWITCHED_THEME,
 			self::ENV_CHANGE_PLUGIN_CHANGE,
+			self::ENV_CHANGE_CORNERSTONE_PAGE_SAVED,
+			self::ENV_CHANGE_CORNERSTONE_PAGES_LIST_UPDATED,
 		);
 	}
 

--- a/projects/plugins/boost/changelog/add-cornerstone-to-site-health
+++ b/projects/plugins/boost/changelog/add-cornerstone-to-site-health
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Critical CSS: Flag a site-health issue if critical CSS is not fresh after cornerstone pages changed.


### PR DESCRIPTION
## Proposed changes:
Show a site health issue to regenerate critical CSS if the cornerstone list is updated or a cornerstone page is updated.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
* Set a page as the cornerstone page
* Do not regenerate critical CSS.
* Check site-health, an issue stating critical CSS needs regen should appear.
* Regenerate critical CSS.
* Update the content of a cornerstone page.
* The site health issue should reappear if you do not regenerate critical CSS.

