### PR TITLE
MU WPCOM: dashboard: add site links/preview

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-site-widget
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-site-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: add site preview and links

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.js
@@ -7,7 +7,7 @@ const data = typeof window === 'object' ? window.JETPACK_MU_WPCOM_DASHBOARD_WIDG
 
 const widgets = [
 	{
-		id: 'wpcom_site_management_widget_main',
+		id: 'wpcom_site_preview_widget_main',
 		Widget: WpcomSiteManagementWidget,
 	},
 ];

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
@@ -17,8 +17,9 @@ function load_wpcom_dashboard_widgets() {
 
 	$wpcom_dashboard_widgets = array(
 		array(
-			'id'       => 'wpcom_site_management_widget',
-			'name'     => __( 'Site Management Panel', 'jetpack-mu-wpcom' ),
+			'id'       => 'wpcom_site_preview_widget',
+			'name'     => __( 'Site', 'jetpack-mu-wpcom' ),
+			'context'  => 'side',
 			'priority' => 'high',
 		),
 	);
@@ -33,7 +34,7 @@ function load_wpcom_dashboard_widgets() {
 				'id'   => $wpcom_dashboard_widget['id'],
 				'name' => $wpcom_dashboard_widget['name'],
 			),
-			'normal',
+			$wpcom_dashboard_widget['context'],
 			$wpcom_dashboard_widget['priority']
 		);
 	}
@@ -49,7 +50,7 @@ function enqueue_wpcom_dashboard_widgets() {
 	$data = wp_json_encode(
 		array(
 			'siteName'    => wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ),
-			'siteDomain'  => wp_parse_url( home_url(), PHP_URL_HOST ),
+			'siteUrl'     => home_url(),
 			'siteIconUrl' => get_site_icon_url( 38 ),
 		)
 	);
@@ -80,7 +81,7 @@ function render_wpcom_dashboard_widget( $post, $callback_args ) {
 	);
 
 	?>
-	<div style="min-height: 200px;">
+	<div>
 		<div class="hide-if-js">
 			<?php echo esc_html( $warning ); ?>
 		</div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
@@ -49,9 +49,10 @@ function enqueue_wpcom_dashboard_widgets() {
 
 	$data = wp_json_encode(
 		array(
-			'siteName'    => wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ),
-			'siteUrl'     => home_url(),
-			'siteIconUrl' => get_site_icon_url( 38 ),
+			'siteName'     => wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ),
+			'siteUrl'      => home_url(),
+			'siteIconUrl'  => get_site_icon_url( 38 ),
+			'isBlockTheme' => wp_is_block_theme(),
 		)
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/index.js
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import React from 'react';
 import './style.scss';
 
