### PR TITLE
MU WPCOM: Don't load ETK on agency sites on all pages

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-etk-feature-on-a4a-site
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-etk-feature-on-a4a-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+MU WPCOM: Don't load ETK on agency sites on all pages

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -173,6 +173,13 @@ class Jetpack_Mu_Wpcom {
 	 * Can be removed once the feature no longer exists in the ETK plugin.
 	 */
 	public static function load_etk_features_flags() {
+		// Don't load on agency sites.
+		if ( is_fully_managed_agency_site() ) {
+			return;
+		}
+
+		// Don't load if the user is not a wpcom user on WP Admin.
+		// The features is still required on the frontend page regardless of the user.
 		if ( is_admin() && ! is_wpcom_user() ) {
 			return;
 		}
@@ -206,6 +213,13 @@ class Jetpack_Mu_Wpcom {
 	 * Can be moved back to load_features() once the feature no longer exists in the ETK plugin.
 	 */
 	public static function load_etk_features() {
+		// Don't load on agency sites.
+		if ( is_fully_managed_agency_site() ) {
+			return;
+		}
+
+		// Don't load if the user is not a wpcom user on WP Admin.
+		// The features is still required on the frontend page regardless of the user.
 		if ( is_admin() && ! is_wpcom_user() ) {
 			return;
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -103,7 +103,7 @@ class Wpcom_Block_Patterns_From_Api {
 		// We prefer to show the starter page patterns modal of wpcom instead of core
 		// if it's available. Hence, we have to update the block types of patterns
 		// to disable the core's.
-		if ( class_exists( '\A8C\FSE\Starter_Page_Templates' ) || class_exists( '\Automattic\Jetpack\Jetpack_Mu_Wpcom\Starter_Page_Templates' ) ) {
+		if ( class_exists( '\A8C\FSE\Starter_Page_Templates', false ) || class_exists( '\Automattic\Jetpack\Jetpack_Mu_Wpcom\Starter_Page_Templates', false ) ) {
 			$this->update_pattern_block_types();
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/utils.php
@@ -9,13 +9,22 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 
 /**
+ * Whether the site is fully managed agency site.
+ *
+ * @return bool True if the site is fully managed agency site.
+ */
+function is_fully_managed_agency_site() {
+	return ! empty( get_option( 'is_fully_managed_agency_site' ) );
+}
+
+/**
  * Whether the current user is logged-in via WordPress.com account.
  *
  * @return bool True if the user has associated WordPress.com account.
  */
 function is_wpcom_user() {
 	// If the site is explicitly marked as agency-managed, treat the user as non-wpcom user.
-	if ( ! empty( get_option( 'is_fully_managed_agency_site' ) ) ) {
+	if ( is_fully_managed_agency_site() ) {
 		return false;
 	}
 

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-etk-feature-on-a4a-site
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-etk-feature-on-a4a-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+MU WPCOM: Don't load ETK on agency sites on all pages

--- a/projects/plugins/wpcomsh/changelog/fix-etk-feature-on-a4a-site
+++ b/projects/plugins/wpcomsh/changelog/fix-etk-feature-on-a4a-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+MU WPCOM: Don't load ETK on agency sites on all pages


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/98746

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Don't load ETK on agency sites on all pages like below. However, it's not the root cause of this issue)
```
[23-Jan-2025 04:01:27 UTC] #0 /wordpress/core/6.7.1/wp-includes/class-wp-hook.php(324): test_disable_page_template(false)
#1 /wordpress/core/6.7.1/wp-includes/plugin.php(205): WP_Hook->apply_filters(false, Array)
#2 /wordpress/plugins/wpcomsh/6.1.0-alpha+rolling.1737565780.g7050119/vendor/automattic/jetpack-mu-wpcom/src/features/starter-page-templates/class-starter-page-templates.php(49): apply_filters('a8c_disable_sta...', false)
#3 /wordpress/plugins/wpcomsh/6.1.0-alpha+rolling.1737565780.g7050119/vendor/automattic/jetpack-mu-wpcom/src/features/starter-page-templates/class-starter-page-templates.php(84): Automattic\Jetpack\Jetpack_Mu_Wpcom\Starter_Page_Templates->__construct()
#4 /wordpress/plugins/wpcomsh/6.1.0-alpha+rolling.1737565780.g7050119/vendor/automattic/jetpack-mu-wpcom/src/features/starter-page-templates/class-starter-page-templates.php(451): Automattic\Jetpack\Jetpack_Mu_Wpcom\Starter_Page_Templates::get_instance()
#5 /wordpress/plugins/wpcomsh/6.1.0-alpha+rolling.1737565780.g7050119/vendor/automattic/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php(244): require_once('/wordpress/plug...')
```
* Disable auto-loading class from [here](https://github.com/Automattic/jetpack/blob/ea0b6d3d7c034e456ba66c0b149d90f95ec88fbf/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php#L106).
```
[23-Jan-2025 03:51:50 UTC] #0 /wordpress/core/6.7.1/wp-includes/class-wp-hook.php(324): test_disable_page_template(false)
#1 /wordpress/core/6.7.1/wp-includes/plugin.php(205): WP_Hook->apply_filters(false, Array)
#2 /wordpress/plugins/wpcomsh/6.1.0-alpha+rolling.1737565780.g7050119/vendor/automattic/jetpack-mu-wpcom/src/features/starter-page-templates/class-starter-page-templates.php(49): apply_filters('a8c_disable_sta...', false)
#3 /wordpress/plugins/wpcomsh/6.1.0-alpha+rolling.1737565780.g7050119/vendor/automattic/jetpack-mu-wpcom/src/features/starter-page-templates/class-starter-page-templates.php(84): Automattic\Jetpack\Jetpack_Mu_Wpcom\Starter_Page_Templates->__construct()
#4 /wordpress/plugins/wpcomsh/6.1.0-alpha+rolling.1737565780.g7050119/vendor/automattic/jetpack-mu-wpcom/src/features/starter-page-templates/class-starter-page-templates.php(451): Automattic\Jetpack\Jetpack_Mu_Wpcom\Starter_Page_Templates::get_instance()
#5 /wordpress/plugins/wpcomsh/6.1.0-alpha+rolling.1737565780.g7050119/vendor/composer/ClassLoader.php(576): include('/wordpress/plug...')
#6 /wordpress/plugins/wpcomsh/6.1.0-alpha+rolling.1737565780.g7050119/vendor/composer/ClassLoader.php(427): Composer\Autoload\{closure}('/wordpress/plug...')
#7 [internal function]: Composer\Autoload\ClassLoader->loadClass('Automattic\\Jetp...')
#8 /wordpress/plugins/wpcomsh/6.1.0-alpha+rolling.1737565780.g7050119/vendor/automattic/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php(106): class_exists('\\Automattic\\Jet...')
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create an agency site
* Add a new page
* Make sure the following error is gone
  ```
  The "page-patterns" plugin has encountered an error and cannot be rendered error on
  ```

