### PR TITLE
MU WPCOM: Remove admin bar launch button from greylisted sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-launch-button-wpcom
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-launch-button-wpcom
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: restore an early return
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -13,7 +13,7 @@
 function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
 	$current_blog_id = get_current_blog_id();
 
-	if ( is_graylisted( $current_blog_id ) ) {
+	if ( function_exists( 'is_graylisted' ) && is_graylisted( $current_blog_id ) ) {
 		return false;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -11,9 +11,29 @@
  * @param WP_Admin_Bar $admin_bar The WordPress admin bar.
  */
 function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
+	$current_blog_id = get_current_blog_id();
+
+	if ( is_graylisted( $current_blog_id ) ) {
+		return false;
+	}
+
+	if ( ! is_user_member_of_blog( get_current_user_id(), $current_blog_id ) ) {
+		return;
+	}
+
 	if ( ! current_user_can( 'manage_options' ) ) {
 		return;
 	}
+
+	if ( has_blog_sticker( 'difm-lite-in-progress' ) ) {
+		return false;
+	}
+
+	// No button for agency-managed sites.
+	if ( ! empty( get_option( 'is_fully_managed_agency_site' ) ) ) {
+		return false;
+	}
+
 	$is_launched = get_option( 'launch-status' ) !== 'unlaunched';
 	if ( $is_launched ) {
 		return;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -17,15 +17,11 @@ function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
 		return false;
 	}
 
-	if ( ! is_user_member_of_blog( get_current_user_id(), $current_blog_id ) ) {
-		return;
-	}
-
 	if ( ! current_user_can( 'manage_options' ) ) {
 		return;
 	}
 
-	if ( has_blog_sticker( 'difm-lite-in-progress' ) ) {
+	if ( function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'difm-lite-in-progress' ) ) {
 		return false;
 	}
 

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-launch-button-wpcom
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-launch-button-wpcom
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: restore an early return
+
+

--- a/projects/plugins/wpcomsh/changelog/fix-launch-button-wpcom
+++ b/projects/plugins/wpcomsh/changelog/fix-launch-button-wpcom
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: restore an early return
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

See #41240.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Restores some conditions that were not ported over from 170225-ghe-Automattic/wpcom#diff-1a7c9396da8a9fbb23f64a8d37623bccc23a502769c14f0fb7636c4b1f435831

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to wordpress.com's wp-admin and check that there is no launch button.

