### PR TITLE
Fix/my jetpack red bubble cache

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-red-bubble-cache
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-red-bubble-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+add caching for the red bubble alerts for My Jetpack

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -64,6 +64,7 @@ class Initializer {
 	const MISSING_CONNECTION_NOTIFICATION_KEY            = 'missing-connection';
 	const VIDEOPRESS_STATS_KEY                           = 'my-jetpack-videopress-stats';
 	const VIDEOPRESS_PERIOD_KEY                          = 'my-jetpack-videopress-period';
+	const MY_JETPACK_RED_BUBBLE_TRANSIENT_KEY            = 'my-jetpack-red-bubble-transient';
 
 	/**
 	 * Holds info/data about the site (from the /sites/%d endpoint)
@@ -281,7 +282,8 @@ class Initializer {
 					'purchases'                 => self::get_purchases(),
 					'modules'                   => self::get_active_modules(),
 				),
-				'redBubbleAlerts'        => self::get_red_bubble_alerts(),
+				// Only in the My Jetpack context, we get the alerts without the cache to make sure we have the most up-to-date info
+				'redBubbleAlerts'        => self::get_red_bubble_alerts( true ),
 				'recommendedModules'     => array(
 					'modules'    => self::get_recommended_modules(),
 					'isFirstRun' => \Jetpack_Options::get_option( 'recommendations_first_run', true ),
@@ -843,17 +845,28 @@ class Initializer {
 	/**
 	 * Collect all possible alerts that we might use a red bubble notification for
 	 *
+	 * @param bool $bypass_cache - whether to bypass the red bubble cache.
 	 * @return array
 	 */
-	public static function get_red_bubble_alerts() {
+	public static function get_red_bubble_alerts( bool $bypass_cache = false ) {
 		static $red_bubble_alerts = array();
 
 		// using a static cache since we call this function more than once in the class
 		if ( ! empty( $red_bubble_alerts ) ) {
 			return $red_bubble_alerts;
 		}
+
+		// check for stored alerts
+		$stored_alerts = get_transient( self::MY_JETPACK_RED_BUBBLE_TRANSIENT_KEY );
+		// Cache bypass for red bubbles should only happen on the My Jetpack page
+		if ( $stored_alerts !== false && $bypass_cache !== true ) {
+			return $stored_alerts;
+		}
+
 		// go find the alerts
 		$red_bubble_alerts = apply_filters( 'my_jetpack_red_bubble_notification_slugs', $red_bubble_alerts );
+		// cache the alerts for one hour
+		set_transient( self::MY_JETPACK_RED_BUBBLE_TRANSIENT_KEY, $red_bubble_alerts, 3600 );
 
 		return $red_bubble_alerts;
 	}

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -859,7 +859,7 @@ class Initializer {
 		// check for stored alerts
 		$stored_alerts = get_transient( self::MY_JETPACK_RED_BUBBLE_TRANSIENT_KEY );
 		// Cache bypass for red bubbles should only happen on the My Jetpack page
-		if ( $stored_alerts !== false && $bypass_cache !== true ) {
+		if ( $stored_alerts !== false && ! ( $bypass_cache ) ) {
 			return $stored_alerts;
 		}
 

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -73,6 +73,13 @@ abstract class Product {
 	const EXPIRATION_CUTOFF_TIME = '+2 months';
 
 	/**
+	 * Transient key for storing site features
+	 *
+	 * @var string;
+	 */
+	const MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY = 'my-jetpack-site-features';
+
+	/**
 	 * Whether this module is a Jetpack feature
 	 *
 	 * @var boolean
@@ -221,6 +228,12 @@ abstract class Product {
 			return $features;
 		}
 
+		// Check for a cached value before doing lookup
+		$stored_features = get_transient( self::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY );
+		if ( $stored_features !== false ) {
+			return $stored_features;
+		}
+
 		$site_id  = Jetpack_Options::get_option( 'id' );
 		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/features', $site_id ), '1.1' );
 
@@ -236,6 +249,8 @@ abstract class Product {
 			'active'    => $feature_return->active,
 			'available' => $feature_return->available,
 		);
+		// set a short transient to help with multiple lookups on the same page load.
+		set_transient( self::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY, $features, 15 );
 
 		return $features;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This diff adds caching around the red-bubble alerts used in My Jetpack. 
It also adds a short transient to prevent multiple api calls for checking site features.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Get a Jetpack test site with the ability to apply this patch (locally or via the beta plugin)
* Before applying the patch, run your test site on the latest trunk code. 
* Open your WordPress dashboard page. Using the query monitor plugin, observe the HTTP API calls made from PHP when loading the WP dashboard. Notice that there are several API calls originating from the My Jetpack package. Note that the call to the "features" endpoint is repeated several times.
![Screenshot 2025-01-16 at 10 42 43 AM](https://github.com/user-attachments/assets/aad381f4-a476-4cd6-8a52-7f40ed6b72c8)
* Now, apply this patch, reload the dashboard a page a couple times (they first load will store the transient)
* Observe again the HTTP requests coming from PHP while on the dashboard. There should be no requests originating from My Jetpack
![Screenshot 2025-01-16 at 10 43 55 AM](https://github.com/user-attachments/assets/79a7e2cc-8c46-4406-9a51-cc892a93e955)
* Now, navigate to My Jetpack by clicking on "Jetpack" in the left-hand menu.
* Using the query monitor plugin, confirm that the API requests are still running while on the My Jetpack page (this is to collect the most recent data, though ideally, these requests should be moved to be async in this context in a later PR).
![Screenshot 2025-01-16 at 10 44 48 AM](https://github.com/user-attachments/assets/0836bb46-0b26-4b8b-b7ab-6d7f4cdd3892)
* Confirm that there are no duplicate requests being made on the My Jetpack page from PHP in the Query Monitor output
