### PR TITLE
Social | Fix publicize unit tests once more

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-publicize-unit-tests-again
+++ b/projects/plugins/jetpack/changelog/fix-publicize-unit-tests-again
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fixed publicize unit test
+
+

--- a/projects/plugins/jetpack/tests/php/modules/publicize/test_class.publicize.php
+++ b/projects/plugins/jetpack/tests/php/modules/publicize/test_class.publicize.php
@@ -264,7 +264,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 				'service_name'     => 'facebook',
 				'connection_id'    => 123,
 				'can_disconnect'   => true,
-				'profile_link'     => false,
+				'profile_link'     => '',
 				'shared'           => false,
 				'status'           => 'ok',
 			),


### PR DESCRIPTION
Publicize unit tests are [failing again](https://github.com/Automattic/jetpack/actions/runs/12905994609/job/35986393177?pr=41239).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix Publicize unit tests

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI Should be happy

