### PR TITLE
Revert "Social | Improve and fix TS types for connection actions and selectors"

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-improve-types-for-connection-actions-and-selectors
+++ b/projects/js-packages/publicize-components/changelog/update-social-improve-types-for-connection-actions-and-selectors
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Improved TS types for connection actions and selectors
-
-

--- a/projects/js-packages/publicize-components/src/social-store/actions/connection-data.ts
+++ b/projects/js-packages/publicize-components/src/social-store/actions/connection-data.ts
@@ -4,7 +4,7 @@ import { dispatch as coreDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { getSocialScriptData } from '../../utils/script-data';
-import { Connection, KeyringResult } from '../types';
+import { Connection } from '../types';
 import {
 	ADD_CONNECTION,
 	DELETE_CONNECTION,
@@ -23,10 +23,10 @@ import {
 
 /**
  * Set connections list
- * @param connections - list of connections
- * @return An action object.
+ * @param {Array<import('../types').Connection>} connections - list of connections
+ * @return {object} - an action object.
  */
-export function setConnections( connections: Array< Connection > ) {
+export function setConnections( connections ) {
 	return {
 		type: SET_CONNECTIONS,
 		connections,
@@ -36,11 +36,11 @@ export function setConnections( connections: Array< Connection > ) {
 /**
  * Set keyring result
  *
- * @param keyringResult - keyring result
+ * @param {import('../types').KeyringResult} [keyringResult] - keyring result
  *
- * @return An action object.
+ * @return {object} - an action object.
  */
-export function setKeyringResult( keyringResult?: KeyringResult ) {
+export function setKeyringResult( keyringResult ) {
 	return {
 		type: SET_KEYRING_RESULT,
 		keyringResult,
@@ -49,10 +49,10 @@ export function setKeyringResult( keyringResult?: KeyringResult ) {
 
 /**
  * Add connection to the list
- * @param connection - connection object
- * @return An action object.
+ * @param {import('../types').Connection} connection - connection object
+ * @return {object} - an action object.
  */
-export function addConnection( connection: Partial< Connection > ) {
+export function addConnection( connection ) {
 	return {
 		type: ADD_CONNECTION,
 		connection,
@@ -61,11 +61,11 @@ export function addConnection( connection: Partial< Connection > ) {
 
 /**
  * Toggle connection enable status.
- * @param connectionId - Connection ID to switch.
+ * @param {string} connectionId - Connection ID to switch.
  *
- * @return Switch connection enable-status action.
+ * @return {object} Switch connection enable-status action.
  */
-export function toggleConnection( connectionId: string ) {
+export function toggleConnection( connectionId ) {
 	return {
 		type: TOGGLE_CONNECTION,
 		connectionId,
@@ -74,13 +74,13 @@ export function toggleConnection( connectionId: string ) {
 
 /**
  * Merge connections with fresh connections.
- * @param freshConnections - list of fresh connections
- * @return A thunk to merge connections.
+ * @param {Array} freshConnections - list of fresh connections
+ * @return {Function} - a function to merge connections.
  */
-export function mergeConnections( freshConnections: Array< Connection > ) {
+export function mergeConnections( freshConnections ) {
 	return function ( { dispatch, select } ) {
 		// Combine current connections with new connections.
-		const prevConnections: Array< Connection > = select.getConnections();
+		const prevConnections = select.getConnections();
 		const connections = [];
 		const defaults = {
 			enabled: true,
@@ -108,12 +108,12 @@ export function mergeConnections( freshConnections: Array< Connection > ) {
 
 /**
  * Create an abort controller.
- * @param abortController - Abort controller.
- * @param requestType     - Type of abort request.
+ * @param {AbortController} abortController - Abort controller.
+ * @param {string}          requestType     - Type of abort request.
  *
- * @return An action object.
+ * @return {object} - an action object.
  */
-export function createAbortController( abortController: AbortController, requestType: string ) {
+export function createAbortController( abortController, requestType ) {
 	return {
 		type: ADD_ABORT_CONTROLLER,
 		requestType,
@@ -124,11 +124,11 @@ export function createAbortController( abortController: AbortController, request
 /**
  * Remove abort controllers.
  *
- * @param requestType - Type of abort request.
+ * @param {string} requestType - Type of abort request.
  *
- * @return An action object.
+ * @return {object} - an action object.
  */
-export function removeAbortControllers( requestType: string ) {
+export function removeAbortControllers( requestType ) {
 	return {
 		type: REMOVE_ABORT_CONTROLLERS,
 		requestType,
@@ -138,11 +138,11 @@ export function removeAbortControllers( requestType: string ) {
 /**
  * Abort a request.
  *
- * @param requestType - Type of abort request.
+ * @param {string} requestType - Type of abort request.
  *
- * @return A thunk to abort a request.
+ * @return {Function} - a function to abort a request.
  */
-export function abortRequest( requestType: string ) {
+export function abortRequest( requestType ) {
 	return function ( { dispatch, select } ) {
 		const abortControllers = select.getAbortControllers( requestType );
 
@@ -158,7 +158,7 @@ export function abortRequest( requestType: string ) {
 /**
  * Abort the refresh connections request.
  *
- * @return A thunk to abort a request.
+ * @return {Function} - a function to abort a request.
  */
 export function abortRefreshConnectionsRequest() {
 	return abortRequest( REQUEST_TYPE_REFRESH_CONNECTIONS );
@@ -167,8 +167,8 @@ export function abortRefreshConnectionsRequest() {
 /**
  * Effect handler which will refresh the connection test results.
  *
- * @param syncToMeta - Whether to sync the connection state to the post meta.
- * @return A thunk to refresh connection test results.
+ * @param {boolean} syncToMeta - Whether to sync the connection state to the post meta.
+ * @return {Function} Refresh connection test results action.
  */
 export function refreshConnectionTestResults( syncToMeta = false ) {
 	return async function ( { dispatch, select } ) {
@@ -188,10 +188,7 @@ export function refreshConnectionTestResults( syncToMeta = false ) {
 			dispatch( createAbortController( abortController, REQUEST_TYPE_REFRESH_CONNECTIONS ) );
 
 			// Pass the abort controller signal to the fetch request.
-			const freshConnections = await apiFetch< Array< Connection > >( {
-				path,
-				signal: abortController.signal,
-			} );
+			const freshConnections = await apiFetch( { path, signal: abortController.signal } );
 
 			dispatch( mergeConnections( freshConnections ) );
 
@@ -211,7 +208,7 @@ export function refreshConnectionTestResults( syncToMeta = false ) {
 /**
  * Syncs the connections to the post meta.
  *
- * @return A thunk to sync connections to post meta.
+ * @return {Function} Sync connections to post meta action.
  */
 export function syncConnectionsToPostMeta() {
 	return function ( { registry, select } ) {
@@ -227,11 +224,11 @@ export function syncConnectionsToPostMeta() {
 /**
  * Toggles the connection enable-status.
  *
- * @param connectionId - Connection ID to switch.
- * @param syncToMeta   - Whether to sync the connection state to the post meta.
- * @return A think to switch connection enable-status.
+ * @param {string}  connectionId - Connection ID to switch.
+ * @param {boolean} syncToMeta   - Whether to sync the connection state to the post meta.
+ * @return {object} Switch connection enable-status action.
  */
-export function toggleConnectionById( connectionId: string, syncToMeta = true ) {
+export function toggleConnectionById( connectionId, syncToMeta = true ) {
 	return function ( { dispatch } ) {
 		dispatch( toggleConnection( connectionId ) );
 
@@ -244,11 +241,11 @@ export function toggleConnectionById( connectionId: string, syncToMeta = true ) 
 /**
  * Deletes a connection.
  *
- * @param connectionId - Connection ID to delete.
+ * @param {string} connectionId - Connection ID to delete.
  *
- * @return An action object.
+ * @return {object} Delete connection action.
  */
-export function deleteConnection( connectionId: string ) {
+export function deleteConnection( connectionId ) {
 	return {
 		type: DELETE_CONNECTION,
 		connectionId,
@@ -258,12 +255,12 @@ export function deleteConnection( connectionId: string ) {
 /**
  * Marks a connection as being deleted.
  *
- * @param connectionId - Connection ID to delete.
- * @param deleting     - Whether the connection is being deleted.
+ * @param {string}  connectionId - Connection ID to delete.
+ * @param {boolean} deleting     - Whether the connection is being deleted.
  *
- * @return An action object.
+ * @return {object} Deleting connection action.
  */
-export function deletingConnection( connectionId: string, deleting = true ) {
+export function deletingConnection( connectionId, deleting = true ) {
 	return {
 		type: DELETING_CONNECTION,
 		connectionId,
@@ -274,19 +271,13 @@ export function deletingConnection( connectionId: string, deleting = true ) {
 /**
  * Deletes a connection by disconnecting it.
  *
- * @param args                   - Arguments.
- * @param args.connectionId      - Connection ID to delete.
- * @param args.showSuccessNotice - Whether to show a success notice.
+ * @param {object}          args                     - Arguments.
+ * @param {string | number} args.connectionId        - Connection ID to delete.
+ * @param {boolean}         [args.showSuccessNotice] - Whether to show a success notice.
  *
- * @return A thunk that resolves to true if the connection was deleted, false otherwise.
+ * @return {boolean} Whether the connection was deleted.
  */
-export function deleteConnectionById( {
-	connectionId,
-	showSuccessNotice = true,
-}: {
-	connectionId: string;
-	showSuccessNotice?: boolean;
-} ) {
+export function deleteConnectionById( { connectionId, showSuccessNotice = true } ) {
 	return async function ( { registry, dispatch } ) {
 		const { createErrorNotice, createSuccessNotice } = coreDispatch( globalNoticesStore );
 
@@ -339,15 +330,11 @@ let uniqueId = 1;
 /**
  * Creates a connection.
  *
- * @param data           - The data for API call.
- * @param optimisticData - Optimistic data for the connection.
- *
- * @return A thunk to create a connection.
+ * @param {Record<string, any>} data           - The data for API call.
+ * @param {Record<string, any>} optimisticData - Optimistic data for the connection.
+ * @return {void}
  */
-export function createConnection(
-	data: Record< string, unknown >,
-	optimisticData: Partial< Connection > = {}
-) {
+export function createConnection( data, optimisticData = {} ) {
 	return async function ( { registry, dispatch } ) {
 		const { createErrorNotice, createSuccessNotice } = coreDispatch( globalNoticesStore );
 
@@ -416,12 +403,12 @@ export function createConnection(
 /**
  * Updates a connection.
  *
- * @param connectionId - Connection ID to update.
- * @param data         - The data.
+ * @param {string}              connectionId - Connection ID to update.
+ * @param {Record<string, any>} data         - The data.
  *
- * @return An action object.
+ * @return {object} Delete connection action.
  */
-export function updateConnection( connectionId: string, data: Partial< Connection > ) {
+export function updateConnection( connectionId, data ) {
 	return {
 		type: UPDATE_CONNECTION,
 		connectionId,
@@ -432,12 +419,12 @@ export function updateConnection( connectionId: string, data: Partial< Connectio
 /**
  * Marks a connection as being updating.
  *
- * @param connectionId - Connection ID being updated.
- * @param updating     - Whether the connection is being updated.
+ * @param {string}  connectionId - Connection ID being updated.
+ * @param {boolean} updating     - Whether the connection is being updated.
  *
- * @return An action object.
+ * @return {object} Deleting connection action.
  */
-export function updatingConnection( connectionId: string, updating = true ) {
+export function updatingConnection( connectionId, updating = true ) {
 	return {
 		type: UPDATING_CONNECTION,
 		connectionId,
@@ -448,11 +435,11 @@ export function updatingConnection( connectionId: string, updating = true ) {
 /**
  * Sets the reconnecting account.
  *
- * @param reconnectingAccount - Account being reconnected.
+ * @param {import('../types').Connection} reconnectingAccount - Account being reconnected.
  *
- * @return An action object.
+ * @return {object} Reconnecting account action.
  */
-export function setReconnectingAccount( reconnectingAccount: Connection ) {
+export function setReconnectingAccount( reconnectingAccount ) {
 	return {
 		type: SET_RECONNECTING_ACCOUNT,
 		reconnectingAccount,
@@ -462,11 +449,11 @@ export function setReconnectingAccount( reconnectingAccount: Connection ) {
 /**
  * Updates a connection.
  *
- * @param connectionId - Connection ID to update.
- * @param data         - The data for API call.
- * @return A thunk to update a connection.
+ * @param {string}              connectionId - Connection ID to update.
+ * @param {Record<string, any>} data         - The data for API call.
+ * @return {void}
  */
-export function updateConnectionById( connectionId: string, data: Partial< Connection > ) {
+export function updateConnectionById( connectionId, data ) {
 	return async function ( { dispatch, select } ) {
 		const { createErrorNotice, createSuccessNotice } = coreDispatch( globalNoticesStore );
 
@@ -514,11 +501,11 @@ export function updateConnectionById( connectionId: string, data: Partial< Conne
 /**
  * Toggles the connections modal.
  *
- * @param isOpen - Whether the modal is open.
+ * @param {boolean} isOpen - Whether the modal is open.
  *
- * @return An action object.
+ * @return {object} - An action object.
  */
-export function toggleConnectionsModal( isOpen: boolean ) {
+export function toggleConnectionsModal( isOpen ) {
 	return {
 		type: TOGGLE_CONNECTIONS_MODAL,
 		isOpen,
@@ -528,7 +515,7 @@ export function toggleConnectionsModal( isOpen: boolean ) {
 /**
  * Opens the connections modal.
  *
- * @return An action object.
+ * @return {object} - An action object.
  */
 export function openConnectionsModal() {
 	return toggleConnectionsModal( true );
@@ -536,7 +523,7 @@ export function openConnectionsModal() {
 
 /**
  * Closes the connections modal.
- * @return An action object.
+ * @return {object} - An action object.
  */
 export function closeConnectionsModal() {
 	return toggleConnectionsModal( false );

--- a/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.ts
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.ts
@@ -2,14 +2,14 @@ import { getScriptData } from '@automattic/jetpack-script-data';
 import { store as coreStore } from '@wordpress/core-data';
 import { createRegistrySelector } from '@wordpress/data';
 import { REQUEST_TYPE_DEFAULT } from '../actions/constants';
-import type { Connection, SocialStoreState } from '../types';
+import { Connection, SocialStoreState } from '../types';
 
 /**
  * Returns the connections list from the store.
  *
- * @param state - State object.
+ * @param {import("../types").SocialStoreState} state - State object.
  *
- * @return The connections list
+ * @return {Array<import("../types").Connection>} The connections list
  */
 export function getConnections( state: SocialStoreState ) {
 	return state.connectionData?.connections ?? [];
@@ -18,25 +18,22 @@ export function getConnections( state: SocialStoreState ) {
 /**
  * Return a connection by its ID.
  *
- * @param state        - State object.
- * @param connectionId - The connection ID.
+ * @param {import("../types").SocialStoreState} state        - State object.
+ * @param {string}                              connectionId - The connection ID.
  *
- * @return The connection.
+ * @return {import("../types").Connection | undefined} The connection.
  */
-export function getConnectionById(
-	state: SocialStoreState,
-	connectionId: string
-): Connection | undefined {
+export function getConnectionById( state, connectionId ) {
 	return getConnections( state ).find( connection => connection.connection_id === connectionId );
 }
 
 /**
  * Returns the broken connections.
  *
- * @param state - State object.
- * @return List of broken connections.
+ * @param {import("../types").SocialStoreState} state - State object.
+ * @return {Array<import("../types").Connection>} List of broken connections.
  */
-export function getBrokenConnections( state: SocialStoreState ) {
+export function getBrokenConnections( state ) {
 	return getConnections( state ).filter( connection => {
 		return connection.status === 'broken';
 	} );
@@ -45,31 +42,31 @@ export function getBrokenConnections( state: SocialStoreState ) {
 /**
  * Returns connections by service name/ID.
  *
- * @param state       - State object.
- * @param serviceName - The service name.
+ * @param {import("../types").SocialStoreState} state       - State object.
+ * @param {string}                              serviceName - The service name.
  *
- * @return  The connections.
+ * @return {Array<import("../types").Connection>} The connections.
  */
-export function getConnectionsByService( state: SocialStoreState, serviceName: string ) {
+export function getConnectionsByService( state, serviceName ) {
 	return getConnections( state ).filter( ( { service_name } ) => service_name === serviceName );
 }
 
 /**
  * Returns whether there are connections in the store.
- * @param state - State object.
- * @return Whether there are connections.
+ * @param {import("../types").SocialStoreState} state - State object.
+ * @return {boolean} Whether there are connections.
  */
-export function hasConnections( state: SocialStoreState ) {
+export function hasConnections( state ) {
 	return getConnections( state ).length > 0;
 }
 
 /**
  * Returns the failed Publicize connections.
  *
- * @param state - State object.
- * @return List of connections.
+ * @param {import("../types").SocialStoreState} state - State object.
+ * @return {Array<import("../types").Connection>} List of connections.
  */
-export function getFailedConnections( state: SocialStoreState ) {
+export function getFailedConnections( state ) {
 	const connections = getConnections( state );
 
 	return connections.filter( connection => 'broken' === connection.status );
@@ -79,10 +76,10 @@ export function getFailedConnections( state: SocialStoreState ) {
  * Returns a list of Publicize connection service names that require reauthentication from users.
  * For example, when LinkedIn switched its API from v1 to v2.
  *
- * @param state - State object.
- * @return List of service names that need reauthentication.
+ * @param {import("../types").SocialStoreState} state - State object.
+ * @return {Array<import("../types").Connection>} List of service names that need reauthentication.
  */
-export function getMustReauthConnections( state: SocialStoreState ) {
+export function getMustReauthConnections( state ) {
 	const connections = getConnections( state );
 	return connections
 		.filter( connection => 'must_reauth' === connection.status )
@@ -92,40 +89,36 @@ export function getMustReauthConnections( state: SocialStoreState ) {
 /**
  * Returns the Publicize connections that are enabled.
  *
- * @param state - State object.
+ * @param {import("../types").SocialStoreState} state - State object.
  *
- * @return List of enabled connections.
+ * @return {Array<import("../types").Connection>} List of enabled connections.
  */
-export function getEnabledConnections( state: SocialStoreState ) {
+export function getEnabledConnections( state ) {
 	return getConnections( state ).filter( connection => connection.enabled );
 }
 
 /**
  * Returns the Publicize connections that are disabled.
  *
- * @param state - State object.
+ * @param {import("../types").SocialStoreState} state - State object.
  *
- * @return List of disabled connections.
+ * @return {Array<import("../types").Connection>} List of disabled connections.
  */
-export function getDisabledConnections( state: SocialStoreState ) {
+export function getDisabledConnections( state ) {
 	return getConnections( state ).filter( connection => ! connection.enabled );
 }
 
 /**
  * Get the profile details for a connection
  *
- * @param state              - State object.
- * @param service            - The service name.
- * @param args               - Arguments.
- * @param args.forceDefaults - Whether to use default values.
+ * @param {import("../types").SocialStoreState} state              - State object.
+ * @param {string}                              service            - The service name.
+ * @param {object}                              args               - Arguments.
+ * @param {boolean}                             args.forceDefaults - Whether to use default values.
  *
- * @return The profile details.
+ * @return {object} The profile details.
  */
-export function getConnectionProfileDetails(
-	state: SocialStoreState,
-	service: string,
-	{ forceDefaults = false }: { forceDefaults?: boolean } = {}
-) {
+export function getConnectionProfileDetails( state, service, { forceDefaults = false } = {} ) {
 	let displayName = '';
 	let profileImage = '';
 	let username = '';
@@ -150,54 +143,54 @@ export function getConnectionProfileDetails(
 /**
  * Get the connections being deleted.
  *
- * @param state - State object.
- * @return The connection being deleted.
+ * @param {import("../types").SocialStoreState} state - State object.
+ * @return {import("../types").ConnectionData['deletingConnections']} The connection being deleted.
  */
-export function getDeletingConnections( state: SocialStoreState ) {
+export function getDeletingConnections( state ) {
 	return state.connectionData?.deletingConnections ?? [];
 }
 
 /**
  * Get the connections being updated.
  *
- * @param state - State object.
- * @return The connection being updated.
+ * @param {import("../types").SocialStoreState} state - State object.
+ * @return {import("../types").ConnectionData['updatingConnections']} The connection being updated.
  */
-export function getUpdatingConnections( state: SocialStoreState ) {
+export function getUpdatingConnections( state ) {
 	return state.connectionData?.updatingConnections ?? [];
 }
 
 /**
  * Get the account being reconnected
  *
- * @param state - State object.
- * @return The account being reconnected.
+ * @param {import("../types").SocialStoreState} state - State object.
+ * @return {import("../types").ConnectionData['reconnectingAccount']} The account being reconnected.
  */
-export function getReconnectingAccount( state: SocialStoreState ) {
+export function getReconnectingAccount( state ) {
 	return state.connectionData?.reconnectingAccount;
 }
 
 /**
  * Get the abort controllers for a specific request type.
  *
- * @param state       - State object.
- * @param requestType - The request type.
+ * @param {import("../types").SocialStoreState} state       - State object.
+ * @param {string}                              requestType - The request type.
  *
- * @return  The abort controllers.
+ * @return {Array<AbortController>} The abort controllers.
  */
-export function getAbortControllers( state: SocialStoreState, requestType = REQUEST_TYPE_DEFAULT ) {
+export function getAbortControllers( state, requestType = REQUEST_TYPE_DEFAULT ) {
 	return state.connectionData?.abortControllers?.[ requestType ] ?? [];
 }
 
 /**
  * Whether a mastodon account is already connected.
  *
- * @param state  - State object.
- * @param handle - The mastodon handle.
+ * @param {import("../types").SocialStoreState} state  - State object.
+ * @param {string}                              handle - The mastodon handle.
  *
- * @return Whether the mastodon account is already connected.
+ * @return {boolean} Whether the mastodon account is already connected.
  */
-export function isMastodonAccountAlreadyConnected( state: SocialStoreState, handle: string ) {
+export function isMastodonAccountAlreadyConnected( state, handle ) {
 	return getConnectionsByService( state, 'mastodon' ).some( connection => {
 		return connection.external_handle === handle;
 	} );
@@ -206,12 +199,12 @@ export function isMastodonAccountAlreadyConnected( state: SocialStoreState, hand
 /**
  * Whether a Bluesky account is already connected.
  *
- * @param state  - State object.
- * @param handle - The Bluesky handle.
+ * @param {import("../types").SocialStoreState} state  - State object.
+ * @param {string}                              handle - The Bluesky handle.
  *
- * @return Whether the Bluesky account is already connected.
+ * @return {boolean} Whether the Bluesky account is already connected.
  */
-export function isBlueskyAccountAlreadyConnected( state: SocialStoreState, handle: string ) {
+export function isBlueskyAccountAlreadyConnected( state, handle ) {
 	return getConnectionsByService( state, 'bluesky' ).some( connection => {
 		return connection.external_handle === handle;
 	} );
@@ -220,21 +213,21 @@ export function isBlueskyAccountAlreadyConnected( state: SocialStoreState, handl
 /**
  * Returns the latest KeyringResult from the store.
  *
- * @param state - State object.
+ * @param {import("../types").SocialStoreState} state - State object.
  *
- * @return The KeyringResult
+ * @return {import("../types").KeyringResult} The KeyringResult
  */
-export function getKeyringResult( state: SocialStoreState ) {
+export function getKeyringResult( state ) {
 	return state.connectionData?.keyringResult;
 }
 
 /**
  * Whether the connections modal is open.
- * @param state - State object.
+ * @param {import("../types").SocialStoreState} state - State object.
  *
- * @return Whether the connections modal is open.
+ * @return {boolean} Whether the connections modal is open.
  */
-export function isConnectionsModalOpen( state: SocialStoreState ) {
+export function isConnectionsModalOpen( state ) {
 	return state.connectionData?.isConnectionsModalOpen ?? false;
 }
 

--- a/projects/js-packages/publicize-components/src/social-store/types.ts
+++ b/projects/js-packages/publicize-components/src/social-store/types.ts
@@ -64,7 +64,6 @@ export type ConnectionData = {
 	reconnectingAccount?: Connection;
 	keyringResult?: KeyringResult;
 	abortControllers?: Record< string, Array< AbortController > >;
-	isConnectionsModalOpen?: boolean;
 };
 
 export type JetpackSettings = {


### PR DESCRIPTION
Reverts Automattic/jetpack#41201

Something related to the deployment of this has broken the WPCOM deployment process, so we're reverting it to clean things up.