### PR TITLE
WPCOM Admin Bar: Update Edit Site destination  

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-admin-bar-menu-edit-site
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-admin-bar-menu-edit-site
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Admin Bar: Point the Edit Site menu item to /site-editor.php 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -291,4 +291,4 @@ function wpcom_edit_site_menu_override( $wp_admin_bar ) {
 		$wp_admin_bar->add_node( $args );
 	}
 }
-add_action( 'admin_bar_menu', 'wpcom_edit_site_menu_override', 9999 );
+add_action( 'admin_bar_menu', 'wpcom_edit_site_menu_override', 41 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -275,3 +275,20 @@ function wpcom_custom_wpcom_admin_bar_class( $wp_admin_bar_class ) {
 	return '\Automattic\Jetpack\Jetpack_Mu_Wpcom\WPCOM_Admin_Bar';
 }
 add_filter( 'wp_admin_bar_class', 'wpcom_custom_wpcom_admin_bar_class' );
+
+/**
+ * Changes the edit site menu to point to the top-level site editor.
+ *
+ * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
+ */
+function wpcom_edit_site_menu( $wp_admin_bar ) {
+	if ( $wp_admin_bar->get_node( 'site-editor' ) ) {
+		$args = array(
+			'id'   => 'site-editor',
+			'href' => home_url( '/wp-admin/site-editor.php' ),
+		);
+
+		$wp_admin_bar->add_node( $args );
+	}
+}
+add_action( 'admin_bar_menu', 'wpcom_edit_site_menu', 11 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -281,14 +281,14 @@ add_filter( 'wp_admin_bar_class', 'wpcom_custom_wpcom_admin_bar_class' );
  *
  * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
  */
-function wpcom_edit_site_menu( $wp_admin_bar ) {
+function wpcom_edit_site_menu_override( $wp_admin_bar ) {
 	if ( $wp_admin_bar->get_node( 'site-editor' ) ) {
 		$args = array(
 			'id'   => 'site-editor',
-			'href' => home_url( '/wp-admin/site-editor.php' ),
+			'href' => admin_url( 'site-editor.php' ),
 		);
 
 		$wp_admin_bar->add_node( $args );
 	}
 }
-add_action( 'admin_bar_menu', 'wpcom_edit_site_menu', 9999 );
+add_action( 'admin_bar_menu', 'wpcom_edit_site_menu_override', 9999 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -291,4 +291,4 @@ function wpcom_edit_site_menu( $wp_admin_bar ) {
 		$wp_admin_bar->add_node( $args );
 	}
 }
-add_action( 'admin_bar_menu', 'wpcom_edit_site_menu', 11 );
+add_action( 'admin_bar_menu', 'wpcom_edit_site_menu', 9999 );

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-admin-bar-menu-edit-site
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-admin-bar-menu-edit-site
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Admin Bar: Point the Edit Site menu item to /site-editor.php

--- a/projects/plugins/wpcomsh/changelog/update-admin-bar-menu-edit-site
+++ b/projects/plugins/wpcomsh/changelog/update-admin-bar-menu-edit-site
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Admin Bar: Point the Edit Site menu item to /site-editor.php


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Changes the default location for the Edit Site button in the admin bar to point to the top-level `wp-admin/site-editor.php` destination. 

<img width="114" alt="image" src="https://github.com/user-attachments/assets/f7e33f7c-182a-4dda-b698-95ffe31d6a80" />

### Other information:

Related to: https://github.com/WordPress/gutenberg/issues/63785 
The same change was proposed and somewhat in progress in Core, though we're paused there. 

Default behavior without this patch was to go directly to the template in the editor, i.e. `/wp-admin/site-editor.php?canvas=edit&p=%2Fwp_template%2Fpub%2Ftwentytwentyfour%2F%2Fhome`. 

#### Checklist

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pfYzsZ-1qQ-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Sandbox a wpcom site 
- Run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin update/admin-bar-menu-edit-site` from your wpcom sandbox public_html/
- View the front end of the site while logged in. Click the "Edit Site" menu item. 
- Be taken to `/wp-admin/site-editor.php`