### PR TITLE
Charts: add back Rollup

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,6 +368,21 @@ importers:
       '@jest/globals':
         specifier: ^29.0.0
         version: 29.7.0
+      '@rollup/plugin-commonjs':
+        specifier: 26.0.1
+        version: 26.0.1(rollup@3.29.5)
+      '@rollup/plugin-json':
+        specifier: 6.1.0
+        version: 6.1.0(rollup@3.29.5)
+      '@rollup/plugin-node-resolve':
+        specifier: 15.3.0
+        version: 15.3.0(rollup@3.29.5)
+      '@rollup/plugin-terser':
+        specifier: 0.4.3
+        version: 0.4.3(rollup@3.29.5)
+      '@rollup/plugin-typescript':
+        specifier: 12.1.0
+        version: 12.1.0(rollup@3.29.5)(tslib@2.5.0)(typescript@5.7.2)
       '@storybook/blocks':
         specifier: 8.4.7
         version: 8.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7)
@@ -440,6 +455,18 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      rollup:
+        specifier: 3.29.5
+        version: 3.29.5
+      rollup-plugin-dts:
+        specifier: 6.1.1
+        version: 6.1.1(rollup@3.29.5)(typescript@5.7.2)
+      rollup-plugin-peer-deps-external:
+        specifier: 2.2.4
+        version: 2.2.4(rollup@3.29.5)
+      rollup-plugin-postcss:
+        specifier: 4.0.2
+        version: 4.0.2(postcss@8.4.47)
       sass:
         specifier: 1.64.1
         version: 1.64.1
@@ -13285,9 +13312,21 @@ packages:
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
 
+  rollup-plugin-dts@6.1.1:
+    resolution: {integrity: sha512-aSHRcJ6KG2IHIioYlvAOcEq6U99sVtqDDKVhnwt70rW6tsz3tv5OSjEiWcgzfsHdLyGXZ/3b/7b/+Za3Y6r1XA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      rollup: ^3.29.4 || ^4
+      typescript: ^4.5 || ^5.0
+
   rollup-plugin-livereload@2.0.5:
     resolution: {integrity: sha512-vqQZ/UQowTW7VoiKEM5ouNW90wE5/GZLfdWuR0ELxyKOJUIaj+uismPZZaICU4DnWPVjnpCDDxEqwU7pcKY/PA==}
     engines: {node: '>=8.3'}
+
+  rollup-plugin-peer-deps-external@2.2.4:
+    resolution: {integrity: sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==}
+    peerDependencies:
+      rollup: '*'
 
   rollup-plugin-postcss@4.0.2:
     resolution: {integrity: sha512-05EaY6zvZdmvPUDi3uCcAQoESDcYnv8ogJJQRp6V5kZ6J6P7uAVJlrTZcaaA20wTH527YTnKfkAoPxWI/jPp4w==}
@@ -17152,6 +17191,15 @@ snapshots:
       '@rollup/pluginutils': 5.1.4(rollup@3.29.5)
       resolve: 1.22.10
       typescript: 5.0.4
+    optionalDependencies:
+      rollup: 3.29.5
+      tslib: 2.5.0
+
+  '@rollup/plugin-typescript@12.1.0(rollup@3.29.5)(tslib@2.5.0)(typescript@5.7.2)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.4(rollup@3.29.5)
+      resolve: 1.22.10
+      typescript: 5.7.2
     optionalDependencies:
       rollup: 3.29.5
       tslib: 2.5.0
@@ -27180,12 +27228,24 @@ snapshots:
 
   robust-predicates@3.0.2: {}
 
+  rollup-plugin-dts@6.1.1(rollup@3.29.5)(typescript@5.7.2):
+    dependencies:
+      magic-string: 0.30.17
+      rollup: 3.29.5
+      typescript: 5.7.2
+    optionalDependencies:
+      '@babel/code-frame': 7.26.2
+
   rollup-plugin-livereload@2.0.5:
     dependencies:
       livereload: 0.9.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  rollup-plugin-peer-deps-external@2.2.4(rollup@3.29.5):
+    dependencies:
+      rollup: 3.29.5
 
   rollup-plugin-postcss@4.0.2(postcss@8.4.47):
     dependencies:

--- a/projects/js-packages/charts/changelog/update-add-back-rollup
+++ b/projects/js-packages/charts/changelog/update-add-back-rollup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Changed back to build with Rollup

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -21,7 +21,9 @@
 		"compile-ts": "tsc --pretty",
 		"clean-build": "rm -rf dist/",
 		"build": "pnpm run build:prod",
-		"build:prod": "pnpm run clean-build && webpack --config webpack.config.cjs --mode production && bash ./tools/fixup.sh && pnpm run build:types",
+		"build:prod": "rollup -c --environment NODE_ENV:production && bash ./tools/fixup.sh",
+		"build:dev": "rollup -c --environment NODE_ENV:development",
+		"build:webpack": "pnpm run clean-build && webpack --config webpack.config.cjs --mode production && bash ./tools/fixup.sh && pnpm run build:types",
 		"build:types": "tsc --emitDeclarationOnly --declaration --declarationDir dist/types"
 	},
 	"main": "./dist/cjs/index.js",
