### PR TITLE
cli: Add `--use-version` option to `jetpack release`

### DIFF
--- a/tools/cli/commands/release.js
+++ b/tools/cli/commands/release.js
@@ -47,6 +47,10 @@ export function releaseDefine( yargs ) {
 					describe: 'Append the GH PR number to each entry',
 					type: 'boolean',
 				} )
+				.option( 'use-version', {
+					describe: 'Specify a version number explicitly',
+					type: 'string',
+				} )
 				.option( 'init-next-cycle', {
 					describe: 'For `version`, init the next release cycle',
 					type: 'boolean',
@@ -141,6 +145,9 @@ export async function scriptRouter( argv ) {
 			} else if ( argv.beta ) {
 				argv.scriptArgs.unshift( '-b' );
 			}
+			if ( argv.useVersion ) {
+				argv.scriptArgs.unshift( '-r', argv.useVersion );
+			}
 			argv.addPrNum && argv.scriptArgs.unshift( '-p' );
 			argv.next = `Finished! You may want to update the readme.txt by running 'jetpack release ${ argv.project } readme' \n`;
 			break;
@@ -162,6 +169,9 @@ export async function scriptRouter( argv ) {
 			argv.script = `vendor/bin/changelogger`;
 			argv.scriptArgs = [ `write`, `--amend` ];
 			argv.addPrNum && argv.scriptArgs.push( '--add-pr-num' );
+			if ( argv.useVersion ) {
+				argv.scriptArgs.push( '--use-version', argv.useVersion );
+			}
 			argv.workingDir = `projects/${ argv.project }`;
 			argv.next = `Finished! You will now likely want to update readme.txt again:
 				    jetpack release ${ argv.project } readme \n`.replace( /^\t+/gm, '' );
@@ -246,9 +256,13 @@ export async function parseProj( argv ) {
  * Get a potential version that we might need when creating a release branch or bumping versions.
  *
  * @param {object} argv - the arguments passed
- * @return {object} argv
+ * @return {string} Version
  */
 export async function getReleaseVersion( argv ) {
+	if ( argv.useVersion ) {
+		return argv.useVersion;
+	}
+
 	let potentialVersion = child_process
 		.execSync( `tools/plugin-version.sh ${ argv.project }` )
 		.toString()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Many of the various commands run by `jetpack release` can take an option for a specific version. Allow this to be done.

In particular, this will be useful for doing the 1.0.0 release of a package.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1736961528818299/1736959724.475999-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try the various subcommands with the `--use-version` option to see if they behave appropriately.