### PR TITLE
Comments:  Default to sign up when trying to comment logged out

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-query-param-to-comments-connect-url
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-query-param-to-comments-connect-url
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Added query param to the wordpress.com login url.

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
@@ -124,6 +124,8 @@ class Verbum_Comments {
 
 		if ( strpos( $primary_redirect, '.wordpress.com' ) === false ) {
 			$connect_url = add_query_arg( 'domain', $primary_redirect, $connect_url );
+		} else {
+			$connect_url = add_query_arg( 'from_comments', 'yes', $connect_url );
 		}
 
 		// Enqueue styles and scripts


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When you comment on a WPCOM blog's post and you're not logged in, you will be prompted to log in through WPCOM/Facebook/Email when you begin typing a comment. 
* Now, we will default to sign up when trying to comment logged out. That logic is handled in the WPCOM code, but we need a query parameter to make that decision on WPCOM. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
*  See 170680 -ghe-Automattic/wpcom

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

*  See 170680 -ghe-Automattic/wpcom

