### PR TITLE
Remove duplicate views: Enable for all a12s (WP Admin)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/.phan/config.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/config.php
@@ -26,6 +26,7 @@ return make_phan_config(
 			__DIR__ . '/../../../plugins/jetpack/modules/custom-css/custom-css.php',        // class Jetpack_Custom_CSS_Enhancements
 			__DIR__ . '/../../../plugins/jetpack/class-jetpack-stats-dashboard-widget.php', // class Jetpack_Stats_Dashboard_Widget
 			__DIR__ . '/../../../plugins/wpcomsh/wpcomsh.php',                              // function wpcomsh_record_tracks_event
+			__DIR__ . '/../../../plugins/wpcomsh/support-session.php',                      // class WPCOMSH_Support_Session_Detect
 		),
 		'exclude_analysis_directory_list' => array(
 			'src/features/custom-css/csstidy/',

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-remove-duplicate-views-a12s
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-remove-duplicate-views-a12s
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove duplicate views: Enable for all a12s

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -22,8 +22,7 @@
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^1.1.1",
 		"automattic/jetpack-changelogger": "@dev",
-		"automattic/wordbless": "^0.4.2",
-		"automattic/wpcomsh": "@dev"
+		"automattic/wordbless": "^0.4.2"
 	},
 	"suggest": {
 		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -71,11 +70,6 @@
 		"autotagger": true,
 		"branch-alias": {
 			"dev-trunk": "6.1.x-dev"
-		},
-		"dependencies": {
-			"test-only": [
-				"plugins/wpcomsh"
-			]
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -23,7 +23,7 @@
 		"yoast/phpunit-polyfills": "^1.1.1",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/wordbless": "^0.4.2",
-		"automattic/jetpack-wpcomsh": "@dev"
+		"automattic/wpcomsh": "@dev"
 	},
 	"suggest": {
 		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -74,7 +74,7 @@
 		},
 		"dependencies": {
 			"test-only": [
-				"packages/jetpack-wpcomsh"
+				"plugins/wpcomsh"
 			]
 		},
 		"textdomain": "jetpack-mu-wpcom",

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -22,7 +22,8 @@
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^1.1.1",
 		"automattic/jetpack-changelogger": "@dev",
-		"automattic/wordbless": "^0.4.2"
+		"automattic/wordbless": "^0.4.2",
+		"automattic/jetpack-wpcomsh": "@dev"
 	},
 	"suggest": {
 		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -70,6 +71,11 @@
 		"autotagger": true,
 		"branch-alias": {
 			"dev-trunk": "6.1.x-dev"
+		},
+		"dependencies": {
+			"test-only": [
+				"packages/jetpack-wpcomsh"
+			]
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -402,7 +402,9 @@ function wpcom_is_duplicate_views_experiment_enabled() {
 	}
 
 	if ( ( new Host() )->is_wpcom_simple() ) {
-		if ( is_automattician() ) {
+		$is_proxy_simple    = defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
+		$is_support_session = defined( 'WPCOM_SUPPORT_SESSION' ) && WPCOM_SUPPORT_SESSION;
+		if ( $is_proxy_simple && ! $is_support_session && is_automattician() ) {
 			return true;
 		}
 		\ExPlat\assign_current_user( $aa_test_name );
@@ -410,8 +412,8 @@ function wpcom_is_duplicate_views_experiment_enabled() {
 		return $is_enabled;
 	}
 
-	$is_proxied = defined( 'AT_PROXIED_REQUEST' ) && AT_PROXIED_REQUEST;
-	if ( $is_proxied && ! WPCOMSH_Support_Session_Detect::is_probably_support_session() ) {
+	$is_proxy_atomic = defined( 'AT_PROXIED_REQUEST' ) && AT_PROXIED_REQUEST;
+	if ( $is_proxy_atomic && ! WPCOMSH_Support_Session_Detect::is_probably_support_session() ) {
 		return true;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -402,9 +402,17 @@ function wpcom_is_duplicate_views_experiment_enabled() {
 	}
 
 	if ( ( new Host() )->is_wpcom_simple() ) {
+		if ( is_automattician() ) {
+			return true;
+		}
 		\ExPlat\assign_current_user( $aa_test_name );
 		$is_enabled = 'treatment' === \ExPlat\assign_current_user( $experiment_name );
 		return $is_enabled;
+	}
+
+	$is_proxied = defined( 'AT_PROXIED_REQUEST' ) && AT_PROXIED_REQUEST;
+	if ( $is_proxied && ! WPCOMSH_Support_Session_Detect::is_probably_support_session() ) {
+		return true;
 	}
 
 	$option_name = 'remove_duplicate_views_experiment_assignment';


### PR DESCRIPTION
## Proposed changes:

Enables the "Remove duplicate views" experiment in wp-admin for all Automatticians, since they are currently getting the `control` variant.

See pbxNRc-4Ls-p2

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Go to the experiment (22167-explat-experiment) and assign yourself to `control`
- Apply these changes to your site
- While proxied and logged in with your a11n account, visit any of the enforced WP Admin screens:
  - Posts
  - Pages
  - Comments
  - ...
- Make sure they all open the WP Admin view