### PR TITLE
Forms: Hide empty radio fields

### DIFF
--- a/projects/packages/forms/changelog/fix-form-radio-with-no-options
+++ b/projects/packages/forms/changelog/fix-form-radio-with-no-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Hide empty radio fields.

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1000,6 +1000,10 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_field( $type, $id, $label, $value, $class, $placeholder, $required, $required_field_text ) {
+		if ( ! $this->is_valid_field( $type ) ) {
+			return null;
+		}
+
 		$class .= ' grunion-field';
 
 		$form_style = $this->get_form_style();
@@ -1139,6 +1143,35 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		}
 
 		return $type;
+	}
+
+	/**
+	 * Determines if a form field is valid.
+	 *
+	 * Add checks here to confirm if any given form field
+	 * is configured correctly and thus should be rendered
+	 * on the frontend.
+	 *
+	 * @param string $type - the field type.
+	 *
+	 * @return bool
+	 */
+	public function is_valid_field( $type ) {
+		// Check for valid radio field.
+		if ( $type === 'radio' ) {
+			$options           = (array) $this->get_attribute( 'options' );
+			$non_empty_options = array_filter(
+				$options,
+				function ( $option ) {
+					return $option !== '';
+				}
+			);
+			if ( count( $non_empty_options ) === 0 ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1000,7 +1000,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_field( $type, $id, $label, $value, $class, $placeholder, $required, $required_field_text ) {
-		if ( ! $this->is_valid_field( $type ) ) {
+		if ( ! $this->is_field_renderable( $type ) ) {
 			return null;
 		}
 
@@ -1156,7 +1156,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 *
 	 * @return bool
 	 */
-	public function is_valid_field( $type ) {
+	public function is_field_renderable( $type ) {
 		// Check for valid radio field.
 		if ( $type === 'radio' ) {
 			$options           = (array) $this->get_attribute( 'options' );
@@ -1166,9 +1166,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					return $option !== '';
 				}
 			);
-			if ( count( $non_empty_options ) === 0 ) {
-				return false;
-			}
+			return count( $non_empty_options ) > 0;
 		}
 
 		return true;

--- a/projects/plugins/jetpack/changelog/fix-form-radio-with-no-options
+++ b/projects/plugins/jetpack/changelog/fix-form-radio-with-no-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Hide empty radio fields.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #41245

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
You can currently publish a form that contains a radio field with no valid options. If you do, just the label will render. If the field is required, the form can never be submitted since no option can be selected. This situation is fairly easy to produce because new radio fields are added with a 'blank' option, and some of our form templates like RSVP will add new, blank radio fields.

We've decided in this case, we should simply avoid displaying the problematic, essentially invalid, form field on the frontend. 

Specific changes:
- Confirm a radio field has at least 1 non-empty option, and if not, do not display the radio field.
- I put this check inside a new is_valid_field() method that can hold similar checks for other fields if they come up in the future. 
- I put the check at the top of the render_field() method because that method outputs the initial html wrapper for all fields, so the check has to come before that wrapper is added to the markup. This also allows us to invoke is_valid_field() once for all fields.

**EXAMPLE: This form, if published, will have the described issue.**

<img width="1304" alt="form-with-empty-radio-2" src="https://github.com/user-attachments/assets/226b0298-adef-4ce9-8530-090ca82f4009" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form to a page. When presented with form templates, choose RSVP. The RSVP form contains a radio field, which like all new radio fields, has only a blank placeholder option. Do not add any options. Publish the page. 
* On the frontend, confirm that the radio field does not display, and that you can submit the form. 

