### PR TITLE
Launchpad: Add messages anchor in customize welcome message task URL

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-messages-anchor-in-customize_welcome_message-task-path
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-messages-anchor-in-customize_welcome_message-task-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add messages area anchor in customize_welcome_message Launchpad task path

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -504,7 +504,7 @@ function wpcom_launchpad_get_task_definitions() {
 				if ( wpcom_launchpad_should_use_wp_admin_link() ) {
 					return admin_url( 'admin.php?page=jetpack#/newsletter' );
 				}
-				return '/settings/newsletter/' . $data['site_slug_encoded'];
+				return '/settings/newsletter/' . $data['site_slug_encoded'] . '#messages';
 			},
 		),
 		'enable_subscribers_modal'        => array(


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/98909.

## Proposed changes:

The `calypso_path` for the "Write a welcome message" Launchpad task doesn't have the `#messages` anchor and, because it's not there, the page wasn't scrolling down to section relative to the task.

### Other information:

~- [ ] Have you written new tests for your changes, if applicable?~
~- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?~
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A, but check 36cae-pb.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Apply this patch to your sandbox and verify that the Launchpad task now points to the "Messages" section within Newsletter settings.