### PR TITLE
Related Posts: Hide settings in block themes

### DIFF
--- a/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
@@ -1,5 +1,4 @@
 import { ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
-import { createInterpolateElement } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import React from 'react';
 import Card from 'components/card';
@@ -97,11 +96,9 @@ class RelatedPostsComponent extends React.Component {
 		return (
 			<>
 				<p>
-					{ createInterpolateElement(
-						__(
-							'Keep your visitors engaged with related content at the bottom of each post.',
-							'jetpack'
-						)
+					{ __(
+						'Keep your visitors engaged with related content at the bottom of each post.',
+						'jetpack'
 					) }
 				</p>
 				<ModuleToggle

--- a/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
@@ -95,11 +95,9 @@ class RelatedPostsComponent extends React.Component {
 		if ( isBlockThemeActive ) {
 			return (
 				<p>
-					{ createInterpolateElement(
-						__(
-							'Keep your visitors engaged with related content at the bottom of each post.',
-							'jetpack'
-						)
+					{ __(
+						'Keep your visitors engaged with related content at the bottom of each post.',
+						'jetpack'
 					) }
 				</p>
 			);

--- a/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
@@ -90,39 +90,18 @@ class RelatedPostsComponent extends React.Component {
 	}
 
 	renderSettings() {
-		const { isBlockThemeActive } = this.props;
-
-		if ( isBlockThemeActive ) {
-			return (
-				<p>
-					{ __(
-						'Keep your visitors engaged with related content at the bottom of each post.',
-						'jetpack'
-					) }
-				</p>
-			);
-		}
-
 		const isRelatedPostsActive = this.props.getOptionValue( 'related-posts' );
 		const unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'related-posts' );
+		const { isBlockThemeActive } = this.props;
 
 		return (
 			<>
 				<p>
 					{ createInterpolateElement(
 						__(
-							'Keep your visitors engaged with related content at the bottom of each post. These settings won’t apply to <a>related posts added using the block editor</a>.',
+							'Keep your visitors engaged with related content at the bottom of each post.',
 							'jetpack'
-						),
-						{
-							a: (
-								<a
-									href={ getRedirectUrl( 'jetpack-support-related-posts' ) }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-						}
+						)
 					) }
 				</p>
 				<ModuleToggle
@@ -136,98 +115,100 @@ class RelatedPostsComponent extends React.Component {
 						{ __( 'Show related content after posts', 'jetpack' ) }
 					</span>
 				</ModuleToggle>
-				<FormFieldset>
-					<ToggleControl
-						checked={ this.props.getOptionValue( 'show_headline', 'related-posts' ) }
-						disabled={
-							! isRelatedPostsActive ||
-							unavailableInOfflineMode ||
-							this.props.isSavingAnyOption( [ 'related-posts' ] )
-						}
-						toggling={ this.props.isSavingAnyOption( [ 'show_headline' ] ) }
-						onChange={ this.handleShowHeadlineToggleChange }
-						label={
-							<span className="jp-form-toggle-explanation">
-								{ __( 'Highlight related content with a heading', 'jetpack' ) }
-							</span>
-						}
-					/>
-					<ToggleControl
-						checked={ this.props.getOptionValue( 'show_thumbnails', 'related-posts' ) }
-						disabled={
-							! isRelatedPostsActive ||
-							unavailableInOfflineMode ||
-							this.props.isSavingAnyOption( [ 'related-posts' ] )
-						}
-						toggling={ this.props.isSavingAnyOption( [ 'show_thumbnails' ] ) }
-						onChange={ this.handleShowThumbnailsToggleChange }
-						label={
-							<span className="jp-form-toggle-explanation">
-								{ __( 'Show a thumbnail image where available', 'jetpack' ) }
-							</span>
-						}
-					/>
-					{ isRelatedPostsActive && (
-						<div>
-							<FormLabel className="jp-form-label-wide">
-								{ _x(
-									'Preview',
-									'A header for a preview area in the configuration screen.',
-									'jetpack'
-								) }
-							</FormLabel>
-							<Card className="jp-related-posts-preview">
-								{ this.state.show_headline && (
-									<div className="jp-related-posts-preview__title">
-										{ __( 'Related', 'jetpack' ) }
-									</div>
-								) }
-								{ [
-									{
-										url: 'cat-blog.png',
-										text: __( 'Big iPhone/iPad Update Now Available', 'jetpack' ),
-										context: _x(
-											'In "Mobile"',
-											'It refers to the category where a post was found. Used in an example preview.',
-											'jetpack'
-										),
-									},
-									{
-										url: 'devices.jpg',
-										text: __( 'The WordPress for Android App Gets a Big Facelift', 'jetpack' ),
-										context: _x(
-											'In "Mobile"',
-											'It refers to the category where a post was found. Used in an example preview.',
-											'jetpack'
-										),
-									},
-									{
-										url: 'mobile-wedding.jpg',
-										text: __( 'Upgrade Focus: VideoPress For Weddings', 'jetpack' ),
-										context: _x(
-											'In "Upgrade"',
-											'It refers to the category where a post was found. Used in an example preview.',
-											'jetpack'
-										),
-									},
-								].map( ( item, index ) => (
-									<div key={ `preview_${ index }` } className="jp-related-posts-preview__item">
-										{ this.state.show_thumbnails && (
-											<img
-												src={ `https://jetpackme.files.wordpress.com/2019/03/${ item.url }` }
-												alt={ item.text }
-											/>
-										) }
-										<h4 className="jp-related-posts-preview__post-title">
-											<a href="#/traffic">{ item.text }</a>
-										</h4>
-										<p className="jp-related-posts-preview__post-context">{ item.context }</p>
-									</div>
-								) ) }
-							</Card>
-						</div>
-					) }
-				</FormFieldset>
+				{ ! isBlockThemeActive && (
+					<FormFieldset>
+						<ToggleControl
+							checked={ this.props.getOptionValue( 'show_headline', 'related-posts' ) }
+							disabled={
+								! isRelatedPostsActive ||
+								unavailableInOfflineMode ||
+								this.props.isSavingAnyOption( [ 'related-posts' ] )
+							}
+							toggling={ this.props.isSavingAnyOption( [ 'show_headline' ] ) }
+							onChange={ this.handleShowHeadlineToggleChange }
+							label={
+								<span className="jp-form-toggle-explanation">
+									{ __( 'Highlight related content with a heading', 'jetpack' ) }
+								</span>
+							}
+						/>
+						<ToggleControl
+							checked={ this.props.getOptionValue( 'show_thumbnails', 'related-posts' ) }
+							disabled={
+								! isRelatedPostsActive ||
+								unavailableInOfflineMode ||
+								this.props.isSavingAnyOption( [ 'related-posts' ] )
+							}
+							toggling={ this.props.isSavingAnyOption( [ 'show_thumbnails' ] ) }
+							onChange={ this.handleShowThumbnailsToggleChange }
+							label={
+								<span className="jp-form-toggle-explanation">
+									{ __( 'Show a thumbnail image where available', 'jetpack' ) }
+								</span>
+							}
+						/>
+						{ isRelatedPostsActive && (
+							<div>
+								<FormLabel className="jp-form-label-wide">
+									{ _x(
+										'Preview',
+										'A header for a preview area in the configuration screen.',
+										'jetpack'
+									) }
+								</FormLabel>
+								<Card className="jp-related-posts-preview">
+									{ this.state.show_headline && (
+										<div className="jp-related-posts-preview__title">
+											{ __( 'Related', 'jetpack' ) }
+										</div>
+									) }
+									{ [
+										{
+											url: 'cat-blog.png',
+											text: __( 'Big iPhone/iPad Update Now Available', 'jetpack' ),
+											context: _x(
+												'In "Mobile"',
+												'It refers to the category where a post was found. Used in an example preview.',
+												'jetpack'
+											),
+										},
+										{
+											url: 'devices.jpg',
+											text: __( 'The WordPress for Android App Gets a Big Facelift', 'jetpack' ),
+											context: _x(
+												'In "Mobile"',
+												'It refers to the category where a post was found. Used in an example preview.',
+												'jetpack'
+											),
+										},
+										{
+											url: 'mobile-wedding.jpg',
+											text: __( 'Upgrade Focus: VideoPress For Weddings', 'jetpack' ),
+											context: _x(
+												'In "Upgrade"',
+												'It refers to the category where a post was found. Used in an example preview.',
+												'jetpack'
+											),
+										},
+									].map( ( item, index ) => (
+										<div key={ `preview_${ index }` } className="jp-related-posts-preview__item">
+											{ this.state.show_thumbnails && (
+												<img
+													src={ `https://jetpackme.files.wordpress.com/2019/03/${ item.url }` }
+													alt={ item.text }
+												/>
+											) }
+											<h4 className="jp-related-posts-preview__post-title">
+												<a href="#/traffic">{ item.text }</a>
+											</h4>
+											<p className="jp-related-posts-preview__post-context">{ item.context }</p>
+										</div>
+									) ) }
+								</Card>
+							</div>
+						) }
+					</FormFieldset>
+				) }
 			</>
 		);
 	}

--- a/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
@@ -51,7 +51,23 @@ class RelatedPostsComponent extends React.Component {
 		const { isBlockThemeActive, lastPostUrl, siteAdminUrl } = this.props;
 
 		if ( isBlockThemeActive ) {
-			return null;
+			return (
+				<Card
+					compact
+					className="jp-settings-card__configure-link"
+					onClick={ this.trackConfigureClick }
+					href={ getRedirectUrl( 'jetpack-support-related-posts', {
+						anchor: 'adding-related-posts-block-theme',
+					} ) }
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					{ __(
+						'Add a Related Posts Block to your site’s template in the site editor',
+						'jetpack'
+					) }
+				</Card>
+			);
 		}
 
 		return (
@@ -81,16 +97,29 @@ class RelatedPostsComponent extends React.Component {
 				<p>
 					{ createInterpolateElement(
 						__(
-							'<a>Add a Related Posts Block to your site’s template in the site editor</a> to keep your visitors engaged with related content at the bottom of each post.',
+							'Keep your visitors engaged with related content at the bottom of each post.',
+							'jetpack'
+						)
+					) }
+				</p>
+			);
+		}
+
+		const isRelatedPostsActive = this.props.getOptionValue( 'related-posts' );
+		const unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'related-posts' );
+
+		return (
+			<>
+				<p>
+					{ createInterpolateElement(
+						__(
+							'Keep your visitors engaged with related content at the bottom of each post. These settings won’t apply to <a>related posts added using the block editor</a>.',
 							'jetpack'
 						),
 						{
 							a: (
 								<a
-									onClick={ this.trackConfigureClick }
-									href={ getRedirectUrl( 'jetpack-support-related-posts', {
-										anchor: 'adding-related-posts-block-theme',
-									} ) }
+									href={ getRedirectUrl( 'jetpack-support-related-posts' ) }
 									target="_blank"
 									rel="noopener noreferrer"
 								/>
@@ -98,140 +127,115 @@ class RelatedPostsComponent extends React.Component {
 						}
 					) }
 				</p>
-			)
-		}
-
-		const isRelatedPostsActive = this.props.getOptionValue( 'related-posts' )
-		const unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'related-posts' );
-
-		return (
-			<>
-					<p>
-						{ createInterpolateElement(
-							__(
-								'Keep your visitors engaged with related content at the bottom of each post. These settings won’t apply to <a>related posts added using the block editor</a>.',
-								'jetpack'
-							),
-							{
-								a: (
-									<a
-										href={ getRedirectUrl( 'jetpack-support-related-posts' ) }
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-							}
-						) }
-					</p>
-					<ModuleToggle
-						slug="related-posts"
-						disabled={ unavailableInOfflineMode }
-						activated={ isRelatedPostsActive }
-						toggling={ this.props.isSavingAnyOption( 'related-posts' ) }
-						toggleModule={ this.props.toggleModuleNow }
-					>
-						<span className="jp-form-toggle-explanation">
-							{ __( 'Show related content after posts', 'jetpack' ) }
-						</span>
-					</ModuleToggle>
-					<FormFieldset>
-						<ToggleControl
-							checked={ this.props.getOptionValue( 'show_headline', 'related-posts' ) }
-							disabled={
-								! isRelatedPostsActive ||
-								unavailableInOfflineMode ||
-								this.props.isSavingAnyOption( [ 'related-posts' ] )
-							}
-							toggling={ this.props.isSavingAnyOption( [ 'show_headline' ] ) }
-							onChange={ this.handleShowHeadlineToggleChange }
-							label={
-								<span className="jp-form-toggle-explanation">
-									{ __( 'Highlight related content with a heading', 'jetpack' ) }
-								</span>
-							}
-						/>
-						<ToggleControl
-							checked={ this.props.getOptionValue( 'show_thumbnails', 'related-posts' ) }
-							disabled={
-								! isRelatedPostsActive ||
-								unavailableInOfflineMode ||
-								this.props.isSavingAnyOption( [ 'related-posts' ] )
-							}
-							toggling={ this.props.isSavingAnyOption( [ 'show_thumbnails' ] ) }
-							onChange={ this.handleShowThumbnailsToggleChange }
-							label={
-								<span className="jp-form-toggle-explanation">
-									{ __( 'Show a thumbnail image where available', 'jetpack' ) }
-								</span>
-							}
-						/>
-						{ isRelatedPostsActive && (
-							<div>
-								<FormLabel className="jp-form-label-wide">
-									{ _x(
-										'Preview',
-										'A header for a preview area in the configuration screen.',
-										'jetpack'
-									) }
-								</FormLabel>
-								<Card className="jp-related-posts-preview">
-									{ this.state.show_headline && (
-										<div className="jp-related-posts-preview__title">
-											{ __( 'Related', 'jetpack' ) }
-										</div>
-									) }
-									{ [
-										{
-											url: 'cat-blog.png',
-											text: __( 'Big iPhone/iPad Update Now Available', 'jetpack' ),
-											context: _x(
-												'In "Mobile"',
-												'It refers to the category where a post was found. Used in an example preview.',
-												'jetpack'
-											),
-										},
-										{
-											url: 'devices.jpg',
-											text: __( 'The WordPress for Android App Gets a Big Facelift', 'jetpack' ),
-											context: _x(
-												'In "Mobile"',
-												'It refers to the category where a post was found. Used in an example preview.',
-												'jetpack'
-											),
-										},
-										{
-											url: 'mobile-wedding.jpg',
-											text: __( 'Upgrade Focus: VideoPress For Weddings', 'jetpack' ),
-											context: _x(
-												'In "Upgrade"',
-												'It refers to the category where a post was found. Used in an example preview.',
-												'jetpack'
-											),
-										},
-									].map( ( item, index ) => (
-										<div key={ `preview_${ index }` } className="jp-related-posts-preview__item">
-											{ this.state.show_thumbnails && (
-												<img
-													src={ `https://jetpackme.files.wordpress.com/2019/03/${ item.url }` }
-													alt={ item.text }
-												/>
-											) }
-											<h4 className="jp-related-posts-preview__post-title">
-												<a href="#/traffic">{ item.text }</a>
-											</h4>
-											<p className="jp-related-posts-preview__post-context">{ item.context }</p>
-										</div>
-									) ) }
-								</Card>
-							</div>
-						) }
-					</FormFieldset>
+				<ModuleToggle
+					slug="related-posts"
+					disabled={ unavailableInOfflineMode }
+					activated={ isRelatedPostsActive }
+					toggling={ this.props.isSavingAnyOption( 'related-posts' ) }
+					toggleModule={ this.props.toggleModuleNow }
+				>
+					<span className="jp-form-toggle-explanation">
+						{ __( 'Show related content after posts', 'jetpack' ) }
+					</span>
+				</ModuleToggle>
+				<FormFieldset>
+					<ToggleControl
+						checked={ this.props.getOptionValue( 'show_headline', 'related-posts' ) }
+						disabled={
+							! isRelatedPostsActive ||
+							unavailableInOfflineMode ||
+							this.props.isSavingAnyOption( [ 'related-posts' ] )
+						}
+						toggling={ this.props.isSavingAnyOption( [ 'show_headline' ] ) }
+						onChange={ this.handleShowHeadlineToggleChange }
+						label={
+							<span className="jp-form-toggle-explanation">
+								{ __( 'Highlight related content with a heading', 'jetpack' ) }
+							</span>
+						}
+					/>
+					<ToggleControl
+						checked={ this.props.getOptionValue( 'show_thumbnails', 'related-posts' ) }
+						disabled={
+							! isRelatedPostsActive ||
+							unavailableInOfflineMode ||
+							this.props.isSavingAnyOption( [ 'related-posts' ] )
+						}
+						toggling={ this.props.isSavingAnyOption( [ 'show_thumbnails' ] ) }
+						onChange={ this.handleShowThumbnailsToggleChange }
+						label={
+							<span className="jp-form-toggle-explanation">
+								{ __( 'Show a thumbnail image where available', 'jetpack' ) }
+							</span>
+						}
+					/>
+					{ isRelatedPostsActive && (
+						<div>
+							<FormLabel className="jp-form-label-wide">
+								{ _x(
+									'Preview',
+									'A header for a preview area in the configuration screen.',
+									'jetpack'
+								) }
+							</FormLabel>
+							<Card className="jp-related-posts-preview">
+								{ this.state.show_headline && (
+									<div className="jp-related-posts-preview__title">
+										{ __( 'Related', 'jetpack' ) }
+									</div>
+								) }
+								{ [
+									{
+										url: 'cat-blog.png',
+										text: __( 'Big iPhone/iPad Update Now Available', 'jetpack' ),
+										context: _x(
+											'In "Mobile"',
+											'It refers to the category where a post was found. Used in an example preview.',
+											'jetpack'
+										),
+									},
+									{
+										url: 'devices.jpg',
+										text: __( 'The WordPress for Android App Gets a Big Facelift', 'jetpack' ),
+										context: _x(
+											'In "Mobile"',
+											'It refers to the category where a post was found. Used in an example preview.',
+											'jetpack'
+										),
+									},
+									{
+										url: 'mobile-wedding.jpg',
+										text: __( 'Upgrade Focus: VideoPress For Weddings', 'jetpack' ),
+										context: _x(
+											'In "Upgrade"',
+											'It refers to the category where a post was found. Used in an example preview.',
+											'jetpack'
+										),
+									},
+								].map( ( item, index ) => (
+									<div key={ `preview_${ index }` } className="jp-related-posts-preview__item">
+										{ this.state.show_thumbnails && (
+											<img
+												src={ `https://jetpackme.files.wordpress.com/2019/03/${ item.url }` }
+												alt={ item.text }
+											/>
+										) }
+										<h4 className="jp-related-posts-preview__post-title">
+											<a href="#/traffic">{ item.text }</a>
+										</h4>
+										<p className="jp-related-posts-preview__post-context">{ item.context }</p>
+									</div>
+								) ) }
+							</Card>
+						</div>
+					) }
+				</FormFieldset>
 			</>
-		)
+		);
 	}
 
 	render() {
-		const isRelatedPostsActive = this.props.getOptionValue( 'related-posts' )
+		const isRelatedPostsActive = this.props.getOptionValue( 'related-posts' );
 		return (
 			<SettingsCard { ...this.props } hideButton module="related-posts">
 				<SettingsGroup

--- a/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
@@ -51,23 +51,7 @@ class RelatedPostsComponent extends React.Component {
 		const { isBlockThemeActive, lastPostUrl, siteAdminUrl } = this.props;
 
 		if ( isBlockThemeActive ) {
-			return (
-				<Card
-					compact
-					className="jp-settings-card__configure-link"
-					onClick={ this.trackConfigureClick }
-					href={ getRedirectUrl( 'jetpack-support-related-posts', {
-						anchor: 'adding-related-posts-block-theme',
-					} ) }
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					{ __(
-						'Add a Related Posts Block to your site’s template in the site editor',
-						'jetpack'
-					) }
-				</Card>
-			);
+			return null;
 		}
 
 		return (
@@ -89,23 +73,39 @@ class RelatedPostsComponent extends React.Component {
 		);
 	}
 
-	render() {
-		const isRelatedPostsActive = this.props.getOptionValue( 'related-posts' ),
-			unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'related-posts' );
-		return (
-			<SettingsCard { ...this.props } hideButton module="related-posts">
-				<SettingsGroup
-					hasChild
-					disableInOfflineMode
-					module={ this.props.getModule( 'related-posts' ) }
-					support={ {
-						text: __(
-							'The feature helps visitors find more of your content by displaying related posts at the bottom of each post.',
+	renderSettings() {
+		const { isBlockThemeActive } = this.props;
+
+		if ( isBlockThemeActive ) {
+			return (
+				<p>
+					{ createInterpolateElement(
+						__(
+							'<a>Add a Related Posts Block to your site’s template in the site editor</a> to keep your visitors engaged with related content at the bottom of each post.',
 							'jetpack'
 						),
-						link: getRedirectUrl( 'jetpack-support-related-posts' ),
-					} }
-				>
+						{
+							a: (
+								<a
+									onClick={ this.trackConfigureClick }
+									href={ getRedirectUrl( 'jetpack-support-related-posts', {
+										anchor: 'adding-related-posts-block-theme',
+									} ) }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						}
+					) }
+				</p>
+			)
+		}
+
+		const isRelatedPostsActive = this.props.getOptionValue( 'related-posts' )
+		const unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'related-posts' );
+
+		return (
+			<>
 					<p>
 						{ createInterpolateElement(
 							__(
@@ -226,6 +226,27 @@ class RelatedPostsComponent extends React.Component {
 							</div>
 						) }
 					</FormFieldset>
+			</>
+		)
+	}
+
+	render() {
+		const isRelatedPostsActive = this.props.getOptionValue( 'related-posts' )
+		return (
+			<SettingsCard { ...this.props } hideButton module="related-posts">
+				<SettingsGroup
+					hasChild
+					disableInOfflineMode
+					module={ this.props.getModule( 'related-posts' ) }
+					support={ {
+						text: __(
+							'The feature helps visitors find more of your content by displaying related posts at the bottom of each post.',
+							'jetpack'
+						),
+						link: getRedirectUrl( 'jetpack-support-related-posts' ),
+					} }
+				>
+					{ this.renderSettings() }
 				</SettingsGroup>
 				{ ! this.props.isUnavailableInOfflineMode( 'related-posts' ) &&
 					isRelatedPostsActive &&

--- a/projects/plugins/jetpack/changelog/update-related-posts-block-theme
+++ b/projects/plugins/jetpack/changelog/update-related-posts-block-theme
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Hide related posts options for block themes

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -7,6 +7,7 @@
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Blocks;
+use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Sync\Settings;
 
 /**
@@ -725,6 +726,24 @@ EOT;
 			esc_html__( 'Show context (category or tag)', 'jetpack' ),
 			esc_html__( 'Preview:', 'jetpack' )
 		);
+
+		// The above settings does not take effect on block themes.
+		if ( wp_is_block_theme() ) {
+			$ui_settings = sprintf(
+				'<p><a href="%s" target="_blank" rel="noopener noreferrer">%s</a> %s</p>',
+				esc_url(
+					Redirect::get_url(
+						'jetpack-support-related-posts',
+						array(
+							'anchor' => 'adding-related-posts-block-theme',
+							'site'   => $this->get_blog_id(),
+						)
+					)
+				),
+				esc_html__( 'Add a Related Posts Block to your site’s template in the site editor', 'jetpack' ),
+				esc_html__( 'to keep your visitors engaged with related content at the bottom of each post.', 'jetpack' )
+			);
+		}
 
 		if ( ! $this->allow_feature_toggle() ) {
 			$template = <<<EOT

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -727,24 +727,6 @@ EOT;
 			esc_html__( 'Preview:', 'jetpack' )
 		);
 
-		// The above settings does not take effect on block themes.
-		if ( wp_is_block_theme() ) {
-			$ui_settings = sprintf(
-				'<p><a href="%s" target="_blank" rel="noopener noreferrer">%s</a> %s</p>',
-				esc_url(
-					Redirect::get_url(
-						'jetpack-support-related-posts',
-						array(
-							'anchor' => 'adding-related-posts-block-theme',
-							'site'   => $this->get_blog_id(),
-						)
-					)
-				),
-				esc_html__( 'Add a Related Posts Block to your site’s template in the site editor', 'jetpack' ),
-				esc_html__( 'to keep your visitors engaged with related content at the bottom of each post.', 'jetpack' )
-			);
-		}
-
 		if ( ! $this->allow_feature_toggle() ) {
 			$template = <<<EOT
 <input type="hidden" name="jetpack_relatedposts[enabled]" value="1" />
@@ -755,6 +737,28 @@ EOT;
 				$ui_settings // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- data is escaped when variable is set.
 			);
 		} else {
+			// Hide settings that does not take effect on block themes.
+			if ( wp_is_block_theme() ) {
+				$ui_settings = sprintf(
+					'<p><a href="%s" target="_blank" rel="noopener noreferrer">%s</a> %s</p>',
+					esc_url(
+						Redirect::get_url(
+							'jetpack-support-related-posts',
+							array(
+								'anchor' => 'adding-related-posts-block-theme',
+								'site'   => $this->get_blog_id(),
+							)
+						)
+					),
+					esc_html__( 'Add a Related Posts Block to your site’s template in the site editor', 'jetpack' ),
+					esc_html__( 'to keep your visitors engaged with related content at the bottom of each post.', 'jetpack' )
+				);
+				printf(
+					$ui_settings // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- data is escaped when variable is set.
+				);
+				return;
+			}
+
 			$template = <<<EOT
 <ul id="settings-reading-relatedposts">
 	<li>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/98190
Related to https://github.com/Automattic/wp-calypso/issues/98190

## Proposed changes:

This PR hides Related Posts settings in block themes;

- in wp-admin's Reading Settings on Atomic Classic and Simple Classic
- in Jetpack Settings on Atomic

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

> [!NOTE]  
> This will need to be tested with a Classic theme like Twenty Ten, and a Block theme like Twenty Twenty Four.

> [!NOTE]  
> To display Related Posts, your site must be:
> - Public 
> - Contain at least 500 bytes (about 100 words) per post.
> - You have posts related to another post (for example, using the same tags)

Reading Settings

* Activate a Classic theme
	* Go to /wp-admin/options-reading.php
	* Observe the settings
		* <img width="1022" alt="Screenshot 2025-01-15 at 14 04 03" src="https://github.com/user-attachments/assets/f8a5db88-4165-41c8-949a-7a68a4ddf1f8" />
	* Go to any post
	* Observe the related posts are displayed on the site's frontend
* Activate a Block theme
	* Go to /wp-admin/options-reading.php
	* Observe the link to the help doc
		* <img width="1198" alt="Screenshot 2025-01-15 at 13 55 47" src="https://github.com/user-attachments/assets/ad589257-537f-4baf-bfbb-b00de7113556" />
	* Go to Appearance > Editor > Templates > Single Posts
	* Add a Related Posts block at the bottom of the posts
	* Go to any post
	* Observe the related posts are displayed on the site's frontend

Jetpack Settings

* Activate a Classic theme
	* Go to /wp-admin/admin.php?page=jetpack#traffic
	* Observe the settings
		* <img width="1054" alt="Screenshot 2025-01-15 at 15 12 51" src="https://github.com/user-attachments/assets/35600e44-08bc-4a3b-a90d-44565264f5d5" />
	* Go to any post
	* Observe the related posts are displayed on the site's frontend
* Activate a Block theme
	* Go to /wp-admin/admin.php?page=jetpack#traffic
	* Observe the link to the help doc
		* <img width="1060" alt="Screenshot 2025-01-15 at 15 10 09" src="https://github.com/user-attachments/assets/4ad0a7b3-876e-4756-a84d-215260717d88" />
	* Go to Appearance > Editor > Templates > Single Posts
	* Add a Related Posts block at the bottom of the posts
	* Go to any post
	* Observe the related posts are displayed on the site's frontend

Advanced

- When the feature is toggled off in Jetpack Settings,
	- <img width="1059" alt="Screenshot 2025-01-15 at 15 15 01" src="https://github.com/user-attachments/assets/80402536-81ab-4667-93f5-b4568140fb69" />
	- <img width="1057" alt="Screenshot 2025-01-15 at 15 15 15" src="https://github.com/user-attachments/assets/0e555762-697b-47c6-84b4-becc35fe8373" />
- Ensure the settings are not displayed in Reading Settings 
- Ensure you can enable the feature via the Block
	- <img width="1154" alt="Screenshot 2025-01-15 at 14 38 39" src="https://github.com/user-attachments/assets/f0794f28-de1b-47bb-a854-55ce0b888269" />

_I referred to https://github.com/Automattic/jetpack/pull/39784 for testing instructions._

<!--
_Please note that when a Block theme is active, users can no longer enable Related Posts through Jetpack Settings **if** it was disabled while the Classic theme was active before switching to a Block theme. However, users can still activate Related Posts using the Related Posts Block, so this should not be an issue._
-->