### PR TITLE
Fix: newsletter toggle in editor sidebar has a visually broken active state

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-broken-newsletter-toggle
+++ b/projects/plugins/jetpack/changelog/fix-broken-newsletter-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix: newsletter toggle in editor sidebar has a visually broken active state.

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -306,7 +306,7 @@ export function NewsletterEmailDocumentSettings() {
 		const postMetaUpdate = {
 			...postMeta,
 			// Meta value is negated, "don't send", but toggle is truthy when enabled "send"
-			[ META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS ]: ! value,
+			[ META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS ]: value === 'post-only',
 		};
 		setPostMeta( postMetaUpdate );
 		saveEditedEntityRecord( 'postType', postType, postId );
@@ -315,7 +315,7 @@ export function NewsletterEmailDocumentSettings() {
 	const isSendEmailEnabled = useSelect( select => {
 		const meta = select( editorStore ).getEditedPostAttribute( 'meta' );
 		// Meta value is negated, "don't send", but toggle is truthy when enabled "send"
-		return ! meta?.[ META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS ];
+		return meta?.[ META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS ] ? 'post-only' : 'post-and-email';
 	} );
 
 	return (
@@ -333,8 +333,11 @@ export function NewsletterEmailDocumentSettings() {
 						__nextHasNoMarginBottom={ true }
 						__next40pxDefaultSize={ true }
 					>
-						<ToggleGroupControlOption label={ __( 'Post & email', 'jetpack' ) } value={ true } />
-						<ToggleGroupControlOption label={ __( 'Post only', 'jetpack' ) } value={ false } />
+						<ToggleGroupControlOption
+							label={ __( 'Post & email', 'jetpack' ) }
+							value="post-and-email"
+						/>
+						<ToggleGroupControlOption label={ __( 'Post only', 'jetpack' ) } value="post-only" />
 					</ToggleGroupControl>
 				);
 			} }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/97139

The [ToggleGroupControl](https://developer.wordpress.org/block-editor/reference-guides/components/toggle-group-control/) component seems unhappy with a `false` value set in a `ToggleGroupControlOption` child component. Despite the value **is** false (and so the right value), the `useAnimatedOffsetRect` component does not calculate valid CSS variables used for animation but instead generates a:

```
--selected-top: 0;
--selected-right: 0;
--selected-bottom: 0;
--selected-left: 0;
--selected-width: 0;
--selected-height: 0;
```

They should be similar to:

```
--selected-top: 4;
--selected-right: 4;
--selected-bottom: 4;
--selected-left: 124;
--selected-width: 120;
--selected-height: 32;
```

Once changed to two strings, it is working. I checked other places where the component is used, and it is working in the same way.

I don't consider this a Gutenberg bug but simply the component that does not accept falsy booleans, and I vote not to open a Gutenberg issue.

https://github.com/user-attachments/assets/6c9e72ae-167e-403e-9865-4cc018a82447

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replace `true/false` values with `"post-and-email"/"post-only"` strings
* Change `toggleSendEmail` and `isSendEmailEnabled` to accept the new values

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You need a Jetpack plan with included the newletter
* If the newsletter is not active, go to `/wp-admin/admin.php?page=jetpack#newsletter` and switch on "Let visitors subscribe to this site and receive emails when you publish a post"
* If you don't have active subscribers, go to https://cloud.jetpack.com/subscribers, select the site, and import one of your emails used for testing.

Then you'll need to do two examples.

* Create a new post, add a title and some content
* Click "Publish" on top right
* Make sure that you can click the "Post & email / Post only" component

Submit the post with the selected "Post & email" and be sure to receive an email with the new post. Create another post with "Post only" selected, submit it, and be sure **not** to receive any email.
