### PR TITLE
Show `Site Address` & `WordPress Address` on Simple Classic

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-siteurl-on-simple
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-siteurl-on-simple
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Show Site Address & WordPress Address on Simple

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -156,6 +156,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php';
 		require_once __DIR__ . '/features/wpcom-profile-settings/profile-settings-notices.php';
 		require_once __DIR__ . '/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php';
+		require_once __DIR__ . '/features/wpcom-siteurl/siteurl.php';
 		require_once __DIR__ . '/features/wpcom-themes/wpcom-themes.php';
 
 		// Only load the Calypsoify and Masterbar features on WoA sites.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-siteurl/siteurl.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-siteurl/siteurl.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Display the site URL in General Settings on Simple Classic sites.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+/**
+ * Enqueues the site URL script and localizes script data for General Settings.
+ */
+function wpcom_add_siteurl_to_general_settings() {
+	if ( ! class_exists( 'Automattic\Jetpack\Status\Host' ) ) {
+		return;
+	}
+
+	$asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-siteurl/wpcom-siteurl.asset.php';
+	wp_enqueue_script(
+		'wpcom-siteurl',
+		plugins_url( 'build/wpcom-siteurl/wpcom-siteurl.js', Jetpack_Mu_Wpcom::BASE_FILE ),
+		$asset_file['dependencies'] ?? array(),
+		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-siteurl/wpcom-siteurl.js' ),
+		true
+	);
+
+	$site_slug           = wpcom_get_site_slug();
+	$options_general_url = admin_url( 'options-general.php' );
+	wp_add_inline_script(
+		'wpcom-siteurl',
+		'window.wpcomSiteUrl = ' . wp_json_encode(
+			array(
+				'siteUrl'           => get_option( 'siteurl' ),
+				'homeUrl'           => get_option( 'home' ),
+				'siteSlug'          => $site_slug,
+				'optionsGeneralUrl' => $options_general_url,
+			)
+		) . ';',
+		'before'
+	);
+}
+add_action( 'load-options-general.php', 'wpcom_add_siteurl_to_general_settings' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-siteurl/siteurl.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-siteurl/siteurl.ts
@@ -22,9 +22,10 @@ const wpcomAddSiteUrl = () => {
 
 	// Create the Site Address (URL) row
 	if ( ! document.getElementById( 'home' ) ) {
+		const homeUrlLabel = __( 'Site Address (URL)', 'jetpack-mu-wpcom' );
 		const homeUrlRow = document.createElement( 'tr' );
 		homeUrlRow.innerHTML = `
-					<th scope="row"><label for="home">Site Address (URL)</label></th>
+					<th scope="row"><label for="home">${ homeUrlLabel }</label></th>
 					<td><input type="url" id="home" value="${ window.wpcomSiteUrl.homeUrl }" class="regular-text code disabled" disabled="disabled" /></td>
 			`;
 		// On UI, `Site Address (URL)` is rendered after `WordPress Address (URL)`
@@ -33,9 +34,10 @@ const wpcomAddSiteUrl = () => {
 
 	// Create the WordPress Address (URL) row
 	if ( ! document.getElementById( 'siteurl' ) ) {
+		const siteUrlLabel = __( 'WordPress Address (URL)', 'jetpack-mu-wpcom' );
 		const siteUrlRow = document.createElement( 'tr' );
 		siteUrlRow.innerHTML = `
-				<th scope="row"><label for="siteurl">WordPress Address (URL)</label></th>
+				<th scope="row"><label for="siteurl">${ siteUrlLabel }</label></th>
 				<td><input type="url" id="siteurl" value="${ window.wpcomSiteUrl.siteUrl }" class="regular-text code disabled" disabled="disabled" /></td>
 		`;
 		settingsTable.insertBefore( siteUrlRow, previousSibling.nextSibling );
@@ -61,7 +63,7 @@ function wpcomAddDomainSettingsLinks() {
 	const domainSettingsLink = document.createElement( 'p' );
 	domainSettingsLink.className = 'description';
 	domainSettingsLink.innerHTML = sprintf(
-		// translators: %s: site slug
+		// translators: %1$s is the site slug, %2$s is the URL to the General Settings page.
 		__(
 			'Buy a <a href="https://wordpress.com/domains/add/%1$s?redirect_to=%2$s">custom domain</a>, ' +
 				'<a href="https://wordpress.com/domains/add/mapping/%1$s?redirect_to=%2$s">map</a> a domain you already own, ' +

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-siteurl/siteurl.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-siteurl/siteurl.ts
@@ -1,0 +1,82 @@
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Adds the Site Address (URL) and WordPress Address (URL) input fields to the General Settings page on Simple sites.
+ */
+const wpcomAddSiteUrl = () => {
+	if ( typeof window.wpcomSiteUrl === 'undefined' ) {
+		return;
+	}
+
+	const settingsTable = document.querySelector( 'table.form-table tbody' );
+	if ( ! settingsTable ) {
+		return;
+	}
+
+	const previousSibling =
+		settingsTable.querySelector( '.site-icon-section' ) ||
+		settingsTable.querySelectorAll( 'tr' )[ 1 ];
+	if ( ! previousSibling ) {
+		return;
+	}
+
+	// Create the Site Address (URL) row
+	if ( ! document.getElementById( 'home' ) ) {
+		const homeUrlRow = document.createElement( 'tr' );
+		homeUrlRow.innerHTML = `
+					<th scope="row"><label for="home">Site Address (URL)</label></th>
+					<td><input type="url" id="home" value="${ window.wpcomSiteUrl.homeUrl }" class="regular-text code disabled" disabled="disabled" /></td>
+			`;
+		// On UI, `Site Address (URL)` is rendered after `WordPress Address (URL)`
+		settingsTable.insertBefore( homeUrlRow, previousSibling.nextSibling );
+	}
+
+	// Create the WordPress Address (URL) row
+	if ( ! document.getElementById( 'siteurl' ) ) {
+		const siteUrlRow = document.createElement( 'tr' );
+		siteUrlRow.innerHTML = `
+				<th scope="row"><label for="siteurl">WordPress Address (URL)</label></th>
+				<td><input type="url" id="siteurl" value="${ window.wpcomSiteUrl.siteUrl }" class="regular-text code disabled" disabled="disabled" /></td>
+		`;
+		settingsTable.insertBefore( siteUrlRow, previousSibling.nextSibling );
+	}
+};
+
+/**
+ * Adds domain settings links under the site URL input fields both on Simple and Atomic sites.
+ */
+function wpcomAddDomainSettingsLinks() {
+	const settingsTable = document.querySelector( 'table.form-table tbody' );
+	if ( ! settingsTable ) {
+		return;
+	}
+
+	const previousSibling =
+		( document.getElementById( 'home' ) as HTMLInputElement ) ||
+		( document.getElementById( 'siteurl' ) as HTMLInputElement );
+	if ( ! previousSibling ) {
+		return;
+	}
+
+	const domainSettingsLink = document.createElement( 'p' );
+	domainSettingsLink.className = 'description';
+	domainSettingsLink.innerHTML = sprintf(
+		// translators: %s: site slug
+		__(
+			'Buy a <a href="https://wordpress.com/domains/add/%1$s?redirect_to=%2$s">custom domain</a>, ' +
+				'<a href="https://wordpress.com/domains/add/mapping/%1$s?redirect_to=%2$s">map</a> a domain you already own, ' +
+				'or <a href="https://wordpress.com/domains/add/site-redirect/%1$s?redirect_to=%2$s">redirect</a> this site.' +
+				' <a href="https://wordpress.com/domains/manage/%1$s/edit/%1$s">You can change your site address in Domain Settings</a>.',
+			'jetpack-mu-wpcom'
+		),
+		window.wpcomSiteUrl.siteSlug,
+		window.wpcomSiteUrl.optionsGeneralUrl
+	);
+
+	previousSibling.parentElement?.appendChild( domainSettingsLink );
+}
+
+document.addEventListener( 'DOMContentLoaded', function () {
+	wpcomAddSiteUrl();
+	wpcomAddDomainSettingsLinks();
+} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-siteurl/types.d.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-siteurl/types.d.ts
@@ -1,0 +1,12 @@
+declare global {
+	interface Window {
+		wpcomSiteUrl: {
+			siteUrl: string;
+			homeUrl: string;
+			siteSlug: string;
+			optionsGeneralUrl: string;
+		};
+	}
+}
+
+export {};

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -52,6 +52,7 @@ module.exports = [
 			'wpcom-profile-settings-link-to-wpcom':
 				'./src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts',
 			'wpcom-sidebar-notice': './src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.js',
+			'wpcom-siteurl': './src/features/wpcom-siteurl/siteurl.js',
 			'starter-page-templates': './src/features/starter-page-templates/index.tsx',
 			'removed-calypso-screen-notice':
 				'./src/features/wpcom-admin-interface/removed-calypso-screen-notice.tsx',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/98187

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR changes to show `Site Address` & `WordPress Address` on Simple Classic.

|| before | after |
|--------|--------|--------|
| Simple Classic | <img width="1246" alt="Screenshot 2025-01-21 at 16 25 43" src="https://github.com/user-attachments/assets/00bd8572-1a7f-47fe-90e5-d07c2f75f4d8" /> | <img width="1240" alt="Screenshot 2025-01-21 at 16 25 11" src="https://github.com/user-attachments/assets/e387f76f-835f-4d33-bcb7-9e2c002c3525" /> |
| Atomic Classic | <img width="639" alt="Screenshot 2025-01-21 at 16 39 28" src="https://github.com/user-attachments/assets/73e8fd46-642c-4c58-8445-a678f59947be" /> | <img width="1081" alt="Screenshot 2025-01-21 at 16 37 41" src="https://github.com/user-attachments/assets/82daf7b0-354e-4c40-923f-1ce10c2492a5" /> | 

See https://github.com/Automattic/wp-calypso/issues/98187 for the links' copy. 

---
I tried to think whether we could achieve this in a "Core way", but I don’t believe we have sufficient justification for modifying this line: https://github.com/WordPress/wordpress-develop/blob/4dafd584c91524f0cfd743f728d5f334df761e11/src/wp-admin/options-general.php#L230.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Simple Classic
* Go to /wp-admin/options-general.php
* Observe the settings (and you cannot update them)
* Observe the links work properly 

Atomic Classic
* Go to /wp-admin/options-general.php
* Observe the links work properly 
