### PR TITLE
Repo Gardening: ping in slack for issues labeled customer report

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/add-repo-gardening-slack-message-customer-reports
+++ b/projects/github-actions/repo-gardening/changelog/add-repo-gardening-slack-message-customer-reports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Support References: send Slack message when an issue is labeled as customer report.

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -451,7 +451,7 @@ async function addHappinessLabel( payload, octokit ) {
 		return false;
 	}
 
-	const message = `This issue has been labeled as a Customer Report. It may need some extra attention.`;
+	const message = `This issue has been labeled as a Customer Report. Please complete first-line triage within 24 hours.`;
 	const slackMessageFormat = formatSlackMessage( payload, channel, message );
 	await sendSlackMessage( message, channel, payload, slackMessageFormat );
 }

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -412,13 +412,19 @@ async function createOrUpdateComment( payload, octokit, issueReferences, issueCo
 /**
  * Add a label to the issue, if it does not exist yet.
  *
- * @param {GitHub} octokit    - Initialized Octokit REST client.
- * @param {string} ownerLogin - Repository owner login.
- * @param {string} repo       - Repository name.
- * @param {number} number     - Issue number.
+ * @param {WebhookPayloadIssue} payload - Issue or issue comment event payload.
+ * @param {GitHub}              octokit - Initialized Octokit REST client.
  * @return {Promise<void>}
  */
-async function addHappinessLabel( octokit, ownerLogin, repo, number ) {
+async function addHappinessLabel( payload, octokit ) {
+	const {
+		issue: { number },
+		repository: {
+			name: repo,
+			owner: { login: ownerLogin },
+		},
+	} = payload;
+
 	const happinessLabel = 'Customer Report';
 
 	const labels = await getLabels( octokit, ownerLogin, repo, number );
@@ -436,6 +442,18 @@ async function addHappinessLabel( octokit, ownerLogin, repo, number ) {
 		issue_number: number,
 		labels: [ happinessLabel ],
 	} );
+
+	// Send Slack notification, if we have the necessary tokens.
+	// No Slack tokens, we won't be able to escalate. Bail.
+	const slackToken = getInput( 'slack_token' );
+	const channel = getInput( 'slack_quality_channel' );
+	if ( ! slackToken || ! channel ) {
+		return false;
+	}
+
+	const message = `This issue has been labeled as a Customer Report. It may need some extra attention.`;
+	const slackMessageFormat = formatSlackMessage( payload, channel, message );
+	await sendSlackMessage( message, channel, payload, slackMessageFormat );
 }
 
 /**
@@ -464,7 +482,7 @@ async function gatherSupportReferences( payload, octokit ) {
 	if ( issueReferences.length > 0 ) {
 		debug( `gather-support-references: Found ${ issueReferences.length } references.` );
 		await createOrUpdateComment( payload, octokit, issueReferences, issueComments );
-		await addHappinessLabel( octokit, owner.login, repo, number );
+		await addHappinessLabel( payload, octokit );
 	}
 }
 

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/readme.md
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/readme.md
@@ -2,7 +2,7 @@
 
 Happiness Engineers can comment on issues to add references to support interactions with customers that would like to be updated whenever the problem is solved.
 
-This task creates a new comment that lists all support references found in all comments on the issue. If it finds a support reference, it will also add a label to the issue, "Customer Report".
+This task creates a new comment that lists all support references found in all comments on the issue. If it finds a support reference, it will also add a label to the issue, "Customer Report". When that label is added, we warn the triage team in Slack.
 
 The tasks also monitors the number of support references it has gathered:
 


### PR DESCRIPTION
## Proposed changes:

As we're trying to act faster on reports from customers, let's ping our triage team in Slack whenever an issue is flagged as a customer report.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Internal references:

- p1736823216576659-slack-C01UW7SB411
- pfVjQF-su-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

This is best tested in a fork. Here is an example:

https://github.com/jeherve/jetpack/issues/199
p1736855651531919-slack-CN2FSK7L4
