### PR TITLE
Boost: Add the success ratios to the cloud css payload

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
@@ -137,15 +137,20 @@ class Cloud_CSS implements Pluggable, Has_Always_Available_Endpoints, Changes_Pa
 	 * with a specific post.
 	 */
 	public function generate_cloud_css( $reason, $providers = array() ) {
-		$grouped_urls = array();
+		$grouped_urls   = array();
+		$grouped_ratios = array();
 
 		foreach ( $providers as $source ) {
-			$provider                  = $source['key'];
-			$grouped_urls[ $provider ] = $source['urls'];
+			$provider                    = $source['key'];
+			$grouped_urls[ $provider ]   = $source['urls'];
+			$grouped_ratios[ $provider ] = $source['success_ratio'];
 		}
 
 		// Send the request to the Cloud.
-		$payload              = array( 'providers' => $grouped_urls );
+		$payload              = array(
+			'providers'     => $grouped_urls,
+			'successRatios' => $grouped_ratios,
+		);
 		$payload['requestId'] = md5( wp_json_encode( $payload ) . time() );
 		$payload['reason']    = $reason;
 		return Boost_API::post( 'cloud-css', $payload );

--- a/projects/plugins/boost/changelog/update-boost-success-ratio
+++ b/projects/plugins/boost/changelog/update-boost-success-ratio
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Cloud CSS: Added the success ratio required for Cloud CSS to succeed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

A minimum number of the pages sent to Cloud CSS must be successfully processed for the minification of that group of pages to be deemed a success, and the minified css used. This PR sends that success ratio to Boost Cloud for processing.


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add the success ratios to the payload sent to the cloud in generate_cloud_css()

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply PR.
* Trigger a cloud CSS event.
* Log the data sent in Boost Cloud to verify the new data was included.