### PR TITLE
Action Bar: Add `Action Bar visibility` general setting

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-action-bar-visibility-general-setting
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-action-bar-visibility-general-setting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add `Action Bar visibility` general setting

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -12,6 +12,32 @@ use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 
 /**
+ * Add the Action Bar display setting on the General settings page.
+ * This setting allows users to hide the Action Bar on the front end of their site.
+ * The setting is stored in the `wpcom_show_action_bar` option.
+ * The setting is displayed only if the has the wp-admin interface selected.
+ */
+function wpcomsh_wpcom_show_action_bar_settings_field() {
+	add_settings_field( 'wpcom_show_action_bar', '', 'wpcom_show_action_bar_display', 'general', 'default' );
+
+	register_setting( 'general', 'wpcom_show_action_bar', array( 'sanitize_callback' => 'esc_attr' ) );
+}
+
+/**
+ * Display the `wpcom_show_action_bar setting` on the General settings page.
+ */
+function wpcom_show_action_bar_display() {
+	$value = get_option( 'wpcom_show_action_bar', 1 );
+
+	echo '<tr valign="top"><th scope="row">' . esc_html__( 'Action Bar visibility', 'jetpack-mu-wpcom' ) . '</th>';
+	echo '<td><label for="wpcom_show_action_bar">';
+	echo '<input type="checkbox" id="wpcom_show_action_bar" name="wpcom_show_action_bar" value="1" ' . checked( $value, 1, false ) . ' />';
+	echo esc_html__( 'Show the Action Bar on the front end of the site.', 'jetpack-mu-wpcom' ) . '</label>';
+	echo '<p class="description"><a href="https://en.support.wordpress.com/action-bar/">' . esc_html__( 'Learn more about Action Bar.', 'jetpack-mu-wpcom' ) . '</a></p></td></tr>';
+}
+add_action( 'admin_init', 'wpcomsh_wpcom_show_action_bar_settings_field' );
+
+/**
  * Add the Admin Interface Style setting on the General settings page.
  * This setting allows users to switch between the classic WP-Admin interface and the WordPress.com legacy dashboard.
  * The setting is stored in the wpcom_admin_interface option.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of: https://github.com/Automattic/wp-calypso/issues/53830

This PR adds a new general setting (`wpcom_show_action_bar`) to conditionally show the Action Bar on the front end of a site. It adds the interface for the classic wp-admin interface and its default value is `true` to preserve current behavior where we always show the Action Bar.

The main issue will need two more PRs to be complete that I'll create and link shortly:
1. `wpcom` to check this option and not enqueue the Action Bar
2. `calypso` to add UI for this setting.



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
I saw that some other settings are being tracked. Do we need to do the same for this one?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. For now (until I create the other PRs) you can go in classic wp-admin interface and check the UI for this new setting and observe that its value is being updated properly and defaults to `true`.

