### PR TITLE
Help Center: Fix help center open state warnings

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-help-center-open-state-bug
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-help-center-open-state-bug
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: It's just a bug fix to get rid of warnings.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-persisted-open-state.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-persisted-open-state.php
@@ -63,7 +63,7 @@ class WP_REST_Help_Center_Persisted_Open_State extends \WP_REST_Controller {
 
 		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
-		$is_open = isset( $response->help_center_open ) && $response->help_center_open;
+		$is_open = $response->help_center_open ?? false;
 
 		$projected_response = array(
 			'help_center_open' => (bool) $is_open,
@@ -101,7 +101,7 @@ class WP_REST_Help_Center_Persisted_Open_State extends \WP_REST_Controller {
 
 		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
-		$is_open = isset( $response->calypso_preferences ) && isset( $response->calypso_preferences->help_center_open ) && $response->help_center_open;
+		$is_open = $response->calypso_preferences->help_center_open ?? false;
 
 		$projected_response = array(
 			'calypso_preferences' => array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-persisted-open-state.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-persisted-open-state.php
@@ -63,8 +63,10 @@ class WP_REST_Help_Center_Persisted_Open_State extends \WP_REST_Controller {
 
 		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
+		$is_open = isset( $response->help_center_open ) && $response->help_center_open;
+
 		$projected_response = array(
-			'help_center_open' => (bool) $response->help_center_open,
+			'help_center_open' => (bool) $is_open,
 		);
 
 		return rest_ensure_response( $projected_response );
@@ -99,9 +101,11 @@ class WP_REST_Help_Center_Persisted_Open_State extends \WP_REST_Controller {
 
 		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
+		$is_open = isset( $response->calypso_preferences ) && isset( $response->calypso_preferences->help_center_open ) && $response->help_center_open;
+
 		$projected_response = array(
 			'calypso_preferences' => array(
-				'help_center_open' => $response->calypso_preferences->help_center_open,
+				'help_center_open' => (bool) $is_open,
 			),
 		);
 


### PR DESCRIPTION
Fixes p1738099880770479-slack-C03N25JPCE4

## Proposed changes:
Use null coalescing to avoid throwing warnings.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to wordpress.com
* Using the widget on the bottom right that says Staging, delete the Calypso preference `help_center_open`. Don't untick, delete it.
*  View your site logs (https://wordpress.com/site-logs/YOUR_SITE)
* Go to /wp-admin/post-new.php. You should see `PHP Warning: Undefined property: stdClass::$help_center_open in /srv/htdocs/wp-content/plugins/jetpack...`.
* Activate this branch on your Atomic site using the Beta Tester plugin.
* View your site logs again.
* Go to /wp-admin/post-new.php
* There shouldn't be any warnings in the logs.