### PR TITLE
Jetpack mu wpcom: Fix WPCOM global style popup issue

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-global-popup-issue
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-global-popup-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Global Styles: Adding hidden style under wpcom-global-style-view

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -205,7 +205,7 @@
 		}
 	}
 
-	.hidden {
+	&.hidden {
 		display: none;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -204,6 +204,10 @@
 			color: #676767;
 		}
 	}
+
+	.hidden {
+		display: none;
+	}
 }
 
 .launch-banner-content .launch-bar-global-styles-preview {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1736994020071699-slack-C02FMH4G8

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adding hidden class in `wpcom-global-styles-view.css` to give it a higher priority

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Switch to a Free Simple site
* Go to the site editor
* Apply some Global Styles
* Save them without upgrading
* Visit the frontend
* Make sure “Upgrade required” popover is not displayed on page load
* Click on it and make sure it opens up, and click on the x icon to make sure it disappeared.