### PR TITLE
Forms: Fixes the missing spacing between the export and 

### DIFF
--- a/projects/packages/forms/changelog/fix-spacing-button-export-form
+++ b/projects/packages/forms/changelog/fix-spacing-button-export-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fixed missing spacing bug in the feedback list view

--- a/projects/packages/forms/src/contact-form/css/grunion-admin.css
+++ b/projects/packages/forms/src/contact-form/css/grunion-admin.css
@@ -32,6 +32,7 @@
 
 .post-type-feedback .actions {
 	display: inline-flex;
+	margin-bottom: 4px;
 }
 
 .column-feedback_response .feedback_response__item {

--- a/projects/packages/forms/src/contact-form/css/grunion-admin.css
+++ b/projects/packages/forms/src/contact-form/css/grunion-admin.css
@@ -26,6 +26,9 @@
 		padding-left: 8px !important;
 	}
 }
+#export-modal-opener {
+	margin-right: 8px;
+}
 
 .column-feedback_response .feedback_response__item {
 	display: grid;

--- a/projects/packages/forms/src/contact-form/css/grunion-admin.css
+++ b/projects/packages/forms/src/contact-form/css/grunion-admin.css
@@ -26,6 +26,7 @@
 		padding-left: 8px !important;
 	}
 }
+
 #export-modal-opener {
 	margin-right: 8px;
 }

--- a/projects/packages/forms/src/contact-form/css/grunion-admin.css
+++ b/projects/packages/forms/src/contact-form/css/grunion-admin.css
@@ -30,6 +30,10 @@
 	margin-right: 8px;
 }
 
+.post-type-feedback .actions {
+	display: inline-flex;
+}
+
 .column-feedback_response .feedback_response__item {
 	display: grid;
 	grid-template-columns: 35% 1fr;

--- a/projects/plugins/jetpack/changelog/fix-spacing-button-export-form
+++ b/projects/plugins/jetpack/changelog/fix-spacing-button-export-form
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Minor bug fix
+
+


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/41426 — the missing space in the feedback list. 

Before:
![Screenshot 2025-01-28 at 11 32 44 AM](https://github.com/user-attachments/assets/ec68edca-98e8-40b2-a345-580a2cb3b07c)


After:
![Screenshot 2025-01-28 at 11 32 34 AM](https://github.com/user-attachments/assets/3e236e5a-74d4-4e5a-b725-d4c8ffd26e65)


## Proposed changes:
* Add a 8px margin right to create a spacing between the form filed. 

### Other information:

- [ x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Apply this PR. 
* Create a form, create some feeedback. 
* Trash one of the feedback.
* Notice the spacing looks correct. 
* Mark a feedback as spam notice the spacing looks correct.


