### PR TITLE
Remove classic view notice from general settings

### DIFF
--- a/projects/packages/masterbar/changelog/remove-classic-view-notice
+++ b/projects/packages/masterbar/changelog/remove-classic-view-notice
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+removed classic view admin notice from general settings (for atomic sites)

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -45,11 +45,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			},
 			0
 		);
-
-		// Add notices to the settings pages when there is a Calypso page available.
-		if ( $this->use_wp_admin_interface() ) {
-			add_action( 'current_screen', array( $this, 'add_settings_page_notice' ) );
-		}
 	}
 
 	/**
@@ -529,56 +524,5 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			$jitm->dismiss( sanitize_text_field( wp_unslash( $_REQUEST['id'] ) ), sanitize_text_field( wp_unslash( $_REQUEST['feature_class'] ) ) );
 		}
 		wp_die();
-	}
-
-	/**
-	 * Adds a notice above each settings page while using the Classic view to indicate
-	 * that the Default view offers more features. Links to the default view.
-	 *
-	 * @return void
-	 */
-	public function add_settings_page_notice() {
-		if ( ! is_admin() ) {
-			return;
-		}
-
-		$current_screen = get_current_screen();
-
-		if ( ! $current_screen instanceof \WP_Screen ) {
-			return;
-		}
-
-		// Show the notice for the following screens and map them to the Calypso page.
-		$screen_map = array(
-			'options-general' => 'general',
-			'options-reading' => 'reading',
-		);
-
-		$mapped_screen = $screen_map[ $current_screen->id ] ?? false;
-
-		if ( ! $mapped_screen ) {
-			return;
-		}
-
-		$switch_url = sprintf( 'https://wordpress.com/settings/%s/%s', $mapped_screen, $this->domain );
-
-		// Close over the $switch_url variable.
-		$admin_notices = function () use ( $switch_url ) {
-			wp_admin_notice(
-				wp_kses(
-					sprintf(
-						// translators: %s is a link to the Calypso settings page.
-						__( 'You are currently using the Classic view, which doesn’t offer the same set of features as the Default view. To access additional settings and features, <a href="%s">switch to the Default view</a>. ', 'jetpack-masterbar' ),
-						esc_url( $switch_url )
-					),
-					array( 'a' => array( 'href' => array() ) )
-				),
-				array(
-					'type' => 'warning',
-				)
-			);
-		};
-
-		add_action( 'admin_notices', $admin_notices );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/98247

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* It removes the following notice from atomic site general settings page. (in classic view)

<img width="613" alt="image" src="https://github.com/user-attachments/assets/44dd4a7b-8801-4912-8fc6-8936c845215b" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test in atomic site using Jetpack beta and applying the `remove-classic-view-notice` branch for WordPress.com Features
* test out for the warning admin message `You are currently using the Classic view, which doesn’t offer the same set of features as the Default view. To access additional settings and features` under general settings and reading setting of the page.
* It should not display the above banner.

