### PR TITLE
Add a launch site button to the admin bar.

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-launch-button
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-launch-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add site launch button to the admin bar.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -115,6 +115,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-hotfixes/wpcom-hotfixes.php';
 		require_once __DIR__ . '/features/wpcom-logout/wpcom-logout.php';
 		require_once __DIR__ . '/features/wpcom-themes/wpcom-theme-fixes.php';
+		require_once __DIR__ . '/features/launch-button/index.php';
 
 		// Initializers, if needed.
 		\Marketplace_Products_Updater::init();

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -105,6 +105,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/google-analytics/google-analytics.php';
 		require_once __DIR__ . '/features/holiday-snow/class-holiday-snow.php';
 		require_once __DIR__ . '/features/import-customizations/import-customizations.php';
+		require_once __DIR__ . '/features/launch-button/index.php';
 		require_once __DIR__ . '/features/marketplace-products-updater/class-marketplace-products-updater.php';
 		require_once __DIR__ . '/features/media/heif-support.php';
 		require_once __DIR__ . '/features/post-categories/quick-actions.php';
@@ -115,7 +116,6 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-hotfixes/wpcom-hotfixes.php';
 		require_once __DIR__ . '/features/wpcom-logout/wpcom-logout.php';
 		require_once __DIR__ . '/features/wpcom-themes/wpcom-theme-fixes.php';
