### PR TITLE
Forms: fix sidebar spacing

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-sidebar-spacing
+++ b/projects/packages/forms/changelog/fix-forms-sidebar-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix spacing issue in sidebar settings

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -74,7 +74,6 @@ function JetpackFieldCheckbox( props ) {
 					<PanelBody title={ __( 'Field Settings', 'jetpack-forms' ) }>
 						<ToggleControl
 							label={ __( 'Field is required', 'jetpack-forms' ) }
-							className="jetpack-field-label__required"
 							checked={ required }
 							onChange={ value => setAttributes( { required: value } ) }
 							help={ __( 'You can edit the "required" label in the editor', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -120,6 +120,7 @@ const JetpackFieldControls = ( {
 				key="placeholderField"
 				label={ __( 'Placeholder text', 'jetpack-forms' ) }
 				value={ placeholder || '' }
+				className="jetpack-field-label__placeholder"
 				onChange={ value => setAttributes( { [ placeholderField ]: value } ) }
 				help={ __(
 					'Show visitors an example of the type of content expected. Otherwise, leave blank.',

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -109,7 +109,6 @@ const JetpackFieldControls = ( {
 		<ToggleControl
 			key="required"
 			label={ __( 'Field is required', 'jetpack-forms' ) }
-			className="jetpack-field-label__required"
 			checked={ required }
 			onChange={ value => setAttributes( { required: value } ) }
 			help={ __( 'You can edit the "required" label in the editor', 'jetpack-forms' ) }
@@ -120,7 +119,6 @@ const JetpackFieldControls = ( {
 				key="placeholderField"
 				label={ __( 'Placeholder text', 'jetpack-forms' ) }
 				value={ placeholder || '' }
-				className="jetpack-field-label__placeholder"
 				onChange={ value => setAttributes( { [ placeholderField ]: value } ) }
 				help={ __(
 					'Show visitors an example of the type of content expected. Otherwise, leave blank.',
@@ -171,9 +169,7 @@ const JetpackFieldControls = ( {
 					<JetpackManageResponsesSettings isChildBlock />
 				</PanelBody>
 				<PanelBody title={ __( 'Field Settings', 'jetpack-forms' ) }>
-					{ fieldSettings.filter( Boolean ).map( ( elt, index ) => (
-						<div key={ index }>{ elt }</div>
-					) ) }
+					<>{ fieldSettings }</>
 				</PanelBody>
 				<PanelColorSettings
 					title={ __( 'Color', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
@@ -82,6 +82,7 @@ const JetpackDatePicker = props => {
 						index: 1,
 						element: (
 							<SelectControl
+								key="date-format"
 								label={ __( 'Date Format', 'jetpack-forms' ) }
 								options={ DATE_FORMATS.map( ( { value, label: optionLabel, example } ) => ( {
 									value,

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -267,16 +267,6 @@
 	.components-base-control {
 		margin-top: -1px;
 		margin-bottom: -3px;
-
-		&.jetpack-field-label__required {
-			.components-form-toggle {
-				margin: 2px 8px 0 16px;
-			}
-
-			.components-toggle-control__label {
-				word-break: normal;
-			}
-		}
 	}
 
 	.rich-text.jetpack-field-label__input {
@@ -498,12 +488,6 @@
 	.components-base-control__field {
 		margin-bottom: 12px;
 	}
-}
-
-.jetpack-field-label__width,
-.jetpack-field-label__required,
-.jetpack-field-label__placeholder {
-	margin-bottom: 1em;
 }
 
 // Duplicated to elevate specificity in order to overwrite core styles

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -500,6 +500,12 @@
 	}
 }
 
+.jetpack-field-label__width,
+.jetpack-field-label__required,
+.jetpack-field-label__placeholder {
+	margin-bottom: 1em;
+}
+
 // Duplicated to elevate specificity in order to overwrite core styles
 .jetpack-field-multiple__list.jetpack-field-multiple__list {
 	list-style-type: none;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/41124

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix spacing -issues in sidebar

**Before**

<img width="280" alt="Screenshot 2025-01-16 at 18 05 32" src="https://github.com/user-attachments/assets/72b8e1fe-004f-4b23-a948-7c231252c50b" />


**After**

<img width="273" alt="Screenshot 2025-01-16 at 18 05 05" src="https://github.com/user-attachments/assets/4ef23acf-e3bc-4e40-b5a8-368251f4cb91" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add forms block
* See field's settings from sidebar

