### PR TITLE
Forms: Add tracks to form submission.

### DIFF
--- a/projects/packages/connection/changelog/update-forms-tracks
+++ b/projects/packages/connection/changelog/update-forms-tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Tracks: Add site type to events

--- a/projects/packages/connection/src/class-tracking.php
+++ b/projects/packages/connection/src/class-tracking.php
@@ -250,6 +250,11 @@ class Tracking {
 
 		$properties['user_lang'] = $user->get( 'WPLANG' );
 
+		if ( ! isset( $properties['site_type'] ) && class_exists( '\Automattic\Jetpack\Status\Host' ) ) {
+			$host                    = new \Automattic\Jetpack\Status\Host();
+			$properties['site_type'] = $host->get_known_host_guess();
+		}
+
 		$blog_details = array(
 			'blog_lang' => isset( $properties['blog_lang'] ) ? $properties['blog_lang'] : get_bloginfo( 'language' ),
 			'blog_id'   => \Jetpack_Options::get_option( 'id' ),

--- a/projects/packages/connection/src/class-tracking.php
+++ b/projects/packages/connection/src/class-tracking.php
@@ -250,11 +250,6 @@ class Tracking {
 
 		$properties['user_lang'] = $user->get( 'WPLANG' );
 
-		if ( ! isset( $properties['site_type'] ) && class_exists( '\Automattic\Jetpack\Status\Host' ) ) {
-			$host                    = new \Automattic\Jetpack\Status\Host();
-			$properties['site_type'] = $host->get_known_host_guess();
-		}
-
 		$blog_details = array(
 			'blog_lang' => isset( $properties['blog_lang'] ) ? $properties['blog_lang'] : get_bloginfo( 'language' ),
 			'blog_id'   => \Jetpack_Options::get_option( 'id' ),

--- a/projects/packages/forms/changelog/update-forms-tracks
+++ b/projects/packages/forms/changelog/update-forms-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: tracks forms submissions in orden to improve the product.

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -288,12 +288,6 @@ class Util {
 			$context = 'template_part';
 		}
 
-		$site_type = 'unknown';
-		if ( class_exists( '\Automattic\Jetpack\Status\Host' ) ) {
-			$host      = new \Automattic\Jetpack\Status\Host();
-			$site_type = $host->get_known_host_guess();
-		}
-
 		$plugin = Contact_Form_Plugin::init();
 
 		$plugin->record_tracks_event(
@@ -303,7 +297,6 @@ class Util {
 				'form_type'   => $form_type,
 				'context'     => $context,
 				'has_consent' => empty( $all_values['email_marketing_consent'] ) ? 0 : 1,
-				'site_type'   => $site_type,
 			)
 		);
 	}

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -279,22 +279,31 @@ class Util {
 		/** This action is documented in jetpack/modules/widgets/social-media-icons.php */
 		do_action( 'jetpack_bump_stats_extras', 'jetpack_forms_message_sent', $extra );
 
-		$form_type = 'post';
-		if ( isset( $extra_values['widget'] ) ) {
-			$form_type = 'widget';
-		} elseif ( isset( $extra_values['block_template'] ) ) {
-			$form_type = 'block_template';
+		$form_type = isset( $extra_values['widget'] ) ? 'widget' : 'block';
+
+		$context = '';
+		if ( isset( $extra_values['block_template'] ) ) {
+			$context = 'template';
 		} elseif ( isset( $extra_values['block_template_part'] ) ) {
-			$form_type = 'block_template_part';
+			$context = 'template_part';
+		}
+
+		$site_type = 'unknown';
+		if ( class_exists( '\Automattic\Jetpack\Status\Host' ) ) {
+			$host      = new \Automattic\Jetpack\Status\Host();
+			$site_type = $host->get_known_host_guess();
 		}
 
 		$plugin = Contact_Form_Plugin::init();
+
 		$plugin->record_tracks_event(
 			'jetpack_forms_message_sent',
 			array(
 				'post_id'     => $post_id,
 				'form_type'   => $form_type,
+				'context'     => $context,
 				'has_consent' => empty( $all_values['email_marketing_consent'] ) ? 0 : 1,
+				'site_type'   => $site_type,
 			)
 		);
 	}

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -35,7 +35,7 @@ class Util {
 
 		add_action( 'init', '\Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init', 9 );
 		add_action( 'grunion_scheduled_delete', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam' );
-		add_action( 'grunion_pre_message_sent', '\Automattic\Jetpack\Forms\ContactForm\Util::jetpack_tracks_record_grunion_pre_message_sent', 12 );
+		add_action( 'grunion_pre_message_sent', '\Automattic\Jetpack\Forms\ContactForm\Util::jetpack_tracks_record_grunion_pre_message_sent', 12, 3 );
 	}
 
 	/**
@@ -262,11 +262,13 @@ class Util {
 	/**
 	 * Send an event to Tracks on form submission.
 	 *
-	 * @param int $post_id - the post_id for the CPT that is created.
+	 * @param int   $post_id - the post_id for the CPT that is created.
+	 * @param array $all_values - array containing all form fields.
+	 * @param array $extra_values - array containing extra form metadata.
 	 *
 	 * @return null|void
 	 */
-	public static function jetpack_tracks_record_grunion_pre_message_sent( $post_id ) {
+	public static function jetpack_tracks_record_grunion_pre_message_sent( $post_id, $all_values = array(), $extra_values = array() ) {
 		$post = get_post( $post_id );
 		if ( $post ) {
 			$extra = gmdate( 'Y-W', strtotime( $post->post_date_gmt ) );
@@ -276,6 +278,25 @@ class Util {
 
 		/** This action is documented in jetpack/modules/widgets/social-media-icons.php */
 		do_action( 'jetpack_bump_stats_extras', 'jetpack_forms_message_sent', $extra );
+
+		$form_type = 'post';
+		if ( isset( $extra_values['widget'] ) ) {
+			$form_type = 'widget';
+		} elseif ( isset( $extra_values['block_template'] ) ) {
+			$form_type = 'block_template';
+		} elseif ( isset( $extra_values['block_template_part'] ) ) {
+			$form_type = 'block_template_part';
+		}
+
+		$plugin = Contact_Form_Plugin::init();
+		$plugin->record_tracks_event(
+			'jetpack_forms_message_sent',
+			array(
+				'post_id'     => $post_id,
+				'form_type'   => $form_type,
+				'has_consent' => empty( $all_values['email_marketing_consent'] ) ? 0 : 1,
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Previously removed here: https://github.com/Automattic/jetpack/pull/29383

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Records a tracks event every time a form is submitted
* Collects the type of form

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1737725216949399-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Submit a form and check that a tracks event is being fired.