### PR TITLE
Improve tracking fidelity on page starter templates pattern insertion

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-improve-tracking-fidelity-on-page-starter-templates-insertion
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-improve-tracking-fidelity-on-page-starter-templates-insertion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improve tracking fidelity by using insert action over replace actions

--- a/projects/packages/jetpack-mu-wpcom/src/features/starter-page-templates/page-patterns-plugin.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/starter-page-templates/page-patterns-plugin.tsx
@@ -52,7 +52,7 @@ function findPostContentBlock( blocks: BlockInstance[] ): BlockInstance | null {
 export function PagePatternsPlugin( props: PagePatternsPluginProps ): JSX.Element {
 	const { setOpenState } = useDispatch( pageLayoutStore );
 	const { setUsedPageOrPatternsModal } = useDispatch( 'automattic/wpcom-welcome-guide' );
-	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
+	const { insertBlocks } = useDispatch( 'core/block-editor' );
 	const { editPost } = useDispatch( 'core/editor' );
 	const { toggleFeature } = useDispatch( 'core/edit-post' );
 	const { disableTips } = useDispatch( 'core/nux' );
@@ -115,12 +115,12 @@ export function PagePatternsPlugin( props: PagePatternsPluginProps ): JSX.Elemen
 			}
 
 			// Replace blocks.
-			replaceInnerBlocks( postContentBlock ? postContentBlock.clientId : '', blocks, false );
+			insertBlocks( blocks, undefined, postContentBlock ? postContentBlock.clientId : '', false );
 
 			// Remove filter.
 			removeFilter( INSERTING_HOOK_NAME, INSERTING_HOOK_NAMESPACE );
 		},
-		[ editPost, postContentBlock, replaceInnerBlocks ]
+		[ editPost, postContentBlock, insertBlocks ]
 	);
 
 	const { isWelcomeGuideActive, areTipsEnabled } = selectProps;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/53634

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use `insertBlocks` over `replaceBlocks` when adding a full page pattern for new Pages.
* This is suitable because the full page pattern modal only appears if the post is empty or contains only a Post Content block
https://github.com/Automattic/jetpack/blob/b816b8e07288ca98968006bcb8178d30527c9920/projects/packages/jetpack-mu-wpcom/src/features/starter-page-templates/class-starter-page-templates.php#L255-L262
https://github.com/Automattic/jetpack/blob/b816b8e07288ca98968006bcb8178d30527c9920/projects/packages/jetpack-mu-wpcom/src/features/starter-page-templates/index.tsx#L29-L32

* Therefore using `replaceBlocks` is not required and we can get more accurate tracking via `insertBlocks`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Following tracking setup test instructions from `Debugging` section of PCYsg-nrf-p2
* Sandbox a testing site
* _Temporarily_ Enable write access to allow creation of new Pages see PCYsg-pcJ-p2
* Create a new Page via `WPAdmin -> Pages -> Add new Page`
* See the modal appear with all the Page Patterns.
* Insert a full page patterm
* See `wpcom_block_inserted` events fired with details about the pattern being inserted.
* Do not see...