### PR TITLE
Forms: Create new default block when pressing Enter on text inputs

### DIFF
--- a/projects/packages/forms/changelog/forms-add-default-block-on-input-enter
+++ b/projects/packages/forms/changelog/forms-add-default-block-on-input-enter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Create new default block when pressing Enter on text inputs

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -274,6 +274,7 @@ const editField = type => props => {
 			id={ props.attributes.id }
 			width={ props.attributes.width }
 			attributes={ props.attributes }
+			insertBlocksAfter={ props.insertBlocksAfter }
 		/>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
@@ -1,4 +1,5 @@
 import { useBlockProps } from '@wordpress/block-editor';
+import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { SelectControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -34,7 +35,7 @@ const DATE_FORMATS = [
 ];
 
 const JetpackDatePicker = props => {
-	const { attributes, clientId, isSelected, name, setAttributes } = props;
+	const { attributes, clientId, isSelected, name, setAttributes, insertBlocksAfter } = props;
 	const { id, label, required, requiredText, width, placeholder, dateFormat } = attributes;
 
 	useFormWrapper( { attributes, clientId, name } );
@@ -67,6 +68,12 @@ const JetpackDatePicker = props => {
 					style={ fieldStyle }
 					type="text"
 					value={ placeholder }
+					onKeyDown={ event => {
+						if ( event.defaultPrevented || event.key !== 'Enter' ) {
+							return;
+						}
+						insertBlocksAfter( createBlock( getDefaultBlockName() ) );
+					} }
 				/>
 			</div>
 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
@@ -1,4 +1,5 @@
 import { useBlockProps } from '@wordpress/block-editor';
+import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { createHigherOrderComponent, compose } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 import clsx from 'clsx';
@@ -21,6 +22,7 @@ const JetpackField = props => {
 		setAttributes,
 		placeholder,
 		width,
+		insertBlocksAfter,
 	} = props;
 
 	const { blockStyle, fieldStyle } = useJetpackFieldStyles( attributes );
@@ -50,6 +52,12 @@ const JetpackField = props => {
 					style={ fieldStyle }
 					type="text"
 					value={ placeholder }
+					onKeyDown={ event => {
+						if ( event.defaultPrevented || event.key !== 'Enter' ) {
+							return;
+						}
+						insertBlocksAfter( createBlock( getDefaultBlockName() ) );
+					} }
 				/>
 			</div>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves: https://github.com/Automattic/jetpack/issues/40954

This PR adds functionality to insert a default block after pressing `Enter` on text Jetpack forms fields. The affected blocks are: `field-text, field-name, field-email, field-url, field-tel and date`. The current approach is to add a new default block in any case without taking into account if the input is empty or what the current selection is.

I think it makes more sense like this, but we could still fine tune it to check the input's selection (collapsed, selectionEnd, etc..). An example would be to only create a new block if the cursor is at the end of the input. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Testing instructions:
1. Insert the above mentioned text fields and press `Enter`
2. Observe a new default block is inserted after.

https://github.com/user-attachments/assets/10290732-611a-48f7-b45c-d665fcb21909




