### PR TITLE
Boost: Clear Page Cache when Image CDN Auto Resize Lazy Images is toggled

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache.php
@@ -8,6 +8,7 @@ use Automattic\Jetpack_Boost\Contracts\Has_Deactivate;
 use Automattic\Jetpack_Boost\Contracts\Optimization;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Modules\Modules_Index;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Image_CDN\Liar;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress\Boost_Cache;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress\Boost_Cache_Settings;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress\Filesystem_Utils;
@@ -47,6 +48,7 @@ class Page_Cache implements Pluggable, Has_Deactivate, Optimization {
 		add_action( 'update_option_' . JETPACK_BOOST_DATASYNC_NAMESPACE . '_minify_js_excludes', array( $this, 'invalidate_cache' ) );
 		add_action( 'update_option_' . JETPACK_BOOST_DATASYNC_NAMESPACE . '_minify_css_excludes', array( $this, 'invalidate_cache' ) );
 		add_action( 'update_option_' . JETPACK_BOOST_DATASYNC_NAMESPACE . '_image_cdn_quality', array( $this, 'invalidate_cache' ) );
+		add_action( 'update_option_jetpack_boost_status_' . Liar::get_slug(), array( $this, 'invalidate_cache' ) );
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/fix-boost-liar-toggle-clear-cache
+++ b/projects/plugins/boost/changelog/fix-boost-liar-toggle-clear-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Page Cache: Clear Page Cache when Image CDN Auto Resize Lazy Images is toggled.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #37815

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When toggling Image CDN Auto-Resize Lazy Images, Page Cache is now invalidated

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure Jetpack Boost Plugin (Premium) is running.
* In Boost's Settings -> Ensure Cache Site Pages, and Image CDN are enabled.
* Open a page in Incognito multiple times, and verify Page Cache will be generated by verifying the `x-jetpack-boost-cache` header is set to `hit`.
* In Normal tab -> Boost Settings, toggle `Auto-Resize Lazy Images`.
* Before fix:
  * In said Incognito tab, refresh same page as initially opened, `x-jetpack-boost-cache` header will still be `hit`.
* After fix:
  * In said Incognito tab, refresh same page as initially opened, `x-jetpack-boost-cache` header will still be `miss`.
  * When refreshing page, `x-jetpack-boost-cache` header should be `hit`.