### PR TITLE
Newsletter launchpad: replace preview task with "launch site"

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-newsletter-goal-site-launched
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-newsletter-goal-site-launched
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Launchpad: Replace newsletter preview task with launch task

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -181,15 +181,6 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/me/account';
 			},
 		),
-		'preview_site'                    => array(
-			'get_title'            => function () {
-				return __( 'Preview your site', 'jetpack-mu-wpcom' );
-			},
-			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
-			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/view/' . $data['site_slug_encoded'];
-			},
-		),
 
 		// Newsletter pre-launch tasks.
 		'first_post_published_newsletter' => array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -112,7 +112,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'start_building_your_audience',
 				'customize_welcome_message',
 				'first_post_published',
-				'preview_site',
+				'site_launched',
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/98773

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Replace the "preview site" task with the "launch site" task for the Newsletter goal
- Remove unused "preview_site" task

It's safe to remove the preview_site task because it was added in #41158 specifically for the newsletter goal. It's not used by any other launchpad.

![CleanShot 2025-01-28 at 11 12 23](https://github.com/user-attachments/assets/afdb8381-1fe4-4b73-a3da-aa45e19ce952)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
As discussed here https://github.com/Automattic/wp-calypso/issues/98773 the launch bar is no longer on the front end. Leading the user to preview the front end of their site. It isn't as viable a method for getting the site launched as it was before.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a site with `/setup/onboarding?flags=onboarding/newsletter-goal`
* Choose "newsletter" on the goals screen
* Once on My Home, observe the "launch site" task
* Ensure the Calypso change is applied https://github.com/Automattic/wp-calypso/pull/98951
* Clicking the task and the site is launched and the celebration modal appears


