### PR TITLE
Fix Jetpack heartbeat deactivation jobs cleanup

### DIFF
--- a/projects/packages/connection/changelog/fix-jetpack-deactivation-jobs-cleanup
+++ b/projects/packages/connection/changelog/fix-jetpack-deactivation-jobs-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add heartbeat deactivation on site disconnection.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -2190,6 +2190,8 @@ class Manager {
 
 		( new Nonce_Handler() )->clean_all();
 
+		Heartbeat::init()->deactivate();
+
 		/**
 		 * Fires before a site is disconnected.
 		 *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/30382

This PR adds a call to `Heartbeat::disconnect` to the site disconnection method. This function is also called at plugin deactivation/removal.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add Heartbeat deactivation when a site is disconnected
* Add relevant unit tests

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new Jetpack site
* Ensure by running `wp cron event list` that `jetpack_clean_nonces (1 hour)` and `jetpack_v2_heartbeat (1 day)` are listed
* Deactivate Jetpack, or disconnect a site, or uninstall Jetpack
* Ensure by running `wp cron event list` that the two events have been removed

