### PR TITLE
Fix: icon in style editor

### DIFF
--- a/projects/packages/forms/changelog/fix-icon-in-site-editor
+++ b/projects/packages/forms/changelog/fix-icon-in-site-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Make the icons show up as expected in the style editor

--- a/projects/packages/forms/src/blocks/contact-form/util/render-material-icon.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/render-material-icon.js
@@ -1,8 +1,7 @@
-import { Path, SVG } from '@wordpress/components';
+import { SVG } from '@wordpress/components';
 
 const renderMaterialIcon = ( svg, width = 24, height = 24, viewbox = '0 0 24 24' ) => (
 	<SVG xmlns="http://www.w3.org/2000/svg" width={ width } height={ height } viewBox={ viewbox }>
-		<Path fill="none" d="M0 0h24v24H0V0z" className="icon-filler" />
 		{ svg }
 	</SVG>
 );

--- a/projects/plugins/jetpack/changelog/fix-icon-in-site-editor
+++ b/projects/plugins/jetpack/changelog/fix-icon-in-site-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Make the icons show up as expected in the style editor

--- a/projects/plugins/jetpack/extensions/blocks/map/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/map/block.json
@@ -8,7 +8,7 @@
 	"version": "12.5.0",
 	"textdomain": "jetpack",
 	"category": "embed",
-	"icon": "<svg viewBox='0 0 24 24' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path fill='none' d='M0 0h24v24H0V0z' /><path d='M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM10 5.47l4 1.4v11.66l-4-1.4V5.47zm-5 .99l3-1.01v11.7l-3 1.16V6.46zm14 11.08l-3 1.01V6.86l3-1.16v11.84z' /></svg>",
+	"icon": "<svg viewBox='0 0 24 24' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM10 5.47l4 1.4v11.66l-4-1.4V5.47zm-5 .99l3-1.01v11.7l-3 1.16V6.46zm14 11.08l-3 1.01V6.86l3-1.16v11.84z' /></svg>",
 	"supports": { "defaultStylePicker": false, "html": false },
 	"attributes": {
 		"align": {


### PR DESCRIPTION
Some block icons don't show up nicely in the style editor
This PR intends to fix this by removing the unnecessary svg path. 

Before:
![Screenshot 2025-01-24 at 11 42 18 AM](https://github.com/user-attachments/assets/7c957aae-b48b-46ab-9c82-b3e93e9e4c24)

After:
![Screenshot 2025-01-24 at 11 29 15 AM](https://github.com/user-attachments/assets/dd92c043-8ee7-4162-b1c3-1edf60daa33b)

## Proposed changes:

* Remove the not needed Path in order to fix how the icon is displayed in the style editor.  

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Load this PR.
* Using a block theme navigate to the style editor. 
* Visit the block styling sidebar panel. 
* Notice that the icons looks as expected. 
* In the block editor add the form and map block notice that the icons look as you would expect. (same as before)

