### PR TITLE
VideoPress: Fix issue with VideoPress block with 0 height and width

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-block-classic-themes
+++ b/projects/packages/videopress/changelog/fix-videopress-block-classic-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix issue with VideoPress block with 0 height and width

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
@@ -11,7 +11,6 @@
 
 	.jetpack-videopress-player__wrapper {
 		position: relative;
-		display: flex;
 		line-height: 0;
 	}
 

--- a/projects/plugins/jetpack/changelog/fix-videopress-block-classic-themes
+++ b/projects/plugins/jetpack/changelog/fix-videopress-block-classic-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: Fix issue with VideoPress block with 0 height and width

--- a/projects/plugins/videopress/changelog/fix-videopress-block-classic-themes
+++ b/projects/plugins/videopress/changelog/fix-videopress-block-classic-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix issue with VideoPress block with 0 height and width


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #41317 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the `flex` display of the video wrapper, going back do `block`. The element contains only one child, so in theory there should be no problem

The script that adjusts the iframe seems to fail when the display is set to `flex` for some reason. My guess is that there is some race condition or browser bug involved, so this seems the simplest way to solve it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On `trunk` (Bleeding Edge with Jetpack Beta), go to the block editor and add a VideoPress blog.
* Upload one video, save and publish the page.
* On the published page, check that the video is displayed as expected on the default theme and other block themes
* Check that the video is NOT displayed on some classic themes such as Shoreditch, Kadence and Twenty Nineteen
* Checkout this branch
* Visit the published page again or reload it
* Check that that the video is visible on all listed themes (bonus points for trying other themes :+1: )
* Now do a quick test with the VideoPress plugin instead of Jetpack, by checking out this branch on VideoPress and removing the Jetpack plugin
* Test also on a simple site

| Before | After |
| - | - |
| ![Screenshot from 2025-01-24 17-39-28](https://github.com/user-attachments/assets/37117fec-70ce-4508-92fc-abf9ad93ce94) | ![Screenshot from 2025-01-24 17-39-44](https://github.com/user-attachments/assets/8563a11a-3557-4f21-b01b-6ba83e7e7df5) |

