### PR TITLE
Forms: Fix dropdown icon position

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-select-field-icon
+++ b/projects/packages/forms/changelog/fix-forms-select-field-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix dropdown icon styling.

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -320,8 +320,8 @@
 
 .contact-form .contact-form__select-wrapper::after {
 	position: absolute;
-	inset-inline-end: calc(var(--jetpack--contact-form--input-padding-left) + 4px);
-	top: calc(var(--jetpack--contact-form--input-padding-top) + var(--jetpack--contact-form--line-height) / 2);
+	inset-inline-end: 20px;
+	top: 50%;
 
   content: "";
   display: block;

--- a/projects/plugins/jetpack/changelog/fix-forms-select-field-icon
+++ b/projects/plugins/jetpack/changelog/fix-forms-select-field-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix dropdown icon style


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #41060

## Proposed changes:

When viewing a form block dropdown field on the frontend, the arrow icon initially loads in the in the wrong place - in the lower right. It then corrects after couple seconds but the delay is very noticeable and jarring. The delay occurs because the position styling is [based on calculations using CSS variables](https://github.com/Automattic/jetpack/blob/4f7022d9d796be0ff70c83aaf5ef66dcdfbcc5fc/projects/packages/forms/src/contact-form/css/grunion.css#L321) that are, in turn, set via JavaScript after page load [here](https://github.com/Automattic/jetpack/blob/4f7022d9d796be0ff70c83aaf5ef66dcdfbcc5fc/projects/packages/forms/src/blocks/contact-form/util/form-styles.js#L25).

This PR replaces the CSS vars and calculations for simpler positioning rules. 

I tested across five themes, and the difference in styling and position for the icon is marginal. 

**Initial Load Before (ignore the shading - just the position of the arrow)**
<img width="616" alt="dropdown arrow" src="https://github.com/user-attachments/assets/d85c6a1e-e1fa-43a2-be41-2d69e8d44a09" />

**Initial Load After**
<img width="627" alt="dropdown-icon-after" src="https://github.com/user-attachments/assets/df4469c2-7f72-492a-9242-9ce1fc3feb1f" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a Jetpack Form with a select dropdown and a few options.
* Go to the frontend and confirm that dropdown arrow initially loads in roughly the right location. 
* Test across a few different themes.
* Note that the icon may still shift a bit within the select field depending on theme, as the same dynamically-set CSS vars are used for a variety of form and input styles, including aspects of the select input.

