### PR TITLE
Forms: Prevent empty string values in block attributes for field styles 

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-clean-up-empty-style-attributes
+++ b/projects/packages/forms/changelog/fix-forms-clean-up-empty-style-attributes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Prevent empty style values within form field block attributes

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -44,7 +44,7 @@ const JetpackFieldControls = ( {
 			const parsedValue = parse( value, 10 );
 
 			setAttributes( {
-				[ key ]: ! isNaN( parsedValue ) ? parsedValue : '',
+				[ key ]: ! isNaN( parsedValue ) ? parsedValue : undefined,
 			} );
 		};
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/41204

## Proposed changes:

* Changes fall back for non-numerical style values from empty string to undefined. 
* This avoids empty strings being saved within the block attributes and therefore the block comment delimiter.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?

No changes to data or activity we track.

## Testing instructions:

1. On trunk, add a contact form to a post
2. Select a field, expand the label styles panel, and set values for font size, line height etc
3. Switch to the code editor view and note the empty string values in the block attributes
4. Checkout this PR branch
5. Repeat the process however this time the empty style values will be omitted from the block attributes

#### Before

```html
<!-- wp:jetpack/contact-form {"align":"wide","style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}},"color":{"background":"#f6f6f6"}}} -->
<div class="wp-block-jetpack-contact-form alignwide has-background" style="background-color:#f6f6f6;padding-top:16px;padding-right:16px;padding-bottom:16px;padding-left:16px"><!-- wp:heading -->
<h2 class="wp-block-heading">Test Contact Form</h2>
<!-- /wp:heading -->

<!-- wp:jetpack/field-name {"required":true,"labelFontSize":"","labelLineHeight":""} /-->

<!-- wp:jetpack/field-email {"required":true,"labelFontSize":"","labelLineHeight":""} /-->

<!-- wp:jetpack/field-textarea {"label":"Message","labelFontSize":"","labelLineHeight":""} /-->

<!-- wp:jetpack/button {"element":"button","text":"Contact Us","lock":{"remove":true},"className":"is-style-outline"} /--></div>
<!-- /wp:jetpack/contact-form -->
```

#### After

```html
<!-- wp:jetpack/contact-form {"align":"wide","style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}},"color":{"background":"#f6f6f6"}}} -->
<div class="wp-block-jetpack-contact-form alignwide has-background" style="background-color:#f6f6f6;padding-top:16px;padding-right:16px;padding-bottom:16px;padding-left:16px"><!-- wp:heading -->
<h2 class="wp-block-heading">Test Contact Form</h2>
<!-- /wp:heading -->

<!-- wp:jetpack/field-name {"required":true} /-->

<!-- wp:jetpack/field-email {"required":true} /-->

<!-- wp:jetpack/field-textarea {"label":"Message"} /-->

<!-- wp:jetpack/button {"element":"button","text":"Contact Us","lock":{"remove":true},"className":"is-style-outline"} /--></div>
<!-- /wp:jetpack/contact-form -->
```
