### PR TITLE
Launchpad: disable launch site task on already launched sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-disable-launch-site-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-disable-launch-site-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Launchpad: Launch site task disabled for launched sites

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -168,6 +168,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'isLaunchTask'          => true,
 			'is_complete_callback'  => 'wpcom_launchpad_is_site_launched',
+			'is_disabled_callback'  => 'wpcom_launchpad_is_site_launched_disabled',
 			'add_listener_callback' => 'wpcom_launchpad_add_site_launch_listener',
 		),
 		'verify_email'                    => array(
@@ -906,6 +907,15 @@ function wpcom_launchpad_is_site_launched( $task, $is_complete ) {
 	} else {
 		return false;
 	}
+}
+
+/**
+ * Disabled when the site is already launched.
+ *
+ * @return boolean
+ */
+function wpcom_launchpad_is_site_launched_disabled() {
+	return 'launched' === get_option( 'launch-status' );
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/98924

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Launching a site is a one time thing, yet it's possible to click the "launch site" task multiple times. This PR disables the launch site task for sites which are already launched.

There's existing logic in the `wpcom_launchpad_is_site_launched()` function for returning true when the site is launched. However it also runs side effects and I didn't want those to be running just because we're setting the disabled flag for the task.

![CleanShot 2025-01-27 at 18 11 43@2x](https://github.com/user-attachments/assets/719ca780-3571-4712-89db-f48df70b88ce)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1737944075506719-slack-C057AH42XQD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a site with "launch site" in the launchpad
  * e.g. `/setup/onboarding`, choose no goals, then skip the full screen launchpad to get to My Home
* Launch the site from the launchpad
* Dismiss the dialog that appears
* In the card that replaces the launchpad on My Home, say you want to go back to setup steps
* The launch task is no longer clickable