### PR TITLE
Jetpack AI: Updates / clean up to Jetpack AI assistant sidebar

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-sidebar-improvements
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-sidebar-improvements
@@ -1,0 +1,10 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Updates / clean up to Jetpack AI assistant sidebar
+* Buttons now have 100% width and are 40px tall
+* Updated text in various places
+* Added message that displays when a post has no content
+* Cleaned up spacing in a few places
+* Changed color of some text
+* Write Brief checkboxes are hidden by toggle now

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -20,6 +20,7 @@ import { getFeatureAvailability } from '../../../../blocks/ai-assistant/lib/util
 import { isBetaExtension } from '../../../../editor';
 import JetpackPluginSidebar from '../../../../shared/jetpack-plugin-sidebar';
 import { PLAN_TYPE_FREE, PLAN_TYPE_UNLIMITED, usePlanType } from '../../../../shared/use-plan-type';
+import usePostContent from '../../hooks/use-post-content';
 import { FeaturedImage } from '../ai-image';
 import { Breve, registerBreveHighlights, Highlight } from '../breve';
 import { getBreveAvailability, canWriteBriefBeEnabled } from '../breve/utils/get-availability';
@@ -102,23 +103,22 @@ const JetpackAndSettingsContent = ( {
 				</PanelRow>
 			) }
 
+			{ ! usePostContent() && (
+				<PanelRow className="jetpack-ai-sidebar__warning-content">
+					<p>{ __( 'The following features requie content to work.', 'jetpack' ) }</p>
+				</PanelRow>
+			) }
+
 			{ canWriteBriefBeEnabled() && isBreveAvailable && (
 				<PanelRow>
 					<BaseControl __nextHasNoMarginBottom={ true }>
 						<BaseControl.VisualLabel>
-							{ __( 'Write Brief with AI (BETA)', 'jetpack' ) }
+							{ __( 'Write Brief (Beta)', 'jetpack' ) }
 						</BaseControl.VisualLabel>
 						<Breve />
 					</BaseControl>
 				</PanelRow>
 			) }
