### PR TITLE
Social | Update connections schema to change `user_id` to `wpcom_user_id`

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-change-user_id-to-wpcom_user_id
+++ b/projects/js-packages/publicize-components/changelog/update-social-change-user_id-to-wpcom_user_id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Changed user_id to wpcom_user_id in connections schema

--- a/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.ts
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.ts
@@ -245,7 +245,7 @@ export const canUserManageConnection = createRegistrySelector(
 			const { current_user } = getScriptData().user;
 
 			// If the current user is the connection owner.
-			if ( current_user.wpcom?.ID === connection.user_id ) {
+			if ( current_user.wpcom?.ID === connection.wpcom_user_id ) {
 				return true;
 			}
 

--- a/projects/js-packages/publicize-components/src/social-store/types.ts
+++ b/projects/js-packages/publicize-components/src/social-store/types.ts
@@ -12,7 +12,7 @@ export type Connection = {
 	service_name: string;
 	shared: boolean;
 	status: ConnectionStatus;
-	user_id: number;
+	wpcom_user_id: number;
 
 	/* DEPRECATED FIELDS  */
 	/**

--- a/projects/packages/publicize/changelog/update-social-change-user_id-to-wpcom_user_id
+++ b/projects/packages/publicize/changelog/update-social-change-user_id-to-wpcom_user_id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Changed user_id to wpcom_user_id in connections schema

--- a/projects/packages/publicize/src/class-connections.php
+++ b/projects/packages/publicize/src/class-connections.php
@@ -89,7 +89,7 @@ class Connections {
 			$wpcom_user_id = ! empty( $wpcom_user_data['ID'] ) ? $wpcom_user_data['ID'] : null;
 		}
 
-		return $wpcom_user_id && $connection['user_id'] === $wpcom_user_id;
+		return $wpcom_user_id && $connection['wpcom_user_id'] === $wpcom_user_id;
 	}
 
 	/**
@@ -241,7 +241,7 @@ class Connections {
 			'service_label'        => (string) Publicize::get_service_label( $service_name ),
 			'service_name'         => $service_name,
 			'shared'               => ! $connection_data['user_id'],
-			'user_id'              => (int) $connection_data['user_id'],
+			'wpcom_user_id'        => (int) $connection_data['user_id'],
 
 			// Deprecated fields.
 			'id'                   => (string) $publicize->get_connection_unique_id( $connection ),

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1015,7 +1015,6 @@ abstract class Publicize_Base {
 					'service_name'    => $service_name,
 					'shared'          => ! $connection_data['user_id'],
 					'status'          => null,
-					'user_id'         => (int) $connection_data['user_id'],
 
 					// Deprecated fields.
 					'id'              => $connection_id,
@@ -1024,6 +1023,7 @@ abstract class Publicize_Base {
 					'done'            => $done,
 					'toggleable'      => $toggleable,
 					'global'          => 0 == $connection_data['user_id'], // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual,WordPress.PHP.StrictComparisons.LooseComparison -- Other types can be used at times.
+					'user_id'         => (int) $connection_data['user_id'],
 				);
 			}
 		}

--- a/projects/packages/publicize/src/rest-api/class-connections-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-controller.php
@@ -180,9 +180,9 @@ class Connections_Controller extends Base_Controller {
 					'must_reauth',
 				),
 			),
-			'user_id'         => array(
+			'wpcom_user_id'   => array(
 				'type'        => 'integer',
-				'description' => __( 'ID of the user the connection belongs to. It is the user ID on wordpress.com', 'jetpack-publicize-pkg' ),
+				'description' => __( 'wordpress.com ID of the user the connection belongs to.', 'jetpack-publicize-pkg' ),
 			),
 		);
 	}

--- a/projects/packages/publicize/src/rest-api/class-connections-post-field.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-post-field.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Publicize\REST_API;
 
+use Automattic\Jetpack\Publicize\Connections;
 use WP_Error;
 use WP_Post;
 use WP_REST_Request;
@@ -179,6 +180,16 @@ class Connections_Post_Field {
 		$properties  = array_keys( $schema['properties'] );
 		$connections = $publicize->get_filtered_connection_data( $post_id );
 
+		$connections_id_map = array_reduce(
+			Connections::get_all(),
+			function ( $map, $connection ) {
+				$map[ $connection['connection_id'] ] = $connection;
+
+				return $map;
+			},
+			array()
+		);
+
 		$output_connections = array();
 		foreach ( $connections as $connection ) {
 			$output_connection = array();
@@ -190,6 +201,7 @@ class Connections_Post_Field {
 
 			$output_connection['id']             = (string) $connection['unique_id'];
 			$output_connection['can_disconnect'] = current_user_can( 'edit_others_posts' ) || get_current_user_id() === (int) $connection['user_id'];
+			$output_connection['wpcom_user_id']  = $connections_id_map[ $connection['connection_id'] ]['wpcom_user_id'] ?? 0;
 
 			$output_connections[] = $output_connection;
 		}


### PR DESCRIPTION
The `user_id` field in the connections schema represents the WPCOM ID of the connection owner. It may be confused with the ID of the user on the local/Jetpack site. So it's better to clear the confusion now than do it later.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update connections schema to change `user_id` to `wpcom_user_id`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox this PR and your site
* You may want to pass `['ignore_cache' => true]` to `Connections::get_all_for_user()` [here](https://github.com/Automattic/jetpack/blob/731426d2ed98988a642ebf38e4ab1b3e4f017e8c/projects/packages/publicize/src/class-publicize-script-data.php#L184) to get the fresh data and to avoid undefined index warnings for `user_id`
* As an admin, goto connections management and add some connections if not added already
* Confirm that you are able to see the "Disconnect" button.
* Mark a few connections as shared
* Login as an author and add a few connections
* Confirm that the author sees the "Disconnect" button for their own connections but not for shared connection.
* Go to the editor
* Confirm that the initial connections in the Jetpack sidebar load fine
* Run this in the console to see the initial connections in case you want
```ts
wp.data.select('core/editor' ).getEditedPostAttribute('jetpack_publicize_connections');
```
* Verify that the data now has `wpcom_user_id` instead of `user_id`
* Enter this in the console
```ts
JetpackScriptData.social.store_initial_state.connectionData.connections
```
* Verify that the data now has `wpcom_user_id` instead of `user_id`


