### PR TITLE
Repo Gardening: add new task to synchronize labels between repos

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - trunk # Every time a PR is merged to trunk.
+
 concurrency:
   # For pull_request_target, cancel any concurrent jobs with the same type (e.g. "opened", "labeled") and branch.
   # Don't cancel any for other events, accomplished by grouping on the unique run_id.

--- a/projects/github-actions/repo-gardening/README.md
+++ b/projects/github-actions/repo-gardening/README.md
@@ -17,6 +17,7 @@ Here is the current list of tasks handled by this action:
 - Triage Issues (`triageIssues`): Adds labels to issues based on issue content, and send Slack notifications depending on Priority.
 - Gather support references (`gatherSupportReferences`): Adds a new comment with a list of all support references on the issue, and escalates that issue via a Slack message if needed.
 - Reply to customers Reminder ( `replyToCustomersReminder` ): sends a Slack message about closed issues to remind Automatticians to update customers.
+- Label sync ( `syncLabels` ): import specific labels ("[Type]", "[Feature]", and "[Feature Group]") from a source repository to the current repository.
 
 Some of the tasks are may not satisfy your needs. If that's the case, you can use the `tasks` option to limit the action to the list of tasks you need in your repo. See the example below to find out more.
 
@@ -86,6 +87,7 @@ The action relies on the following parameters.
 - (Optional) `project_board_url` is the URL of a GitHub Project Board. We'll automate some of the work on that board in the `triageIssues` task.
 - (Optional) `labels_team_assignments` is a list of features you can provide, with matching team names, as specified in the "Team" field of your GitHub Project Board used for the `triageIssues` task, and lists of labels in use in your repository.
 - (Optional) `openai_api_key` is the API key for OpenAI. This is required if you want to use the `triageIssues` task to automatically add labels to your issues. **Note**: this option is only available for Automattic-hosted repositories.
+- (Optional) `labels_source_repo` is the full URL of a GitHub repository. It is required if you want to use the `syncLabels` task.
 
 #### How to create a Slack bot and get your SLACK_TOKEN
 

--- a/projects/github-actions/repo-gardening/action.yml
+++ b/projects/github-actions/repo-gardening/action.yml
@@ -60,6 +60,10 @@ inputs:
     description: "OpenAI API key"
     required: false
     default: ""
+  labels_source_repo:
+    description: "Repository to fetch labels from"
+    required: false
+    default: "https://github.com/automattic/jetpack"
 runs:
   using: node20
   main: "dist/index.js"

--- a/projects/github-actions/repo-gardening/changelog/add-repo-gardening-label-sync
+++ b/projects/github-actions/repo-gardening/changelog/add-repo-gardening-label-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Label sync: add new task to synchronize labels between repos.

--- a/projects/github-actions/repo-gardening/src/index.js
+++ b/projects/github-actions/repo-gardening/src/index.js
@@ -10,6 +10,7 @@ const gatherSupportReferences = require( './tasks/gather-support-references' );
 const notifyDesign = require( './tasks/notify-design' );
 const notifyEditorial = require( './tasks/notify-editorial' );
 const replyToCustomersReminder = require( './tasks/reply-to-customers-reminder' );
+const syncLabels = require( './tasks/sync-labels' );
 const triageIssues = require( './tasks/triage-issues' );
 const debug = require( './utils/debug' );
 const ifNotClosed = require( './utils/if-not-closed' );
@@ -80,6 +81,10 @@ const automations = [
 		event: 'issues',
 		action: [ 'closed' ],
 		task: replyToCustomersReminder,
+	},
+	{
+		event: 'workflow_dispatch',
+		task: syncLabels,
 	},
 ];
 

