### PR TITLE
Stop showing limited global styles notice in editor distraction free mode (v2)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/revert-40907-fix-global-styles-notice-distraction-free
+++ b/projects/packages/jetpack-mu-wpcom/changelog/revert-40907-fix-global-styles-notice-distraction-free
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Global Styles: Revert changes that hide notice in distraction free mode

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/notices.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/notices.js
@@ -1,5 +1,6 @@
 /* global wpcomGlobalStyles */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { ExternalLink, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -238,19 +239,31 @@ function GlobalStylesEditNotice() {
 		upgradePlan,
 	] );
 
+	const isDistractionFree = useSelect(
+		select => select( blockEditorStore ).getSettings().isDistractionFree,
+		[]
+	);
+
 	useEffect( () => {
 		if ( ! isSiteEditor && ! isPostEditor ) {
 			return;
 		}
 
-		if ( globalStylesInUse ) {
+		if ( globalStylesInUse && ! isDistractionFree ) {
 			showNotice();
 		} else {
 			removeNotice( NOTICE_ID );
 		}
 
 		return () => removeNotice( NOTICE_ID );
-	}, [ globalStylesInUse, isSiteEditor, isPostEditor, removeNotice, showNotice ] );
+	}, [
+		globalStylesInUse,
+		isDistractionFree,
+		isSiteEditor,
+		isPostEditor,
+		removeNotice,
+		showNotice,
+	] );
 
 	return null;
 }


### PR DESCRIPTION
Reverts Automattic/jetpack#41028
Fixes #40906 

The proposed changes are the same as for the original [PR](https://github.com/Automattic/jetpack/pull/40907).

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

- Open the site editor on a Free WP.com site
- Make some style changes and save them
- Open the post editor
- Observe the limited Global Styles notice
- In the Options menu, enable the distraction free mode
- Observe the limited Global Styles notice disappears
- In the Options menu, disable the distraction free mode
- Observe the limited Global Styles notice reappears
- Check that the global styles upgrade modal is functional on the frontend