### PR TITLE
Pexels: Update title of option to be sentence case

### DIFF
--- a/projects/plugins/jetpack/changelog/update-sentence-case-pexels
+++ b/projects/plugins/jetpack/changelog/update-sentence-case-pexels
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Update title of "Pexels Free Photos" to be sentence case to match adjacent options.

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
@@ -11,8 +11,8 @@ import { MediaSource } from './types';
 
 // Pexels constants
 const PEXELS_ID = 'pexels';
-const PEXELS_NAME = __( 'Pexels Free Photos', 'jetpack' );
-const PEXELS_SEARCH_PLACEHOLDER = __( 'Search Pexels Free Photos', 'jetpack' );
+const PEXELS_NAME = __( 'Pexels free photos', 'jetpack' );
+const PEXELS_SEARCH_PLACEHOLDER = __( 'Search Pexels free photos', 'jetpack' );
 const DEFAULT_PEXELS_SEARCH: MediaSearch = {
 	per_page: 10,
 	search: 'mountain',

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/index.js
@@ -61,7 +61,7 @@ export const externalMediaSources = [
 	},
 	{
 		id: SOURCE_PEXELS,
-		label: __( 'Pexels Free Photos', 'jetpack' ),
+		label: __( 'Pexels free photos', 'jetpack' ),
 		icon: <PexelsIcon className="components-menu-items__item-icon" />,
 		keyword: 'pexels',
 	},


### PR DESCRIPTION
Addresses an issue noted in https://github.com/Automattic/dotcom-forge/issues/10213#issuecomment-2589269608.

## Proposed changes:

The WordPress block editor, and increasingly as this is being fixed in the broader WordPress as well, all actions, menu items, and buttons use sentence case with capital proper nouns. A few examples:

![Screenshot 2025-01-14 at 11 55 05](https://github.com/user-attachments/assets/ba84b279-5d66-4ce6-9d9a-ef26ca5b2caf)

![Screenshot 2025-01-14 at 11 55 33](https://github.com/user-attachments/assets/8b2a24b2-c787-40d3-9eea-2c8072f72257)

This PR changes "Pexels Free Photos" to "Pexels free photos". Before:

![Screenshot 2025-01-14 at 11 51 57](https://github.com/user-attachments/assets/0c2b18c3-bd29-47ce-a33a-1d010b409a98)

**I made this PR from my local env, and since Pexels requires a public connection to work, I was not able to test this PR. I'm submitting it regardless as it's a relatively simple code change.**

### Other information:

This change will also make the text case consistent with the media library:

![402856029-43a48ea6-881a-4ca0-88fc-8083b77b4fe9](https://github.com/user-attachments/assets/56e1a104-4633-4c7b-8c28-a4e16be492c5)


## Testing instructions:

* Add a new post.
* Insert an image block, and click "Select Image". 

The item for Pexels should use sentence case.

## Does this pull request change what data or activity we track or use?

No.