### PR TITLE
Fix form block checkbox field italics+bold rendering

### DIFF
--- a/projects/packages/forms/changelog/fix-form-checkbox-italcs-rendering
+++ b/projects/packages/forms/changelog/fix-form-checkbox-italcs-rendering
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Minor fix
+
+

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -693,7 +693,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$field  = "<div class='contact-form__checkbox-wrap'>";
 		$field .= "<input id='" . esc_attr( $id ) . "' type='checkbox' name='" . esc_attr( $id ) . "' value='" . esc_attr__( 'Yes', 'jetpack-forms' ) . "' " . $class . checked( (bool) $value, true, false ) . ' ' . ( $required ? "required aria-required='true'" : '' ) . "/> \n";
 		$field .= "<label for='" . esc_attr( $id ) . "' class='grunion-field-label checkbox" . ( $this->is_error() ? ' form-error' : '' ) . "' style='" . $this->label_styles . "'>";
-		$field .= esc_html( $label ) . ( $required ? '<span class="grunion-label-required" aria-hidden="true">' . $required_field_text . '</span>' : '' );
+		$field .= wp_kses_post( $label ) . ( $required ? '<span class="grunion-label-required" aria-hidden="true">' . $required_field_text . '</span>' : '' );
 		$field .= "</label>\n";
 		$field .= "<div class='clear-form'></div>\n";
 		$field .= '</div>';
@@ -717,7 +717,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		} else {
 			$field .= "\t\t<input type='checkbox' name='" . esc_attr( $id ) . "' value='" . esc_attr__( 'Yes', 'jetpack-forms' ) . "' " . $class . "/> \n";
 		}
-		$field .= "\t\t" . esc_html( $consent_message );
+		$field .= "\t\t" . wp_kses_post( $consent_message );
 		$field .= "</label>\n";
 		$field .= "<div class='clear-form'></div>\n";
 		return $field;


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/41180

This PR fixes the limited checkbox and consent field formating. 

Currently in the Editor UI we allow for the italic for the checkbox labels. 
This PR make the italic something that shows up as expected on the front end.
<img width="597" alt="Screenshot 2025-01-17 at 1 09 56 PM" src="https://github.com/user-attachments/assets/e5102b43-bd58-4adc-bcf8-be27ad6db0af" />

See

Before:

<img width="500" alt="Screenshot 2025-01-17 at 1 11 40 PM" src="https://github.com/user-attachments/assets/3e37296c-b157-4e6e-a5de-2f9ae7cd803c" />

After:
<img width="500" alt="Screenshot 2025-01-17 at 1 12 16 PM" src="https://github.com/user-attachments/assets/1177031a-6f2e-4ca1-9dae-bac452a77cb3" />

## Proposed changes:
* Fixes the issue by used the `wp_kses_post` vs the `esc_html` function. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Load this PR. 
* Add the form block. 
* Add the consent and checkbox block fields. 
* In the field italicise part of the word in the labels. 
* Notice that on the frontend the formatting looks correct. 

