### PR TITLE
Fix: Footer credit is always displayed on AT sites with infinite scroll.

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-Footer-credit-is-always-displayed-on-AT-sites-with-infinite-scroll
+++ b/projects/plugins/wpcomsh/changelog/fix-Footer-credit-is-always-displayed-on-AT-sites-with-infinite-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix: Footer credit is always displayed on AT sites with infinite scroll.

--- a/projects/plugins/wpcomsh/footer-credit/footer-credit/footer-credit.php
+++ b/projects/plugins/wpcomsh/footer-credit/footer-credit/footer-credit.php
@@ -89,6 +89,7 @@ function footercredit_replace_theme( $credit ) {
 	return '';
 }
 add_filter( 'wpcom_better_footer_theme_link', 'footercredit_replace_theme', 10, 2 );
+add_filter( 'infinite_scroll_credit', 'footercredit_replace_theme', 10, 2 );
 
 /**
  * The footer credits available in the UI - add future options here


### PR DESCRIPTION
**Fixes:** https://github.com/Automattic/themes/issues/5169

Currently, if infinite scroll is enabled and the footer credits are hidden, the footer credit setting is being ignored, resulting in the footer credits still being displayed.



## Proposed Changes:
This pull request uses the existing function `footercredit_replace_theme`, which removes footer credits when they are hidden. This function is now applied to the `infinite_scroll_credit` filter, which affects the infinite scroll markup. 

These changes resolve the issue across all themes by utilizing the available functions and filters.


## Testing instructions:
1. Enable the Independent Publisher 2 theme.
2. In the Jetpack settings, activate the infinite scroll feature.
3. Visit your site and check to see if credits appear while scrolling. (You will need a substantial number of posts for the infinite scroll footer to display.)
4. Open the Customizer, go to the Site Identity settings, and set the footer credits to "hidden."
5. Return to the homepage, scroll down, and confirm that the infinite footer with the link to the top/homepage is still visible, but without the credits section (on the trunk, the credits are still displayed).


## Does this pull request change what data or activity we track or use?

No.
