### PR TITLE
Remove duplicate views: Rename experiment

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-remove-duplicate-views-experiment-rename
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-remove-duplicate-views-experiment-rename
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -393,7 +393,7 @@ add_action( 'admin_notices', 'wpcom_show_admin_interface_notice' );
  */
 function wpcom_is_duplicate_views_experiment_enabled() {
 	$experiment_platform = 'calypso';
-	$experiment_name     = "{$experiment_platform}_post_onboarding_holdout_120924";
+	$experiment_name     = "{$experiment_platform}_post_onboarding_holdout_160125";
 	$aa_test_name        = "{$experiment_platform}_post_onboarding_aa_150125";
 
 	static $is_enabled = null;


### PR DESCRIPTION
## Proposed changes:

See p1737035707671349-slack-C04DZ8M0GHW

I disabled the "Remove duplicate views" experiment after launching it and mistakenly thinking it was causing fatals. Such fatals were unrelated, but now we can longer use the disabled experiment, because it cannot be launched again.

Because of that, we had to clone the experiment. This PR updated the experiment name to use the new one.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
N/A