### PR TITLE
Fix: Warnings on any theme using customizer colors.

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-warnings-on-any-theme-using-customizer-colors
+++ b/projects/plugins/wpcomsh/changelog/fix-warnings-on-any-theme-using-customizer-colors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix: Undefined array key warnings on any customizer theme with colors.

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -1432,8 +1432,12 @@ class Colors_Manager_Common {
 
 		$colors = $opts['colors'];
 
-		$colors['border'] = $colors['fg1'];
-		$colors['url']    = $colors['link'];
+		if ( isset( $colors['fg1'] ) ) {
+			$colors['border'] = $colors['fg1'];
+		}
+		if ( isset( $colors['link'] ) ) {
+			$colors['url'] = $colors['link'];
+		}
 		if ( isset( $colors['txt'] ) ) {
 			$colors['text'] = $colors['txt'];
 		}


### PR DESCRIPTION
The warning shared below appears on every page served, which significantly clutters the logs. It is also not ideal for our clients to see warnings on their sites caused by code that we provide and that they do not control. 

These warnings occur on any theme where colors have been changed in the customizer.

<img width="1418" alt="Screenshot 2025-01-16 at 16 45 48" src="https://github.com/user-attachments/assets/fbf62ce0-e596-4e2b-b432-c7780c6c9a6e" />

## Proposed Changes:
This pull request adds checks before accessing certain keys in the array to prevent the warnings.

## Does this pull request change the data or activity we track or use?
No.

## Testing Instructions:
- For any theme utilizing customizer colors (e.g., Colinear, Cubic, etc.), change a few colors in the customizer.
- Load the site to verify that the colors are applied correctly.
- Check the logs at https://wordpress.com/site-logs/SITE/php to ensure that the previously mentioned warning is no longer present.

