### PR TITLE
renovate: Work around bug in `atomically` package

### DIFF
--- a/.github/files/renovate-post-upgrade-run.sh
+++ b/.github/files/renovate-post-upgrade-run.sh
@@ -7,4 +7,15 @@ if [[ ! -e /tmp/dummy-log/xdebug_remote.log ]]; then
 fi
 
 docker pull --quiet ghcr.io/automattic/jetpack-wordpress-dev:latest
-docker run --rm --workdir "$PWD" --user $EUID --volume /tmp/:/tmp/ --volume /tmp/dummy-log:/var/log/php ghcr.io/automattic/jetpack-wordpress-dev:latest /tmp/monorepo/.github/files/renovate-post-upgrade.sh "$@"
+
+# Work around https://github.com/fabiospampinato/atomically/issues/13 by extracting /etc/passwd from the container and appending the entry for $EUID to it.
+TMPFILE=$( mktemp )
+function cleanup {
+	rm -f "$TMPFILE"
+}
+trap cleanup exit
+chmod 0644 "$TMPFILE"
+docker run --rm ghcr.io/automattic/jetpack-wordpress-dev:latest cat /etc/passwd > "$TMPFILE"
+getent passwd $EUID >> "$TMPFILE"
+
+docker run --rm --workdir "$PWD" --user $EUID --volume "$TMPFILE":/etc/passwd --volume /tmp/:/tmp/ --volume /tmp/dummy-log:/var/log/php ghcr.io/automattic/jetpack-wordpress-dev:latest /tmp/monorepo/.github/files/renovate-post-upgrade.sh "$@"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When #40842 updated `configstore`, that brought in `atomically` v2.0.3 which has a bug where it crashes if the current user is not listed in `/etc/passwd`, which happens inside our docker container during the renovate run.

Work around this by making sure an appropriate entry is added to `/etc/passwd` inside the container.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Trigger a Renovate run using this branch, see if it regenerates #41233 properly.
  * [x] https://github.com/Automattic/jetpack/pull/41233/commits/eb508e779828a5a0e3566d9984ff38f1e6ebbdda