### PR TITLE
Forms: Fix translation issue with %

### DIFF
--- a/projects/packages/forms/changelog/fix-spam-percent-translation
+++ b/projects/packages/forms/changelog/fix-spam-percent-translation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Translations: Fix spam % character.

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -1315,7 +1315,7 @@ class Admin {
 
 		$button_parameters = array(
 			/* translators: The placeholder is for showing how much of the process has completed, as a percent. e.g., "Emptying Spam (40%)" */
-			'progress_label' => __( 'Emptying Spam (%1$s%)', 'jetpack-forms' ),
+			'progress_label' => __( 'Emptying Spam (%1$s%%)', 'jetpack-forms' ),
 			'success_url'    => $success_url,
 			'failure_url'    => $failure_url,
 			'spam_count'     => $spam_count,

--- a/projects/packages/forms/src/contact-form/js/grunion-admin.js
+++ b/projects/packages/forms/src/contact-form/js/grunion-admin.js
@@ -83,7 +83,10 @@ jQuery( function ( $ ) {
 
 		// Update the label on the "Empty Spam" button to use the active "Emptying Spam" language.
 		$( '.jetpack-empty-spam' ).text(
-			$( '.jetpack-empty-spam' ).data( 'progress-label' ).replace( '%1$s', '0' )
+			$( '.jetpack-empty-spam' )
+				.data( 'progress-label' )
+				.replace( '%1$s', '0' )
+				.replace( '%%', '%' ) // Convert escaped %% into a single %
 		);
 
 		initial_spam_count = parseInt( $( this ).data( 'spam-feedbacks-count' ), 10 );
@@ -106,7 +109,10 @@ jQuery( function ( $ ) {
 
 		// Update the progress counter on the "Check for Spam" button.
 		empty_spam_buttons.text(
-			empty_spam_buttons.data( 'progress-label' ).replace( '%1$s', percentage_complete )
+			empty_spam_buttons
+				.data( 'progress-label' )
+				.replace( '%1$s', percentage_complete )
+				.replace( '%%', '%' ) // Convert escaped %% into a single %
 		);
 
 		$.post( ajaxurl, {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #19940

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Fixes translation issue with `__( 'Emptying Spam (%1$s%)', 'jetpack' )`. The last % is a literal % that should render, but causes an error during translation because its perceived as an escaping character. 
- Fix PHP issue: This if fixed by adding an extra % before the %. This fixes the PHP error. 
- Fix JS issue ([see related comment](https://github.com/Automattic/jetpack/issues/19940#issuecomment-848915935)): the PHP fix causes a secondary issue. The string is later passed to JS. We replace the %1$s with a value, but leave %% in place and render it. To fix this new issue, in the same place, we also replace %% to %. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to a site with a form block, and generate a few form submissions from the front end. 
* Go to the 'Feedback' page in the backend, and mark the submissions as spam. 
* Go to the 'Feedback' > 'Spam' tab, and click the `Empty Spam` button at the end. Confirm the button text renders correctly as `Emptying Spam (0%)` (percentage may vary). 
* Update your site to a foreign language, and re-run the test above to confirm the text string still renders correctly and spam is deleted.