### PR TITLE
Protect: Check plan on load of plugin's admin screen

### DIFF
--- a/projects/packages/protect-status/changelog/fix-protect-plan-check-cache
+++ b/projects/packages/protect-status/changelog/fix-protect-plan-check-cache
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Protect: ensure plan is checked on load of plugin's admin page.
+
+

--- a/projects/packages/protect-status/src/class-status.php
+++ b/projects/packages/protect-status/src/class-status.php
@@ -57,7 +57,7 @@ class Status {
 	 * @return Status_Model
 	 */
 	public static function get_status( $refresh_from_wpcom = false ) {
-		$use_scan_status = Plan::has_required_plan();
+		$use_scan_status = Plan::has_required_plan( $refresh_from_wpcom );
 
 		if ( defined( 'JETPACK_PROTECT_DEV__DATA_SOURCE' ) ) {
 			if ( 'scan_api' === JETPACK_PROTECT_DEV__DATA_SOURCE ) {

--- a/projects/plugins/protect/changelog/fix-protect-plan-check-cache
+++ b/projects/plugins/protect/changelog/fix-protect-plan-check-cache
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Protect: ensure plan is checked on load of plugin's admin page.
+
+

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -224,7 +224,7 @@ class Jetpack_Protect {
 			'siteSuffix'         => ( new Jetpack_Status() )->get_site_suffix(),
 			'blogID'             => Connection_Manager::get_site_id( true ),
 			'jetpackScan'        => My_Jetpack_Products::get_product( 'scan' ),
-			'hasPlan'            => Plan::has_required_plan(),
+			'hasPlan'            => Plan::has_required_plan( true ),
 			'onboardingProgress' => Onboarding::get_current_user_progress(),
 			'waf'                => array(
 				'wafSupported'        => Waf_Runner::is_supported_environment(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/jetpack/pull/41010

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensures the `$refresh_from_wpcom` argument is passed from `get_status` to the `Plan::has_required_plan` call inside of it.
* Ensures Protect checks the plan on load of the Protect admin page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1736794507070729-slack-C02LK1W8T4Z

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run this branch on JN, with the Protect plugin.
* Start for free.
* Upgrade your plan.
* Validate the Protect dashboard immediately starts showing paid features.