### PR TITLE
Fix some missed `${var}` deprecations

### DIFF
--- a/projects/packages/analyzer/.phan/baseline.php
+++ b/projects/packages/analyzer/.phan/baseline.php
@@ -20,7 +20,6 @@ return [
     // PhanTypeArraySuspiciousNullable : 5 occurrences
     // PhanTypeMismatchArgumentNullable : 5 occurrences
     // PhanUndeclaredTypeParameter : 4 occurrences
-    // PhanDeprecatedEncapsVar : 2 occurrences
     // PhanNonClassMethodCall : 2 occurrences
     // PhanPluginDuplicateCatchStatementBody : 2 occurrences
     // PhanTypeMismatchDeclaredParam : 2 occurrences
@@ -36,7 +35,6 @@ return [
         'scripts/core-calls.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchDeclaredParam', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter'],
         'scripts/core-definitions.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchDeclaredParam', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter'],
         'scripts/example.php' => ['PhanTypeMismatchArgumentProbablyReal'],
-        'scripts/jetpack-slurper.php' => ['PhanDeprecatedEncapsVar'],
         'scripts/jetpack-svn.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable'],
         'src/Declarations/class-declaration.php' => ['PhanUndeclaredProperty'],
         'src/Differences/class-class-const-missing.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
@@ -56,7 +54,6 @@ return [
         'src/class-invocations.php' => ['PhanPluginDuplicateCatchStatementBody'],
         'src/class-utils.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter'],
         'src/class-warnings.php' => ['PhanUndeclaredMethod'],
-        'src/diff-generator.php' => ['PhanDeprecatedEncapsVar'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/analyzer/changelog/fix-php-dollar-brace-deprecations
+++ b/projects/packages/analyzer/changelog/fix-php-dollar-brace-deprecations
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Change `${var}` to `{$var}`, as the former is deprecated in php 8.4.
+
+

--- a/projects/packages/analyzer/scripts/jetpack-slurper.php
+++ b/projects/packages/analyzer/scripts/jetpack-slurper.php
@@ -51,7 +51,7 @@ $differences = new Automattic\Jetpack\Analyzer\Differences();
 $differences->find( $jetpack_new_declarations, $jetpack_old_declarations, $jetpack_new_path );
 
 foreach ( glob( $slurper_path . '/*' ) as $folder_name ) {
-	echo "Looking for invocations in:\n${folder_name}\n\n";
+	echo "Looking for invocations in:\n{$folder_name}\n\n";
 	$invocations = new Automattic\Jetpack\Analyzer\Invocations();
 	$invocations->scan( $folder_name );
 

--- a/projects/packages/analyzer/src/diff-generator.php
+++ b/projects/packages/analyzer/src/diff-generator.php
@@ -54,7 +54,7 @@ class Scripts {
 		$warnings_folder = dirname( __DIR__ ) . '/output/warnings/';
 		$invocations_folder = dirname( __DIR__ ) . '/output/invocations/';
 
-		echo "Looking for invocations in:\n${folder_name}\n\n";
+		echo "Looking for invocations in:\n{$folder_name}\n\n";
 		$invocations = new Invocations();
 		$invocations->scan( $folder_name, $excludes );
 		$invocations->save( $invocations_folder . basename( $folder_name ) . '.json', false );

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-php-dollar-brace-deprecations
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-php-dollar-brace-deprecations
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Change `${var}` to `{$var}`, as the former is deprecated in php 8.4.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css/preprocessors/lessc.inc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css/preprocessors/lessc.inc.php
@@ -1296,7 +1296,7 @@ class lessc {
 					$name = $name . ": ";
 				}
 
-				$this->throwError("${name}expecting $expectedArgs arguments, got $numValues");
+				$this->throwError("{$name}expecting $expectedArgs arguments, got $numValues");
 			}
 
 			return $values;
@@ -1646,7 +1646,7 @@ class lessc {
 		}
 
 		// type based operators
-		$fname = "op_${ltype}_${rtype}";
+		$fname = "op_{$ltype}_{$rtype}";
 		if (is_callable(array($this, $fname))) {
 			$out = $this->$fname($op, $left, $right);
 			if (!is_null($out)) return $out;

--- a/projects/plugins/beta/changelog/fix-php-dollar-brace-deprecations
+++ b/projects/plugins/beta/changelog/fix-php-dollar-brace-deprecations
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Change `${var}` to `{$var}`, as the former is deprecated in php 8.4.
+
+

--- a/projects/plugins/beta/src/class-autoupdateself.php
+++ b/projects/plugins/beta/src/class-autoupdateself.php
@@ -162,7 +162,7 @@ class AutoupdateSelf {
 	 * when an update is available. This is the way: catch the setting of the relevant
 	 * transient and add ourself in.
 	 *
-	 * @todo Consider switching to the `update_plugins_${hostmane}` hook introduced in WP 5.8.
+	 * @todo Consider switching to the `update_plugins_{$hostname}` hook introduced in WP 5.8.
 	 *
 	 * @param object $transient The transient we're checking.
 	 * @return object $transient


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Two in packages/analyzer, which disables all phpcompatibility sniffs.

One in a file in jetpack-mu-wpcom which has `phpcs:disable` at the top.

And one in a comment in plugins/beta, because why not.

The rest I found while grepping seem to be inside single-quoted strings or in embedded JS code.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. Saw one of these paths flagged in a wpcom PR while looking at something else.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* 🤷 Should continue to work as before.