### PR TITLE
Add phpcs:ignores for wpcom

### DIFF
--- a/projects/packages/connection/changelog/add-phpcs-ignore-for-wpcut
+++ b/projects/packages/connection/changelog/add-phpcs-ignore-for-wpcut
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Add phpcs:ignore for wpcom. No changes to functionality.
+
+

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -189,6 +189,7 @@ class Manager {
 		add_action( 'pre_update_jetpack_option_blog_token', array( $this, 'reset_connection_status' ) );
 		add_action( 'pre_update_jetpack_option_user_token', array( $this, 'reset_connection_status' ) );
 		add_action( 'pre_update_jetpack_option_user_tokens', array( $this, 'reset_connection_status' ) );
+		// phpcs:ignore WPCUT.SwitchBlog.SwitchBlog -- wpcom flags **every** use of switch_blog, apparently expecting valid instances to ignore or suppress the sniff.
 		add_action( 'switch_blog', array( $this, 'reset_connection_status' ) );
 
 		self::$connection_invalidators_added = true;

--- a/projects/plugins/jetpack/changelog/add-phpcs-ignore-for-wpcut
+++ b/projects/plugins/jetpack/changelog/add-phpcs-ignore-for-wpcut
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Add phpcs:ignore for wpcom. No changes to functionality.
+
+

--- a/projects/plugins/jetpack/modules/markdown/easy-markdown.php
+++ b/projects/plugins/jetpack/modules/markdown/easy-markdown.php
@@ -93,6 +93,7 @@ class WPCom_Markdown {
 		$this->add_default_post_type_support();
 		$this->maybe_load_actions_and_filters();
 		if ( defined( 'REST_API_REQUEST' ) && REST_API_REQUEST ) {
+			// phpcs:ignore WPCUT.SwitchBlog.SwitchBlog -- wpcom flags **every** use of switch_blog, apparently expecting valid instances to ignore or suppress the sniff.
 			add_action( 'switch_blog', array( $this, 'maybe_load_actions_and_filters' ), 10, 2 );
 		}
 		add_action( 'admin_init', array( $this, 'register_setting' ) );

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -234,6 +234,7 @@ class Jetpack_Memberships {
 	private function register_init_hook() {
 		add_action( 'init', array( $this, 'init_hook_action' ) );
 		add_action( 'jetpack_register_gutenberg_extensions', array( $this, 'register_gutenberg_block' ) );
+		// phpcs:ignore WPCUT.SwitchBlog.SwitchBlog -- wpcom flags **every** use of switch_blog, apparently expecting valid instances to ignore or suppress the sniff.
 		add_action( 'switch_blog', array( $this, 'clear_post_access_level_cache' ) );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Wpcom has a linting check that flags every use of the `switch_blog` hook, apparently with the intention that any "valid" uses ignore the sniff. So let's do that so as to not block any deploys that happen to touch near these lines (as is currently happening).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1737729222088279/1737705098.911989-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy? 🤷