### PR TITLE
MU WPCOM: Add more defensive checks when loading the Coming Soon feature

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-load-coming-soon-remove-etk-version-check
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-load-coming-soon-remove-etk-version-check
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Coming Soon: Avoid checking ETK version.
+Coming Soon: Add more checks to the ETK version comparison.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-load-coming-soon-remove-etk-version-check
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-load-coming-soon-remove-etk-version-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Coming Soon: Avoid checking ETK version.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -263,7 +263,7 @@ class Jetpack_Mu_Wpcom {
 		 * See: https://developer.wordpress.org/reference/functions/get_plugin_data/
 		 */
 		$fse_plugin                 = 'full-site-editing/full-site-editing-plugin.php';
-		$fse_plugin_path            = WP_PLUGIN_DIR . '/'. $fse_plugin;
+		$fse_plugin_path            = WP_PLUGIN_DIR . '/' . $fse_plugin;
 		$invalid_fse_version_active =
 			is_plugin_active( $fse_plugin ) &&
 			file_exists( $fse_plugin_path ) &&

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -258,18 +258,6 @@ class Jetpack_Mu_Wpcom {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		/**
-		 * Explicitly pass $markup = false in get_plugin_data to avoid indirectly calling wptexturize that could cause unintended side effects.
-		 * See: https://developer.wordpress.org/reference/functions/get_plugin_data/
-		 */
-		$invalid_fse_version_active =
-			is_plugin_active( 'full-site-editing/full-site-editing-plugin.php' ) &&
-			version_compare( get_plugin_data( WP_PLUGIN_DIR . '/full-site-editing/full-site-editing-plugin.php', false )['Version'], '3.56084', '<' );
-
-		if ( $invalid_fse_version_active ) {
-			return;
-		}
-
 		if (
 			( defined( 'WPCOM_PUBLIC_COMING_SOON' ) && WPCOM_PUBLIC_COMING_SOON ) ||
 			apply_filters( 'a8c_enable_public_coming_soon', false )

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -258,6 +258,22 @@ class Jetpack_Mu_Wpcom {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
+		/**
+		 * Explicitly pass $markup = false in get_plugin_data to avoid indirectly calling wptexturize that could cause unintended side effects.
+		 * See: https://developer.wordpress.org/reference/functions/get_plugin_data/
+		 */
+		$fse_plugin                 = 'full-site-editing/full-site-editing-plugin.php';
+		$fse_plugin_path            = WP_PLUGIN_DIR . '/'. $fse_plugin;
+		$invalid_fse_version_active =
+			is_plugin_active( $fse_plugin ) &&
+			file_exists( $fse_plugin_path ) &&
+			is_file( $fse_plugin_path ) &&
+			version_compare( get_plugin_data( $fse_plugin_path, false )['Version'], '3.56084', '<' );
+
+		if ( $invalid_fse_version_active ) {
+			return;
+		}
+
 		if (
 			( defined( 'WPCOM_PUBLIC_COMING_SOON' ) && WPCOM_PUBLIC_COMING_SOON ) ||
 			apply_filters( 'a8c_enable_public_coming_soon', false )

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -265,9 +265,9 @@ class Jetpack_Mu_Wpcom {
 		$fse_plugin                 = 'full-site-editing/full-site-editing-plugin.php';
 		$fse_plugin_path            = WP_PLUGIN_DIR . '/' . $fse_plugin;
 		$invalid_fse_version_active =
-			is_plugin_active( $fse_plugin ) &&
 			file_exists( $fse_plugin_path ) &&
 			is_file( $fse_plugin_path ) &&
+			is_plugin_active( $fse_plugin ) &&
 			version_compare( get_plugin_data( $fse_plugin_path, false )['Version'], '3.56084', '<' );
 
 		if ( $invalid_fse_version_active ) {


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR adds more checks in the ETK version comparison to ensure that the plugin file exists before calling the function `get_plugin_data()`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Smoke-test the Coming Soon functionality.
