### PR TITLE
Revert "Revert "Forms: rename "URL" field to "Website" and update icon""

### DIFF
--- a/projects/packages/forms/changelog/update-forms-url-field-rename
+++ b/projects/packages/forms/changelog/update-forms-url-field-rename
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: rename "URL" field to "Website"

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -1,7 +1,7 @@
 import { createBlock } from '@wordpress/blocks';
-import { Path } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
+import { Path, Icon } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
+import { globe } from '@wordpress/icons';
 import { filter, isEmpty, map, startsWith, trim } from 'lodash';
 import JetpackField from './components/jetpack-field';
 import JetpackFieldCheckbox from './components/jetpack-field-checkbox';
@@ -409,7 +409,7 @@ export const childBlocks = [
 		name: 'field-url',
 		settings: {
 			...FieldDefaults,
-			title: __( 'URL Field', 'jetpack-forms' ),
+			title: __( 'Website Field', 'jetpack-forms' ),
 			keywords: [
 				__( 'url', 'jetpack-forms' ),
 				__( 'internet page', 'jetpack-forms' ),
@@ -417,18 +417,13 @@ export const childBlocks = [
 				__( 'website', 'jetpack-forms' ),
 			],
 			description: __( 'Collect a website address from your site visitors.', 'jetpack-forms' ),
-			icon: renderMaterialIcon(
-				<>
-					<Path
-						fill={ getIconColor() }
-						d="M4.47118 8.5H3V12.9489C3 14.4653 4.14479 15.5 5.94723 15.5C7.74479 15.5 8.88958 14.4653 8.88958 12.9489V8.5H7.4184V12.8059C7.4184 13.688 6.88742 14.265 5.94723 14.265C5.00216 14.265 4.47118 13.688 4.47118 12.8059V8.5Z"
-					/>
-					<Path
-						fill={ getIconColor() }
-						d="M11.5348 9.62534H12.7867C13.5175 9.62534 13.9754 10.0545 13.9754 10.7221C13.9754 11.404 13.5418 11.8188 12.8014 11.8188H11.5348V9.62534ZM11.5348 12.8631H12.7137L14.0241 15.3808H15.6901L14.2092 12.6485C15.0179 12.3386 15.4855 11.5756 15.4855 10.6935C15.4855 9.33447 14.5599 8.5 12.9426 8.5H10.0636V15.3808H11.5348V12.8631Z"
-					/>
-					<Path fill={ getIconColor() } d="M21 14.1887H17.9261V8.5H16.4549V15.3808H21V14.1887Z" />
-				</>
+			icon: (
+				<Icon
+					icon={ globe }
+					style={ {
+						fill: getIconColor(),
+					} }
+				/>
 			),
 			edit: editField( 'url' ),
 			attributes: {


### PR DESCRIPTION
Reverts Automattic/jetpack#41026 thus re-deploying https://github.com/Automattic/jetpack/pull/40994 but [E2E changes already done](https://github.com/Automattic/wp-calypso/pull/98337) time.

