### PR TITLE
MU WPCOM: dashboard: add general tasks widget scaffolding + one card (domain upsell)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-dashboard-general-task-widget
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-dashboard-general-task-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: add general tasks widget

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.js
@@ -3,6 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import CelebrateLaunchModal from './celebrate-launch/celebrate-launch-modal';
 import WpcomDailyWritingPrompt from './wpcom-daily-writing-prompt';
+import WpcomGeneralTasksWidget from './wpcom-general-tasks-widget';
 import WpcomLaunchpadWidget from './wpcom-launchpad-widget';
 import WpcomSiteManagementWidget from './wpcom-site-management-widget';
 const data = typeof window === 'object' ? window.JETPACK_MU_WPCOM_DASHBOARD_WIDGETS : {};
@@ -19,6 +20,10 @@ const widgets = [
 	{
 		id: 'wpcom_site_preview_widget_main',
 		Widget: WpcomSiteManagementWidget,
+	},
+	{
+		id: 'wpcom_general_tasks_widget_main',
+		Widget: WpcomGeneralTasksWidget,
 	},
 ];
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
@@ -33,6 +33,7 @@ function load_wpcom_dashboard_widgets() {
 			foreach ( $layout['secondary'] as $item ) {
 				if ( is_array( $item ) ) {
 					$tasks = $item;
+					break;
 				}
 			}
 		}
@@ -120,13 +121,6 @@ function enqueue_wpcom_dashboard_widgets( $args = array() ) {
 			'hasCustomDomain' => wpcom_site_has_feature( 'custom-domain' ),
 			'siteId'          => get_current_blog_id(),
 			'tasks'           => $args['tasks'],
-			'siteSuggestions' => Client::wpcom_json_api_request_as_blog(
-				'/sites/' . get_current_blog_id() . '/home/layout',
-				'v2',
-				array(),
-				null,
-				'wpcom'
-			),
 		)
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
@@ -15,7 +15,7 @@ function load_wpcom_dashboard_widgets() {
 		return;
 	}
 
