### PR TITLE
Revert "RDV: Fix the performance issue on AT sites (#41248)"

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-experiment-performance-issue
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-experiment-performance-issue
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fixed a performance issue on AT that was reproducing only for a12s.
-
-

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -451,24 +451,16 @@ function wpcom_is_duplicate_views_experiment_enabled() {
 
 	$data = json_decode( wp_remote_retrieve_body( $response ), true );
 
-	if ( isset( $data['variations'][ $experiment_name ] ) ) {
+	if ( isset( $data['variations'] ) && isset( $data['variations'][ $experiment_name ] ) ) {
 		$variation = $data['variations'][ $experiment_name ];
 		update_user_option( get_current_user_id(), RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, $variation, true );
 
 		$is_enabled = 'treatment' === $variation;
-	} elseif ( isset( $data['variations'] ) ) {
-		/**
-		 * If the variations array is set but the variation value is null chances are this is an a11n (since ExPlat returns null for a12s).
-		 *
-		 * We set treatment for all a12s.
-		 */
-		update_user_option( get_current_user_id(), RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, 'treatment', true );
-		$is_enabled = true;
+		return $is_enabled;
 	} else {
 		$is_enabled = false;
+		return $is_enabled;
 	}
-
-	return $is_enabled;
 }
 
 /**


### PR DESCRIPTION
This reverts commit cbd695796d1c55fd7c0b4c3ce01a6f2fc519e209.


Related to https://github.com/Automattic/wp-calypso/issues/98603

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Revert the performance changes since it affects variation assignment

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* It's a revert

