### PR TITLE
Forms: Fix block placeholder error when the Forms module is disabled

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-placeholder
+++ b/projects/packages/forms/changelog/fix-contact-form-placeholder
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix the block placeholder throwing an error when the Forms module is disabled.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-contact-form-placeholder.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-contact-form-placeholder.js
@@ -9,7 +9,7 @@ export const ContactFormPlaceholder = ( { changeStatus, isLoading, isModuleActiv
 
 	return (
 		<Placeholder
-			icon={ settings.icon }
+			icon={ settings.icon.src }
 			instructions={ __(
 				'You’ll need to activate the Contact Form feature to use this block.',
 				'jetpack-forms'

--- a/projects/plugins/jetpack/changelog/fix-contact-form-placeholder
+++ b/projects/plugins/jetpack/changelog/fix-contact-form-placeholder
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix the block placeholder throwing an error when the Forms module is disabled.


### PR DESCRIPTION
## Proposed changes:
Fixes the Form block's placeholder icon. This is the placeholder that shows when the Forms module is deactivated but the user tries inserting the block, prompting the user to activate the module.

The placeholder uses the icon defined in the block settings, but there were some changes to the block icon that weren't compatible with the `Placeholder` component.

This PR fixes by passing the `src` property from the settings through to the `Placeholder`. See how the icon is defined in the settings for reference:
https://github.com/Automattic/jetpack/blob/9a9f08e7bf866d9bc5c8b090191acabb54edfb92/projects/packages/forms/src/blocks/contact-form/index.js#L44

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Deactivate the Form module, but keep the Jetpack Settings > Writing > Jetpack Blocks option active
2. Open the editor and insert a Form block
3. The block shows This block has encountered an error and cannot be previewed.
