### PR TITLE
Full sync comments return expected structure to avoid ending early

### DIFF
--- a/projects/packages/sync/changelog/update-full-sync-comments-return-expected-structure-to-avoid-ending-early
+++ b/projects/packages/sync/changelog/update-full-sync-comments-return-expected-structure-to-avoid-ending-early
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+

--- a/projects/packages/sync/src/modules/class-comments.php
+++ b/projects/packages/sync/src/modules/class-comments.php
@@ -552,6 +552,7 @@ class Comments extends Module {
 	public function get_next_chunk( $config, $status, $chunk_size ) {
 
 		$comment_ids = parent::get_next_chunk( $config, $status, $chunk_size );
+		// If no comment IDs were fetched, return an empty array.
 		if ( empty( $comment_ids ) ) {
 			return array();
 		}
@@ -562,8 +563,13 @@ class Comments extends Module {
 				'order'       => 'DESC',
 			)
 		);
+		// If no comments were fetched, make sure to return the expected structure so that status is updated correctly.
 		if ( empty( $comments ) ) {
-			return array();
+			return array(
+				'object_ids' => $comment_ids,
+				'objects'    => array(),
+				'meta'       => array(),
+			);
 		}
 		// Get the comment IDs from the comments that were fetched.
 		$fetched_comment_ids = wp_list_pluck( $comments, 'comment_ID' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes bug introduced by https://github.com/Automattic/jetpack/pull/41183

When looping through all comments while doing a full sync, if expanded objects create empty arrays we need to not send the action but keep looping through all comment ids.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Make sure we return array with expected structure so that the status is properly updated and the loop is not exited early.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run the tests in https://github.com/Automattic/jetpack/pull/41183

### Mark all comments of a loop as Spam to not send actions when doing Full Sync
- The easier way will be to change sync settings to have chunk_size for comments to something reduced. If you change it to 1, by only marking one (not the last one) comment id  to spam
- Mark comment in a loop as Spam by running in your site's DB something like  
```
UPDATE `wp_comments` SET `comment_approved` = 'spam' WHERE `comment_id` = <YOUR_COMMENT_ID>;
```
- Run a Full Sync only for comments 
- Ensure all expected comments are sent to wpcom.
- Do the same with trunk and you will see that comments will be only sent until you reach the comment_id markets as spam.

