### PR TITLE
Form: Remove old block editor back-compat code and improve code quality

### DIFF
--- a/projects/packages/forms/changelog/update-contact-form-block-code-quality
+++ b/projects/packages/forms/changelog/update-contact-form-block-code-quality
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: Remove old back compat code and improve code quality

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -9,6 +9,7 @@ import {
 	URLInput,
 	useBlockProps,
 	useInnerBlocksProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -18,7 +19,9 @@ import {
 	Notice,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
+import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
@@ -76,9 +79,9 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 	const instanceId = useInstanceId( JetpackContactFormEdit );
 	const { canUserInstallPlugins, hasInnerBlocks, postAuthorEmail } = useSelect(
 		select => {
-			const { getBlocks } = select( 'core/block-editor' );
-			const { getEditedPostAttribute } = select( 'core/editor' );
-			const { getUser, canUser } = select( 'core' );
+			const { getBlocks } = select( blockEditorStore );
+			const { getEditedPostAttribute } = select( editorStore );
+			const { getUser, canUser } = select( coreStore );
 			const innerBlocks = getBlocks( clientId );
 
 			const authorId = getEditedPostAttribute( 'author' );

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -13,7 +13,7 @@ import {
 	__experimentalBlockVariationPicker as BlockVariationPicker, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalBlockPatternSetup as BlockPatternSetup, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/block-editor';
-import { createBlock, registerBlockVariation } from '@wordpress/blocks';
+import { createBlock } from '@wordpress/blocks';
 import {
 	Button,
 	Modal,
@@ -38,7 +38,6 @@ import JetpackEmailConnectionSettings from './components/jetpack-email-connectio
 import JetpackManageResponsesSettings from './components/jetpack-manage-responses-settings';
 import NewsletterIntegrationSettings from './components/jetpack-newsletter-integration-settings';
 import SalesforceLeadFormSettings from './components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings';
-import defaultVariations from './variations';
 import './util/form-styles.js';
 
 const validFields = filter( childBlocks, ( { settings } ) => {
@@ -112,8 +111,8 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 			return {
 				blockType: getBlockType && getBlockType( name ),
 				canUserInstallPlugins: canUser( 'create', 'plugins' ),
-				defaultVariation: getDefaultBlockVariation && getDefaultBlockVariation( name, 'block' ),
-				variations: getBlockVariations && getBlockVariations( name, 'block' ),
+				defaultVariation: getDefaultBlockVariation( name, 'block' ),
+				variations: getBlockVariations( name, 'block' ),
 				hasInnerBlocks: innerBlocks.length > 0,
 				postAuthorEmail: authorEmail,
 			};
@@ -128,7 +127,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		useModuleStatus( 'contact-form' );
 
 	const formClassnames = clsx( className, 'jetpack-contact-form', {
-		'is-placeholder': ! hasInnerBlocks && registerBlockVariation,
+		'is-placeholder': ! hasInnerBlocks,
 	} );
 
 	const isSalesForceExtensionEnabled =
@@ -157,16 +156,8 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 	};
 
 	useEffect( () => {
-		// Populate default variation on older versions of WP or GB that don't support variations.
-		if ( ! hasInnerBlocks && ! registerBlockVariation ) {
-			setVariation( defaultVariations[ 0 ] );
-		}
-	} );
-
-	useEffect( () => {
 		if (
 			! hasInnerBlocks &&
-			registerBlockVariation &&
 			! isPatternsModalOpen &&
 			window.location.search.indexOf( 'showJetpackFormsPatterns' ) !== -1
 		) {
@@ -189,7 +180,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 				/>
 			);
 		}
-	} else if ( ! hasInnerBlocks && registerBlockVariation ) {
+	} else if ( ! hasInnerBlocks ) {
 		elt = (
 			<div className={ formClassnames }>
 				<BlockVariationPicker

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -138,7 +138,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 	} else if ( ! hasInnerBlocks ) {
 		elt = (
 			<VariationPicker
-				blockType={ name }
+				blockName={ name }
 				setAttributes={ setAttributes }
 				clientId={ clientId }
 				classNames={ formClassnames }

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -143,18 +143,6 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		return blocks;
 	};
 
-	const setVariation = variation => {
-		if ( variation.attributes ) {
-			setAttributes( variation.attributes );
-		}
-
-		if ( variation.innerBlocks ) {
-			replaceInnerBlocks( clientId, createBlocksFromInnerBlocksTemplate( variation.innerBlocks ) );
-		}
-
-		selectBlock( clientId );
-	};
-
 	useEffect( () => {
 		if (
 			! hasInnerBlocks &&
@@ -192,7 +180,18 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 					) }
 					variations={ filter( variations, v => ! v.hiddenFromPicker ) }
 					onSelect={ ( nextVariation = defaultVariation ) => {
-						setVariation( nextVariation );
+						if ( nextVariation.attributes ) {
+							setAttributes( nextVariation.attributes );
+						}
+
+						if ( nextVariation.innerBlocks ) {
+							replaceInnerBlocks(
+								clientId,
+								createBlocksFromInnerBlocksTemplate( nextVariation.innerBlocks )
+							);
+						}
+
+						selectBlock( clientId );
 					} }
 				/>
 				<div className="form-placeholder__footer">

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -4,7 +4,12 @@ import {
 	isSimpleSite,
 	useModuleStatus,
 } from '@automattic/jetpack-shared-extension-utils';
-import { InnerBlocks, InspectorControls, URLInput, useBlockProps } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	URLInput,
+	useBlockProps,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
 import {
 	PanelBody,
 	SelectControl,
@@ -55,7 +60,6 @@ const ALLOWED_BLOCKS = [
 	'core/subhead',
 	'core/video',
 ];
-
 const PRIORITIZED_INSERTER_BLOCKS = [ ...map( validFields, block => `jetpack/${ block.name }` ) ];
 
 function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, className } ) {
@@ -96,10 +100,21 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 	const wrapperRef = useRef();
 	const innerRef = useRef();
 	const blockProps = useBlockProps( { ref: wrapperRef } );
+	const formClassnames = clsx( className, 'jetpack-contact-form' );
+	const innerBlocksProps = useInnerBlocksProps(
+		{
+			ref: innerRef,
+			className: formClassnames,
+			style: window.jetpackForms.generateStyleVariables( innerRef.current ),
+		},
+		{
+			allowedBlocks: ALLOWED_BLOCKS,
+			prioritizedInserterBlocks: PRIORITIZED_INSERTER_BLOCKS,
+			templateInsertUpdatesSelection: false,
+		}
+	);
 	const { isLoadingModules, isChangingStatus, isModuleActive, changeStatus } =
 		useModuleStatus( 'contact-form' );
-
-	const formClassnames = clsx( className, 'jetpack-contact-form' );
 
 	const isSalesForceExtensionEnabled =
 		!! window?.Jetpack_Editor_Initial_State?.available_blocks[
@@ -130,7 +145,6 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 			/>
 		);
 	} else {
-		const style = window.jetpackForms.generateStyleVariables( innerRef.current );
 		elt = (
 			<>
 				<InspectorControls>
@@ -232,14 +246,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 						</>
 					) }
 				</InspectorControls>
-
-				<div className={ formClassnames } style={ style } ref={ innerRef }>
-					<InnerBlocks
-						allowedBlocks={ ALLOWED_BLOCKS }
-						prioritizedInserterBlocks={ PRIORITIZED_INSERTER_BLOCKS }
-						templateInsertUpdatesSelection={ false }
-					/>
-				</div>
+				<div { ...innerBlocksProps } />
 			</>
 		);
 	}

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -1,22 +1,11 @@
 import { ThemeProvider } from '@automattic/jetpack-components';
 import {
-	getJetpackData,
 	isAtomicSite,
 	isSimpleSite,
 	useModuleStatus,
 } from '@automattic/jetpack-shared-extension-utils';
+import { InnerBlocks, InspectorControls, URLInput, useBlockProps } from '@wordpress/block-editor';
 import {
-	InnerBlocks,
-	InspectorControls,
-	URLInput,
-	useBlockProps,
-	__experimentalBlockVariationPicker as BlockVariationPicker, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	__experimentalBlockPatternSetup as BlockPatternSetup, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-} from '@wordpress/block-editor';
-import { createBlock } from '@wordpress/blocks';
-import {
-	Button,
-	Modal,
 	PanelBody,
 	SelectControl,
 	TextareaControl,
@@ -24,11 +13,11 @@ import {
 	Notice,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { filter, get, isArray, map } from 'lodash';
+import { filter, isArray, map } from 'lodash';
 import { childBlocks } from './child-blocks';
 import InspectorHint from './components/inspector-hint';
 import { ContactFormPlaceholder } from './components/jetpack-contact-form-placeholder';
@@ -38,6 +27,7 @@ import JetpackEmailConnectionSettings from './components/jetpack-email-connectio
 import JetpackManageResponsesSettings from './components/jetpack-manage-responses-settings';
 import NewsletterIntegrationSettings from './components/jetpack-newsletter-integration-settings';
 import SalesforceLeadFormSettings from './components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings';
+import VariationPicker from './variation-picker';
 import './util/form-styles.js';
 
 const validFields = filter( childBlocks, ( { settings } ) => {
@@ -68,9 +58,6 @@ const ALLOWED_BLOCKS = [
 
 const PRIORITIZED_INSERTER_BLOCKS = [ ...map( validFields, block => `jetpack/${ block.name }` ) ];
 
-const RESPONSES_PATH = `${ get( getJetpackData(), 'adminUrl', false ) }edit.php?post_type=feedback`;
-const CUSTOMIZING_FORMS_URL = 'https://jetpack.com/support/jetpack-blocks/contact-form/';
-
 function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, className } ) {
 	const {
 		to,
@@ -83,25 +70,15 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		salesforceData,
 	} = attributes;
 	const instanceId = useInstanceId( JetpackContactFormEdit );
-	const { replaceInnerBlocks, selectBlock } = useDispatch( 'core/block-editor' );
-	const {
-		blockType,
-		canUserInstallPlugins,
-		defaultVariation,
-		variations,
-		hasInnerBlocks,
-		postAuthorEmail,
-	} = useSelect(
+	const { canUserInstallPlugins, hasInnerBlocks, postAuthorEmail } = useSelect(
 		select => {
-			const { getBlockType, getBlockVariations, getDefaultBlockVariation } =
-				select( 'core/blocks' );
 			const { getBlocks } = select( 'core/block-editor' );
 			const { getEditedPostAttribute } = select( 'core/editor' );
 			const { getUser, canUser } = select( 'core' );
 			const innerBlocks = getBlocks( clientId );
 
 			const authorId = getEditedPostAttribute( 'author' );
-			const authorEmail = authorId && getUser( authorId ) && getUser( authorId ).email;
+			const authorEmail = authorId && getUser( authorId )?.email;
 			const submitButton = innerBlocks.find( block => block.name === 'jetpack/button' );
 			if ( submitButton && ! submitButton.attributes.lock ) {
 				const lock = { move: false, remove: true };
@@ -109,50 +86,25 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 			}
 
 			return {
-				blockType: getBlockType && getBlockType( name ),
 				canUserInstallPlugins: canUser( 'create', 'plugins' ),
-				defaultVariation: getDefaultBlockVariation( name, 'block' ),
-				variations: getBlockVariations( name, 'block' ),
 				hasInnerBlocks: innerBlocks.length > 0,
 				postAuthorEmail: authorEmail,
 			};
 		},
-		[ clientId, name ]
+		[ clientId ]
 	);
-	const [ isPatternsModalOpen, setIsPatternsModalOpen ] = useState( false );
 	const wrapperRef = useRef();
 	const innerRef = useRef();
 	const blockProps = useBlockProps( { ref: wrapperRef } );
 	const { isLoadingModules, isChangingStatus, isModuleActive, changeStatus } =
 		useModuleStatus( 'contact-form' );
 
-	const formClassnames = clsx( className, 'jetpack-contact-form', {
-		'is-placeholder': ! hasInnerBlocks,
-	} );
+	const formClassnames = clsx( className, 'jetpack-contact-form' );
 
 	const isSalesForceExtensionEnabled =
 		!! window?.Jetpack_Editor_Initial_State?.available_blocks[
 			'contact-form/salesforce-lead-form'
 		];
-
-	const createBlocksFromInnerBlocksTemplate = innerBlocksTemplate => {
-		const blocks = map( innerBlocksTemplate, ( [ blockName, attr, innerBlocks = [] ] ) =>
-			createBlock( blockName, attr, createBlocksFromInnerBlocksTemplate( innerBlocks ) )
-		);
-
-		return blocks;
-	};
-
-	useEffect( () => {
-		if (
-			! hasInnerBlocks &&
-			! isPatternsModalOpen &&
-			window.location.search.indexOf( 'showJetpackFormsPatterns' ) !== -1
-		) {
-			setIsPatternsModalOpen( true );
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
 
 	let elt;
 
@@ -170,70 +122,12 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		}
 	} else if ( ! hasInnerBlocks ) {
 		elt = (
-			<div className={ formClassnames }>
-				<BlockVariationPicker
-					icon={ get( blockType, [ 'icon', 'src' ] ) }
-					label={ get( blockType, [ 'title' ] ) }
-					instructions={ __(
-						'Start building a form by selecting one of these form templates, or search in the patterns library for more forms:',
-						'jetpack-forms'
-					) }
-					variations={ filter( variations, v => ! v.hiddenFromPicker ) }
-					onSelect={ ( nextVariation = defaultVariation ) => {
-						if ( nextVariation.attributes ) {
-							setAttributes( nextVariation.attributes );
-						}
-
-						if ( nextVariation.innerBlocks ) {
-							replaceInnerBlocks(
-								clientId,
-								createBlocksFromInnerBlocksTemplate( nextVariation.innerBlocks )
-							);
-						}
-
-						selectBlock( clientId );
-					} }
-				/>
-				<div className="form-placeholder__footer">
-					<Button variant="secondary" onClick={ () => setIsPatternsModalOpen( true ) }>
-						{ __( 'Explore Form Patterns', 'jetpack-forms' ) }
-					</Button>
-					<div className="form-placeholder__footer-links">
-						<Button
-							variant="link"
-							className="form-placeholder__external-link"
-							href={ CUSTOMIZING_FORMS_URL }
-							target="_blank"
-						>
-							{ __( 'Learn more about customizing forms', 'jetpack-forms' ) }
-						</Button>
-						<Button
-							variant="link"
-							className="form-placeholder__external-link"
-							href={ RESPONSES_PATH }
-							target="_blank"
-						>
-							{ __( 'View and export your form responses here', 'jetpack-forms' ) }
-						</Button>
-					</div>
-				</div>
-				{ isPatternsModalOpen && (
-					<Modal
-						className="form-placeholder__patterns-modal"
-						title={ __( 'Choose a pattern', 'jetpack-forms' ) }
-						closeLabel={ __( 'Cancel', 'jetpack-forms' ) }
-						onRequestClose={ () => setIsPatternsModalOpen( false ) }
-					>
-						<BlockPatternSetup
-							initialViewMode="grid"
-							filterPatternsFn={ pattern => {
-								return pattern.content.indexOf( 'jetpack/contact-form' ) !== -1;
-							} }
-							clientId={ clientId }
-						/>
-					</Modal>
-				) }
-			</div>
+			<VariationPicker
+				blockType={ name }
+				setAttributes={ setAttributes }
+				clientId={ clientId }
+				classNames={ formClassnames }
+			/>
 		);
 	} else {
 		const style = window.jetpackForms.generateStyleVariables( innerRef.current );

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.js
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.js
@@ -2,8 +2,9 @@ import { getJetpackData } from '@automattic/jetpack-shared-extension-utils';
 import {
 	__experimentalBlockVariationPicker as BlockVariationPicker, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalBlockPatternSetup as BlockPatternSetup, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, store as blocksStore } from '@wordpress/blocks';
 import { Button, Modal } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
@@ -25,11 +26,10 @@ const createBlocksFromInnerBlocksTemplate = innerBlocksTemplate => {
 
 export default function VariationPicker( { blockName, setAttributes, clientId, classNames } ) {
 	const [ isPatternsModalOpen, setIsPatternsModalOpen ] = useState( false );
-	const { replaceInnerBlocks, selectBlock } = useDispatch( 'core/block-editor' );
+	const { replaceInnerBlocks, selectBlock } = useDispatch( blockEditorStore );
 	const { blockType, defaultVariation, variations } = useSelect(
 		select => {
-			const { getBlockType, getBlockVariations, getDefaultBlockVariation } =
-				select( 'core/blocks' );
+			const { getBlockType, getBlockVariations, getDefaultBlockVariation } = select( blocksStore );
 
 			return {
 				blockType: getBlockType( blockName ),

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.js
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.js
@@ -11,7 +11,6 @@ import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { filter, get, map } from 'lodash';
 import './util/form-styles.js';
-import { name } from './index';
 
 const RESPONSES_PATH = `${ get( getJetpackData(), 'adminUrl', false ) }edit.php?post_type=feedback`;
 const CUSTOMIZING_FORMS_URL = 'https://jetpack.com/support/jetpack-blocks/contact-form/';
@@ -24,18 +23,22 @@ const createBlocksFromInnerBlocksTemplate = innerBlocksTemplate => {
 	return blocks;
 };
 
-export default function VariationPicker( { setAttributes, clientId, classNames } ) {
+export default function VariationPicker( { blockName, setAttributes, clientId, classNames } ) {
 	const [ isPatternsModalOpen, setIsPatternsModalOpen ] = useState( false );
 	const { replaceInnerBlocks, selectBlock } = useDispatch( 'core/block-editor' );
-	const { blockType, defaultVariation, variations } = useSelect( select => {
-		const { getBlockType, getBlockVariations, getDefaultBlockVariation } = select( 'core/blocks' );
+	const { blockType, defaultVariation, variations } = useSelect(
+		select => {
+			const { getBlockType, getBlockVariations, getDefaultBlockVariation } =
+				select( 'core/blocks' );
 
-		return {
-			blockType: getBlockType( name ),
-			defaultVariation: getDefaultBlockVariation( name, 'block' ),
-			variations: getBlockVariations( name, 'block' ),
-		};
-	}, [] );
+			return {
+				blockType: getBlockType( blockName ),
+				defaultVariation: getDefaultBlockVariation( blockName, 'block' ),
+				variations: getBlockVariations( blockName, 'block' ),
+			};
+		},
+		[ blockName ]
+	);
 
 	useEffect( () => {
 		if (

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.js
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.js
@@ -1,0 +1,116 @@
+import { getJetpackData } from '@automattic/jetpack-shared-extension-utils';
+import {
+	__experimentalBlockVariationPicker as BlockVariationPicker, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalBlockPatternSetup as BlockPatternSetup, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
+import { Button, Modal } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+import { filter, get, map } from 'lodash';
+import './util/form-styles.js';
+import { name } from './index';
+
+const RESPONSES_PATH = `${ get( getJetpackData(), 'adminUrl', false ) }edit.php?post_type=feedback`;
+const CUSTOMIZING_FORMS_URL = 'https://jetpack.com/support/jetpack-blocks/contact-form/';
+
+const createBlocksFromInnerBlocksTemplate = innerBlocksTemplate => {
+	const blocks = map( innerBlocksTemplate, ( [ blockName, attr, innerBlocks = [] ] ) =>
+		createBlock( blockName, attr, createBlocksFromInnerBlocksTemplate( innerBlocks ) )
+	);
+
+	return blocks;
+};
+
+export default function VariationPicker( { setAttributes, clientId, classNames } ) {
+	const [ isPatternsModalOpen, setIsPatternsModalOpen ] = useState( false );
+	const { replaceInnerBlocks, selectBlock } = useDispatch( 'core/block-editor' );
+	const { blockType, defaultVariation, variations } = useSelect( select => {
+		const { getBlockType, getBlockVariations, getDefaultBlockVariation } = select( 'core/blocks' );
+
+		return {
+			blockType: getBlockType( name ),
+			defaultVariation: getDefaultBlockVariation( name, 'block' ),
+			variations: getBlockVariations( name, 'block' ),
+		};
+	}, [] );
+
+	useEffect( () => {
+		if (
+			! isPatternsModalOpen &&
+			window.location.search.indexOf( 'showJetpackFormsPatterns' ) !== -1
+		) {
+			setIsPatternsModalOpen( true );
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	return (
+		<div className={ clsx( classNames, 'is-placeholder' ) }>
+			<BlockVariationPicker
+				icon={ get( blockType, [ 'icon', 'src' ] ) }
+				label={ get( blockType, [ 'title' ] ) }
+				instructions={ __(
+					'Start building a form by selecting one of these form templates, or search in the patterns library for more forms:',
+					'jetpack-forms'
+				) }
+				variations={ filter( variations, v => ! v.hiddenFromPicker ) }
+				onSelect={ ( nextVariation = defaultVariation ) => {
+					if ( nextVariation.attributes ) {
+						setAttributes( nextVariation.attributes );
+					}
+
+					if ( nextVariation.innerBlocks ) {
+						replaceInnerBlocks(
+							clientId,
+							createBlocksFromInnerBlocksTemplate( nextVariation.innerBlocks )
+						);
+					}
+
+					selectBlock( clientId );
+				} }
+			/>
+			<div className="form-placeholder__footer">
+				<Button variant="secondary" onClick={ () => setIsPatternsModalOpen( true ) }>
+					{ __( 'Explore Form Patterns', 'jetpack-forms' ) }
+				</Button>
+				<div className="form-placeholder__footer-links">
+					<Button
+						variant="link"
+						className="form-placeholder__external-link"
+						href={ CUSTOMIZING_FORMS_URL }
+						target="_blank"
+					>
+						{ __( 'Learn more about customizing forms', 'jetpack-forms' ) }
+					</Button>
+					<Button
+						variant="link"
+						className="form-placeholder__external-link"
+						href={ RESPONSES_PATH }
+						target="_blank"
+					>
+						{ __( 'View and export your form responses here', 'jetpack-forms' ) }
+					</Button>
+				</div>
+			</div>
+			{ isPatternsModalOpen && (
+				<Modal
+					className="form-placeholder__patterns-modal"
+					title={ __( 'Choose a pattern', 'jetpack-forms' ) }
+					closeLabel={ __( 'Cancel', 'jetpack-forms' ) }
+					onRequestClose={ () => setIsPatternsModalOpen( false ) }
+				>
+					<BlockPatternSetup
+						initialViewMode="grid"
+						filterPatternsFn={ pattern => {
+							return pattern.content.indexOf( 'jetpack/contact-form' ) !== -1;
+						} }
+						clientId={ clientId }
+					/>
+				</Modal>
+			) }
+		</div>
+	);
+}


### PR DESCRIPTION
Follows up on code review comments from @ntsekouras in #41274

Again, this is a fairly big diff, but most of it is moving code 😅 

## Proposed changes:
- Remove old back compat code from the form block (e.g. checking whether APIs like `getDefaultBlockVariation` exist before using them). These APIs have been in the WordPress codebase for many versions now.
- Switch to using imported store names (`import { store as blockEditorStore } from '@wordpress/block-editor';`) instead of hard coded store names `'core/block-editor'`.
- Extract the variation placeholder code into a separate component
- Use the `useInnerBlocksProps` hook instead of the `InnerBlocks` components. This removes one of the `<div>` elements from the editor markup.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Add a 'Form' block
2. Check that all the placeholder options work - selecting different form variations and inserting patterns
3. Insert 'Contact Form' or other variations directly and check that still works.