### PR TITLE
Fix Jetpack Google Fonts rendering in classic themes

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-google-fonts-in-classic-themes
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-google-fonts-in-classic-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix the rendering of jetpack google fonts font faces for classic themes.

--- a/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
@@ -27,7 +27,12 @@ class Jetpack_Google_Font_Face {
 		add_action( 'current_screen', array( $this, 'current_screen' ), 10 );
 
 		// Collect and print fonts in use
-		add_action( 'wp_head', array( $this, 'print_font_faces' ), 50 );
+		if ( wp_is_block_theme() ) {
+			add_action( 'wp_head', array( $this, 'print_font_faces' ), 50 );
+		} else {
+			// In classic themes wp_head runs before the blocks are processed to collect the block fonts.
+			add_action( 'wp_footer', array( $this, 'print_font_faces' ), 50 );
+		}
 		add_filter( 'pre_render_block', array( $this, 'collect_block_fonts' ), 10, 2 );
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/Automattic/jetpack/issues/41189

## Proposed changes:
Hook the print of the font face CSS of fonts used in classic themes in the footer instead of the in header.
In Classic themes the order of the hooks doesn't work the same as in block themes.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Follow the reproduction steps listed in https://github.com/Automattic/jetpack/issues/41189