### PR TITLE
Full sync: Set chunk size of comments dynamically

### DIFF
--- a/projects/packages/sync/changelog/update-full-sync-comments-dynamically
+++ b/projects/packages/sync/changelog/update-full-sync-comments-dynamically
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Sync: Full Sync comments now send dynamic chunks if chunk size default is too big

--- a/projects/packages/sync/src/modules/class-comments.php
+++ b/projects/packages/sync/src/modules/class-comments.php
@@ -14,6 +14,25 @@ use Automattic\Jetpack\Sync\Settings;
  * Class to handle sync for comments.
  */
 class Comments extends Module {
+
+	/**
+	 * Max bytes allowed for full sync upload.
+	 * Current Setting : 7MB.
+	 *
+	 * @access public
+	 *
+	 * @var int
+	 */
+	const MAX_SIZE_FULL_SYNC = 7000000;
+	/**
+	 * Max bytes allowed for post meta_value => length.
+	 * Current Setting : 2MB.
+	 *
+	 * @access public
+	 *
+	 * @var int
+	 */
+	const MAX_COMMENT_META_LENGTH = 2000000;
 	/**
 	 * Sync module name.
 	 *
@@ -573,10 +592,21 @@ class Comments extends Module {
 		}
 		// Get the comment IDs from the comments that were fetched.
 		$fetched_comment_ids = wp_list_pluck( $comments, 'comment_ID' );
+		$metadata            = $this->get_metadata( $fetched_comment_ids, 'comment', Settings::get_setting( 'comment_meta_whitelist' ) );
+
+		// Filter the comments and metadata based on the maximum size constraints.
+		list( $filtered_comment_ids, $filtered_comments, $filtered_comments_metadata ) = $this->filter_objects_and_metadata_by_size(
+			'comment',
+			$comments,
+			$metadata,
+			self::MAX_COMMENT_META_LENGTH, // Replace with appropriate comment meta length constant.
+			self::MAX_SIZE_FULL_SYNC
+		);
+
 		return array(
-			'object_ids' => $comment_ids, // Still send the original comment IDs since we need them to update the status.
-			'objects'    => $comments,
-			'meta'       => $this->get_metadata( $fetched_comment_ids, 'comment', Settings::get_setting( 'comment_meta_whitelist' ) ),
+			'object_ids' => $filtered_comment_ids,
+			'objects'    => $filtered_comments,
+			'meta'       => $filtered_comments_metadata,
 		);
 	}
 

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -708,7 +708,7 @@ abstract class Module {
 			$metadata_size    = 0;
 
 			foreach ( $metadata as $key => $metadata_item ) {
-				if ( (int) $metadata_item->{$type . '_id'} === $object->{$this->id_field()} ) {
+				if ( (int) $metadata_item->{$type . '_id'} === (int) $object->{$this->id_field()} ) {
 					$metadata_item_size = strlen( maybe_serialize( $metadata_item->meta_value ) );
 					if ( $metadata_item_size >= $max_meta_size ) {
 						$metadata_item->meta_value = ''; // Trim metadata if too large.

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -692,11 +692,11 @@ abstract class Module {
 	 * @param string $type The type of objects to filter (e.g., 'post' or 'comment').
 	 * @param array  $objects The array of objects to filter (e.g., posts or comments).
 	 * @param array  $metadata The array of metadata to filter.
-	 * @param int    $max_object_size Maximum size for individual objects.
+	 * @param int    $max_meta_size Maximum size for individual objects.
 	 * @param int    $max_total_size Maximum combined size for objects and metadata.
 	 * @return array An array containing the filtered object IDs, filtered objects, and filtered metadata.
 	 */
-	protected function filter_objects_and_metadata_by_size( $type, $objects, $metadata, $max_object_size, $max_total_size ) {
+	public function filter_objects_and_metadata_by_size( $type, $objects, $metadata, $max_meta_size, $max_total_size ) {
 		$filtered_objects    = array();
 		$filtered_metadata   = array();
 		$filtered_object_ids = array();
@@ -710,11 +710,11 @@ abstract class Module {
 			foreach ( $metadata as $key => $metadata_item ) {
 				if ( (int) $metadata_item->{$type . '_id'} === $object->{$this->id_field()} ) {
 					$metadata_item_size = strlen( maybe_serialize( $metadata_item->meta_value ) );
-					if ( $metadata_item_size >= $max_object_size ) {
+					if ( $metadata_item_size >= $max_meta_size ) {
 						$metadata_item->meta_value = ''; // Trim metadata if too large.
 					}
 					$current_metadata[] = $metadata_item;
-					$metadata_size     += $metadata_item_size >= $max_object_size ? 0 : $metadata_item_size;
+					$metadata_size     += $metadata_item_size >= $max_meta_size ? 0 : $metadata_item_size;
 
 					if ( ! empty( $filtered_object_ids ) && ( $current_size + $object_size + $metadata_size ) > $max_total_size ) {
 						break 2; // Exit both loops.

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -682,4 +682,62 @@ abstract class Module {
 	public function get_where_sql( $config ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return '1=1';
 	}
+
+	/**
+	 * Filters objects and metadata based on maximum size constraints.
+	 * It always allows the first object with its metadata, even if they exceed the limit.
+	 *
+	 * @access protected
+	 *
+	 * @param string $type The type of objects to filter (e.g., 'post' or 'comment').
+	 * @param array  $objects The array of objects to filter (e.g., posts or comments).
+	 * @param array  $metadata The array of metadata to filter.
+	 * @param int    $max_object_size Maximum size for individual objects.
+	 * @param int    $max_total_size Maximum combined size for objects and metadata.
+	 * @return array An array containing the filtered object IDs, filtered objects, and filtered metadata.
+	 */
+	protected function filter_objects_and_metadata_by_size( $type, $objects, $metadata, $max_object_size, $max_total_size ) {
+		$filtered_objects    = array();
+		$filtered_metadata   = array();
+		$filtered_object_ids = array();
+		$current_size        = 0;
+
+		foreach ( $objects as $object ) {
+			$object_size      = strlen( maybe_serialize( $object ) );
+			$current_metadata = array();
+			$metadata_size    = 0;
+
+			foreach ( $metadata as $key => $metadata_item ) {
+				if ( (int) $metadata_item->{$type . '_id'} === $object->{$this->id_field()} ) {
+					$metadata_item_size = strlen( maybe_serialize( $metadata_item->meta_value ) );
+					if ( $metadata_item_size >= $max_object_size ) {
+						$metadata_item->meta_value = ''; // Trim metadata if too large.
+					}
+					$current_metadata[] = $metadata_item;
+					$metadata_size     += $metadata_item_size >= $max_object_size ? 0 : $metadata_item_size;
+
+					if ( ! empty( $filtered_object_ids ) && ( $current_size + $object_size + $metadata_size ) > $max_total_size ) {
+						break 2; // Exit both loops.
+					}
+					unset( $metadata[ $key ] );
+				}
+			}
+
+			// Always allow the first object with metadata.
+			if ( empty( $filtered_object_ids ) || ( $current_size + $object_size + $metadata_size ) <= $max_total_size ) {
+				$filtered_object_ids[] = strval( $object->{$this->id_field()} );
+				$filtered_objects[]    = $object;
+				$filtered_metadata     = array_merge( $filtered_metadata, $current_metadata );
+				$current_size         += $object_size + $metadata_size;
+			} else {
+				break;
+			}
+		}
+
+		return array(
+			$filtered_object_ids,
+			$filtered_objects,
+			$filtered_metadata,
+		);
+	}
 }

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -687,7 +687,7 @@ abstract class Module {
 	 * Filters objects and metadata based on maximum size constraints.
 	 * It always allows the first object with its metadata, even if they exceed the limit.
 	 *
-	 * @access protected
+	 * @access public
 	 *
 	 * @param string $type The type of objects to filter (e.g., 'post' or 'comment').
 	 * @param array  $objects The array of objects to filter (e.g., posts or comments).

--- a/projects/packages/sync/src/modules/class-posts.php
+++ b/projects/packages/sync/src/modules/class-posts.php
@@ -875,11 +875,29 @@ class Posts extends Module {
 			return array();
 		}
 
-		$posts          = $this->expand_posts( $post_ids );
-		$posts_metadata = $this->get_metadata( $post_ids, 'post', Settings::get_setting( 'post_meta_whitelist' ) );
+		$posts = $this->expand_posts( $post_ids );
 
-		// Filter posts and metadata based on maximum size constraints.
-		list( $filtered_post_ids, $filtered_posts, $filtered_posts_metadata ) = $this->filter_posts_and_metadata_max_size( $posts, $posts_metadata );
+		// If no posts were fetched, make sure to return the expected structure so that status is updated correctly.
+		if ( empty( $posts ) ) {
+			return array(
+				'object_ids' => $post_ids,
+				'objects'    => array(),
+				'meta'       => array(),
+			);
+		}
+		// Get the post IDs from the posts that were fetched.
+		$fetched_post_ids = wp_list_pluck( $posts, 'post_ID' );
+		$metadata         = $this->get_metadata( $fetched_post_ids, 'post', Settings::get_setting( 'post_meta_whitelist' ) );
+
+		// Filter the posts and metadata based on the maximum size constraints.
+		list( $filtered_post_ids, $filtered_posts, $filtered_posts_metadata ) = $this->filter_objects_and_metadata_by_size(
+			'post',
+			$posts,
+			$metadata,
+			self::MAX_POST_META_LENGTH,
+			self::MAX_SIZE_FULL_SYNC
+		);
+
 		return array(
 			'object_ids' => $filtered_post_ids,
 			'objects'    => $filtered_posts,
@@ -899,57 +917,6 @@ class Posts extends Module {
 		$posts = array_map( array( $this, 'filter_post_content_and_add_links' ), $posts );
 		$posts = array_values( $posts ); // Reindex in case posts were deleted.
 		return $posts;
-	}
-
-	/**
-	 * Filters posts and metadata based on maximum size constraints.
-	 * It always allows the first post with its metadata even if they exceed the limit, otherwise they will never be synced.
-	 *
-	 * @access public
-	 *
-	 * @param array $posts The array of posts to filter.
-	 * @param array $metadata The array of metadata to filter.
-	 * @return array An array containing the filtered post IDs, filtered posts, and filtered metadata.
-	 */
-	public function filter_posts_and_metadata_max_size( $posts, $metadata ) {
-		$filtered_posts    = array();
-		$filtered_metadata = array();
-		$filtered_post_ids = array();
-		$current_size      = 0;
-		foreach ( $posts as $post ) {
-			$post_content_size = isset( $post->post_content ) ? strlen( $post->post_content ) : 0;
-			$current_metadata  = array();
-			$metadata_size     = 0;
-			foreach ( $metadata as $key => $metadata_item ) {
-				if ( (int) $metadata_item->post_id === $post->ID ) {
-					// Trimming metadata if it exceeds limit. Similar to trim_post_meta.
-					$metadata_item_size = strlen( maybe_serialize( $metadata_item->meta_value ) );
-					if ( $metadata_item_size >= self::MAX_POST_META_LENGTH ) {
-						$metadata_item->meta_value = '';
-					}
-					$current_metadata[] = $metadata_item;
-					$metadata_size     += $metadata_item_size >= self::MAX_POST_META_LENGTH ? 0 : $metadata_item_size;
-					if ( ! empty( $filtered_post_ids ) && ( $current_size + $post_content_size + $metadata_size ) > ( self::MAX_SIZE_FULL_SYNC ) ) {
-						break 2; // Break both foreach loops.
-					}
-					unset( $metadata[ $key ] );
-				}
-			}
-			// Always allow the first post with its metadata.
-			if ( empty( $filtered_post_ids ) || ( $current_size + $post_content_size + $metadata_size ) <= ( self::MAX_SIZE_FULL_SYNC ) ) {
-				$filtered_post_ids[] = strval( $post->ID );
-				$filtered_posts[]    = $post;
-				$filtered_metadata   = array_merge( $filtered_metadata, $current_metadata );
-				$current_size       += $post_content_size + $metadata_size;
-			} else {
-				break;
-			}
-		}
-		return array(
-			$filtered_post_ids,
-			$filtered_posts,
-			$filtered_metadata,
-		);
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-posts.php
+++ b/projects/packages/sync/src/modules/class-posts.php
@@ -886,7 +886,7 @@ class Posts extends Module {
 			);
 		}
 		// Get the post IDs from the posts that were fetched.
-		$fetched_post_ids = wp_list_pluck( $posts, 'post_ID' );
+		$fetched_post_ids = wp_list_pluck( $posts, 'ID' );
 		$metadata         = $this->get_metadata( $fetched_post_ids, 'post', Settings::get_setting( 'post_meta_whitelist' ) );
 
 		// Filter the posts and metadata based on the maximum size constraints.

--- a/projects/packages/sync/tests/php/modules/test-module.php
+++ b/projects/packages/sync/tests/php/modules/test-module.php
@@ -1,0 +1,107 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+/**
+ * Test file for Automattic\Jetpack\Sync\Modules\Module
+ *
+ * @package automattic/jetpack-masterbar
+ */
+
+namespace Automattic\Jetpack\Sync;
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Class Test_Module
+ *
+ * @covers Automattic\Jetpack\Sync\Modules\Module
+ */
+class Test_Module extends BaseTestCase {
+
+	/**
+	 * The module instance.
+	 *
+	 * @var \Automattic\Jetpack\Sync\Modules\Module
+	 */
+	private $module_instance;
+
+	/**
+	 * Runs before every test in this class.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->module_instance = $this->getMockBuilder( 'Automattic\Jetpack\Sync\Modules\Module' )
+			->setMethods( array( 'id_field', 'name' ) )
+			->getMock();
+		$this->module_instance->method( 'id_field' )->willReturn( 'ID' );
+		$this->module_instance->method( 'name' )->willReturn( 'module' );
+	}
+	/**
+	 * Test filter_objects_and_metadata_by_size with no constraints of size
+	 */
+	public function filter_objects_and_metadata_by_size_no_constraints() {
+		$objects  = array(
+			(object) array(
+				'ID'           => 1,
+				'module_title' => 'Post 1',
+			),
+		);
+		$metadata = array(
+			(object) array(
+				'module_id'  => 1,
+				'meta_value' => 'meta1',
+			),
+		);
+
+		$result = $this->module_instance->filter_objects_and_metadata_by_size( 'module', $objects, $metadata, PHP_INT_MAX, PHP_INT_MAX );
+
+		$this->assertCount( 1, $result[0] );
+		$this->assertCount( 1, $result[1] );
+		$this->assertCount( 1, $result[2] );
+	}
+	/**
+	 * Test filter_objects_and_metadata_by_size with constraints of size for metadata
+	 */
+	public function test_filter_objects_exceeding_max_meta_size() {
+		$objects  = array(
+			(object) array(
+				'ID'           => 1,
+				'module_title' => 'Post 1',
+			),
+		);
+		$metadata = array(
+			(object) array(
+				'module_id'  => 1,
+				'meta_value' => str_repeat( 'a', 100 ),
+			),
+		);
+
+		$result = $this->module_instance->filter_objects_and_metadata_by_size( 'module', $objects, $metadata, 50, 200 );
+
+		$this->assertSame( '', $result[2][0]->meta_value );
+	}
+	/**
+	 * Test filter_objects_and_metadata_by_size with constraints of size for total size
+	 */
+	public function test_filter_objects_exceeding_max_total_size() {
+		$objects  = array(
+			(object) array(
+				'ID'           => 1,
+				'module_title' => 'Post 1',
+			),
+			(object) array(
+				'ID'           => 2,
+				'module_title' => 'Post 2',
+			),
+		);
+		$metadata = array(
+			(object) array(
+				'module_id'  => 1,
+				'meta_value' => 'meta1',
+			),
+		);
+
+		$result = $this->module_instance->filter_objects_and_metadata_by_size( 'module', $objects, $metadata, 50, 10 );
+
+		$this->assertCount( 1, $result[0] ); // Should only include the first object
+	}
+}

--- a/projects/packages/sync/tests/php/modules/test-module.php
+++ b/projects/packages/sync/tests/php/modules/test-module.php
@@ -30,7 +30,7 @@ class Test_Module extends BaseTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		$this->module_instance = $this->getMockBuilder( 'Automattic\Jetpack\Sync\Modules\Module' )
-			->setMethods( array( 'id_field', 'name' ) )
+			->onlyMethods( array( 'id_field', 'name' ) )
 			->getMock();
 		$this->module_instance->method( 'id_field' )->willReturn( 'ID' );
 		$this->module_instance->method( 'name' )->willReturn( 'module' );

--- a/projects/plugins/jetpack/changelog/update-full-sync-comments-dynamically
+++ b/projects/plugins/jetpack/changelog/update-full-sync-comments-dynamically
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Sync: Full Sync comments now send dynamic chunks if chunk size default is too big

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -1541,16 +1541,22 @@ That was a cool video.';
 
 		$post_sync_module = Modules::get_module( 'posts' );
 		'@phan-var \Automattic\Jetpack\Sync\Modules\Posts $post_sync_module';
-		list( ,, $filtered_metadata ) = $post_sync_module->filter_posts_and_metadata_max_size( array( $this->post ), $metadata );
+		list( ,, $filtered_metadata ) = $post_sync_module->filter_objects_and_metadata_by_size(
+			'post',
+			array( $this->post ),
+			$metadata,
+			Automattic\Jetpack\Sync\Modules\Posts::MAX_POST_META_LENGTH,
+			Automattic\Jetpack\Sync\Modules\Posts::MAX_SIZE_FULL_SYNC
+		);
 
 		$this->assertNotEmpty( $filtered_metadata[0]->meta_value, 'Filtered metadata meta_value is not empty for strings of allowed length.' );
 		$this->assertEmpty( $filtered_metadata[1]->meta_value, 'Filtered metadata meta_value is trimmed for strings larger than allowed length.' );
 	}
 
 	/**
-	 * Verify test_filter_posts_and_metadata_max_size returns all posts and metadata when the total size is less than MAX_SIZE_FULL_SYNC.
+	 * Verify test_filter_objects_and_metadata_by_size returns all posts and metadata when the total size is less than MAX_SIZE_FULL_SYNC.
 	 */
-	public function test_filter_posts_and_metadata_max_size_returns_all_posts_and_metadata() {
+	public function test_filter_objects_and_metadata_by_size_returns_all_posts_and_metadata() {
 
 		$post_ids  = self::factory()->post->create_many( 3 );
 		$post_id_1 = $post_ids[0];
@@ -1599,7 +1605,13 @@ That was a cool video.';
 
 		$post_sync_module = Modules::get_module( 'posts' );
 		'@phan-var \Automattic\Jetpack\Sync\Modules\Posts $post_sync_module';
-		list( $filtered_post_ids, $filtered_posts, $filtered_metadata ) = $post_sync_module->filter_posts_and_metadata_max_size( $posts, $metadata );
+		list( $filtered_post_ids, $filtered_posts, $filtered_metadata ) = $post_sync_module->filter_objects_and_metadata_by_size(
+			'post',
+			$posts,
+			$metadata,
+			Automattic\Jetpack\Sync\Modules\Posts::MAX_POST_META_LENGTH,
+			Automattic\Jetpack\Sync\Modules\Posts::MAX_SIZE_FULL_SYNC
+		);
 
 		$this->assertEquals( $filtered_post_ids, $post_ids );
 		$this->assertEquals( $filtered_posts, $posts );
@@ -1607,9 +1619,9 @@ That was a cool video.';
 	}
 
 	/**
-	 * Verify test_filter_posts_and_metadata_max_size returns only one post when the first post and its meta is bigger than MAX_SIZE_FULL_SYNC.
+	 * Verify test_filter_objects_and_metadata_by_size returns only one post when the first post and its meta is bigger than MAX_SIZE_FULL_SYNC.
 	 */
-	public function test_filter_posts_and_metadata_max_size_returns_only_one_post() {
+	public function test_filter_objects_and_metadata_by_size_returns_only_one_post() {
 
 		$post_id_1 = self::factory()->post->create();
 		$post_id_2 = self::factory()->post->create();
@@ -1646,7 +1658,13 @@ That was a cool video.';
 
 		$post_sync_module = Modules::get_module( 'posts' );
 		'@phan-var \Automattic\Jetpack\Sync\Modules\Posts $post_sync_module';
-		list( $filtered_post_ids, $filtered_posts, $filtered_metadata ) = $post_sync_module->filter_posts_and_metadata_max_size( $posts, $metadata );
+		list( $filtered_post_ids, $filtered_posts, $filtered_metadata ) = $post_sync_module->filter_objects_and_metadata_by_size(
+			'post',
+			$posts,
+			$metadata,
+			Automattic\Jetpack\Sync\Modules\Posts::MAX_POST_META_LENGTH,
+			Automattic\Jetpack\Sync\Modules\Posts::MAX_SIZE_FULL_SYNC
+		);
 
 		$this->assertEquals( $filtered_post_ids, array( $post_id_1 ) );
 		$this->assertEquals( $filtered_posts, array( $post_1 ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Part of https://github.com/Automattic/vulcan/issues/661

Full Syncs always sends a fixed amount of items depending on the sync module (posts, comments, users). That is determined by a setting in which defaults are [full_sync_limits](https://github.com/Automattic/jetpack/blob/update/full-sync-comments-expanding-while-geting-next-chunk/projects/packages/sync/src/class-defaults.php#L1325).

https://github.com/Automattic/jetpack/pull/34390 created the ability to have a dynamic number of items sent for posts. The final number of items sent will be determined by reaching the MAX_SIZE for a number of items or if we reach the chunk_size in `full_sync_limits`.



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Abstract the code used in posts to the **module** class by creating the `filter_objects_and_metadata_by_size` method.
* Use the above method for posts and comments 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Repeat the instructions in https://github.com/Automattic/jetpack/pull/34390 but do them for comments as well this time



