### PR TITLE
Classic Theme Helper: Fix Fatal in Jetpack_Portfolio

### DIFF
--- a/projects/packages/classic-theme-helper/changelog/fix-jetpack-portfolio-fatal
+++ b/projects/packages/classic-theme-helper/changelog/fix-jetpack-portfolio-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Classic Theme Helper: Fix Fatal in Jetpack_Portfolio

--- a/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-portfolio.php
+++ b/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-portfolio.php
@@ -1069,7 +1069,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Jetpack_Portfolio' ) ) {
 				$project_type_link = get_term_link( $project_type, self::CUSTOM_TAXONOMY_TYPE );
 
 				if ( is_wp_error( $project_type_link ) ) {
-					return $project_type_link;
+					return '';
 				}
 
 				$types[] = '<a href="' . esc_url( $project_type_link ) . '" rel="tag">' . esc_html( $project_type->name ) . '</a>';
@@ -1102,7 +1102,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Jetpack_Portfolio' ) ) {
 				$project_tag_link = get_term_link( $project_tag, self::CUSTOM_TAXONOMY_TYPE );
 
 				if ( is_wp_error( $project_tag_link ) ) {
-					return $project_tag_link;
+					return '';
 				}
 
 				$tags[] = '<a href="' . esc_url( $project_tag_link ) . '" rel="tag">' . esc_html( $project_tag->name ) . '</a>';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes the following Fatal: `Uncaught Error: Object of class WP_Error could not be converted to string` in `class-jetpack-portfolio.php`

This happens because `get_project_type` is supposed to only return a string, however it can return a `WP_Error` too.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Jetpack_Portfolio::get_project_type`: Return an empty string instead of a `WP_Error`
* `Jetpack_Portfolio::get_project_tags`: Return an empty string instead of a `WP_Error`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1737712867801939-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code Review should be enough in this case