### PR TITLE
REST API: Enhance author details by including additional data when either user_id or site_id are available.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-author-details-are-missing
+++ b/projects/plugins/jetpack/changelog/fix-author-details-are-missing
@@ -1,5 +1,3 @@
 Significance: patch
-Type: other
-Comment: Testing the commit process.
-
-
+Type: enhancement
+Comment: REST API: Enhance author details by including additional data when user_id, site_id, or both are available.

--- a/projects/plugins/jetpack/changelog/fix-author-details-are-missing
+++ b/projects/plugins/jetpack/changelog/fix-author-details-are-missing
@@ -1,3 +1,3 @@
 Significance: patch
 Type: enhancement
-Comment: REST API: Enhance author details by including additional data when user_id, site_id, or both are available.
+Comment: REST API: Enhance author details by including additional data when either user_id or site_id are available.

--- a/projects/plugins/jetpack/changelog/fix-author-details-are-missing
+++ b/projects/plugins/jetpack/changelog/fix-author-details-are-missing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Testing the commit process.
+
+

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1389,7 +1389,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 		$url        = null;
 		$ip_address = isset( $author->comment_author_IP ) ? $author->comment_author_IP : '';
 
-		if ( isset( $author->comment_author_email ) ) {
+		if ( isset( $author->comment_author_email ) && ! $author->user_id ) {
 			$id          = ( isset( $author->user_id ) && $author->user_id ) ? $author->user_id : 0;
 			$login       = '';
 			$email       = $author->comment_author_email;

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1388,109 +1388,118 @@ abstract class WPCOM_JSON_API_Endpoint {
 		$nice       = null;
 		$url        = null;
 		$ip_address = isset( $author->comment_author_IP ) ? $author->comment_author_IP : '';
+		$site_id    = -1;
 
-		if ( isset( $author->comment_author_email ) && ! $author->user_id ) {
-			$id          = ( isset( $author->user_id ) && $author->user_id ) ? $author->user_id : 0;
-			$login       = '';
-			$email       = $author->comment_author_email;
-			$name        = $author->comment_author;
-			$first_name  = '';
-			$last_name   = '';
-			$url         = $author->comment_author_url;
-			$avatar_url  = $this->api->get_avatar_url( $author );
-			$profile_url = 'https://gravatar.com/' . md5( strtolower( trim( $email ) ) );
-			$nice        = '';
-			$site_id     = -1;
+		if ( isset( $author->comment_author_email ) ) {
+			$id         = ( isset( $author->user_id ) && $author->user_id ) ? $author->user_id : 0;
+			$login      = '';
+			$email      = $author->comment_author_email;
+			$name       = $author->comment_author;
+			$first_name = '';
+			$last_name  = '';
+			$url        = $author->comment_author_url;
+			$avatar_url = $this->api->get_avatar_url( $author );
+			$nice       = '';
+
+			// Add additional user data to the response if a valid user ID is available.
+			if ( 0 < $id ) {
+				$user = get_user_by( 'id', $id );
+				if ( $user instanceof WP_User ) {
+					$login      = $user->user_login;
+					$first_name = $user->first_name;
+					$last_name  = $user->last_name;
+					$nice       = $user->user_nicename;
+				} else {
+					trigger_error( 'Unknown user', E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+				}
+			}
 
 			// Comment author URLs and Emails are sent through wp_kses() on save, which replaces "&" with "&amp;"
 			// "&" is the only email/URL character altered by wp_kses().
 			foreach ( array( 'email', 'url' ) as $field ) {
 				$$field = str_replace( '&amp;', '&', $$field );
 			}
-		} else {
-			if ( $author instanceof WP_User || isset( $author->user_email ) ) {
-				$author = $author->ID;
-			} elseif ( isset( $author->user_id ) && $author->user_id ) {
-				$author = $author->user_id;
-			} elseif ( isset( $author->post_author ) ) {
-				// then $author is a Post Object.
-				if ( ! $author->post_author ) {
-					return null;
-				}
-				/**
-				 * Filter whether the current site is a Jetpack site.
-				 *
-				 * @module json-api
-				 *
-				 * @since 3.3.0
-				 *
-				 * @param bool false Is the current site a Jetpack site. Default to false.
-				 * @param int get_current_blog_id() Blog ID.
-				 */
-				$is_jetpack = true === apply_filters( 'is_jetpack_site', false, get_current_blog_id() );
-				$post_id    = $author->ID;
-				if ( $is_jetpack && ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
-					$id         = get_post_meta( $post_id, '_jetpack_post_author_external_id', true );
-					$email      = get_post_meta( $post_id, '_jetpack_author_email', true );
-					$login      = '';
-					$name       = get_post_meta( $post_id, '_jetpack_author', true );
-					$first_name = '';
-					$last_name  = '';
-					$url        = '';
-					$nice       = '';
-				} else {
-					$author = $author->post_author;
-				}
+		} elseif ( $author instanceof WP_User || isset( $author->user_email ) ) {
+			$author = $author->ID;
+		} elseif ( isset( $author->user_id ) && $author->user_id ) {
+			$author = $author->user_id;
+		} elseif ( isset( $author->post_author ) ) {
+			// then $author is a Post Object.
+			if ( ! $author->post_author ) {
+				return null;
 			}
-
-			if ( ! isset( $id ) ) {
-				$user = get_user_by( 'id', $author );
-				if ( ! $user || is_wp_error( $user ) ) {
-					trigger_error( 'Unknown user', E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-
-					return null;
-				}
-				$id         = $user->ID;
-				$email      = $user->user_email;
-				$login      = $user->user_login;
-				$name       = $user->display_name;
-				$first_name = $user->first_name;
-				$last_name  = $user->last_name;
-				$url        = $user->user_url;
-				$nice       = $user->user_nicename;
-			}
-			if ( defined( 'IS_WPCOM' ) && IS_WPCOM && ! $is_jetpack ) {
-				$site_id = -1;
-
-				/**
-				 * Allow customizing the blog ID returned with the author in WordPress.com REST API queries.
-				 *
-				 * @since 12.9
-				 *
-				 * @module json-api
-				 *
-				 * @param bool|int $active_blog  Blog ID, or false by default.
-				 * @param int      $id           User ID.
-				 */
-				$active_blog = apply_filters( 'wpcom_api_pre_get_active_blog_author', false, $id );
-				if ( false === $active_blog ) {
-					$active_blog = get_active_blog_for_user( $id );
-				}
-				if ( ! empty( $active_blog ) ) {
-					$site_id = $active_blog->blog_id;
-				}
-				if ( $site_id > -1 ) {
-					$site_visible = (
-						-1 !== (int) $active_blog->public ||
-						is_private_blog_user( $site_id, get_current_user_id() )
-					);
-				}
-				$profile_url = "https://gravatar.com/{$login}";
+			/**
+			 * Filter whether the current site is a Jetpack site.
+			 *
+			 * @module json-api
+			 *
+			 * @since 3.3.0
+			 *
+			 * @param bool false Is the current site a Jetpack site. Default to false.
+			 * @param int get_current_blog_id() Blog ID.
+			 */
+			$is_jetpack = true === apply_filters( 'is_jetpack_site', false, get_current_blog_id() );
+			$post_id    = $author->ID;
+			if ( $is_jetpack && ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
+				$id         = get_post_meta( $post_id, '_jetpack_post_author_external_id', true );
+				$email      = get_post_meta( $post_id, '_jetpack_author_email', true );
+				$login      = '';
+				$name       = get_post_meta( $post_id, '_jetpack_author', true );
+				$first_name = '';
+				$last_name  = '';
+				$url        = '';
+				$nice       = '';
 			} else {
-				$profile_url = 'https://gravatar.com/' . md5( strtolower( trim( $email ) ) );
-				$site_id     = -1;
+				$author = $author->post_author;
 			}
+		}
 
+		if ( ! isset( $id ) ) {
+			$user = get_user_by( 'id', $author );
+			if ( ! $user || is_wp_error( $user ) ) {
+				trigger_error( 'Unknown user', E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+
+				return null;
+			}
+			$id         = $user->ID;
+			$email      = $user->user_email;
+			$login      = $user->user_login;
+			$name       = $user->display_name;
+			$first_name = $user->first_name;
+			$last_name  = $user->last_name;
+			$url        = $user->user_url;
+			$nice       = $user->user_nicename;
+		}
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM && ! $is_jetpack ) {
+			/**
+			 * Allow customizing the blog ID returned with the author in WordPress.com REST API queries.
+			 *
+			 * @since 12.9
+			 *
+			 * @module json-api
+			 *
+			 * @param bool|int $active_blog  Blog ID, or false by default.
+			 * @param int      $id           User ID.
+			 */
+			$active_blog = apply_filters( 'wpcom_api_pre_get_active_blog_author', false, $id );
+			if ( false === $active_blog ) {
+				$active_blog = get_active_blog_for_user( $id );
+			}
+			if ( ! empty( $active_blog ) ) {
+				$site_id = $active_blog->blog_id;
+			}
+			if ( $site_id > - 1 ) {
+				$site_visible = (
+					- 1 !== (int) $active_blog->public ||
+					is_private_blog_user( $site_id, get_current_user_id() )
+				);
+			}
+			$profile_url = "https://gravatar.com/{$login}";
+		} else {
+			$profile_url = 'https://gravatar.com/' . md5( strtolower( trim( $email ) ) );
+		}
+
+		if ( ! isset( $avatar_url ) ) {
 			$avatar_url = $this->api->get_avatar_url( $email );
 		}
 

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1391,7 +1391,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 		$site_id    = -1;
 
 		if ( isset( $author->comment_author_email ) ) {
-			$id         = ( isset( $author->user_id ) && $author->user_id ) ? $author->user_id : 0;
+			$id         = empty( $author->user_id ) ? 0 : (int) $author->user_id;
 			$login      = '';
 			$email      = $author->comment_author_email;
 			$name       = $author->comment_author;

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1405,10 +1405,10 @@ abstract class WPCOM_JSON_API_Endpoint {
 			if ( 0 < $id ) {
 				$user = get_user_by( 'id', $id );
 				if ( $user instanceof WP_User ) {
-					$login      = $user->user_login;
-					$first_name = $user->first_name;
-					$last_name  = $user->last_name;
-					$nice       = $user->user_nicename;
+					$login      = $user->user_login ?? '';
+					$first_name = $user->first_name ?? '';
+					$last_name  = $user->last_name ?? '';
+					$nice       = $user->user_nicename ?? '';
 				} else {
 					trigger_error( 'Unknown user', E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 				}

--- a/projects/plugins/jetpack/tests/php/json-api/test_class.json-api-jetpack-base-endpoint.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test_class.json-api-jetpack-base-endpoint.php
@@ -135,6 +135,10 @@ class WP_Test_Jetpack_Base_Json_Api_Endpoints extends WP_UnitTestCase {
 		$this->assertSame( self::$super_admin_user_id, $author->ID );
 	}
 
+	/**
+	 * @covers Jetpack_JSON_API_Endpoint::get_author
+	 * @group json-api
+	 */
 	public function test_get_author_should_provide_additional_data_when_user_id_is_specified() {
 		$endpoint                            = $this->get_dummy_endpoint();
 		$commment_data                       = new stdClass();
@@ -144,20 +148,54 @@ class WP_Test_Jetpack_Base_Json_Api_Endpoints extends WP_UnitTestCase {
 		$commment_data->user_id              = static::$contributor_user_id;
 		$comment                             = new WP_Comment( $commment_data );
 
-		$author = $endpoint->get_author( $comment );
-		$this->assertIsObject( $author );
-		$this->assertIsObject( $author );
-		$this->assertSame( $commment_data->comment_author_email, $author->email );
-		$this->assertSame( $commment_data->comment_author, $author->name );
-		$this->assertSame( $commment_data->comment_author_url, $author->url );
+		$author = $endpoint->get_author( $comment, true );
+
+		$this->assertIsObject( $author, 'The returned author should be an object.' );
+		$this->assertNotNull( $author, 'The returned author should not be null.' );
+		$this->assertSame(
+			$commment_data->comment_author_email,
+			$author->email,
+			'The author email does not match the expected comment author email.'
+		);
+		$this->assertSame(
+			$commment_data->comment_author,
+			$author->name,
+			'The author name does not match the expected comment author name.'
+		);
+		$this->assertSame(
+			$commment_data->comment_author_url,
+			$author->URL, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			'The author URL does not match the expected comment author URL.'
+		);
 
 		$user = get_user_by( 'id', static::$contributor_user_id );
+
 		// The user should be the same as the one passed as object to the method.
-		$this->assertSame( static::$contributor_user_id, $author->ID );
-		$this->assertSame( $user->login, $author->email );
-		$this->assertSame( $user->first_name, $author->first_name );
-		$this->assertSame( $user->last_name, $author->last_name );
-		$this->assertSame( $user->user_nicename, $author->user_nicename );
+		$this->assertSame(
+			static::$contributor_user_id,
+			$author->ID,
+			'The author ID does not match the expected user ID.'
+		);
+		$this->assertSame(
+			$user->user_login,
+			$author->login,
+			'The author login does not match the expected user login.'
+		);
+		$this->assertSame(
+			$user->first_name,
+			$author->first_name,
+			'The author first name does not match the expected first name.'
+		);
+		$this->assertSame(
+			$user->last_name,
+			$author->last_name,
+			'The author last name does not match the expected last name.'
+		);
+		$this->assertSame(
+			$user->user_nicename,
+			$author->nice_name,
+			'The author nicename does not match the expected nicename.'
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/json-api/test_class.json-api-jetpack-base-endpoint.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test_class.json-api-jetpack-base-endpoint.php
@@ -64,7 +64,7 @@ class WP_Test_Jetpack_Base_Json_Api_Endpoints extends WP_UnitTestCase {
 				'first_name'    => 'John',
 				'last_name'     => 'Doe',
 				'description'   => 'This is a dummy user for testing.',
-				'role'          => 'subscriber',
+				'role'          => 'contributor',
 			)
 		);
 	}

--- a/projects/plugins/jetpack/tests/php/json-api/test_class.json-api-jetpack-base-endpoint.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test_class.json-api-jetpack-base-endpoint.php
@@ -29,6 +29,13 @@ class WP_Test_Jetpack_Base_Json_Api_Endpoints extends WP_UnitTestCase {
 	private static $super_admin_alt_user_id;
 
 	/**
+	 * A contributor user used for test.
+	 *
+	 * @var int
+	 */
+	private static $contributor_user_id;
+
+	/**
 	 * Inserts globals needed to initialize the endpoint.
 	 */
 	private function set_globals() {
@@ -45,6 +52,21 @@ class WP_Test_Jetpack_Base_Json_Api_Endpoints extends WP_UnitTestCase {
 	public static function wpSetUpBeforeClass( $factory ) {
 		self::$super_admin_user_id     = $factory->user->create( array( 'role' => 'administrator' ) );
 		self::$super_admin_alt_user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$contributor_user_id     = $factory->user->create(
+			array(
+				'user_login'    => 'john_doe',
+				'user_pass'     => 'password123',
+				'user_nicename' => 'John Doe',
+				'user_email'    => 'john.doe@example.com',
+				'user_url'      => 'https://example.com',
+				'display_name'  => 'John Doe',
+				'nickname'      => 'Johnny',
+				'first_name'    => 'John',
+				'last_name'     => 'Doe',
+				'description'   => 'This is a dummy user for testing.',
+				'role'          => 'subscriber',
+			)
+		);
 	}
 
 	/**
@@ -111,6 +133,31 @@ class WP_Test_Jetpack_Base_Json_Api_Endpoints extends WP_UnitTestCase {
 		// The user should be the same as the one passed as object to the method.
 		$this->assertIsObject( $author );
 		$this->assertSame( self::$super_admin_user_id, $author->ID );
+	}
+
+	public function test_get_author_should_provide_additional_data_when_user_id_is_specified() {
+		$endpoint                            = $this->get_dummy_endpoint();
+		$commment_data                       = new stdClass();
+		$commment_data->comment_author_email = 'foo@bar.foo';
+		$commment_data->comment_author       = 'John Doe';
+		$commment_data->comment_author_url   = 'https://foo.bar.foo';
+		$commment_data->user_id              = static::$contributor_user_id;
+		$comment                             = new WP_Comment( $commment_data );
+
+		$author = $endpoint->get_author( $comment );
+		$this->assertIsObject( $author );
+		$this->assertIsObject( $author );
+		$this->assertSame( $commment_data->comment_author_email, $author->email );
+		$this->assertSame( $commment_data->comment_author, $author->name );
+		$this->assertSame( $commment_data->comment_author_url, $author->url );
+
+		$user = get_user_by( 'id', static::$contributor_user_id );
+		// The user should be the same as the one passed as object to the method.
+		$this->assertSame( static::$contributor_user_id, $author->ID );
+		$this->assertSame( $user->login, $author->email );
+		$this->assertSame( $user->first_name, $author->first_name );
+		$this->assertSame( $user->last_name, $author->last_name );
+		$this->assertSame( $user->user_nicename, $author->user_nicename );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #9984

## Proposed changes:
- [x] Use the `wp_comments` table as the source of truth if the `$author` parameter passed to the `WPCOM_JSON_API_Endpoint::get_author` method is an instance of `WP_Comment`;
- [x] If the `WP_Comment` instance has a valid `user_id`, include the `first_name`, `last_name`, `nice_name`, and `login` fields in the response;
- [x] Add the `site_id` field to the response when a `WP_Comment` instance is passed to the `WPCOM_JSON_API_Endpoint::get_author` method.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Apply the changes from this branch to your WordPress.com development website.
2. After applying the changes, open the comments page in **wp-admin**. The request to the `public-api.wordpress.com` comments endpoint should return complete data about the commenter, including the `login`, `first_name`, `last_name`, and `nice_name` fields, if the `user_id` value in the `wp_comments` table is defined.  

Refer to the screenshots below for comparison:  

**Before the patch:**  
<img width="714" alt="Screenshot of the comments page before changes" src="https://github.com/user-attachments/assets/ef35effb-22cc-415a-9665-5d60869adfa9" />

**After the patch:**  
<img width="839" alt="Screenshot of the comments page after changes" src="https://github.com/user-attachments/assets/baf7bc67-a257-4551-b165-dc5e2fe5229e" />  
