### PR TITLE
Forms: Add checkbox and consent field enter action that creates a new block

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-checkbox-enter-new-block
+++ b/projects/packages/forms/changelog/fix-forms-checkbox-enter-new-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add Checkbox and Consent field enter action to create a new block

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -315,11 +315,19 @@ const EditCheckbox = props => {
 			id={ props.attributes.id }
 			width={ props.attributes.width }
 			attributes={ props.attributes }
+			insertBlocksAfter={ props.insertBlocksAfter }
 		/>
 	);
 };
 
-const EditConsent = ( { attributes, clientId, isSelected, name, setAttributes } ) => {
+const EditConsent = ( {
+	attributes,
+	clientId,
+	isSelected,
+	name,
+	setAttributes,
+	insertBlocksAfter,
+} ) => {
 	useFormWrapper( { attributes, clientId, name } );
 
 	const { id, width, consentType, implicitConsentMessage, explicitConsentMessage } = attributes;
@@ -334,6 +342,7 @@ const EditConsent = ( { attributes, clientId, isSelected, name, setAttributes } 
 			explicitConsentMessage={ explicitConsentMessage }
 			setAttributes={ setAttributes }
 			attributes={ attributes }
+			insertBlocksAfter={ insertBlocksAfter }
 		/>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -25,6 +25,7 @@ function JetpackFieldCheckbox( props ) {
 		width,
 		defaultValue,
 		attributes,
+		insertBlocksAfter,
 	} = props;
 
 	const { blockStyle } = useJetpackFieldStyles( attributes );
@@ -56,6 +57,7 @@ function JetpackFieldCheckbox( props ) {
 					label={ label }
 					setAttributes={ setAttributes }
 					attributes={ attributes }
+					insertBlocksAfter={ insertBlocksAfter }
 				/>
 				<InspectorControls>
 					<PanelBody title={ __( 'Checkbox Settings', 'jetpack-forms' ) }>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
@@ -15,6 +15,7 @@ const JetpackFieldConsent = ( {
 	explicitConsentMessage,
 	setAttributes,
 	attributes,
+	insertBlocksAfter,
 } ) => {
 	const blockProps = useBlockProps( {
 		id: `jetpack-field-consent-${ instanceId }`,
@@ -42,6 +43,7 @@ const JetpackFieldConsent = ( {
 					__( 'Add %s consent message…', 'jetpack-forms' ),
 					consentType
 				) }
+				insertBlocksAfter={ insertBlocksAfter }
 			/>
 			<InspectorControls>
 				<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>

--- a/projects/plugins/jetpack/changelog/fix-forms-checkbox-enter-new-block
+++ b/projects/plugins/jetpack/changelog/fix-forms-checkbox-enter-new-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Forms: Add Checkbox and Consent field enter action to create a new block


### PR DESCRIPTION
Similar to https://github.com/Automattic/jetpack/pull/41177 

This PR Adds support for the single checkbox and consent fields enter action that creates a new block if enter is pressed. 

See

https://github.com/user-attachments/assets/a63dc25b-4530-467b-8352-737832034ad9



## Proposed changes:
* If you are editing a checkbox label and you push enter you now end up creating a new default block. This make it easier to add more form fields. 
* This Pr adds a similar action that is already added to other fields. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Load this PR. 
* Add a new form block to a new post or page
* Add the single checkbox. Press `Enter` and notice that you end up with new block on a new line. 
* If you push Shift + Enter you just go to a new line. (As expected) 
* This shouldn't work for other labels in the form. 


