### PR TITLE
Forms: Fix redirect field styles

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-redirect-address-styles
+++ b/projects/packages/forms/changelog/fix-contact-form-redirect-address-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix redirect field styles

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -15,7 +15,6 @@ import {
 } from '@wordpress/block-editor';
 import { createBlock, registerBlockVariation } from '@wordpress/blocks';
 import {
-	BaseControl,
 	Button,
 	Modal,
 	PanelBody,
@@ -198,18 +197,14 @@ export const JetpackContactFormEdit = forwardRef(
 					) }
 
 					{ 'redirect' === customThankyou && (
-						<BaseControl
-							label={ __( 'Redirect Address', 'jetpack-forms' ) }
-							id={ `contact-form-${ instanceId }-thankyou-url` }
-							__nextHasNoMarginBottom={ true }
-						>
+						<div>
 							<URLInput
-								id={ `contact-form-${ instanceId }-thankyou-url` }
+								label={ __( 'Redirect Address', 'jetpack-forms' ) }
 								value={ customThankyouRedirect }
 								className="jetpack-contact-form__thankyou-redirect-url"
 								onChange={ newURL => setAttributes( { customThankyouRedirect: newURL } ) }
 							/>
-						</BaseControl>
+						</div>
 					) }
 				</>
 			);

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -240,12 +240,16 @@
 	width: 100%;
 }
 
+.jetpack-contact-form__thankyou-redirect-url {
+	min-width: auto;
+}
+
 .jetpack-contact-form__thankyou-redirect-url input[type='text'] {
 	width: 100%;
 }
 
 .jetpack-contact-form__thankyou-redirect-url__suggestions {
-	width: 260px;
+	width: 230px;
 }
 
 .jetpack-contact-form__integration-panel {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes: https://github.com/Automattic/jetpack/issues/41022

This PR fixes some styles with the redirect address field. Additionally I updated a bit the styles for the suggestions to have smaller width.



## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. insert a contact form
2. in Inspector controls under `Submission settings`, go to `on submission` and select `Redirect to another webpage`.
3. Observe that the input width is correct
4. Type something for some suggestions to show
5. Observe the smaller width of the dialog.


Before     | After
:-------------------------:|:-------------------------:
<img width="283" alt="before" src="https://github.com/user-attachments/assets/9bc7f6d7-40a6-4378-8f32-cade8e5ab597" /> | <img width="283" alt="after" src="https://github.com/user-attachments/assets/bad1026b-e942-4bd1-b85d-b94e0c5e945b" />


