### PR TITLE
Forms: allow disabling email notifications after submission

### DIFF
--- a/projects/packages/forms/changelog/forms-allow-disabling-email-notifications
+++ b/projects/packages/forms/changelog/forms-allow-disabling-email-notifications
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: allow disabling email notifcations after submission

--- a/projects/packages/forms/src/blocks/contact-form/attributes.js
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.js
@@ -9,6 +9,10 @@ export default {
 		type: 'string',
 		default: window.jpFormsBlocks?.defaults?.to || '',
 	},
+	sendEmailOnSubmission: {
+		type: 'boolean',
+		default: window.jpFormsBlocks?.defaults?.sendEmailOnSubmission ?? true,
+	},
 	customThankyou: {
 		type: 'string',
 		default: '',

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -173,8 +173,9 @@ class Contact_Form_Block {
 
 		$data = array(
 			'defaults' => array(
-				'to'      => wp_get_current_user()->user_email,
-				'subject' => '[' . get_bloginfo( 'name' ) . ']' . ( isset( $post ) ? ' ' . esc_html( $post->post_title ) : '' ),
+				'to'                    => wp_get_current_user()->user_email,
+				'subject'               => '[' . get_bloginfo( 'name' ) . ']' . ( isset( $post ) ? ' ' . esc_html( $post->post_title ) : '' ),
+				'sendEmailOnSubmission' => apply_filters( 'grunion_should_send_email', true ),
 			),
 		);
 

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -175,7 +175,7 @@ class Contact_Form_Block {
 			'defaults' => array(
 				'to'                    => wp_get_current_user()->user_email,
 				'subject'               => '[' . get_bloginfo( 'name' ) . ']' . ( isset( $post ) ? ' ' . esc_html( $post->post_title ) : '' ),
-				'sendEmailOnSubmission' => apply_filters( 'grunion_should_send_email', true ),
+				'sendEmailOnSubmission' => apply_filters( 'grunion_should_send_email', true, null ),
 			),
 		);
 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-email-connection-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-email-connection-settings.js
@@ -89,11 +89,14 @@ const JetpackEmailConnectionSettings = ( {
 		<>
 			<ToggleControl
 				checked={ !! sendEmailOnSubmission }
-				label={ __( 'Enable email notifications', 'jetpack-forms' ) }
+				label={ __( 'Receive email notifications', 'jetpack-forms' ) }
 				onChange={ newValue => {
 					setAttributes( { sendEmailOnSubmission: newValue } );
 				} }
-				help={ __( 'Get incoming form responses sent to your email inbox.', 'jetpack-forms' ) }
+				help={ __(
+					'Disable this option if you do not want to receive email notifications when the form is submitted.',
+					'jetpack-forms'
+				) }
 			/>
 			{ sendEmailOnSubmission && (
 				<>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-email-connection-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-email-connection-settings.js
@@ -1,9 +1,8 @@
-import { TextControl } from '@wordpress/components';
+import { TextControl, ToggleControl } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import emailValidator from 'email-validator';
 import HelpMessage from '../components/help-message';
-import InspectorHint from '../components/inspector-hint';
 
 const JetpackEmailConnectionSettings = ( {
 	emailAddress = '',
@@ -11,6 +10,7 @@ const JetpackEmailConnectionSettings = ( {
 	instanceId,
 	setAttributes,
 	postAuthorEmail,
+	sendEmailOnSubmission,
 } ) => {
 	const [ emailErrors, setEmailErrors ] = useState( false );
 
@@ -87,44 +87,51 @@ const JetpackEmailConnectionSettings = ( {
 
 	return (
 		<>
-			<InspectorHint>
-				{ __( 'Get incoming form responses sent to your email inbox:', 'jetpack-forms' ) }
-			</InspectorHint>
-			<TextControl
-				aria-describedby={ `contact-form-${ instanceId }-email-${
-					hasEmailErrors() ? 'error' : 'help'
-				}` }
-				label={ __( 'Email address to send to', 'jetpack-forms' ) }
-				placeholder={ __( 'name@example.com', 'jetpack-forms' ) }
-				onKeyDown={ e => {
-					if ( event.key === 'Enter' ) {
-						e.preventDefault();
-						e.stopPropagation();
-					}
+			<ToggleControl
+				checked={ !! sendEmailOnSubmission }
+				label={ __( 'Enable email notifications', 'jetpack-forms' ) }
+				onChange={ newValue => {
+					setAttributes( { sendEmailOnSubmission: newValue } );
 				} }
-				value={ emailAddress }
-				onBlur={ onBlurEmailField }
-				onChange={ onChangeEmailField }
-				help={ __(
-					'You can enter multiple email addresses separated by commas.',
-					'jetpack-forms'
-				) }
-				__nextHasNoMarginBottom={ true }
-				__next40pxDefaultSize={ true }
+				help={ __( 'Get incoming form responses sent to your email inbox.', 'jetpack-forms' ) }
 			/>
-
-			<HelpMessage isError id={ `contact-form-${ instanceId }-email-error` }>
-				{ getEmailErrors() }
-			</HelpMessage>
-
-			<TextControl
-				label={ __( 'Email subject line', 'jetpack-forms' ) }
-				value={ emailSubject }
-				placeholder={ __( 'Enter a subject', 'jetpack-forms' ) }
-				onChange={ newSubject => setAttributes( { subject: newSubject } ) }
-				__nextHasNoMarginBottom={ true }
-				__next40pxDefaultSize={ true }
-			/>
+			{ sendEmailOnSubmission && (
+				<>
+					<TextControl
+						aria-describedby={ `contact-form-${ instanceId }-email-${
+							hasEmailErrors() ? 'error' : 'help'
+						}` }
+						label={ __( 'Email address to send to', 'jetpack-forms' ) }
+						placeholder={ __( 'name@example.com', 'jetpack-forms' ) }
+						onKeyDown={ e => {
+							if ( event.key === 'Enter' ) {
+								e.preventDefault();
+								e.stopPropagation();
+							}
+						} }
+						value={ emailAddress }
+						onBlur={ onBlurEmailField }
+						onChange={ onChangeEmailField }
+						help={ __(
+							'You can enter multiple email addresses separated by commas.',
+							'jetpack-forms'
+						) }
+						__nextHasNoMarginBottom={ true }
+						__next40pxDefaultSize={ true }
+					/>
+					<HelpMessage isError id={ `contact-form-${ instanceId }-email-error` }>
+						{ getEmailErrors() }
+					</HelpMessage>
+					<TextControl
+						label={ __( 'Email subject line', 'jetpack-forms' ) }
+						value={ emailSubject }
+						placeholder={ __( 'Enter a subject', 'jetpack-forms' ) }
+						onChange={ newSubject => setAttributes( { subject: newSubject } ) }
+						__nextHasNoMarginBottom={ true }
+						__next40pxDefaultSize={ true }
+					/>
+				</>
+			) }
 		</>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -95,6 +95,7 @@ export const JetpackContactFormEdit = forwardRef(
 		const {
 			to,
 			subject,
+			sendEmailOnSubmission,
 			customThankyou,
 			customThankyouHeading,
 			customThankyouMessage,
@@ -313,6 +314,7 @@ export const JetpackContactFormEdit = forwardRef(
 								emailSubject={ subject }
 								instanceId={ instanceId }
 								postAuthorEmail={ postAuthorEmail }
+								sendEmailOnSubmission={ sendEmailOnSubmission }
 								setAttributes={ setAttributes }
 							/>
 						</PanelBody>

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1227,7 +1227,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// Is it spam?
 		/** This filter is already documented in \Automattic\Jetpack\Forms\ContactForm\Admin */
 		$is_spam = apply_filters( 'jetpack_contact_form_is_spam', false, $akismet_values );
-		$is_spam = false;
 		if ( is_wp_error( $is_spam ) ) { // WP_Error to abort
 			return $is_spam; // abort
 		} elseif ( $is_spam === true ) {  // TRUE to flag a spam

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -153,6 +153,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'hiddenFields'           => null,
 		);
 
+		if ( isset( $attributes['sendEmailOnSubmission'] ) ) {
+			$this->defaults['sendEmailOnSubmission'] = $attributes['sendEmailOnSubmission'];
+		}
+
 		$attributes = shortcode_atts( $this->defaults, $attributes, 'contact-form' );
 
 		// We only enable the contact-field shortcode temporarily while processing the contact-form shortcode.
@@ -1223,6 +1227,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// Is it spam?
 		/** This filter is already documented in \Automattic\Jetpack\Forms\ContactForm\Admin */
 		$is_spam = apply_filters( 'jetpack_contact_form_is_spam', false, $akismet_values );
+		$is_spam = false;
 		if ( is_wp_error( $is_spam ) ) { // WP_Error to abort
 			return $is_spam; // abort
 		} elseif ( $is_spam === true ) {  // TRUE to flag a spam
@@ -1547,9 +1552,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		if ( $is_spam !== true ) {
 			// We first need to check if `sendEmailOnSubmission` prop is set and prioritize that.
-			$send_email_on_submission = $this->attributes['sendEmailOnSubmission'];
-			if ( isset( $send_email_on_submission ) ) {
-				if ( $send_email_on_submission ) {
+			if ( isset( $this->attributes['sendEmailOnSubmission'] ) ) {
+				if ( $this->attributes['sendEmailOnSubmission'] ) {
+					$message .= 'other flow';
 					self::wp_mail( $to, "{$spam}{$subject}", $message, $headers );
 				}
 			} elseif (
@@ -1561,8 +1566,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 				 * @since 2.6.0
 				 *
 				 * @param bool true Should an email be sent after a form submission. Default to true.
+				 * @param int $post_id Post ID.
 				 */
-				true === apply_filters( 'grunion_should_send_email', true ) ) {
+				true === apply_filters( 'grunion_should_send_email', true, $post_id ) ) {
 				self::wp_mail( $to, "{$spam}{$subject}", $message, $headers );
 			}
 		} elseif (

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1545,23 +1545,27 @@ class Contact_Form extends Contact_Form_Shortcode {
 			wp_schedule_event( time() + 250, 'daily', 'grunion_scheduled_delete' );
 		}
 
-		if (
-			$is_spam !== true &&
-			/**
-			 * Filter to choose whether an email should be sent after each successful contact form submission.
-			 *
-			 * @module contact-form
-			 *
-			 * @since 2.6.0
-			 *
-			 * @param bool true Should an email be sent after a form submission. Default to true.
-			 * @param int $post_id Post ID.
-			 */
-			true === apply_filters( 'grunion_should_send_email', true, $post_id )
-		) {
-			self::wp_mail( $to, "{$spam}{$subject}", $message, $headers );
+		if ( $is_spam !== true ) {
+			// We first need to check if `sendEmailOnSubmission` prop is set and prioritize that.
+			$send_email_on_submission = $this->attributes['sendEmailOnSubmission'];
+			if ( isset( $send_email_on_submission ) ) {
+				if ( $send_email_on_submission ) {
+					self::wp_mail( $to, "{$spam}{$subject}", $message, $headers );
+				}
+			} elseif (
+				/**
+				 * Filter to choose whether an email should be sent after each successful contact form submission.
+				 *
+				 * @module contact-form
+				 *
+				 * @since 2.6.0
+				 *
+				 * @param bool true Should an email be sent after a form submission. Default to true.
+				 */
+				true === apply_filters( 'grunion_should_send_email', true ) ) {
+				self::wp_mail( $to, "{$spam}{$subject}", $message, $headers );
+			}
 		} elseif (
-			true === $is_spam &&
 			/**
 			 * Choose whether an email should be sent for each spam contact form submission.
 			 *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves https://github.com/Automattic/jetpack/issues/31850
Resolves FORMS-221

This PR adds a new block attribute to send an email notification after form submission or not. It first checks if this attribute is set and if it is, it takes precedence over the [grunion_should_send_email](https://developer.jetpack.com/hooks/grunion_should_send_email/) filter.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Testing instructions:

**Notes**
This PR could also use this PR too 170538-ghe-Automattic/wpcom

1. Insert a form and go to `Email Connection` panel in Inspector controls
2. Observe that the default value for enabling email is honored ( `grunion_should_send_email` filter  which defaults to `true`).
3. Update this setting for a specific form and test email notifications.
4. Also test the same after adding `add_filter( 'grunion_should_send_email', '__return_false' );` somewhere in your code.


<img width="849" alt="Screenshot 2025-01-21 at 9 08 10 AM" src="https://github.com/user-attachments/assets/443f1339-c8fd-452e-ad80-866ebfe00125" />