### PR TITLE
Update usage of deprecated block editor APIs

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-deprecated-block-editor-code
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-deprecated-block-editor-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Code Quality: Update deprecated block editor API usage.

--- a/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/variants/wpcom/components/wpcom-tour-kit-step-card.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/variants/wpcom/components/wpcom-tour-kit-step-card.tsx
@@ -25,7 +25,7 @@ const WpcomTourKitStepCard: React.FunctionComponent< WpcomTourStepRendererProps 
 	const description = descriptions[ isMobile ? 'mobile' : 'desktop' ] ?? descriptions.desktop;
 
 	return (
-		<Card className="wpcom-tour-kit-step-card" isElevated>
+		<Card className="wpcom-tour-kit-step-card" elevation={ 2 }>
 			<WpcomTourKitStepCardOverlayControls onDismiss={ onDismiss } onMinimize={ onMinimize } />
 			{ imgSrc && (
 				<CardMedia className="wpcom-tour-kit-step-card__media">

--- a/projects/packages/jetpack-mu-wpcom/src/features/starter-page-templates/page-patterns-plugin.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/starter-page-templates/page-patterns-plugin.tsx
@@ -5,7 +5,6 @@ import { useCallback } from '@wordpress/element';
 import { addFilter, removeFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import { pageLayoutStore } from './store';
-import '@wordpress/nux';
 
 const INSERTING_HOOK_NAME = 'isInsertingPagePattern';
 const INSERTING_HOOK_NAMESPACE = 'automattic/full-site-editing/inserting-pattern';

--- a/projects/packages/jetpack-mu-wpcom/src/features/starter-page-templates/page-patterns-plugin.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/starter-page-templates/page-patterns-plugin.tsx
@@ -22,9 +22,6 @@ type CoreEditorPlaceholder = {
 type CoreEditPostPlaceholder = {
 	isFeatureActive: ( ...args: unknown[] ) => boolean;
 };
-type CoreNuxPlaceholder = {
-	areTipsEnabled: ( ...args: unknown[] ) => boolean;
-};
 
 /**
  * Recursively finds the Content block if any.
@@ -57,7 +54,6 @@ export function PagePatternsPlugin( props: PagePatternsPluginProps ): JSX.Elemen
 	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
 	const { editPost } = useDispatch( 'core/editor' );
 	const { toggleFeature } = useDispatch( 'core/edit-post' );
-	const { disableTips } = useDispatch( 'core/nux' );
 
 	const selectProps = useSelect( select => {
 		const getMetaNew = () =>
@@ -73,7 +69,6 @@ export function PagePatternsPlugin( props: PagePatternsPluginProps ): JSX.Elemen
 			isWelcomeGuideActive: (
 				select( 'core/edit-post' ) as CoreEditPostPlaceholder
 			 ).isFeatureActive( 'welcomeGuide' ) as boolean,
-			areTipsEnabled: ( select( 'core/nux' ) as CoreNuxPlaceholder ).areTipsEnabled() as boolean,
 			...( isPatternPicker() && {
 				title: __( 'Choose a Pattern', 'jetpack-mu-wpcom' ),
 				description: __(
@@ -124,17 +119,13 @@ export function PagePatternsPlugin( props: PagePatternsPluginProps ): JSX.Elemen
 		[ editPost, postContentBlock, replaceInnerBlocks ]
 	);
 
-	const { isWelcomeGuideActive, areTipsEnabled } = selectProps;
+	const { isWelcomeGuideActive } = selectProps;
 
 	const hideWelcomeGuide = useCallback( () => {
 		if ( isWelcomeGuideActive ) {
-			// Gutenberg 7.2.0 or higher.
 			toggleFeature( 'welcomeGuide' );
-		} else if ( areTipsEnabled ) {
-			// Gutenberg 7.1.0 or lower.
-			disableTips();
 		}
-	}, [ areTipsEnabled, disableTips, isWelcomeGuideActive, toggleFeature ] );
+	}, [ isWelcomeGuideActive, toggleFeature ] );
 
 	const handleClose = useCallback( () => {
 		setOpenState( 'CLOSED' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/starter-page-templates/page-patterns-plugin.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/starter-page-templates/page-patterns-plugin.tsx
@@ -13,8 +13,10 @@ const INSERTING_HOOK_NAMESPACE = 'automattic/full-site-editing/inserting-pattern
 interface PagePatternsPluginProps {
 	patterns: PatternDefinition[];
 }
-type CoreEditorPlaceholder = {
+type CoreBlockEditorPlaceholder = {
 	getBlocks: ( ...args: unknown[] ) => BlockInstance[];
+};
+type CoreEditorPlaceholder = {
 	getEditedPostAttribute: ( ...args: unknown[] ) => unknown;
 };
 type CoreEditPostPlaceholder = {
@@ -58,8 +60,15 @@ export function PagePatternsPlugin( props: PagePatternsPluginProps ): JSX.Elemen
 	const { disableTips } = useDispatch( 'core/nux' );
 
 	const selectProps = useSelect( select => {
+		const getMetaNew = () =>
+			( select( 'core/editor' ) as CoreEditorPlaceholder ).getEditedPostAttribute( 'meta' );
+		const currentBlocks = (
+			select( 'core/block-editor' ) as CoreBlockEditorPlaceholder
+		 ).getBlocks();
 		const { isOpen, isPatternPicker } = select( pageLayoutStore );
 		return {
+			getMeta: getMetaNew,
+			postContentBlock: findPostContentBlock( currentBlocks ),
 			isOpen: isOpen(),
 			isWelcomeGuideActive: (
 				select( 'core/edit-post' ) as CoreEditPostPlaceholder
@@ -75,15 +84,7 @@ export function PagePatternsPlugin( props: PagePatternsPluginProps ): JSX.Elemen
 		};
 	}, [] );
 
-	const { getMeta, postContentBlock } = useSelect( select => {
-		const getMetaNew = () =>
-			( select( 'core/editor' ) as CoreEditorPlaceholder ).getEditedPostAttribute( 'meta' );
-		const currentBlocks = ( select( 'core/editor' ) as CoreEditorPlaceholder ).getBlocks();
-		return {
-			getMeta: getMetaNew,
-			postContentBlock: findPostContentBlock( currentBlocks ),
-		};
-	}, [] );
+	const { getMeta, postContentBlock } = selectProps;
 
 	const savePatternChoice = useCallback(
 		( name: string, selectedCategory: string | null ) => {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/index.js
@@ -2,7 +2,7 @@
 import '../../common/public-path';
 import { register } from './src/store';
 
-import './src/disable-core-nux';
+import './src/disable-core-welcome-guide';
 import './src/block-editor-nux';
 
 register();

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/disable-core-welcome-guide.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/disable-core-welcome-guide.js
@@ -1,10 +1,7 @@
 import { select, dispatch, subscribe } from '@wordpress/data';
 
-import '@wordpress/nux'; //ensure nux store loads
-
-// Disable nux and welcome guide features from core.
+// Disable welcome guide features from core.
 const unsubscribe = subscribe( () => {
-	dispatch( 'core/nux' ).disableTips();
 	if ( select( 'core/edit-post' )?.isFeatureActive( 'welcomeGuide' ) ) {
 		dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
 		unsubscribe();
@@ -16,12 +13,7 @@ const unsubscribe = subscribe( () => {
 } );
 
 // Listen for these features being triggered to call dotcom welcome guide instead.
-// Note migration of areTipsEnabled: https://github.com/WordPress/gutenberg/blob/5c3a32dabe4393c45f7fe6ac5e4d78aebd5ee274/packages/data/src/plugins/persistence/index.js#L269
 subscribe( () => {
-	if ( select( 'core/nux' ).areTipsEnabled() ) {
-		dispatch( 'core/nux' ).disableTips();
-		dispatch( 'automattic/wpcom-welcome-guide' ).setShowWelcomeGuide( true );
-	}
 	if ( select( 'core/edit-post' )?.isFeatureActive( 'welcomeGuide' ) ) {
 		dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
 		// On mounting, the welcomeGuide feature is turned on by default. This opens the welcome guide despite `welcomeGuideStatus` value.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/welcome-tour/tour-launch.jsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/welcome-tour/tour-launch.jsx
@@ -113,7 +113,7 @@ function WelcomeTour( { siteIntent } ) {
 	}
 	const { isInserterOpened, isSidebarOpened, isSettingsOpened } = useSelect(
 		select => ( {
-			isInserterOpened: select( 'core/edit-post' ).isInserterOpened(),
+			isInserterOpened: select( 'core/editor' ).isInserterOpened(),
 			isSidebarOpened: select( 'automattic/block-editor-nav-sidebar' )?.isSidebarOpened() ?? false, // The sidebar store may not always be loaded.
 			isSettingsOpened:
 				select( 'core/interface' ).getActiveComplementaryArea( 'core/edit-post' ) ===

--- a/projects/plugins/jetpack/changelog/update-deprecated-block-editor-code
+++ b/projects/plugins/jetpack/changelog/update-deprecated-block-editor-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Code Quality: Update deprecated block editor APU usage.

--- a/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/voice-to-content/edit.tsx
@@ -8,9 +8,10 @@ import {
 } from '@automattic/jetpack-ai-client';
 import { ThemeProvider } from '@automattic/jetpack-components';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { BlockInstance } from '@wordpress/blocks';
 import { Button, Modal, Icon } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { external } from '@wordpress/icons';
@@ -58,11 +59,12 @@ const transcriptionStateHelper = (
 export default function VoiceToContentEdit( { clientId } ) {
 	const [ audio, setAudio ] = useState< Blob >( null );
 
-	const { removeBlock } = useDispatch( 'core/block-editor' ) as {
-		removeBlock: ( id: string ) => void;
+	const { removeBlock } = useDispatch( blockEditorStore );
+	// TODO: The second `deps` argument shouldn't be needed, but it's added to make the type checker happy.
+	// This can be removed when the core data types are updated to fix the issue.
+	const { getBlocks } = useSelect( blockEditorStore, [] ) as {
+		getBlocks: () => BlockInstance[];
 	};
-
-	const { getBlocks } = useSelect( select => select( editorStore ), [] );
 
 	const destroyBlock = useCallback( () => {
 		// Remove the block from the editor

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-service/index.ts
@@ -210,16 +210,10 @@ const isMediaSourceConnected = async ( source: MediaSource ) =>
  * @return {boolean} True if the inserter is opened false otherwise.
  */
 const isInserterOpened = (): boolean => {
-	/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-	const selectIsInserterOpened = ( select( 'core/editor' ) as any )?.isInserterOpened;
+	const editorIsInserterOpened = select( 'core/editor' ).isInserterOpened?.();
 
-	const editorIsInserterOpened = selectIsInserterOpened?.();
-
-	return (
-		editorIsInserterOpened ||
-		select( 'core/edit-site' )?.isInserterOpened() ||
-		select( 'core/edit-widgets' )?.isInserterOpened()
-	);
+	// The widgets editor doesn't use the `core/editor` store, so check is separately.
+	return editorIsInserterOpened || select( 'core/edit-widgets' )?.isInserterOpened();
 };
 
 const registerInInserter = ( mediaCategoryProvider: () => object ) =>


### PR DESCRIPTION
Updates usage of deprecated block editor API functions.

## Proposed changes:
The following APIs have been deprecated for a while. Jetpack supports WordPress 6.6, so I've only removed APIs that are prior to that version:
- Since WordPress 5.3 - `wp.data.select( 'core/editor' ).getBlocks` has moved to the block editor package, it should be updated to `wp.data.select( 'core/block-editor' ).getBlocks`.
- Since WordPress 5.4 - the `@wordpress/nux` package has been completely deprecated. I've removed any usage of it. 
- Since WordPress 5.9 - the `Card` component's `isElevated` prop has been replaced by `elevation={ 2 }`.
- Since WordPress 6.5 - the `wp.data.select( 'core/edit-post' ).isInserterOpened` and `wp.data.select( 'core/edit-site' ).isInserterOpened` have been replaced by `wp.data.select( 'core/editor' ).isInserterOpened`.

There are still some deprecation messages showing in the browser console after this, but from what I can tell they're:
- WordPress 6.6 onwards
- Related to plain-text block descriptions (being tracked in https://github.com/Automattic/jetpack/issues/26792), and it's one that I don't have a solution for. 
- Not from the jetpack codebase

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:

### New Page pattern picker
1. Create a new page
2. Ensure the pattern picker modal is shown
3. Dismiss the pattern picker, toggle the Welcome Guide on from the Editor Options menu
4. Go back to WP Admin and create another new page, ensure the Welcome Guide is hidden and the pattern picker is shown
5. Select a pattern and insert it
6. Save the page
7. Reload the page
8. Since the page now has content, the pattern picker modal should not be shown

### Welcome Guide
1. From the Editor Options menu select the Welcome Guide
2.  Ensure all the steps in the guide are shown correctly
3. Switch to a mobile viewport
4. Toggle the Block Inserter sidebar open
5. The Welcome Guide should minimize

### Pexels in the Inserter Media Tab
1. Open the Block Inserter sidebar
2. Go to the Media Tab in the sidebar
3. Check that Pexels Free Photos show up, and you can insert one of the images

### Voice to Content block
I'm not sure how to test this one, I couldn't see the block in my editor

## Does this pull request change what data or activity we track or use?

No

