### PR TITLE
RDV: Remove the switcher on post filter pages

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-remove-quick-switcher-on-post-filter
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-remove-quick-switcher-on-post-filter
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Remove the quick switcher for post filter pages (Posts > drafts)
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -120,6 +120,7 @@ add_filter( 'pre_update_option_wpcom_admin_interface', 'wpcom_admin_interface_pr
 const WPCOM_DUPLICATED_VIEW = array(
 	'edit.php',
 	'edit.php?post_type=page',
+	'edit.php?post_type=post', // Alias for posts. It's used for the post filters (published, draft, sticky, etc).
 	'edit.php?post_type=jetpack-portfolio',
 	'edit.php?post_type=jetpack-testimonial',
 	'edit-comments.php',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/98741

Post filter pages were considered separate pages and the current RDV implementation ignored them. 

This PR flags the post type "post" as an alias for posts - removing the quick switcher from the page.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add edit.php?post_type=post in the duplicate view array

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change on your sandbox/Atomic site
* Go to Posts  and click on the Sticky, published, draft filters
* You shouldn't be able to see the quick switcher anymore

