### PR TITLE
Fix/form radio button missing div

### DIFF
--- a/projects/packages/forms/changelog/fix-form-radio-button-missing-div
+++ b/projects/packages/forms/changelog/fix-form-radio-button-missing-div
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Adds missing deprecation for checkboxes and radio fields

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -1,3 +1,4 @@
+import { InnerBlocks } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { Path, Icon } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
@@ -594,7 +595,14 @@ export const childBlocks = [
 		name: JetpackFieldSingleChoice.name,
 		settings: mergeSettings( FieldDefaults, {
 			...JetpackFieldSingleChoice.settings,
-			deprecated: [ multiFieldV1( 'radio' ) ],
+			deprecated: [
+				{
+					save() {
+						return <InnerBlocks.Content />;
+					},
+				},
+				multiFieldV1( 'radio' ),
+			],
 		} ),
 	},
 	JetpackFieldSingleChoiceItem,
@@ -602,7 +610,14 @@ export const childBlocks = [
 		name: JetpackFieldMultipleChoice.name,
 		settings: mergeSettings( FieldDefaults, {
 			...JetpackFieldMultipleChoice.settings,
-			deprecated: [ multiFieldV1( 'checkbox' ) ],
+			deprecated: [
+				{
+					save() {
+						return <InnerBlocks.Content />;
+					},
+				},
+				multiFieldV1( 'checkbox' ),
+			],
 		} ),
 	},
 	JetpackFieldMultipleChoiceItem,

--- a/projects/plugins/jetpack/changelog/fix-form-radio-button-missing-div
+++ b/projects/plugins/jetpack/changelog/fix-form-radio-button-missing-div
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Seems like a minor bug fix
+
+


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/41059

## Proposed changes:
* This PR fixes the 41059 by adding a deprecation. So that content that doesn't have the <div> wrapper gets converted as expected. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Load this PR. 
* Create a new post and navigate to the code editor. 
* Add the content found in 36b0d-pb/raw/ in the code editor. 
* Switch to the block editor. Notice that the form appears as expected.