### PR TITLE
Remove duplicate views: Remove icons object

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-remove-duplicate-views-icons
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-remove-duplicate-views-icons
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Removed no longer used code
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/removed-calypso-screen-notice.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/removed-calypso-screen-notice.tsx
@@ -146,17 +146,7 @@ const Notice = () => {
 		},
 	};
 
-	const icons = {
-		'edit.php': verse,
-		'edit.php?post_type=page': pages,
-		'edit.php?post_type=jetpack-portfolio': archive,
-		'edit.php?post_type=jetpack-testimonial': commentContent,
-		'edit-comments.php': postComments,
-		'edit-tags.php?taxonomy=category': category,
-		'edit-tags.php?taxonomy=post_tag': tag,
-	};
-
-	if ( ! Object.keys( icons ).includes( removedCalypsoScreenNoticeConfig.screen ) ) {
+	if ( ! Object.keys( config ).includes( removedCalypsoScreenNoticeConfig.screen ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
Follow-up of https://github.com/Automattic/jetpack/pull/40996

## Proposed changes:

- I forgot to remove the `icons` object in the above refactor which is no longer necessary, so this PR cleans up that part of the code.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Assign yourself to the `treatment` variant of the 22129-explat-experiment experiment
- Apply these changes to your sandbox
- Visit any of the enforced WP Admin views:
  - edit.php
  - edit.php?post_type=page
  - edit.php?post_type=jetpack-portfolio
  - edit.php?post_type=jetpack-testimonial
  - edit-comments.php
  - edit-tags.php?taxonomy=category
  - edit-tags.php?taxonomy=post_tag
- Make sure the notices show up
