### PR TITLE
Hotfix: Fix Query Loop with excerpt outputting invalid HTML

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/hotfix-query-loop-bug
+++ b/projects/packages/jetpack-mu-wpcom/changelog/hotfix-query-loop-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Hotfix for a {Gutenberg 20.0.0, WP 6.7.x} bug causing the Content block to output truncated HTML.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-hotfixes/wpcom-hotfixes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-hotfixes/wpcom-hotfixes.php
@@ -24,3 +24,29 @@ add_filter(
 	},
 	20
 );
+
+/**
+ * Hotfix for a {Gutenberg 20.0.0, WP 6.7.x} bug causing the Content block to output truncated HTML.
+ * See: https://github.com/WordPress/gutenberg/issues/68614
+ */
+if (
+	// WordPress 6.7.x contains the buggy remove_serialized_parent_block() function.
+	version_compare( get_bloginfo( 'version' ), '6.8', '<' ) ) {
+
+	add_filter(
+		'the_content',
+		function ( $content ) {
+			if ( has_filter( 'the_content', 'remove_serialized_parent_block' ) ) {
+				// We will revert the content manipulation done in https://github.com/WordPress/gutenberg/pull/67272.
+
+				// Reverts https://github.com/WordPress/gutenberg/pull/67272/files#diff-611d9e2b5a9b00eb2fbe68d044eccb195759a422e36f525186d43d752bee3d71R65-R68
+				remove_filter( 'the_content', 'remove_serialized_parent_block', 8 );
+
+				// Reverts https://github.com/WordPress/gutenberg/pull/67272/files#diff-611d9e2b5a9b00eb2fbe68d044eccb195759a422e36f525186d43d752bee3d71R57-R63
+				return remove_serialized_parent_block( $content );
+			}
+			return $content;
+		},
+		1
+	);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/98922

## Proposed changes:

This PR "reverts" the logic added in https://github.com/WordPress/gutenberg/pull/67272, purely from Dotcom side.

The above PR broke Query Loop block which contains excerpts. This is more visible when the posts have nontrivial blocks at the beginning, e.g. blockquote:

|Before (with the bug)|After (with this hotfix)|
|-|-|
|<img width="710" alt="image" src="https://github.com/user-attachments/assets/df2a8f14-80cb-4f4a-819f-4a1a1a168e83" />|<img width="710" alt="image" src="https://github.com/user-attachments/assets/2cfd12f4-16d0-4639-944c-e0edb409c991" />|
 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

1. Create a post.
2. Add some non-trivial blocks in the post such as blockquote.
3. Publish the post.
4. Create a page.
5. Insert a Query Loop block, which includes post excerpt in the setting.
6. Publish the page.
7. View the page.
8. Verify it contains broken HTML (see screenshot above).
9. Patch this PR.
10. Verify the page does not contain broken HTML anymore.

