### PR TITLE
VideoPress Block: Fix block line-height.

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-block-line-height
+++ b/projects/packages/videopress/changelog/fix-videopress-block-line-height
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix VideoPress block line-height.

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
@@ -129,5 +129,6 @@
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
 	"style": "file:./style.css",
-	"viewScript": "file:./view.js"
+	"viewScript": "file:./view.js",
+	"viewStyle": "file:./view.css"
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
@@ -12,6 +12,7 @@
 	.jetpack-videopress-player__wrapper {
 		position: relative;
 		display: flex;
+		line-height: 0;
 	}
 
 	.jetpack-videopress-player__overlay {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.scss
@@ -1,0 +1,1 @@
+@import './style.scss';

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -6,7 +6,7 @@ import domReady from '@wordpress/dom-ready';
 /**
  * Internal dependencies
  */
-import './style.scss';
+import './view.scss';
 
 /**
  * Preview on Hover effect for VideoPress videos.


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack/issues/40899

## Proposed changes:

* Fix VideoPress block line-height.
* Add missing view styles.
  * The view-related CSS wasn't included on simple sites, so overlay and caption were displayed incorrectly.

**Before**
<img width="643" alt="Screenshot 2025-01-15 at 18 44 33" src="https://github.com/user-attachments/assets/f0f3071c-c3e3-4708-a2cb-821532f2d670" />

**After**
<img width="646" alt="Screenshot 2025-01-15 at 18 43 59" src="https://github.com/user-attachments/assets/89ab58ca-98a3-4412-be75-40909a0391ea" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/jetpack/issues/40899#issuecomment-2579975296

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use a test site with VideoPress enabled.
* Follow [these instructions](https://github.com/Automattic/jetpack/pull/41102#issuecomment-2593747299) to apply the changes on your env.
* On the test site, publish a post with a VideoPress block.
* Go to the post and verify if there is no spacing at the bottom of the block.
* Add other videos using the caption and the poster features.
* Verify if they are rendered as expected.