### PR TITLE
Fix/bug with critical error when main jetpack plugin not installed

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-bug-with-critical-error-when-main-jetpack-plugin-not-installed
+++ b/projects/packages/my-jetpack/changelog/fix-bug-with-critical-error-when-main-jetpack-plugin-not-installed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix bug where My Jetpack would throw critical error if only a standalone plugin is not installed

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -240,6 +240,13 @@ class Initializer {
 		$waf_config    = array();
 		$waf_supported = false;
 
+		$sandboxed_domain = '';
+		$is_dev_version   = false;
+		if ( class_exists( 'Jetpack' ) ) {
+			$is_dev_version   = Jetpack::is_development_version();
+			$sandboxed_domain = defined( 'JETPACK__SANDBOX_DOMAIN' ) ? JETPACK__SANDBOX_DOMAIN : '';
+		}
+
 		if ( class_exists( 'Automattic\Jetpack\Waf\Waf_Runner' ) ) {
 			$waf_config    = Waf_Runner::get_config();
 			$waf_supported = Waf_Runner::is_supported_environment();
@@ -292,8 +299,8 @@ class Initializer {
 				'isStatsModuleActive'    => $modules->is_active( 'stats' ),
 				'isUserFromKnownHost'    => self::is_user_from_known_host(),
 				'isCommercial'           => self::is_commercial_site(),
-				'sandboxedDomain'        => JETPACK__SANDBOX_DOMAIN,
-				'isDevVersion'           => Jetpack::is_development_version(),
+				'sandboxedDomain'        => $sandboxed_domain,
+				'isDevVersion'           => $is_dev_version,
 				'isAtomic'               => ( new Status_Host() )->is_woa_site(),
 				'jetpackManage'          => array(
 					'isEnabled'       => Jetpack_Manage::could_use_jp_manage(),


### PR DESCRIPTION
## Proposed changes:

* Check that the main plugin is installed before checking the sandboxed domain or whether or not a development version of the plugin is being used

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Install only a Standalone plugin (ex. Protect)
3. Go to `My Jetpack` and ensure the page loads okay
![image](https://github.com/user-attachments/assets/b41c0775-3e70-4296-9902-8de9b209d659)

This does mean that the options reset and the sandboxed API tag will only be shown if the main jetpack plugin is installed, but I think that is okay as it's only for developers and matches the functionality on the Dashboard (the Dashboard only shows up with the main Jetpack plugin installed, not for any of the standalone plugins. Therefore you only ever saw the Sandboxed tag or reset options with the Jetpack plugin installed anyway)

