### PR TITLE
Only run GB 19.8 hotfix for non-admin users

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/hotfix-template-locked-bug-2
+++ b/projects/packages/jetpack-mu-wpcom/changelog/hotfix-template-locked-bug-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+GB 19.8.0 hotfix: further refine hotfix so site editor opens correct template by default

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-hotfixes/wpcom-hotfixes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-hotfixes/wpcom-hotfixes.php
@@ -13,6 +13,12 @@
 add_filter(
 	'register_post_type_args',
 	function ( $args ) {
+		if ( current_user_can( 'manage_options' ) ) {
+			// Admins still need default_rendering_mode for the site editor to select the correct default template.
+			// See: p1736989403607879-slack-C02FMH4G8
+			return $args;
+		}
+
 		unset( $args['default_rendering_mode'] );
 		return $args;
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/98450

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure the GB 19.8 hotfix (added here #40664) is only applied for non-admin users

The original GB 19.8 bug (https://github.com/WordPress/gutenberg/pull/68110) is that loading the page editor fails for non-admin users. A fix is coming in GB 20, but we applied a hotfix in https://github.com/Automattic/jetpack/pull/40664 since breaking the page editor for non-admins is a blocking bug.

However the bugfix changed behaviour in the site editor for admin users. https://github.com/Automattic/wp-calypso/issues/98450. The site editor, rather than opening the whole site template, instead defaulted to opening the home page in the site editor.

This PR attempts to keep a fix for both issues by only applying the hotfix for non-admin users.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* **Reproduce the bug**
  * As a site admin, add a page to your site
  * Go to Settings > Reader and set your page as the homepage
  * Open the site editor
  * The editor doesn't show the full site layout, only the page content of the front page
* **Test Fix**
  * [Apply the change to a WoA or simple site](https://github.com/Automattic/jetpack/pull/41110#issuecomment-2594348773)
  * Re-load the site editor. You should now wee the full page layout
  * Create a test user with an Editor role
  * Open a page in the page editor
  * The page editor should load correctly