-const WpcomSiteManagementWidget = ( { siteName, siteUrl, siteIconUrl } ) => {
+const WpcomSiteManagementWidget = ( { siteName, siteUrl, siteIconUrl, isBlockTheme } ) => {
 	const siteDomain = new URL( siteUrl ).hostname;
 	return (
 		<>
@@ -37,9 +37,11 @@ const WpcomSiteManagementWidget = ( { siteName, siteUrl, siteIconUrl } ) => {
 					<a className="button-secondary" href={ `https://wordpress.com/overview/${ siteDomain }` }>
 						{ __( 'Hosting Overview', 'jetpack-mu-wpcom' ) }
 					</a>
-					<a className="button-secondary" href={ `site-editor.php` }>
-						{ __( 'Edit Site', 'jetpack-mu-wpcom' ) }
-					</a>
+					{ isBlockTheme ? (
+						<a className="button-secondary" href={ `site-editor.php` }>
+							{ __( 'Edit Site', 'jetpack-mu-wpcom' ) }
+						</a>
+					) : null }
 				</div>
 			</div>
 		</>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 import './style.scss';
 
 const WpcomSiteManagementWidget = ( { siteName, siteUrl, siteIconUrl } ) => {
+	const siteDomain = new URL( siteUrl ).hostname;
 	return (
 		<>
 			<div className="wpcom_site_preview_wrapper">
@@ -29,12 +30,12 @@ const WpcomSiteManagementWidget = ( { siteName, siteUrl, siteIconUrl } ) => {
 				<div className="wpcom_site_management_widget__site-info">
 					<div className="wpcom_site_management_widget__site-name">{ siteName }</div>
 					<div className="wpcom_site_management_widget__site-url">
-						{ new URL( siteUrl ).hostname }
+						<a href={ siteUrl }>{ siteDomain }</a>
 					</div>
 				</div>
 				<div className="wpcom_site_management_widget__site-actions">
-					<a className="button-secondary" href={ siteUrl }>
-						{ __( 'Visit Site', 'jetpack-mu-wpcom' ) }
+					<a className="button-secondary" href={ `https://wordpress.com/overview/${ siteDomain }` }>
+						{ __( 'Hosting Overview', 'jetpack-mu-wpcom' ) }
 					</a>
 					<a className="button-secondary" href={ `site-editor.php` }>
 						{ __( 'Edit Site', 'jetpack-mu-wpcom' ) }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/index.js
@@ -12,8 +12,7 @@ const WpcomSiteManagementWidget = ( { siteName, siteUrl, siteIconUrl, isBlockThe
 						loading="lazy"
 						title="Site Preview"
 						src={ `${ siteUrl }/?hide_banners=true&preview_overlay=true&preview=true` }
-						tabIndex="-1"
-						aria-hidden
+						inert="true"
 					></iframe>
 				</div>
 			</div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/index.js
@@ -13,6 +13,7 @@ const WpcomSiteManagementWidget = ( { siteName, siteUrl, siteIconUrl, isBlockThe
 						title="Site Preview"
 						src={ `${ siteUrl }/?hide_banners=true&preview_overlay=true&preview=true` }
 						tabIndex="-1"
+						aria-hidden
 					></iframe>
 				</div>
 			</div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/index.js
@@ -2,32 +2,19 @@ import { __ } from '@wordpress/i18n';
 import React from 'react';
 import './style.scss';
 
-const WpcomSiteManagementWidget = ( { siteName, siteDomain, siteIconUrl } ) => {
-	const devToolItems = [
-		{
-			name: __( 'Deployments', 'jetpack-mu-wpcom' ),
-			href: `/github-deployments/${ siteDomain }`,
-		},
-		{
-			name: __( 'Monitoring', 'jetpack-mu-wpcom' ),
-			href: `/site-monitoring/${ siteDomain }`,
-		},
-		{
-			name: __( 'Logs', 'jetpack-mu-wpcom' ),
-			href: `/site-logs/${ siteDomain }/php`,
-		},
-		{
-			name: __( 'Staging Site', 'jetpack-mu-wpcom' ),
-			href: `/staging-site/${ siteDomain }`,
-		},
-		{
-			name: __( 'Server Settings', 'jetpack-mu-wpcom' ),
-			href: `/hosting-config/${ siteDomain }`,
-		},
-	];
-
+const WpcomSiteManagementWidget = ( { siteName, siteUrl, siteIconUrl } ) => {
 	return (
 		<>
+			<div className="wpcom_site_preview_wrapper">
+				<div className="wpcom_site_preview">
+					<iframe
+						loading="lazy"
+						title="Site Preview"
+						src={ `${ siteUrl }/?hide_banners=true&preview_overlay=true&preview=true` }
+						tabIndex="-1"
+					></iframe>
+				</div>
+			</div>
 			<div className="wpcom_site_management_widget__header">
 				<div className="wpcom_site_management_widget__site-favicon">
 					{
@@ -41,34 +28,17 @@ const WpcomSiteManagementWidget = ( { siteName, siteDomain, siteIconUrl } ) => {
 				</div>
 				<div className="wpcom_site_management_widget__site-info">
 					<div className="wpcom_site_management_widget__site-name">{ siteName }</div>
-					<div className="wpcom_site_management_widget__site-url">{ siteDomain }</div>
+					<div className="wpcom_site_management_widget__site-url">
+						{ new URL( siteUrl ).hostname }
+					</div>
 				</div>
 				<div className="wpcom_site_management_widget__site-actions">
-					<a className="button-primary" href={ `https://wordpress.com/overview/${ siteDomain }` }>
-						{ __( 'Overview', 'jetpack-mu-wpcom' ) }
+					<a className="button-secondary" href={ siteUrl }>
+						{ __( 'Visit Site', 'jetpack-mu-wpcom' ) }
 					</a>
-				</div>
-			</div>
-			<div className="wpcom_site_management_widget__content">
-				<p>
-					{ __(
-						'Get a quick overview of your plans, storage, and domains, or easily access your development tools using the links provided below:',
-						'jetpack-mu-wpcom'
-					) }
-				</p>
-				<div className="wpcom_site_management_widget__dev-tools">
-					<div className="wpcom_site_management_widget__dev-tools-title">
-						{ __( 'DEV TOOLS:', 'jetpack-mu-wpcom' ) }
-					</div>
-					<div className="wpcom_site_management_widget__dev-tools-content">
-						<ul>
-							{ devToolItems.map( item => (
-								<li key={ item.name }>
-									<a href={ `https://wordpress.com${ item.href }` }>{ item.name }</a>
-								</li>
-							) ) }
-						</ul>
-					</div>
+					<a className="button-secondary" href={ `site-editor.php` }>
+						{ __( 'Edit Site', 'jetpack-mu-wpcom' ) }
+					</a>
 				</div>
 			</div>
 		</>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/style.scss
@@ -17,7 +17,6 @@
 		display: block;
 		max-width: 425px;
 		height: 200px;
-		pointer-events: none;
 		overflow: hidden;
 		margin: 0 auto;
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/style.scss
@@ -10,12 +10,12 @@
 	.wpcom_site_preview_wrapper {
 		background: #f0f0f1;
 		margin-bottom: 12px;
-		padding-top: 12px;
+		padding: 12px 12px 0;
 	}
 
 	.wpcom_site_preview {
 		display: block;
-		width: 425px;
+		max-width: 425px;
 		height: 200px;
 		pointer-events: none;
 		overflow: hidden;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/style.scss
@@ -1,4 +1,4 @@
-#wpcom_site_management_widget {
+#wpcom_site_preview_widget {
 	color: #1e1e1e;
 
 	.postbox-title-action {
@@ -6,7 +6,31 @@
 	}
 }
 
-#wpcom_site_management_widget_main {
+#wpcom_site_preview_widget_main {
+	.wpcom_site_preview_wrapper {
+		background: #f0f0f1;
+		margin-bottom: 12px;
+		padding-top: 12px;
+	}
+
+	.wpcom_site_preview {
+		display: block;
+		width: 425px;
+		height: 200px;
+		pointer-events: none;
+		overflow: hidden;
+		margin: 0 auto;
+
+		iframe {
+			max-width: 250%;
+			min-height: 375%;
+			transform: scale(.4);
+			transform-origin: top left;
+			translate: 0 -13px;
+			width: 250%;
+		}
+	}
+
 	.wpcom_site_management_widget__header {
 		display: flex;
 		align-items: center;
@@ -60,42 +84,7 @@
 
 	.wpcom_site_management_widget__site-actions {
 		flex-shrink: 0;
-	}
-
-	.wpcom_site_management_widget__content p {
-		margin: 12px 0;
-		font-size: 13px;
-		font-weight: 400;
-		line-height: 18px;
-	}
-
-	.wpcom_site_management_widget__dev-tools-title {
-		margin-bottom: 12px;
-		font-size: 11px;
-		font-weight: 600;
-		line-height: 16px;
-		text-transform: uppercase;
-	}
-
-	.wpcom_site_management_widget__dev-tools-content {
-		ul {
-			display: grid;
-			grid-template-columns: 1fr 1fr;
-			gap: 12px;
-			margin-bottom: 0;
-			list-style: disc inside;
-		}
-
-		li {
-			margin: 0 8px;
-			color: #0073aa;
-			font-size: 13px;
-			font-weight: 400;
-			line-height: 18px;
-
-			&::marker {
-				margin-inline-end: 2px;
-			}
-		}
+		display: flex;
+		gap: 12px;
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-site-widget
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-site-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: add site preview and links

--- a/projects/plugins/wpcomsh/changelog/add-site-widget
+++ b/projects/plugins/wpcomsh/changelog/add-site-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: add site preview and links


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

See https://github.com/Automattic/wp-calypso/issues/95386

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change "Site Management Tools" something more similar to the site preview and links found in My Home.
* The widget has been added to the second column ("side"), so users can find it in the same place.

<img width="1464" alt="image" src="https://github.com/user-attachments/assets/198f03cc-3e1d-41bd-841d-eaa764a139ee" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the Classic style admin and go to the dashboard.

