### PR TITLE
Package protect-status: Fix Current_Plan::supports from busting cache on every call.

### DIFF
--- a/projects/packages/protect-status/changelog/fix-protect-current-plan-supports-allow-cached
+++ b/projects/packages/protect-status/changelog/fix-protect-current-plan-supports-allow-cached
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Protect-status package: Fix Current_Plan::supports() call from breaking cache on every call.

--- a/projects/packages/protect-status/src/class-plan.php
+++ b/projects/packages/protect-status/src/class-plan.php
@@ -101,7 +101,7 @@ class Plan {
 			$products = array_column( Current_Plan::get_products(), 'product_slug' );
 
 			// Check for a plan or product that enables scan.
-			$plan_supports_scan = Current_Plan::supports( 'scan', true );
+			$plan_supports_scan = Current_Plan::supports( 'scan', $force_refresh );
 			$has_scan_product   = count( array_intersect( array( 'jetpack_scan', 'jetpack_scan_monthly' ), $products ) ) > 0;
 			$has_scan           = $plan_supports_scan || $has_scan_product;
 		}


### PR DESCRIPTION
Prior to this PR, when calling Plan::has_required_plan() from in the `protect-status` package, there was a bug that was busting the cache on every call. This PR fixes this and allows the `Current_Plan::supports` call to use cached results, rather than busting the cache every time.

See Slack discussion: p1736794507070729-slack-C02LK1W8T4Z
and Slack discussion: p1736361284540509-slack-CDLH4C1UZ

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the `true` argument passed into the second argument of `Current_Plan::supports`, replace it with the variable `$force_refresh`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* I'm not completely sure how to test this exactly.  Otherwise, you can simply view the simple code change and see that a static `true` **was** being passed into the second argument of call: `Current_Plan::supports( 'scan', true );`, when rather the second argument should be a variable (`$force_refresh`), allowing us to pass in a boolean indicating whether we want to force-refresh the cache or not.
*