### PR TITLE
My Jetpack: fix Protect card secondary action

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
@@ -79,7 +79,7 @@ const ProductCard: FC< ProductCardProps > = props => {
 
 	const [ isActionLoading, setIsActionLoading ] = useState( false );
 	const { recordEvent } = useAnalytics();
-	const { siteIsRegistering } = useMyJetpackConnection();
+	const { siteIsRegistering, isUserConnected } = useMyJetpackConnection();
 	const { connectSite } = useConnectSite( {
 		tracksInfo: {
 			event: `jetpack_myjetpack_product_card_fix_site_connection`,
@@ -95,7 +95,11 @@ const ProductCard: FC< ProductCardProps > = props => {
 		} );
 	}, [ slug, recordEvent ] );
 
-	if ( ! secondaryAction && status === PRODUCT_STATUSES.CAN_UPGRADE ) {
+	if (
+		! secondaryAction &&
+		status === PRODUCT_STATUSES.CAN_UPGRADE &&
+		! ( slug === 'protect' && ! isUserConnected )
+	) {
 		secondaryAction = {
 			href: manageUrl,
 			label: __( 'View', 'jetpack-my-jetpack' ),

--- a/projects/packages/my-jetpack/changelog/fix-protect-default-secondary
+++ b/projects/packages/my-jetpack/changelog/fix-protect-default-secondary
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: fix secondary action of Protect card when plugin is not installed.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR removes the secondary action button of the Protect card in My Jetpack in case the user does not match a certain condition (not user-connected). That prevents the secondary action from sending the user to the wrong location when clicking on the "View" button

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with Jetpack Beta pointing to this feature branch `fix/protect-default-secondary`
* Go to My Jetpack, connect your site and check the Protect card
* Confirm that the secondary "View" button isn't there
* Now, connect your user and you'll see the "View" button
* If you click on that button, you'll be redirected to Jetpack Cloud, to the Scan page

