### PR TITLE
Full Sync: Avoid sending actions when expanded objects create empty arrays

### DIFF
--- a/projects/packages/sync/changelog/update-full-sync-comments-expanding-while-geting-next-chunk
+++ b/projects/packages/sync/changelog/update-full-sync-comments-expanding-while-geting-next-chunk
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Sync: Full sync doesn't send actions for posts and comments with no items

--- a/projects/packages/sync/src/modules/class-comments.php
+++ b/projects/packages/sync/src/modules/class-comments.php
@@ -318,8 +318,14 @@ class Comments extends Module {
 	 * @access public
 	 */
 	public function init_before_send() {
+
 		// Full sync.
-		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_comments', array( $this, 'expand_comment_ids' ) );
+		$sync_module = Modules::get_module( 'full-sync' );
+		if ( $sync_module instanceof Full_Sync_Immediately ) {
+			add_filter( 'jetpack_sync_before_send_jetpack_full_sync_comments', array( $this, 'extract_comments_and_meta' ) );
+		} else {
+			add_filter( 'jetpack_sync_before_send_jetpack_full_sync_comments', array( $this, 'expand_comment_ids' ) );
+		}
 	}
 
 	/**
@@ -499,6 +505,32 @@ class Comments extends Module {
 	 * @return array The expanded hook parameters.
 	 */
 	public function expand_comment_ids( $args ) {
+		list( $comment_ids, $previous_interval_end ) = $args;
+		$comments                                    = get_comments(
+			array(
+				'include_unapproved' => true,
+				'comment__in'        => $comment_ids,
+				'orderby'            => 'comment_ID',
+				'order'              => 'DESC',
+			)
+		);
+
+		return array(
+			$comments,
+			$this->get_metadata( $comment_ids, 'comment', Settings::get_setting( 'comment_meta_whitelist' ) ),
+			$previous_interval_end,
+		);
+	}
+
+	/**
+	 * Expand the comment IDs to comment objects and meta before being serialized and sent to the server.
+	 *
+	 * @access public
+	 *
+	 * @param array $args The hook parameters.
+	 * @return array The expanded hook parameters.
+	 */
+	public function extract_comments_and_meta( $args ) {
 		list( $filtered_comments, $previous_end ) = $args;
 		return array(
 			$filtered_comments['objects'],

--- a/projects/packages/sync/src/modules/class-comments.php
+++ b/projects/packages/sync/src/modules/class-comments.php
@@ -557,10 +557,9 @@ class Comments extends Module {
 		}
 		$comments = get_comments(
 			array(
-				'include_unapproved' => true,
-				'comment__in'        => $comment_ids,
-				'orderby'            => 'comment_ID',
-				'order'              => 'DESC',
+				'comment__in' => $comment_ids,
+				'orderby'     => 'comment_ID',
+				'order'       => 'DESC',
 			)
 		);
 		if ( empty( $comments ) ) {

--- a/projects/packages/sync/src/modules/class-comments.php
+++ b/projects/packages/sync/src/modules/class-comments.php
@@ -499,8 +499,31 @@ class Comments extends Module {
 	 * @return array The expanded hook parameters.
 	 */
 	public function expand_comment_ids( $args ) {
-		list( $comment_ids, $previous_interval_end ) = $args;
-		$comments                                    = get_comments(
+		list( $filtered_comments, $previous_end ) = $args;
+		return array(
+			$filtered_comments['objects'],
+			$filtered_comments['meta'],
+			$previous_end,
+		);
+	}
+
+	/**
+	 * Given the Module Configuration and Status return the next chunk of items to send.
+	 * This function also expands the posts and metadata and filters them based on the maximum size constraints.
+	 *
+	 * @param array $config This module Full Sync configuration.
+	 * @param array $status This module Full Sync status.
+	 * @param int   $chunk_size Chunk size.
+	 *
+	 * @return array
+	 */
+	public function get_next_chunk( $config, $status, $chunk_size ) {
+
+		$comment_ids = parent::get_next_chunk( $config, $status, $chunk_size );
+		if ( empty( $comment_ids ) ) {
+			return array();
+		}
+		$comments = get_comments(
 			array(
 				'include_unapproved' => true,
 				'comment__in'        => $comment_ids,
@@ -508,11 +531,31 @@ class Comments extends Module {
 				'order'              => 'DESC',
 			)
 		);
-
+		if ( empty( $comments ) ) {
+			return array();
+		}
 		return array(
-			$comments,
-			$this->get_metadata( $comment_ids, 'comment', Settings::get_setting( 'comment_meta_whitelist' ) ),
-			$previous_interval_end,
+			'object_ids' => $comment_ids,
+			'objects'    => $comments,
+			'meta'       => $this->get_metadata( $comment_ids, 'comment', Settings::get_setting( 'comment_meta_whitelist' ) ),
 		);
+	}
+
+	/**
+	 * Set the status of the full sync action based on the objects that were sent.
+	 *
+	 * @access public
+	 *
+	 * @param array $status This module Full Sync status.
+	 * @param array $objects This module Full Sync objects.
+	 *
+	 * @return array The updated status.
+	 */
+	public function set_send_full_sync_actions_status( $status, $objects ) {
+
+		$object_ids          = $objects['object_ids'];
+		$status['last_sent'] = end( $object_ids );
+		$status['sent']     += count( $object_ids );
+		return $status;
 	}
 }

--- a/projects/packages/sync/src/modules/class-comments.php
+++ b/projects/packages/sync/src/modules/class-comments.php
@@ -565,10 +565,12 @@ class Comments extends Module {
 		if ( empty( $comments ) ) {
 			return array();
 		}
+		// Get the comment IDs from the comments that were fetched.
+		$fetched_comment_ids = wp_list_pluck( $comments, 'comment_ID' );
 		return array(
-			'object_ids' => $comment_ids,
+			'object_ids' => $comment_ids, // Still send the original comment IDs since we need them to update the status.
 			'objects'    => $comments,
-			'meta'       => $this->get_metadata( $comment_ids, 'comment', Settings::get_setting( 'comment_meta_whitelist' ) ),
+			'meta'       => $this->get_metadata( $fetched_comment_ids, 'comment', Settings::get_setting( 'comment_meta_whitelist' ) ),
 		);
 	}
 

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -405,13 +405,16 @@ abstract class Module {
 				$status['finished'] = true;
 				return $status;
 			}
-			$key = $this->full_sync_action_name() . '_' . crc32( wp_json_encode( $status['last_sent'] ) );
-
-			$result = $this->send_action( $this->full_sync_action_name(), array( $objects, $status['last_sent'] ), $key );
-			if ( is_wp_error( $result ) || $wpdb->last_error ) {
-				$status['error'] = true;
-				return $status;
+			// If we don't have objects as a key it means get_next_chunk is being overridden, we need to check for it being an empty array.
+			if ( ! isset( $objects['objects'] ) || array() !== $objects['objects'] ) {
+				$key    = $this->full_sync_action_name() . '_' . crc32( wp_json_encode( $status['last_sent'] ) );
+				$result = $this->send_action( $this->full_sync_action_name(), array( $objects, $status['last_sent'] ), $key );
+				if ( is_wp_error( $result ) || $wpdb->last_error ) {
+					$status['error'] = true;
+					return $status;
+				}
 			}
+
 			// Updated the sent and last_sent status.
 			$status = $this->set_send_full_sync_actions_status( $status, $objects );
 			if ( $last_item === $status['last_sent'] ) {

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -405,7 +405,8 @@ abstract class Module {
 				$status['finished'] = true;
 				return $status;
 			}
-			// If we don't have objects as a key it means get_next_chunk is being overridden, we need to check for it being an empty array.
+			// If we have objects as a key it means get_next_chunk is being overridden, we need to check for it being an empty array.
+			// In case it is an empty array, we should not send the action or increase the chunks_sent, we just need to update the status.
 			if ( ! isset( $objects['objects'] ) || array() !== $objects['objects'] ) {
 				$key    = $this->full_sync_action_name() . '_' . crc32( wp_json_encode( $status['last_sent'] ) );
 				$result = $this->send_action( $this->full_sync_action_name(), array( $objects, $status['last_sent'] ), $key );
@@ -413,6 +414,7 @@ abstract class Module {
 					$status['error'] = true;
 					return $status;
 				}
+				++$chunks_sent;
 			}
 
 			// Updated the sent and last_sent status.
@@ -421,7 +423,6 @@ abstract class Module {
 				$status['finished'] = true;
 				return $status;
 			}
-			++$chunks_sent;
 		}
 
 		return $status;

--- a/projects/packages/sync/src/modules/class-posts.php
+++ b/projects/packages/sync/src/modules/class-posts.php
@@ -809,13 +809,12 @@ class Posts extends Module {
 	 * @return array $args The expanded hook parameters.
 	 */
 	public function add_term_relationships( $args ) {
-		list( $filtered_posts, $previous_interval_end )                       = $args;
-		list( $filtered_post_ids, $filtered_posts, $filtered_posts_metadata ) = $filtered_posts;
+		list( $filtered_posts, $previous_interval_end ) = $args;
 
 		return array(
-			$filtered_posts,
-			$filtered_posts_metadata,
-			$this->get_term_relationships( $filtered_post_ids ),
+			$filtered_posts['objects'],
+			$filtered_posts['meta'],
+			$this->get_term_relationships( $filtered_posts['object_ids'] ),
 			$previous_interval_end,
 		);
 	}
@@ -882,9 +881,9 @@ class Posts extends Module {
 		// Filter posts and metadata based on maximum size constraints.
 		list( $filtered_post_ids, $filtered_posts, $filtered_posts_metadata ) = $this->filter_posts_and_metadata_max_size( $posts, $posts_metadata );
 		return array(
-			$filtered_post_ids,
-			$filtered_posts,
-			$filtered_posts_metadata,
+			'object_ids' => $filtered_post_ids,
+			'objects'    => $filtered_posts,
+			'meta'       => $filtered_posts_metadata,
 		);
 	}
 
@@ -964,8 +963,10 @@ class Posts extends Module {
 	 * @return array The updated status.
 	 */
 	public function set_send_full_sync_actions_status( $status, $objects ) {
-		$status['last_sent'] = end( $objects[0] );
-		$status['sent']     += count( $objects[0] );
+
+		$object_ids          = $objects['object_ids'];
+		$status['last_sent'] = end( $object_ids );
+		$status['sent']     += count( $object_ids );
 		return $status;
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/vulcan/issues/656

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When sending full sync actions, get_next_chunk from the module class will try to get a chunk of ids based on [full_sync_limits](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/class-defaults.php#L1325). But even though an array of `object_ids` is returned and the loop to send items for the chunk relies on it, when preparing items to send (e.g. `jetpack_sync_before_send_jetpack_full_sync_comments` [filter](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/modules/class-comments.php#L322)) the number of items to send can be 0. If that is the case, we don't want to send any actions and want to proceed to next chunk.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
### Make sure Full Sync runs as it used to:
With a site with content already ( For example JN with pre-generated content)
- Run a Full Sync. (Either via Debugger or if the site is new and it is just connected, leave it run the initial full sync)
- Check no errors have occurred (both in the remote site as WPCOM)
- Check the content is in WPCOM

### Mark all comments as Spam to not send actions when doing Full Sync
- Mark comments as Spam by running in your site's DB something like  
```
UPDATE `wp_comments` SET `comment_approved` = 'spam' WHERE 1=1;
```
- Run a Full Sync only for comments 
- Ensure no `jetpack_full_sync_comments` actions should have been sent to wpcom by checking ES logs .
- Do the same with trunk and you will see actions sent with no `full_sync_items`


Ideally we should be able to test with posts as well but I was not able to reproduce the same. But there has to be some config for posts that removes them from the elements to send when expanding, since logs show similar issues.