--- a/projects/github-actions/repo-gardening/src/tasks/sync-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/sync-labels/index.js
@@ -1,0 +1,83 @@
+const { getInput } = require( '@actions/core' );
+const debug = require( '../../utils/debug' );
+const formatSlackMessage = require( '../../utils/slack/format-slack-message' );
+const sendSlackMessage = require( '../../utils/slack/send-slack-message' );
+
+/* global GitHub, WebhookPayloadIssue */
+
+/**
+ * Synchronize specific labels from a source repository to the current repository.
+ * It synchronizes all [Type], [Feature], and [Feature Group] labels.
+ *
+ * This task is only triggered manually so far.
+ * By default, we synchronize labels from the automattic/jetpack repo.
+ *
+ * This task can send 2 different types of Slack notifications:
+ * - If an issue is determined as High or Blocker priority,
+ * - If no priority is determined.
+ *
+ * @param {WebhookPayloadIssue} payload - Issue event payload.
+ * @param {GitHub}              octokit - Initialized Octokit REST client.
+ */
+async function syncLabels( payload, octokit ) {
+	const {
+		repository: {
+			owner: { login: ownerLogin },
+			name,
+		},
+	} = payload;
+
+	const sourceRepo = getInput( 'labels_source_repo' );
+
+	// If we do not know where to pull labels from, we cannot proceed.
+	if ( ! sourceRepo ) {
+		debug( 'sync-labels: No source repo provided. Skipping sync.' );
+		return;
+	}
+	const [ , owner, repo ] = sourceRepo.match( /https:\/\/github\.com\/([^/]+)\/([^/]+)/ );
+	if ( ! owner || ! repo ) {
+		debug( 'sync-labels: Invalid source repo provided. Skipping sync.' );
+		return;
+	}
+
+	const qualityChannel = getInput( 'slack_quality_channel' );
+	if ( qualityChannel ) {
+		const message = `Label sync has been triggered. Labels are being synced from ${ owner }/${ repo } to ${ ownerLogin }/${ name }.`;
+		const slackMessageFormat = formatSlackMessage( payload, qualityChannel, message );
+		await sendSlackMessage( message, qualityChannel, payload, slackMessageFormat );
+	}
+
+	// Get all labels from the source repo.
+	for await ( const response of octokit.paginate.iterator( octokit.rest.issues.listLabelsForRepo, {
+		owner,
+		repo,
+		per_page: 100,
+	} ) ) {
+		for ( const label of response.data ) {
+			if ( ! label.name.match( /\[Type\]|\[Feature\]|\[Feature Group\]/ ) ) {
+				continue;
+			}
+
+			debug( `sync-labels: adding "${ label.name }" label to repo` );
+			try {
+				await octokit.rest.issues.createLabel( {
+					owner: ownerLogin,
+					repo: name,
+					name: label.name,
+					color: label.color,
+					description: label.description,
+				} );
+			} catch ( error ) {
+				if ( error.status === 422 && error.message.includes( 'already_exists' ) ) {
+					debug( `sync-labels: "${ label.name }" label already exists in the repo. Skipping` );
+				} else {
+					debug( `sync-labels: error while creating a new label: ${ error.message }` );
+				}
+			}
+
+			// Sleep for 2 seconds to avoid rate limiting
+			await new Promise( resolve => setTimeout( resolve, 2000 ) );
+		}
+	}
+}
+module.exports = syncLabels;

--- a/projects/github-actions/repo-gardening/src/tasks/sync-labels/readme.md
+++ b/projects/github-actions/repo-gardening/src/tasks/sync-labels/readme.md
@@ -1,0 +1,22 @@
+# Sync Labels
+
+This task is triggered
+
+#### Usage
+
+
+Example:
+```yml
+  ...
+  with:
+    tasks: 'syncLabels'
+    labels_source_repo: 'https://github.com/automattic/jetpack/'
+```
+
+### Sending Slack notifications
+
+Slack notifications are sent to the Quality team when a new sync is triggered, and if you've specified a Slack token and Slack channel ID in your workflow configuration.
+
+## Rationale
+
+* 

--- a/projects/github-actions/repo-gardening/src/utils/slack/send-slack-message.js
+++ b/projects/github-actions/repo-gardening/src/utils/slack/send-slack-message.js
@@ -15,7 +15,7 @@ const { WebClient, ErrorCode } = require( '@slack/web-api' );
 async function sendSlackMessage( message, channel, payload, customMessageFormat = {} ) {
 	const token = getInput( 'slack_token' );
 	if ( ! token ) {
-		setFailed( 'triage-issues: Input slack_token is required but missing. Aborting.' );
+		setFailed( 'slack notifications: Input slack_token is required but missing. Aborting.' );
 		return;
 	}
 


### PR DESCRIPTION
## Proposed changes:

Let's ensure that our different repos all ship with the same Feature, Type, and Feature Group labels. It will make triage and reporting easier.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Internal reference: pfVjQF-su-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

*TBD
