### PR TITLE
Post List: Add a Copy Link Quick Action

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2817,6 +2817,22 @@ importers:
         specifier: 6.0.1
         version: 6.0.1(webpack@5.94.0)
 
+  projects/packages/post-list:
+    dependencies:
+      '@wordpress/i18n':
+        specifier: 5.16.0
+        version: 5.16.0
+    devDependencies:
+      '@automattic/jetpack-webpack-config':
+        specifier: workspace:*
+        version: link:../../js-packages/webpack-config
+      webpack:
+        specifier: 5.94.0
+        version: 5.94.0(webpack-cli@6.0.1)
+      webpack-cli:
+        specifier: 6.0.1
+        version: 6.0.1(webpack@5.94.0)
+
   projects/packages/protect-models: {}
 
   projects/packages/protect-status: {}

--- a/projects/packages/post-list/.gitattributes
+++ b/projects/packages/post-list/.gitattributes
@@ -1,16 +1,19 @@
 # Files not needed to be distributed in the package.
-.gitattributes    export-ignore
-.github/          export-ignore
-package.json      export-ignore
-webpack.config.js export-ignore
-phpunit.xml.dist  export-ignore
-.babelrc          export-ignore
+.gitattributes     export-ignore
+.github/           export-ignore
+package.json       export-ignore
+webpack.config.js  export-ignore
+phpunit.xml.dist   export-ignore
+.babelrc           export-ignore
 
 # Files to include in the mirror repo
-/build/**         production-include
+/build/**          production-include
 
 # Files to exclude from the mirror repo
-/changelog/**     production-exclude
-.gitignore        production-exclude
-.phpcs.dir.xml    production-exclude
-_inc/**           production-exclude
+/changelog/**      production-exclude
+.gitignore         production-exclude
+.phpcs.dir.xml     production-exclude
+_inc/**            production-exclude
+/package.json      production-exclude
+/src/**/*.js       production-exclude
+/webpack.config.js production-exclude

--- a/projects/packages/post-list/changelog/add-copy-post-link-action-in-posts-list
+++ b/projects/packages/post-list/changelog/add-copy-post-link-action-in-posts-list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Post List: Add a Copy Link Quick Action

--- a/projects/packages/post-list/composer.json
+++ b/projects/packages/post-list/composer.json
@@ -39,11 +39,11 @@
 		"test-php": [
 			"@composer phpunit"
 		],
+		"build-production": [
+			"pnpm run build-production"
+		],
 		"build-development": [
 			"pnpm run build"
-		],
-		"build-production": [
-			"pnpm run build-production-concurrently"
 		]
 	},
 	"minimum-stability": "dev",

--- a/projects/packages/post-list/composer.json
+++ b/projects/packages/post-list/composer.json
@@ -38,6 +38,12 @@
 		],
 		"test-php": [
 			"@composer phpunit"
+		],
+		"build-development": [
+			"pnpm run build"
+		],
+		"build-production": [
+			"pnpm run build-production-concurrently"
 		]
 	},
 	"minimum-stability": "dev",

--- a/projects/packages/post-list/package.json
+++ b/projects/packages/post-list/package.json
@@ -1,0 +1,29 @@
+{
+	"private": true,
+	"description": "Enhance the classic view of the Admin section of your WordPress site",
+	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/post-list/#readme",
+	"bugs": {
+		"url": "https://github.com/Automattic/jetpack/labels/[Package] Post List"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Automattic/jetpack.git",
+		"directory": "projects/packages/post-list"
+	},
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic",
+	"scripts": {
+		"build": "pnpm run clean && pnpm run build-client",
+		"build-client": "pnpm webpack --config webpack.config.js",
+		"clean": "rm -rf build/",
+		"watch": "pnpm run build && pnpm webpack watch"
+	},
+	"dependencies": {
+		"@wordpress/i18n": "5.16.0"
+	},
+	"devDependencies": {
+		"@automattic/jetpack-webpack-config": "workspace:*",
+		"webpack": "5.94.0",
+		"webpack-cli": "6.0.1"
+	}
+}

--- a/projects/packages/post-list/package.json
+++ b/projects/packages/post-list/package.json
@@ -17,8 +17,8 @@
 		"build-js": "webpack",
 		"build-production": "pnpm run clean && pnpm run build-production-js && pnpm run validate",
 		"build-production-js": "NODE_ENV=production BABEL_ENV=production pnpm run build-js",
