### PR TITLE
[WooCommerce Analytics] Add woocomerceanalytics_session

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/tweak-analytics_session_id
+++ b/projects/packages/woocommerce-analytics/changelog/tweak-analytics_session_id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Set woocommerceanalytics_session

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -31,9 +31,6 @@ class Universal {
 		// delayed events stored in session (can be add_to_carts, product_views...)
 		add_action( 'wp_head', array( $this, 'loop_session_events' ), 2 );
 
-		// Initialize session
-		add_action( 'template_redirect', array( $this, 'initialize_woocommerceanalytics_session' ) );
-
 		// Capture search
 		add_action( 'template_redirect', array( $this, 'capture_search_query' ), 11 );
 
@@ -72,35 +69,6 @@ class Universal {
 
 		// cart page view
 		add_action( 'wp_footer', array( $this, 'capture_cart_view' ), 11 );
-	}
-
-	/**
-	 * Set a UUID for the current session if is not yet loaded and record the session started event
-	 */
-	public function initialize_woocommerceanalytics_session() {
-		if ( ! isset( $_COOKIE['woocommerceanalytics_session'] ) ) {
-			$session_id         = wp_generate_uuid4();
-			$this->session_id   = $session_id;
-			$this->landing_page = sanitize_url( wp_unslash( ( empty( $_SERVER['HTTPS'] ) ? 'http' : 'https' ) . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]" ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidatedNotSanitized -- actually escaped with sanitize_url.
-			// Disabled the below temporarily to avoid caching issues.
-			// phpcs:disable Squiz.PHP.CommentedOutCode.Found
-			// setcookie(
-			// 'woocommerceanalytics_session',
-			// wp_json_encode(
-			// array(
-			// 'session_id'   => $this->session_id,
-			// 'landing_page' => $this->landing_page,
-			// )
-			// ),
-			// 0,
-			// COOKIEPATH,
-			// COOKIE_DOMAIN,
-			// is_ssl(),
-			// true
-			// );
-			// $this->record_event( 'woocommerceanalytics_session_started' );
-			// phpcs:enable Squiz.PHP.CommentedOutCode.Found
-		}
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -330,7 +330,7 @@ trait Woo_Analytics_Trait {
 	/**
 	 * In case session_id is empty. A new session should be created.
 	 *
-	 * @return string|void
+	 * @return void
 	 */
 	public function maybe_start_session() {
 		if ( ! isset( $_COOKIE['woocommerceanalytics_session'] ) ) {

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -57,14 +57,14 @@ trait Woo_Analytics_Trait {
 	 *
 	 *  @var string
 	 */
-	protected $session_id;
+	protected $session_id = '';
 
 	/**
 	 *  Landing page where session started.
 	 *
 	 *  @var string
 	 */
-	protected $landing_page;
+	protected $landing_page = '';
 
 	/**
 	 * Format Cart Items or Order Items to an array
@@ -263,19 +263,16 @@ trait Woo_Analytics_Trait {
 	 * @return array Array of standard event props.
 	 */
 	public function get_common_properties() {
-		// phpcs:disable Squiz.PHP.CommentedOutCode.Found
-		// Disabled the below temporarily to avoid caching issues.
-		// $session_data       = json_decode( sanitize_text_field( wp_unslash( $_COOKIE['woocommerceanalytics_session'] ?? '' ) ), true ) ?? array();
-		// $session_id         = sanitize_text_field( $session_data['session_id'] ?? $this->session_id );
-		// $landing_page       = sanitize_url( $session_data['landing_page'] ?? $this->landing_page );
-		// phpcs:enable Squiz.PHP.CommentedOutCode.Found
+		$session_data       = json_decode( sanitize_text_field( wp_unslash( $_COOKIE['woocommerceanalytics_session'] ?? '' ) ), true ) ?? array();
+		$session_id         = sanitize_text_field( $session_data['session_id'] ?? $this->session_id );
+		$landing_page       = sanitize_url( $session_data['landing_page'] ?? $this->landing_page );
 		$site_info          = array(
-			'session_id'                         => null,
+			'session_id'                         => $session_id,
 			'blog_id'                            => Jetpack_Connection::get_site_id(),
 			'store_id'                           => defined( '\\WC_Install::STORE_ID_OPTION' ) ? get_option( \WC_Install::STORE_ID_OPTION ) : false,
 			'ui'                                 => $this->get_user_id(),
 			'url'                                => home_url(),
-			'landing_page'                       => null,
+			'landing_page'                       => $landing_page,
 			'woo_version'                        => WC()->version,
 			'wp_version'                         => get_bloginfo( 'version' ),
 			'store_admin'                        => in_array( array( 'administrator', 'shop_manager' ), wp_get_current_user()->roles, true ) ? 1 : 0,
@@ -325,8 +322,32 @@ trait Woo_Analytics_Trait {
 	 * @return string|void
 	 */
 	public function record_event( $event_name, $properties = array(), $product_id = null ) {
+		$this->maybe_start_session();
 		$js = $this->process_event_properties( $event_name, $properties, $product_id );
 		wc_enqueue_js( "_wca.push({$js});" );
+	}
+
+	/**
+	 * In case session_id is empty. A new session should be created.
+	 *
+	 * @return string|void
+	 */
+	public function maybe_start_session() {
+		if ( ! isset( $_COOKIE['woocommerceanalytics_session'] ) ) {
+			$session_id         = wp_generate_uuid4();
+			$this->session_id   = $session_id;
+			$this->landing_page = sanitize_url( wp_unslash( ( empty( $_SERVER['HTTPS'] ) ? 'http' : 'https' ) . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]" ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidatedNotSanitized -- actually escaped with sanitize_url.
+			$event_js           = $this->process_event_properties( 'woocommerceanalytics_session_started' );
+			$cookie_js          = "
+            const sessionData = JSON.stringify({
+                    session_id: '{$this->session_id}',
+                    landing_page: encodeURIComponent('{$this->landing_page}'),
+            });
+            document.cookie = `woocommerceanalytics_session=\${sessionData}; path=/; secure; samesite=strict`;
+            ";
+			wc_enqueue_js( $cookie_js ); // save the session cookie for further events in the session
+			wc_enqueue_js( "_wca.push({$event_js});" ); // trigger session started event
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes and issue with the way we set the cookie for storing woocomerceanalytics_session that created cache issues.

In this PR we do set the cookie using JS to avoid those cache misses.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Set the woocomerceanalytics_session using JS

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up a Jurassic Ninja site using the code in this PR for WooCommerce Analytics
* Verify the cache by hitting different pages with curl -I 
* When running it the second time you should see something like:

<img width="1247" alt="Screenshot 2025-01-15 at 13 50 25" src="https://github.com/user-attachments/assets/1eca8f11-96ee-4dd9-abea-33b49c66a4c4" />

See how it was before when the set cookie was set in PHP headers

<img width="1728" alt="Screenshot 2025-01-14 at 17 03 59" src="https://github.com/user-attachments/assets/31b039f4-7766-43f8-b7bd-9ca86de5823e" />


* Close all the incognito windows and open a new one, navigate to a Product (or perform any other event like going to checkout or cart)
* See session_started event is triggered and also the event contains session_id
* Create more events, see they have session_id and landfing_page in the props.
* Tests edge cases, like Empty carts or going to checkout when cart is empty.

Note: 

Mybe you want to quickly push the plugin to a live JN site without waiting for the builds. This rsync wrapper knows which files to send and not send.

Rsync the Jetpack plugin to server destination: 

`jetpack rsync jetpack user@your.server.example.com:/home/path/to/wp-content/plugins`

Find the command in your JN site

<img width="1357" alt="Screenshot 2025-01-15 at 15 07 09" src="https://github.com/user-attachments/assets/9a3fbf98-f5d5-4af2-a96d-b20b5e9d2cb1" />

Notice also that for track to happen USage TRcking should be enabled in WoCommerce -> Settings -> Advanced -> WooCommerce.com -> "Allow usage tracking"

Also JP (or WPCOM) should be connected 
