### PR TITLE
Social | Remove upgrade nudge for vip sites

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-remove-upgrade-nudge-for-vip-sites
+++ b/projects/js-packages/publicize-components/changelog/fix-social-remove-upgrade-nudge-for-vip-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure that VIP sites don't see the upgrade nudge

--- a/projects/js-packages/publicize-components/src/components/form/enhanced-features-nudge.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/enhanced-features-nudge.tsx
@@ -1,21 +1,18 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import {
-	getSiteFragment,
-	isAtomicSite,
-	isSimpleSite,
-} from '@automattic/jetpack-shared-extension-utils';
+import { AdminSiteData, getScriptData } from '@automattic/jetpack-script-data';
+import { getSiteFragment } from '@automattic/jetpack-shared-extension-utils';
 import { Button, PanelRow } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
 import { hasSocialPaidFeatures } from '../../utils';
 import styles from './styles.module.scss';
 import { useAutoSaveAndRedirect } from './use-auto-save-and-redirect';
 
+const DISABLE_NUDGE_FOR: Array< AdminSiteData[ 'host' ] > = [ 'wpcom', 'atomic', 'woa', 'vip' ];
+
 export const EnhancedFeaturesNudge: React.FC = () => {
 	const autosaveAndRedirect = useAutoSaveAndRedirect();
 
-	const isWpcom = isSimpleSite() || isAtomicSite();
-
-	if ( isWpcom || hasSocialPaidFeatures() ) {
+	if ( hasSocialPaidFeatures() || DISABLE_NUDGE_FOR.includes( getScriptData().site.host ) ) {
 		return null;
 	}
 

--- a/projects/plugins/jetpack/changelog/fix-social-remove-upgrade-nudge-for-vip-sites
+++ b/projects/plugins/jetpack/changelog/fix-social-remove-upgrade-nudge-for-vip-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Social | Ensure that VIP sites don't see the upgrade nudge

--- a/projects/plugins/social/changelog/fix-social-remove-upgrade-nudge-for-vip-sites
+++ b/projects/plugins/social/changelog/fix-social-remove-upgrade-nudge-for-vip-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure that VIP sites don't see the upgrade nudge


### PR DESCRIPTION
VIP sites have Social plan included and thus those shouldn't see the upgrade nudge in the editor. This PR does exactly that.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the logic for the upgrade nudge to skip it for VIP sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Fire up a Jetpack site without a social plan
* Goto the editor and open Jetpack/Social sidebar
* Confirm that the upgrade nudge in the editor is visible
* Now purchase the Social plan
* Confirm that the nudge is gone
* Now apply this branch to an Atomic/WoA site
* Confirm that the nudge is not visible
* Confirm the same for Simple and Vip sites


<img width="310" alt="Screenshot 2025-01-17 at 9 38 41 AM" src="https://github.com/user-attachments/assets/93543cd8-5b84-48c0-9d7c-4e121e6f9df8" />

