### PR TITLE
Remove duplicate views: Store experiment assignment in a different option

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-remove-duplicate-views-experiment-assignment-option
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-remove-duplicate-views-experiment-assignment-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -405,7 +405,7 @@ function wpcom_is_duplicate_views_experiment_enabled() {
 		return $is_enabled;
 	}
 
-	$option_name = 'duplicate_views_experiment_assignment';
+	$option_name = 'remove_duplicate_views_experiment_assignment';
 	$variation   = get_user_option( $option_name, get_current_user_id() );
 
 	if ( false !== $variation ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/98341

## Proposed changes:

On Atomic sites, we currently cache the "Remove duplicate views" experiment assignment to avoid many requests to the ExPlat endpoints. But this code already lives in prod, so the current default assignment is being cached for all Atomic users.

To ensure that the right assignment is stored when the experiment starts, this PR changes the option where we cache it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

N/A