-	$layout_response = Client::wpcom_json_api_request_as_blog(
+	$layout_response = Client::wpcom_json_api_request_as_user(
 		'/sites/' . get_wpcom_blog_id() . '/home/layout',
 		'v2',
 		array(),

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
@@ -23,7 +23,7 @@ function load_wpcom_dashboard_widgets() {
 		'wpcom'
 	);
 
-	$tasks = null;
+	$tasks = array();
 
 	if ( ! is_wp_error( $layout_response ) ) {
 		$layout = json_decode( $layout_response['body'], true );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
@@ -32,7 +32,12 @@ function load_wpcom_dashboard_widgets() {
 			// list.
 			foreach ( $layout['secondary'] as $item ) {
 				if ( is_array( $item ) ) {
-					$tasks = $item;
+					// Delete any tasks that don't have a corresponding PHP file.
+					foreach ( $item as $task ) {
+						if ( file_exists( __DIR__ . '/wpcom-general-tasks-widget/tasks/' . $task ) ) {
+							$tasks[] = $task;
+						}
+					}
 					break;
 				}
 			}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
@@ -5,6 +5,8 @@
  * @package automattic/jetpack-mu-plugins
  */
 
+use Automattic\Jetpack\Connection\Client;
+
 /**
  * Load all wpcom dashboard widgets.
  */
@@ -13,7 +15,30 @@ function load_wpcom_dashboard_widgets() {
 		return;
 	}
 
-	enqueue_wpcom_dashboard_widgets();
+	$layout_response = Client::wpcom_json_api_request_as_blog(
+		'/sites/' . get_current_blog_id() . '/home/layout',
+		'v2',
+		array(),
+		null,
+		'wpcom'
+	);
+
+	$tasks = null;
+
+	if ( ! is_wp_error( $layout_response ) ) {
+		$layout = json_decode( $layout_response['body'], true );
+		if ( isset( $layout['secondary'] ) && is_array( $layout['secondary'] ) ) {
+			// If there's an array within the secondary section, it's the task
+			// list.
+			foreach ( $layout['secondary'] as $item ) {
+				if ( is_array( $item ) ) {
+					$tasks = $item;
+				}
+			}
+		}
+	}
+
+	enqueue_wpcom_dashboard_widgets( array( 'tasks' => $tasks ) );
 
 	$wpcom_dashboard_widgets = array(
 		array(
@@ -46,6 +71,15 @@ function load_wpcom_dashboard_widgets() {
 		);
 	}
 
+	if ( ! empty( $tasks ) ) {
+		$wpcom_dashboard_widgets[] = array(
+			'id'       => 'wpcom_general_tasks_widget',
+			'name'     => __( 'Suggestions', 'jetpack-mu-wpcom' ),
+			'context'  => 'normal',
+			'priority' => 'high',
+		);
+	}
+
 	foreach ( $wpcom_dashboard_widgets as $wpcom_dashboard_widget ) {
 		wp_add_dashboard_widget(
 			$wpcom_dashboard_widget['id'],
@@ -65,8 +99,10 @@ add_action( 'wp_dashboard_setup', 'load_wpcom_dashboard_widgets' );
 
 /**
  * Enqueue the assets of the wpcom dashboard widgets.
+ *
+ * @param array $args Settings to pass.
  */
-function enqueue_wpcom_dashboard_widgets() {
+function enqueue_wpcom_dashboard_widgets( $args = array() ) {
 	$handle = jetpack_mu_wpcom_enqueue_assets( 'wpcom-dashboard-widgets', array( 'js', 'css' ) );
 
 	$bundles      = wp_list_filter( wpcom_get_site_purchases(), array( 'product_type' => 'bundle' ) );
@@ -82,6 +118,15 @@ function enqueue_wpcom_dashboard_widgets() {
 			'siteIntent'      => get_option( 'site_intent' ),
 			'sitePlan'        => $current_plan,
 			'hasCustomDomain' => wpcom_site_has_feature( 'custom-domain' ),
+			'siteId'          => get_current_blog_id(),
+			'tasks'           => $args['tasks'],
+			'siteSuggestions' => Client::wpcom_json_api_request_as_blog(
+				'/sites/' . get_current_blog_id() . '/home/layout',
+				'v2',
+				array(),
+				null,
+				'wpcom'
+			),
 		)
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
@@ -15,7 +15,10 @@ function load_wpcom_dashboard_widgets() {
 		return;
 	}
 
-	$layout_response = Client::wpcom_json_api_request_as_user(
+	// wpcom_json_api_request_as_user does not support internal requests.
+	$request = defined( 'IS_WPCOM' ) && IS_WPCOM ? 'wpcom_json_api_request_as_blog' : 'wpcom_json_api_request_as_user';
+
+	$layout_response = Client::$request(
 		'/sites/' . get_wpcom_blog_id() . '/home/layout',
 		'v2',
 		array(),

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
@@ -16,7 +16,7 @@ function load_wpcom_dashboard_widgets() {
 	}
 
 	$layout_response = Client::wpcom_json_api_request_as_blog(
-		'/sites/' . get_current_blog_id() . '/home/layout',
+		'/sites/' . get_wpcom_blog_id() . '/home/layout',
 		'v2',
 		array(),
 		null,
@@ -119,7 +119,6 @@ function enqueue_wpcom_dashboard_widgets( $args = array() ) {
 			'siteIntent'      => get_option( 'site_intent' ),
 			'sitePlan'        => $current_plan,
 			'hasCustomDomain' => wpcom_site_has_feature( 'custom-domain' ),
-			'siteId'          => get_current_blog_id(),
 			'tasks'           => $args['tasks'],
 		)
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-general-tasks-widget/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-general-tasks-widget/index.js
@@ -1,5 +1,4 @@
-import apiFetch from '@wordpress/api-fetch';
-import { useEffect, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import TaskDomainUpsell from './tasks/home-task-domain-upsell';
 
@@ -9,27 +8,8 @@ const taskMap = {
 	'home-task-domain-upsell': TaskDomainUpsell,
 };
 
-export default ( { siteId } ) => {
-	const [ response, setResponse ] = useState( [] );
+export default ( { tasks } ) => {
 	const [ index, setIndex ] = useState( 0 );
-
-	useEffect( () => {
-		const path = `/wpcom/v2/sites/${ siteId }/home/layout`;
-		apiFetch( { path } ).then( setResponse );
-	}, [ siteId ] );
-
-	if ( ! Array.isArray( response?.secondary ) ) {
-		return null;
-	}
-
-	// The secondary array countains strings that refer to cards, except for the
-	// tasks which is an array.
-	const tasks = response.secondary.find( item => Array.isArray( item ) );
-
-	if ( ! tasks ) {
-		return <p>{ __( 'No suggestions.', 'jetpack-mu-wpcom' ) }</p>;
-	}
-
 	const task = tasks[ index ];
 	const TaskComponent = taskMap[ task ];
 
@@ -52,38 +32,7 @@ export default ( { siteId } ) => {
 					{ __( 'Next →', 'jetpack-mu-wpcom' ) }
 				</button>
 			</p>
-			{ TaskComponent ? (
-				<TaskComponent />
-			) : (
-				<p style={ { minHeight: '180px' } }>To do: { task }</p>
-			) }
-			{ /* { createPortal(
-				<span className="wpcom_general_tasks_widget_buttons">
-					<button
-						className="button button-link"
-						onClick={ event => {
-							event.preventDefault();
-							event.stopPropagation();
-							setIndex( index - 1 );
-						} }
-						disabled={ index === 0 }
-					>
-						{ __( '← Previous', 'jetpack-mu-wpcom' ) }
-					</button>
-					<button
-						className="button button-link"
-						onClick={ event => {
-							event.preventDefault();
-							event.stopPropagation();
-							setIndex( index + 1 );
-						} }
-						disabled={ index === tasks.length - 1 }
-					>
-						{ __( 'Next →', 'jetpack-mu-wpcom' ) }
-					</button>
-				</span>,
-				document.querySelector( '#wpcom_general_tasks_widget .wpcom_general_tasks_widget_title' )
-			) } */ }
+			{ TaskComponent ? <TaskComponent /> : <p style={ { minHeight: '180px' } }>[{ task }]</p> }
 		</>
 	);
 };

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-general-tasks-widget/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-general-tasks-widget/index.js
@@ -1,0 +1,89 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import TaskDomainUpsell from './tasks/home-task-domain-upsell';
+
+import './style.scss';
+
+const taskMap = {
+	'home-task-domain-upsell': TaskDomainUpsell,
+};
+
+export default ( { siteId } ) => {
+	const [ response, setResponse ] = useState( [] );
+	const [ index, setIndex ] = useState( 0 );
+
+	useEffect( () => {
+		const path = `/wpcom/v2/sites/${ siteId }/home/layout`;
+		apiFetch( { path } ).then( setResponse );
+	}, [ siteId ] );
+
+	if ( ! Array.isArray( response?.secondary ) ) {
+		return null;
+	}
+
+	// The secondary array countains strings that refer to cards, except for the
+	// tasks which is an array.
+	const tasks = response.secondary.find( item => Array.isArray( item ) );
+
+	if ( ! tasks ) {
+		return <p>{ __( 'No suggestions.', 'jetpack-mu-wpcom' ) }</p>;
+	}
+
+	const task = tasks[ index ];
+	const TaskComponent = taskMap[ task ];
+
+	return (
+		<>
+			<p className="wpcom_general_tasks_widget_buttons">
+				<button
+					className="button button-link"
+					onClick={ () => setIndex( index - 1 ) }
+					disabled={ index === 0 }
+				>
+					{ __( '← Previous', 'jetpack-mu-wpcom' ) }
+				</button>
+				{ ' ' }
+				<button
+					className="button button-link"
+					onClick={ () => setIndex( index + 1 ) }
+					disabled={ index === tasks.length - 1 }
+				>
+					{ __( 'Next →', 'jetpack-mu-wpcom' ) }
+				</button>
+			</p>
+			{ TaskComponent ? (
+				<TaskComponent />
+			) : (
+				<p style={ { minHeight: '180px' } }>To do: { task }</p>
+			) }
+			{ /* { createPortal(
+				<span className="wpcom_general_tasks_widget_buttons">
+					<button
+						className="button button-link"
+						onClick={ event => {
+							event.preventDefault();
+							event.stopPropagation();
+							setIndex( index - 1 );
+						} }
+						disabled={ index === 0 }
+					>
+						{ __( '← Previous', 'jetpack-mu-wpcom' ) }
+					</button>
+					<button
+						className="button button-link"
+						onClick={ event => {
+							event.preventDefault();
+							event.stopPropagation();
+							setIndex( index + 1 );
+						} }
+						disabled={ index === tasks.length - 1 }
+					>
+						{ __( 'Next →', 'jetpack-mu-wpcom' ) }
+					</button>
+				</span>,
+				document.querySelector( '#wpcom_general_tasks_widget .wpcom_general_tasks_widget_title' )
+			) } */ }
+		</>
+	);
+};

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-general-tasks-widget/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-general-tasks-widget/index.js
@@ -8,31 +8,34 @@ const taskMap = {
 	'home-task-domain-upsell': TaskDomainUpsell,
 };
 
-export default ( { tasks } ) => {
+export default ( { tasks, ...props } ) => {
+	const availableTasks = tasks.filter( _task => taskMap[ _task ] );
 	const [ index, setIndex ] = useState( 0 );
-	const task = tasks[ index ];
+	const task = availableTasks[ index ];
 	const TaskComponent = taskMap[ task ];
 
 	return (
 		<>
-			<p className="wpcom_general_tasks_widget_buttons">
-				<button
-					className="button button-link"
-					onClick={ () => setIndex( index - 1 ) }
-					disabled={ index === 0 }
-				>
-					{ __( '← Previous', 'jetpack-mu-wpcom' ) }
-				</button>
-				{ ' ' }
-				<button
-					className="button button-link"
-					onClick={ () => setIndex( index + 1 ) }
-					disabled={ index === tasks.length - 1 }
-				>
-					{ __( 'Next →', 'jetpack-mu-wpcom' ) }
-				</button>
-			</p>
-			{ TaskComponent ? <TaskComponent /> : <p style={ { minHeight: '180px' } }>[{ task }]</p> }
+			{ availableTasks.length > 1 && (
+				<p className="wpcom_general_tasks_widget_buttons">
+					<button
+						className="button button-link"
+						onClick={ () => setIndex( index - 1 ) }
+						disabled={ index === 0 }
+					>
+						{ __( '← Previous', 'jetpack-mu-wpcom' ) }
+					</button>
+					{ ' ' }
+					<button
+						className="button button-link"
+						onClick={ () => setIndex( index + 1 ) }
+						disabled={ index === availableTasks.length - 1 }
+					>
+						{ __( 'Next →', 'jetpack-mu-wpcom' ) }
+					</button>
+				</p>
+			) }
+			<TaskComponent { ...props } />
 		</>
 	);
 };

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-general-tasks-widget/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-general-tasks-widget/style.scss
@@ -16,7 +16,3 @@
         background: none !important; // Has !important for core style.
     }
 }
-
-// #wpcom_general_tasks_widget .wpcom_general_tasks_widget_title_text {
-//     display: none;
-// }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-general-tasks-widget/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-general-tasks-widget/style.scss
@@ -1,0 +1,22 @@
+#wpcom_general_tasks_widget_main {
+    min-height: 180px;
+
+    h2 {
+        padding: 0;
+    }
+}
+
+.wpcom_general_tasks_widget_buttons .button.button-link {
+    min-height: auto;
+    line-height: 1.4;
+    background: none;
+
+    &:disabled,
+    &:hover {
+        background: none !important; // Has !important for core style.
+    }
+}
+
+// #wpcom_general_tasks_widget .wpcom_general_tasks_widget_title_text {
+//     display: none;
+// }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-general-tasks-widget/tasks/home-task-domain-upsell/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-general-tasks-widget/tasks/home-task-domain-upsell/index.js
@@ -1,12 +1,56 @@
-export default () => {
-	// To do: actually fetch it from the API.
-	const domain = new URL( window.location.href ).hostname.split( '.' )[ 0 ] + '.com';
+import apiFetch from '@wordpress/api-fetch';
+import { useState, useEffect, createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+
+export default ( { siteDomain, sitePlan } ) => {
+	const [ domains, setDomains ] = useState( [] );
+	useEffect( () => {
+		const path = addQueryArgs( `/rest/v1.1/domains/suggestions`, {
+			query: siteDomain.split( '.' )[ 0 ],
+			quantity: 1,
+			vendor: 'domain-upsell',
+			only_wordpressdotcom: false,
+			include_dotblogsubdomain: false,
+			include_wordpressdotcom: false,
+		} );
+		apiFetch( { path, global: true } ).then( setDomains );
+	}, [ siteDomain ] );
+
+	if ( domains.length === 0 ) {
+		return null;
+	}
+
+	const domain = domains[ 0 ].domain_name;
+	const cart = [ `domain_reg:${ domain }` ];
+
+	if ( ! sitePlan || sitePlan.product_slug.includes( 'monthly' ) ) {
+		cart.push( 'personal' );
+	}
+
+	const getLink = `http://wordpress.com/checkout/${ siteDomain }/${ cart.join( ',' ) }`;
+	const searchLink = addQueryArgs( `https://wordpress.com/domains/add/${ siteDomain }`, {
+		domainAndPlanPackage: true,
+		domain: true,
+	} );
+
 	return (
 		<>
-			<h2>Own a domain. Build a site.</h2>
+			<h2>{ __( 'Own a domain. Build a site.', 'jetpack-mu-wpcom' ) }</h2>
 			<p>
-				<strong>{ domain }</strong> is a perfect site address. It’s available, easy to find, share,
-				and follow. Get it now and claim a corner of the web.
+				{ createInterpolateElement(
+					sprintf(
+						// translators: %s is the domain name.
+						__(
+							'<strong>%s</strong> is a perfect site address. It’s available, easy to find, share, and follow. Get it now and claim a corner of the web.',
+							'jetpack-mu-wpcom'
+						),
+						domain
+					),
+					{
+						strong: <strong />,
+					}
+				) }
 			</p>
 			<p style={ { position: 'relative' } }>
 				{ /* To do: convert to SVG.  */ }
@@ -26,12 +70,12 @@ export default () => {
 				/>
 			</p>
 			<div>
-				<a href="https://wordpress.com/domains/register" className="button button-primary">
-					Get this domain
+				<a href={ getLink } className="button button-primary">
+					{ __( 'Get this domain', 'jetpack-mu-wpcom' ) }
 				</a>
 				{ ' ' }
-				<a href="https://wordpress.com/domains/register" className="button button-secondary">
-					Find other domains
+				<a href={ searchLink } className="button button-secondary">
+					{ __( 'Find other domains', 'jetpack-mu-wpcom' ) }
 				</a>
 			</div>
 		</>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-general-tasks-widget/tasks/home-task-domain-upsell/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-general-tasks-widget/tasks/home-task-domain-upsell/index.js
@@ -1,0 +1,39 @@
+export default () => {
+	// To do: actually fetch it from the API.
+	const domain = new URL( window.location.href ).hostname.split( '.' )[ 0 ] + '.com';
+	return (
+		<>
+			<h2>Own a domain. Build a site.</h2>
+			<p>
+				<strong>{ domain }</strong> is a perfect site address. It’s available, easy to find, share,
+				and follow. Get it now and claim a corner of the web.
+			</p>
+			<p style={ { position: 'relative' } }>
+				{ /* To do: convert to SVG.  */ }
+				<span
+					style={ {
+						position: 'absolute',
+						transform: 'translate(130px, 14px)',
+						fontSize: '16px',
+					} }
+				>
+					{ domain }
+				</span>
+				<img
+					src="https://wordpress.com/calypso/images/illustration--feature-domain-upsell-3eff1284ca73c71a3c77.svg"
+					alt={ domain }
+					style={ { width: '100%' } }
+				/>
+			</p>
+			<div>
+				<a href="https://wordpress.com/domains/register" className="button button-primary">
+					Get this domain
+				</a>
+				{ ' ' }
+				<a href="https://wordpress.com/domains/register" className="button button-secondary">
+					Find other domains
+				</a>
+			</div>
+		</>
+	);
+};

--- a/projects/packages/jetpack-mu-wpcom/src/utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/utils.php
@@ -127,3 +127,30 @@ function jetpack_mu_wpcom_enqueue_assets( $asset_name, $asset_types = array() ) 
 
 	return $asset_handle;
 }
+
+/**
+ * Returns the WP.com blog ID for the current site.
+ *
+ * @return int|false The WP.com blog ID, or false if the site does not have a WP.com blog ID.
+ */
+function get_wpcom_blog_id() {
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		return get_current_blog_id();
+	}
+
+	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+		/*
+		 * Atomic sites have the WP.com blog ID stored as a Jetpack option. This
+		 * code deliberately doesn't use `Jetpack_Options::get_option` so it
+		 * works even when Jetpack has not been loaded.
+		 */
+		$jetpack_options = get_option( 'jetpack_options' );
+		if ( is_array( $jetpack_options ) && isset( $jetpack_options['id'] ) ) {
+			return (int) $jetpack_options['id'];
+		}
+
+		return get_current_blog_id();
+	}
+
+	return false;
+}

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-dashboard-general-task-widget
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-dashboard-general-task-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: add general tasks widget

--- a/projects/plugins/wpcomsh/changelog/add-dashboard-general-task-widget
+++ b/projects/plugins/wpcomsh/changelog/add-dashboard-general-task-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: add general tasks widget


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

See https://github.com/Automattic/wp-calypso/issues/95386.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds scaffolding for the general tasks widget and a first card, the domain upsell card.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With classic style admin enabled, check the Dashboard and test the widget. Note that the site must be launched, and the entire checklist on My Home should be completed. Alternatively you could manually set the `onboarding_checklist_completed` site option (OR if your blog is older than 2018-02-01, it should always appear). If you need a site to test you can use `ellaiseulde`.

