### PR TITLE
Add new site setting to hide the Action Bar

### DIFF
--- a/projects/plugins/jetpack/changelog/add-wpcom_hide_action_bar-site-option
+++ b/projects/plugins/jetpack/changelog/add-wpcom_hide_action_bar-site-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add new site setting to hide the Action Bar

--- a/projects/plugins/jetpack/changelog/add-wpcom_hide_action_bar-site-option
+++ b/projects/plugins/jetpack/changelog/add-wpcom_hide_action_bar-site-option
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Add new site setting to hide the Action Bar
+Add a new site setting to hide the Action Bar in the REST API endpoint

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -499,6 +499,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'jetpack_waf_share_debug_data'     => (bool) get_option( 'jetpack_waf_share_debug_data' ),
 						'jetpack_waf_automatic_rules_last_updated_timestamp' => (int) get_option( 'jetpack_waf_automatic_rules_last_updated_timestamp' ),
 						'is_fully_managed_agency_site'     => (bool) get_option( 'is_fully_managed_agency_site' ),
+						'wpcom_hide_action_bar'            => (bool) get_option( 'wpcom_hide_action_bar' ),
 					);
 
 					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -1189,6 +1190,11 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					if ( update_option( $key, $coerce_value ) ) {
 						$updated[ $key ] = (bool) $coerce_value;
 					}
+					break;
+
+				case 'wpcom_hide_action_bar':
+					update_option( $key, (int) (bool) $value );
+					$updated[ $key ] = (int) (bool) $value;
 					break;
 
 				default:

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1186,15 +1186,11 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 
 				case 'is_fully_managed_agency_site':
+				case 'wpcom_hide_action_bar':
 					$coerce_value = (int) (bool) $value;
 					if ( update_option( $key, $coerce_value ) ) {
 						$updated[ $key ] = (bool) $coerce_value;
 					}
-					break;
-
-				case 'wpcom_hide_action_bar':
-					update_option( $key, (int) (bool) $value );
-					$updated[ $key ] = (int) (bool) $value;
 					break;
 
 				default:

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -147,6 +147,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'highlander_comment_form_prompt'            => '(string) The prompt for the comment form',
 			'jetpack_comment_form_color_scheme'         => '(string) The color scheme for the comment form',
 			'is_fully_managed_agency_site'              => '(bool) Whether the site is a fully managed agency site',
+			'wpcom_hide_action_bar'                     => '(bool) Whether to hide the Action bar',
 		),
 
 		'response_format' => array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/53830

This PR adds a new general setting (wpcom_hide_action_bar) to conditionally show the Action Bar on the front end of a site. The default value will be falsy to preserve the current behavior that Action Bar is shown.

The main issue will need 2 more PRs to be complete that I'll create and link shortly:

1. 169996-ghe-Automattic/wpcom to add the check for this option and not enqueue the Action Bar. Additionally it handles the setting in classic wp-admin interface.
2. [Calypso PR ](https://github.com/Automattic/wp-calypso/pull/98318) that adds the UI for the default interface

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
You need to test this PR with the other linked PRs. 
1. Go to general settings and update the value 
2. Go to the front-end and observe that the Action Bar is rendered based on that option.