### PR TITLE
Social | Fix the connections field schema to allow null where it can be

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-status-set-default-fo-unknown
+++ b/projects/packages/publicize/changelog/fix-social-status-set-default-fo-unknown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social | Fixed the status field for connections to allow null

--- a/projects/packages/publicize/src/rest-api/class-connections-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-controller.php
@@ -131,7 +131,7 @@ class Connections_Controller extends Base_Controller {
 				'description' => __( 'Display name of the connected account.', 'jetpack-publicize-pkg' ),
 			),
 			'external_handle' => array(
-				'type'        => 'string',
+				'type'        => array( 'string', 'null' ),
 				'description' => __( 'The external handle or username of the connected account.', 'jetpack-publicize-pkg' ),
 			),
 			'external_id'     => array(
@@ -159,11 +159,12 @@ class Connections_Controller extends Base_Controller {
 				'description' => __( 'Whether the connection is shared with other users.', 'jetpack-publicize-pkg' ),
 			),
 			'status'          => array(
-				'type'        => 'string',
+				'type'        => array( 'string', 'null' ),
 				'description' => __( 'The connection status.', 'jetpack-publicize-pkg' ),
 				'enum'        => array(
 					'ok',
 					'broken',
+					null,
 				),
 			),
 			'user_id'         => array(


### PR DESCRIPTION
When adding a new connection from the editor and trying to save the post, it results in an error about invalid data type for connection `status` field, which is set to `null` by default but expected as a string.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Allow `null` values for `status` field and the `external_handle` field.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Steps:
- On trunk, create a new post
- Add a new connection from the editor
- Try to save the post as a draft to see the error
- Now try that in this branch
- Confirm that there is no error

![Image](https://github.com/user-attachments/assets/651d979c-5437-42db-a463-545adfce4719)
