### PR TITLE
Forms: Fix encoding when feedback marked as spam

### DIFF
--- a/projects/packages/forms/changelog/fix-endcoding-when-marking-as-spam
+++ b/projects/packages/forms/changelog/fix-endcoding-when-marking-as-spam
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Form: Fix encoding when going from spam to regular type

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -1116,14 +1116,23 @@ class Admin {
 		$post_type_object = get_post_type_object( $post->post_type );
 		$akismet_values   = get_post_meta( $post_id, '_feedback_akismet_values', true );
 		if ( $_POST['make_it'] === 'spam' ) {
-			$post->post_status = 'spam';
-			$status            = wp_insert_post( $post );
+
+			$status = wp_update_post(
+				array(
+					'ID'          => $post_id,
+					'post_status' => 'spam',
+				)
+			);
 
 			/** This action is already documented in \Automattic\Jetpack\Forms\ContactForm\Admin */
 			do_action( 'contact_form_akismet', 'spam', $akismet_values );
 		} elseif ( $_POST['make_it'] === 'ham' ) {
-			$post->post_status = 'publish';
-			$status            = wp_insert_post( $post );
+			$status = wp_update_post(
+				array(
+					'ID'          => $post_id,
+					'post_status' => 'publish',
+				)
+			);
 
 			/** This action is already documented in \Automattic\Jetpack\Forms\ContactForm\Admin */
 			do_action( 'contact_form_akismet', 'ham', $akismet_values );

--- a/projects/plugins/jetpack/changelog/fix-endcoding-when-marking-as-spam
+++ b/projects/plugins/jetpack/changelog/fix-endcoding-when-marking-as-spam
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: keep content as is when going from spam to publish and from publish to spam feedback.


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/40740

This PR fixes the issue by making sure that the content doesn't get change when going from spam to published and from published to spam. 

## Proposed changes:

* Instead of using the `wp_insert_post` use the `wp_update_post` function and only update the post status the the expected value. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load this PR. 
* Add a form. 
* Fill out the form that would normal be encoded such as an emoji. 🔥 
* Mark the feedback as spam. 
* Mark the feedback as not spam. 

Notice that the feedback data show up as expected. You should always see the emojis. 

