### PR TITLE
Jetpack AI: fix AI excerpt panel to work for pages in site editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-excerpt-site-editor
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-excerpt-site-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: excerpt panel now uses PluginDocumentSettingPanel slotfill for compatibility with site and post editor

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -30,6 +30,7 @@ import { AiExcerptControl } from '../../components/ai-excerpt-control';
 import type { LanguageProp } from '../../../../blocks/ai-assistant/components/i18n-dropdown-control';
 import type { ToneProp } from '../../../../blocks/ai-assistant/components/tone-dropdown-control';
 import type { AiModelTypeProp, PromptProp } from '@automattic/jetpack-ai-client';
+import type { ReactElement } from 'react';
 
 import './style.scss';
 
@@ -307,15 +308,15 @@ export const PluginDocumentSettingPanelAiExcerpt = () => {
 	if ( isExcerptUsedAsDescription ) {
 		return null;
 	}
-	return (
-		<PostTypeSupportCheck supportKeys="excerpt">
-			<PluginDocumentSettingPanel
-				className={ isBetaExtension( 'ai-content-lens' ) ? 'is-beta-extension inset-shadow' : '' }
-				name="ai-content-lens-plugin"
-				title={ __( 'Excerpt', 'jetpack' ) }
-			>
-				<AiPostExcerpt />
-			</PluginDocumentSettingPanel>
-		</PostTypeSupportCheck>
-	);
+
+	const pluginPanel = (
+		<PluginDocumentSettingPanel
+			className={ isBetaExtension( 'ai-content-lens' ) ? 'is-beta-extension inset-shadow' : '' }
+			name="ai-content-lens-plugin"
+			title={ __( 'Excerpt', 'jetpack' ) }
+		>
+			<AiPostExcerpt />
+		</PluginDocumentSettingPanel>
+	 ) as ReactElement;
+	return <PostTypeSupportCheck supportKeys="excerpt">{ pluginPanel }</PostTypeSupportCheck>;
 };

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -309,14 +309,24 @@ export const PluginDocumentSettingPanelAiExcerpt = () => {
 		return null;
 	}
 
-	const pluginPanel = (
-		<PluginDocumentSettingPanel
-			className={ isBetaExtension( 'ai-content-lens' ) ? 'is-beta-extension inset-shadow' : '' }
-			name="ai-content-lens-plugin"
-			title={ __( 'Excerpt', 'jetpack' ) }
-		>
-			<AiPostExcerpt />
-		</PluginDocumentSettingPanel>
-	 ) as ReactElement;
-	return <PostTypeSupportCheck supportKeys="excerpt">{ pluginPanel }</PostTypeSupportCheck>;
+	const SettingPanel = props => {
+		const Panel = PluginDocumentSettingPanel as unknown as React.ComponentType< {
+			className?: string;
+			name?: string;
+			title?: string;
+		} >;
+		return ( <Panel { ...props } /> ) as ReactElement;
+	};
+
+	return (
+		<PostTypeSupportCheck supportKeys="excerpt">
+			<SettingPanel
+				className={ isBetaExtension( 'ai-content-lens' ) ? 'is-beta-extension inset-shadow' : '' }
+				name="ai-content-lens-plugin"
+				title={ __( 'Excerpt', 'jetpack' ) }
+			>
+				<AiPostExcerpt />
+			</SettingPanel>
+		</PostTypeSupportCheck>
+	);
 };

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -9,8 +9,11 @@ import {
 } from '@automattic/jetpack-shared-extension-utils';
 import { TextareaControl, ExternalLink, Button, Notice, BaseControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
-import { store as editorStore, PostTypeSupportCheck } from '@wordpress/editor';
+import {
+	store as editorStore,
+	PostTypeSupportCheck,
+	PluginDocumentSettingPanel,
+} from '@wordpress/editor';
 import { useState, useEffect, useCallback } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { count } from '@wordpress/wordcount';


### PR DESCRIPTION


Fixes #41227 

## Proposed changes:
The slotfill exported from `editor` package allows for the panel to be rendered on both site and post editor.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
#41227 

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Follow the case on the issue, see that is now fixed. Test the site editor with different entities, only post and pages (or postTypes with support excerpt) should show the AI excerpt panel (or the excerpt mini-modal when AI is disabled).

Test the post editor to confirm excerpt (AI panel or default mini-modal) continues to work normally.