### PR TITLE
Infinite Scroll: Add settings in wp-admin on Simple sites

### DIFF
--- a/projects/plugins/jetpack/changelog/update-infinite-scroll-simple-classic
+++ b/projects/plugins/jetpack/changelog/update-infinite-scroll-simple-classic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Show Infinite Scroll options in Simple Classic

--- a/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
+++ b/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
@@ -3,7 +3,6 @@
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- TODO: Move classes to appropriately-named class files.
 
 use Automattic\Jetpack\Assets;
-use Automattic\Jetpack\Redirect;
 
 /*
 Plugin Name: The Neverending Home Page.
@@ -432,34 +431,9 @@ class The_Neverending_Home_Page {
 			return;
 		}
 
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			// This setting is no longer configurable in wp-admin on WordPress.com -- leave a pointer
-			add_settings_field(
-				self::$option_name_enabled,
-				'<span id="infinite-scroll-options">' . esc_html__( 'Infinite Scroll Behavior', 'jetpack' ) . '</span>',
-				array( $this, 'infinite_setting_html_calypso_placeholder' ),
-				'reading'
-			);
-			return;
-		}
-
 		// Add the setting field [infinite_scroll] and place it in Settings > Reading
 		add_settings_field( self::$option_name_enabled, '<span id="infinite-scroll-options">' . esc_html__( 'Infinite Scroll Behavior', 'jetpack' ) . '</span>', array( $this, 'infinite_setting_html' ), 'reading' );
 		register_setting( 'reading', self::$option_name_enabled, 'esc_attr' );
-	}
-
-	/**
-	 * Render the redirect link to the infinite scroll settings in Calypso.
-	 */
-	public function infinite_setting_html_calypso_placeholder() {
-		$details     = get_blog_details();
-		$writing_url = Redirect::get_url( 'calypso-settings-writing', array( 'site' => $details->domain ) );
-		echo '<span>' . sprintf(
-			/* translators: Variables are the enclosing link to the settings page */
-			esc_html__( 'This option has moved. You can now manage it %1$shere%2$s.', 'jetpack' ),
-			'<a href="' . esc_url( $writing_url ) . '">',
-			'</a>'
-		) . '</span>';
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/98189

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This PR adds Infinite Scroll options in Simple Classic on the Reading Settings page. See https://github.com/Automattic/wp-calypso/issues/98189 for context.

Since there is no change to the existing Calypso, this change is not behind the flag.

---
We can remove this safely since the IS on wp-admin still works.

- Infinite Scroll options were removed from Simple Classic when we were working on adding Infinite Scroll to Calypso for wp-admin parity (p7DVsv-48r-p2).
	- r168325-wpcom
	- r168315-wpcom
	- r168073-wpcom
	- https://github.com/Automattic/wp-calypso/pull/21120

---
This PR does not address the following issues:

1. **“Shows 0 posts on each load” in certain conditions (existing bug)**  
   - We won't be addressing this in this PR.  
   - Observations:
     - When the option is checked, it always displays “Shows 0 posts”.
     - When the option is unchecked **and** the "Blog pages show at most" is set to 10, it always shows “Shows 0 posts”.
     - When the option is unchecked **and** "Blog pages show at most" is not set to 10, it displays the correct count of posts. https://github.com/Automattic/jetpack/pull/17130, https://github.com/Automattic/jetpack/issues/16471. 
2. **UI discrepancy between Reading Settings (checkbox) and Jetpack Settings (radio button)**  
   - This will not be addressed in this PR.  
   - There have been prior discussions about this UI inconsistency:
     - https://github.com/Automattic/wp-calypso/pull/13341, https://github.com/Automattic/wp-calypso/issues/12174, https://github.com/Automattic/wp-calypso/issues/13237
   - While the radio button is intuitive, we have implemented it as a toggle in Calypso to maintain technical parity with wp-admin.
3. **Google Analytics with Infinite Scroll cannot be configured on Simple Default and Simple Classic**  
   - This issue persists even for Premium plan users (pfsHM7-14i-p2).  
   - We will not be adding support for this in Simple in this PR.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Simple

* Apply this patch to your sandbox
* Prepare and sandbox a Simple Classic site 
* Activate one of the compatible Classic themes (e.g., Twenty Thirteen)
* Go to /wp-admin/options-reading.php (Reading Settings)
	* Observe the Infinite Scroll settings there
		* <img width="830" alt="Screenshot 2025-01-17 at 13 32 47" src="https://github.com/user-attachments/assets/39facb4d-b4c7-4f38-90a0-2e684dcc1014" />
	* Go to the site's frontend and test the Infinite Scroll works (You can change the "Blog pages show at most" setting in Reading Settings)

Atomic (regression tests)

* Apply this patch to your Atomic Classic site
* Activate one of the compatible Classic themes (e.g., Twenty Thirteen)
* Go to /wp-admin/options-reading.php (Reading Settings)
	* Observe the Infinite Scroll settings there
		* <img width="994" alt="Screenshot 2025-01-17 at 13 35 39" src="https://github.com/user-attachments/assets/0fad72ae-d56b-4940-930a-ce132733163d" />
	* Go to the site's frontend and test the Infinite Scroll works (You can change the "Blog pages show at most" setting in Reading Settings)
* Go to /wp-admin/admin.php?page=jetpack#writing
	* Test the following setting works
		* <img width="1061" alt="Screenshot 2025-01-17 at 10 38 41" src="https://github.com/user-attachments/assets/f110bd8d-d7b1-446d-adbc-4b770ce27e64" />
	* Note the "Load more posts using the default theme behavior" option might disable the Infinite Scroll