### PR TITLE
Forms: Fix missing tab focus in Safari

### DIFF
--- a/projects/packages/forms/changelog/fix-form-missing-tabfocus-in-safari
+++ b/projects/packages/forms/changelog/fix-form-missing-tabfocus-in-safari
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Add button tabindex 

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -148,8 +148,22 @@ class Contact_Form_Block {
 		}
 
 		self::load_view_scripts();
-
+		$content = self::add_tabindex_to_button( $content );
 		return Contact_Form::parse( $atts, do_blocks( $content ) );
+	}
+	/**
+	 * Add tabindex to button submit button so that it can be focused.
+	 *
+	 * @param string $block_content The block content.
+	 *
+	 * @return string
+	 */
+	public static function add_tabindex_to_button( $block_content ) {
+		if ( false === strpos( $block_content, '<button ' ) ) {
+			return $block_content;
+		}
+		$block_content = str_replace( '<button ', '<button tabindex="0" ', $block_content );
+		return $block_content;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -412,7 +412,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 					$submit_button_text = $form->get_attribute( 'submit_button_text' );
 				}
 
-				$r .= "\t\t<button type='submit' class='" . esc_attr( $submit_button_class ) . "'";
+				$r .= "\t\t<button tabindex='0' type='submit' class='" . esc_attr( $submit_button_class ) . "'";
 				if ( ! empty( $submit_button_styles ) ) {
 					$r .= " style='" . esc_attr( $submit_button_styles ) . "'";
 				}

--- a/projects/plugins/jetpack/changelog/fix-form-missing-tabfocus-in-safari
+++ b/projects/plugins/jetpack/changelog/fix-form-missing-tabfocus-in-safari
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+


### PR DESCRIPTION
Currently in Safari Browser on Mac you are not able to navigate to the submit button using the `tab` or arrow keys. 

This is helpful if you want to submit the form using the keyboard only. 

Before:

https://github.com/user-attachments/assets/54aecaba-06a4-4404-95cb-ce386c7325c4

After:

https://github.com/user-attachments/assets/f56c206d-312b-47a6-bb61-229cb3167b33

## Proposed changes:
* Add a tabindex="0" all form buttons so that they can be focusable in safari. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No
 
## Testing instructions:
Use the Safari Browser open
* Load this PR. 
* Create a contact form is you don't have this already. 
* Load the form in the front end. Notice that you can now tab to the submit button. 