-
-			<PanelRow className="jetpack-ai-sidebar__feature-section">
-				<BaseControl __nextHasNoMarginBottom={ true }>
-					<BaseControl.VisualLabel>{ __( 'AI Feedback', 'jetpack' ) }</BaseControl.VisualLabel>
-					<Feedback placement={ placement } busy={ false } disabled={ requireUpgrade } />
-				</BaseControl>
-			</PanelRow>
 
 			{ isAITitleOptimizationAvailable && (
 				<PanelRow className="jetpack-ai-sidebar__feature-section">
@@ -128,16 +128,25 @@ const JetpackAndSettingsContent = ( {
 					</BaseControl>
 				</PanelRow>
 			) }
+
 			{ isAIFeaturedImageAvailable && (
 				<PanelRow className="jetpack-ai-sidebar__feature-section">
 					<BaseControl __nextHasNoMarginBottom={ true }>
 						<BaseControl.VisualLabel>
-							{ __( 'AI Featured Image', 'jetpack' ) }
+							{ __( 'Get Featured Image', 'jetpack' ) }
 						</BaseControl.VisualLabel>
 						<FeaturedImage busy={ false } disabled={ requireUpgrade } placement={ placement } />
 					</BaseControl>
 				</PanelRow>
 			) }
+
+			<PanelRow className="jetpack-ai-sidebar__feature-section">
+				<BaseControl __nextHasNoMarginBottom={ true }>
+					<BaseControl.VisualLabel>{ __( 'Get Feedback', 'jetpack' ) }</BaseControl.VisualLabel>
+					<Feedback placement={ placement } busy={ false } disabled={ requireUpgrade } />
+				</BaseControl>
+			</PanelRow>
+
 			{ requireUpgrade && ! isUsagePanelAvailable && (
 				<PanelRow>
 					<Upgrade placement={ placement } type={ upgradeType } upgradeUrl={ checkoutUrl } />
@@ -149,21 +158,21 @@ const JetpackAndSettingsContent = ( {
 				</PanelRow>
 			) }
 
-			<PanelRow>
-				<ExternalLink href="https://jetpack.com/redirect/?source=jetpack-ai-feedback">
-					{ __( 'Provide feedback', 'jetpack' ) }
-				</ExternalLink>
-			</PanelRow>
-
-			<PanelRow>
+			<PanelRow className="jetpack-ai-sidebar__external-link">
 				<ExternalLink href={ productPageUrl }>
 					{ __( 'Learn more about Jetpack AI', 'jetpack' ) }
 				</ExternalLink>
 			</PanelRow>
 
-			<PanelRow>
+			<PanelRow className="jetpack-ai-sidebar__external-link">
+				<ExternalLink href="https://jetpack.com/redirect/?source=jetpack-ai-feedback">
+					{ __( 'Give us feedback', 'jetpack' ) }
+				</ExternalLink>
+			</PanelRow>
+
+			<PanelRow className="jetpack-ai-sidebar__external-link">
 				<ExternalLink href="https://jetpack.com/redirect/?source=ai-guidelines">
-					{ __( 'AI Guidelines', 'jetpack' ) }
+					{ __( 'AI guidelines', 'jetpack' ) }
 				</ExternalLink>
 			</PanelRow>
 		</>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -20,7 +20,6 @@ import { getFeatureAvailability } from '../../../../blocks/ai-assistant/lib/util
 import { isBetaExtension } from '../../../../editor';
 import JetpackPluginSidebar from '../../../../shared/jetpack-plugin-sidebar';
 import { PLAN_TYPE_FREE, PLAN_TYPE_UNLIMITED, usePlanType } from '../../../../shared/use-plan-type';
-import usePostContent from '../../hooks/use-post-content';
 import { FeaturedImage } from '../ai-image';
 import { Breve, registerBreveHighlights, Highlight } from '../breve';
 import { getBreveAvailability, canWriteBriefBeEnabled } from '../breve/utils/get-availability';
@@ -74,6 +73,8 @@ const JetpackAndSettingsContent = ( {
 	const { productPageUrl } = useAiProductPage();
 	const isBreveAvailable = getBreveAvailability();
 
+	const isPostEmpty = useSelect( select => select( editorStore ).isEditedPostEmpty(), [] );
+
 	const currentTitleOptimizationSectionLabel = __( 'Optimize Publishing', 'jetpack' );
 	const SEOTitleOptimizationSectionLabel = __( 'Optimize Title', 'jetpack' );
 	const titleOptimizationSectionLabel = isAITitleOptimizationKeywordsFeatureAvailable
@@ -103,7 +104,7 @@ const JetpackAndSettingsContent = ( {
 				</PanelRow>
 			) }
 
-			{ ! usePostContent() && (
+			{ isPostEmpty && (
 				<PanelRow className="jetpack-ai-sidebar__warning-content">
 					<Notice isDismissible={ false } status="warning">
 						{ __( 'The following features requie content to work.', 'jetpack' ) }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { JetpackEditorPanelLogo, useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { PanelBody, PanelRow, BaseControl, ExternalLink } from '@wordpress/components';
+import { PanelBody, PanelRow, BaseControl, ExternalLink, Notice } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { PluginPrePublishPanel, PluginDocumentSettingPanel } from '@wordpress/edit-post';
@@ -105,7 +105,9 @@ const JetpackAndSettingsContent = ( {
 
 			{ ! usePostContent() && (
 				<PanelRow className="jetpack-ai-sidebar__warning-content">
-					<p>{ __( 'The following features requie content to work.', 'jetpack' ) }</p>
+					<Notice isDismissible={ false } status="warning">
+						{ __( 'The following features requie content to work.', 'jetpack' ) }
+					</Notice>
 				</PanelRow>
 			) }
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -107,7 +107,7 @@ const JetpackAndSettingsContent = ( {
 			{ isPostEmpty && (
 				<PanelRow className="jetpack-ai-sidebar__warning-content">
 					<Notice isDismissible={ false } status="warning">
-						{ __( 'The following features requie content to work.', 'jetpack' ) }
+						{ __( 'The following features require content to work.', 'jetpack' ) }
 					</Notice>
 				</PanelRow>
 			) }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/style.scss
@@ -40,3 +40,12 @@
 		margin-left: 4px;
 	}
 }
+
+.jetpack-ai__write-brief-card {
+	width: 100%;
+	margin-bottom: 12px;
+
+	p {
+		margin: 0;
+	}
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/style.scss
@@ -29,11 +29,7 @@
 }
 
 .jetpack-ai-sidebar__warning-content {
-	p {
-		border-left: 4px solid #F0B849;
-		background: color-mix(in srgb, #FFF 80%, #F0B849);
-		padding: 8px 4px;
-	}
+	padding-bottom: 12px;
 }
 
 .jetpack-ai__feedback-button {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/style.scss
@@ -1,9 +1,23 @@
 .jetpack-ai-sidebar__feature-section {
 	margin-bottom: 2em;
+	display: block;
 
 	p, p > * {
 		text-wrap: pretty;
 	}
+
+	button {
+		width: 100%;
+		justify-content: center;
+	}
+}
+
+.jetpack-ai-sidebar__external-link {
+	min-height: unset;
+}
+
+.jetpack-ai-assistant__help-text {
+	color: #757575;
 }
 
 .jetpack-ai-feedback__label {
@@ -11,6 +25,14 @@
 	gap: 16px;
 	.components-toggle-control {
 		margin-bottom: 8px;
+	}
+}
+
+.jetpack-ai-sidebar__warning-content {
+	p {
+		border-left: 4px solid #F0B849;
+		background: color-mix(in srgb, #FFF 80%, #F0B849);
+		padding: 8px 4px;
 	}
 }
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -374,12 +374,15 @@ export default function FeaturedImage( {
 			{ ( placement === PLACEMENT_JETPACK_SIDEBAR ||
 				placement === PLACEMENT_DOCUMENT_SETTINGS ) && (
 				<>
-					<p>{ __( 'Create and use an AI generated featured image for your post.', 'jetpack' ) }</p>
+					<p className="jetpack-ai-assistant__help-text">
+						{ __( 'Based on your post content.', 'jetpack' ) }
+					</p>
 					<Button
 						onClick={ handleModalOpen }
 						isBusy={ busy }
 						disabled={ disabled || notEnoughRequests }
 						variant="secondary"
+						__next40pxDefaultSize
 					>
 						{ __( 'Generate image', 'jetpack' ) }
 					</Button>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/breve.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/breve.scss
@@ -19,11 +19,6 @@
 		margin-bottom: 16px;
 	}
 
-	&__grade-label {
-		color: #757575;
-		margin-left: 12px;
-	}
-
 	&__help-text {
 		font-size: 12px;
 		color: #757575;
@@ -33,5 +28,11 @@
 		display: flex;
 		flex-direction: column;
 		gap: 12px;
+	}
+
+	&__grade-level-container {
+		svg {
+			fill: #757575;
+		}
 	}
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/breve.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/breve.scss
@@ -1,8 +1,6 @@
 @import './features/features.colors';
 
 .jetpack-ai-proofread {
-	margin-bottom: 24px;
-
 	.components-checkbox-control {
 		&__input:not( :disabled ) {
 			@include features-colors( ( 'border-color' ) );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.tsx
@@ -103,27 +103,9 @@ const Controls = ( { blocks, disabledFeatures } ) => {
 
 	return (
 		<div className="jetpack-ai-proofread">
-			<p> { __( 'Improve your writing with AI.', 'jetpack' ) }</p>
-			<PanelRow>
-				<BaseControl __nextHasNoMarginBottom={ true }>
-					<div className="grade-level-container">
-						{ gradeLevel === null ? (
-							<p className="jetpack-ai-proofread__help-text">
-								{ __( 'Write to see your grade level.', 'jetpack' ) }
-							</p>
-						) : (
-							<Tooltip text={ __( 'To make it easy to read, aim for level 8–12', 'jetpack' ) }>
-								<p>
-									{ gradeLevel }
-									<span className="jetpack-ai-proofread__grade-label">
-										{ __( 'Reading grade score', 'jetpack' ) }
-									</span>
-								</p>
-							</Tooltip>
-						) }
-					</div>
-				</BaseControl>
-			</PanelRow>
+			<p className="jetpack-ai-assistant__help-text">
+				{ __( 'Visualize issues and apply AI suggestions.', 'jetpack' ) }
+			</p>
 
 			<PanelRow>
 				<BaseControl __nextHasNoMarginBottom={ true }>
@@ -148,6 +130,27 @@ const Controls = ( { blocks, disabledFeatures } ) => {
 										__nextHasNoMarginBottom={ true }
 									/>
 								)
+						) }
+					</div>
+				</BaseControl>
+			</PanelRow>
+
+			<PanelRow>
+				<BaseControl __nextHasNoMarginBottom={ true }>
+					<div className="grade-level-container">
+						{ gradeLevel === null ? (
+							<p className="jetpack-ai-proofread__help-text">
+								{ __( 'Write to see your grade level.', 'jetpack' ) }
+							</p>
+						) : (
+							<Tooltip text={ __( 'To make it easy to read, aim for level 8–12', 'jetpack' ) }>
+								<p>
+									{ gradeLevel }
+									<span className="jetpack-ai-proofread__grade-label">
+										{ __( 'Reading grade score', 'jetpack' ) }
+									</span>
+								</p>
+							</Tooltip>
 						) }
 					</div>
 				</BaseControl>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.tsx
@@ -8,10 +8,14 @@ import {
 	CheckboxControl,
 	ToggleControl,
 	Tooltip,
+	Card,
+	CardBody,
+	CardFooter,
 } from '@wordpress/components';
 import { compose, useDebounce } from '@wordpress/compose';
 import { useDispatch, useSelect, withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { Icon, help } from '@wordpress/icons';
 /**
  * External dependencies
  */
@@ -112,49 +116,55 @@ const Controls = ( { blocks, disabledFeatures } ) => {
 					<ToggleControl
 						checked={ isProofreadEnabled }
 						onChange={ handleAiFeedbackToggle }
-						label={ __( 'Show suggestions', 'jetpack' ) }
+						label={ __( 'Show issues & suggestions', 'jetpack' ) }
 						__nextHasNoMarginBottom={ true }
 					/>
-					<div className="feature-checkboxes-container">
-						{ features.map(
-							feature =>
-								canWriteBriefFeatureBeEnabled( feature.config.name ) && (
-									<CheckboxControl
-										className={ isProofreadEnabled ? '' : 'is-disabled' }
-										disabled={ ! isProofreadEnabled }
-										data-breve-type={ feature.config.name }
-										key={ feature.config.name }
-										label={ feature.config.title }
-										checked={ ! disabledFeatures.includes( feature.config.name ) }
-										onChange={ handleToggleFeature( feature.config.name ) }
-										__nextHasNoMarginBottom={ true }
-									/>
-								)
-						) }
-					</div>
 				</BaseControl>
 			</PanelRow>
 
-			<PanelRow>
-				<BaseControl __nextHasNoMarginBottom={ true }>
-					<div className="grade-level-container">
-						{ gradeLevel === null ? (
-							<p className="jetpack-ai-proofread__help-text">
-								{ __( 'Write to see your grade level.', 'jetpack' ) }
-							</p>
-						) : (
-							<Tooltip text={ __( 'To make it easy to read, aim for level 8–12', 'jetpack' ) }>
-								<p>
-									{ gradeLevel }
-									<span className="jetpack-ai-proofread__grade-label">
-										{ __( 'Reading grade score', 'jetpack' ) }
-									</span>
+			{ isProofreadEnabled && (
+				<PanelRow>
+					<Card size="small" className="jetpack-ai__write-brief-card">
+						<CardBody size="small">
+							<BaseControl __nextHasNoMarginBottom={ true }>
+								<div className="feature-checkboxes-container">
+									{ features.map(
+										feature =>
+											canWriteBriefFeatureBeEnabled( feature.config.name ) && (
+												<CheckboxControl
+													className={ isProofreadEnabled ? '' : 'is-disabled' }
+													disabled={ ! isProofreadEnabled }
+													data-breve-type={ feature.config.name }
+													key={ feature.config.name }
+													label={ feature.config.title }
+													checked={ ! disabledFeatures.includes( feature.config.name ) }
+													onChange={ handleToggleFeature( feature.config.name ) }
+													__nextHasNoMarginBottom={ true }
+												/>
+											)
+									) }
+								</div>
+							</BaseControl>
+						</CardBody>
+						<CardFooter size="small" className="jetpack-ai-proofread__grade-level-container">
+							{ gradeLevel === null ? (
+								<p className="jetpack-ai-proofread__help-text">
+									{ __( 'Write to see your grade level.', 'jetpack' ) }
 								</p>
-							</Tooltip>
-						) }
-					</div>
-				</BaseControl>
-			</PanelRow>
+							) : (
+								<>
+									<div className="jetpack-ai-proofread__grade-label">
+										{ gradeLevel } { __( 'Reading grade score', 'jetpack' ) }
+									</div>
+									<Tooltip text={ __( 'To make it easy to read, aim for level 8–12', 'jetpack' ) }>
+										<Icon icon={ help } size={ 20 } />
+									</Tooltip>
+								</>
+							) }
+						</CardFooter>
+					</Card>
+				</PanelRow>
+			) }
 		</div>
 	);
 };

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/feedback/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/feedback/index.tsx
@@ -98,12 +98,15 @@ export default function Feedback( {
 					<div className="ai-assistant-post-feedback__suggestion">{ suggestion }</div>
 				</AiAssistantModal>
 			) }
-			<p>{ __( 'Get feedback on content structure.', 'jetpack' ) }</p>
+			<p className="jetpack-ai-assistant__help-text">
+				{ __( 'Get feedback on content structure.', 'jetpack' ) }
+			</p>
 			<Button
 				onClick={ handleRequest }
 				variant="secondary"
 				disabled={ ! postContent || disabled }
 				isBusy={ busy }
+				__next40pxDefaultSize
 			>
 				{ __( 'Generate feedback', 'jetpack' ) }
 			</Button>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/index.tsx
@@ -83,17 +83,17 @@ export default function TitleOptimization( {
 	const SEOModalTitle = __( 'Improve title for SEO', 'jetpack' );
 	const modalTitle = isKeywordsFeatureAvailable ? SEOModalTitle : currentModalTitle;
 
-	const currentSidebarDescription = __( 'Use AI to optimize key details of your post.', 'jetpack' );
+	const currentSidebarDescription = __( 'Based on your post content.', 'jetpack' );
 	const SEOSidebarDescription = __(
-		'AI suggested titles based on your content and keywords for better SEO results.',
+		'Based on your post content and SEO best practices.',
 		'jetpack'
 	);
 	const sidebarDescription = isKeywordsFeatureAvailable
 		? SEOSidebarDescription
 		: currentSidebarDescription;
 
-	const currentSidebarButtonLabel = __( 'Improve title', 'jetpack' );
-	const SEOSidebarButtonLabel = __( 'Improve title for SEO', 'jetpack' );
+	const currentSidebarButtonLabel = __( 'Generate title options', 'jetpack' );
+	const SEOSidebarButtonLabel = __( 'Generate title options', 'jetpack' );
 	const sidebarButtonLabel = isKeywordsFeatureAvailable
 		? SEOSidebarButtonLabel
 		: currentSidebarButtonLabel;
@@ -228,12 +228,13 @@ export default function TitleOptimization( {
 
 	return (
 		<div>
-			<p>{ sidebarDescription }</p>
+			<p className="jetpack-ai-assistant__help-text">{ sidebarDescription }</p>
 			<Button
 				isBusy={ busy }
 				disabled={ ! postContent || disabled }
 				onClick={ handleTitleOptimization }
 				variant="secondary"
+				__next40pxDefaultSize
 			>
 				{ sidebarButtonLabel }
 			</Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #41007 and #41140

## Proposed changes:
* As outlined in this P2 post: p1HpG7-uEC-p2
* Adjustments and changes to put the Jetpack AI Assistant sidebar more inline with the rest of Gutenberg

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
P2: p1HpG7-uEC-p2

## Does this pull request change what data or activity we track or use?

## Testing instructions:
* Check out the Jetpack AI Assistant sidebar and observe that it looks how it's always looked
* Check out and build this branch or otherwise spin it up somewhere
* Refresh and look at the Jetpack AI Sidebar
* The sidebar should more or less behave the same but look more like the designs in the above P2
* Verify that the sidebar behaves as you'd expect. There should be no major changes to functionality.
* Check for typos! I already found one 😓 
* The changes are not pixel perfect as I was working with existing components that have their own styling options.
* Verify that a message that says "The following features require content to work." appears at the top of the sidebar if the current post is empty and disappears when something is added, and then re-appears if you remove all content.

## Screenshots

![Screenshot 2025-01-17 at 11 51 48 AM](https://github.com/user-attachments/assets/7dbd858f-48db-46bf-a2d4-7e61b9a5b99c)

![Screenshot 2025-01-17 at 11 13 01 AM](https://github.com/user-attachments/assets/039f6c94-d3a5-484b-9407-ecd0fd8a288c)

![Screenshot 2025-01-17 at 11 52 19 AM](https://github.com/user-attachments/assets/468916b1-b1ea-4d37-9eb4-5e812d4a071b)
