### PR TITLE
Publicize | Fix PHP unit tests

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-publicize-php-unit-tests
+++ b/projects/plugins/jetpack/changelog/fix-publicize-php-unit-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fixed Publicize unit tests
+
+

--- a/projects/plugins/jetpack/tests/php/modules/publicize/test_class.publicize.php
+++ b/projects/plugins/jetpack/tests/php/modules/publicize/test_class.publicize.php
@@ -251,6 +251,9 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	}
 
 	public function test_publicize_get_all_connections_for_user() {
+		if ( ! defined( 'JETPACK_SOCIAL_USE_ADMIN_UI_V1' ) ) {
+			define( 'JETPACK_SOCIAL_USE_ADMIN_UI_V1', true );
+		}
 		$facebook_connection = array(
 			'id_number' => array(
 				'connection_data'  => array(

--- a/projects/plugins/jetpack/tests/php/modules/publicize/test_class.publicize.php
+++ b/projects/plugins/jetpack/tests/php/modules/publicize/test_class.publicize.php
@@ -253,16 +253,32 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	public function test_publicize_get_all_connections_for_user() {
 		$facebook_connection = array(
 			'id_number' => array(
-				'connection_data' => array(
+				'connection_data'  => array(
+					'id'      => 123,
 					'user_id' => 0,
 				),
+				'external_display' => 'Test',
+				'service_name'     => 'facebook',
+				'connection_id'    => 123,
+				'can_disconnect'   => true,
+				'profile_link'     => false,
+				'shared'           => false,
+				'status'           => 'ok',
 			),
 		);
 		$twitter_connection  = array(
 			'id_number_2' => array(
-				'connection_data' => array(
+				'connection_data'  => array(
+					'id'      => 456,
 					'user_id' => 1,
 				),
+				'external_display' => '@test',
+				'service_name'     => 'twitter',
+				'connection_id'    => 456,
+				'can_disconnect'   => true,
+				'profile_link'     => 'https://twitter.com/test',
+				'shared'           => false,
+				'status'           => 'ok',
 			),
 		);
 
@@ -277,21 +293,26 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 
 		// When logged out, assert that blog-level connections are returned.
 		wp_set_current_user( 0 );
-		$this->assertSame( array( 'facebook' => $facebook_connection ), $publicize->get_all_connections_for_user() );
+		$this->assertSame(
+			array(
+				$facebook_connection['id_number'],
+			),
+			$publicize->get_all_connections_for_user()
+		);
 
 		// When logged in, assert that blog-level connections AND any connections for the current user are returned.
 		wp_set_current_user( 1 );
 		$this->assertSame(
 			array(
-				'facebook' => $facebook_connection,
-				'twitter'  => $twitter_connection,
+				$facebook_connection['id_number'],
+				$twitter_connection['id_number_2'],
 			),
 			$publicize->get_all_connections_for_user()
 		);
 
 		// There are no connections for user 2, so we should only get blog-level connections.
 		wp_set_current_user( 2 );
-		$this->assertSame( array( 'facebook' => $facebook_connection ), $publicize->get_all_connections_for_user() );
+		$this->assertSame( array( $facebook_connection['id_number'] ), $publicize->get_all_connections_for_user() );
 	}
 
 	/**


### PR DESCRIPTION
Publicize PHP unit tests have been [failing intermittently](https://github.com/Automattic/jetpack/actions/runs/12901700531/job/35974190813?pr=41219) following #40679 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix publicize unit tests

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI should be happy

