### PR TITLE
Global Styles on Personal AB: Change group assignment for n-treatments

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-change-gs-on-personal-assignment-for-multiple-treatments
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-change-gs-on-personal-assignment-for-multiple-treatments
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+We now use the control group as discriminator for enabling Global Styles on Personal experiment.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -809,7 +809,7 @@ function wpcom_site_has_global_styles_in_personal_plan( $blog_id = 0 ) {
 
 	// Placeholder experiment key, we need to update this to the new experiment key once it's created.
 	$experiment_assignment              = \ExPlat\assign_given_user( 'calypso_plans_global_styles_personal_20240127', $owner );
-	$has_global_styles_in_personal_plan = $experiment_assignment !== null;
+	$has_global_styles_in_personal_plan = null !== $experiment_assignment;
 	// Cache the experiment assignment to prevent duplicate DB queries in the frontend.
 	wp_cache_set( $cache_key, $has_global_styles_in_personal_plan, 'a8c_experiments', MONTH_IN_SECONDS );
 	return $has_global_styles_in_personal_plan;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -809,7 +809,7 @@ function wpcom_site_has_global_styles_in_personal_plan( $blog_id = 0 ) {
 
 	// Placeholder experiment key, we need to update this to the new experiment key once it's created.
 	$experiment_assignment              = \ExPlat\assign_given_user( 'calypso_plans_global_styles_personal_20240127', $owner );
-	$has_global_styles_in_personal_plan = $experiment_assignment && 'control' !== $experiment_assignment;
+	$has_global_styles_in_personal_plan = $experiment_assignment !== null;
 	// Cache the experiment assignment to prevent duplicate DB queries in the frontend.
 	wp_cache_set( $cache_key, $has_global_styles_in_personal_plan, 'a8c_experiments', MONTH_IN_SECONDS );
 	return $has_global_styles_in_personal_plan;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -807,7 +807,6 @@ function wpcom_site_has_global_styles_in_personal_plan( $blog_id = 0 ) {
 		return false;
 	}
 
-	// Placeholder experiment key, we need to update this to the new experiment key once it's created.
 	$experiment_assignment              = \ExPlat\assign_given_user( 'calypso_plans_global_styles_personal_20240127', $owner );
 	$has_global_styles_in_personal_plan = null !== $experiment_assignment;
 	// Cache the experiment assignment to prevent duplicate DB queries in the frontend.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -809,7 +809,7 @@ function wpcom_site_has_global_styles_in_personal_plan( $blog_id = 0 ) {
 
 	// Placeholder experiment key, we need to update this to the new experiment key once it's created.
 	$experiment_assignment              = \ExPlat\assign_given_user( 'calypso_plans_global_styles_personal_20240127', $owner );
-	$has_global_styles_in_personal_plan = 'treatment' === $experiment_assignment;
+	$has_global_styles_in_personal_plan = 'control' !== $experiment_assignment;
 	// Cache the experiment assignment to prevent duplicate DB queries in the frontend.
 	wp_cache_set( $cache_key, $has_global_styles_in_personal_plan, 'a8c_experiments', MONTH_IN_SECONDS );
 	return $has_global_styles_in_personal_plan;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -809,7 +809,7 @@ function wpcom_site_has_global_styles_in_personal_plan( $blog_id = 0 ) {
 
 	// Placeholder experiment key, we need to update this to the new experiment key once it's created.
 	$experiment_assignment              = \ExPlat\assign_given_user( 'calypso_plans_global_styles_personal_20240127', $owner );
-	$has_global_styles_in_personal_plan = 'control' !== $experiment_assignment;
+	$has_global_styles_in_personal_plan = $experiment_assignment && 'control' !== $experiment_assignment;
 	// Cache the experiment assignment to prevent duplicate DB queries in the frontend.
 	wp_cache_set( $cache_key, $has_global_styles_in_personal_plan, 'a8c_experiments', MONTH_IN_SECONDS );
 	return $has_global_styles_in_personal_plan;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
In this PR we change the way we determine if Global Syles is enabled on the Personal plan or not. We have 2 treatment groups, every treatment group has GS enabled. The proposed change is to use the `control` variant as a discriminator so that only the control group gets Global Styles on the Premium plan.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply these changes
* Sandbox your API
* Assign yourself to the treatment group of the experiment key (look at the code for the specific key)
* Go to Calypso theme showcase (logged in)
* Open the network tab and filter requests by `global-styles/status`
* On the request response you should see a new field `globalStylesInPersonalPlan`
* Based on the assigned experiment group you should see the correct value.

## Does this pull request change what data or activity we track or use?
No