### PR TITLE
Revert "Stop showing limited global styles notice in editor distraction free mode"

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/revert-40907-fix-global-styles-notice-distraction-free
+++ b/projects/packages/jetpack-mu-wpcom/changelog/revert-40907-fix-global-styles-notice-distraction-free
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Global Styles: Revert changes that hide notice in distraction free mode

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/notices.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/notices.js
@@ -1,6 +1,5 @@
 /* global wpcomGlobalStyles */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 import { ExternalLink, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -239,31 +238,19 @@ function GlobalStylesEditNotice() {
 		upgradePlan,
 	] );
 
-	const isDistractionFree = useSelect(
-		select => select( blockEditorStore ).getSettings().isDistractionFree,
-		[]
-	);
-
 	useEffect( () => {
 		if ( ! isSiteEditor && ! isPostEditor ) {
 			return;
 		}
 
-		if ( globalStylesInUse && ! isDistractionFree ) {
+		if ( globalStylesInUse ) {
 			showNotice();
 		} else {
 			removeNotice( NOTICE_ID );
 		}
 
 		return () => removeNotice( NOTICE_ID );
-	}, [
-		globalStylesInUse,
-		isDistractionFree,
-		isSiteEditor,
-		isPostEditor,
-		removeNotice,
-		showNotice,
-	] );
+	}, [ globalStylesInUse, isSiteEditor, isPostEditor, removeNotice, showNotice ] );
 
 	return null;
 }

--- a/projects/plugins/wpcomsh/changelog/fix-global-styles-notice-distraction-free
+++ b/projects/plugins/wpcomsh/changelog/fix-global-styles-notice-distraction-free
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Global Styles: Stop showing the limited global styles notice in distraction free mode.

--- a/projects/plugins/wpcomsh/changelog/fix-global-styles-notice-distraction-free
+++ b/projects/plugins/wpcomsh/changelog/fix-global-styles-notice-distraction-free
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Global Styles: Stop showing the limited global styles notice in distraction free mode.


### PR DESCRIPTION
Reverts Automattic/jetpack#40907

## Proposed changes:

See p1736855095811369-slack-C02FMH4G8


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:

- Apply these changes to your sandbox
- Sandbox a Free Simple site
- Go to the site editor
- Apply some Global Styles
- Save them without upgrading
- Visit the frontend
- Notice the "Upgrade required" button in the banner
- Make sure the popover is visible

