### PR TITLE
MU WPCOM: dashboard: add daily writing prompt

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-dashboard-daily-prompt
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-dashboard-daily-prompt
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: added Daily Writing Prompt widget

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/index.js
@@ -28,27 +28,30 @@ export default () => {
 
 	return (
 		<>
-			<p>{ prompt.text }</p>
-			<div className="wpcom-daily-writing-prompt--action-row">
-				<div className="wpcom-daily-writing-prompt--previous-next">
-					<a className="button" href={ `post-new.php?answer_prompt=${ prompt.id }` }>
-						{ __( 'Post Answer', 'jetpack-mu-wpcom' ) }
-					</a>
+			<div className="wpcom-daily-writing-prompt--prompt">
+				<p>{ prompt.text }</p>
+				<p className="wpcom-daily-writing-prompt--previous-next">
 					<button
-						className="button"
+						className="button button-link"
 						onClick={ () => setIndex( index - 1 ) }
 						disabled={ index === 0 }
 					>
-						‹
+						{ __( '← Previous', 'jetpack-mu-wpcom' ) }
 					</button>
+					{ ' ' }
 					<button
-						className="button"
+						className="button button-link"
 						onClick={ () => setIndex( index + 1 ) }
 						disabled={ index === prompts.length - 1 }
 					>
-						›
+						{ __( 'Next →', 'jetpack-mu-wpcom' ) }
 					</button>
-				</div>
+				</p>
+			</div>
+			<div className="wpcom-daily-writing-prompt--action-row">
+				<a className="button" href={ `post-new.php?answer_prompt=${ prompt.id }` }>
+					{ __( 'Post Answer', 'jetpack-mu-wpcom' ) }
+				</a>
 				{ prompt.answered_users_sample.length > 0 && (
 					<div className="wpcom-daily-writing-prompt--answered-users">
 						{ prompt.answered_users_count > 0 && (

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/index.js
@@ -30,7 +30,7 @@ export default () => {
 		<>
 			<div className="wpcom-daily-writing-prompt--prompt">
 				<p>{ prompt.text }</p>
-				<p className="wpcom-daily-writing-prompt--previous-next">
+				<div className="wpcom-daily-writing-prompt--previous-next">
 					<button
 						className="button button-link"
 						onClick={ () => setIndex( index - 1 ) }
@@ -46,7 +46,7 @@ export default () => {
 					>
 						{ __( 'Next →', 'jetpack-mu-wpcom' ) }
 					</button>
-				</p>
+				</div>
 			</div>
 			<div className="wpcom-daily-writing-prompt--action-row">
 				<a className="button" href={ `post-new.php?answer_prompt=${ prompt.id }` }>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/index.js
@@ -2,7 +2,6 @@ import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import moment from 'moment';
 
 import './style.scss';
 
@@ -10,10 +9,13 @@ export default () => {
 	const [ prompts, setPrompts ] = useState( [] );
 	const [ index, setIndex ] = useState( 0 );
 	useEffect( () => {
+		const now = new Date();
+		const mm = String( now.getMonth() + 1 ).padStart( 2, '0' );
+		const dd = String( now.getDate() ).padStart( 2, '0' );
 		// See projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/blogging-prompts-modal/index.js
 		const path = addQueryArgs( `/wpcom/v3/blogging-prompts`, {
 			per_page: 10,
-			after: moment().format( '--MM-DD' ),
+			after: `--${ mm }-${ dd }`,
 			order: 'desc',
 			force_year: new Date().getFullYear(),
 		} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/index.js
@@ -1,0 +1,79 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import moment from 'moment';
+
+import './style.scss';
+
+export default () => {
+	const [ prompts, setPrompts ] = useState( [] );
+	const [ index, setIndex ] = useState( 0 );
+	useEffect( () => {
+		// See projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/blogging-prompts-modal/index.js
+		const path = addQueryArgs( `/wpcom/v3/blogging-prompts`, {
+			per_page: 10,
+			after: moment().format( '--MM-DD' ),
+			order: 'desc',
+			force_year: new Date().getFullYear(),
+		} );
+		apiFetch( { path } ).then( setPrompts );
+	}, [] );
+
+	if ( prompts.length === 0 ) {
+		return null;
+	}
+
+	const prompt = prompts[ index ];
+
+	return (
+		<>
+			<p>{ prompt.text }</p>
+			<div className="wpcom-daily-writing-prompt--action-row">
+				<div className="wpcom-daily-writing-prompt--previous-next">
+					<a className="button" href={ `post-new.php?answer_prompt=${ prompt.id }` }>
+						{ __( 'Post Answer', 'jetpack-mu-wpcom' ) }
+					</a>
+					<button
+						className="button"
+						onClick={ () => setIndex( index - 1 ) }
+						disabled={ index === 0 }
+					>
+						‹
+					</button>
+					<button
+						className="button"
+						onClick={ () => setIndex( index + 1 ) }
+						disabled={ index === prompts.length - 1 }
+					>
+						›
+					</button>
+				</div>
+				{ prompt.answered_users_sample.length > 0 && (
+					<div className="wpcom-daily-writing-prompt--answered-users">
+						{ prompt.answered_users_count > 0 && (
+							<a href={ new URL( prompt.answered_link ) }>
+								{ __( 'View all responses', 'jetpack-mu-wpcom' ) }
+							</a>
+						) }{ ' ' }
+						<span>
+							{ prompt.answered_users_sample.map( sample => {
+								return (
+									<img
+										alt={ __( 'User avatar', 'jetpack-mu-wpcom' ) }
+										src={ addQueryArgs( sample.avatar, {
+											s: 22 * 2,
+										} ) }
+										width={ 22 }
+										height={ 22 }
+										key={ sample.avatar }
+									/>
+								);
+							} ) }
+						</span>
+					</div>
+				) }
+			</div>
+		</>
+	);
+};

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/style.scss
@@ -1,3 +1,24 @@
+.wpcom-daily-writing-prompt--prompt {
+	background-color: #f0f0f1;
+	padding: 1px 12px;
+	border-radius: 4px;
+	margin: 1em 0;
+
+	button.button-link {
+		line-height: inherit;
+		min-height: auto;
+
+		&[disabled] {
+			background-color: transparent !important;
+		}
+	}
+}
+
+.wpcom-daily-writing-prompt--previous-next {
+	display: flex;
+	justify-content: flex-end;
+}
+
 .wpcom-daily-writing-prompt--action-row {
 	display: flex;
 	flex-direction: row;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/style.scss
@@ -1,0 +1,23 @@
+.wpcom-daily-writing-prompt--action-row {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	gap: 10px;
+
+	img {
+		vertical-align: middle;
+		border-radius: 100%;
+		border: 2px solid #fff;
+		margin-left: -10px;
+	}
+
+	img:first-child {
+		margin-left: 0;
+	}
+
+	.wpcom-daily-writing-prompt--previous-next {
+		display: flex;
+		flex-direction: row;
+		gap: 5px;
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/style.scss
@@ -17,6 +17,7 @@
 .wpcom-daily-writing-prompt--previous-next {
 	display: flex;
 	justify-content: flex-end;
+	margin: .5em 0;
 }
 
 .wpcom-daily-writing-prompt--action-row {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/style.scss
@@ -1,12 +1,15 @@
 .wpcom-daily-writing-prompt--prompt {
 	background-color: #f0f0f1;
-	padding: 1px 12px;
+	padding: 1px 16px;
 	border-radius: 4px;
 	margin: 1em 0;
 
 	button.button-link {
 		line-height: inherit;
 		min-height: auto;
+		// Override mobile styles.
+		padding: 0;
+    	margin: 0;
 
 		&[disabled] {
 			background-color: transparent !important;
@@ -17,7 +20,7 @@
 .wpcom-daily-writing-prompt--previous-next {
 	display: flex;
 	justify-content: flex-end;
-	margin: .5em 0;
+	margin: 1em 0;
 }
 
 .wpcom-daily-writing-prompt--action-row {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.js
@@ -2,6 +2,7 @@ import '../../common/public-path';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import CelebrateLaunchModal from './celebrate-launch/celebrate-launch-modal';
+import WpcomDailyWritingPrompt from './wpcom-daily-writing-prompt';
 import WpcomLaunchpadWidget from './wpcom-launchpad-widget';
 import WpcomSiteManagementWidget from './wpcom-site-management-widget';
 const data = typeof window === 'object' ? window.JETPACK_MU_WPCOM_DASHBOARD_WIDGETS : {};
@@ -10,6 +11,10 @@ const widgets = [
 	{
 		id: 'wpcom_launchpad_widget_main',
 		Widget: WpcomLaunchpadWidget,
+	},
+	{
+		id: 'wpcom_daily_writing_prompt_main',
+		Widget: WpcomDailyWritingPrompt,
 	},
 	{
 		id: 'wpcom_site_preview_widget_main',

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
@@ -22,6 +22,12 @@ function load_wpcom_dashboard_widgets() {
 			'context'  => 'side',
 			'priority' => 'high',
 		),
+		array(
+			'id'       => 'wpcom_daily_writing_prompt',
+			'name'     => __( 'Daily Writing Prompt', 'jetpack-mu-wpcom' ),
+			'context'  => 'side',
+			'priority' => 'high',
+		),
 	);
 
 	$launchpad_context = 'customer-home';

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
@@ -51,7 +51,7 @@ function load_wpcom_dashboard_widgets() {
 			$wpcom_dashboard_widget['id'],
 			$wpcom_dashboard_widget['name'],
 			'render_wpcom_dashboard_widget',
-			null,
+			null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. See https://core.trac.wordpress.org/ticket/52539.
 			array(
 				'id'   => $wpcom_dashboard_widget['id'],
 				'name' => $wpcom_dashboard_widget['name'],

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
@@ -51,7 +51,7 @@ function load_wpcom_dashboard_widgets() {
 			$wpcom_dashboard_widget['id'],
 			$wpcom_dashboard_widget['name'],
 			'render_wpcom_dashboard_widget',
-			function () {},
+			null,
 			array(
 				'id'   => $wpcom_dashboard_widget['id'],
 				'name' => $wpcom_dashboard_widget['name'],

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/style.scss
@@ -1,9 +1,5 @@
 #wpcom_site_preview_widget {
 	color: #1e1e1e;
-
-	.postbox-title-action {
-		display: none;
-	}
 }
 
 #wpcom_site_preview_widget_main {
@@ -11,6 +7,7 @@
 		background: #f0f0f1;
 		margin-bottom: 12px;
 		padding: 12px 12px 0;
+		border-radius: 4px;
 	}
 
 	.wpcom_site_preview {

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-dashboard-daily-prompt
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-dashboard-daily-prompt
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: added Daily Writing Prompt widget

--- a/projects/plugins/wpcomsh/changelog/add-dashboard-daily-prompt
+++ b/projects/plugins/wpcomsh/changelog/add-dashboard-daily-prompt
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: added Daily Writing Prompt widget


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

<img width="1464" alt="image" src="https://github.com/user-attachments/assets/761b8ea9-be43-4a92-9f95-f8863809329d" />


See https://github.com/Automattic/wp-calypso/issues/95386.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added a small new widget with the prompt.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With classic style admin enabled, check the Dashboard and test the widget.

