### PR TITLE
Social | Use the proxy trait from connection package

### DIFF
--- a/projects/packages/publicize/src/class-connections.php
+++ b/projects/packages/publicize/src/class-connections.php
@@ -175,7 +175,7 @@ class Connections {
 
 		$request = new WP_REST_Request( 'GET', '/wpcom/v2/publicize/connections' );
 
-		$connections = $proxy->proxy_request_to_wpcom( $request, '', 'blog' );
+		$connections = $proxy->proxy_request_to_wpcom_as_blog( $request );
 
 		if ( is_wp_error( $connections ) ) {
 			// @todo log error.

--- a/projects/packages/publicize/src/rest-api/class-connections-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-controller.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Publicize\REST_API;
 
+use Automattic\Jetpack\Connection\Traits\WPCOM_REST_API_Proxy_Request;
 use Automattic\Jetpack\Publicize\Connections;
 use Automattic\Jetpack\Publicize\Publicize_Utils;
 use WP_Error;
@@ -19,25 +20,17 @@ use WP_REST_Server;
  */
 class Connections_Controller extends Base_Controller {
 
-	/**
-	 * The API version.
-	 *
-	 * @var string
-	 */
-	protected $version = 'v2';
-
-	/**
-	 * The base API path.
-	 *
-	 * @var string
-	 */
-	protected $base_api_path = 'wpcom';
+	use WPCOM_REST_API_Proxy_Request;
 
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		parent::__construct();
+
+		$this->base_api_path = 'wpcom';
+		$this->version       = 'v2';
+
 		$this->namespace = "{$this->base_api_path}/{$this->version}";
 		$this->rest_base = 'publicize/connections';
 
@@ -266,9 +259,7 @@ class Connections_Controller extends Base_Controller {
 
 			$connections = Connections::wpcom_get_connections( $args );
 		} else {
-			$proxy = new Proxy_Requests( $this->rest_base );
-
-			$connections = $proxy->proxy_request_to_wpcom( $request );
+			$connections = $this->proxy_request_to_wpcom_as_user( $request );
 		}
 
 		if ( is_wp_error( $connections ) ) {
@@ -342,9 +333,7 @@ class Connections_Controller extends Base_Controller {
 
 		}
 
-		$proxy = new Proxy_Requests( $this->rest_base );
-
-		$response = $proxy->proxy_request_to_wpcom( $request, '', 'user', array( 'timeout' => 120 ) );
+		$response = $this->proxy_request_to_wpcom_as_user( $request, '', array( 'timeout' => 120 ) );
 
 		if ( is_wp_error( $response ) ) {
 			return new WP_Error(
@@ -423,9 +412,7 @@ class Connections_Controller extends Base_Controller {
 			return $response;
 		}
 
-		$proxy = new Proxy_Requests( $this->rest_base );
-
-		$response = $proxy->proxy_request_to_wpcom( $request, $connection_id, 'user', array( 'timeout' => 120 ) );
+		$response = $this->proxy_request_to_wpcom_as_user( $request, $connection_id, array( 'timeout' => 120 ) );
 
 		if ( is_wp_error( $response ) ) {
 			return new WP_Error(
@@ -482,9 +469,7 @@ class Connections_Controller extends Base_Controller {
 			return $response;
 		}
 
-		$proxy = new Proxy_Requests( $this->rest_base );
-
-		$response = $proxy->proxy_request_to_wpcom( $request, $connection_id, 'user', array( 'timeout' => 120 ) );
+		$response = $this->proxy_request_to_wpcom_as_user( $request, $connection_id, array( 'timeout' => 120 ) );
 
 		if ( is_wp_error( $response ) ) {
 			return new WP_Error(

--- a/projects/packages/publicize/src/rest-api/class-proxy-requests.php
+++ b/projects/packages/publicize/src/rest-api/class-proxy-requests.php
@@ -7,37 +7,14 @@
 
 namespace Automattic\Jetpack\Publicize\REST_API;
 
-use Automattic\Jetpack\Connection\Client;
-use Automattic\Jetpack\Connection\Manager;
-use Automattic\Jetpack\Status\Visitor;
-use WP_Error;
-use WP_REST_Request;
+use Automattic\Jetpack\Connection\Traits\WPCOM_REST_API_Proxy_Request;
 
 /**
  * Helper class to make proxy requests to wpcom.
  */
 class Proxy_Requests {
 
-	/**
-	 * The rest base.
-	 *
-	 * @var string
-	 */
-	protected $rest_base;
-
-	/**
-	 * The base API path.
-	 *
-	 * @var string
-	 */
-	protected $base_api_path;
-
-	/**
-	 * The API version.
-	 *
-	 * @var string
-	 */
-	protected $version;
+	use WPCOM_REST_API_Proxy_Request;
 
 	/**
 	 * Constructor.
@@ -50,89 +27,5 @@ class Proxy_Requests {
 		$this->rest_base     = $rest_base;
 		$this->base_api_path = $base_api_path;
 		$this->version       = $version;
-	}
-
-	/**
-	 * Copied from WPCOM_REST_API_Proxy_Request_Trait. See the @todo below.
-	 *
-	 * Proxy request to wpcom servers on behalf of a user or using the Site-level Connection (blog token).
-	 *
-	 * @todo Swap this with the trait when it's available 🔗👇
-	 * @link https://github.com/Automattic/jetpack/issues/40947
-	 *
-	 * @param WP_Rest_Request $request Request to proxy.
-	 * @param string          $path Path to append to the rest base.
-	 * @param string          $context Can be Either 'user' or 'blog'. Defaults to 'user'.
-	 * @param array           $request_options Request options to pass to wp_remote_request.
-	 *
-	 * @return mixed|WP_Error           Response from wpcom servers or an error.
-	 */
-	public function proxy_request_to_wpcom( $request, $path = '', $context = 'user', $request_options = array() ) {
-		$blog_id      = \Jetpack_Options::get_option( 'id' );
-		$path         = '/sites/' . rawurldecode( $blog_id ) . '/' . rawurldecode( ltrim( $this->rest_base, '/' ) ) . ( $path ? '/' . rawurldecode( ltrim( $path, '/' ) ) : '' );
-		$query_params = $request->get_query_params();
-		$manager      = new Manager();
-
-		/*
-		 * A rest_route parameter can be added when using plain permalinks.
-		 * It is not necessary to pass them to WordPress.com,
-		 * and may even cause issues with some endpoints.
-		 * Let's remove it.
-		 */
-		if ( isset( $query_params['rest_route'] ) ) {
-			unset( $query_params['rest_route'] );
-		}
-		$api_url = add_query_arg( $query_params, $path );
-
-		$request_options = array_replace_recursive(
-			array(
-				'headers' => array(
-					'Content-Type'    => 'application/json',
-					'X-Forwarded-For' => ( new Visitor() )->get_ip( true ),
-				),
-				'method'  => $request->get_method(),
-			),
-			$request_options
-		);
-
-		// If no body is present, passing it as $request->get_body() will cause an error.
-		$body = $request->get_body() ? $request->get_body() : null;
-
-		$response = new WP_Error(
-			'rest_unauthorized',
-			__( 'Please connect your user account to WordPress.com', 'jetpack-publicize-pkg' ),
-			array( 'status' => rest_authorization_required_code() )
-		);
-
-		if ( 'user' === $context ) {
-			if ( ! $manager->is_user_connected() ) {
-				return $response;
-			}
-			$response = Client::wpcom_json_api_request_as_user( $api_url, $this->version, $request_options, $body, $this->base_api_path );
-		}
-
-		if ( 'blog' === $context ) {
-			if ( ! $manager->is_connected() ) {
-				return $response;
-			}
-
-			$response = Client::wpcom_json_api_request_as_blog( $api_url, $this->version, $request_options, $body, $this->base_api_path );
-		}
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
-		$response_status = wp_remote_retrieve_response_code( $response );
-		$response_body   = json_decode( wp_remote_retrieve_body( $response ), true );
-
-		if ( $response_status >= 400 ) {
-			$code    = isset( $response_body['code'] ) ? $response_body['code'] : 'unknown_error';
-			$message = isset( $response_body['message'] ) ? $response_body['message'] : __( 'An unknown error occurred.', 'jetpack-publicize-pkg' );
-
-			return new WP_Error( $code, $message, array( 'status' => $response_status ) );
-		}
-
-		return $response_body;
 	}
 }


### PR DESCRIPTION
Now that we have the `WPCOM_REST_API_Proxy_Request` trait in trunk following #41023, we can use it to remove the copied code

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use the `WPCOM_REST_API_Proxy_Request` trait from connection package
* Remove the copied code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to connections management
* Verify that the connections load fine for both admin and author
* Verify connection test results

