### PR TITLE
Forms: opt TextControl component to 40px default size in Gutenberg

### DIFF
--- a/projects/packages/forms/changelog/update-forms-textcontrol-40px-default
+++ b/projects/packages/forms/changelog/update-forms-textcontrol-40px-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: settings, opt-in for default 40px size in gutenberg

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-email-connection-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-email-connection-settings.js
@@ -110,6 +110,7 @@ const JetpackEmailConnectionSettings = ( {
 					'jetpack-forms'
 				) }
 				__nextHasNoMarginBottom={ true }
+				__next40pxDefaultSize={ true }
 			/>
 
 			<HelpMessage isError id={ `contact-form-${ instanceId }-email-error` }>
@@ -122,6 +123,7 @@ const JetpackEmailConnectionSettings = ( {
 				placeholder={ __( 'Enter a subject', 'jetpack-forms' ) }
 				onChange={ newSubject => setAttributes( { subject: newSubject } ) }
 				__nextHasNoMarginBottom={ true }
+				__next40pxDefaultSize={ true }
 			/>
 		</>
 	);

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
@@ -79,6 +79,7 @@ const JetpackFieldConsent = ( {
 							] }
 							onChange={ value => setAttributes( { consentType: value } ) }
 							__nextHasNoMarginBottom={ true }
+							__next40pxDefaultSize={ true }
 						/>
 					</BaseControl>
 				</PanelBody>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -126,6 +126,7 @@ const JetpackFieldControls = ( {
 					'jetpack-forms'
 				) }
 				__nextHasNoMarginBottom={ true }
+				__next40pxDefaultSize={ true }
 			/>
 		),
 		<JetpackFieldWidth key="width" setAttributes={ setAttributes } width={ width } />,
@@ -274,6 +275,7 @@ const JetpackFieldControls = ( {
 						'jetpack-forms'
 					) }
 					__nextHasNoMarginBottom={ true }
+					__next40pxDefaultSize={ true }
 				/>
 			</InspectorAdvancedControls>
 		</>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
@@ -98,6 +98,7 @@ const JetpackDatePicker = props => {
 									'jetpack-forms'
 								) }
 								__nextHasNoMarginBottom={ true }
+								__next40pxDefaultSize={ true }
 							/>
 						),
 					},

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings.js
@@ -138,6 +138,7 @@ export default ( { salesforceData, setAttributes, instanceId } ) => {
 						onChange={ setOrganizationId }
 						help={ __( 'Enter the Salesforce organization ID to send Leads to.', 'jetpack-forms' ) }
 						__nextHasNoMarginBottom={ true }
+						__next40pxDefaultSize={ true }
 					/>
 					{ organizationIdError && (
 						<HelpMessage isError id={ `contact-form-${ instanceId }-email-error` }>

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -184,6 +184,7 @@ export const JetpackContactFormEdit = forwardRef(
 							placeholder={ __( 'Your message has been sent', 'jetpack-forms' ) }
 							onChange={ newHeading => setAttributes( { customThankyouHeading: newHeading } ) }
 							__nextHasNoMarginBottom={ true }
+							__next40pxDefaultSize={ true }
 						/>
 					) }
 

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -175,6 +175,7 @@ export const JetpackContactFormEdit = forwardRef(
 						] }
 						onChange={ newMessage => setAttributes( { customThankyou: newMessage } ) }
 						__nextHasNoMarginBottom={ true }
+						__next40pxDefaultSize={ true }
 					/>
 
 					{ 'redirect' !== customThankyou && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/41128

Addresses warning:

> index.js:77 36px default size for wp.components.TextControl is deprecated since version 6.8 and will be removed in version 7.1. Note: Set the `__next40pxDefaultSize` prop to true to start opting into the new default size, which will become the default in a future version.

<img width="630" alt="image" src="https://github.com/user-attachments/assets/3ae4b9ae-04f3-47fb-a605-f02d6542a07a" />

Note that there are unrelated [spacing issues](https://github.com/Automattic/jetpack/issues/41124) in fields that I'll fix separately.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

**Before**

<img width="284" alt="Screenshot 2025-01-16 at 17 03 02 before" src="https://github.com/user-attachments/assets/99fb810b-986c-46eb-b720-08a7ff5c146f" />

**After**

<img width="268" alt="Screenshot 2025-01-16 at 17 06 15 after" src="https://github.com/user-attachments/assets/0b6d07ad-ae52-42ae-9ea9-a28f0daa402e" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add form block
* See text fields from settings in the sidebar

