### PR TITLE
RDV: Add experiment assignment override and reset

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-add-rdv-override
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-add-rdv-override
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Remove duplicate views: add possibility to override and reset the experiment variation

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -463,6 +463,31 @@ function wpcom_is_duplicate_views_experiment_enabled() {
 }
 
 /**
+ * Set the Calypso preference for rdv.
+ *
+ * This is needed to override the ExPlat variation assignment in order to be able to revert the variation for some users.
+ *
+ * @param string|null $assignment
+ * @return void
+ */
+function wpcom_set_remove_duplicate_views_calypso_preference( $assignment ) {
+	if ( ( new Host() )->is_wpcom_simple() ) {
+		$preferences = get_user_attribute( get_current_user_id(), 'calypso_preferences' );
+		$preferences[ RDV_EXPERIMENT_FORCE_ASSIGN_OPTION ] = $assignment;
+		update_user_attribute( get_current_user_id(), 'calypso_preferences', $preferences );
+	} else {
+		Client::wpcom_json_api_request_as_user(
+			'/me/preferences',
+			'2',
+			array(
+				'method' => 'POST',
+			),
+			array( 'calypso_preferences' => (object) array( RDV_EXPERIMENT_FORCE_ASSIGN_OPTION => $assignment ) )
+		);
+	}
+}
+
+/**
  * Force a variation (control/treatment) for the Remove Duplicate Views experiment.
  *
  * @return void
@@ -478,6 +503,8 @@ function wpcom_force_assign_variation_for_remove_duplicate_views_experiment() {
 		return;
 	}
 
+	wpcom_set_remove_duplicate_views_calypso_preference( $assignment );
+
 	/**
 	 * Setting the option globally (third parameter) will have the following behavior:
 	 * - On Simple Sites, the option will be shared between them.
@@ -488,7 +515,7 @@ function wpcom_force_assign_variation_for_remove_duplicate_views_experiment() {
 	 * For example, if the option is set on a Simple Site, every other site will get it, except for the Atomic ones.
 	 * If the option is set on an Atomic Site, this will apply only on this site - it won't be shared between the other Atomic Sites OR Simple Sites.
 	 *
-	 * Since this should be used only in exceptional cases, there's no need to implement something better.
+	 *  This option is also not moved from Simple to Atomic on AT transfer.
 	 */
 	update_user_option( get_current_user_id(), RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, $assignment, true );
 }
@@ -503,6 +530,8 @@ function wpcom_reset_assignment_for_remove_duplicate_views_experiment() {
 		return;
 	}
 
