### PR TITLE
CRM: Remove legacy Groove code

### DIFF
--- a/projects/plugins/crm/.phan/baseline.php
+++ b/projects/plugins/crm/.phan/baseline.php
@@ -103,7 +103,6 @@ return [
     // PhanUnextractableAnnotation : 2 occurrences
     // PhanImpossibleTypeComparisonInLoop : 1 occurrence
     // PhanNoopVariable : 1 occurrence
-    // PhanParamTooFewInternal : 1 occurrence
     // PhanPluginDuplicateArrayKey : 1 occurrence
     // PhanPluginDuplicateCatchStatementBody : 1 occurrence
     // PhanPluginUseReturnValueInternalKnown : 1 occurrence
@@ -172,7 +171,7 @@ return [
         'api/customers.php' => ['PhanPluginSimplifyExpressionBool'],
         'api/status.php' => ['PhanTypePossiblyInvalidDimOffset'],
         'includes/ZeroBSCRM.AJAX.php' => ['PhanDeprecatedFunction', 'PhanImpossibleCondition', 'PhanParamTooMany', 'PhanPluginDuplicateAdjacentStatement', 'PhanPluginDuplicateExpressionAssignment', 'PhanPluginNeverReturnFunction', 'PhanPluginRedundantAssignment', 'PhanPluginSimplifyExpressionBool', 'PhanPluginUnreachableCode', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanTypeArraySuspicious', 'PhanTypeArraySuspiciousNullable', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchDimFetch', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeVoidAssignment', 'PhanUndeclaredConstant', 'PhanUndeclaredVariableDim'],
-        'includes/ZeroBSCRM.API.php' => ['PhanCommentParamWithoutRealParam', 'PhanParamTooFewInternal', 'PhanParamTooMany', 'PhanRedefineFunctionInternal', 'PhanRedundantCondition', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgumentInternal'],
+        'includes/ZeroBSCRM.API.php' => ['PhanCommentParamWithoutRealParam', 'PhanRedefineFunctionInternal', 'PhanRedundantCondition', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgumentInternal'],
         'includes/ZeroBSCRM.AdminPages.Checks.php' => ['PhanPluginUnreachableCode'],
         'includes/ZeroBSCRM.AdminPages.php' => ['PhanDeprecatedFunction', 'PhanImpossibleCondition', 'PhanPluginDuplicateAdjacentStatement', 'PhanPluginRedundantAssignment', 'PhanPossiblyUndeclaredVariable', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeSuspiciousEcho', 'PhanUndeclaredVariableDim'],
         'includes/ZeroBSCRM.AdminStyling.php' => ['PhanDeprecatedFunction', 'PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchArgument'],

--- a/projects/plugins/crm/api/customer_search.php
+++ b/projects/plugins/crm/api/customer_search.php
@@ -52,34 +52,9 @@ if ( isset( $_GET['email'] ) ) {
 		)
 	);
 
+	// Send an empty array if no matches.
 	if ( ! $customer_matches ) {
 		wp_send_json( array() );
-	}
-
-	// Groove Sidebar has extra information, will do this way, for file compatibility
-	if ( isset( $_GET['api_token'] ) && defined( 'ZBSGROOVECHECKED' ) ) {
-		// then it's coming from Groove, so send back total value and last purchased information
-		$customerID                      = $customer_matches['id'];
-		$total_value                     = zeroBS_customerTotalValue( $customerID, $customer_matches['invoices'], $customer_matches['transactions'] );
-		$customer_matches['total_value'] = $total_value;
-
-		// also needs
-		/**
-		 * purchase_item
-		 * purchase_value
-		 * purchase_date
-		 */
-
-		if ( isset( $customer_matches['transactions'] ) && is_array( $customer_matches['transactions'] ) && count( $customer_matches['transactions'] ) > 0 ) {
-
-			$customer_matches['purchase_item']  = $customer_matches['transactions'][0]['meta']['item'];
-			$customer_matches['purchase_value'] = $customer_matches['transactions'][0]['meta']['total'];
-			$customer_matches['purchase_date']  = $customer_matches['transactions'][0]['created'];
-
-		}
-
-		/* should also format the bl00dy dates */
-
 	}
 } else {
 	// could be more matches (don't return financial data - unperformant)

--- a/projects/plugins/crm/changelog/remove-crm-legacy_groove_code
+++ b/projects/plugins/crm/changelog/remove-crm-legacy_groove_code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove legacy Groove code.

--- a/projects/plugins/crm/includes/ZeroBSCRM.API.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.API.php
@@ -245,21 +245,7 @@ function zeroBSCRM_API_get_api_endpoint( $template_name, $args = array(), $tempa
 
 // function similar to is_user_logged_in()
 function jpcrm_is_api_request_authorised() {
-
-	// WH - I've added api_secret here to bolster security,
 	// We should switch authentication method to "headers" not parameters - will be cleaner :)
-
-	// unclear if we're still needing this...
-	// we are coming from GROOVE HQ - define in wp-config.php
-	if ( defined( 'GROOVE_API_TOKEN' ) && ! empty( $_GET['api_token'] ) ) {
-		if ( hash_equals( sanitize_text_field( $_GET['api_token'], GROOVE_API_TOKEN ) ) ) {
-			// and define that we've checked
-			if ( ! defined( 'ZBSGROOVECHECKED' ) ) {
-				define( 'ZBSGROOVECHECKED', time() );
-			}
-			return true;
-		}
-	}
 
 	// the the API key/secret are currently in the URL
 	$possible_api_key    = isset( $_GET['api_key'] ) ? sanitize_text_field( $_GET['api_key'] ) : '';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This removes legacy code that has been broken for almost 2.5 years and unused for who knows how much longer.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In #41167 I was addressing a bunch of false-positives in Phan for the `PhanParamTooFewInternal` error. It turns out CRM had one actual instance:

```
hash_equals( sanitize_text_field( $_GET['api_token'], GROOVE_API_TOKEN ) )
```

If you look carefully, you'll notice `sanitize_text_field` is receiving two params instead of one, and `hash_equals` is receiving one param instead of two. As such, the related chain of code never would run.

Given we don't use this anymore, it's been broken so long, and no one's complained, it's certainly safe to remove. If we wanted to reintroduce a similar feature in the future, it'd be better to do so via the Groove extension and/or generic means.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

🤷
