### PR TITLE
Forms: Fix empty form block - show nothing

### DIFF
--- a/projects/packages/forms/changelog/fix-empty-form-block-remove-render
+++ b/projects/packages/forms/changelog/fix-empty-form-block-remove-render
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove the rending of the form block if it is empty

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -133,6 +133,11 @@ class Contact_Form_Block {
 	 * @return string
 	 */
 	public static function gutenblock_render_form( $atts, $content ) {
+		// If the user has not selected any type of form lets not display the default form but display nothing.
+		if ( empty( $atts ) && trim( $content ) === '<div class="wp-block-jetpack-contact-form"></div>' ) {
+			return '';
+		}
+
 		// We should not render block is module is disabled
 		if ( ! Jetpack::is_module_active( 'contact-form' ) ) {
 			return '';

--- a/projects/plugins/jetpack/changelog/fix-empty-form-block-remove-render
+++ b/projects/plugins/jetpack/changelog/fix-empty-form-block-remove-render
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Remove the rendering of the form block if it is empty


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/41244

This PR fixes the case where a user added the contact form block but didn't select any form. 

Editor 
![Screenshot 2025-01-24 at 11 11 18 AM](https://github.com/user-attachments/assets/fb150986-2205-469c-a2f9-39957961d646)



Front end Before: We should show a simple contact form. Notice that the form doesn't have the expected styling.

![Screenshot 2025-01-24 at 11 11 49 AM](https://github.com/user-attachments/assets/f6c41685-f008-4331-95c9-7c37871af332)

Front end | After: We show nothing. 

![Screenshot 2025-01-24 at 11 12 03 AM](https://github.com/user-attachments/assets/3b3d2a34-3031-485d-a4a7-b9531bb250df)


## Proposed changes:
* Remove the form from the fronted if the user doesn't select the a type of form.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Load this PR. 
* Create a new page and add the form block. Publish the post. 
* Notice that on the front end we don't show any type of form. 

