### PR TITLE
Show "verify email" task in newsletter goal's launchpad

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-verify-email-task-newsletter-goal
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-verify-email-task-newsletter-goal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Adds verify email task to newsletter goal launchpad

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -180,17 +180,6 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/me/account';
 			},
 		),
-		'verify_email_hidden_if_verified' => array(
-			'get_title'            => function () {
-				return __( 'Verify email address', 'jetpack-mu-wpcom' );
-			},
-			'is_complete_callback' => 'wpcom_launchpad_is_email_verified',
-			'is_disabled_callback' => 'wpcom_launchpad_is_email_verified',
-			'is_visible_callback'  => 'wpcom_launchpad_is_email_unverified',
-			'get_calypso_path'     => function () {
-				return '/me/account';
-			},
-		),
 		'preview_site'                    => array(
 			'get_title'            => function () {
 				return __( 'Preview your site', 'jetpack-mu-wpcom' );
@@ -1895,22 +1884,6 @@ function wpcom_launchpad_is_email_verified() {
 	}
 
 	return ! Email_Verification::is_email_unverified();
-}
-
-/**
- * Callback for email verification incompletion.
- *
- * @return bool True if email is unverified, false otherwise.
- */
-function wpcom_launchpad_is_email_unverified() {
-	// TODO: handle the edge case where an Atomic user can be unverified.
-	if ( ! class_exists( 'Email_Verification' ) ) {
-		// Function is used when deciding visilibity of the verify email task.
-		// If we can't determine the email verification status, we should keep the task hidden.
-		return false;
-	}
-
-	return Email_Verification::is_email_unverified();
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -180,6 +180,17 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/me/account';
 			},
 		),
+		'verify_email_hidden_if_verified' => array(
+			'get_title'            => function () {
+				return __( 'Verify email address', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_is_email_verified',
+			'is_disabled_callback' => 'wpcom_launchpad_is_email_verified',
+			'is_visible_callback'  => 'wpcom_launchpad_is_email_unverified',
+			'get_calypso_path'     => function () {
+				return '/me/account';
+			},
+		),
 		'preview_site'                    => array(
 			'get_title'            => function () {
 				return __( 'Preview your site', 'jetpack-mu-wpcom' );
@@ -1884,6 +1895,22 @@ function wpcom_launchpad_is_email_verified() {
 	}
 
 	return ! Email_Verification::is_email_unverified();
+}
+
+/**
+ * Callback for email verification incompletion.
+ *
+ * @return bool True if email is unverified, false otherwise.
+ */
+function wpcom_launchpad_is_email_unverified() {
+	// TODO: handle the edge case where an Atomic user can be unverified.
+	if ( ! class_exists( 'Email_Verification' ) ) {
+		// Function is used when deciding visilibity of the verify email task.
+		// If we can't determine the email verification status, we should keep the task hidden.
+		return false;
+	}
+
+	return Email_Verification::is_email_unverified();
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -107,7 +107,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
 			'task_ids'            => array(
-				'verify_email_hidden_if_verified',
+				'verify_email',
 				'site_title',
 				'start_building_your_audience',
 				'customize_welcome_message',

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -107,6 +107,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
 			'task_ids'            => array(
+				'verify_email_hidden_if_verified',
 				'site_title',
 				'start_building_your_audience',
 				'customize_welcome_message',


### PR DESCRIPTION
Task is only shown if the email isn't already verified.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/wp-calypso#98780

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Creates new version of the verify email task, that only appears when the email isn't already verified.
* Add this task to the `intent-newsletter-goal` launchpad.

![CleanShot 2025-01-24 at 18 02 15@2x](https://github.com/user-attachments/assets/23467a8d-8916-46f1-92e0-e9ad0073e105)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

This is a WP.com change to implement a version of the tailored newsletter flow that instead works with the onboarding goals. pet6gk-1Po-p2

~~While the current newsletter tailored flow continues to show the "verify email" task after the email is verified. I'm asking about that here p1737692005156429-slack-C057AH42XQD but I don't think it's a blocker for this PR.~~

This PR uses the same logic as the existing tailored flow. We will follow up with further improvements for the verify email task itself p1737704815393259/1737692005.156429-slack-C057AH42XQD

Follow up task for further improvements: https://github.com/Automattic/wp-calypso/issues/98877

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* After applying this change to your sand box ...
* Either
  * Create a new site with `/setup/onboarding?flags=onboarding/newsletter-goal` and choose the newsletter goal.
  * Use an existing site but update the `site_intent` option to `intent-newsletter-goal`.
* Visit `/home`
* Verify the task only appears when the user hasn't already verified their email.
* Verify the task ~~disappears~~ is ticked once the email is verified.
* Other than that, confirm that the task behaves the same as the existing verify email task from the tailored onboarding flow i.e. `/setup/newsletter`