### PR TITLE
Fix: Customiser color settings affect block editor UI.

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-customizer-color-css-affects-block-edior-ui
+++ b/projects/plugins/wpcomsh/changelog/fix-customizer-color-css-affects-block-edior-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixes an issue where setting color identity on the customizer breaks block editor UI elements.

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -1494,21 +1494,16 @@ class Colors_Manager_Common {
 
 		$css = self::get_theme_css();
 
-		if ( is_array( $editor_settings['styles'] ) ) {
-			$editor_settings['styles'] [] = array(
-				'css'            => $css,
-				'__unstableType' => 'theme',
-				'isGlobalStyles' => false,
-			);
-		} else {
-			$editor_settings['styles'] = array(
-				array(
-					'css'            => $css,
-					'__unstableType' => 'theme',
-					'isGlobalStyles' => false,
-				),
-			);
+		if ( ! is_array( $editor_settings['styles'] ) ) {
+			$editor_settings['styles'] = array();
 		}
+
+		$editor_settings['styles'] [] = array(
+			'css'            => $css,
+			'__unstableType' => 'theme',
+			'isGlobalStyles' => false,
+		);
+
 		return $editor_settings;
 	}
 

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -1487,25 +1487,27 @@ class Colors_Manager_Common {
 	 *
 	 * @param array $editor_settings Block editor settings.
 	 */
-	public static function add_block_editor_css( $editor_settings) {
+	public static function add_block_editor_css( $editor_settings ) {
 		if ( ! self::should_enable_colors() ) {
 			return $editor_settings;
 		}
 
 		$css = self::get_theme_css();
-		
-		if( is_array( $editor_settings['styles'] ) ) {
-			$editor_settings['styles'] []= array(
+
+		if ( is_array( $editor_settings['styles'] ) ) {
+			$editor_settings['styles'] [] = array(
 				'css'            => $css,
 				'__unstableType' => 'theme',
 				'isGlobalStyles' => false,
 			);
 		} else {
-			$editor_settings['styles'] = array( array(
-				'css'            => $css,
-				'__unstableType' => 'theme',
-				'isGlobalStyles' => false,
-			) );
+			$editor_settings['styles'] = array(
+				array(
+					'css'            => $css,
+					'__unstableType' => 'theme',
+					'isGlobalStyles' => false,
+				),
+			);
 		}
 		return $editor_settings;
 	}

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -163,7 +163,7 @@ class Colors_Manager_Common {
 				self::override_themecolors();
 
 				// NOTE: Using `get_called_class()` here is crucial for the Gutenberg styles to be processed.
-				add_action( 'enqueue_block_editor_assets', array( get_called_class(), 'print_block_editor_css' ) );
+				add_filter( 'block_editor_settings_all', array( get_called_class(), 'add_block_editor_css' ), 10, 2 );
 			}
 		} else {
 			// Classic Background stats
@@ -1483,17 +1483,31 @@ class Colors_Manager_Common {
 	}
 
 	/**
-	 * Print block editor CSS.
+	 * Adds block editor CSS to the block editor settings.
+	 *
+	 * @param array $editor_settings Block editor settings.
 	 */
-	public static function print_block_editor_css() {
+	public static function add_block_editor_css( $editor_settings) {
 		if ( ! self::should_enable_colors() ) {
-			return;
+			return $editor_settings;
 		}
-		$css = self::get_theme_css();
 
-		wp_register_style( 'custom-colors-editor-css', false, array(), '20210311' ); // Register an empty stylesheet to append custom CSS to.
-		wp_enqueue_style( 'custom-colors-editor-css' );
-		wp_add_inline_style( 'custom-colors-editor-css', $css ); // Append inline style to our new stylesheet
+		$css = self::get_theme_css();
+		
+		if( is_array( $editor_settings['styles'] ) ) {
+			$editor_settings['styles'] []= array(
+				'css'            => $css,
+				'__unstableType' => 'theme',
+				'isGlobalStyles' => false,
+			);
+		} else {
+			$editor_settings['styles'] = array( array(
+				'css'            => $css,
+				'__unstableType' => 'theme',
+				'isGlobalStyles' => false,
+			) );
+		}
+		return $editor_settings;
 	}
 
 	/**


### PR DESCRIPTION
Currently when colors are choosen on "Colors & Backgrounds" section of the customizer, the styles on the editor are not enqued as block editor styles and affect/break the block editor UI.


Fixes https://github.com/Automattic/themes/issues/7818.

## Proposed changes:
This PR instead of printing the styles directly on the block editor, uses the filter block_editor_settings_all and adds the styles in the styles sections. This change ensures that the styles are wrapped with the editor's content container and don't break the editor UI. It also makes the content of the post editor reflect the chosen styles.

This is an issue that affects all sites with a theme using customiser, when colors are choose the editor UI gets broken, creating a bad experience for the users.

## Before

### Colinear


<img width="276" alt="Screenshot 2025-01-14 at 23 52 06" src="https://github.com/user-attachments/assets/1d0f3574-87a1-44b7-9d40-134d1addb92b" />
<img width="236" alt="Screenshot 2025-01-14 at 23 51 56" src="https://github.com/user-attachments/assets/a2afac67-2e77-42e0-895e-9b29e309b632" />

### Cubic
<img width="990" alt="Screenshot 2025-01-14 at 23 59 36" src="https://github.com/user-attachments/assets/c6cddcfd-a499-4fe7-bf64-fc3d03b32a08" />


## After

<img width="281" alt="Screenshot 2025-01-14 at 23 51 09" src="https://github.com/user-attachments/assets/3d849a35-f775-4c77-8315-57a3057711a1" />
<img width="188" alt="Screenshot 2025-01-14 at 23 50 53" src="https://github.com/user-attachments/assets/6f7a9f45-4516-4c3a-9314-dbd5698949f4" />


### Cubic
<img width="998" alt="Screenshot 2025-01-14 at 23 58 28" src="https://github.com/user-attachments/assets/f72484d5-41d0-4fa2-ad6d-488338ca80d7" />





## Testing instructions:
Enable the "Colinear" theme (other themes with customizer have similar issues or even worse problems).
Go to the customizer, open "Colors & Backgrounds" make the link color green (second color).
Create a new post and add a link in a pagraph verify the link is green (on trunk it is not).
Hoover around the editor UI on sections like "Excerpt" "Categories" etc, verify the UI looks ok (on trunk the elements become green on hoover).

Repeats the steps with the Cubic theme, verify the background color is reflected on the editor on this branch but not on trunk.

## Does this pull request change what data or activity we track or use?

No.
