### PR TITLE
Fix Buttons inside Form blocks to not be full width on the front end

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-form-button-width
+++ b/projects/plugins/jetpack/changelog/fix-form-button-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Form block: ensure consistent width of form buttons.

--- a/projects/plugins/jetpack/extensions/blocks/button/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/button/view.scss
@@ -6,4 +6,7 @@
 	&:not(.is-style-outline) button {
 		border: none;
 	}
+	.wp-block-button__link {
+		width: inherit;
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #40268

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds an explicit width to the `wp-block-button__link` element on the front end (inside the block's `view.scss` file) to override the `width: 100%` rule coming from core. (The core rule was a fairly recent addition in https://github.com/WordPress/gutenberg/pull/64770)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
* Add a Jetpack Form block in a post, any variation.
* Make sure you have a theme enabled where the issue is reproducible, e.g. TT5.
* Publish the post and check the the Form Button doesn't stretch to full width on the front end.

Before:

<img width="647" alt="Screenshot 2025-01-22 at 4 05 19 pm" src="https://github.com/user-attachments/assets/ad08ecd2-7817-482a-b6e3-4139fd49b3ad" />

After:

<img width="638" alt="Screenshot 2025-01-22 at 4 05 28 pm" src="https://github.com/user-attachments/assets/82c9a888-8bd3-4463-aaea-ff29b553c10e" />


