### PR TITLE
Jetpack Sync: Use static vs self for calling 'get_setting' within 'Settings' class

### DIFF
--- a/projects/packages/sync/changelog/update-jetpack-sync-settings-static-usage
+++ b/projects/packages/sync/changelog/update-jetpack-sync-settings-static-usage
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Jetpack Sync Settings: Use static vs self for calling 'get_setting' within class
+
+

--- a/projects/packages/sync/src/class-settings.php
+++ b/projects/packages/sync/src/class-settings.php
@@ -115,7 +115,7 @@ class Settings {
 	public static function get_settings() {
 		$settings = array();
 		foreach ( array_keys( self::$valid_settings ) as $setting ) {
-			$settings[ $setting ] = self::get_setting( $setting );
+			$settings[ $setting ] = static::get_setting( $setting );
 		}
 
 		return $settings;
@@ -350,7 +350,7 @@ class Settings {
 	 * @return string SQL WHERE clause.
 	 */
 	public static function get_blacklisted_post_types_sql() {
-		return 'post_type NOT IN (\'' . implode( '\', \'', array_map( 'esc_sql', self::get_setting( 'post_types_blacklist' ) ) ) . '\')';
+		return 'post_type NOT IN (\'' . implode( '\', \'', array_map( 'esc_sql', static::get_setting( 'post_types_blacklist' ) ) ) . '\')';
 	}
 
 	/**
@@ -365,7 +365,7 @@ class Settings {
 		return array(
 			'post_type' => array(
 				'operator' => 'NOT IN',
-				'values'   => array_map( 'esc_sql', self::get_setting( 'post_types_blacklist' ) ),
+				'values'   => array_map( 'esc_sql', static::get_setting( 'post_types_blacklist' ) ),
 			),
 		);
 	}
@@ -380,7 +380,7 @@ class Settings {
 	 * @return string SQL WHERE clause.
 	 */
 	public static function get_blacklisted_taxonomies_sql() {
-		return "taxonomy NOT IN ('" . implode( "', '", array_map( 'esc_sql', self::get_setting( 'taxonomies_blacklist' ) ) ) . "')";
+		return "taxonomy NOT IN ('" . implode( "', '", array_map( 'esc_sql', static::get_setting( 'taxonomies_blacklist' ) ) ) . "')";
 	}
 
 	/**
@@ -393,7 +393,7 @@ class Settings {
 	 * @return string SQL WHERE clause.
 	 */
 	public static function get_whitelisted_post_meta_sql() {
-		return 'meta_key IN (\'' . implode( '\', \'', array_map( 'esc_sql', self::get_setting( 'post_meta_whitelist' ) ) ) . '\')';
+		return 'meta_key IN (\'' . implode( '\', \'', array_map( 'esc_sql', static::get_setting( 'post_meta_whitelist' ) ) ) . '\')';
 	}
 
 	/**
@@ -408,7 +408,7 @@ class Settings {
 		return array(
 			'meta_key' => array(
 				'operator' => 'IN',
-				'values'   => array_map( 'esc_sql', self::get_setting( 'post_meta_whitelist' ) ),
+				'values'   => array_map( 'esc_sql', static::get_setting( 'post_meta_whitelist' ) ),
 			),
 		);
 	}
@@ -425,7 +425,7 @@ class Settings {
 		return array(
 			'taxonomy' => array(
 				'operator' => 'NOT IN',
-				'values'   => array_map( 'esc_sql', self::get_setting( 'taxonomies_blacklist' ) ),
+				'values'   => array_map( 'esc_sql', static::get_setting( 'taxonomies_blacklist' ) ),
 			),
 		);
 	}
@@ -442,7 +442,7 @@ class Settings {
 		global $wp_taxonomies;
 
 		$allowed_taxonomies = array_keys( $wp_taxonomies );
-		$allowed_taxonomies = array_diff( $allowed_taxonomies, self::get_setting( 'taxonomies_blacklist' ) );
+		$allowed_taxonomies = array_diff( $allowed_taxonomies, static::get_setting( 'taxonomies_blacklist' ) );
 		return array(
 			'taxonomy' => array(
 				'operator' => 'IN',
@@ -461,7 +461,7 @@ class Settings {
 	 * @return string SQL WHERE clause.
 	 */
 	public static function get_whitelisted_comment_meta_sql() {
-		return 'meta_key IN (\'' . implode( '\', \'', array_map( 'esc_sql', self::get_setting( 'comment_meta_whitelist' ) ) ) . '\')';
+		return 'meta_key IN (\'' . implode( '\', \'', array_map( 'esc_sql', static::get_setting( 'comment_meta_whitelist' ) ) ) . '\')';
 	}
 
 	/**
@@ -476,7 +476,7 @@ class Settings {
 		return array(
 			'meta_key' => array(
 				'operator' => 'IN',
-				'values'   => array_map( 'esc_sql', self::get_setting( 'comment_meta_whitelist' ) ),
+				'values'   => array_map( 'esc_sql', static::get_setting( 'comment_meta_whitelist' ) ),
 			),
 		);
 	}
@@ -573,7 +573,7 @@ class Settings {
 	 * @return boolean Whether sync is enabled.
 	 */
 	public static function is_sync_enabled() {
-		return ! ( self::get_setting( 'disable' ) || self::get_setting( 'network_disable' ) );
+		return ! ( static::get_setting( 'disable' ) || static::get_setting( 'network_disable' ) );
 	}
 
 	/**
@@ -664,7 +664,7 @@ class Settings {
 	 * @return boolean Whether sync is enabled.
 	 */
 	public static function is_sender_enabled( $queue_id ) {
-		return (bool) self::get_setting( $queue_id . '_sender_enabled' );
+		return (bool) static::get_setting( $queue_id . '_sender_enabled' );
 	}
 
 	/**
@@ -676,7 +676,7 @@ class Settings {
 	 * @return boolean Whether sync is enabled.
 	 */
 	public static function is_checksum_enabled() {
-		return ! (bool) self::get_setting( 'checksum_disable' );
+		return ! (bool) static::get_setting( 'checksum_disable' );
 	}
 
 	/**
@@ -688,7 +688,7 @@ class Settings {
 	 * @return boolean Whether dedicated Sync flow is enabled.
 	 */
 	public static function is_dedicated_sync_enabled() {
-		return (bool) self::get_setting( 'dedicated_sync_enabled' );
+		return (bool) static::get_setting( 'dedicated_sync_enabled' );
 	}
 
 	/**
@@ -700,7 +700,7 @@ class Settings {
 	 * @return boolean Whether custom queue table is enabled.
 	 */
 	public static function is_custom_queue_table_enabled() {
-		return (bool) self::get_setting( 'custom_queue_table_enabled' );
+		return (bool) static::get_setting( 'custom_queue_table_enabled' );
 	}
 
 	/**
@@ -712,6 +712,6 @@ class Settings {
 	 * @return boolean Whether wpcom rest api is enabled.
 	 */
 	public static function is_wpcom_rest_api_enabled() {
-		return (bool) self::get_setting( 'wpcom_rest_api_enabled' );
+		return (bool) static::get_setting( 'wpcom_rest_api_enabled' );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This will allow child classes to override `get_setting` method.
Particularly useful on WPCOM, see fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Szh%2Qcyhtvaf%2Swrgcnpx%2Sflap%2Spynff.wrgcnpx%2Qflap%2Qfrggvatf.cuc%3Se%3Qs741rsq5%2334-og

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Settings`: Replace `self` with `static` keyword to allow child classes to override the `get_setting` method

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code review