+	wpcom_set_remove_duplicate_views_calypso_preference( null );
+
 	/**
 	 * Setting the option globally (third parameter) will have the following behavior:
 	 * - On Simple Sites, the option will be shared between them.
@@ -512,6 +541,8 @@ function wpcom_reset_assignment_for_remove_duplicate_views_experiment() {
 	 *
 	 * For example, if the option is set on a Simple Site, every other site will get it, except for the Atomic ones.
 	 * If the option is set on an Atomic Site, this will apply only on this site - it won't be shared between the other Atomic Sites OR Simple Sites.
+	 *
+	 * This option is also not moved from Simple to Atomic on AT transfer.
 	 *
 	 * Since this should be used only in exceptional cases, there's no need to implement something better.
 	 */

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -387,6 +387,11 @@ function wpcom_show_admin_interface_notice() {
 add_action( 'admin_notices', 'wpcom_show_admin_interface_notice' );
 
 /**
+ * Option to force and cache the Remove duplicate Views experiment assigned variation.
+ */
+const RDV_EXPERIMENT_FORCE_ASSIGN_OPTION = 'remove_duplicate_views_experiment_assignment';
+
+/**
  * Check if the duplicate views experiment is enabled.
  *
  * @return boolean
@@ -401,17 +406,16 @@ function wpcom_is_duplicate_views_experiment_enabled() {
 		return $is_enabled;
 	}
 
-	if ( ( new Host() )->is_wpcom_simple() ) {
-		\ExPlat\assign_current_user( $aa_test_name );
-		$is_enabled = 'treatment' === \ExPlat\assign_current_user( $experiment_name );
-		return $is_enabled;
-	}
-
-	$option_name = 'remove_duplicate_views_experiment_assignment';
-	$variation   = get_user_option( $option_name, get_current_user_id() );
+	$variation   = get_user_option( RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, get_current_user_id() );
 
 	if ( false !== $variation ) {
 		$is_enabled = 'treatment' === $variation;
+		return $is_enabled;
+	}
+
+	if ( ( new Host() )->is_wpcom_simple() ) {
+		\ExPlat\assign_current_user( $aa_test_name );
+		$is_enabled = 'treatment' === \ExPlat\assign_current_user( $experiment_name );
 		return $is_enabled;
 	}
 
@@ -448,7 +452,7 @@ function wpcom_is_duplicate_views_experiment_enabled() {
 
 	if ( isset( $data['variations'] ) && isset( $data['variations'][ $experiment_name ] ) ) {
 		$variation = $data['variations'][ $experiment_name ];
-		update_user_option( get_current_user_id(), $option_name, $variation, true );
+		update_user_option( get_current_user_id(), RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, $variation, true );
 
 		$is_enabled = 'treatment' === $variation;
 		return $is_enabled;
@@ -456,6 +460,68 @@ function wpcom_is_duplicate_views_experiment_enabled() {
 		$is_enabled = false;
 		return $is_enabled;
 	}
+}
+
+die('hehehe');
+/**
+ * Force a variation (control/treatment) for the Remove Duplicate Views experiment.
+ *
+ * @return void
+ */
+function wpcom_force_assign_variation_for_remove_duplicate_views_experiment() {
+	if ( ! isset( $_GET['force-assign-rdv-variation'] ) ) {
+		return;
+	}
+
+	$assignment = in_array( $_GET['force-assign-rdv-variation'], array( 'control', 'treatment' ), true ) ? $_GET['force-assign-rdv-variation'] : false;
+
+	if ( ! $assignment ) {
+		return;
+	}
+
+	/**
+	 * Setting the option globally (third parameter) will have the following behavior:
+	 * - On Simple Sites, the option will be shared between them.
+	 * - On Atomic Sites, the option will NOT be shared.
+	 *
+	 * This also means that if a user has a Simple Sites and Atomic sites, the option will not be shared between them.
+	 *
+	 * For example, if the option is set on a Simple Site, every other site will get it, except for the Atomic ones.
+	 * If the option is set on an Atomic Site, this will apply only on this site - it won't be shared between the other Atomic Sites OR Simple Sites.
+	 *
+	 * Since this should be used only in exceptional cases, there's no need to implement something better.
+	 */
+	update_user_option( get_current_user_id(), RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, $assignment, true );
+}
+
+/**
+ * Reset the assignment cache for the Remove duplicate views experiment.
+ *
+ * @return void
+ */
+function wpcom_reset_assignment_for_remove_duplicate_views_experiment() {
+	if ( ! isset( $_GET['force-reset-rdv-variation'] ) ) {
+		return;
+	}
+
+	/**
+	 * Setting the option globally (third parameter) will have the following behavior:
+	 * - On Simple Sites, the option will be shared between them.
+	 * - On Atomic Sites, the option will NOT be shared.
+	 *
+	 * This also means that if a user has a Simple Sites and Atomic sites, the option will not be shared between them.
+	 *
+	 * For example, if the option is set on a Simple Site, every other site will get it, except for the Atomic ones.
+	 * If the option is set on an Atomic Site, this will apply only on this site - it won't be shared between the other Atomic Sites OR Simple Sites.
+	 *
+	 * Since this should be used only in exceptional cases, there's no need to implement something better.
+	 */
+	delete_user_option( get_current_user_id(), RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, true );
+}
+
+if ( defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST || defined( 'AT_PROXIED_REQUEST' ) && AT_PROXIED_REQUEST ) {
+	add_action( 'admin_init', 'wpcom_force_assign_variation_for_remove_duplicate_views_experiment' );
+	add_action( 'admin_init', 'wpcom_reset_assignment_for_remove_duplicate_views_experiment' );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -467,12 +467,12 @@ function wpcom_is_duplicate_views_experiment_enabled() {
  *
  * This is needed to override the ExPlat variation assignment in order to be able to revert the variation for some users.
  *
- * @param string|null $assignment
+ * @param string|null $assignment The experiment variation.
  * @return void
  */
 function wpcom_set_remove_duplicate_views_calypso_preference( $assignment ) {
 	if ( ( new Host() )->is_wpcom_simple() ) {
-		$preferences = get_user_attribute( get_current_user_id(), 'calypso_preferences' );
+		$preferences                                       = get_user_attribute( get_current_user_id(), 'calypso_preferences' );
 		$preferences[ RDV_EXPERIMENT_FORCE_ASSIGN_OPTION ] = $assignment;
 		update_user_attribute( get_current_user_id(), 'calypso_preferences', $preferences );
 	} else {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -472,7 +472,7 @@ function wpcom_force_assign_variation_for_remove_duplicate_views_experiment() {
 		return;
 	}
 
-	$assignment = in_array(  $_GET['force-assign-rdv-variation'], array( 'control', 'treatment' ), true ) ? wp_unslash( $_GET['force-assign-rdv-variation'] ) : false;
+	$assignment = in_array( $_GET['force-assign-rdv-variation'], array( 'control', 'treatment' ), true ) ? sanitize_text_field( wp_unslash( $_GET['force-assign-rdv-variation'] ) ) : false;
 
 	if ( ! $assignment ) {
 		return;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -470,7 +470,7 @@ function wpcom_is_duplicate_views_experiment_enabled() {
  * @param string|null $assignment The experiment variation.
  * @return void
  */
-function wpcom_set_remove_duplicate_views_calypso_preference( $assignment ) {
+function wpcom_set_rdv_calypso_preference( $assignment ) {
 	if ( ( new Host() )->is_wpcom_simple() ) {
 		$preferences                                       = get_user_attribute( get_current_user_id(), 'calypso_preferences' );
 		$preferences[ RDV_EXPERIMENT_FORCE_ASSIGN_OPTION ] = $assignment;
@@ -482,7 +482,7 @@ function wpcom_set_remove_duplicate_views_calypso_preference( $assignment ) {
 			array(
 				'method' => 'POST',
 			),
-			array( 'calypso_preferences' => (object) array( RDV_EXPERIMENT_FORCE_ASSIGN_OPTION => $assignment ) )
+			array( 'calypso_preferences' => array( RDV_EXPERIMENT_FORCE_ASSIGN_OPTION => $assignment ) )
 		);
 	}
 }
@@ -503,7 +503,7 @@ function wpcom_force_assign_variation_for_remove_duplicate_views_experiment() {
 		return;
 	}
 
-	wpcom_set_remove_duplicate_views_calypso_preference( $assignment );
+	wpcom_set_rdv_calypso_preference( $assignment );
 
 	/**
 	 * Setting the option globally (third parameter) will have the following behavior:
@@ -530,7 +530,7 @@ function wpcom_reset_assignment_for_remove_duplicate_views_experiment() {
 		return;
 	}
 
-	wpcom_set_remove_duplicate_views_calypso_preference( null );
+	wpcom_set_rdv_calypso_preference( null );
 
 	/**
 	 * Setting the option globally (third parameter) will have the following behavior:

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -406,7 +406,7 @@ function wpcom_is_duplicate_views_experiment_enabled() {
 		return $is_enabled;
 	}
 
-	$variation   = get_user_option( RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, get_current_user_id() );
+	$variation = get_user_option( RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, get_current_user_id() );
 
 	if ( false !== $variation ) {
 		$is_enabled = 'treatment' === $variation;
@@ -462,7 +462,6 @@ function wpcom_is_duplicate_views_experiment_enabled() {
 	}
 }
 
-die('hehehe');
 /**
  * Force a variation (control/treatment) for the Remove Duplicate Views experiment.
  *
@@ -473,7 +472,7 @@ function wpcom_force_assign_variation_for_remove_duplicate_views_experiment() {
 		return;
 	}
 
-	$assignment = in_array( $_GET['force-assign-rdv-variation'], array( 'control', 'treatment' ), true ) ? $_GET['force-assign-rdv-variation'] : false;
+	$assignment = in_array(  $_GET['force-assign-rdv-variation'], array( 'control', 'treatment' ), true ) ? wp_unslash( $_GET['force-assign-rdv-variation'] ) : false;
 
 	if ( ! $assignment ) {
 		return;


### PR DESCRIPTION
In exceptional cases, we want a12s to be able to switch the experiment variation on the current user.

This behavior is needed as an escape hatch where the experience in Calypso is better in certain scenarios.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a way for a12s to override the RDV assignment
* Add a way for a12s to clear this override and let ExPlat to assign it

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply it on your sandbox and on your Atomic site using the instructions from the comments
* Go to a test site WP-Admin and enable the flag: `wp-admin/?force-assign-rdv-variation=treatment`
* Refresh the page again and you'll notice that you get the WP-Admin experience.
* Apply control: `wp-admin/?force-assign-rdv-variation=control`
* Notice that you get Calypso
* Go to WP-Admin test the reset feature: `wp-admin/?force-reset-rdv-variation`
* Go to another Simple Site and notice that the setting is shared between sites
* On Atomic sites the **option is not shared**!

