### PR TITLE
Jetpack SEO Assistant: add steps codependency flow

### DIFF
--- a/projects/plugins/jetpack/changelog/change-jetpack-seo-assistant-steps-codependency
+++ b/projects/plugins/jetpack/changelog/change-jetpack-seo-assistant-steps-codependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO Assistant: improve assistant flow by letting steps depend on previous steps

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
@@ -38,7 +38,7 @@ export default function AssistantWizard( { close, tasks } ) {
 	);
 
 	const handleNext = useCallback(
-		( options?: Parameters< OnStartFunction >[ 0 ] ) => {
+		( options: Parameters< OnStartFunction >[ 0 ] ) => {
 			debug( steps[ currentStep ].value );
 			debug( steps[ currentStep + 1 ].value );
 			if ( currentStep + 1 < steps.length ) {
@@ -52,10 +52,10 @@ export default function AssistantWizard( { close, tasks } ) {
 	);
 
 	const handleStepSubmit = useCallback( async () => {
-		await steps[ currentStep ]?.onSubmit?.();
+		const stepValue = await steps[ currentStep ]?.onSubmit?.();
 		debug( 'step submitted, moving next' );
 		// always give half a second before moving forward
-		setTimeout( handleNext, 500 );
+		setTimeout( () => handleNext( { fromSkip: ! stepValue.trim(), stepValue } ), 500 );
 	}, [ currentStep, handleNext, steps ] );
 
 	const jumpToStep = useCallback(

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
@@ -8,7 +8,7 @@ import { useMetaDescriptionStep } from './use-meta-description-step';
 import { useTitleStep } from './use-title-step';
 import { OptionsInput, TextInput, CompletionInput } from './wizard-input';
 import WizardStep from './wizard-step';
-import type { Step, Option } from './types';
+import type { Step, Option, OnStartFunction } from './types';
 
 const debug = debugFactory( 'jetpack-seo:assistant-wizard' );
 
@@ -37,14 +37,19 @@ export default function AssistantWizard( { close, tasks } ) {
 		[ tasks, keywordsStepData, titleStepData, metaStepData ]
 	);
 
-	const handleNext = useCallback( () => {
-		if ( currentStep + 1 < steps.length ) {
-			debug( 'moving to ' + ( currentStep + 1 ) );
-			setCurrentStep( currentStep + 1 );
-			setCurrentStepData( steps[ currentStep + 1 ] );
-			steps[ currentStep + 1 ].onStart?.();
-		}
-	}, [ currentStep, steps ] );
+	const handleNext = useCallback(
+		( options?: Parameters< OnStartFunction >[ 0 ] ) => {
+			debug( steps[ currentStep ].value );
+			debug( steps[ currentStep + 1 ].value );
+			if ( currentStep + 1 < steps.length ) {
+				debug( 'moving to ' + ( currentStep + 1 ) );
+				setCurrentStep( currentStep + 1 );
+				setCurrentStepData( steps[ currentStep + 1 ] );
+				steps[ currentStep + 1 ].onStart?.( options );
+			}
+		},
+		[ currentStep, steps ]
+	);
 
 	const handleStepSubmit = useCallback( async () => {
 		await steps[ currentStep ]?.onSubmit?.();
@@ -91,10 +96,13 @@ export default function AssistantWizard( { close, tasks } ) {
 		}
 	};
 
-	const handleSkip = async () => {
+	const handleSkip = useCallback( async () => {
 		await currentStepData?.onSkip?.();
-		handleNext();
-	};
+		handleNext( {
+			fromSkip: true,
+			stepValue: steps[ currentStep ].value,
+		} );
+	}, [ currentStep, currentStepData, handleNext, steps ] );
 
 	// Reset states and close the wizard
 	const handleDone = () => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
@@ -8,7 +8,7 @@ import { useMetaDescriptionStep } from './use-meta-description-step';
 import { useTitleStep } from './use-title-step';
 import { OptionsInput, TextInput, CompletionInput } from './wizard-input';
 import WizardStep from './wizard-step';
-import type { Step, Option, OnStartFunction } from './types';
+import type { Step, OptionMessage, OnStartFunction } from './types';
 
 const debug = debugFactory( 'jetpack-seo:assistant-wizard' );
 
@@ -39,8 +39,8 @@ export default function AssistantWizard( { close, tasks } ) {
 
 	const handleNext = useCallback(
 		( options: Parameters< OnStartFunction >[ 0 ] ) => {
-			debug( steps[ currentStep ].value );
-			debug( steps[ currentStep + 1 ].value );
+			debug( 'step value', steps[ currentStep ].value );
+			debug( 'next step value', steps[ currentStep + 1 ].value );
 			if ( currentStep + 1 < steps.length ) {
 				debug( 'moving to ' + ( currentStep + 1 ) );
 				setCurrentStep( currentStep + 1 );
@@ -69,7 +69,7 @@ export default function AssistantWizard( { close, tasks } ) {
 	);
 
 	const handleSelect = useCallback(
-		( stepNumber: number, option: Option ) => {
+		( stepNumber: number, option: OptionMessage ) => {
 			if ( stepNumber !== currentStep ) {
 				jumpToStep( stepNumber );
 			}
@@ -100,9 +100,10 @@ export default function AssistantWizard( { close, tasks } ) {
 		await currentStepData?.onSkip?.();
 		handleNext( {
 			fromSkip: true,
-			stepValue: steps[ currentStep ].value,
+			// if skip is NOT meant to reset, pass stepValue as steps[ currentStep ].value
+			stepValue: '',
 		} );
-	}, [ currentStep, currentStepData, handleNext, steps ] );
+	}, [ currentStepData, handleNext ] );
 
 	// Reset states and close the wizard
 	const handleDone = () => {
@@ -136,7 +137,6 @@ export default function AssistantWizard( { close, tasks } ) {
 						key={ step.id }
 						messages={ step.messages }
 						visible={ currentStep >= index }
-						options={ step.options || [] }
 						onSelect={ option => handleSelect( index, option ) }
 					/>
 				) ) }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/seo-assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/seo-assistant-wizard.tsx
@@ -17,7 +17,7 @@ export default function SeoAssistantWizard( { close }: { close?: () => void } ) 
 					title: __( 'Optimise for SEO', 'jetpack' ),
 					label: 'welcome',
 					type: 'welcome',
-					autoAdvance: 1000,
+					autoAdvance: 1,
 					messages: [
 						{
 							content: createInterpolateElement(

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/style.scss
@@ -67,7 +67,6 @@
 
 	&__message {
 		border-radius: 16px;
-		white-space: pre-line;
 		animation: messageAppear 0.3s ease-out;
 		font-size: 13px;
 		line-height: 1.5;
@@ -77,8 +76,9 @@
 
 		.assistant-wizard__message-icon {
 			flex-shrink: 0;
-			align-self: center;
+			align-self: baseline;
 			flex-basis: 26px;
+			line-height: 2;
 
 			img {
 				vertical-align: middle;
@@ -86,7 +86,7 @@
 		}
 
 		.assistant-wizard__message-text {
-			padding: 4px 12px;
+			padding: 0px 12px;
 			// flex: 1 0 200px;
 		}
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/style.scss
@@ -3,8 +3,8 @@
 	bottom: 32px;
 	left: 50%;
 	transform: translateX(-50%);
-	width: 384px;
-	height: 434px;
+	width: 440px;
+	max-height: 434px;
 	background: white;
 	border-radius: 24px;
 	outline: 0.5px solid var( --jp-gray-5 );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/types.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/types.tsx
@@ -22,7 +22,7 @@ interface BaseStep {
 	messages: Message[];
 	type: StepType;
 	onStart?: OnStartFunction;
-	onSubmit?: () => void;
+	onSubmit?: () => Promise< string >;
 	onSkip?: () => void;
 	value?: string;
 	setValue?:

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/types.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/types.tsx
@@ -21,7 +21,7 @@ interface BaseStep {
 	label?: string;
 	messages: Message[];
 	type: StepType;
-	onStart?: () => void;
+	onStart?: OnStartFunction;
 	onSubmit?: () => void;
 	onSkip?: () => void;
 	value?: string;
@@ -51,3 +51,5 @@ interface CompletionStep extends BaseStep {
 }
 
 export type Step = InputStep | OptionsStep | CompletionStep;
+
+export type OnStartFunction = ( options?: { fromSkip: boolean; stepValue: string } ) => void;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/types.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/types.tsx
@@ -2,18 +2,14 @@ type StepType = 'welcome' | 'input' | 'options' | 'completion';
 
 export interface Message {
 	id?: string;
-	content?: string | React.ReactNode;
+	content: string | React.ReactNode;
 	isUser?: boolean;
 	showIcon?: boolean;
 	type?: string;
-	options?: Option[];
-}
-
-export interface Option {
-	id: string;
-	content: string;
 	selected?: boolean;
 }
+
+export type OptionMessage = Pick< Message, 'id' | 'content' >;
 
 interface BaseStep {
 	id: string;
@@ -39,8 +35,8 @@ export interface InputStep extends BaseStep {
 
 interface OptionsStep extends BaseStep {
 	type: 'options';
-	options: Option[];
-	onSelect: ( option: Option ) => void;
+	options: OptionMessage[];
+	onSelect: ( option: OptionMessage ) => void;
 	submitCtaLabel?: string;
 	onRetry?: () => void;
 	retryCtaLabel?: string;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-keywords-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-keywords-step.tsx
@@ -22,8 +22,8 @@ export const useKeywordsStep = (): InputStep => {
 	}, [ setMessages ] );
 
 	const handleSkip = useCallback( () => {
-		addMessage( { content: __( 'Skipped!', 'jetpack' ) } );
-	}, [ addMessage ] );
+		// addMessage( { content: __( 'Skipped!', 'jetpack' ) } );
+	}, [] );
 
 	const handleKeywordsSubmit = useCallback( async () => {
 		if ( ! keywords.trim() ) {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-keywords-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-keywords-step.tsx
@@ -27,7 +27,7 @@ export const useKeywordsStep = (): InputStep => {
 
 	const handleKeywordsSubmit = useCallback( async () => {
 		if ( ! keywords.trim() ) {
-			return handleSkip();
+			return '';
 		}
 		addMessage( { content: keywords, isUser: true } );
 		addMessage( { content: <TypingMessage /> } );
@@ -60,7 +60,8 @@ export const useKeywordsStep = (): InputStep => {
 		);
 		addMessage( { content: message } );
 		setCompleted( true );
-	}, [ addMessage, keywords, handleSkip, removeLastMessage ] );
+		return keywords;
+	}, [ addMessage, keywords, removeLastMessage ] );
 
 	return {
 		id: 'keywords',

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-keywords-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-keywords-step.tsx
@@ -37,6 +37,10 @@ export const useKeywordsStep = (): InputStep => {
 				const commaSeparatedKeywords = keywords
 					.split( ',' )
 					.map( k => k.trim() )
+					// remove empty entries
+					.filter( v => v )
+					// remove duped entries, inefficient but we don't expect a lot of entries here
+					.filter( ( v, i, arr ) => arr.indexOf( v ) === i )
 					.reduce( ( acc, curr, i, arr ) => {
 						if ( arr.length === 1 ) {
 							return curr;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-keywords-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-keywords-step.tsx
@@ -21,10 +21,6 @@ export const useKeywordsStep = (): InputStep => {
 		] );
 	}, [ setMessages ] );
 
-	const handleSkip = useCallback( () => {
-		// addMessage( { content: __( 'Skipped!', 'jetpack' ) } );
-	}, [] );
-
 	const handleKeywordsSubmit = useCallback( async () => {
 		if ( ! keywords.trim() ) {
 			return '';
@@ -75,7 +71,6 @@ export const useKeywordsStep = (): InputStep => {
 		type: 'input',
 		placeholder: __( 'Photography, plants', 'jetpack' ),
 		onSubmit: handleKeywordsSubmit,
-		onSkip: handleSkip,
 		completed,
 		setCompleted,
 		value: keywords,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -41,34 +41,58 @@ export const useMetaDescriptionStep = (): Step => {
 		setCompleted( true );
 	}, [ selectedMetaDescription, addMessage, editPost, removeLastMessage ] );
 
-	const handleMetaDescriptionGenerate = useCallback( async () => {
-		let newMetaDescriptions;
-		// we only generate if options are empty
-		if ( metaDescriptionOptions.length === 0 ) {
-			addMessage( { content: <TypingMessage /> } );
-			newMetaDescriptions = await new Promise( resolve =>
-				setTimeout(
-					() =>
-						resolve( [
-							{
-								id: 'meta-1',
-								content:
-									'Explore breathtaking flower and plant photography in our Flora Guide, featuring tips and inspiration for gardening and plant enthusiasts to enhance their outdoor spaces.',
-							},
-						] ),
-					2000
-				)
-			);
-			removeLastMessage();
-		}
-		const editedFirstMessage = createInterpolateElement(
-			__( "Now, let's optimize your meta description.<br />Here's a suggestion:", 'jetpack' ),
-			{ br: <br /> }
-		);
-		// addMessage( { content: __( "Here's a suggestion:", 'jetpack' ) } );
-		editLastMessage( editedFirstMessage );
-		setMetaDescriptionOptions( newMetaDescriptions || metaDescriptionOptions );
-	}, [ metaDescriptionOptions, addMessage, removeLastMessage, editLastMessage ] );
+	const handleMetaDescriptionGenerate = useCallback(
+		async ( { fromSkip } ) => {
+			const initialMessage = fromSkip
+				? {
+						content: createInterpolateElement(
+							__( "Skipped!<br />Now, let's optimize your meta description.", 'jetpack' ),
+							{ br: <br /> }
+						),
+						showIcon: true,
+				  }
+				: {
+						content: __( "Now, let's optimize your meta description.", 'jetpack' ),
+						showIcon: true,
+				  };
+			setMessages( [ initialMessage ] );
+			let newMetaDescriptions;
+			// we only generate if options are empty
+			if ( metaDescriptionOptions.length === 0 ) {
+				addMessage( { content: <TypingMessage /> } );
+				newMetaDescriptions = await new Promise( resolve =>
+					setTimeout(
+						() =>
+							resolve( [
+								{
+									id: 'meta-1',
+									content:
+										'Explore breathtaking flower and plant photography in our Flora Guide, featuring tips and inspiration for gardening and plant enthusiasts to enhance their outdoor spaces.',
+								},
+							] ),
+						2000
+					)
+				);
+				removeLastMessage();
+			}
+			const editedFirstMessage = fromSkip
+				? createInterpolateElement(
+						__(
+							"Skipped!<br />Now, let's optimize your meta description.<br />Here's a suggestion:",
+							'jetpack'
+						),
+						{ br: <br /> }
+				  )
+				: createInterpolateElement(
+						__( "Now, let's optimize your meta description.<br />Here's a suggestion:", 'jetpack' ),
+						{ br: <br /> }
+				  );
+			// addMessage( { content: __( "Here's a suggestion:", 'jetpack' ) } );
+			editLastMessage( editedFirstMessage );
+			setMetaDescriptionOptions( newMetaDescriptions || metaDescriptionOptions );
+		},
+		[ metaDescriptionOptions, addMessage, removeLastMessage, editLastMessage, setMessages ]
+	);
 
 	const handleMetaDescriptionRegenerate = useCallback( async () => {
 		setMetaDescriptionOptions( [] );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -88,7 +88,6 @@ export const useMetaDescriptionStep = (): Step => {
 						__( "Now, let's optimize your meta description.<br />Here's a suggestion:", 'jetpack' ),
 						{ br: <br /> }
 				  );
-			// addMessage( { content: __( "Here's a suggestion:", 'jetpack' ) } );
 			editLastMessage( editedFirstMessage );
 			setMetaDescriptionOptions( newMetaDescriptions || metaDescriptionOptions );
 		},
@@ -113,7 +112,6 @@ export const useMetaDescriptionStep = (): Step => {
 			)
 		);
 		removeLastMessage();
-		// addMessage( { content: __( "Here's a new suggestion:", 'jetpack' ) } );
 		const editedFirstMessage = createInterpolateElement(
 			__( "Now, let's optimize your meta description.<br />Here's a new suggestion:", 'jetpack' ),
 			{ br: <br /> }
@@ -121,10 +119,6 @@ export const useMetaDescriptionStep = (): Step => {
 		editLastMessage( editedFirstMessage );
 		setMetaDescriptionOptions( newMetaDescription );
 	}, [ addMessage, removeLastMessage, editLastMessage ] );
-
-	const handleSkip = useCallback( () => {
-		// addMessage( { content: __( 'Skipped!', 'jetpack' ) } );
-	}, [] );
 
 	return {
 		id: 'meta',
@@ -138,7 +132,6 @@ export const useMetaDescriptionStep = (): Step => {
 		onRetry: handleMetaDescriptionRegenerate,
 		retryCtaLabel: __( 'Regenerate', 'jetpack' ),
 		onStart: handleMetaDescriptionGenerate,
-		onSkip: handleSkip,
 		value: selectedMetaDescription,
 		setValue: setSelectedMetaDescription,
 		completed,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -71,11 +71,27 @@ export const useMetaDescriptionStep = (): Step => {
 				removeLastMessage();
 			}
 			setMetaDescriptionOptions( newMetaDescriptions );
+			const editedFirstMessage = fromSkip
+				? createInterpolateElement(
+						__(
+							"Skipped!<br />Now, let's optimize your meta description.<br />Here's a new suggestion:",
+							'jetpack'
+						),
+						{ br: <br /> }
+				  )
+				: createInterpolateElement(
+						__(
+							"Now, let's optimize your meta description.<br />Here's a new suggestion:",
+							'jetpack'
+						),
+						{ br: <br /> }
+				  );
+			editLastMessage( editedFirstMessage );
 			newMetaDescriptions.forEach( meta =>
 				addMessage( { ...meta, type: 'option', isUser: true } )
 			);
 		},
-		[ metaDescriptionOptions, addMessage, removeLastMessage, setMessages ]
+		[ metaDescriptionOptions, addMessage, removeLastMessage, setMessages, editLastMessage ]
 	);
 
 	const handleMetaDescriptionRegenerate = useCallback( async () => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -98,8 +98,8 @@ export const useMetaDescriptionStep = (): Step => {
 	}, [ addMessage, removeLastMessage, editLastMessage ] );
 
 	const handleSkip = useCallback( () => {
-		addMessage( { content: __( 'Skipped!', 'jetpack' ) } );
-	}, [ addMessage ] );
+		// addMessage( { content: __( 'Skipped!', 'jetpack' ) } );
+	}, [] );
 
 	return {
 		id: 'meta',

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -39,6 +39,7 @@ export const useMetaDescriptionStep = (): Step => {
 		removeLastMessage();
 		addMessage( { content: __( 'Meta description updated! ✅', 'jetpack' ) } );
 		setCompleted( true );
+		return selectedMetaDescription;
 	}, [ selectedMetaDescription, addMessage, editPost, removeLastMessage ] );
 
 	const handleMetaDescriptionGenerate = useCallback(

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -1,37 +1,31 @@
 import { useDispatch } from '@wordpress/data';
-import { useCallback, useState, useEffect, createInterpolateElement } from '@wordpress/element';
+import { useCallback, useState, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import TypingMessage from './typing-message';
 import { useMessages } from './wizard-messages';
-import type { Step, Option } from './types';
+import type { Step, OptionMessage } from './types';
 
 export const useMetaDescriptionStep = (): Step => {
 	const [ selectedMetaDescription, setSelectedMetaDescription ] = useState< string >();
-	const [ metaDescriptionOptions, setMetaDescriptionOptions ] = useState< Option[] >( [] );
-	const { messages, setMessages, addMessage, removeLastMessage, editLastMessage } = useMessages();
+	const [ metaDescriptionOptions, setMetaDescriptionOptions ] = useState< OptionMessage[] >( [] );
+	const {
+		messages,
+		setMessages,
+		addMessage,
+		removeLastMessage,
+		editLastMessage,
+		setSelectedMessage,
+	} = useMessages();
 	const { editPost } = useDispatch( 'core/editor' );
 	const [ completed, setCompleted ] = useState( false );
 
-	useEffect( () => {
-		if ( messages.length === 0 ) {
-			setMessages( [
-				{
-					content: __( "Now, let's optimize your meta description.", 'jetpack' ),
-					showIcon: true,
-				},
-			] );
-		}
-	}, [ setMessages, messages ] );
-
-	const handleMetaDescriptionSelect = useCallback( ( option: Option ) => {
-		setSelectedMetaDescription( option.content );
-		setMetaDescriptionOptions( prev =>
-			prev.map( opt => ( {
-				...opt,
-				selected: opt.id === option.id,
-			} ) )
-		);
-	}, [] );
+	const handleMetaDescriptionSelect = useCallback(
+		( option: OptionMessage ) => {
+			setSelectedMetaDescription( option.content as string );
+			setSelectedMessage( option );
+		},
+		[ setSelectedMessage ]
+	);
 
 	const handleMetaDescriptionSubmit = useCallback( async () => {
 		addMessage( { content: <TypingMessage /> } );
@@ -56,10 +50,10 @@ export const useMetaDescriptionStep = (): Step => {
 						content: __( "Now, let's optimize your meta description.", 'jetpack' ),
 						showIcon: true,
 				  };
-			setMessages( [ initialMessage ] );
-			let newMetaDescriptions;
+			let newMetaDescriptions = [ ...metaDescriptionOptions ];
 			// we only generate if options are empty
-			if ( metaDescriptionOptions.length === 0 ) {
+			setMessages( [ initialMessage ] );
+			if ( newMetaDescriptions.length === 0 ) {
 				addMessage( { content: <TypingMessage /> } );
 				newMetaDescriptions = await new Promise( resolve =>
 					setTimeout(
@@ -76,34 +70,26 @@ export const useMetaDescriptionStep = (): Step => {
 				);
 				removeLastMessage();
 			}
-			const editedFirstMessage = fromSkip
-				? createInterpolateElement(
-						__(
-							"Skipped!<br />Now, let's optimize your meta description.<br />Here's a suggestion:",
-							'jetpack'
-						),
-						{ br: <br /> }
-				  )
-				: createInterpolateElement(
-						__( "Now, let's optimize your meta description.<br />Here's a suggestion:", 'jetpack' ),
-						{ br: <br /> }
-				  );
-			editLastMessage( editedFirstMessage );
-			setMetaDescriptionOptions( newMetaDescriptions || metaDescriptionOptions );
+			setMetaDescriptionOptions( newMetaDescriptions );
+			newMetaDescriptions.forEach( meta =>
+				addMessage( { ...meta, type: 'option', isUser: true } )
+			);
 		},
-		[ metaDescriptionOptions, addMessage, removeLastMessage, editLastMessage, setMessages ]
+		[ metaDescriptionOptions, addMessage, removeLastMessage, setMessages ]
 	);
 
 	const handleMetaDescriptionRegenerate = useCallback( async () => {
 		setMetaDescriptionOptions( [] );
-		editLastMessage( __( "Now, let's optimize your meta description.", 'jetpack' ) );
+		setMessages( [
+			{ content: __( "Now, let's optimize your meta description.", 'jetpack' ), showIcon: true },
+		] );
 		addMessage( { content: <TypingMessage /> } );
-		const newMetaDescription = await new Promise< Array< Option > >( resolve =>
+		const newMetaDescription = await new Promise< Array< OptionMessage > >( resolve =>
 			setTimeout(
 				() =>
 					resolve( [
 						{
-							id: 'meta-1',
+							id: 'meta-1' + Math.random(),
 							content:
 								'Explore breathtaking flower and plant photography in our Flora Guide, featuring tips and inspiration for gardening and plant enthusiasts to enhance their outdoor spaces.',
 						},
@@ -118,7 +104,8 @@ export const useMetaDescriptionStep = (): Step => {
 		);
 		editLastMessage( editedFirstMessage );
 		setMetaDescriptionOptions( newMetaDescription );
-	}, [ addMessage, removeLastMessage, editLastMessage ] );
+		newMetaDescription.forEach( meta => addMessage( { ...meta, type: 'option', isUser: true } ) );
+	}, [ addMessage, removeLastMessage, editLastMessage, setMessages ] );
 
 	return {
 		id: 'meta',

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -105,8 +105,8 @@ export const useTitleStep = (): Step => {
 	}, [ selectedTitle, addMessage, editPost, removeLastMessage ] );
 
 	const handleSkip = useCallback( () => {
-		addMessage( { content: __( 'Skipped!', 'jetpack' ) } );
-	}, [ addMessage ] );
+		// addMessage( { content: __( 'Skipped!', 'jetpack' ) } );
+	}, [] );
 
 	return {
 		id: 'title',

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -9,7 +9,7 @@ export const useTitleStep = (): Step => {
 	const [ selectedTitle, setSelectedTitle ] = useState< string >();
 	const [ titleOptions, setTitleOptions ] = useState< Option[] >( [] );
 	const { editPost } = useDispatch( 'core/editor' );
-	const { messages, setMessages, addMessage, removeLastMessage } = useMessages();
+	const { messages, setMessages, addMessage, removeLastMessage, editLastMessage } = useMessages();
 	const [ completed, setCompleted ] = useState( false );
 	const [ prevStepValue, setPrevStepValue ] = useState( '' );
 
@@ -66,24 +66,40 @@ export const useTitleStep = (): Step => {
 				);
 				removeLastMessage();
 			}
+			let editedMessage;
 			if ( keywords ) {
-				addMessage( {
-					content: __(
+				if ( fromSkip ) {
+					editedMessage = createInterpolateElement(
+						__(
+							'Skipped!<br />Here are some suggestions for a better title based on your keywords:',
+							'jetpack'
+						),
+						{ br: <br /> }
+					);
+				} else {
+					editedMessage = __(
 						'Here are some suggestions for a better title based on your keywords:',
 						'jetpack'
-					),
-				} );
-			} else {
-				addMessage( {
-					content: __(
-						'Here are some suggestions for a better title based on your post:',
+					);
+				}
+			} else if ( fromSkip ) {
+				editedMessage = createInterpolateElement(
+					__(
+						'Skipped!<br />Here are some suggestions for a better title based on your post:',
 						'jetpack'
 					),
-				} );
+					{ br: <br /> }
+				);
+			} else {
+				editedMessage = __(
+					'Here are some suggestions for a better title based on your post:',
+					'jetpack'
+				);
 			}
+			editLastMessage( editedMessage );
 			setTitleOptions( newTitles || titleOptions );
 		},
-		[ titleOptions, addMessage, removeLastMessage, setMessages, prevStepValue ]
+		[ titleOptions, addMessage, removeLastMessage, setMessages, prevStepValue, editLastMessage ]
 	);
 
 	const handleTitleRegenerate = useCallback( async () => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -1,5 +1,5 @@
 import { useDispatch } from '@wordpress/data';
-import { useCallback, useState, useEffect } from '@wordpress/element';
+import { useCallback, useState, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import TypingMessage from './typing-message';
 import { useMessages } from './wizard-messages';
@@ -11,6 +11,7 @@ export const useTitleStep = (): Step => {
 	const { editPost } = useDispatch( 'core/editor' );
 	const { messages, setMessages, addMessage, removeLastMessage } = useMessages();
 	const [ completed, setCompleted ] = useState( false );
+	const [ prevStepValue, setPrevStepValue ] = useState( '' );
 
 	const handleTitleSelect = useCallback( ( option: Option ) => {
 		setSelectedTitle( option.content );
@@ -22,63 +23,81 @@ export const useTitleStep = (): Step => {
 		);
 	}, [] );
 
-	useEffect( () => {
-		setMessages( [
-			{
-				content: __( "Let's optimise your title.", 'jetpack' ),
-				showIcon: true,
-			},
-		] );
-	}, [ setMessages ] );
-
-	const handleTitleGenerate = useCallback( async () => {
-		let newTitles;
-		// we only generate if options are empty
-		if ( titleOptions.length === 0 ) {
-			addMessage( { content: <TypingMessage /> } );
-			newTitles = await new Promise( resolve =>
-				setTimeout(
-					() =>
-						resolve( [
-							{
-								id: '1',
-								content: 'A Photo Gallery for Gardening Enthusiasths: Flora Guide',
-							},
-							{
-								id: '2',
-								content:
-									'Flora Guide: Beautiful Photos of Flowers and Plants for Gardening Enthusiasts',
-							},
-						] ),
-					2000
-				)
-			);
-			removeLastMessage();
-		}
-		addMessage( {
-			content: __(
-				'Here are two suggestions based on your keywords. Select the one you prefer:',
-				'jetpack'
-			),
-		} );
-		setTitleOptions( newTitles || titleOptions );
-	}, [ titleOptions, addMessage, removeLastMessage ] );
+	const handleTitleGenerate = useCallback(
+		async ( { fromSkip, stepValue: keywords } ) => {
+			const prevStepHasChanged = keywords !== prevStepValue;
+			const initialMessage = fromSkip
+				? {
+						content: createInterpolateElement(
+							__( "Skipped!<br />Let's optimise your title.", 'jetpack' ),
+							{ br: <br /> }
+						),
+						showIcon: true,
+				  }
+				: {
+						content: __( "Let's optimise your title.", 'jetpack' ),
+						showIcon: true,
+				  };
+			setMessages( [ initialMessage ] );
+			if ( prevStepHasChanged ) {
+				setTitleOptions( [] );
+			}
+			let newTitles;
+			// we only generate if options are empty
+			if ( titleOptions.length === 0 || prevStepHasChanged ) {
+				setPrevStepValue( keywords );
+				addMessage( { content: <TypingMessage /> } );
+				newTitles = await new Promise( resolve =>
+					setTimeout(
+						() =>
+							resolve( [
+								{
+									id: '1',
+									content: 'A Photo Gallery for Gardening Enthusiasths: Flora Guide',
+								},
+								{
+									id: '2',
+									content:
+										'Flora Guide: Beautiful Photos of Flowers and Plants for Gardening Enthusiasts',
+								},
+							] ),
+						2000
+					)
+				);
+				removeLastMessage();
+			}
+			if ( keywords ) {
+				addMessage( {
+					content: __(
+						'Here are some suggestions for a better title based on your keywords:',
+						'jetpack'
+					),
+				} );
+			} else {
+				addMessage( {
+					content: __(
+						'Here are some suggestions for a better title based on your post:',
+						'jetpack'
+					),
+				} );
+			}
+			setTitleOptions( newTitles || titleOptions );
+		},
+		[ titleOptions, addMessage, removeLastMessage, setMessages, prevStepValue ]
+	);
 
 	const handleTitleRegenerate = useCallback( async () => {
-		// This would typically be an async call to generate new titles
-		// replaceOptionsWithFauxUseMessages();
-		setTitleOptions( [] );
 		addMessage( { content: <TypingMessage /> } );
 		const newTitles = await new Promise< Array< Option > >( resolve =>
 			setTimeout(
 				() =>
 					resolve( [
 						{
-							id: '1',
+							id: '1' + Math.random(),
 							content: 'A Photo Gallery for Gardening Enthusiasths: Flora Guide',
 						},
 						{
-							id: '2',
+							id: '2' + Math.random(),
 							content:
 								'Flora Guide: Beautiful Photos of Flowers and Plants for Gardening Enthusiasts',
 						},
@@ -87,14 +106,8 @@ export const useTitleStep = (): Step => {
 			)
 		);
 		removeLastMessage();
-		addMessage( {
-			content: __(
-				'Here are two new suggestions based on your keywords. Select the one you prefer:',
-				'jetpack'
-			),
-		} );
-		setTitleOptions( newTitles );
-	}, [ addMessage, removeLastMessage ] );
+		setTitleOptions( [ ...titleOptions, ...newTitles ] );
+	}, [ addMessage, removeLastMessage, titleOptions ] );
 
 	const handleTitleSubmit = useCallback( async () => {
 		addMessage( { content: <TypingMessage /> } );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -3,29 +3,38 @@ import { useCallback, useState, createInterpolateElement } from '@wordpress/elem
 import { __ } from '@wordpress/i18n';
 import TypingMessage from './typing-message';
 import { useMessages } from './wizard-messages';
-import type { Step, Option } from './types';
+import type { Step, OptionMessage } from './types';
 
 export const useTitleStep = (): Step => {
-	const [ selectedTitle, setSelectedTitle ] = useState< string >();
-	const [ titleOptions, setTitleOptions ] = useState< Option[] >( [] );
+	const [ selectedTitle, setSelectedTitle ] = useState< string >( '' );
+	const [ titleOptions, setTitleOptions ] = useState< OptionMessage[] >( [] );
 	const { editPost } = useDispatch( 'core/editor' );
-	const { messages, setMessages, addMessage, removeLastMessage, editLastMessage } = useMessages();
+	const {
+		messages,
+		setMessages,
+		addMessage,
+		removeLastMessage,
+		editLastMessage,
+		setSelectedMessage,
+	} = useMessages();
 	const [ completed, setCompleted ] = useState( false );
-	const [ prevStepValue, setPrevStepValue ] = useState( '' );
+	const [ prevStepValue, setPrevStepValue ] = useState();
 
-	const handleTitleSelect = useCallback( ( option: Option ) => {
-		setSelectedTitle( option.content );
-		setTitleOptions( prev =>
-			prev.map( opt => ( {
-				...opt,
-				selected: opt.id === option.id,
-			} ) )
-		);
-	}, [] );
+	const handleTitleSelect = useCallback(
+		( option: OptionMessage ) => {
+			setSelectedTitle( option.content as string );
+			setSelectedMessage( option );
+		},
+		[ setSelectedMessage ]
+	);
 
 	const handleTitleGenerate = useCallback(
 		async ( { fromSkip, stepValue: keywords } ) => {
 			const prevStepHasChanged = keywords !== prevStepValue;
+			if ( ! prevStepHasChanged ) {
+				return;
+			}
+			setPrevStepValue( keywords );
 			const initialMessage = fromSkip
 				? {
 						content: createInterpolateElement(
@@ -39,13 +48,9 @@ export const useTitleStep = (): Step => {
 						showIcon: true,
 				  };
 			setMessages( [ initialMessage ] );
-			if ( prevStepHasChanged ) {
-				setTitleOptions( [] );
-			}
-			let newTitles;
+			let newTitles = [ ...titleOptions ];
 			// we only generate if options are empty
-			if ( titleOptions.length === 0 || prevStepHasChanged ) {
-				setPrevStepValue( keywords );
+			if ( newTitles.length === 0 || prevStepHasChanged ) {
 				addMessage( { content: <TypingMessage /> } );
 				newTitles = await new Promise( resolve =>
 					setTimeout(
@@ -97,14 +102,19 @@ export const useTitleStep = (): Step => {
 				);
 			}
 			editLastMessage( editedMessage );
-			setTitleOptions( newTitles || titleOptions );
+			if ( newTitles.length ) {
+				// this sets the title options for internal state
+				setTitleOptions( newTitles );
+				// this addes title options as message-buttons
+				newTitles.forEach( title => addMessage( { ...title, type: 'option', isUser: true } ) );
+			}
 		},
 		[ titleOptions, addMessage, removeLastMessage, setMessages, prevStepValue, editLastMessage ]
 	);
 
 	const handleTitleRegenerate = useCallback( async () => {
 		addMessage( { content: <TypingMessage /> } );
-		const newTitles = await new Promise< Array< Option > >( resolve =>
+		const newTitles = await new Promise< Array< OptionMessage > >( resolve =>
 			setTimeout(
 				() =>
 					resolve( [
@@ -123,6 +133,7 @@ export const useTitleStep = (): Step => {
 		);
 		removeLastMessage();
 		setTitleOptions( [ ...titleOptions, ...newTitles ] );
+		newTitles.forEach( title => addMessage( { ...title, type: 'option', isUser: true } ) );
 	}, [ addMessage, removeLastMessage, titleOptions ] );
 
 	const handleTitleSubmit = useCallback( async () => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -115,6 +115,7 @@ export const useTitleStep = (): Step => {
 		removeLastMessage();
 		addMessage( { content: __( 'Title updated! ✅', 'jetpack' ) } );
 		setCompleted( true );
+		return selectedTitle;
 	}, [ selectedTitle, addMessage, editPost, removeLastMessage ] );
 
 	const handleSkip = useCallback( () => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -134,10 +134,6 @@ export const useTitleStep = (): Step => {
 		return selectedTitle;
 	}, [ selectedTitle, addMessage, editPost, removeLastMessage ] );
 
-	const handleSkip = useCallback( () => {
-		// addMessage( { content: __( 'Skipped!', 'jetpack' ) } );
-	}, [] );
-
 	return {
 		id: 'title',
 		title: __( 'Optimise Title', 'jetpack' ),
@@ -150,7 +146,6 @@ export const useTitleStep = (): Step => {
 		onRetry: handleTitleRegenerate,
 		retryCtaLabel: __( 'Regenerate', 'jetpack' ),
 		onStart: handleTitleGenerate,
-		onSkip: handleSkip,
 		value: selectedTitle,
 		setValue: setSelectedTitle,
 		completed,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-messages.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-messages.tsx
@@ -48,16 +48,23 @@ export const useMessages = () => {
 		} );
 	};
 
+	const setSelectedMessage = message => {
+		setMessages( prev =>
+			prev.map( prevMessage => ( { ...prevMessage, selected: message.id === prevMessage.id } ) )
+		);
+	};
+
 	return {
 		messages,
 		setMessages: wrapMessagesWithId,
 		addMessage,
 		removeLastMessage,
 		editLastMessage,
+		setSelectedMessage,
 	};
 };
 
-export const MessageBubble = ( { message } ) => {
+export const MessageBubble = ( { message, onSelect = a => a } ) => {
 	return (
 		<div
 			className={ clsx( 'assistant-wizard__message', {
@@ -70,19 +77,15 @@ export const MessageBubble = ( { message } ) => {
 				) }
 			</div>
 
-			{ message.type === 'past-options' && (
-				<div className="assistant-wizard__options">
-					{ message.options.map( option => (
-						<div
-							key={ option.id }
-							className={ clsx( 'assistant-wizard__option', {
-								'is-selected': option.selected,
-							} ) }
-						>
-							{ option.content }
-						</div>
-					) ) }
-				</div>
+			{ message.type === 'option' && (
+				<button
+					className={ clsx( 'assistant-wizard__option', {
+						'is-selected': message.selected,
+					} ) }
+					onClick={ () => onSelect( message ) }
+				>
+					{ message.content }
+				</button>
 			) }
 
 			{ ( ! message.type || message.type === 'chat' ) && (
@@ -92,34 +95,7 @@ export const MessageBubble = ( { message } ) => {
 	);
 };
 
-const OptionMessages = ( { options = [], onSelect } ) => {
-	if ( ! options.length ) {
-		return null;
-	}
-
-	return (
-		<div className="assistant-wizard__message">
-			<div className="assistant-wizard__message-icon"></div>
-			<div className="assistant-wizard__message-text">
-				<div className="assistant-wizard__options">
-					{ options.map( option => (
-						<button
-							key={ option.id }
-							className={ clsx( 'assistant-wizard__option', {
-								'is-selected': option.selected,
-							} ) }
-							onClick={ () => onSelect( option ) }
-						>
-							{ option.content }
-						</button>
-					) ) }
-				</div>
-			</div>
-		</div>
-	);
-};
-
-export default function Messages( { options, onSelect, messages, loading } ) {
+export default function Messages( { onSelect, messages, loading } ) {
 	const messagesEndRef = useRef< HTMLDivElement >( null );
 	const scrollToBottom = () => {
 		messagesEndRef.current?.scrollIntoView( { behavior: 'smooth' } );
@@ -133,9 +109,8 @@ export default function Messages( { options, onSelect, messages, loading } ) {
 		<>
 			<div className="assistant-wizard__messages">
 				{ messages.map( message => (
-					<MessageBubble key={ message.id } message={ message } />
+					<MessageBubble key={ message.id } onSelect={ onSelect } message={ message } />
 				) ) }
-				<OptionMessages options={ options } onSelect={ onSelect } />
 				{ loading && <MessageBubble message={ { content: <TypingMessage /> } } /> }
 			</div>
 			<div ref={ messagesEndRef } />

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-step.tsx
@@ -7,19 +7,13 @@ export default function WizardStep( {
 	messages,
 	visible,
 	loading = false,
-	options = [],
 	onSelect,
 } ) {
 	const stepRef = useRef( null );
 	const classes = clsx( 'assistant-wizard-step', className );
 	return (
 		<div ref={ stepRef } className={ classes } style={ { display: visible ? 'block' : 'none' } }>
-			<WizardMessages
-				messages={ messages }
-				loading={ loading }
-				options={ options }
-				onSelect={ onSelect }
-			/>
+			<WizardMessages messages={ messages } loading={ loading } onSelect={ onSelect } />
 		</div>
 	);
 }


### PR DESCRIPTION
Fixes #41070 

## Proposed changes:
This PR changes the step's start handler to allow passing previous step's status and values.
It allows for a more cohesive composing, adding the ability to edit messages and concat messages to achieve desired chat flow.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pe4Cmx-2ZI-p2
p1HpG7-vtt-p2


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Complete the first "one click connect" to Jetpack.

- Add "Code Snippets" plugin and add the filter on a snippet (save & activate):

```
add_filter( 'ai_seo_assistant_enabled', '__return_true' );
```

- Go to WP Admin Sidebar -> Settings -> Jetpack Constants and set Type of blocks to "Beta"
 
Head to the editor and you should see the SEO panel on Jetpack Sidebar. Enable SEO module from there and the assistant trigger should be available.
Observe the flow and messages on each step. Skipping and regenerating should now work as in the designs.
See that keywords can be submitted with Enter key