### PR TITLE
Remove customization for hiding Core's start page options modal

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-remove-update_pattern_block_types
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-remove-update_pattern_block_types
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Remove customization for the start page options modal

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -100,13 +100,6 @@ class Wpcom_Block_Patterns_From_Api {
 			}
 		}
 
-		// We prefer to show the starter page patterns modal of wpcom instead of core
-		// if it's available. Hence, we have to update the block types of patterns
-		// to disable the core's.
-		if ( class_exists( '\A8C\FSE\Starter_Page_Templates', false ) || class_exists( '\Automattic\Jetpack\Jetpack_Mu_Wpcom\Starter_Page_Templates', false ) ) {
-			$this->update_pattern_block_types();
-		}
-
 		// Temporarily removing the call to `update_pattern_post_types` while we investigate
 		// https://github.com/Automattic/wp-calypso/issues/79145.
 
@@ -200,31 +193,6 @@ class Wpcom_Block_Patterns_From_Api {
 
 				$pattern['postTypes'] = $post_types;
 				$pattern_name         = $pattern['name'];
-				unset( $pattern['name'] );
-				register_block_pattern( $pattern_name, $pattern );
-			}
-		}
-	}
-
-	/**
-	 * Ensure that all patterns with a blockType property are registered with appropriate postTypes.
-	 */
-	private function update_pattern_block_types() {
-		if ( ! class_exists( 'WP_Block_Patterns_Registry' ) ) {
-			return;
-		}
-		foreach ( \WP_Block_Patterns_Registry::get_instance()->get_all_registered() as $pattern ) {
-			if ( ! array_key_exists( 'blockTypes', $pattern ) || empty( $pattern['blockTypes'] ) ) {
-				continue;
-			}
-
-			$post_content_offset = array_search( 'core/post-content', $pattern['blockTypes'], true );
-			$is_page_pattern     = empty( $pattern['postTypes'] ) || in_array( 'page', $pattern['postTypes'], true );
-			if ( $post_content_offset !== false && $is_page_pattern ) {
-				unregister_block_pattern( $pattern['name'] );
-
-				array_splice( $pattern['blockTypes'], $post_content_offset, 1 );
-				$pattern_name = $pattern['name'];
 				unset( $pattern['name'] );
 				register_block_pattern( $pattern_name, $pattern );
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to 
- https://github.com/Automattic/wp-calypso/pull/83750
- https://github.com/Automattic/wp-calypso/issues/98892

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Remove `update_pattern_block_types` since;

- we should fix the bug where core/post-content is stripped out of registered patterns. https://github.com/Automattic/wp-calypso/issues/98892
- Core's start page options modal was [replaced](https://github.com/WordPress/gutenberg/pull/66836) with the sidebar. 
	- I believe we can remove our whole starter page template modal, but this PR focuses on removing `update_pattern_block_types` only.

See p1737695864171759/1737538662.329279-slack-C03N25JPCE4 for more context.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Patch this PR by following the instructions in https://github.com/Automattic/jetpack/pull/41324#issuecomment-2614685477
* Create a new page
* Ensure our starter page template modal is displayed correctly
	* <img width="2513" alt="Screenshot 2025-01-27 at 15 01 41" src="https://github.com/user-attachments/assets/fba39b55-ec2c-4456-95ec-9674a1f66724" />
	* i.e., Ensure Core's start page options modal isn't displayed
		* on Core: <img width="2500" alt="Screenshot 2025-01-27 at 15 06 19" src="https://github.com/user-attachments/assets/d9359f86-527d-420d-8154-fd9d5aa37945" />