-		"clean": "rm -rf dist",
-		"validate": "pnpm exec validate-es dist/"
+		"clean": "rm -rf build",
+		"validate": "pnpm exec validate-es build/"
 	},
 	"dependencies": {
 		"@wordpress/i18n": "5.16.0"

--- a/projects/packages/post-list/package.json
+++ b/projects/packages/post-list/package.json
@@ -13,10 +13,12 @@
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",
 	"scripts": {
-		"build": "pnpm run clean && pnpm run build-client",
-		"build-client": "pnpm webpack --config webpack.config.js",
-		"clean": "rm -rf build/",
-		"watch": "pnpm run build && pnpm webpack watch"
+		"build": "pnpm run clean && pnpm run build-js",
+		"build-js": "webpack",
+		"build-production": "pnpm run clean && pnpm run build-production-js && pnpm run validate",
+		"build-production-js": "NODE_ENV=production BABEL_ENV=production pnpm run build-js",
+		"clean": "rm -rf dist",
+		"validate": "pnpm exec validate-es dist/"
 	},
 	"dependencies": {
 		"@wordpress/i18n": "5.16.0"

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Post_List;
 
+use Automattic\Jetpack\Assets;
 use WP_Post;
 use WP_Screen;
 
@@ -91,12 +92,15 @@ class Post_List {
 				'rtl',
 				plugin_dir_url( __DIR__ ) . './src/rtl.css'
 			);
-			wp_enqueue_script(
+			Assets::register_script(
 				'jetpack_posts_list',
-				plugin_dir_url( __DIR__ ) . './build/index.js',
-				array(),
-				self::PACKAGE_VERSION,
-				true
+				'../build/index.js',
+				__FILE__,
+				array(
+					'in_footer'  => true,
+					'enqueue'    => true,
+					'textdomain' => 'jetpack-post-list',
+				)
 			);
 		}
 	}

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -190,7 +190,7 @@ class Post_List {
 	 * @return array The modified post actions array.
 	 */
 	public function add_copy_link_action( $post_actions, $post ) {
-		if ( ! is_post_publicly_viewable( $post ) ) {
+		if ( $post->post_status === 'trash' ) {
 			return $post_actions;
 		}
 

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -91,6 +91,13 @@ class Post_List {
 				'rtl',
 				plugin_dir_url( __DIR__ ) . './src/rtl.css'
 			);
+			wp_enqueue_script(
+				'jetpack_posts_list',
+				plugin_dir_url( __DIR__ ) . './build/index.js',
+				array(),
+				self::PACKAGE_VERSION,
+				true
+			);
 		}
 	}
 
@@ -166,19 +173,6 @@ class Post_List {
 		if ( ! is_post_type_viewable( $post_type ) ) {
 			return;
 		}
-
-		wp_add_inline_script(
-			'common',
-			'function copyLinkQuickAction( event ) {
-				event.preventDefault();
-				window.navigator.clipboard.writeText( event.target.getAttribute("href") ).then(() => {
-					event.target.textContent = "' . esc_js( __( 'Copied!', 'jetpack-post-list' ) ) . '";
-					setTimeout(() => {
-						event.target.textContent = "' . esc_js( __( 'Copy link', 'jetpack-post-list' ) ) . '";
-					}, 2000);
-				});
-			}'
-		);
 		add_filter( 'post_row_actions', array( $this, 'add_copy_link_action' ), 20, 2 );
 		add_filter( 'page_row_actions', array( $this, 'add_copy_link_action' ), 20, 2 );
 	}
@@ -197,7 +191,7 @@ class Post_List {
 		}
 
 		$post_actions['copy-link'] = sprintf(
-			'<a href="%1$s" aria-label="%2$s" onclick="copyLinkQuickAction(event)">%3$s</a>',
+			'<a href="%1$s" aria-label="%2$s" class="jetpack-post-list__copy-link-action">%3$s</a>',
 			esc_url( get_permalink( $post ) ),
 			esc_html__( 'Copy link to clipboard', 'jetpack-post-list' ),
 			esc_html__( 'Copy link', 'jetpack-post-list' )

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -163,21 +163,24 @@ class Post_List {
 	 * @param string $post_type The post type associated with the current request.
 	 */
 	public function maybe_add_copy_link_action( $post_type ) {
-		if ( is_post_type_viewable( $post_type ) ) {
-			wp_add_inline_script(
-				'common',
-				'function copyLinkQuickAction( event ) {
-					event.preventDefault();
-					window.navigator.clipboard.writeText( event.target.getAttribute("href") ).then(() => {
-						event.target.textContent = "' . esc_js( __( 'Copied!', 'jetpack-post-list' ) ) . '";
-						setTimeout(() => {
-							event.target.textContent = "' . esc_js( __( 'Copy link', 'jetpack-post-list' ) ) . '";
-						}, 2000);
-					});
-				}'
-			);
-			add_filter( 'post_row_actions', array( $this, 'add_copy_link_action' ), 20, 2 );
+		if ( ! is_post_type_viewable( $post_type ) ) {
+			return;
 		}
+
+		wp_add_inline_script(
+			'common',
+			'function copyLinkQuickAction( event ) {
+				event.preventDefault();
+				window.navigator.clipboard.writeText( event.target.getAttribute("href") ).then(() => {
+					event.target.textContent = "' . esc_js( __( 'Copied!', 'jetpack-post-list' ) ) . '";
+					setTimeout(() => {
+						event.target.textContent = "' . esc_js( __( 'Copy link', 'jetpack-post-list' ) ) . '";
+					}, 2000);
+				});
+			}'
+		);
+		add_filter( 'post_row_actions', array( $this, 'add_copy_link_action' ), 20, 2 );
+		add_filter( 'page_row_actions', array( $this, 'add_copy_link_action' ), 20, 2 );
 	}
 
 	/**
@@ -194,7 +197,7 @@ class Post_List {
 		}
 
 		$post_actions['copy-link'] = sprintf(
-			' <a href="%1$s" aria-label="%2$s" onclick="copyLinkQuickAction(event)">%3$s</a>',
+			'<a href="%1$s" aria-label="%2$s" onclick="copyLinkQuickAction(event)">%3$s</a>',
 			esc_url( get_permalink( $post ) ),
 			esc_html__( 'Copy link to clipboard', 'jetpack-post-list' ),
 			esc_html__( 'Copy link', 'jetpack-post-list' )

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -153,6 +153,53 @@ class Post_List {
 
 		$this->maybe_customize_columns( $current_screen->post_type );
 		$this->maybe_add_share_action( $current_screen->post_type );
+		$this->maybe_add_copy_link_action( $current_screen->post_type );
+	}
+
+	/**
+	 * Checks the current post type and adds the Copy link post
+	 * action if it is appropriate to do so.
+	 *
+	 * @param string $post_type The post type associated with the current request.
+	 */
+	public function maybe_add_copy_link_action( $post_type ) {
+		if ( is_post_type_viewable( $post_type ) ) {
+			wp_add_inline_script(
+				'common',
+				'function copyLinkQuickAction( event ) {
+					event.preventDefault();
+					window.navigator.clipboard.writeText( event.target.getAttribute("href") ).then(() => {
+						event.target.textContent = "' . esc_js( __( 'Copied!', 'jetpack-post-list' ) ) . '";
+						setTimeout(() => {
+							event.target.textContent = "' . esc_js( __( 'Copy link', 'jetpack-post-list' ) ) . '";
+						}, 2000);
+					});
+				}'
+			);
+			add_filter( 'post_row_actions', array( $this, 'add_copy_link_action' ), 20, 2 );
+		}
+	}
+
+	/**
+	 * Adds the Copy link post action which copies the post link to the clipboard.
+	 *
+	 * @param array   $post_actions The current array of post actions.
+	 * @param WP_Post $post The current post in the post list table.
+	 *
+	 * @return array The modified post actions array.
+	 */
+	public function add_copy_link_action( $post_actions, $post ) {
+		if ( ! is_post_publicly_viewable( $post ) ) {
+			return $post_actions;
+		}
+
+		$post_actions['copy-link'] = sprintf(
+			' <a href="%1$s" aria-label="%2$s" onclick="copyLinkQuickAction(event)">%3$s</a>',
+			esc_url( get_permalink( $post ) ),
+			esc_html__( 'Copy link to clipboard', 'jetpack-post-list' ),
+			esc_html__( 'Copy link', 'jetpack-post-list' )
+		);
+		return $post_actions;
 	}
 
 	/**

--- a/projects/packages/post-list/src/index.js
+++ b/projects/packages/post-list/src/index.js
@@ -1,0 +1,31 @@
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Closure function to copy the link to the clipboard.
+ *
+ * @return {Function} The click event handler.
+ */
+function copyLinkQuickAction() {
+	let timoutId;
+	/**
+	 * Copy the link to the clipboard.
+	 * @param {object} event - The event object.
+	 */
+	function onClick( event ) {
+		event.preventDefault();
+		clearTimeout( timoutId );
+		window.navigator.clipboard.writeText( event.target.getAttribute( 'href' ) ).then( () => {
+			event.target.textContent = __( 'Copied!', 'jetpack-post-list' );
+			timoutId = setTimeout( () => {
+				event.target.textContent = __( 'Copy link', 'jetpack-post-list' );
+			}, 2000 );
+		} );
+	}
+	return onClick;
+}
+
+document.addEventListener( 'DOMContentLoaded', () => {
+	document.querySelectorAll( '.jetpack-post-list__copy-link-action' ).forEach( node => {
+		node.addEventListener( 'click', copyLinkQuickAction() );
+	} );
+} );

--- a/projects/packages/post-list/tests/php/test-post-list.php
+++ b/projects/packages/post-list/tests/php/test-post-list.php
@@ -104,8 +104,10 @@ class Test_Post_List extends BaseTestCase {
 		$this->assertTrue( has_action( 'manage_posts_custom_column' ) );
 		$this->assertTrue( has_filter( 'manage_pages_columns' ) );
 		$this->assertTrue( has_action( 'manage_pages_custom_column' ) );
-		$this->assertFalse( has_action( 'post_row_actions', 'add_share_action' ) );
-		$this->assertFalse( has_action( 'page_row_actions', 'add_share_action' ) );
+		$this->assertFalse( has_action( 'post_row_actions', array( $post_list, 'add_share_action' ) ) );
+		$this->assertFalse( has_action( 'page_row_actions', array( $post_list, 'add_share_action' ) ) );
+		$this->assertNotFalse( has_action( 'post_row_actions', array( $post_list, 'add_copy_link_action' ) ) );
+		$this->assertNotFalse( has_action( 'page_row_actions', array( $post_list, 'add_copy_link_action' ) ) );
 	}
 
 	/**
@@ -197,8 +199,10 @@ class Test_Post_List extends BaseTestCase {
 		$this->assertTrue( has_action( 'manage_posts_custom_column' ) );
 		$this->assertTrue( has_filter( 'manage_pages_columns' ) );
 		$this->assertTrue( has_action( 'manage_pages_custom_column' ) );
-		$this->assertFalse( has_action( 'post_row_actions', 'add_share_action' ) );
-		$this->assertFalse( has_action( 'page_row_actions', 'add_share_action' ) );
+		$this->assertFalse( has_action( 'post_row_actions', array( $post_list, 'add_share_action' ) ) );
+		$this->assertFalse( has_action( 'page_row_actions', array( $post_list, 'add_share_action' ) ) );
+		$this->assertNotFalse( has_action( 'post_row_actions', array( $post_list, 'add_copy_link_action' ) ) );
+		$this->assertNotFalse( has_action( 'page_row_actions', array( $post_list, 'add_copy_link_action' ) ) );
 	}
 
 	/**

--- a/projects/packages/post-list/tests/php/test-post-list.php
+++ b/projects/packages/post-list/tests/php/test-post-list.php
@@ -104,8 +104,8 @@ class Test_Post_List extends BaseTestCase {
 		$this->assertTrue( has_action( 'manage_posts_custom_column' ) );
 		$this->assertTrue( has_filter( 'manage_pages_columns' ) );
 		$this->assertTrue( has_action( 'manage_pages_custom_column' ) );
-		$this->assertFalse( has_action( 'post_row_actions' ) );
-		$this->assertFalse( has_action( 'page_row_actions' ) );
+		$this->assertFalse( has_action( 'post_row_actions', 'add_share_action' ) );
+		$this->assertFalse( has_action( 'page_row_actions', 'add_share_action' ) );
 	}
 
 	/**
@@ -197,8 +197,8 @@ class Test_Post_List extends BaseTestCase {
 		$this->assertTrue( has_action( 'manage_posts_custom_column' ) );
 		$this->assertTrue( has_filter( 'manage_pages_columns' ) );
 		$this->assertTrue( has_action( 'manage_pages_custom_column' ) );
-		$this->assertFalse( has_action( 'post_row_actions' ) );
-		$this->assertFalse( has_action( 'page_row_actions' ) );
+		$this->assertFalse( has_action( 'post_row_actions', 'add_share_action' ) );
+		$this->assertFalse( has_action( 'page_row_actions', 'add_share_action' ) );
 	}
 
 	/**

--- a/projects/packages/post-list/webpack.config.js
+++ b/projects/packages/post-list/webpack.config.js
@@ -1,0 +1,27 @@
+const path = require( 'path' );
+const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
+
+module.exports = [
+	{
+		entry: {
+			index: './src/index.js',
+		},
+		mode: jetpackWebpackConfig.mode,
+		devtool: jetpackWebpackConfig.devtool,
+		output: {
+			...jetpackWebpackConfig.output,
+			path: path.resolve( './build' ),
+		},
+		optimization: {
+			...jetpackWebpackConfig.optimization,
+		},
+		resolve: {
+			...jetpackWebpackConfig.resolve,
+		},
+		node: false,
+		plugins: [ ...jetpackWebpackConfig.StandardPlugins() ],
+		module: {
+			strictExportPresence: true,
+		},
+	},
+];

--- a/projects/packages/post-list/webpack.config.js
+++ b/projects/packages/post-list/webpack.config.js
@@ -22,6 +22,12 @@ module.exports = [
 		plugins: [ ...jetpackWebpackConfig.StandardPlugins() ],
 		module: {
 			strictExportPresence: true,
+			rules: [
+				// Transpile JavaScript
+				jetpackWebpackConfig.TranspileRule( {
+					exclude: /node_modules\//,
+				} ),
+			],
 		},
 	},
 ];

--- a/projects/plugins/jetpack/changelog/add-copy-post-link-action-in-posts-list
+++ b/projects/plugins/jetpack/changelog/add-copy-post-link-action-in-posts-list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Post List: Add a Copy Link Quick Action

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2000,7 +2000,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/post-list",
-				"reference": "f5f91acacd48fd2ed2d080fa7f94b1051e17376f"
+				"reference": "ac564239b69dc4fddeeebc05ba9e62bd029cdabc"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -2043,6 +2043,12 @@
 				],
 				"test-php": [
 					"@composer phpunit"
+				],
+				"build-production": [
+					"pnpm run build-production"
+				],
+				"build-development": [
+					"pnpm run build"
 				]
 			},
 			"license": [

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2000,7 +2000,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/post-list",
-				"reference": "ac564239b69dc4fddeeebc05ba9e62bd029cdabc"
+				"reference": "767b62df31802e14760b2ff5351dd28412e87fd4"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",

--- a/projects/plugins/social/changelog/add-copy-post-link-action-in-posts-list
+++ b/projects/plugins/social/changelog/add-copy-post-link-action-in-posts-list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Post List: Add a Copy Link Quick Action

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1293,7 +1293,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/post-list",
-				"reference": "ac564239b69dc4fddeeebc05ba9e62bd029cdabc"
+				"reference": "767b62df31802e14760b2ff5351dd28412e87fd4"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1293,7 +1293,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/post-list",
-				"reference": "f5f91acacd48fd2ed2d080fa7f94b1051e17376f"
+				"reference": "ac564239b69dc4fddeeebc05ba9e62bd029cdabc"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -1336,6 +1336,12 @@
 				],
 				"test-php": [
 					"@composer phpunit"
+				],
+				"build-production": [
+					"pnpm run build-production"
+				],
+				"build-development": [
+					"pnpm run build"
 				]
 			},
 			"license": [

--- a/projects/plugins/wpcomsh/changelog/add-copy-post-link-action-in-posts-list
+++ b/projects/plugins/wpcomsh/changelog/add-copy-post-link-action-in-posts-list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Post List: Add a Copy Link Quick Action

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1416,7 +1416,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/post-list",
-                "reference": "f5f91acacd48fd2ed2d080fa7f94b1051e17376f"
+                "reference": "ac564239b69dc4fddeeebc05ba9e62bd029cdabc"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1459,6 +1459,12 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "build-development": [
+                    "pnpm run build"
                 ]
             },
             "license": [

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1416,7 +1416,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/post-list",
-                "reference": "ac564239b69dc4fddeeebc05ba9e62bd029cdabc"
+                "reference": "767b62df31802e14760b2ff5351dd28412e87fd4"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves: https://github.com/Automattic/wp-calypso/issues/98587

This PR aims to add  a "Copy Link" quick action to wp-admin for any post type and any post status to match previous calypso implementation, except `trash` status that I added here.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Testing instructions:
1. In any post type's list that is viewable (posts, pages, products, etc..) hover an entity to see the quick actions
2. Observe the `copy link` action
3. Check that works properly

