### PR TITLE
Add a watch script for masterbar package

### DIFF
--- a/projects/packages/masterbar/changelog/add-masterbar-watch
+++ b/projects/packages/masterbar/changelog/add-masterbar-watch
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Add watch command in the masterbar package

--- a/projects/packages/masterbar/composer.json
+++ b/projects/packages/masterbar/composer.json
@@ -47,6 +47,10 @@
 		"test-php": [
 			"pnpm run build-production",
 			"@composer phpunit"
+		],
+		"watch": [
+			"Composer\\Config::disableProcessTimeout",
+			"pnpm run watch"
 		]
 	},
 	"repositories": [

--- a/projects/packages/masterbar/package.json
+++ b/projects/packages/masterbar/package.json
@@ -21,7 +21,7 @@
 		"build-production-js": "NODE_ENV=production BABEL_ENV=production pnpm run build-js",
 		"clean": "rm -rf dist/ .cache/",
 		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern dist/",
-		"watch": "pnpm run build && pnpm webpack watch"
+		"watch": "pnpm run build && pnpm webpack watch --config tools/webpack.config.js"
 	},
 	"dependencies": {
 		"@automattic/calypso-color-schemes": "3.1.3",

--- a/projects/plugins/jetpack/changelog/add-masterbar-watch
+++ b/projects/plugins/jetpack/changelog/add-masterbar-watch
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+update composer.lock files

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1741,7 +1741,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/masterbar",
-				"reference": "f4317f289a90af787f81e695268be1ef00cd0255"
+				"reference": "f26d6309fe2d4ef4298d616f25f4e4d815c388bd"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -1814,6 +1814,10 @@
 				"test-php": [
 					"pnpm run build-production",
 					"@composer phpunit"
+				],
+				"watch": [
+					"Composer\\Config::disableProcessTimeout",
+					"pnpm run watch"
 				]
 			},
 			"license": [

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-masterbar-watch
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-masterbar-watch
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+update composer.lock files

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -971,7 +971,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "f4317f289a90af787f81e695268be1ef00cd0255"
+                "reference": "f26d6309fe2d4ef4298d616f25f4e4d815c388bd"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1044,6 +1044,10 @@
                 "test-php": [
                     "pnpm run build-production",
                     "@composer phpunit"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [

--- a/projects/plugins/wpcomsh/changelog/add-masterbar-watch
+++ b/projects/plugins/wpcomsh/changelog/add-masterbar-watch
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+update composer.lock file

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1108,7 +1108,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "f4317f289a90af787f81e695268be1ef00cd0255"
+                "reference": "f26d6309fe2d4ef4298d616f25f4e4d815c388bd"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1181,6 +1181,10 @@
                 "test-php": [
                     "pnpm run build-production",
                     "@composer phpunit"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [


### PR DESCRIPTION
## Proposed changes:
- Add a watch script in the `composer.json` file to be able to watch build this package.
- Add the path to the webpack config in the `package.json` watch script.

Without this change you get this message when trying to watch changes in this package:
```
✔ Please choose which project · masterbar
This project does not have a watch step defined in composer.json.
```

The same command is added here following other packages example: https://github.com/Automattic/jetpack/pull/40927

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Run the command `jetpack watch`
2. Select `packages`
3. Select `masterbar`
4. Observe that the package builds and watches for changes.