### PR TITLE
Social | Fix social connections list initial state feature check

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-connections-list-feature-check
+++ b/projects/packages/publicize/changelog/fix-social-connections-list-feature-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social | Fix feature check for social connections list initial state

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -184,7 +184,7 @@ class Publicize_Script_Data {
 
 		return array(
 			'connectionData' => array(
-				'connections' => Connections::get_all_for_user(),
+				'connections' => self::has_feature_flag( 'connections-management' ) ? Connections::get_all_for_user() : array(),
 			),
 			'shareStatus'    => $share_status,
 		);

--- a/projects/plugins/jetpack/changelog/fix-social-connections-list-feature-check
+++ b/projects/plugins/jetpack/changelog/fix-social-connections-list-feature-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Social | Fix publicize error in the editor due to malformed connections data

--- a/projects/plugins/social/changelog/fix-social-connections-list-feature-check
+++ b/projects/plugins/social/changelog/fix-social-connections-list-feature-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix publicize error in the editor due to malformed connections data


### PR DESCRIPTION


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure that the connections list in  the initial state is populated only if the connections management feature is active.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to connections manage
* Add a few connections, if none is present
* Goto the editor
* Confirm that there is no error in the editor related to publicize
* Enter this in the browser console
```js
JetpackScriptData.social.store_initial_state.connectionData.connections
```
* Confirm that it's an array of connections and not an object (with service like 'facebook' as key), if the connections management feature is active, otherwise it should be an empty array.
* Confirm that the above is an empty array on Simple and Atomic sites
