### PR TITLE
Tooling: Set default skeleton versions to 0.1.0-alpha

### DIFF
--- a/tools/cli/skeletons/packages/src/class-example.php
+++ b/tools/cli/skeletons/packages/src/class-example.php
@@ -12,6 +12,6 @@ namespace Automattic\Jetpack;
  */
 class Package_Name {
 
-	const PACKAGE_VERSION = '1.0.0-alpha';
+	const PACKAGE_VERSION = '0.1.0-alpha';
 
 }

--- a/tools/cli/skeletons/plugins/plugin.php
+++ b/tools/cli/skeletons/plugins/plugin.php
@@ -4,7 +4,7 @@
  * Plugin Name: TBD
  * Plugin URI: TBD
  * Description: TBD
- * Version: 1.0.0-alpha
+ * Version: 0.1.0-alpha
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Our `jetpack generate` tooling sets `0.1.0-alpha` as the initial SemVer version, but our project skeletons use `1.0.0-alpha`. The CI will spot a mismatch unless this is bumped after creating a new project, e.g.:

https://github.com/Automattic/jetpack/actions/runs/12691002248/job/35373082324?pr=40923#step:4:462

## Proposed changes:
This changes the skeleton versions to `0.1.0-alpha`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Is CI complaining?