### PR TITLE
RDV: Assign treatment to a12s on Simple Sites when assigned is null

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-set-unassigned-variation-to-treatment
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-set-unassigned-variation-to-treatment
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: An experiment change that only affects a12s
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -416,7 +416,14 @@ function wpcom_is_duplicate_views_experiment_enabled() {
 
 	if ( ( new Host() )->is_wpcom_simple() ) {
 		\ExPlat\assign_current_user( $aa_test_name );
-		$is_enabled = 'treatment' === \ExPlat\assign_current_user( $experiment_name );
+		$assigned_variation = \ExPlat\assign_current_user( $experiment_name );
+		$is_enabled         = 'treatment' === $assigned_variation;
+
+		if ( null === $assigned_variation ) {
+			update_user_option( get_current_user_id(), RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, 'treatment', true );
+			$is_enabled = true;
+		}
+
 		return $is_enabled;
 	}
 


### PR DESCRIPTION
When the RDV test variation is null, we now hardcode it to "treatment". This means that a12s will now be switched to treatment by default (since a12s are excluded from experiments).

This change only affects Simple Sites since on Atomic this was already implemented.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Set treatment for users that don't get a variation (e.g. a12s) on Simple Sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the PR on your sandbox
* Make sure that you haven't used the escape hatch - go to `wp-admin/?force-reset-rdv-variation` to reset it.
* Go to WP-Admin > Posts or Pages
* Notice that you get WP-Admin
* Notice that there's no View quick switcher

