### PR TITLE
Update onboarding newsletter goal tasks

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-newletter-goal-tasks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-newletter-goal-tasks
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add intent-newsletter-goal tasks for newsletter goal in /onboarding.
+Add intent-newsletter-goal tasks for newsletter goal in /setup/onboarding.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-newletter-goal-tasks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-newletter-goal-tasks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add newsletter-v2 tasks for newsletter goal in /onboarding.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-newletter-goal-tasks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-newletter-goal-tasks
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add newsletter-v2 tasks for newsletter goal in /onboarding.
+Add intent-newsletter-goal tasks for newsletter goal in /onboarding.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -497,7 +497,7 @@ function wpcom_launchpad_get_task_definitions() {
 
 		'customize_welcome_message'       => array(
 			'get_title'            => function () {
-				return __( 'Customize welcome message', 'jetpack-mu-wpcom' );
+				return __( 'Write a welcome message', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -269,7 +269,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 		),
 
-		// intent-newsletter-v2 tasks
+		// intent-newsletter-goal tasks
 		'start_building_your_audience'    => array(
 			'get_title'            => function () {
 				return __( 'Start building your audience', 'jetpack-mu-wpcom' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -279,15 +279,6 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/subscribers/' . $data['site_slug_encoded'];
 			},
 		),
-		'write_welcome_message'           => array(
-			'get_title'            => function () {
-				return __( 'Write a welcome message', 'jetpack-mu-wpcom' );
-			},
-			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
-			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/settings/newsletter/' . $data['site_slug_encoded'] . '#messages';
-			},
-		),
 
 		// Link in bio tasks.
 		'link_in_bio_launched'            => array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -180,6 +180,15 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/me/account';
 			},
 		),
+		'preview_site'                    => array(
+			'get_title'            => function () {
+				return __( 'Preview your site', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/view/' . $data['site_slug_encoded'];
+			},
+		),
 
 		// Newsletter pre-launch tasks.
 		'first_post_published_newsletter' => array(
@@ -257,6 +266,26 @@ function wpcom_launchpad_get_task_definitions() {
 					return admin_url( 'import.php' );
 				}
 				return '/import/' . $data['site_slug_encoded'];
+			},
+		),
+
+		// intent-newsletter-v2 tasks
+		'start_building_your_audience'    => array(
+			'get_title'            => function () {
+				return __( 'Start building your audience', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/subscribers/' . $data['site_slug_encoded'];
+			},
+		),
+		'write_welcome_message'           => array(
+			'get_title'            => function () {
+				return __( 'Write a welcome message', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/settings/newsletter/' . $data['site_slug_encoded'] . '#messages';
 			},
 		),
 
@@ -2498,7 +2527,7 @@ function wpcom_launchpad_is_edit_page_task_visible() {
 
 /**
  * Mark the customize_welcome_message task complete
- * if the subscription_options['invitation'] value
+ * if the subscription_options['welcome'] value
  * for the welcome message has changed on option update.
  *
  * @param mixed $old_value The old value of the welcome message.
@@ -2507,9 +2536,9 @@ function wpcom_launchpad_is_edit_page_task_visible() {
  * @return void
  */
 function wpcom_launchpad_mark_customize_welcome_message_complete_on_update( $old_value, $value ) {
-	$new_invitation = is_array( $value ) && isset( $value['invitation'] ) ? $value['invitation'] : '';
-	$old_invitation = is_array( $old_value ) && isset( $old_value['invitation'] ) ? $old_value['invitation'] : '';
-	if ( $new_invitation !== $old_invitation ) {
+	$new_welcome = is_array( $value ) && isset( $value['welcome'] ) ? $value['welcome'] : '';
+	$old_welcome = is_array( $old_value ) && isset( $old_value['welcome'] ) ? $old_value['welcome'] : '';
+	if ( $new_welcome !== $old_welcome ) {
 		wpcom_mark_launchpad_task_complete( 'customize_welcome_message' );
 	}
 }
@@ -2517,7 +2546,7 @@ add_action( 'update_option_subscription_options', 'wpcom_launchpad_mark_customiz
 
 /**
  * Mark the customize_welcome_message task complete
- * if the subscription_options['invitation'] value
+ * if the subscription_options['welcome'] value
  * for the welcome message has been added.
  *
  * @param mixed $value The value of the welcome message.
@@ -2525,7 +2554,7 @@ add_action( 'update_option_subscription_options', 'wpcom_launchpad_mark_customiz
  * @return void
  */
 function wpcom_launchpad_mark_customize_welcome_message_complete_on_add( $value ) {
-	if ( is_array( $value ) && $value['invitation'] ) {
+	if ( is_array( $value ) && $value['welcome'] ) {
 		wpcom_mark_launchpad_task_complete( 'customize_welcome_message' );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -102,7 +102,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'intent-newsletter-v2'    => array(
+		'intent-newsletter-goal'  => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -1106,17 +1106,17 @@ function wpcom_launchpad_is_paid_newsletter_enabled() {
 }
 
 /**
- * Checks if the Newsletter v2 flow task list is enabled.
+ * Checks if the Newsletter goal flow task list is enabled.
  *
  * @return bool True if the task list is enabled, false otherwise.
  */
-function wpcom_launchpad_is_newsletter_v2_enabled() {
+function wpcom_launchpad_is_newsletter_goal_enabled() {
 	$intent = get_option( 'site_intent', false );
-	if ( 'intent-newsletter-v2' !== $intent ) {
+	if ( 'intent-newsletter-goal' !== $intent ) {
 		return false;
 	}
 
-	return apply_filters( 'wpcom_launchpad_intent_newsletter_v2_enabled', false );
+	return apply_filters( 'wpcom_launchpad_intent_newsletter_goal_enabled', false );
 }
 /**
  * Add launchpad options to Jetpack Sync.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -102,6 +102,20 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
+		'intent-newsletter-v2'    => array(
+			'get_title'           => function () {
+				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
+			},
+			'task_ids'            => array(
+				'site_title',
+				'start_building_your_audience',
+				'customize_welcome_message',
+				'add_about_page',
+				'first_post_published',
+				'preview_site',
+			),
+			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
+		),
 		'videopress'              => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
@@ -1091,6 +1105,19 @@ function wpcom_launchpad_is_paid_newsletter_enabled() {
 	return wpcom_launchpad_has_goal_paid_subscribers() && apply_filters( 'wpcom_launchpad_intent_paid_newsletter_enabled', false );
 }
 
+/**
+ * Checks if the Newsletter v2 flow task list is enabled.
+ *
+ * @return bool True if the task list is enabled, false otherwise.
+ */
+function wpcom_launchpad_is_newsletter_v2_enabled() {
+	$intent = get_option( 'site_intent', false );
+	if ( 'intent-newsletter-v2' !== $intent ) {
+		return false;
+	}
+
+	return apply_filters( 'wpcom_launchpad_intent_newsletter_v2_enabled', false );
+}
 /**
  * Add launchpad options to Jetpack Sync.
  *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/96384

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added a new set of launchpad tasks when the user chooses the Newsletter goal in /setup/onboarding

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See testing instructions in https://github.com/Automattic/wp-calypso/pull/98546


