### PR TITLE
JITMs: allow shortcircuiting via existing filter

### DIFF
--- a/projects/packages/masterbar/changelog/fix-jitm-without-shortcircuit
+++ b/projects/packages/masterbar/changelog/fix-jitm-without-shortcircuit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JITMs: ensure we offer the same shortcircuit as in other elements where JITMs can be injected.

--- a/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
@@ -479,6 +479,12 @@ class Admin_Menu extends Base_Admin_Menu {
 	public function wp_ajax_upsell_nudge_jitm() {
 		check_ajax_referer( 'upsell_nudge_jitm' );
 
+		// Filter to turn off all just in time messages
+		/** This action is already documented in \Automattic\Jetpack\JITMS\JITM */
+		if ( ! apply_filters( 'jetpack_just_in_time_msgs', true ) ) {
+			wp_die();
+		}
+
 		$nudge = $this->get_upsell_nudge();
 		if ( ! $nudge ) {
 			wp_die();


### PR DESCRIPTION
## Proposed changes:

We currently offer a filter that can be used to shortcircuit JITMs in other places of the dashboard. It's fair to assume that one using the filter would expect it to apply to all JITMs, including those in the admin menu.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a WoA site where you have purchased a WordPress.com Business plan, but have not registered a domain yet.
* Upon going to wp-admin, you should see a JITM appear at the top of the admin menu bar, above the "Dashboard" menu item.
* Now install the Jetpack Beta tester plugin, and switch to this branch in the "WordPress.com Features" beta plugin settings
* The JITM should remain.
* Now, in a functionality plugin, add the following code snippet: `add_filter( 'jetpack_just_in_time_msgs', '__return_false', 99 );`
* The JITM should disappear.
