### PR TITLE
Jetpack button: fix width and alignment settings

### DIFF
--- a/projects/packages/forms/changelog/fix-jetpack-button-styling
+++ b/projects/packages/forms/changelog/fix-jetpack-button-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix submit button width and alignment

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -50,7 +50,8 @@
 
 		.wp-block {
 			flex: 0 0 100%;
-			margin: 0;
+			margin-top: 0;
+			margin-bottom: 0;
 
 			&.wp-block-jetpack-button {
 				flex-basis: auto;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -52,6 +52,10 @@
 			flex: 0 0 100%;
 			margin: 0;
 
+			&.wp-block-jetpack-button {
+				flex-basis: auto;
+			}
+
 			&.jetpack-field__width-25,
 			&.jetpack-field__width-50,
 			&.jetpack-field__width-75 {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -230,7 +230,7 @@
 	gap: var(--wp--style--block-gap, 1.5rem);
 }
 
-.wp-block-jetpack-contact-form > * {
+.wp-block-jetpack-contact-form > *:not(.wp-block-jetpack-button) {
 	flex: 0 0 100%;
 	box-sizing: border-box;
 }
@@ -241,8 +241,27 @@
 	padding-left: 0;
 }
 
-.wp-block-jetpack-button.alignright button {
-	float: right;
+.wp-block-jetpack-contact-form .wp-block-jetpack-button {
+	width: fit-content;
+}
+
+.wp-block-jetpack-contact-form .wp-block-jetpack-button.aligncenter {
+	display: block;
+
+	margin-left: auto;
+	margin-right: auto;
+}
+
+.wp-block-jetpack-contact-form .wp-block-jetpack-button.alignleft {
+	display: block;
+
+	margin-right: auto;
+}
+
+.wp-block-jetpack-contact-form .wp-block-jetpack-button.alignright {
+	display: block;
+
+	margin-left: auto;
 }
 
 .wp-block-jetpack-contact-form .grunion-field-wrap {

--- a/projects/plugins/jetpack/changelog/fix-jetpack-button-styling
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-button-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack button: fix width and alignment

--- a/projects/plugins/jetpack/extensions/blocks/button/button.php
+++ b/projects/plugins/jetpack/extensions/blocks/button/button.php
@@ -166,7 +166,6 @@ function get_button_styles( $attributes ) {
 	$has_named_gradient          = array_key_exists( 'gradient', $attributes );
 	$has_custom_gradient         = array_key_exists( 'customGradient', $attributes );
 	$has_border_radius           = array_key_exists( 'borderRadius', $attributes );
-	$has_width                   = array_key_exists( 'width', $attributes );
 	$has_font_family             = array_key_exists( 'fontFamily', $attributes );
 	$has_typography_styles       = array_key_exists( 'style', $attributes ) && array_key_exists( 'typography', $attributes['style'] );
 	$has_custom_font_size        = $has_typography_styles && array_key_exists( 'fontSize', $attributes['style']['typography'] );
@@ -206,11 +205,6 @@ function get_button_styles( $attributes ) {
 		$styles[] = sprintf( 'border-radius: %spx;', $attributes['borderRadius'] );
 	}
 
-	if ( $has_width ) {
-		$styles[] = sprintf( 'width: %s;', $attributes['width'] );
-		$styles[] = 'max-width: 100%';
-	}
-
 	return implode( ' ', $styles );
 }
 
@@ -226,7 +220,7 @@ function get_button_wrapper_styles( $attributes ) {
 	$has_width = array_key_exists( 'width', $attributes );
 
 	if ( $has_width ) {
-		$styles[] = 'max-width: 100%';
+		$styles[] = sprintf( 'width: %s;', $attributes['width'] );
 	}
 
 	return implode( ' ', $styles );

--- a/projects/plugins/jetpack/extensions/blocks/button/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/button/edit.js
@@ -8,21 +8,16 @@ import {
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import useWidth from '../../shared/use-width';
-import applyFallbackStyles from './apply-fallback-styles';
 import { IS_GRADIENT_AVAILABLE } from './constants';
 import ButtonControls from './controls';
 import usePassthroughAttributes from './use-passthrough-attributes';
 import './editor.scss';
 
 export function ButtonEdit( props ) {
-	const { attributes, backgroundColor, className, clientId, context, setAttributes, textColor } =
-		props;
+	const { attributes, backgroundColor, className, clientId, setAttributes, textColor } = props;
 	const { borderRadius, element, placeholder, text, width, fontSize } = attributes;
-	const isWidthSetOnParentBlock = 'jetpack/parentBlockWidth' in context;
 
 	usePassthroughAttributes( { attributes, clientId, setAttributes } );
-	useWidth( { attributes, disableEffects: isWidthSetOnParentBlock, setAttributes } );
 
 	/* eslint-disable react-hooks/rules-of-hooks */
 	const {
@@ -39,6 +34,7 @@ export function ButtonEdit( props ) {
 
 	const blockProps = useBlockProps( {
 		className: clsx( 'wp-block-button', className ),
+		style: { width },
 	} );
 
 	const buttonClasses = clsx( 'wp-block-button__link', {
@@ -48,7 +44,6 @@ export function ButtonEdit( props ) {
 		[ textColor.class ]: textColor.class,
 		[ gradientClass ]: gradientClass,
 		'no-border-radius': 0 === borderRadius,
-		'has-custom-width': !! width,
 		[ `has-${ fontSize }-font-size` ]: !! fontSize,
 		'has-custom-font-size': !! fontSize,
 	} );
@@ -60,7 +55,6 @@ export function ButtonEdit( props ) {
 		fontSize: attributes.style?.typography?.fontSize,
 		color: textColor.color,
 		borderRadius: borderRadius ? borderRadius + 'px' : undefined,
-		width,
 	};
 
 	return (
@@ -90,6 +84,5 @@ export function ButtonEdit( props ) {
 }
 
 export default compose(
-	withColors( { backgroundColor: 'background-color' }, { textColor: 'color' } ),
-	applyFallbackStyles
+	withColors( { backgroundColor: 'background-color' }, { textColor: 'color' } )
 )( ButtonEdit );

--- a/projects/plugins/jetpack/extensions/blocks/button/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/button/editor.scss
@@ -6,6 +6,12 @@
 	max-width: 100%;
 	width: fit-content;
 	margin: 0;
+
+	&.is-style-outline > .wp-block-button__link {
+		background-color: transparent;
+		border: solid 1px currentColor;
+		color: currentColor;
+	}
 }
 
 // Support align feature for older themes

--- a/projects/plugins/jetpack/extensions/blocks/button/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/button/editor.scss
@@ -1,8 +1,32 @@
 @import "../../shared/styles/align";
 
-.wp-block-jetpack-button {
+// This level of CSS specificity is required to overwrite existing styles
+.editor-styles-wrapper .block-editor-block-list__block.wp-block-jetpack-button {
 	@include align-block;
 	max-width: 100%;
 	width: fit-content;
 	margin: 0;
+}
+
+// Support align feature for older themes
+.wp-block[data-align]:has(> .wp-block-jetpack-button) {
+	margin-left: 0;
+	margin-right: 0;
+}
+
+.wp-block[data-align] > .wp-block-jetpack-button {
+	display: block;
+}
+
+.wp-block[data-align="center"] > .wp-block-jetpack-button {
+	margin-left: auto;
+	margin-right: auto;
+}
+
+.wp-block[data-align="left"] > .wp-block-jetpack-button {
+	margin-right: auto;
+}
+
+.wp-block[data-align="right"] > .wp-block-jetpack-button {
+	margin-left: auto;
 }

--- a/projects/plugins/jetpack/extensions/blocks/button/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/button/editor.scss
@@ -1,24 +1,8 @@
+@import "../../shared/styles/align";
+
 .wp-block-jetpack-button {
+	@include align-block;
 	max-width: 100%;
 	width: fit-content;
 	margin: 0;
-
-	&.aligncenter {
-		display: block;
-
-		margin-left: auto;
-		margin-right: auto;
-	}
-
-	&.alignleft {
-		display: block;
-
-		margin-right: auto;
-	}
-
-	&.alignright {
-		display: block;
-
-		margin-left: auto;
-	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/button/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/button/editor.scss
@@ -1,42 +1,24 @@
-.wp-block[data-type='jetpack/button'] {
-	display: inline-block;
-	margin: 0 auto;
-
-	&.is-style-outline > .wp-block-button__link {
-		background-color: transparent;
-		border: solid 1px currentColor;
-		color: currentColor;
-	}
-}
-
-.wp-block[data-align="center"] {
-	.wp-block-jetpack-button {
-		display: flex;
-		justify-content: center;
-	}
-}
-
-.wp-block[data-align="right"] {
-	.wp-block-jetpack-button {
-		display: flex;
-		justify-content: flex-end;
-	}
-}
-
-div[data-type="jetpack/button"]:not([data-align='left']):not([data-align='right']) {
-	width: 100%;
-}
-
-div[data-type="jetpack/button"][data-align] {
-	z-index: 1;
-	width: 100%;
-
-	.wp-block > div {
-		max-width: 100%;
-	}
-}
-
-.wp-block-jetpack-button,
-.wp-block-button__link.has-custom-width {
+.wp-block-jetpack-button {
 	max-width: 100%;
+	width: fit-content;
+	margin: 0;
+
+	&.aligncenter {
+		display: block;
+
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	&.alignleft {
+		display: block;
+
+		margin-right: auto;
+	}
+
+	&.alignright {
+		display: block;
+
+		margin-left: auto;
+	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/button/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/button/view.scss
@@ -5,19 +5,17 @@
 }
 
 .wp-block-jetpack-button {
-<<<<<<< HEAD
-	&.is-style-outline > .wp-block-button__link {
-		background-color: transparent;
-		border: solid 1px currentColor;
-		color: currentColor;
-	}
-=======
 	@include align-block;
 	max-width: 100%;
 	width: fit-content;
 	margin: 0;
 
->>>>>>> 27b3cb7cc9 (Move align styles in mixin)
+	&.is-style-outline > .wp-block-button__link {
+		background-color: transparent;
+		border: solid 1px currentColor;
+		color: currentColor;
+	}
+
 	&:not(.is-style-outline) button {
 		border: none;
 	}

--- a/projects/plugins/jetpack/extensions/blocks/button/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/button/view.scss
@@ -1,13 +1,23 @@
+@import "../../shared/styles/align";
+
 .amp-wp-article .wp-block-jetpack-button {
 	color: #ffffff;
 }
 
 .wp-block-jetpack-button {
+<<<<<<< HEAD
 	&.is-style-outline > .wp-block-button__link {
 		background-color: transparent;
 		border: solid 1px currentColor;
 		color: currentColor;
 	}
+=======
+	@include align-block;
+	max-width: 100%;
+	width: fit-content;
+	margin: 0;
+
+>>>>>>> 27b3cb7cc9 (Move align styles in mixin)
 	&:not(.is-style-outline) button {
 		border: none;
 	}

--- a/projects/plugins/jetpack/extensions/blocks/calendly/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/view.scss
@@ -17,4 +17,23 @@
 
 .wp-block-jetpack-calendly .wp-block-jetpack-button {
 	color: #ffffff;
+
+	&.aligncenter {
+		display: block;
+
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	&.alignleft {
+		display: block;
+
+		margin-right: auto;
+	}
+
+	&.alignright {
+		display: block;
+
+		margin-left: auto;
+	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/calendly/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/view.scss
@@ -1,3 +1,5 @@
+@import "../../shared/styles/align";
+
 .admin-bar .calendly-overlay .calendly-popup-close {
 	top: 47px;
 }
@@ -16,24 +18,7 @@
 }
 
 .wp-block-jetpack-calendly .wp-block-jetpack-button {
+	@include align-block;
+
 	color: #ffffff;
-
-	&.aligncenter {
-		display: block;
-
-		margin-left: auto;
-		margin-right: auto;
-	}
-
-	&.alignleft {
-		display: block;
-
-		margin-right: auto;
-	}
-
-	&.alignright {
-		display: block;
-
-		margin-left: auto;
-	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/editor.scss
@@ -1,5 +1,11 @@
+@import '../../shared/styles/align';
+
 .wp-block-jetpack-eventbrite {
 	position: relative;
+
+	.wp-block-jetpack-button {
+		@include align-block;
+	}
 
 	.components-placeholder__learn-more {
 		margin-top: 1em;

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/style.scss
@@ -1,3 +1,4 @@
+@import "../../shared/styles/align";
 // Hide the link if an iframe got appended to the container.
 .eventbrite__direct-link:not(:only-child) {
 	display: none;
@@ -68,23 +69,6 @@
 
 .wp-block-jetpack-eventbrite {
 	.wp-block-jetpack-button {
-		&.aligncenter {
-			display: block;
-
-			margin-left: auto;
-			margin-right: auto;
-		}
-
-		&.alignleft {
-			display: block;
-
-			margin-right: auto;
-		}
-
-		&.alignright {
-			display: block;
-
-			margin-left: auto;
-		}
+		@include align-block;
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/style.scss
@@ -65,3 +65,26 @@
 	height: 40px;
 	/* @todo More styling could be copied from Eventbrite */
 }
+
+.wp-block-jetpack-eventbrite {
+	.wp-block-jetpack-button {
+		&.aligncenter {
+			display: block;
+
+			margin-left: auto;
+			margin-right: auto;
+		}
+
+		&.alignleft {
+			display: block;
+
+			margin-right: auto;
+		}
+
+		&.alignright {
+			display: block;
+
+			margin-left: auto;
+		}
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/view.scss
@@ -1,5 +1,6 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 @import '../../shared/styles/jetpack-variables.scss';
+@import "../../shared/styles/align";
 
 .wp-block-jetpack-mailchimp {
 	&.is-processing {
@@ -9,26 +10,9 @@
 	}
 
 	.wp-block-jetpack-button, p {
+		@include align-block;
+
 		margin-bottom: 1em;
-
-		&.aligncenter {
-			display: block;
-
-			margin-left: auto;
-			margin-right: auto;
-		}
-
-		&.alignleft {
-			display: block;
-
-			margin-right: auto;
-		}
-
-		&.alignright {
-			display: block;
-
-			margin-left: auto;
-		}
 	}
 
 	input {

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/view.scss
@@ -10,6 +10,25 @@
 
 	.wp-block-jetpack-button, p {
 		margin-bottom: 1em;
+
+		&.aligncenter {
+			display: block;
+
+			margin-left: auto;
+			margin-right: auto;
+		}
+
+		&.alignleft {
+			display: block;
+
+			margin-right: auto;
+		}
+
+		&.alignright {
+			display: block;
+
+			margin-left: auto;
+		}
 	}
 
 	input {

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/editor.scss
@@ -1,9 +1,5 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
-.editor-styles-wrapper .wp-block-jetpack-payment-buttons {
-	--jetpack-payment-buttons-gap: 0.5em;
-}
-
 .wp-block-premium-content-container .premium-content-tabs {
 	align-items: center;
 	background: $white;

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/editor.scss
@@ -1,5 +1,9 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
+.editor-styles-wrapper .wp-block-jetpack-payment-buttons {
+	--jetpack-payment-buttons-gap: 0.5em;
+}
+
 .wp-block-premium-content-container .premium-content-tabs {
 	align-items: center;
 	background: $white;
@@ -49,6 +53,8 @@
 /* Subscribe/Login buttons */
 
 .wp-block-buttons .wp-block[data-type='jetpack/recurring-payments'] {
+	--jetpack-payment-buttons-gap: 0.5em;
+	
 	display: inline-block;
 	margin: 0 0.5em 0 0;
 	width: auto;

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/view.scss
@@ -14,6 +14,8 @@
 
 /** Subscribe button **/
 .wp-block-premium-content-logged-out-view .wp-block-jetpack-recurring-payments {
+	--jetpack-payment-buttons-gap: 0.5em;
+
 	display: inline-block;
 	margin-inline-end: 0.5em;
 }

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/editor.scss
@@ -116,6 +116,7 @@
 	}
 
 	.wp-block[data-type='jetpack/button'] {
+		width: 100%;
 		margin-top: 0;
 		margin-bottom: 0;
 	}

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/editor.scss
@@ -115,6 +115,7 @@
 		display: block;
 	}
 
+	.wp-block-jetpack-button,
 	.wp-block[data-type='jetpack/button'] {
 		width: 100%;
 		margin-top: 0;

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/view.scss
@@ -3,3 +3,9 @@
 .wp-block-jetpack-recurring-payments.aligncenter .wp-block-jetpack-button {
 	text-align: center;
 }
+
+.wp-block-jetpack-recurring-payments {
+	.wp-block-jetpack-button {
+		width: 100%;
+	}
+}

--- a/projects/plugins/jetpack/extensions/shared/styles/align.scss
+++ b/projects/plugins/jetpack/extensions/shared/styles/align.scss
@@ -1,0 +1,20 @@
+@mixin align-block {
+	&.aligncenter,
+	&.alignleft,
+	&.alignright {
+		display: block;
+	}
+
+	&.aligncenter {
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	&.alignleft {
+		margin-right: auto;
+	}
+
+	&.alignright {
+		margin-left: auto;
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack/issues/38779

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Setting the width and alignment of a `jetpack/button` block doesn't work consistently, depending on how it is integrated with its parent block and whether we're in the editor or site frontend.

For instance, in a Form block, setting the button width to 50% in the editor shrinks it instead of making it half the container's width, which is what you'd expect from a user's perspective.
<img width="500" alt="Screenshot 2025-01-16 at 3 32 57 PM" src="https://github.com/user-attachments/assets/e1c052d8-72fa-4648-a417-f1a1320b5ccd" />

In a Mailchimp block, trying to align the button (to the right in the capture below) doesn't work.
<img width="443" alt="Screenshot 2025-01-16 at 3 33 08 PM" src="https://github.com/user-attachments/assets/abb60192-5ab0-4292-b545-dbc42f26840c" />

The following blocks use the `jetpack/button` block and show one or both faulty behaviors we've highlighted: 
- Form
- Premium Content
- Mailchimp
- Calendly
- Eventbrite
- Recipe
- Recurring Payments/Payment Button
 
The AI Assistant might as well, though I haven't been able to experience it.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
To address that, this PR does two things in the `jetpack/button` block:

1. It removes a class-less `div` from the markup generated by the block
<img width="488" alt="Screenshot 2025-01-16 at 3 37 38 PM" src="https://github.com/user-attachments/assets/62d48b02-c621-4e64-ae6f-05ae33f50feb" />

This `div` prevents the flexbox layout applied to `.block-editor-block-list__layout` from working as intended.

2. It applies the selected width to `.wp-block-button` instead of `.wp-block-button__link`.

Indeed, [this Gutenberg PR ](https://github.com/WordPress/gutenberg/pull/64770) forces `.wp-block-button__link` to have a width of 100%, breaking the width settings behavior.

Furthermore, the PR also updates the blocks consuming `jetpack/button` so the width and alignment settings work as expected. Here are some caveats:
- Setting the width or alignment of `jetpack/button` in the Recipe block doesn't work as one would expect, given the width is relative to the grid items of the block. Solving this should be part of a broader discussion.
- Similarly, aligning the `jetpack/button` of a Form is confusing when it's not in its row. It deserves a separate discussion too.
- The alignment of buttons in a similar row is not implemented (Premium Content and Recurring Payments blocks). Again, this should be a separate concern.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Do not checkout this branch just yet
- Spin up a test Jetpack site
- Create a new post
- Add the following blocks:
  - Form
  - Premium Content
  - Mailchimp
  - Calendly
  - Eventbrite
  - Recurring Payments/Payment Button.
- You'll need to connect various accounts. It's not worth adding the Recipe block (see caveat above)
- For Calendly and Eventbrite, select the view that renders a submit button (in the sidebar)
- Apply this PR
- Refresh the post in the editor
- Verify you're not seeing any block compatibility issues in the UI
- Set a width on all submit buttons
- Verify they're rendered with the proper width in both the editor and front end
<img width="350" alt="Screenshot 2025-01-17 at 4 03 09 PM" src="https://github.com/user-attachments/assets/0cf444bc-8a75-4c1a-85fd-b9da0b452146" />
<img width="350" alt="Screenshot 2025-01-17 at 4 03 13 PM" src="https://github.com/user-attachments/assets/fd0840c1-ba4f-45d9-98e8-301380e68295" />
<img width="350" alt="Screenshot 2025-01-17 at 4 03 17 PM" src="https://github.com/user-attachments/assets/d56a53f9-516b-4dd2-9fbd-5670ba65f236" />
<img width="350" alt="Screenshot 2025-01-17 at 4 03 20 PM" src="https://github.com/user-attachments/assets/b39750b1-b60c-482d-b645-ad833209ef01" />
<img width="350" alt="Screenshot 2025-01-17 at 4 03 22 PM" src="https://github.com/user-attachments/assets/baf846e2-706b-456b-a648-6e48d13ce978" />
<img width="350" alt="Screenshot 2025-01-17 at 4 03 27 PM" src="https://github.com/user-attachments/assets/1435b3c5-8e77-4e96-8194-bb7b4a552712" />

- Play with the buttons' alignment
- Verify the alignment is correct in both the editor and front end, except for the Premium Content and Recurring blocks (see caveat above).
- Verify this works with a simple site too