@@ -35,14 +37,13 @@
 		".": {
 			"import": "./dist/mjs/index.js",
 			"require": "./dist/cjs/index.js",
-			"types": "./dist/types/*.d.ts"
+			"types": "./dist/index.d.ts"
 		},
 		"./components/*": {
 			"import": "./dist/mjs/components/*/index.js",
-			"require": "./dist/cjs/components/*/index.js",
-			"types": "./dist/types/*.d.ts"
+			"require": "./dist/cjs/components/*/index.js"
 		},
-		"./style.css": "./dist/cjs/style.css"
+		"./style.css": "./dist/mjs/style.css"
 	},
 	"dependencies": {
 		"@babel/runtime": "7.26.0",
@@ -68,6 +69,11 @@
 		"@babel/preset-env": "7.26.0",
 		"@babel/preset-react": "7.26.3",
 		"@babel/preset-typescript": "7.26.0",
+		"@rollup/plugin-commonjs": "26.0.1",
+		"@rollup/plugin-json": "6.1.0",
+		"@rollup/plugin-node-resolve": "15.3.0",
+		"@rollup/plugin-terser": "0.4.3",
+		"@rollup/plugin-typescript": "12.1.0",
 		"@storybook/blocks": "8.4.7",
 		"@storybook/react": "8.4.7",
 		"@types/react": "18.3.18",
@@ -85,6 +91,10 @@
 		"postcss-modules": "6.0.1",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
+		"rollup": "3.29.5",
+		"rollup-plugin-dts": "6.1.1",
+		"rollup-plugin-peer-deps-external": "2.2.4",
+		"rollup-plugin-postcss": "4.0.2",
 		"sass": "1.64.1",
 		"sass-embedded": "1.83.0",
 		"sass-loader": "^13.0.0",

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -14,14 +14,14 @@
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",
 	"scripts": {
-		"clean": "rm -rf node_modules",
+		"clean": "rm -rf dist",
 		"test": "jest --config=tests/jest.config.cjs",
 		"test-coverage": "pnpm run test --coverage",
 		"storybook": "cd ../storybook && pnpm run storybook:dev",
 		"compile-ts": "tsc --pretty",
 		"clean-build": "rm -rf dist/",
 		"build": "pnpm run build:prod",
-		"build:prod": "rollup -c --environment NODE_ENV:production && bash ./tools/fixup.sh",
+		"build:prod": "pnpm run clean && rollup -c --environment NODE_ENV:production && bash ./tools/fixup.sh",
 		"build:dev": "rollup -c --environment NODE_ENV:development",
 		"build:webpack": "pnpm run clean-build && webpack --config webpack.config.cjs --mode production && bash ./tools/fixup.sh && pnpm run build:types",
 		"build:types": "tsc --emitDeclarationOnly --declaration --declarationDir dist/types"

--- a/projects/js-packages/charts/rollup.config.mjs
+++ b/projects/js-packages/charts/rollup.config.mjs
@@ -1,0 +1,142 @@
+// Import necessary plugins for building the library
+import commonjs from '@rollup/plugin-commonjs';
+import json from '@rollup/plugin-json';
+import resolve from '@rollup/plugin-node-resolve';
+import terser from '@rollup/plugin-terser';
+import typescript from '@rollup/plugin-typescript';
+import { defineConfig } from 'rollup';
+import dts from 'rollup-plugin-dts';
+import peerDepsExternal from 'rollup-plugin-peer-deps-external';
+import postcss from 'rollup-plugin-postcss';
+
+// Common plugins used across all build configurations
+const commonPlugins = [
+	// Automatically externalize peer dependencies
+	peerDepsExternal( {
+		includeDependencies: true,
+	} ),
+	// Locate and bundle third-party dependencies from node_modules
+	resolve( {
+		preferBuiltins: true,
+		extensions: [ '.tsx', '.ts', '.js', '.jsx' ],
+	} ),
+	// Convert CommonJS modules to ES6
+	commonjs(),
+	// Allow importing JSON files
+	json(),
+	// Process SCSS/CSS modules
+	postcss( {
+		// Configure CSS modules with scoped names
+		modules: {
+			generateScopedName: '[name]__[local]__[hash:base64:5]',
+		},
+		extract: 'style.css',
+		autoModules: false,
+		use: [ 'sass' ],
+	} ),
+];
+
+// Main bundle configuration for the entire library
+const mainConfig = {
+	// Entry point for the bundle
+	input: 'src/index.ts',
+	// Output configuration for different module formats
+	output: [
+		{
+			file: './dist/cjs/index.js',
+			format: 'cjs', // CommonJS format for Node.js
+			sourcemap: true,
+			sourcemapPathTransform: relativeSourcePath => {
+				return `/@automattic/charts/${ relativeSourcePath }`;
+			},
+		},
+		{
+			file: './dist/mjs/index.js',
+			format: 'esm', // ES modules for modern bundlers
+			sourcemap: true,
+		},
+	],
+	// Mark all dependencies as external to avoid bundling them
+	external: [ 'react', 'react-dom', /^@visx\/.*/, '@react-spring/web', 'clsx', 'tslib' ],
+	plugins: [
+		...commonPlugins,
+		// TypeScript compilation
+		typescript( {
+			tsconfig: './tsconfig.json',
+			declaration: false, // Declarations handled by dts plugin
+			sourceMap: true,
+			compilerOptions: {
+				verbatimModuleSyntax: true,
+			},
+		} ),
+		terser(),
+	],
+	// Handle circular dependencies warning
+	onwarn( warning, warn ) {
+		if ( warning.code === 'CIRCULAR_DEPENDENCY' ) {
+			return;
+		}
+		warn( warning );
+	},
+};
+
+// List of components to build individually
+const components = [
+	'components/bar-chart',
+	'components/line-chart',
+	'components/pie-chart',
+	'components/pie-semi-circle-chart',
+	'components/tooltip',
+	'components/legend',
+	'components/grid-control',
+	'providers/theme',
+];
+
+// Generate individual bundles for each component
+const componentConfigs = components.map( component => ( {
+	// Component entry point - try both .tsx and .ts extensions
+	input: `src/${ component }/index`,
+	// Output both ESM and CJS formats
+	output: [
+		{
+			file: `dist/mjs/${ component }/index.js`,
+			format: 'esm',
+			sourcemap: true,
+		},
+		{
+			file: `dist/cjs/${ component }/index.js`,
+			format: 'cjs',
+			sourcemap: true,
+		},
+	],
+	// Same external config as main bundle
+	external: [ 'react', 'react-dom', /^@visx\/.*/, '@react-spring/web', 'clsx', 'tslib' ],
+	plugins: [
+		...commonPlugins,
+		typescript( {
+			tsconfig: './tsconfig.json',
+			declaration: false,
+			sourceMap: true,
+			compilerOptions: {
+				verbatimModuleSyntax: true,
+			},
+		} ),
+		terser(),
+	],
+} ) );
+
+// Configuration for generating TypeScript declaration files
+const typesConfig = {
+	input: 'src/index.ts',
+	output: [ { file: 'dist/index.d.ts', format: 'es' } ],
+	plugins: [
+		dts( {
+			respectExternal: true,
+		} ),
+	],
+	// Don't include style imports in type definitions
+	external: [ /\.scss$/, /\.css$/, 'react', /@types\/.*/, /^@visx\/.*/, 'react/jsx-runtime' ],
+};
+
+// Export all configurations to be built in parallel
+export default defineConfig( [ mainConfig, ...componentConfigs, typesConfig ] );

--- a/projects/js-packages/charts/tsconfig.json
+++ b/projects/js-packages/charts/tsconfig.json
@@ -1,10 +1,9 @@
 {
-	"extends": "jetpack-js-tools/tsconfig.tsc-declaration-only.json",
+	"extends": "jetpack-js-tools/tsconfig.base.json",
 	"compilerOptions": {
-		"typeRoots": [ "./node_modules/@types/", "src/*" ],
-		"outDir": "./dist/types"
+		"typeRoots": [ "./node_modules/@types/", "src/*" ]
 	},
 	// List all sources and source-containing subdirs.
-	"include": [ "./src/index.ts" ],
+	"include": [ "./src" ],
 	"exclude": [ "node_modules", "dist", "**/stories/**" ]
 }


### PR DESCRIPTION
Related: 

## Proposed changes:

* Reverting back to https://github.com/Automattic/jetpack/pull/40817/ and excluded external types from the build
* Webpack building is not working, and I don't see we can resolve it soon. In the meanwhile, Rollup builds are really beautiful and does exactly what we'd like it to do for a package. In fact, Rollup is very much tailored to handle lib builds. We'll give Webpack another shot later to see if we solve it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1736402379633149-slack-C081YUPEVDF
p1737389590271299-slack-C081YUPEVDF
p1736901670506079/1736725346.535749-slack-C081YUPEVDF

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure all actions pass on Github