### PR TITLE
Forms: Fix: Email recipient field does not correctly handle other users editing a page with a form

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-send-to-settings
+++ b/projects/packages/forms/changelog/fix-forms-send-to-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix send to settings for multiple authors

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -156,7 +156,6 @@ class Contact_Form_Block {
 	 * Loads scripts
 	 */
 	public static function load_editor_scripts() {
-		global $post;
 
 		$handle = 'jp-forms-blocks';
 
@@ -171,10 +170,14 @@ class Contact_Form_Block {
 			)
 		);
 
+		// Create a Contact_Form instance to get the default values
+		$contact_form = new Contact_Form( array() );
+		$defaults     = $contact_form->defaults;
+
 		$data = array(
 			'defaults' => array(
-				'to'      => wp_get_current_user()->user_email,
-				'subject' => '[' . get_bloginfo( 'name' ) . ']' . ( isset( $post ) ? ' ' . esc_html( $post->post_title ) : '' ),
+				'to'      => $defaults['to'],
+				'subject' => $defaults['subject'],
 			),
 		);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/40108

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use the same default values as the frontend.
* After this change an editor will see the initial post author email if no address was set before.

<img width="283" alt="Screenshot 2025-01-24 at 8 01 46 AM" src="https://github.com/user-attachments/assets/521d14ab-9c5e-454a-bab6-0a5941cfb262" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Log in as the admin, install, activate, and connect Jetpack to WordPress.com.
2. Go to Pages > Add New
3. Insert a Form block on the page.
4. Publish the page.
    * At that point, if someone submits a form on that page, an email is sent to the page author's email address, `admin@example.com`.
5. Log out of the site.
6. Log back in with the editor's account.
7. Go to Pages > All Pages
8. Open the page containing the form in the block editor.
9. Click on one of the form block elements.
10. Click to get to the parent block, the contact form block.
11. Check the block sidebar: confirm that you see `admin@example.com`
12. Change the address to the editor one `editor@example.com`.
13. Go to the frontend and send the form
14. Confirm that `editor@example.com` is the one receiving the submission.

