### PR TITLE
Comments API: Add wpcom user fields option for Jetpack sites

### DIFF
--- a/projects/plugins/jetpack/changelog/add-comment-endpoint-wpcom-user-fields
+++ b/projects/plugins/jetpack/changelog/add-comment-endpoint-wpcom-user-fields
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Comments API: Add wpcom_id and wpcom_login fields to Jetpack site comment author responses when requested via author_wpcom_data parameter.
+Comments API: Add wpcom_id and wpcom_login fields to comment author responses when requested via author_wpcom_data parameter.

--- a/projects/plugins/jetpack/changelog/add-comment-endpoint-wpcom-user-fields
+++ b/projects/plugins/jetpack/changelog/add-comment-endpoint-wpcom-user-fields
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Comments API: Add wpcom_id and wpcom_login fields to comment responses when explicitly requested via _fields parameter.
+Comments API: Add wpcom_id and wpcom_login fields to Jetpack site comment author responses when requested via author_wpcom_data parameter.

--- a/projects/plugins/jetpack/changelog/add-comment-endpoint-wpcom-user-fields
+++ b/projects/plugins/jetpack/changelog/add-comment-endpoint-wpcom-user-fields
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Comments API: Add wpcom_id and wpcom_login fields to comment responses when explicitly requested via _fields parameter.

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1524,22 +1524,21 @@ abstract class WPCOM_JSON_API_Endpoint {
 		}
 
 		// Only include WordPress.com user data when author_wpcom_data is enabled.
-		$args              = $this->query_args();
-		$author_wpcom_data = isset( $args['author_wpcom_data'] ) && $args['author_wpcom_data'];
+		$args = $this->query_args();
 
-		if ( ! empty( $id ) && $author_wpcom_data ) {
+		if ( ! empty( $id ) && ! empty( $args['author_wpcom_data'] ) ) {
 			// If this is a Jetpack site, use the connection manager to get the user data.
 			if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
 				$connection_manager = new \Automattic\Jetpack\Connection\Manager();
 				$wpcom_user_data    = $connection_manager->get_connected_user_data( $id );
 				if ( $wpcom_user_data && isset( $wpcom_user_data['ID'] ) ) {
 					$author['wpcom_id']    = (int) $wpcom_user_data['ID'];
-					$author['wpcom_login'] = isset( $wpcom_user_data['login'] ) ? $wpcom_user_data['login'] : '';
+					$author['wpcom_login'] = $wpcom_user_data['login'] ?? '';
 				}
 			} else {
 				$user                  = get_user_by( 'id', $id );
 				$author['wpcom_id']    = isset( $user->ID ) ? (int) $user->ID : null;
-				$author['wpcom_login'] = isset( $user->user_login ) ? $user->user_login : '';
+				$author['wpcom_login'] = $user->user_login ?? '';
 			}
 		}
 

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1523,7 +1523,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 			$author['site_visible'] = $site_visible;
 		}
 
-		// Get the WordPress.com user data only if the fields are requested.
+		// Only include WordPress.com user data on Jetpack sites when author_wpcom_data is enabled.
 		$args              = $this->query_args();
 		$author_wpcom_data = isset( $args['author_wpcom_data'] ) && $args['author_wpcom_data'];
 

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1527,7 +1527,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 		$args              = $this->query_args();
 		$author_wpcom_data = isset( $args['author_wpcom_data'] ) && $args['author_wpcom_data'];
 
