### PR TITLE
Jetpack button: implement outline style

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-form-submit-button-outline
+++ b/projects/plugins/jetpack/changelog/fix-form-submit-button-outline
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack button: implement outline style

--- a/projects/plugins/jetpack/extensions/blocks/button/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/button/editor.scss
@@ -1,6 +1,12 @@
 .wp-block[data-type='jetpack/button'] {
 	display: inline-block;
 	margin: 0 auto;
+
+	&.is-style-outline > .wp-block-button__link {
+		background-color: transparent;
+		border: solid 1px currentColor;
+		color: currentColor;
+	}
 }
 
 .wp-block[data-align="center"] {

--- a/projects/plugins/jetpack/extensions/blocks/button/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/button/view.scss
@@ -3,6 +3,11 @@
 }
 
 .wp-block-jetpack-button {
+	&.is-style-outline > .wp-block-button__link {
+		background-color: transparent;
+		border: solid 1px currentColor;
+		color: currentColor;
+	}
 	&:not(.is-style-outline) button {
 		border: none;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/40432

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR implements the Outline style of the Jetpack Button.
<img width="400" alt="Screenshot 2025-01-20 at 5 06 43 PM" src="https://github.com/user-attachments/assets/1b6fc74c-c99b-4cb7-a8fb-370a92654c51" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test Jetpack site
- Create a new post
- Add a Contact Form
- Select the submit button
- In the Styles panel (see screenshot above), select Outline
- Notice the style is properly applied in both the editor and front end

