### PR TITLE
OG Tags: do not output our tags when SEOPress is active

### DIFF
--- a/projects/plugins/jetpack/changelog/update-og-tags-conflicting-plugins
+++ b/projects/plugins/jetpack/changelog/update-og-tags-conflicting-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Open Graph Meta Tags: do not display Jetpack's tags when the SEOPress plugin is active.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -258,7 +258,6 @@ class Jetpack {
 	 *
 	 * - All in One SEO Pack, All in one SEO Pack Pro
 	 * - WordPress SEO by Yoast, WordPress SEO Premium by Yoast
-	 * - SEOPress, SEOPress Pro
 	 *
 	 * Plugin authors: If you'd like to prevent Jetpack's Open Graph tag generation in your plugin, you can do so via this filter:
 	 * add_filter( 'jetpack_enable_open_graph', '__return_false' );
@@ -303,6 +302,8 @@ class Jetpack {
 		'wp-facebook-like-send-open-graph-meta/wp-facebook-like-send-open-graph-meta.php', // WP Facebook Like Send & Open Graph Meta.
 		'wp-facebook-open-graph-protocol/wp-facebook-ogp.php',   // WP Facebook Open Graph protocol.
 		'wp-ogp/wp-ogp.php',                                     // WP-OGP.
+		'wp-seopress/seopress.php',                              // SEOPress.
+		'wp-seopress-pro/seopress-pro.php',                      // SEOPress Pro.
 		'zoltonorg-social-plugin/zosp.php',                      // Zolton.org Social Plugin.
 		'wp-fb-share-like-button/wp_fb_share-like_widget.php',   // WP Facebook Like Button.
 		'open-graph-metabox/open-graph-metabox.php',              // Open Graph Metabox.

--- a/projects/plugins/social/changelog/update-og-tags-conflicting-plugins
+++ b/projects/plugins/social/changelog/update-og-tags-conflicting-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Open Graph Meta Tags: do not display Jetpack's tags when the SEOPress plugin is active.

--- a/projects/plugins/social/src/class-meta-tags.php
+++ b/projects/plugins/social/src/class-meta-tags.php
@@ -61,6 +61,8 @@ class Meta_Tags {
 		'wp-facebook-like-send-open-graph-meta/wp-facebook-like-send-open-graph-meta.php', // WP Facebook Like Send & Open Graph Meta.
 		'wp-facebook-open-graph-protocol/wp-facebook-ogp.php',   // WP Facebook Open Graph protocol.
 		'wp-ogp/wp-ogp.php',                                     // WP-OGP.
+		'wp-seopress/seopress.php',                              // SEOPress.
+		'wp-seopress-pro/seopress-pro.php',                      // SEOPress Pro.
 		'zoltonorg-social-plugin/zosp.php',                      // Zolton.org Social Plugin.
 		'wp-fb-share-like-button/wp_fb_share-like_widget.php',   // WP Facebook Like Button.
 		'open-graph-metabox/open-graph-metabox.php',             // Open Graph Metabox.


### PR DESCRIPTION
## Proposed changes:

The SEOPress plugin previously relied on the jetpack_enable_open_graph filter to automatically disable Jetpack's OG tags. They stopped using the filter in version 8.5 of their plugin, thus causing a duplicate set of tags on sites using both plugins.

To solve this, let's add both SEOPRes and SEOPress Pro to the list of conflicting plugins for OG tags on our end.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site connected to WordPress.com.
* Go to Jetpack > Settings > Sharing and enable sharing buttons or Publicize.
* Go to the site's frontend ; you should see the Jetpack OG tags in the `head`.
* Now install the SEOPres plugin from Plugins > Add New
* Visit your site's frontend again ; Jetpack's OG tags shoul be gone.
