### PR TITLE
Fix: Remove customiser color styles from the editor.

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-remove-customizer-color-styles-from-the-editor
+++ b/projects/plugins/wpcomsh/changelog/fix-remove-customizer-color-styles-from-the-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix: Remove customiser color styles from the editor.

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -154,18 +154,7 @@ class Colors_Manager_Common {
 			return;
 		}
 
-		if ( self::is_gutenberg() ) {
-			// This will load the annotations.
-			self::has_annotations();
-
-			// CSS only to be printed if colors are set, on the editor.
-			if ( self::theme_has_set_colors() ) {
-				self::override_themecolors();
-
-				// NOTE: Using `get_called_class()` here is crucial for the Gutenberg styles to be processed.
-				add_filter( 'block_editor_settings_all', array( get_called_class(), 'add_block_editor_css' ), 10, 2 );
-			}
-		} else {
+		if ( ! self::is_gutenberg() ) {
 			// Classic Background stats
 			add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_classic_stats' ) );
 			// always load ajax actions
@@ -1480,31 +1469,6 @@ class Colors_Manager_Common {
 			wp_strip_all_tags( $css ), // phpcs:ignore -- CSS can't be properly escaped with esc_html
 			"\n"
 		);
-	}
-
-	/**
-	 * Adds block editor CSS to the block editor settings.
-	 *
-	 * @param array $editor_settings Block editor settings.
-	 */
-	public static function add_block_editor_css( $editor_settings ) {
-		if ( ! self::should_enable_colors() ) {
-			return $editor_settings;
-		}
-
-		$css = self::get_theme_css();
-
-		if ( ! is_array( $editor_settings['styles'] ) ) {
-			$editor_settings['styles'] = array();
-		}
-
-		$editor_settings['styles'] [] = array(
-			'css'            => $css,
-			'__unstableType' => 'theme',
-			'isGlobalStyles' => false,
-		);
-
-		return $editor_settings;
 	}
 
 	/**


### PR DESCRIPTION
Previously, the customizer colors caused issues with the editor UI, as noted in https://github.com/Automattic/themes/issues/7818. This occurred because, although we attempted to load the customizer colors' CSS into the block editor, we were not utilizing the block editor styles API. As a result, the styles affected the editor interface instead of the editor content.

To resolve the issue of the customizer colors disrupting the editor interface, we updated the code to use the block editor styles API, as seen in https://github.com/Automattic/jetpack/pull/41073. This change ensured that the customizer colors no longer impacted the editor interface and instead affected the editor content. While it initially seemed beneficial for the editor to reflect the front-end colors, this approach proved problematic in certain themes, where the background color could differ from the content background color see https://github.com/Automattic/wp-calypso/issues/98569.

For instance, consider a scenario where the site’s background color ( black set using the customizer) differs from the content background color (set to white via theme CSS), with the text color being black (also set via the customizer). In this case, the editor would display a black background with black text, rendering it unusable. The customizer colors would apply correctly with the styles API, but the theme styles would not be used, as the theme does not utilize the styles API.

cc: @mmtr 

Fixes : https://github.com/Automattic/wp-calypso/issues/98569

## Proposed changes

To resolve the issue, we will stop loading the customizer colors in the block editor all. This way, we can still fix https://github.com/Automattic/jetpack/pull/41073 while ensuring the colors do not affect the editor content as they did before.

## Testing Instructions:
1. Enable the Cubic theme.
2. Set a background color in the customizer.
3. Load the editor and verify that the editor background remains white (in the trunk version, it reflects the color selected in the customizer).