### PR TITLE
[WordAds]: Remove second belowpost option

### DIFF
--- a/projects/packages/sync/changelog/update-remove-wordads-second-belowpost
+++ b/projects/packages/sync/changelog/update-remove-wordads-second-belowpost
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+WordAds: remove unused second belowpost option

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -176,7 +176,6 @@ class Defaults {
 		'wordads_display_front_page',
 		'wordads_display_page',
 		'wordads_display_post',
-		'wordads_second_belowpost',
 		'wordads_inline_enabled',
 		'woocommerce_custom_orders_table_enabled',
 		'wp_mobile_app_promos',

--- a/projects/plugins/jetpack/_inc/client/earn/ads.jsx
+++ b/projects/plugins/jetpack/_inc/client/earn/ads.jsx
@@ -119,10 +119,6 @@ export const Ads = withModuleSettingsFormHelpers(
 			const isAdsActive = this.props.getOptionValue( 'wordads' );
 			const unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'wordads' );
 			const enable_header_ad = this.props.getOptionValue( 'enable_header_ad', 'wordads' );
-			const wordads_second_belowpost = this.props.getOptionValue(
-				'wordads_second_belowpost',
-				'wordads'
-			);
 			const wordads_inline_enabled = this.props.getOptionValue(
 				'wordads_inline_enabled',
 				'wordads'
@@ -262,17 +258,6 @@ export const Ads = withModuleSettingsFormHelpers(
 								toggling={ this.props.isSavingAnyOption( [ 'enable_header_ad' ] ) }
 								onChange={ this.handleChange( 'enable_header_ad' ) }
 								label={ __( 'Top of each page', 'jetpack' ) }
-							/>
-							<ToggleControl
-								checked={ wordads_second_belowpost }
-								disabled={
-									! isAdsActive ||
-									unavailableInOfflineMode ||
-									this.props.isSavingAnyOption( [ 'wordads' ] )
-								}
-								toggling={ this.props.isSavingAnyOption( [ 'wordads_second_belowpost' ] ) }
-								onChange={ this.handleChange( 'wordads_second_belowpost' ) }
-								label={ __( 'Second ad below post', 'jetpack' ) }
 							/>
 							<ToggleControl
 								checked={ wordads_inline_enabled }

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2871,13 +2871,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'wordads',
 			),
-			'wordads_second_belowpost'                  => array(
-				'description'       => esc_html__( 'Display second ad below post?', 'jetpack' ),
-				'type'              => 'boolean',
-				'default'           => 1,
-				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'jp_group'          => 'wordads',
-			),
 			'wordads_inline_enabled'                    => array(
 				'description'       => esc_html__( 'Display inline ad within post content?', 'jetpack' ),
 				'type'              => 'boolean',

--- a/projects/plugins/jetpack/changelog/update-remove-wordads-second-belowpost
+++ b/projects/plugins/jetpack/changelog/update-remove-wordads-second-belowpost
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+WordAds: remove unused second belowpost option

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -672,9 +672,6 @@ HTML;
 		} elseif ( 'house' === $type ) {
 			$leaderboard = 'top' === $spot && ! $this->params->mobile_device;
 			$snippet     = $this->get_house_ad( $leaderboard ? 'leaderboard' : 'mrec' );
-			if ( 'belowpost' === $spot && $this->option( 'wordads_second_belowpost', true ) ) {
-				$snippet .= $this->get_house_ad( $leaderboard ? 'leaderboard' : 'mrec' );
-			}
 		}
 
 		return $snippet;

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-params.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-params.php
@@ -91,7 +91,6 @@ class WordAds_Params {
 			'wordads_house'                        => true,
 			'wordads_unsafe'                       => false,
 			'enable_header_ad'                     => true,
-			'wordads_second_belowpost'             => true,
 			'wordads_inline_enabled'               => true,
 			'wordads_bottom_sticky_enabled'        => false,
 			'wordads_sidebar_sticky_right_enabled' => false,

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -218,7 +218,6 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'mailserver_port'                              => 1,
 			'wp_page_for_privacy_policy'                   => false,
 			'enable_header_ad'                             => '1',
-			'wordads_second_belowpost'                     => '1',
 			'wordads_inline_enabled'                       => true,
 			'wordads_cmp_enabled'                          => false,
 			'wordads_display_front_page'                   => '1',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove second belowpost option which we've not been supporting, except for the fallback house ad use.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

