### PR TITLE
Newsletter: Update newsletter copies when the site is not public. 

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-editor-copies-for-coming-soon
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-editor-copies-for-coming-soon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated text copies based on whether the site is public.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -1,9 +1,5 @@
 import { useConnection } from '@automattic/jetpack-connection';
-import {
-	isSimpleSite,
-	isPrivateSite,
-	isComingSoon,
-} from '@automattic/jetpack-shared-extension-utils';
+import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { Button, PanelBody, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { useSelect } from '@wordpress/data';
 import { PluginSidebar } from '@wordpress/edit-post';
@@ -55,18 +51,9 @@ const NewsletterMenu = ( { openPreviewModal } ) => {
 						{ ! shouldPromptForConnection ? (
 							<>
 								<p>
-									{ isPrivateSite() || isComingSoon() ? (
-										<>
-											{ __(
-												'Your site is private or in coming soon mode. Emails will only be sent when your site is public.',
-												'jetpack'
-											) }
-										</>
-									) : (
-										__(
-											'Ensure your email looks perfect. Use the buttons below to view a preview or send a test email.',
-											'jetpack'
-										)
+									{ __(
+										'Ensure your email looks perfect. Use the buttons below to view a preview or send a test email.',
+										'jetpack'
 									) }
 								</p>
 								<HStack wrap={ true }>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -1,5 +1,9 @@
 import { useConnection } from '@automattic/jetpack-connection';
-import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
+import {
+	isSimpleSite,
+	isPrivateSite,
+	isComingSoon,
+} from '@automattic/jetpack-shared-extension-utils';
 import { Button, PanelBody, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { useSelect } from '@wordpress/data';
 import { PluginSidebar } from '@wordpress/edit-post';
@@ -51,9 +55,18 @@ const NewsletterMenu = ( { openPreviewModal } ) => {
 						{ ! shouldPromptForConnection ? (
 							<>
 								<p>
-									{ __(
-										'Ensure your email looks perfect. Use the buttons below to view a preview or send a test email.',
-										'jetpack'
+									{ isPrivateSite() || isComingSoon() ? (
+										<>
+											{ __(
+												'Your site is private or in coming soon mode. Emails will only be sent when your site is public.',
+												'jetpack'
+											) }
+										</>
+									) : (
+										__(
+											'Ensure your email looks perfect. Use the buttons below to view a preview or send a test email.',
+											'jetpack'
+										)
 									) }
 								</p>
 								<HStack wrap={ true }>

--- a/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
@@ -1,3 +1,4 @@
+import { isPrivateSite, isComingSoon } from '@automattic/jetpack-shared-extension-utils';
 import { Animate } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
@@ -260,6 +261,11 @@ function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
 
 	if ( ! isSendEmailEnabled() ) {
 		text = __( 'Not sent via email.', 'jetpack' );
+	} else if ( isPrivateSite() || isComingSoon() ) {
+		text = __(
+			'Your site is private or in coming soon mode. Emails are sent when your site is public.',
+			'jetpack'
+		);
 	} else if ( newsletterCategoriesEnabled && newsletterCategories.length > 0 && ! isPaidPost ) {
 		// Get newsletter category copy & count separately, unless post is paid
 		text = getCopyForCategorySubscribers( {

--- a/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
@@ -1,4 +1,4 @@
-import { isPrivateSite, isComingSoon } from '@automattic/jetpack-shared-extension-utils';
+import { isComingSoon } from '@automattic/jetpack-shared-extension-utils';
 import { Animate } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
@@ -261,9 +261,9 @@ function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
 
 	if ( ! isSendEmailEnabled() ) {
 		text = __( 'Not sent via email.', 'jetpack' );
-	} else if ( isPrivateSite() || isComingSoon() ) {
+	} else if ( isComingSoon() ) {
 		text = __(
-			'Your site is private or in coming soon mode. Emails are sent when your site is public.',
+			'Your site is in Coming Soon mode. Emails are sent only when your site is public.',
 			'jetpack'
 		);
 	} else if ( newsletterCategoriesEnabled && newsletterCategories.length > 0 && ! isPaidPost ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/40485

When a simple/atomic site is in the 'coming soon' mode, we incorrectly display the 'This post will be sent to 1 subscriber.' copy. I have attached the screenshot of the issue and the steps to reproduce it. 

<img width="743" alt="Screenshot 2025-01-29 at 6 32 03 PM" src="https://github.com/user-attachments/assets/13ec94d4-c42b-468c-a345-931e19476671" />


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the copy to say that we won't be sending the emails if the site is in the 'Coming Soon' mode. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Simple sites/Atomic sites:

To setup, run `bin/jetpack-downloader test jetpack fix/newsletter-editor-copies-for-coming-soon` on the sandbox and sandbox your test simple site. Install the Jetpack Beta plugin on your Atomic site and run this branch  to test atomic sites. 

- On a test simple site that hasn't been launched yet, write a new post and open the newsletter panel. You will see this. 

<img width="254" alt="Screenshot 2025-01-29 at 4 41 01 PM" src="https://github.com/user-attachments/assets/a07c00ca-2ade-49f4-a21a-cf827e8d2159" />

- Launch the site, write a new post and open the newsletter panel. You will see this. 

<img width="372" alt="Screenshot 2025-01-29 at 4 42 38 PM" src="https://github.com/user-attachments/assets/6cfbfa07-4e63-49cf-9da7-b9c03ddd9aef" />

- After the post is published, if you refresh the page and visit the newsletter panel of the post, you will see this. 

<img width="398" alt="Screenshot 2025-01-29 at 4 45 22 PM" src="https://github.com/user-attachments/assets/379e5d2c-6847-4e56-a091-294e244ca7b5" />

- Now put the site in coming soon mode again. If repeat the above step, you will see this

<img width="367" alt="Screenshot 2025-01-29 at 4 47 27 PM" src="https://github.com/user-attachments/assets/00f2c373-bf67-45ed-95ae-f30c8781bdf7" />

Jetpack Sites:

- This change won't affect jetpack sites, just sanity test to ensure you can see the newsletter panel in the editor sidebar.

<img width="299" alt="Screenshot 2025-01-29 at 6 29 13 PM" src="https://github.com/user-attachments/assets/b705f011-a055-428f-98ec-b9a697460d27" />