-		require_once __DIR__ . '/features/launch-button/index.php';
 
 		// Initializers, if needed.
 		\Marketplace_Products_Updater::init();

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -1,0 +1,38 @@
+<?php
+
+use Automattic\Jetpack\Status;
+
+function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
+	$is_launched = true;
+	$blog_id = get_current_blog_id();
+
+	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+		$is_launched = get_option( 'launch-status' ) === 'launched';
+		$blog_domain = ( new Status() )->get_site_suffix();
+	} else if ( function_exists( '\WPCOM\Lib\Launch_Site\is_launched' ) ) {
+		$is_launched = \WPCOM\Lib\Launch_Site\is_launched( $blog_id );
+		$blog_domain  = preg_replace( '!^https?://!', '', get_primary_redirect( $blog_id ) );
+	}
+	if ( $is_launched ) {
+		return;
+	}
+	$admin_bar->add_menu(
+		array(
+			'id'     => 'menu-id',
+			'parent' => null,
+			'group'  => null,
+			'title'  => __( 'Launch site' ),
+			'href'   => 'https://wordpress.com/start/launch-site?siteSlug=' . $blog_domain,
+			'meta'   => array(
+				'class' => 'launch-site',
+			),
+		)
+	);
+}
+
+function wpcom_enqueue_launch_button_styles() {
+	wp_enqueue_style( 'launch-banner', plugins_url( 'style.css', __FILE__ ) );
+}
+
+add_action( 'admin_bar_menu', 'wpcom_add_launch_button_to_admin_bar', 500 );
+add_action( 'wp_enqueue_scripts', 'wpcom_enqueue_launch_button_styles' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -13,6 +13,9 @@ use Automattic\Jetpack\Status;
  * @param WP_Admin_Bar $admin_bar The WordPress admin bar.
  */
 function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
 	$is_launched = get_option( 'launch-status' ) !== 'unlaunched';
 	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
 		$blog_domain = ( new Status() )->get_site_suffix();
@@ -41,6 +44,9 @@ function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
  * Enqueue the necessary styles for the admin bar button.
  */
 function wpcom_enqueue_launch_button_styles() {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
 	$version = filemtime( __DIR__ . '/style.css' );
 	wp_enqueue_style( 'launch-banner', plugins_url( 'style.css', __FILE__ ), array(), $version );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -1,7 +1,15 @@
 <?php
+/**
+ * Adds a "launch site" button to the admin bar.
+ */
 
 use Automattic\Jetpack\Status;
 
+/**
+ * Adds a "launch site" button to the admin bar.
+ * 
+ * @param WP_Admin_Bar $admin_bar The WordPress admin bar.
+ */
 function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
 	$is_launched = true;
 	$blog_id = get_current_blog_id();
@@ -21,7 +29,7 @@ function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
 			'id'     => 'menu-id',
 			'parent' => null,
 			'group'  => null,
-			'title'  => __( 'Launch site' ),
+			'title'  => __( 'Launch site', 'jetpack-mu-wpcom' ),
 			'href'   => 'https://wordpress.com/start/launch-site?siteSlug=' . $blog_domain,
 			'meta'   => array(
 				'class' => 'launch-site',
@@ -30,6 +38,9 @@ function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
 	);
 }
 
+/**
+ * Enqueue the necessary styles for the admin bar button.
+ */
 function wpcom_enqueue_launch_button_styles() {
 	wp_enqueue_style( 'launch-banner', plugins_url( 'style.css', __FILE__ ) );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -1,13 +1,15 @@
 <?php
 /**
  * Adds a "launch site" button to the admin bar.
+ *
+ * @package automattic/jetpack-mu-wpcom
  */
 
 use Automattic\Jetpack\Status;
 
 /**
  * Adds a "launch site" button to the admin bar.
- * 
+ *
  * @param WP_Admin_Bar $admin_bar The WordPress admin bar.
  */
 function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
@@ -15,8 +17,8 @@ function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
 	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
 		$blog_domain = ( new Status() )->get_site_suffix();
 	} else {
-		$blog_id = get_current_blog_id();
-		$blog_domain  = preg_replace( '!^https?://!', '', get_primary_redirect( $blog_id ) );
+		$blog_id     = get_current_blog_id();
+		$blog_domain = preg_replace( '!^https?://!', '', get_primary_redirect( $blog_id ) );
 	}
 	if ( $is_launched ) {
 		return;
@@ -39,7 +41,8 @@ function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
  * Enqueue the necessary styles for the admin bar button.
  */
 function wpcom_enqueue_launch_button_styles() {
-	wp_enqueue_style( 'launch-banner', plugins_url( 'style.css', __FILE__ ) );
+	$version = filemtime( __DIR__ . '/style.css' );
+	wp_enqueue_style( 'launch-banner', plugins_url( 'style.css', __FILE__ ), array(), $version );
 }
 
 add_action( 'admin_bar_menu', 'wpcom_add_launch_button_to_admin_bar', 500 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -5,8 +5,6 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
-use Automattic\Jetpack\Status;
-
 /**
  * Adds a "launch site" button to the admin bar.
  *
@@ -17,15 +15,10 @@ function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
 		return;
 	}
 	$is_launched = get_option( 'launch-status' ) !== 'unlaunched';
-	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
-		$blog_domain = ( new Status() )->get_site_suffix();
-	} else {
-		$blog_id     = get_current_blog_id();
-		$blog_domain = preg_replace( '!^https?://!', '', get_primary_redirect( $blog_id ) );
-	}
 	if ( $is_launched ) {
 		return;
 	}
+	$blog_domain = wp_parse_url( home_url(), PHP_URL_HOST );
 	$admin_bar->add_menu(
 		array(
 			'id'     => 'menu-id',

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -11,14 +11,11 @@ use Automattic\Jetpack\Status;
  * @param WP_Admin_Bar $admin_bar The WordPress admin bar.
  */
 function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
-	$is_launched = true;
-	$blog_id = get_current_blog_id();
-
+	$is_launched = get_option( 'launch-status' ) !== 'unlaunched';
 	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
-		$is_launched = get_option( 'launch-status' ) === 'launched';
 		$blog_domain = ( new Status() )->get_site_suffix();
-	} else if ( function_exists( '\WPCOM\Lib\Launch_Site\is_launched' ) ) {
-		$is_launched = \WPCOM\Lib\Launch_Site\is_launched( $blog_id );
+	} else {
+		$blog_id = get_current_blog_id();
 		$blog_domain  = preg_replace( '!^https?://!', '', get_primary_redirect( $blog_id ) );
 	}
 	if ( $is_launched ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -53,3 +53,4 @@ function wpcom_enqueue_launch_button_styles() {
 
 add_action( 'admin_bar_menu', 'wpcom_add_launch_button_to_admin_bar', 500 );
 add_action( 'wp_enqueue_scripts', 'wpcom_enqueue_launch_button_styles' );
+add_action( 'admin_enqueue_scripts', 'wpcom_enqueue_launch_button_styles' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/style.css
@@ -1,0 +1,3 @@
+#wpadminbar .launch-site {
+	background: var(--wp-admin-theme-color);
+}

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-launch-button
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-launch-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add site launch button to the admin bar.

--- a/projects/plugins/wpcomsh/changelog/add-launch-button
+++ b/projects/plugins/wpcomsh/changelog/add-launch-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add site launch button to the admin bar.


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/98895.

## Proposed changes:

We recently removed the "launch bar" from the frontend of wp.com websites, that said, it's important for users to know that there's site is yet to be launched for users as raised by @scruffian 

The current PR adds a "launch site" button to the admin bar of both simple and atomic sites.

<img width="1470" alt="Screenshot 2025-01-22 at 11 17 34 AM" src="https://github.com/user-attachments/assets/1a264a9e-4d91-4ccc-93ab-140d3ec585e1" />

## Testing instructions:

 - apply the PR changes
 - Open the frontend of your unlaunched site
 - Notice the "launch site" button in the admin bar
 - Click the button and launch your site
 - The button is gone from the admin bar.

## Does this pull request change what data or activity we track or use?

No