### PR TITLE
Social | Disable caching for publicize services list

### DIFF
--- a/projects/packages/publicize/changelog/update-social-disable-caching-for-publicize-services-list
+++ b/projects/packages/publicize/changelog/update-social-disable-caching-for-publicize-services-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social Disable caching for publicize services list to avoid stale nonces

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -229,6 +229,12 @@ class Publicize_Script_Data {
 	 * @return array List of external services and their settings.
 	 */
 	public static function get_supported_services() {
+		/**
+		 * Disable caching for now to avoid nonce errors
+		 * for secondary users trying to connect an account
+		 *
+		 * @link https://github.com/Automattic/jetpack/pull/41149
+		 */
 		return Publicize_Services::get_all( true /* Ignore cache */ );
 	}
 

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -229,7 +229,7 @@ class Publicize_Script_Data {
 	 * @return array List of external services and their settings.
 	 */
 	public static function get_supported_services() {
-		return Publicize_Services::get_all();
+		return Publicize_Services::get_all( true /* Ignore cache */ );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-social-disable-caching-for-publicize-services-list
+++ b/projects/plugins/jetpack/changelog/update-social-disable-caching-for-publicize-services-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Social | Fix wordpress.com log in error when connecting Social accounts

--- a/projects/plugins/social/changelog/update-social-disable-caching-for-publicize-services-list
+++ b/projects/plugins/social/changelog/update-social-disable-caching-for-publicize-services-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed wordpress.com log in error when connecting Social accounts


### PR DESCRIPTION
Currently, the publicize services list is cached following #40596, which also caches the nonces expected by WPCOM when connecting an account. So, the cached nonces are either expired or not valid for all users.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disable caching for publicize services list for now

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Goto the connections management
* Connect an account 
* Confirm that you are able to connect an account
* Now login as another admin/author
* Connect an account using this account
* Confirm that it works fine