-		if ( $author_wpcom_data && ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) ) {
+		if ( ! empty( $id ) && $author_wpcom_data && ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) ) {
 			$connection_manager = new \Automattic\Jetpack\Connection\Manager();
 			$wpcom_user_data    = $connection_manager->get_connected_user_data( $id );
 			if ( $wpcom_user_data && isset( $wpcom_user_data['ID'] ) ) {

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -6,7 +6,9 @@
  */
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Status\Host;
 
 require_once __DIR__ . '/json-api-config.php';
 require_once __DIR__ . '/sal/class.json-api-links.php';
@@ -1527,18 +1529,17 @@ abstract class WPCOM_JSON_API_Endpoint {
 		$args = $this->query_args();
 
 		if ( ! empty( $id ) && ! empty( $args['author_wpcom_data'] ) ) {
-			// If this is a Jetpack site, use the connection manager to get the user data.
-			if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
-				$connection_manager = new \Automattic\Jetpack\Connection\Manager();
-				$wpcom_user_data    = $connection_manager->get_connected_user_data( $id );
+			if ( ( new Host() )->is_wpcom_simple() ) {
+				$user                  = get_user_by( 'id', $id );
+				$author['wpcom_id']    = isset( $user->ID ) ? (int) $user->ID : null;
+				$author['wpcom_login'] = $user->user_login ?? '';
+			} else {
+				// If this is a Jetpack site, use the connection manager to get the user data.
+				$wpcom_user_data = ( new Manager() )->get_connected_user_data( $id );
 				if ( $wpcom_user_data && isset( $wpcom_user_data['ID'] ) ) {
 					$author['wpcom_id']    = (int) $wpcom_user_data['ID'];
 					$author['wpcom_login'] = $wpcom_user_data['login'] ?? '';
 				}
-			} else {
-				$user                  = get_user_by( 'id', $id );
-				$author['wpcom_id']    = isset( $user->ID ) ? (int) $user->ID : null;
-				$author['wpcom_login'] = $user->user_login ?? '';
 			}
 		}
 

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -771,6 +771,8 @@ abstract class WPCOM_JSON_API_Endpoint {
 					'is_super_admin' => '(bool)',
 					'roles'          => '(array:string)',
 					'ip_address'     => '(string|false)',
+					'wpcom_id'       => '(int|null)',
+					'wpcom_login'    => '(string|null)',
 				);
 				$return[ $key ] = (object) $this->cast_and_filter( $value, $docs, false, $for_output );
 				break;
@@ -1514,13 +1516,24 @@ abstract class WPCOM_JSON_API_Endpoint {
 			'avatar_URL'  => (string) esc_url_raw( $avatar_url ),
 			'profile_URL' => (string) esc_url_raw( $profile_url ),
 			'ip_address'  => $ip_address, // string|bool.
-			'wpcom_id'    => $id > 0 ? (int) get_user_meta( $id, 'wpcom_user_id', true ) : null,
-			'wpcom_login' => $id > 0 ? (string) get_user_meta( $id, 'wpcom_user_login', true ) : null,
 		);
 
 		if ( $site_id > -1 ) {
 			$author['site_ID']      = (int) $site_id;
 			$author['site_visible'] = $site_visible;
+		}
+
+		// Get the WordPress.com user data only if the fields are requested.
+		$args              = $this->query_args();
+		$author_wpcom_data = isset( $args['author_wpcom_data'] ) && $args['author_wpcom_data'];
+
+		if ( $author_wpcom_data && ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) ) {
+			$connection_manager = new \Automattic\Jetpack\Connection\Manager();
+			$wpcom_user_data    = $connection_manager->get_connected_user_data( $id );
+			if ( $wpcom_user_data && isset( $wpcom_user_data['ID'] ) ) {
+				$author['wpcom_id']    = (int) $wpcom_user_data['ID'];
+				$author['wpcom_login'] = isset( $wpcom_user_data['login'] ) ? $wpcom_user_data['login'] : '';
+			}
 		}
 
 		return (object) $author;

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1523,16 +1523,23 @@ abstract class WPCOM_JSON_API_Endpoint {
 			$author['site_visible'] = $site_visible;
 		}
 
-		// Only include WordPress.com user data on Jetpack sites when author_wpcom_data is enabled.
+		// Only include WordPress.com user data when author_wpcom_data is enabled.
 		$args              = $this->query_args();
 		$author_wpcom_data = isset( $args['author_wpcom_data'] ) && $args['author_wpcom_data'];
 
-		if ( ! empty( $id ) && $author_wpcom_data && ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) ) {
-			$connection_manager = new \Automattic\Jetpack\Connection\Manager();
-			$wpcom_user_data    = $connection_manager->get_connected_user_data( $id );
-			if ( $wpcom_user_data && isset( $wpcom_user_data['ID'] ) ) {
-				$author['wpcom_id']    = (int) $wpcom_user_data['ID'];
-				$author['wpcom_login'] = isset( $wpcom_user_data['login'] ) ? $wpcom_user_data['login'] : '';
+		if ( ! empty( $id ) && $author_wpcom_data ) {
+			// If this is a Jetpack site, use the connection manager to get the user data.
+			if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
+				$connection_manager = new \Automattic\Jetpack\Connection\Manager();
+				$wpcom_user_data    = $connection_manager->get_connected_user_data( $id );
+				if ( $wpcom_user_data && isset( $wpcom_user_data['ID'] ) ) {
+					$author['wpcom_id']    = (int) $wpcom_user_data['ID'];
+					$author['wpcom_login'] = isset( $wpcom_user_data['login'] ) ? $wpcom_user_data['login'] : '';
+				}
+			} else {
+				$user                  = get_user_by( 'id', $id );
+				$author['wpcom_id']    = isset( $user->ID ) ? (int) $user->ID : null;
+				$author['wpcom_login'] = isset( $user->user_login ) ? $user->user_login : '';
 			}
 		}
 

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1514,6 +1514,8 @@ abstract class WPCOM_JSON_API_Endpoint {
 			'avatar_URL'  => (string) esc_url_raw( $avatar_url ),
 			'profile_URL' => (string) esc_url_raw( $profile_url ),
 			'ip_address'  => $ip_address, // string|bool.
+			'wpcom_id'    => $id > 0 ? (int) get_user_meta( $id, 'wpcom_user_id', true ) : null,
+			'wpcom_login' => $id > 0 ? (string) get_user_meta( $id, 'wpcom_user_login', true ) : null,
 		);
 
 		if ( $site_id > -1 ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-comment-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-comment-endpoint.php
@@ -43,6 +43,8 @@ abstract class WPCOM_JSON_API_Comment_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'meta'         => '(object) Meta data',
 		'can_moderate' => '(bool) Whether current user can moderate the comment.',
 		'i_replied'    => '(bool) Has the current user replied to this comment?',
+		'wpcom_id'     => '(int|null) The user\'s WordPress.com ID if available.',
+		'wpcom_login'  => '(string|null) The user\'s WordPress.com username if available.',
 	);
 
 	/**
@@ -242,6 +244,16 @@ abstract class WPCOM_JSON_API_Comment_Endpoint extends WPCOM_JSON_API_Endpoint {
 							'count'   => true,
 						)
 					);
+					break;
+				case 'wpcom_id':
+					if ( isset( $comment->user_id ) && $comment->user_id ) {
+						$response[ $key ] = (int) get_user_meta( $comment->user_id, 'wpcom_user_id', true );
+					}
+					break;
+				case 'wpcom_login':
+					if ( isset( $comment->user_id ) && $comment->user_id ) {
+						$response[ $key ] = (string) get_user_meta( $comment->user_id, 'wpcom_user_login', true );
+					}
 					break;
 			}
 		}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-comment-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-comment-endpoint.php
@@ -43,8 +43,6 @@ abstract class WPCOM_JSON_API_Comment_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'meta'         => '(object) Meta data',
 		'can_moderate' => '(bool) Whether current user can moderate the comment.',
 		'i_replied'    => '(bool) Has the current user replied to this comment?',
-		'wpcom_id'     => '(int|null) The user\'s WordPress.com ID if available.',
-		'wpcom_login'  => '(string|null) The user\'s WordPress.com username if available.',
 	);
 
 	/**
@@ -244,16 +242,6 @@ abstract class WPCOM_JSON_API_Comment_Endpoint extends WPCOM_JSON_API_Endpoint {
 							'count'   => true,
 						)
 					);
-					break;
-				case 'wpcom_id':
-					if ( isset( $comment->user_id ) && $comment->user_id ) {
-						$response[ $key ] = (int) get_user_meta( $comment->user_id, 'wpcom_user_id', true );
-					}
-					break;
-				case 'wpcom_login':
-					if ( isset( $comment->user_id ) && $comment->user_id ) {
-						$response[ $key ] = (string) get_user_meta( $comment->user_id, 'wpcom_user_login', true );
-					}
 					break;
 			}
 		}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
@@ -161,32 +161,36 @@ class WPCOM_JSON_API_List_Comments_Endpoint extends WPCOM_JSON_API_Comment_Endpo
 		$this->query = array_merge(
 			$this->query,
 			array(
-				'number'       => '(int=20) The number of comments to return.  Limit: 100. When using hierarchical=1, number refers to the number of top-level comments returned.',
-				'offset'       => '(int=0) 0-indexed offset. Not available if using hierarchical=1.',
-				'page'         => '(int) Return the Nth 1-indexed page of comments.  Takes precedence over the <code>offset</code> parameter. When using hierarchical=1, pagination is a bit different.  See the note on the number parameter.',
-				'order'        => array(
+				'number'            => '(int=20) The number of comments to return.  Limit: 100. When using hierarchical=1, number refers to the number of top-level comments returned.',
+				'offset'            => '(int=0) 0-indexed offset. Not available if using hierarchical=1.',
+				'page'              => '(int) Return the Nth 1-indexed page of comments.  Takes precedence over the <code>offset</code> parameter. When using hierarchical=1, pagination is a bit different.  See the note on the number parameter.',
+				'order'             => array(
 					'DESC' => 'Return comments in descending order from newest to oldest.',
 					'ASC'  => 'Return comments in ascending order from oldest to newest.',
 				),
-				'hierarchical' => array(
+				'hierarchical'      => array(
 					'false' => '',
 					'true'  => '(BETA) Order the comment list hierarchically.',
 				),
-				'after'        => '(ISO 8601 datetime) Return comments dated on or after the specified datetime. Not available if using hierarchical=1.',
-				'before'       => '(ISO 8601 datetime) Return comments dated on or before the specified datetime. Not available if using hierarchical=1.',
-				'type'         => array(
+				'after'             => '(ISO 8601 datetime) Return comments dated on or after the specified datetime. Not available if using hierarchical=1.',
+				'before'            => '(ISO 8601 datetime) Return comments dated on or before the specified datetime. Not available if using hierarchical=1.',
+				'type'              => array(
 					'any'       => 'Return all comments regardless of type.',
 					'comment'   => 'Return only regular comments.',
 					'trackback' => 'Return only trackbacks.',
 					'pingback'  => 'Return only pingbacks.',
 					'pings'     => 'Return both trackbacks and pingbacks.',
 				),
-				'status'       => array(
+				'status'            => array(
 					'approved'   => 'Return only approved comments.',
 					'unapproved' => 'Return only comments in the moderation queue.',
 					'spam'       => 'Return only comments marked as spam.',
 					'trash'      => 'Return only comments in the trash.',
 					'all'        => 'Return comments of all statuses.',
+				),
+				'author_wpcom_data' => array(
+					'false' => 'Do not add wpcom_id and wpcom_login fields to Jetpack comment authorresponses (default)',
+					'true'  => 'Add wpcom_id and wpcom_login fields to Jetpack comment author responses',
 				),
 			)
 		);

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
@@ -189,7 +189,7 @@ class WPCOM_JSON_API_List_Comments_Endpoint extends WPCOM_JSON_API_Comment_Endpo
 					'all'        => 'Return comments of all statuses.',
 				),
 				'author_wpcom_data' => array(
-					'false' => 'Do not add wpcom_id and wpcom_login fields to Jetpack comment authorresponses (default)',
+					'false' => 'Do not add wpcom_id and wpcom_login fields to Jetpack comment author responses (default)',
 					'true'  => 'Add wpcom_id and wpcom_login fields to Jetpack comment author responses',
 				),
 			)

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
@@ -189,8 +189,8 @@ class WPCOM_JSON_API_List_Comments_Endpoint extends WPCOM_JSON_API_Comment_Endpo
 					'all'        => 'Return comments of all statuses.',
 				),
 				'author_wpcom_data' => array(
-					'false' => 'Do not add wpcom_id and wpcom_login fields to Jetpack comment author responses (default)',
-					'true'  => 'Add wpcom_id and wpcom_login fields to Jetpack comment author responses',
+					'false' => 'Do not add wpcom_id and wpcom_login fields to comment author responses (default)',
+					'true'  => 'Add wpcom_id and wpcom_login fields to comment author responses',
 				),
 			)
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/loop/issues/336

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds an optional `author_wpcom_data` query parameter on the `/sites/%s/posts/%d/replies/` endpoint that defaults to `false`
* When the `author_wpcom_data` query parameter is included and `true` in the endpoint request we include additional `wpcom_id` and `wpcom_login` fields that contain the user's ID and login/username as it exists on WordPress.com (as opposed to the local ID and login on the Jetpack site).
* This change is backward compatible because it does not change the response shape unless `author_wpcom_data` is explicitly requested in the query parameters.

> [!NOTE]  
> On a Jetpack site `wpcom_id` and `wpcom_login` will only be returned and populated on comment authors who are members of the site and are connected to wpcom via Jetpack connection. It will be returned and populated for all wpcom simple sites.

<img width="1249" alt="Screenshot 2025-01-23 at 11 17 46 AM" src="https://github.com/user-attachments/assets/9cccb033-1de4-41f5-948a-9e893aa7a572" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1737479496740729-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The `/sites/%s/posts/%d/replies/` endpoint works by "proxying" the request to the Jetpack site. So, you hit WordPress.com servers with public-api.wordpress.com. WordPress.com servers then make a request to the actual Jetpack site to get the data. Finally, WordPress.com servers process the returned data and serve it to the `/sites/%s/posts/%d/replies/` endpoint.

The code changes in this PR that are made to `get_author` run on the Jetpack site servers. The addition of the new `author_wpcom_data` query param definition runs on WordPress.com servers. In the case of a wpcom Simple site, all the code runs on WordPress.com servers.

* To test this PR you need a Jetpack site to apply this PR to, and you need to update your wpcom Sandbox.
* On a Jetpack site (you can create one with https://jurassic.ninja) add the [Jetpack Beta plugin](https://jetpack.com/download-jetpack-beta/).
* Activate this PR using the Jetpack Beta plugin.
<img width="998" alt="Screenshot 2025-01-22 at 4 03 58 PM" src="https://github.com/user-attachments/assets/bef8b30a-c07d-445a-98f3-7642d4b339eb" />

* To apply this PR to your sandbox run the command `bin/jetpack-downloader test jetpack add/comment-endpoint-wpcom-user-fields` found in the [comments below](https://github.com/Automattic/jetpack/pull/41254#issuecomment-2607616464).
* Once the PR is applied to the Jetpack site and your Sandbox, Sandbox the API.
* Now you can use https://developer.wordpress.com/docs/api/console/ to test the `/sites/%s/posts/%d/replies/` endpoint. Keep in mind these changes are only on your test Jetpack site, so you'll need to add some posts and comments to test with.
* In the endpoint response under Comments.Author check that you get your `wpcom_id` and `wpcom_login` back when you call the endpoint with `author_wpcom_data=true` EX: `/sites/%s/posts/%d/replies?author_wpcom_data=true`
* Test that removing `author_wpcom_data` removes the `wpcom_id` and `wpcom_login` fields.
* Test that `wpcom_id` and `wpcom_login` show up when expected and are correct.
* Repeat the test on an Atomic site (Use Jetpack Beta tester plugin to apply this PR to your Atomic site)
* Repeat the test on a Simple site (In this case Jetpack Beta tester plugin is not needed)
