### PR TITLE
Jetpack Dev Env: 1.0 release

### DIFF
--- a/projects/js-packages/jetpack-cli/CHANGELOG.md
+++ b/projects/js-packages/jetpack-cli/CHANGELOG.md
@@ -5,3 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0 - 2025-01-15
+### Added
+- Initial version.

--- a/projects/js-packages/jetpack-cli/changelog/add-auto-publish-cli
+++ b/projects/js-packages/jetpack-cli/changelog/add-auto-publish-cli
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: No functionality change, adding mirror repo info
-
-

--- a/projects/js-packages/jetpack-cli/changelog/initial-version
+++ b/projects/js-packages/jetpack-cli/changelog/initial-version
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Initial version.

--- a/projects/js-packages/jetpack-cli/package.json
+++ b/projects/js-packages/jetpack-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-cli",
-	"version": "0.1.0-alpha",
+	"version": "1.0.0",
 	"description": "Docker-based CLI for Jetpack development",
 	"bin": {
 		"jp": "bin/jp.js"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Sets the new Dev Env to version 1.0 (and provides an option for me to confirm the update notify feature is working)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Not yet, p2 forthcoming.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* None needed. I'll ensure that the autotagging and publishing happens, but that's post-merge.

