### PR TITLE
MU WPCOM: don't enqueue block scripts in the canvas iframe!

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-block-asset-enqueueing
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-block-asset-enqueueing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Performance fix
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/newspack-blocks/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/newspack-blocks/index.php
@@ -86,7 +86,7 @@ if ( ! $disable_blog_posts_block ) {
 	);
 
 	add_action(
-		is_admin() ? 'enqueue_block_assets' : 'enqueue_block_editor_assets',
+		'enqueue_block_editor_assets',
 		function () {
 			$handle = \jetpack_mu_wpcom_enqueue_assets( 'newspack-blocks-blog-posts-editor', array( 'js', 'css' ) );
 			enqueue_newspack_blocks_data( $handle );
@@ -112,7 +112,7 @@ if ( ! $disable_posts_carousel_block ) {
 	);
 
 	add_action(
-		is_admin() ? 'enqueue_block_assets' : 'enqueue_block_editor_assets',
+		'enqueue_block_editor_assets',
 		function () {
 			$handle = \jetpack_mu_wpcom_enqueue_assets( 'newspack-blocks-carousel-editor', array( 'js', 'css' ) );
 			enqueue_newspack_blocks_data( $handle );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/event-countdown/event-countdown.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/event-countdown/event-countdown.php
@@ -47,8 +47,4 @@ function load_assets( $attr, $content ) {
 function enqueue_block_editor_assets() {
 	\jetpack_mu_wpcom_enqueue_assets( 'wpcom-blocks-event-countdown-editor', array( 'js', 'css' ) );
 }
-if ( is_admin() ) {
-	add_action( 'enqueue_block_assets', __NAMESPACE__ . '\enqueue_block_editor_assets' );
-} else {
-	add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_block_editor_assets' );
-}
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_block_editor_assets' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/timeline/timeline.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/timeline/timeline.php
@@ -47,8 +47,4 @@ function load_assets( $attr, $content ) {
 function enqueue_block_editor_assets() {
 	\jetpack_mu_wpcom_enqueue_assets( 'wpcom-blocks-timeline-editor', array( 'js', 'css' ) );
 }
-if ( is_admin() ) {
-	add_action( 'enqueue_block_assets', __NAMESPACE__ . '\enqueue_block_editor_assets' );
-} else {
-	add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_block_editor_assets' );
-}
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_block_editor_assets' );

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-block-asset-enqueueing
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-block-asset-enqueueing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Performance fix
+
+

--- a/projects/plugins/wpcomsh/changelog/fix-block-asset-enqueueing
+++ b/projects/plugins/wpcomsh/changelog/fix-block-asset-enqueueing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Performance fix
+
+


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/98447
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Problem:

React and most block editor packages are currently loaded in _both_ the main window _and_ the editor canvas iframe. This should not happen. (Note that you don't need any blocks inserted.)

<img width="1464" alt="image" src="https://github.com/user-attachments/assets/a6f40f07-ca04-4fcb-afd7-fc47cc212194" />

Additionally there's an error message from one of the scripts that's added in the iframe:

<img width="922" alt="image" src="https://github.com/user-attachments/assets/7a788a99-c132-4007-a6ec-110e5e6dfa2e" />


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The problem is that 4 blocks are currently enqueueing their editor scripts with `enqueue_block_assets` for some reason. This is wrong, since that hook is meant for assets to the block itself rather than assets to register the blocks. Instead, `enqueue_block_editor_assets` should be used.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a simple site, just visit the post editor and check the `<head>` of the canvas.
* Try adding a timeline block for example and check that it still works in the editor.

