### PR TITLE
Fix/form textarea default border stylinig

### DIFF
--- a/projects/packages/forms/changelog/fix-form-textarea-default-border-stylinig
+++ b/projects/packages/forms/changelog/fix-form-textarea-default-border-stylinig
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: THis seems like a minor fix
+
+

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -318,10 +318,10 @@
 	}
 
 	.jetpack-field__textarea {
-		border: var(--jetpack--contact-form--border);
-		border-color: var(--jetpack--contact-form--border-color);
-		border-style: var(--jetpack--contact-form--border-style);
-		border-width: var(--jetpack--contact-form--border-size);
+		border: var(--jetpack--contact-form--border, 1px solid #8c8f94);
+		border-color: var(--jetpack--contact-form--border-color, #8c8f94);
+		border-style: var(--jetpack--contact-form--border-style, solid );
+		border-width: var(--jetpack--contact-form--border-size, 1px );
 	}
 
 	.components-base-control__field {

--- a/projects/plugins/jetpack/changelog/fix-form-textarea-default-border-stylinig
+++ b/projects/plugins/jetpack/changelog/fix-form-textarea-default-border-stylinig
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Forms: fixed default editor stying for textarea


### PR DESCRIPTION
This Pr fixes the default contact form missing textarea border when it first loaded. The border would eventually show up.

This PR make it so that the border is always there by default. 

Before:
<img width="712" alt="Screenshot 2025-01-21 at 10 43 28 AM" src="https://github.com/user-attachments/assets/27c13621-b674-4f95-b9c3-f7428194898b" />


After:
<img width="706" alt="Screenshot 2025-01-21 at 10 44 28 AM" src="https://github.com/user-attachments/assets/4a026ffb-1ccb-4a7d-9859-46494fa005e7" />


## Proposed changes:
* It adds a default variable set for the css variables when these value are set to undefined. 
* The default values are the same as the one define in the previous css rule. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load up this PR. 
* Use the twenty twenty five theme and go to the editor. 
* Add the jetpack form block. 
* Add the contact form. 
* Notice that the text area had a border right away. 


