### PR TITLE
Move WPCOM_REST_API_Proxy_Request trait to the connection package

### DIFF
--- a/projects/packages/connection/changelog/update-move-wpcom-rest-api-proxy-request-trait
+++ b/projects/packages/connection/changelog/update-move-wpcom-rest-api-proxy-request-trait
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Moved WPCOM_REST_API_Proxy_Request trait to the connection package

--- a/projects/packages/connection/src/traits/trait-wpcom-rest-api-proxy-request.php
+++ b/projects/packages/connection/src/traits/trait-wpcom-rest-api-proxy-request.php
@@ -128,11 +128,12 @@ trait WPCOM_REST_API_Proxy_Request {
 	 *
 	 * @param WP_REST_Request $request Request to proxy.
 	 * @param string          $path Path to append to the rest base.
+	 * @param array           $request_options Request options to pass to wp_remote_request.
 	 *
 	 * @return mixed|WP_Error           Response from wpcom servers or an error.
 	 */
-	public function proxy_request_to_wpcom_as_user( $request, $path = '' ) {
-		return $this->proxy_request_to_wpcom( $request, $path, 'user' );
+	public function proxy_request_to_wpcom_as_user( $request, $path = '', $request_options = array() ) {
+		return $this->proxy_request_to_wpcom( $request, $path, 'user', false, $request_options );
 	}
 
 	/**
@@ -140,10 +141,11 @@ trait WPCOM_REST_API_Proxy_Request {
 	 *
 	 * @param WP_REST_Request $request Request to proxy.
 	 * @param string          $path Path to append to the rest base.
+	 * @param array           $request_options Request options to pass to wp_remote_request.
 	 *
 	 * @return mixed|WP_Error           Response from wpcom servers or an error.
 	 */
-	public function proxy_request_to_wpcom_as_blog( $request, $path = '' ) {
-		return $this->proxy_request_to_wpcom( $request, $path, 'blog' );
+	public function proxy_request_to_wpcom_as_blog( $request, $path = '', $request_options = array() ) {
+		return $this->proxy_request_to_wpcom( $request, $path, 'blog', false, $request_options );
 	}
 }

--- a/projects/packages/connection/src/traits/trait-wpcom-rest-api-proxy-request.php
+++ b/projects/packages/connection/src/traits/trait-wpcom-rest-api-proxy-request.php
@@ -1,29 +1,34 @@
 <?php
 /**
- * Trait WPCOM_REST_API_Proxy_Request_Trait
+ * Trait WPCOM_REST_API_Proxy_Request
  *
  * Used to proxy requests to wpcom servers.
  *
- * @package automattic/jetpack
+ * @package automattic/jetpack-connection
  */
+
+namespace Automattic\Jetpack\Connection\Traits;
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Status\Visitor;
+use WP_Error;
+use WP_REST_Request;
 
-trait WPCOM_REST_API_Proxy_Request_Trait {
+trait WPCOM_REST_API_Proxy_Request {
 
 	/**
 	 * Proxy request to wpcom servers on behalf of a user or using the Site-level Connection (blog token).
 	 *
-	 * @param WP_Rest_Request $request Request to proxy.
+	 * @param WP_REST_Request $request Request to proxy.
 	 * @param string          $path Path to append to the rest base.
 	 * @param string          $context Whether the request should be proxied on behalf of the current user or using the Site-level Connection, aka 'blog' token. Can be Either 'user' or 'blog'. Defaults to 'user'.
 	 * @param bool            $allow_fallback_to_blog If the $context is 'user', whether we should fallback to using the Site-level Connection in case the current user is not connected.
+	 * @param array           $request_options Request options to pass to wp_remote_request.
 	 *
 	 * @return mixed|WP_Error           Response from wpcom servers or an error.
 	 */
-	public function proxy_request_to_wpcom( $request, $path = '', $context = 'user', $allow_fallback_to_blog = false ) {
+	public function proxy_request_to_wpcom( $request, $path = '', $context = 'user', $allow_fallback_to_blog = false, $request_options = array() ) {
 		$blog_id      = \Jetpack_Options::get_option( 'id' );
 		$path         = '/sites/' . rawurldecode( $blog_id ) . '/' . rawurldecode( ltrim( $this->rest_base, '/' ) ) . ( $path ? '/' . rawurldecode( ltrim( $path, '/' ) ) : '' );
 		$query_params = $request->get_query_params();
@@ -40,12 +45,15 @@ trait WPCOM_REST_API_Proxy_Request_Trait {
 		}
 		$api_url = add_query_arg( $query_params, $path );
 
-		$request_options = array(
-			'headers' => array(
-				'Content-Type'    => 'application/json',
-				'X-Forwarded-For' => ( new Visitor() )->get_ip( true ),
+		$request_options = array_replace_recursive(
+			array(
+				'headers' => array(
+					'Content-Type'    => 'application/json',
+					'X-Forwarded-For' => ( new Visitor() )->get_ip( true ),
+				),
+				'method'  => $request->get_method(),
 			),
-			'method'  => $request->get_method(),
+			$request_options
 		);
 
 		// If no body is present, passing it as $request->get_body() will cause an error.
@@ -53,7 +61,7 @@ trait WPCOM_REST_API_Proxy_Request_Trait {
 
 		$response = new WP_Error(
 			'rest_unauthorized',
-			__( 'Please connect your user account to WordPress.com', 'jetpack' ),
+			__( 'Please connect your user account to WordPress.com', 'jetpack-connection' ),
 			array( 'status' => rest_authorization_required_code() )
 		);
 
@@ -86,7 +94,7 @@ trait WPCOM_REST_API_Proxy_Request_Trait {
 
 		if ( $response_status >= 400 ) {
 			$code    = isset( $response_body['code'] ) ? $response_body['code'] : 'unknown_error';
-			$message = isset( $response_body['message'] ) ? $response_body['message'] : __( 'An unknown error occurred.', 'jetpack' );
+			$message = isset( $response_body['message'] ) ? $response_body['message'] : __( 'An unknown error occurred.', 'jetpack-connection' );
 
 			return new WP_Error( $code, $message, array( 'status' => $response_status ) );
 		}

--- a/projects/packages/connection/src/traits/trait-wpcom-rest-api-proxy-request.php
+++ b/projects/packages/connection/src/traits/trait-wpcom-rest-api-proxy-request.php
@@ -18,6 +18,27 @@ use WP_REST_Request;
 trait WPCOM_REST_API_Proxy_Request {
 
 	/**
+	 * Base path for the API.
+	 *
+	 * @var string
+	 */
+	public $base_api_path;
+
+	/**
+	 * Version of the API.
+	 *
+	 * @var string
+	 */
+	public $version;
+
+	/**
+	 * REST Base.
+	 *
+	 * @var string
+	 */
+	public $rest_base;
+
+	/**
 	 * Proxy request to wpcom servers on behalf of a user or using the Site-level Connection (blog token).
 	 *
 	 * @param WP_REST_Request $request Request to proxy.
@@ -93,8 +114,8 @@ trait WPCOM_REST_API_Proxy_Request {
 		$response_body   = json_decode( wp_remote_retrieve_body( $response ), true );
 
 		if ( $response_status >= 400 ) {
-			$code    = isset( $response_body['code'] ) ? $response_body['code'] : 'unknown_error';
-			$message = isset( $response_body['message'] ) ? $response_body['message'] : __( 'An unknown error occurred.', 'jetpack-connection' );
+			$code    = $response_body['code'] ?? 'unknown_error';
+			$message = $response_body['message'] ?? __( 'An unknown error occurred.', 'jetpack-connection' );
 
 			return new WP_Error( $code, $message, array( 'status' => $response_status ) );
 		}

--- a/projects/packages/connection/src/traits/trait-wpcom-rest-api-proxy-request.php
+++ b/projects/packages/connection/src/traits/trait-wpcom-rest-api-proxy-request.php
@@ -126,7 +126,7 @@ trait WPCOM_REST_API_Proxy_Request {
 	/**
 	 * Proxy request to wpcom servers on behalf of a user.
 	 *
-	 * @param WP_Rest_Request $request Request to proxy.
+	 * @param WP_REST_Request $request Request to proxy.
 	 * @param string          $path Path to append to the rest base.
 	 *
 	 * @return mixed|WP_Error           Response from wpcom servers or an error.
@@ -138,7 +138,7 @@ trait WPCOM_REST_API_Proxy_Request {
 	/**
 	 * Proxy request to wpcom servers using the Site-level Connection (blog token).
 	 *
-	 * @param WP_Rest_Request $request Request to proxy.
+	 * @param WP_REST_Request $request Request to proxy.
 	 * @param string          $path Path to append to the rest base.
 	 *
 	 * @return mixed|WP_Error           Response from wpcom servers or an error.

--- a/projects/packages/connection/src/traits/trait-wpcom-rest-api-proxy-request.php
+++ b/projects/packages/connection/src/traits/trait-wpcom-rest-api-proxy-request.php
@@ -22,21 +22,21 @@ trait WPCOM_REST_API_Proxy_Request {
 	 *
 	 * @var string
 	 */
-	public $base_api_path;
+	protected $base_api_path;
 
 	/**
 	 * Version of the API.
 	 *
 	 * @var string
 	 */
-	public $version;
+	protected $version;
 
 	/**
-	 * REST Base.
+	 * The base of the controller's route.
 	 *
 	 * @var string
 	 */
-	public $rest_base;
+	protected $rest_base;
 
 	/**
 	 * Proxy request to wpcom servers on behalf of a user or using the Site-level Connection (blog token).

--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -141,7 +141,6 @@ return [
         '_inc/lib/core-api/wpcom-endpoints/publicize-connections.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchArgument'],
         '_inc/lib/core-api/wpcom-endpoints/publicize-services.php' => ['PhanParamSignatureMismatch', 'PhanPluginMixedKeyNoKey', 'PhanTypeMismatchArgument'],
         '_inc/lib/core-api/wpcom-endpoints/service-api-keys.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspicious', 'PhanTypeMismatchReturnProbablyReal'],
-        '_inc/lib/core-api/wpcom-endpoints/trait-wpcom-rest-api-proxy-request-trait.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanUndeclaredProperty'],
         '_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMissingReturn'],
         '_inc/lib/debugger/class-jetpack-cxn-test-base.php' => ['PhanDeprecatedFunctionInternal', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturn'],
         '_inc/lib/debugger/class-jetpack-cxn-tests.php' => ['PhanPluginSimplifyExpressionBool'],

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-email-preview.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-email-preview.php
@@ -6,10 +6,10 @@
  */
 
 use Automattic\Jetpack\Connection\Manager;
+use Automattic\Jetpack\Connection\Traits\WPCOM_REST_API_Proxy_Request;
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service;
 use Automattic\Jetpack\Status\Host;
 
-require_once __DIR__ . '/trait-wpcom-rest-api-proxy-request-trait.php';
 require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
 
 /**
@@ -19,7 +19,7 @@ require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subsc
  */
 class WPCOM_REST_API_V2_Endpoint_Email_Preview extends WP_REST_Controller {
 
-	use WPCOM_REST_API_Proxy_Request_Trait;
+	use WPCOM_REST_API_Proxy_Request;
 
 	/**
 	 * Constructor.

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-newsletter-categories-list.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-newsletter-categories-list.php
@@ -6,15 +6,14 @@
  * @since 12.6
  */
 
+use Automattic\Jetpack\Connection\Traits\WPCOM_REST_API_Proxy_Request;
 use Automattic\Jetpack\Status\Host;
-
-require_once __DIR__ . '/trait-wpcom-rest-api-proxy-request-trait.php';
 
 /**
  * Class WPCOM_REST_API_V2_Endpoint_Following
  */
 class WPCOM_REST_API_V2_Endpoint_Newsletter_Categories_List extends WP_REST_Controller {
-	use WPCOM_REST_API_Proxy_Request_Trait;
+	use WPCOM_REST_API_Proxy_Request;
 
 	/**
 	 * Constructor.

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-newsletter-categories-subscriptions-count.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-newsletter-categories-subscriptions-count.php
@@ -6,15 +6,14 @@
  * @since 12.6
  */
 
+use Automattic\Jetpack\Connection\Traits\WPCOM_REST_API_Proxy_Request;
 use Automattic\Jetpack\Status\Host;
-
-require_once __DIR__ . '/trait-wpcom-rest-api-proxy-request-trait.php';
 
 /**
  * Class WPCOM_REST_API_V2_Endpoint_Newsletter_Categories_Subscriptions_Count
  */
 class WPCOM_REST_API_V2_Endpoint_Newsletter_Categories_Subscriptions_Count extends WP_REST_Controller {
-	use WPCOM_REST_API_Proxy_Request_Trait;
+	use WPCOM_REST_API_Proxy_Request;
 
 	/**
 	 * Constructor.

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-send-email-preview.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-send-email-preview.php
@@ -6,9 +6,8 @@
  */
 
 use Automattic\Jetpack\Connection\Manager;
+use Automattic\Jetpack\Connection\Traits\WPCOM_REST_API_Proxy_Request;
 use Automattic\Jetpack\Status\Host;
-
-require_once __DIR__ . '/trait-wpcom-rest-api-proxy-request-trait.php';
 
 /**
  * Class WPCOM_REST_API_V2_Endpoint_Send_Email_Preview
@@ -16,7 +15,7 @@ require_once __DIR__ . '/trait-wpcom-rest-api-proxy-request-trait.php';
  */
 class WPCOM_REST_API_V2_Endpoint_Send_Email_Preview extends WP_REST_Controller {
 
-	use WPCOM_REST_API_Proxy_Request_Trait;
+	use WPCOM_REST_API_Proxy_Request;
 
 	/**
 	 * Constructor.

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
@@ -5,15 +5,14 @@
  * @package automattic/jetpack
  */
 
-// Ensure WPCOM_REST_API_Proxy_Request_Trait is present.
-require_once __DIR__ . '/trait-wpcom-rest-api-proxy-request-trait.php';
+use Automattic\Jetpack\Connection\Traits\WPCOM_REST_API_Proxy_Request;
 
 /**
  * REST API endpoint wpcom/v3/sites/%s/blogging-prompts.
  */
 class WPCOM_REST_API_V3_Endpoint_Blogging_Prompts extends WP_REST_Posts_Controller {
 
-	use WPCOM_REST_API_Proxy_Request_Trait;
+	use WPCOM_REST_API_Proxy_Request;
 
 	const TEMPLATE_BLOG_ID = 205876834;
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -6,7 +6,7 @@
  * @since      7.3.0
  */
 
-require_once __DIR__ . '/trait-wpcom-rest-api-proxy-request-trait.php';
+use Automattic\Jetpack\Connection\Traits\WPCOM_REST_API_Proxy_Request;
 
 /**
  * Class WPCOM_REST_API_V2_Endpoint_Memberships
@@ -14,7 +14,7 @@ require_once __DIR__ . '/trait-wpcom-rest-api-proxy-request-trait.php';
  */
 class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 
-	use WPCOM_REST_API_Proxy_Request_Trait;
+	use WPCOM_REST_API_Proxy_Request;
 
 	/**
 	 * WPCOM_REST_API_V2_Endpoint_Memberships constructor.

--- a/projects/plugins/jetpack/changelog/update-move-wpcom-rest-api-proxy-request-trait
+++ b/projects/plugins/jetpack/changelog/update-move-wpcom-rest-api-proxy-request-trait
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Moved WPCOM_REST_API_Proxy_Request trait to the connection package


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #40947

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move WPCOM_REST_API_Proxy_Request trait to the connection package
* Add an option to override [`$request_options`](https://github.com/Automattic/jetpack/blob/2578d642e19a1f05a7a436c7d497bf7e859fe23f/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/trait-wpcom-rest-api-proxy-request-trait.php#L43-L49) to allow passing additional options like `timeout`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test the affected endpoints for self-hosted, AT and Simple sites. You can use the [dev console](https://developer.wordpress.com/docs/api/console/).
* Hit these endpoints and verify that there are no PHP errors
* `/wpcom/v2/email-preview`
```js
await wp.apiFetch({
    path: '/wpcom/v2/email-preview?post_id=32'
});
```
<img width="599" alt="image" src="https://github.com/user-attachments/assets/23573304-0671-46a6-861f-ccdc8b24b88a" />

* `/wpcom/v2/newsletter-categories`
```js
await wp.apiFetch({
    path: '/wpcom/v2/newsletter-categories'
});
```
<img width="501" alt="image" src="https://github.com/user-attachments/assets/6f1e4201-6710-4bfe-83b8-cde428fc08cf" />

* `/wpcom/v2/newsletter-categories/count`
```js
await wp.apiFetch({
    path: '/wpcom/v2/newsletter-categories/count'
});
```
<img width="444" alt="image" src="https://github.com/user-attachments/assets/95b09fce-f944-4568-b926-d741e7e4153a" />

* `/wpcom/v2/send-email-preview?id=32`
```js
await wp.apiFetch({
    path: '/wpcom/v2/send-email-preview?id=32',
    method: 'POST',
});
```
<img width="427" alt="image" src="https://github.com/user-attachments/assets/8bb48cf2-7d00-44b7-ba67-c65908593e42" />

* Verify that you receive the email
* `/wpcom/v3/blogging-prompts`
```js
await wp.apiFetch({
    path: '/wpcom/v3/blogging-prompts'
});
```
<img width="697" alt="image" src="https://github.com/user-attachments/assets/49aa4bb6-5764-4130-8bc5-c1514eec8f48" />

* `/wpcom/v2/memberships/status`
```js
await wp.apiFetch({
    path: '/wpcom/v2/memberships/status',
});
```
<img width="516" alt="image" src="https://github.com/user-attachments/assets/e3129f40-de9d-4c49-814e-0e6a76d104fc" />

* `/wpcom/v2/memberships/products`
```js
await wp.apiFetch({
    path: '/wpcom/v2/memberships/products',
});
```
<img width="412" alt="image" src="https://github.com/user-attachments/assets/af631dcf-2ad6-4472-9905-3c75691331d2" />

     
* Test those endpoints for a self-hosted site with an old version of the JP plugin and, e.g., Backups on this branch
* Do a sanity check for everything else

I also tested it on my Simple site

<img width="829" alt="image" src="https://github.com/user-attachments/assets/f95a8637-8d91-43b2-8843-927df9dc3ee7" />
