### PR TITLE
Forms: Fixes date picker field compatibility with dark themes

### DIFF
--- a/projects/packages/forms/changelog/fix-editor-select-field
+++ b/projects/packages/forms/changelog/fix-editor-select-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix dark themes date picker styles

--- a/projects/packages/forms/src/contact-form/css/jquery-ui-datepicker.css
+++ b/projects/packages/forms/src/contact-form/css/jquery-ui-datepicker.css
@@ -12,6 +12,13 @@
 	width: auto;
 }
 
+.ui-datepicker-calendar,
+.ui-datepicker-header .ui-datepicker-title,
+.ui-datepicker-header a {
+  color: #444;
+  text-decoration: none;
+}
+
 .ui-datepicker * {
 	padding: 0;
 	-webkit-border-radius: 0;

--- a/projects/plugins/jetpack/changelog/fix-editor-select-field
+++ b/projects/plugins/jetpack/changelog/fix-editor-select-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fixed datepicker appearance on dark themes


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/29793

Before:
![Screenshot 2025-01-27 at 10 31 10 AM](https://github.com/user-attachments/assets/e0e3d3ed-774b-4c3a-812d-379b88da18ab)

After:

![Screenshot 2025-01-27 at 12 06 23 PM](https://github.com/user-attachments/assets/dce05b39-04fb-4e75-b945-2c343c611dbf)



## Proposed changes:
* Add colour and underline styling for the datepicker so that the picker renders more as expected.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Load up this PR. 
* Set the twenty twenty five theme to pallet dark mode 
* Add the appointment form to a page. 
* Notice that the date picker now renders the header and the month navigation. 

