### PR TITLE
Repo gardening: don't send slack notifs for closed issues

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-no-slack-customer-warnings-closed-issues
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-no-slack-customer-warnings-closed-issues
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Issue Triage: do not send Slack notifications for closed issues
+
+

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -414,7 +414,7 @@ async function createOrUpdateComment( payload, octokit, issueReferences, issueCo
  */
 async function addHappinessLabel( payload, octokit ) {
 	const {
-		issue: { number },
+		issue: { number, state },
 		repository: {
 			name: repo,
 			owner: { login: ownerLogin },
@@ -441,9 +441,10 @@ async function addHappinessLabel( payload, octokit ) {
 
 	// Send Slack notification, if we have the necessary tokens.
 	// No Slack tokens, we won't be able to escalate. Bail.
+	// If the issue is already closed, do not send any Slack reminder.
 	const slackToken = getInput( 'slack_token' );
 	const channel = getInput( 'slack_quality_channel' );
-	if ( ! slackToken || ! channel ) {
+	if ( ! slackToken || ! channel || state === 'closed' ) {
 		return false;
 	}
 


### PR DESCRIPTION
## Proposed changes:

This should avoid slack notifications like this one:

p1737134904935319/1737134740.218539-slack-C07418EJ0

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

This can only be tested in a fork I'm afraid. I cannot link to a Slack notification since this stops sending notifs. :)
