### PR TITLE
Forms: Fixes permenatly delete form responses

### DIFF
--- a/projects/packages/forms/changelog/fix-permenatly-delete-form-responses
+++ b/projects/packages/forms/changelog/fix-permenatly-delete-form-responses
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix permently deleting form reponses via the quicklinks

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -1200,6 +1200,14 @@ class Admin {
 			if ( ! wp_trash_post( $post_id ) ) {
 				wp_die( esc_html__( 'Error in moving to Trash.', 'jetpack-forms' ) );
 			}
+		} elseif ( $_POST['make_it'] === 'delete' ) {
+			if ( ! current_user_can( $post_type_object->cap->delete_post, $post_id ) ) {
+				wp_die( esc_html__( 'You are not allowed to move this item to the Trash.', 'jetpack-forms' ) );
+			}
+
+			if ( ! wp_delete_post( $post_id, true ) ) {
+				wp_die( esc_html__( 'Error in deleting post.', 'jetpack-forms' ) );
+			}
 		}
 
 		$sql          = "

--- a/projects/packages/forms/src/contact-form/js/grunion-admin.js
+++ b/projects/packages/forms/src/contact-form/js/grunion-admin.js
@@ -187,6 +187,11 @@ jQuery( function ( $ ) {
 				e.preventDefault();
 				updateStatus( postId, 'publish', '#59C859' );
 			}
+
+			if ( $( e.target ).parent().hasClass( 'delete' ) ) {
+				e.preventDefault();
+				updateStatus( postId, 'delete', '#FF7979' );
+			}
 		} );
 	} );
 

--- a/projects/plugins/jetpack/changelog/fix-permenatly-delete-form-responses
+++ b/projects/plugins/jetpack/changelog/fix-permenatly-delete-form-responses
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix permently deleting form reponses via the quicklinks


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/40736

https://github.com/user-attachments/assets/39c2534d-53f5-4a9e-a88f-653b80998a53

## Proposed changes:
* This Pr fixes the permanently deleting of form responses by fixing the broken link in the classic form responses view. 
* Since there is already a new form response view. I left this bug fix minimal. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Load this PR. 
* Create a form on a page.
* In a different browser window fill out the form. 
* Navigate to the form responses
* Trash the response. Navigate the trashed responses (filter)
* Delete the response permanently using the quick links. 

