### PR TITLE
Social | Move initial state from Social plugin to publicize package

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-move-initial-state-from-social-to-publicize
+++ b/projects/js-packages/publicize-components/changelog/update-social-move-initial-state-from-social-to-publicize
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Move initial state from Social plugin to publicize package

--- a/projects/js-packages/publicize-components/src/social-store/selectors/pricing-page.ts
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/pricing-page.ts
@@ -12,8 +12,5 @@ export const shouldShowPricingPage = createRegistrySelector( select => () => {
 	const settings = getSite( undefined, { _fields: SHOW_PRICING_PAGE_KEY } );
 
 	// If the settings are not available in the store yet, use the default settings.
-	return (
-		settings?.[ SHOW_PRICING_PAGE_KEY ] ??
-		getSocialScriptData().settings?.socialPlugin?.show_pricing_page
-	);
+	return settings?.[ SHOW_PRICING_PAGE_KEY ] ?? getSocialScriptData().settings?.showPricingPage;
 } );

--- a/projects/js-packages/publicize-components/src/social-store/selectors/share-status.ts
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/share-status.ts
@@ -4,11 +4,6 @@ import { PostShareStatus, SocialStoreState } from '../types';
 
 /**
  * Get the post share status.
- *
- * @param {SocialStoreState} state  - State object.
- * @param {number}           postId - The post ID.
- *
- * @return {PostShareStatus} - The post share status.
  */
 export const getPostShareStatus = createRegistrySelector(
 	select =>
@@ -18,7 +13,7 @@ export const getPostShareStatus = createRegistrySelector(
 
 			return state.shareStatus?.[ id ] ?? { shares: [] };
 		}
-) as ( state: SocialStoreState, postId?: number ) => PostShareStatus;
+);
 
 /**
  * Whether the share status modal is open.

--- a/projects/js-packages/publicize-components/src/social-store/selectors/social-image-generator.ts
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/social-image-generator.ts
@@ -2,7 +2,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { createRegistrySelector } from '@wordpress/data';
 import { getSocialScriptData } from '../../utils';
 import { SIG_SETTINGS_KEY } from '../constants';
-import { SocialImageGeneratorConfig, SocialSettingsFields } from '../types';
+import { SocialSettingsFields } from '../types';
 
 /**
  * Returns the Social Image Generator settings for the current site.
@@ -14,4 +14,4 @@ export const getSocialImageGeneratorConfig = createRegistrySelector( select => (
 
 	// If the settings are not available in the store yet, use the default settings.
 	return settings?.[ SIG_SETTINGS_KEY ] ?? getSocialScriptData().settings.socialImageGenerator;
-} ) as ( state: object ) => SocialImageGeneratorConfig;
+} );

--- a/projects/js-packages/publicize-components/src/social-store/selectors/social-notes.ts
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/social-notes.ts
@@ -14,8 +14,7 @@ export const isSocialNotesEnabled = createRegistrySelector( select => () => {
 	} );
 	// If the settings are not available in the store yet, use the default settings.
 	return (
-		settings?.[ SOCIAL_NOTES_ENABLED_KEY ] ??
-		getSocialScriptData().settings?.socialPlugin?.social_notes_enabled
+		settings?.[ SOCIAL_NOTES_ENABLED_KEY ] ?? getSocialScriptData().settings?.socialNotes?.enabled
 	);
 } );
 
@@ -31,7 +30,6 @@ export const getSocialNotesConfig = createRegistrySelector( select => () => {
 
 	// If the settings are not available in the store yet, use the default settings.
 	return (
-		settings?.[ SOCIAL_NOTES_CONFIG_KEY ] ??
-		getSocialScriptData().settings?.socialPlugin?.social_notes_config
+		settings?.[ SOCIAL_NOTES_CONFIG_KEY ] ?? getSocialScriptData().settings?.socialNotes?.config
 	);
 } );

--- a/projects/js-packages/publicize-components/src/social-store/selectors/social-plugin-settings.ts
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/social-plugin-settings.ts
@@ -9,14 +9,12 @@ import { SocialPluginSettings } from '../types';
 export const getSocialPluginSettings = createRegistrySelector( select => () => {
 	const data = select( coreStore ).getEntityRecord( 'jetpack/v4', 'social/settings', undefined );
 
-	return data ?? getSocialScriptData().settings.socialPlugin;
+	return data ?? { publicize_active: getSocialScriptData().is_publicize_enabled };
 } ) as ( state: object ) => SocialPluginSettings;
 
 /**
  * Returns whether the Social plugin settings are being saved
- *
- * @type {() => boolean} Whether the Social plugin settings are being saved
  */
 export const isSavingSocialPluginSettings = createRegistrySelector( select => () => {
 	return select( coreStore ).isSavingEntityRecord( 'jetpack/v4', 'social/settings', undefined );
-} ) as () => boolean;
+} );

