### PR TITLE
RDV: Fix a performance issue and assign a12s treatment

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/.phan/config.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/config.php
@@ -26,6 +26,7 @@ return make_phan_config(
 			__DIR__ . '/../../../plugins/jetpack/modules/custom-css/custom-css.php',        // class Jetpack_Custom_CSS_Enhancements
 			__DIR__ . '/../../../plugins/jetpack/class-jetpack-stats-dashboard-widget.php', // class Jetpack_Stats_Dashboard_Widget
 			__DIR__ . '/../../../plugins/wpcomsh/wpcomsh.php',                              // function wpcomsh_record_tracks_event
+			__DIR__ . '/../../../plugins/wpcomsh/support-session.php',
 		),
 		'exclude_analysis_directory_list' => array(
 			'src/features/custom-css/csstidy/',

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-rdv-caching-and-a12s
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-rdv-caching-and-a12s
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Caching fixes for RDV project

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -390,7 +390,7 @@ add_action( 'admin_notices', 'wpcom_show_admin_interface_notice' );
 /**
  * Option to force and cache the Remove duplicate Views experiment assigned variation.
  */
-const RDV_EXPERIMENT_FORCE_ASSIGN_OPTION = 'remove_duplicate_views_experiment_assignment';
+const RDV_EXPERIMENT_FORCE_ASSIGN_OPTION = 'remove_duplicate_views_experiment_assignment_160125';
 
 /**
  * Check if the duplicate views experiment is enabled.
@@ -409,6 +409,11 @@ function wpcom_is_duplicate_views_experiment_enabled() {
 
 	$variation = get_user_option( RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, get_current_user_id() );
 
+	/**
+	 * We cache it for both AT and Simple because we want to give a12s to be able to switch between variations for their accounts - this can be useful during support.
+	 *
+	 * If we don't cache it, the is_automattician conditions will force treatment every time.
+	 */
 	if ( false !== $variation ) {
 		$is_enabled = 'treatment' === $variation;
 		return $is_enabled;
@@ -417,7 +422,29 @@ function wpcom_is_duplicate_views_experiment_enabled() {
 	if ( ( new Host() )->is_wpcom_simple() ) {
 		\ExPlat\assign_current_user( $aa_test_name );
 		$is_enabled = 'treatment' === \ExPlat\assign_current_user( $experiment_name );
+
+		if ( is_automattician() ) {
+			$is_enabled = true;
+			update_user_option( get_current_user_id(), RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, 'treatment', true );
+		}
+
 		return $is_enabled;
+	}
+
+	$is_proxy_atomic    = defined( 'AT_PROXIED_REQUEST' ) && AT_PROXIED_REQUEST;
+	$is_support_session = WPCOMSH_Support_Session_Detect::is_probably_support_session();
+
+	/**
+	 * This handles two contexts: Calypso and WP-Admin.
+	 *
+	 * Calypso: WPCOM admin-menu API endpoint mapper sends a "admin_menu_is_a11n" param for a12s. If the param exists, then we'll switch to treatment.
+	 * WP-Admin: We check if the user is proxied and if it's not in a support session.
+	 */
+	if ( isset( $_GET['admin_menu_is_a11n'] ) || ( $is_proxy_atomic && ! $is_support_session ) ) {
+		update_user_option( get_current_user_id(), RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, 'treatment', true );
+		$is_enabled = true;
+
+		return true;
 	}
 
 	if ( ! ( new Jetpack_Connection() )->is_user_connected() ) {
@@ -451,7 +478,7 @@ function wpcom_is_duplicate_views_experiment_enabled() {
 
 	$data = json_decode( wp_remote_retrieve_body( $response ), true );
 
-	if ( isset( $data['variations'] ) && isset( $data['variations'][ $experiment_name ] ) ) {
+	if ( isset( $data['variations'] ) && array_key_exists( $experiment_name, $data['variations'] ) ) {
 		$variation = $data['variations'][ $experiment_name ];
 		update_user_option( get_current_user_id(), RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, $variation, true );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -433,6 +433,7 @@ function wpcom_is_duplicate_views_experiment_enabled() {
 
 	$is_proxy_atomic    = defined( 'AT_PROXIED_REQUEST' ) && AT_PROXIED_REQUEST;
 	$is_support_session = WPCOMSH_Support_Session_Detect::is_probably_support_session();
+	$admin_menu_is_a11n = isset( $_GET['admin_menu_is_a11n'] ) && function_exists( 'wpcomsh_is_admin_menu_api_request' ) && wpcomsh_is_admin_menu_api_request();
 
 	/**
 	 * This handles two contexts: Calypso and WP-Admin.
@@ -440,7 +441,8 @@ function wpcom_is_duplicate_views_experiment_enabled() {
 	 * Calypso: WPCOM admin-menu API endpoint mapper sends a "admin_menu_is_a11n" param for a12s. If the param exists, then we'll switch to treatment.
 	 * WP-Admin: We check if the user is proxied and if it's not in a support session.
 	 */
-	if ( isset( $_GET['admin_menu_is_a11n'] ) || ( $is_proxy_atomic && ! $is_support_session ) ) {
+
+	if ( $admin_menu_is_a11n || ( $is_proxy_atomic && ! $is_support_session ) ) {
 		update_user_option( get_current_user_id(), RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, 'treatment', true );
 		$is_enabled = true;
 


### PR DESCRIPTION
Fixed an issue that caused to make an API request to ExPlat on each page request for users that were in control or if they were a12s.

This PR also forces treatment to all a12s on both Simple and Atomic sites.

On Simple sites, we use is_automattician since that's more accurate than relying on proxy. Although not needed for performance, the result is also cached in the user option so that a12s to be able to use the escape hatch.

On Atomic sites, the logic is a bit more complicated. The switch for a12s is handled with two conditions: Calypo: if there's an admin_menu_a11n query param (which is passed by WPCOM admin-menu API mapper

WP-Admin: Rely on the is proxy check.

Since this PR comes after a revert, we also need to change the caching key to pull again the experiment assignment from ExPlat.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/98603

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add caching for Simple and Atomic explat assignment
* Apply treatment for a12s on Simple and Atomic
* Change the key

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Simple Sites**
* Use the Jetpack downloader and install the changes on your sandbox
* Go to a Simple Site
* Notice that you now get treatment

**Atomic Sites**
* Checkout this branch on your sandbox 171436-ghe-Automattic/wpcom
* Go to WPCOM and grab your user id (get_current_user_id() doesn't work well in `wp shell` on AT)
* SSH into your AT site and delete the option, just in case: `wp shell > delete_user_option('your-wpcom-simple-user-id', 'remove_duplicate_views_experiment_assignment_160125', true);`
* Go to an Atomic site with Calypso - like /home/your-site. It's important to be the first request (and not a WP-Admin one) because you're testing if the site gets treatment from the API request
* Notice that the admin menu is pointing to WP-Admin
* Go to an another Atomic site
* Go directly to a WP-Admin screen 
* Make sure you get treatment
* Open the debug panel and notice that we don't make an API request on each page load to explat