### PR TITLE
Forms: update width control to use more modern togglecontrol

### DIFF
--- a/projects/packages/forms/changelog/update-forms-width-togglecontrol
+++ b/projects/packages/forms/changelog/update-forms-width-togglecontrol
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: update width control to use more modern ToggleGroupControl

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-width.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-width.js
@@ -1,4 +1,8 @@
-import { BaseControl, Button, ButtonGroup } from '@wordpress/components';
+import {
+	BaseControl,
+	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export default function JetpackFieldWidth( { setAttributes, width } ) {
@@ -11,21 +15,25 @@ export default function JetpackFieldWidth( { setAttributes, width } ) {
 			className="jetpack-field-label__width"
 			__nextHasNoMarginBottom={ true }
 		>
-			<BaseControl.VisualLabel>{ __( 'Field Width', 'jetpack-forms' ) }</BaseControl.VisualLabel>
-			<ButtonGroup aria-label={ __( 'Field Width', 'jetpack-forms' ) }>
+			<ToggleGroupControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				aria-label={ __( 'Field Width', 'jetpack-forms' ) }
+				isBlock
+				label={ __( 'Field Width', 'jetpack-forms' ) }
+				onClick={ value => setAttributes( { width: value } ) }
+				value={ width }
+			>
 				{ [ 25, 50, 75, 100 ].map( widthValue => {
 					return (
-						<Button
+						<ToggleGroupControlOption
 							key={ widthValue }
-							isSmall
-							variant={ widthValue === width ? 'primary' : undefined }
-							onClick={ () => setAttributes( { width: widthValue } ) }
-						>
-							{ widthValue }%
-						</Button>
+							label={ `${ widthValue }%` }
+							value={ widthValue }
+						/>
 					);
 				} ) }
-			</ButtonGroup>
+			</ToggleGroupControl>
 		</BaseControl>
 	);
 }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-width.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-width.js
@@ -19,9 +19,9 @@ export default function JetpackFieldWidth( { setAttributes, width } ) {
 			<ToggleGroupControl
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
-				aria-label={ __( 'Field Width', 'jetpack-forms' ) }
+				aria-label={ __( 'Width', 'jetpack-forms' ) }
 				isBlock
-				label={ __( 'Field Width', 'jetpack-forms' ) }
+				label={ __( 'Width', 'jetpack-forms' ) }
 				onChange={ value => setAttributes( { width: value } ) }
 				value={ width }
 			>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-width.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-width.js
@@ -5,6 +5,8 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+const PERCENTAGE_WIDTHS = [ 25, 50, 75, 100 ];
+
 export default function JetpackFieldWidth( { setAttributes, width } ) {
 	return (
 		<BaseControl
@@ -12,7 +14,6 @@ export default function JetpackFieldWidth( { setAttributes, width } ) {
 				'Adjust the width of the field to include multiple fields on a single line.',
 				'jetpack-forms'
 			) }
-			className="jetpack-field-label__width"
 			__nextHasNoMarginBottom={ true }
 		>
 			<ToggleGroupControl
@@ -24,7 +25,7 @@ export default function JetpackFieldWidth( { setAttributes, width } ) {
 				onChange={ value => setAttributes( { width: value } ) }
 				value={ width }
 			>
-				{ [ 25, 50, 75, 100 ].map( widthValue => {
+				{ PERCENTAGE_WIDTHS.map( widthValue => {
 					return (
 						<ToggleGroupControlOption
 							key={ widthValue }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-width.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-width.js
@@ -21,7 +21,7 @@ export default function JetpackFieldWidth( { setAttributes, width } ) {
 				aria-label={ __( 'Field Width', 'jetpack-forms' ) }
 				isBlock
 				label={ __( 'Field Width', 'jetpack-forms' ) }
-				onClick={ value => setAttributes( { width: value } ) }
+				onChange={ value => setAttributes( { width: value } ) }
 				value={ width }
 			>
 				{ [ 25, 50, 75, 100 ].map( widthValue => {

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -481,13 +481,7 @@
 }
 
 .jetpack-field-label__width {
-	.components-button-group {
-		display: block;
-	}
-
-	.components-base-control__field {
-		margin-bottom: 12px;
-	}
+	margin-bottom: 1em;
 }
 
 // Duplicated to elevate specificity in order to overwrite core styles

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -480,10 +480,6 @@
 	}
 }
 
-.jetpack-field-label__width {
-	margin-bottom: 1em;
-}
-
 // Duplicated to elevate specificity in order to overwrite core styles
 .jetpack-field-multiple__list.jetpack-field-multiple__list {
 	list-style-type: none;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves https://github.com/Automattic/jetpack/issues/41129
Partly fixes spacing issues noted at https://github.com/Automattic/jetpack/issues/41124

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update width field control to use more modern `ToggleGroupControl`
* Fix no spacing under the control due to `__nextHasNoMarginBottom`


Before

<img width="280" alt="Screenshot 2025-01-16 at 17 37 45" src="https://github.com/user-attachments/assets/9376ab3b-1a83-40e0-84c3-940ebe07e561" />

After

<img width="274" alt="Screenshot 2025-01-16 at 17 33 56" src="https://github.com/user-attachments/assets/993ad348-3509-4941-b2cb-c1badaf137a0" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add forms block
* In a text field, test "width" setting from the sidebar before and after the change.

<img width="1483" alt="Screenshot 2025-01-16 at 17 51 59" src="https://github.com/user-attachments/assets/225c68fb-d097-41fe-a579-44e0201de5f8" />