--- a/projects/js-packages/publicize-components/src/social-store/selectors/utm-settings.ts
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/utm-settings.ts
@@ -2,7 +2,6 @@ import { store as coreStore } from '@wordpress/core-data';
 import { createRegistrySelector } from '@wordpress/data';
 import { getSocialScriptData } from '../../utils';
 import { UTM_ENABLED_KEY } from '../constants';
-import { SocialSettingsFields, UtmSettingsConfig } from '../types';
 
 /**
  * Returns the UTM state.
@@ -10,8 +9,8 @@ import { SocialSettingsFields, UtmSettingsConfig } from '../types';
 export const getUtmSettings = createRegistrySelector( select => () => {
 	const { getSite } = select( coreStore );
 
-	const settings = getSite( undefined, { _fields: UTM_ENABLED_KEY } ) as SocialSettingsFields;
+	const settings = getSite( undefined, { _fields: UTM_ENABLED_KEY } );
 
 	// If the settings are not available in the store yet, use the default settings.
 	return settings?.[ UTM_ENABLED_KEY ] ?? getSocialScriptData().settings.utmSettings;
-} ) as ( state: object ) => UtmSettingsConfig;
+} );

--- a/projects/js-packages/publicize-components/src/social-store/types.ts
+++ b/projects/js-packages/publicize-components/src/social-store/types.ts
@@ -137,14 +137,13 @@ export type SocialNotesConfig = {
 	link_format: 'full_url' | 'shortlink' | 'permashortcitation';
 };
 
+export type SocialNotesSettings = {
+	enabled: boolean;
+	config: SocialNotesConfig;
+};
+
 export type SocialPluginSettings = {
 	publicize_active: boolean;
-	show_pricing_page: boolean;
-	social_notes_enabled: boolean;
-	social_notes_config: {
-		append_link: boolean;
-		link_format: 'full_url' | 'shortlink' | 'permashortcitation';
-	};
 };
 
 export type SocialSettingsFields = {

--- a/projects/js-packages/publicize-components/src/types.ts
+++ b/projects/js-packages/publicize-components/src/types.ts
@@ -1,8 +1,8 @@
 import {
 	SocialImageGeneratorConfig,
-	SocialPluginSettings,
 	UtmSettingsConfig,
 	SocialStoreState,
+	SocialNotesSettings,
 } from './social-store/types';
 
 export interface SocialUrls {
@@ -39,7 +39,8 @@ export interface ApiPaths {
 export type SocialSettings = {
 	socialImageGenerator: SocialImageGeneratorConfig;
 	utmSettings: UtmSettingsConfig;
-	socialPlugin: SocialPluginSettings;
+	socialNotes: SocialNotesSettings;
+	showPricingPage: boolean;
 };
 
 export type PluginInfo = Record< 'social' | 'jetpack', { version: string } >;

--- a/projects/packages/publicize/changelog/update-social-move-initial-state-from-social-to-publicize
+++ b/projects/packages/publicize/changelog/update-social-move-initial-state-from-social-to-publicize
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Move initial state from Social plugin to publicize package

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -162,6 +162,11 @@ class Publicize_Script_Data {
 		return array(
 			'socialImageGenerator' => $settings->get_image_generator_settings(),
 			'utmSettings'          => $settings->get_utm_settings(),
+			'socialNotes'          => array(
+				'enabled' => $settings->is_social_notes_enabled(),
+				'config'  => $settings->get_social_notes_config(),
+			),
+			'showPricingPage'      => $settings->should_show_pricing_page(),
 		);
 	}
 

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -277,7 +277,7 @@ class Publicize_Script_Data {
 	 * @return ?array
 	 */
 	public static function get_shares_data() {
-		return self::publicize()->get_publicize_shares_info( Jetpack_Options::get_option( 'id' ) );
+		return self::publicize()->get_publicize_shares_info( Jetpack_Options::get_option( 'id' ) ) ?? array();
 	}
 
 	/**

--- a/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
+++ b/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
@@ -250,6 +250,15 @@ class Settings {
 	}
 
 	/**
+	 * Check if the pricing page should be displayed.
+	 *
+	 * @return bool
+	 */
+	public static function should_show_pricing_page() {
+		return (bool) get_option( self::JETPACK_SOCIAL_SHOW_PRICING_PAGE, true );
+	}
+
+	/**
 	 * Get if the social notes feature is enabled.
 	 *
 	 * @return bool

--- a/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
+++ b/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
@@ -264,7 +264,7 @@ class Settings {
 	 * @return bool
 	 */
 	public function is_social_notes_enabled() {
-		return get_option( self::JETPACK_SOCIAL_NOTE_CPT_ENABLED, false );
+		return (bool) get_option( self::JETPACK_SOCIAL_NOTE_CPT_ENABLED, false );
 	}
 
 	/**

--- a/projects/plugins/social/changelog/update-social-move-initial-state-from-social-to-publicize
+++ b/projects/plugins/social/changelog/update-social-move-initial-state-from-social-to-publicize
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Move initial state from Social plugin to publicize package

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -118,8 +118,6 @@ class Jetpack_Social {
 		add_filter( 'plugin_action_links_' . JETPACK_SOCIAL_PLUGIN_FOLDER . '/jetpack-social.php', array( $this, 'add_settings_link' ) );
 
 		add_shortcode( 'jp_shares_shortcode', array( $this, 'add_shares_shortcode' ) );
-
-		add_filter( 'jetpack_social_admin_script_data', array( $this, 'set_social_admin_script_data' ) );
 	}
 
 	/**
@@ -174,40 +172,6 @@ class Jetpack_Social {
 			$shares_info = $publicize->get_publicize_shares_info( Jetpack_Options::get_option( 'id' ) );
 		}
 		return ! is_wp_error( $shares_info ) ? $shares_info : null;
-	}
-
-	/**
-	 * Set the social admin script data.
-	 *
-	 * @param array $data The initial state data.
-	 * @return array
-	 */
-	public function set_social_admin_script_data( $data ) {
-
-		$data['plugin_info']['social'] = array(
-			'version' => $this->get_plugin_version(),
-		);
-
-		$data['settings']['socialPlugin'] = array(
-			'publicize_active' => self::is_publicize_active(),
-
-		);
-
-		if ( $this->is_connected() ) {
-
-			$jetpack_social_settings = new Automattic\Jetpack\Publicize\Jetpack_Social_Settings\Settings();
-
-			$data['settings']['socialPlugin'] = array_merge(
-				$data['settings']['socialPlugin'],
-				array(
-					'show_pricing_page'    => self::should_show_pricing_page(),
-					'social_notes_enabled' => $jetpack_social_settings->is_social_notes_enabled(),
-					'social_notes_config'  => $jetpack_social_settings->get_social_notes_config(),
-				)
-			);
-		}
-
-		return $data;
 	}
 
 	/**


### PR DESCRIPTION
To address https://github.com/Automattic/jetpack/pull/41239#discussion_r1930552451 and to allow Social admin page to be available in Jetpack and on WPCOM, we need to remove the dependency of the initial state of the UI on the Social plugin.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move the initial state from Social plugin to publicize package
* Update the front-end selectors and types to use the updated data
* Ensure that shares data is not null if the API call to WPCOM fails for any reason

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Social admin page
* Toggle Social Notes ON/OFF
* Confirm that it works fine
* Reload the page
* Confirm that the value is retained on page load
* Change the social notes config
* Confirm that it is retained on page load
* Run `jetpack docker wp option delete jetpack-social_show_pricing_page`
* Remove any paid Social plan for the site
* Reload the Social admin page
* Confirm that the pricing page is shown
* Click on start for free
* Confirm that the pricing page disappears
* Reload the page
* Confirm that pricing page is not shown

