### PR TITLE
Fix cookie consent registration call

### DIFF
--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -176,7 +176,6 @@ return [
         'extensions/blocks/blog-stats/blog-stats.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/blogroll/blogroll-item/blogroll-item.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'extensions/blocks/calendly/calendly.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal'],
-        'extensions/blocks/cookie-consent/cookie-consent.php' => ['PhanParamTooMany'],
         'extensions/blocks/donations/donations.php' => ['PhanTypeMismatchArgument'],
         'extensions/blocks/gif/gif.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/google-calendar/google-calendar.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],

--- a/projects/plugins/jetpack/changelog/fix-cookie-consent-reg
+++ b/projects/plugins/jetpack/changelog/fix-cookie-consent-reg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/block.json
@@ -63,5 +63,6 @@
 			"type": "boolean",
 			"default": false
 		}
-	}
+	},
+	"viewScript": "file:./view.js"
 }

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/block.json
@@ -39,7 +39,7 @@
 			"default": {
 				"color": {
 					"text": "var(--wp--preset--color--contrast)",
-					"background": "var(--wp--preset--color--tertiary, #fff)",
+					"background": "var(--wp--preset--color--tertiary)",
 					"link": "var(--wp--preset--color--contrast)"
 				},
 				"spacing": {

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/block.json
@@ -15,7 +15,8 @@
 		"anchor": false,
 		"color": {
 			"gradients": true,
-			"link": true
+			"link": true,
+			"background": true
 		},
 		"spacing": {
 			"padding": true
@@ -38,7 +39,7 @@
 			"default": {
 				"color": {
 					"text": "var(--wp--preset--color--contrast)",
-					"background": "var(--wp--preset--color--tertiary)",
+					"background": "var(--wp--preset--color--tertiary, #fff)",
 					"link": "var(--wp--preset--color--contrast)"
 				},
 				"spacing": {

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/cookie-consent.php
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/cookie-consent.php
@@ -47,9 +47,9 @@ function register_block() {
 
 	Blocks::jetpack_register_block(
 		__DIR__,
-		array( 'render_callback' => __NAMESPACE__ . '\load_assets' ),
 		array(
-			'attributes' => array(
+			'render_callback' => __NAMESPACE__ . '\load_assets',
+			'attributes'      => array(
 				'render_from_template' => array(
 					'default' => false,
 					'type'    => 'boolean',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The register call for the cookie consent block was wrong.
This PR updates the registration call to the correct one.

> the problem was the registration call which was totally wrong. it accepted 2 args and we were calling it with 3. which created issues in the static analysis and this is what I'm fixing

Via thread p1737567664742849-slack-C02T4NVL4JJ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Test for possible regressions by using the cookie consent block

<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*