### PR TITLE
Global Styles on Personal AB: Update assignment cache key

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-global-styles-on-personal-experiment-cache-if-running
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-global-styles-on-personal-experiment-cache-if-running
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-We now check if the experiment is running before caching the assignment
+Changed the experiment cache key so that users get assigned once the experiment starts.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-global-styles-on-personal-experiment-cache-if-running
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-global-styles-on-personal-experiment-cache-if-running
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+We now check if the experiment is running before caching the assignment

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -781,7 +781,14 @@ function wpcom_site_has_global_styles_in_personal_plan( $blog_id = 0 ) {
 		return false;
 	}
 
-	if ( ! function_exists( '\ExPlat\assign_given_user' ) ) {
+	if ( ! function_exists( '\ExPlat\assign_given_user' ) || ! function_exists( '\WPCOM\Experiments\Internal\get_cached_experiment_by_name' ) ) {
+		return false;
+	}
+
+	// If the experiment is not running and the request isn't proxied, we can return early.
+	$exp     = \WPCOM\Experiments\Internal\get_cached_experiment_by_name( 'calypso_plans_global_styles_personal_20240127' );
+	$proxied = function_exists( 'wpcom_is_proxied_request' ) ? wpcom_is_proxied_request() : false;
+	if ( $exp->status !== 'running' && ! $proxied ) {
 		return false;
 	}
 
@@ -789,7 +796,7 @@ function wpcom_site_has_global_styles_in_personal_plan( $blog_id = 0 ) {
 		$blog_id = get_current_blog_id();
 	}
 
-	$cache_key                          = "global-styles-on-personal-feb-2025-$blog_id";
+	$cache_key                          = "global-styles-on-personal-02-2025-$blog_id";
 	$found_in_cache                     = false;
 	$has_global_styles_in_personal_plan = wp_cache_get( $cache_key, 'a8c_experiments', false, $found_in_cache );
 	if ( $found_in_cache ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -781,14 +781,7 @@ function wpcom_site_has_global_styles_in_personal_plan( $blog_id = 0 ) {
 		return false;
 	}
 
-	if ( ! function_exists( '\ExPlat\assign_given_user' ) || ! function_exists( '\WPCOM\Experiments\Internal\get_cached_experiment_by_name' ) ) {
-		return false;
-	}
-
-	// If the experiment is not running and the request isn't proxied, we can return early.
-	$exp     = \WPCOM\Experiments\Internal\get_cached_experiment_by_name( 'calypso_plans_global_styles_personal_20240127' );
-	$proxied = function_exists( 'wpcom_is_proxied_request' ) ? wpcom_is_proxied_request() : false;
-	if ( $exp->status !== 'running' && ! $proxied ) {
+	if ( ! function_exists( '\ExPlat\assign_given_user' ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Since the changes are already merged, users are assigned to the control group, and the assignment is cached. With these changes, we're changing the cache key so that users get re-assigned once we merge these changes

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply these changes
* Sandbox your API
* Go to Calypso theme showcase (logged in)
* Open the network tab and filter requests by `global-styles/status`
* By default you should get the corresponding assignment. Change the assignment and clear the cache and you should have the new assignment group.
