### PR TITLE
Forms: Fix html block rendering inside the form by wrapping the block

### DIFF
--- a/projects/packages/forms/changelog/fix-html-block-rendering-wrap-block
+++ b/projects/packages/forms/changelog/fix-html-block-rendering-wrap-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Form: Add wrapping div to the core html block when inserted inside the form block

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -30,6 +30,44 @@ class Contact_Form_Block {
 				'render_callback' => array( __CLASS__, 'gutenblock_render_form' ),
 			)
 		);
+
+		add_filter( 'render_block_data', array( __CLASS__, 'find_nested_html_block' ), 10, 3 );
+		add_filter( 'render_block_core/html', array( __CLASS__, 'render_wrapped_html_block' ), 10, 2 );
+	}
+
+	/**
+	 *  Find nested html block that reside in the contact form block.
+	 *  We are using this to wrap the html block with div if it is nested inside contact form block. So that the elements render as expected.
+	 *
+	 *  @param array  $parsed_block - the parsed block.
+	 *  @param array  $source_block - the source block.
+	 *  @param object $parent_block - the parent WP_Block.
+	 *
+	 *  @return array
+	 */
+	public static function find_nested_html_block( $parsed_block, $source_block, $parent_block ) {
+		if ( $parsed_block['blockName'] === 'core/html' && isset( $parent_block->parsed_block ) && $parent_block->parsed_block['blockName'] === 'jetpack/contact-form' ) {
+			$parsed_block['hasJPFormParent'] = true;
+		}
+		return $parsed_block;
+	}
+
+	/**
+	 * Render wrapped html block that is inside the form block with a wrapped div so that the elements render as expected.
+	 * The extra div is needed because the form block has a `flex: 0 0 100%;` applied to all the children of the form block.
+	 * This cases all the elementes inside the block to render in a single line and make it not possible to add have inline elements.
+	 *
+	 * @param string $content - the content of the block.
+	 * @param array  $parsed_block - the parsed block.
+	 *
+	 * @return string
+	 */
+	public static function render_wrapped_html_block( $content, $parsed_block ) {
+		if ( ! empty( $parsed_block['hasJPFormParent'] ) ) {
+			return '<div>' . $content . '</div>';
+		}
+
+		return $content;
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-html-block-rendering-wrap-block
+++ b/projects/plugins/jetpack/changelog/fix-html-block-rendering-wrap-block
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: this is a new block
+
+


### PR DESCRIPTION
This PR fixes the rendering of the (newly added) html block inside the form. 

Give the following blocks. 

![Screenshot 2025-01-22 at 3 16 03 PM](https://github.com/user-attachments/assets/0d1ad0cc-3b2c-4b25-b66c-69ccbdc7045e)

See 

Before:
![Screenshot 2025-01-22 at 2 58 27 PM](https://github.com/user-attachments/assets/f0cc4f86-f627-48a5-9b8c-f28147c8f83f)

After:

![Screenshot 2025-01-22 at 2 58 07 PM](https://github.com/user-attachments/assets/c91b361d-f535-4c47-90bc-b1abca9acf60)

Note the changes in the "this is a custom block" and how they are split up in a couple of lines. 

## Proposed changes:
* Wrap HTML blocks content in a div so that the content inside it behaves more like expected. We are doing this because the form has the following css line 
 ```
.wp-block-jetpack-contact-form > * {
    flex: 0 0 100%;
    box-sizing: border-box;
}
```

Which makes any html element behave as if it is a block div. Making inline elements not possible. 
A workaround to this would be to add the content of the html block inside a `div` or a `p` for example but this would need to be done by each user. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* load up this PR. 
* On a page or post 
* add the form block. 
* Inside the form block add an html block. Add some html to it. 
* Notice that it displays like expected. 
