### PR TITLE
Media Library: Implement upload media from URL

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/wpcom-media-url-upload
+++ b/projects/packages/jetpack-mu-wpcom/changelog/wpcom-media-url-upload
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Allows uploading media from URL in Media Library

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -152,6 +152,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-command-palette/wpcom-command-palette.php';
 		require_once __DIR__ . '/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php';
 		require_once __DIR__ . '/features/wpcom-locale/sync-locale-from-calypso-to-atomic.php';
+		require_once __DIR__ . '/features/wpcom-media/wpcom-media-url-upload.php';
 		require_once __DIR__ . '/features/wpcom-options-general/options-general.php';
 		require_once __DIR__ . '/features/wpcom-plugins/wpcom-plugins.php';
 		require_once __DIR__ . '/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import './style.scss';
 
-const WpcomMediaUrlUploadForm = ( { ajaxUrl, action, nonce, isSiteEditor } ) => {
+const WpcomMediaUrlUploadForm = ( { ajaxUrl, action, nonce, isEditor } ) => {
 	const [ url, setUrl ] = useState( '' );
 
 	const [ show, setShow ] = useState( false );
@@ -48,7 +48,7 @@ const WpcomMediaUrlUploadForm = ( { ajaxUrl, action, nonce, isSiteEditor } ) => 
 							.collection.add( attachmentToAdd );
 					};
 
-					if ( isSiteEditor ) {
+					if ( isEditor ) {
 						const mediaLibraryTab = window.wp.media.frame.state( 'library' );
 						mediaLibraryTab.trigger( 'open' );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
@@ -81,7 +81,7 @@ const WpcomMediaUrlUploadForm = ( { ajaxUrl, action, nonce, isSiteEditor } ) => 
 			buttonText = __( 'Uploading…', 'jetpack-mu-wpcom' );
 		}
 		return (
-			<form onSubmit="return false;">
+			<form onSubmit={ handleSubmit }>
 				<input
 					type="url"
 					value={ url }
@@ -91,10 +91,10 @@ const WpcomMediaUrlUploadForm = ( { ajaxUrl, action, nonce, isSiteEditor } ) => 
 					readOnly={ isUploading }
 				/>
 				<button
+					type="submit"
 					className={ clsx( 'button', 'button-primary', {
 						'updating-message': isUploading,
 					} ) }
-					onClick={ handleSubmit }
 					readOnly={ isUploading }
 				>
 					{ buttonText }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
@@ -46,13 +46,13 @@ const WpcomMediaUrlUploadForm = ( { ajaxUrl, action, nonce, isSiteEditor } ) => 
 						const mediaLibraryTab = window.wp.media.frame.state( 'library' );
 						mediaLibraryTab.trigger( 'open' );
 
-						window.wp.media.frame.content.get().collection.add( attachment );
+						window.wp.media.frame.controller.browserView.collection.add( attachment );
 
 						const selection = mediaLibraryTab.get( 'selection' );
 						selection.reset();
 						selection.add( [ attachment ] );
 					} else {
-						window.wp.media.frame.content.get().collection.add( attachment );
+						window.wp.media.frame.controller.browserView.collection.add( attachment );
 					}
 
 					setIsUploading( false );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
@@ -75,9 +75,12 @@ const WpcomMediaUrlUploadForm = ( { ajaxUrl, action, nonce, isSiteEditor } ) => 
 
 	const renderLink = () => {
 		return (
-			<a href="#" onClick={ () => setShow( true ) } className="woy">
+			<button
+				className="button wpcom-media-url-upload-form__pre-upload-button"
+				onClick={ () => setShow( true ) }
+			>
 				{ __( 'Upload from URL', 'jetpack-mu-wpcom' ) }
-			</a>
+			</button>
 		);
 	};
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
@@ -1,0 +1,109 @@
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+import { useState } from 'react';
+
+import './style.scss';
+
+const WpcomMediaUrlUploadForm = ( { ajaxUrl, action, nonce, isSiteEditor } ) => {
+	const [ url, setUrl ] = useState( '' );
+
+	const [ show, setShow ] = useState( false );
+	const [ isUploading, setIsUploading ] = useState( false );
+
+	const handleUrlChange = e => {
+		setUrl( e.target.value );
+	};
+
+	const handleSubmit = async e => {
+		if ( isUploading ) {
+			return false;
+		}
+		try {
+			new URL( url ); // eslint-disable-line no-new
+		} catch {
+			return false;
+		}
+		e.preventDefault();
+
+		const formData = new FormData();
+		formData.append( 'action', action );
+		formData.append( 'url', url );
+		formData.append( '_ajax_nonce', nonce );
+
+		setIsUploading( true );
+
+		const response = await fetch( ajaxUrl, {
+			method: 'POST',
+			body: formData,
+		} );
+
+		const { success, data } = await response.json();
+
+		if ( success ) {
+			window.wp.media.model.Attachment.get( data.attachment_id ).fetch( {
+				success: function ( attachment ) {
+					if ( isSiteEditor ) {
+						const mediaLibraryTab = window.wp.media.frame.state( 'library' );
+						mediaLibraryTab.trigger( 'open' );
+
+						window.wp.media.frame.content.get().collection.add( attachment );
+
+						const selection = mediaLibraryTab.get( 'selection' );
+						selection.reset();
+						selection.add( [ attachment ] );
+					} else {
+						window.wp.media.frame.content.get().collection.add( attachment );
+					}
+
+					setIsUploading( false );
+					setUrl( '' );
+				},
+			} );
+		} else {
+			setIsUploading( false );
+			window.wp.Uploader.errors.add( { file: { name: url }, message: data[ 0 ].message } );
+		}
+
+		return false;
+	};
+
+	const renderLink = () => {
+		return (
+			<a href="#" onClick={ () => setShow( true ) }>
+				{ __( 'Upload from URL', 'jetpack-mu-wpcom' ) }
+			</a>
+		);
+	};
+
+	const renderForm = () => {
+		let buttonText = __( 'Upload', 'jetpack-mu-wpcom' );
+		if ( isUploading ) {
+			buttonText = __( 'Uploading…', 'jetpack-mu-wpcom' );
+		}
+		return (
+			<form onSubmit="return false;">
+				<input
+					type="url"
+					value={ url }
+					onChange={ handleUrlChange }
+					placeholder={ __( 'Enter media URL', 'jetpack-mu-wpcom' ) }
+					required
+					readOnly={ isUploading }
+				/>
+				<button
+					className={ clsx( 'button', 'button-primary', {
+						'updating-message': isUploading,
+					} ) }
+					onClick={ handleSubmit }
+					readOnly={ isUploading }
+				>
+					{ buttonText }
+				</button>
+			</form>
+		);
+	};
+
+	return <div className="wpcom-media-url-upload-form">{ show ? renderForm() : renderLink() }</div>;
+};
+
+export default WpcomMediaUrlUploadForm;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
@@ -69,7 +69,7 @@ const WpcomMediaUrlUploadForm = ( { ajaxUrl, action, nonce, isSiteEditor } ) => 
 
 	const renderLink = () => {
 		return (
-			<a href="#" onClick={ () => setShow( true ) }>
+			<a href="#" onClick={ () => setShow( true ) } className="woy">
 				{ __( 'Upload from URL', 'jetpack-mu-wpcom' ) }
 			</a>
 		);

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
@@ -42,17 +42,23 @@ const WpcomMediaUrlUploadForm = ( { ajaxUrl, action, nonce, isSiteEditor } ) => 
 		if ( success ) {
 			window.wp.media.model.Attachment.get( data.attachment_id ).fetch( {
 				success: function ( attachment ) {
+					const addAttachment = attachmentToAdd => {
+						( window.wp.media.frame.controller || window.wp.media.frame ).content
+							.get()
+							.collection.add( attachmentToAdd );
+					};
+
 					if ( isSiteEditor ) {
 						const mediaLibraryTab = window.wp.media.frame.state( 'library' );
 						mediaLibraryTab.trigger( 'open' );
 
-						window.wp.media.frame.controller.browserView.collection.add( attachment );
+						addAttachment( attachment );
 
 						const selection = mediaLibraryTab.get( 'selection' );
 						selection.reset();
 						selection.add( [ attachment ] );
 					} else {
-						window.wp.media.frame.controller.browserView.collection.add( attachment );
+						addAttachment( attachment );
 					}
 
 					setIsUploading( false );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/style.scss
@@ -1,19 +1,15 @@
 .wpcom-media-url-upload-form {
+	margin-top: -15px;
+	margin-bottom: 15px;
+	height: 30px;
+
 	button#{&}__pre-upload-button {
 		padding: 0 21px;
-		margin-top: -15px;
-		margin-bottom: 20px;
 	}
 
 	input {
 		width: 100%;
 		max-width: 600px;
 		margin-right: 6px;
-		margin-bottom: 5px;
-	}
-
-	form {
-		margin-top: -15px;
-	    margin-bottom: 21.5px;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/style.scss
@@ -1,0 +1,7 @@
+.wpcom-media-url-upload-form {
+	input {
+		width: 100%;
+		max-width: 600px;
+		margin-bottom: 5px;
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/style.scss
@@ -1,12 +1,19 @@
 .wpcom-media-url-upload-form {
+	button#{&}__pre-upload-button {
+		padding: 0 21px;
+		margin-top: -15px;
+		margin-bottom: 20px;
+	}
+
 	input {
 		width: 100%;
 		max-width: 600px;
 		margin-right: 6px;
 		margin-bottom: 5px;
 	}
-}
 
-.media-frame a.woy {
-	color: unset;
+	form {
+		margin-top: -15px;
+	    margin-bottom: 21.5px;
+	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/style.scss
@@ -2,6 +2,7 @@
 	input {
 		width: 100%;
 		max-width: 600px;
+		margin-right: 6px;
 		margin-bottom: 5px;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/style.scss
@@ -6,3 +6,7 @@
 		margin-bottom: 5px;
 	}
 }
+
+.media-frame a.woy {
+	color: unset;
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import WpcomMediaUrlUploadForm from './wpcom-media-url-upload-form';
+
+const props = typeof window === 'object' ? window.JETPACK_MU_WPCOM_MEDIA_URL_UPLOAD : {};
+
+document.addEventListener( 'DOMContentLoaded', function () {
+	if ( window.wp?.media?.view?.UploaderInline ) {
+		const originalUploaderInline = window.wp.media.view.UploaderInline;
+
+		window.wp.media.view.UploaderInline = originalUploaderInline.extend( {
+			ready: function () {
+				originalUploaderInline.prototype.ready.apply( this, arguments );
+
+				const container = document.getElementById( 'wpcom-media-url-upload' );
+				if ( container ) {
+					const root = ReactDOM.createRoot( container );
+					root.render( <WpcomMediaUrlUploadForm { ...props } /> );
+				}
+			},
+		} );
+	}
+} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.php
@@ -72,7 +72,7 @@ function wpcom_handle_media_url_upload() {
 	}
 }
 
-if ( current_user_can( 'upload_files' ) ) {
+if ( current_user_can( 'upload_files' ) && ! empty( $_GET['untangling-media'] ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
 	add_action( 'pre-upload-ui', 'wpcom_media_url_upload', 9 );
 	add_action( 'wp_ajax_wpcom_media_url_upload', 'wpcom_handle_media_url_upload' );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Allows uploading media from URL in Media Library.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Appends the wpcom media URL upload form.
+ */
+function wpcom_media_url_upload() {
+	global $pagenow;
+
+	?>
+	<div id="wpcom-media-url-upload"></div>
+	<?php
+
+	$handle = jetpack_mu_wpcom_enqueue_assets( 'wpcom-media-url-upload', array( 'js', 'css' ) );
+
+	$data = wp_json_encode(
+		array(
+			'ajaxUrl'      => admin_url( 'admin-ajax.php' ),
+			'action'       => 'wpcom_media_url_upload',
+			'nonce'        => wp_create_nonce( 'wpcom_media_url_upload' ),
+			'isSiteEditor' => $pagenow === 'site-editor.php',
+		)
+	);
+
+	wp_add_inline_script(
+		$handle,
+		"window.JETPACK_MU_WPCOM_MEDIA_URL_UPLOAD = $data;",
+		'before'
+	);
+}
+
+/**
+ * AJAX handler for the wpcom media URL upload.
+ */
+function wpcom_handle_media_url_upload() {
+	check_ajax_referer( 'wpcom_media_url_upload' );
+
+	if ( ! isset( $_POST['url'] ) ) {
+		return;
+	}
+
+	$url = esc_url_raw( wp_unslash( $_POST['url'] ) );
+
+	$tmp = download_url( $url );
+	if ( is_wp_error( $tmp ) ) {
+		return wp_send_json_error( $tmp );
+	}
+
+	if ( is_multisite() ) {
+		add_filter( 'wp_handle_sideload_prefilter', 'check_upload_size' );
+	}
+
+	$attachment_id = media_handle_sideload(
+		array(
+			'name'     => basename( wp_parse_url( $url, PHP_URL_PATH ) ),
+			'tmp_name' => $tmp,
+		)
+	);
+
+	if ( file_exists( $tmp ) ) {
+		wp_delete_file( $tmp );
+	}
+
+	if ( is_wp_error( $attachment_id ) ) {
+		return wp_send_json_error( $attachment_id );
+	} else {
+		return wp_send_json_success( array( 'attachment_id' => $attachment_id ) );
+	}
+}
+
+if ( current_user_can( 'upload_files' ) ) {
+	add_action( 'post-plupload-upload-ui', 'wpcom_media_url_upload', 20 );
+	add_action( 'wp_ajax_wpcom_media_url_upload', 'wpcom_handle_media_url_upload' );
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.php
@@ -11,6 +11,10 @@
 function wpcom_media_url_upload() {
 	global $pagenow;
 
+	if ( empty( $_GET['untangling-media'] ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
+		return;
+	}
+
 	?>
 	<div id="wpcom-media-url-upload"></div>
 	<?php
@@ -72,7 +76,7 @@ function wpcom_handle_media_url_upload() {
 	}
 }
 
-if ( current_user_can( 'upload_files' ) && ! empty( $_GET['untangling-media'] ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
+if ( current_user_can( 'upload_files' ) ) {
 	add_action( 'pre-upload-ui', 'wpcom_media_url_upload', 9 );
 	add_action( 'wp_ajax_wpcom_media_url_upload', 'wpcom_handle_media_url_upload' );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.php
@@ -19,10 +19,10 @@ function wpcom_media_url_upload() {
 
 	$data = wp_json_encode(
 		array(
-			'ajaxUrl'      => admin_url( 'admin-ajax.php' ),
-			'action'       => 'wpcom_media_url_upload',
-			'nonce'        => wp_create_nonce( 'wpcom_media_url_upload' ),
-			'isSiteEditor' => $pagenow === 'site-editor.php',
+			'ajaxUrl'  => admin_url( 'admin-ajax.php' ),
+			'action'   => 'wpcom_media_url_upload',
+			'nonce'    => wp_create_nonce( 'wpcom_media_url_upload' ),
+			'isEditor' => $pagenow !== 'upload.php',
 		)
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.php
@@ -73,6 +73,6 @@ function wpcom_handle_media_url_upload() {
 }
 
 if ( current_user_can( 'upload_files' ) ) {
-	add_action( 'post-plupload-upload-ui', 'wpcom_media_url_upload', 20 );
+	add_action( 'pre-upload-ui', 'wpcom_media_url_upload', 9 );
 	add_action( 'wp_ajax_wpcom_media_url_upload', 'wpcom_handle_media_url_upload' );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.php
@@ -45,9 +45,9 @@ function wpcom_handle_media_url_upload() {
 
 	$url = esc_url_raw( wp_unslash( $_POST['url'] ) );
 
-	$tmp = download_url( $url );
-	if ( is_wp_error( $tmp ) ) {
-		return wp_send_json_error( $tmp );
+	$tmp_file = download_url( $url );
+	if ( is_wp_error( $tmp_file ) ) {
+		return wp_send_json_error( $tmp_file );
 	}
 
 	if ( is_multisite() ) {
@@ -57,12 +57,12 @@ function wpcom_handle_media_url_upload() {
 	$attachment_id = media_handle_sideload(
 		array(
 			'name'     => basename( wp_parse_url( $url, PHP_URL_PATH ) ),
-			'tmp_name' => $tmp,
+			'tmp_name' => $tmp_file,
 		)
 	);
 
-	if ( file_exists( $tmp ) ) {
-		wp_delete_file( $tmp );
+	if ( file_exists( $tmp_file ) ) {
+		wp_delete_file( $tmp_file );
 	}
 
 	if ( is_wp_error( $attachment_id ) ) {

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -45,6 +45,7 @@ module.exports = [
 				'./src/features/wpcom-global-styles/wpcom-global-styles-view.js',
 			'wpcom-documentation-links':
 				'./src/features/wpcom-documentation-links/wpcom-documentation-links.ts',
+			'wpcom-media-url-upload': './src/features/wpcom-media/wpcom-media-url-upload.js',
 			'wpcom-options-general': [
 				'./src/features/wpcom-options-general/options-general.js',
 				'./src/features/wpcom-options-general/options-general.scss',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/10180


## Proposed changes:

This PR implements the feature where we can upload media files from URL in the Media Library and Site Editor.

The UX is implemented by following the default file upload behavior as similar as possible.

See the following videos:

### Media Library

https://github.com/user-attachments/assets/28630d2e-00c3-42a8-98b5-be9447ddad2f

### Site Editor

https://github.com/user-attachments/assets/a9a73832-01dd-4dd2-b2e7-b1dfccfa59ed

### Implementation Details

This feature is implemented by showing a simple url input form after the `Plupload` uploader via the `post-plupload-upload-ui` hook. On submitting the form, it calls an AJAX handler, which then call Core's `download_url()` and then `media_handle_sideload()`. This logic is very similar to [that of the original endpoint](https://github.com/Automattic/jetpack/blob/83c66ed92ff9d6a99d08bddf9c598955f0bc2257/projects/plugins/jetpack/class.json-api-endpoints.php#L2390) used by Calypso version of the Media Library.

### Limitations

- This feature is currently not available in Media -> Add New Media File.
- This feature currently won't send video files to VideoPress; we still need to use the dropzone.

### Failure Cases

The upload form can handle failure cases, e.g. when the media has unsupported extension. It will show an error notice, similar to when we upload the file via the dropzone:


https://github.com/user-attachments/assets/0fdf0c61-50e7-4b87-8962-fa8e8d0e552c



### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Patch this PR using the instructions provided by the bot.
2. Try to upload via URL in both Media -> Library and Site Editor as per the videos above.
3. Test in both Simple and Atomic sites.
4. Try to break it.