### PR TITLE
Jetpack Sync: Checksum performance optimizations for Meta Sync Module

### DIFF
--- a/projects/packages/sync/.phan/baseline.php
+++ b/projects/packages/sync/.phan/baseline.php
@@ -66,7 +66,7 @@ return [
         'src/modules/class-full-sync-immediately.php' => ['PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchReturn'],
         'src/modules/class-full-sync.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanTypeComparisonFromArray'],
         'src/modules/class-import.php' => ['PhanTypeMismatchArgumentInternal'],
-        'src/modules/class-meta.php' => ['PhanParamSignatureMismatch', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgumentProbablyReal'],
+        'src/modules/class-meta.php' => ['PhanParamSignatureMismatch', 'PhanTypeArraySuspicious'],
         'src/modules/class-module.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
         'src/modules/class-network-options.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchReturnProbablyReal'],
         'src/modules/class-options.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchReturnProbablyReal'],

--- a/projects/packages/sync/.phan/baseline.php
+++ b/projects/packages/sync/.phan/baseline.php
@@ -23,7 +23,7 @@ return [
     // PhanRedundantCondition : 4 occurrences
     // PhanTypeExpectedObjectPropAccess : 4 occurrences
     // PhanTypeMismatchArgumentInternal : 4 occurrences
-    // PhanTypeArraySuspicious : 3 occurrences
+    // PhanTypeArraySuspicious : 2 occurrences
     // PhanTypeArraySuspiciousNullable : 3 occurrences
     // PhanAccessMethodInternal : 2 occurrences
     // PhanImpossibleCondition : 2 occurrences
@@ -66,7 +66,7 @@ return [
         'src/modules/class-full-sync-immediately.php' => ['PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchReturn'],
         'src/modules/class-full-sync.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanTypeComparisonFromArray'],
         'src/modules/class-import.php' => ['PhanTypeMismatchArgumentInternal'],
-        'src/modules/class-meta.php' => ['PhanParamSignatureMismatch', 'PhanTypeArraySuspicious'],
+        'src/modules/class-meta.php' => ['PhanParamSignatureMismatch'],
         'src/modules/class-module.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
         'src/modules/class-network-options.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchReturnProbablyReal'],
         'src/modules/class-options.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchReturnProbablyReal'],

--- a/projects/packages/sync/changelog/update-sync-meta-module
+++ b/projects/packages/sync/changelog/update-sync-meta-module
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack Sync: Checksum performance optimizations for Meta Sync Module

--- a/projects/packages/sync/src/modules/class-meta.php
+++ b/projects/packages/sync/src/modules/class-meta.php
@@ -84,7 +84,9 @@ class Meta extends Module {
 			}
 		}
 
-		$conditionals[] = $where_sql;
+		if ( ! empty( $where_sql ) ) {
+			$conditionals[] = $where_sql;
+		}
 
 		$meta_objects = array();
 

--- a/projects/packages/sync/src/modules/class-meta.php
+++ b/projects/packages/sync/src/modules/class-meta.php
@@ -59,7 +59,7 @@ class Meta extends Module {
 			}
 		}
 
-		$conditionals         = array();
+		$meta_objects         = array();
 		$where_sql            = '';
 		$current_query_length = 0;
 
@@ -78,38 +78,14 @@ class Meta extends Module {
 			$current_query_length += strlen( $where_sql );
 
 			if ( $current_query_length > self::MAX_DB_QUERY_LENGTH ) {
-				$conditionals[]       = $where_sql;
+				$meta_objects         = $this->fetch_prepared_meta_from_db( $object_type, $where_sql, $meta_objects );
 				$where_sql            = '';
 				$current_query_length = 0;
 			}
 		}
 
 		if ( ! empty( $where_sql ) ) {
-			$conditionals[] = $where_sql;
-		}
-
-		$meta_objects = array();
-
-		foreach ( $conditionals as $where ) {
-			$meta = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				"SELECT * FROM {$table} WHERE {$where}",
-				ARRAY_A
-			);
-
-			if ( ! is_wp_error( $meta ) && ! empty( $meta ) ) {
-				foreach ( $meta as $meta_entry ) {
-					$object_id = $meta_entry[ $object_id_column ];
-					$meta_key  = $meta_entry['meta_key'];
-					$key       = $object_id . '-' . $meta_key;
-
-					if ( ! isset( $meta_objects[ $key ] ) ) {
-						$meta_objects[ $key ] = array();
-					}
-
-					$meta_objects[ $key ][] = $this->get_prepared_meta_object( $object_type, $meta_entry );
-				}
-			}
+			$meta_objects = $this->fetch_prepared_meta_from_db( $object_type, $where_sql, $meta_objects );
 		}
 
 		return $meta_objects;
@@ -131,25 +107,60 @@ class Meta extends Module {
 			return null;
 		}
 
-		$table            = _get_meta_table( $object_type );
+		$table = _get_meta_table( $object_type );
+
+		if ( ! $table ) {
+			return null;
+		}
+
 		$object_id_column = $object_type . '_id';
 
 		// Sanitize so that the array only has integer values.
-		$meta = $wpdb->get_results(
-			$wpdb->prepare(
+		$where_condition = $wpdb->prepare(
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				"SELECT * FROM {$table} WHERE {$object_id_column} = %d AND meta_key = %s",
-				$id,
-				$meta_key
-			),
+			"{$object_id_column} = %d AND meta_key = %s",
+			$id,
+			$meta_key
+		);
+
+		$meta_objects = $this->fetch_prepared_meta_from_db( $object_type, $where_condition );
+
+		$key = $id . '-' . $meta_key;
+
+		return $meta_objects[ $key ] ?? null;
+	}
+
+	/**
+	 * Fetch meta from DB and return them in a standard format.
+	 *
+	 * @param  string $object_type   The meta object type, eg 'post', 'user' etc.
+	 * @param  string $where         Prepared SQL 'where' statement.
+	 * @param  array  $meta_objects  An existing array of meta to populate. Defaults to an empty array.
+	 * @return array
+	 */
+	private function fetch_prepared_meta_from_db( $object_type, $where, $meta_objects = array() ) {
+		global $wpdb;
+
+		$table            = _get_meta_table( $object_type );
+		$object_id_column = $object_type . '_id';
+
+		$meta = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"SELECT * FROM {$table} WHERE {$where}",
 			ARRAY_A
 		);
 
-		$meta_objects = null;
-
 		if ( ! is_wp_error( $meta ) && ! empty( $meta ) ) {
 			foreach ( $meta as $meta_entry ) {
-				$meta_objects[] = $this->get_prepared_meta_object( $object_type, $meta_entry );
+				$object_id = $meta_entry[ $object_id_column ];
+				$meta_key  = $meta_entry['meta_key'];
+				$key       = $object_id . '-' . $meta_key;
+
+				if ( ! isset( $meta_objects[ $key ] ) ) {
+					$meta_objects[ $key ] = array();
+				}
+
+				$meta_objects[ $key ][] = $this->get_prepared_meta_object( $object_type, $meta_entry );
 			}
 		}
 

--- a/projects/packages/sync/src/modules/class-meta.php
+++ b/projects/packages/sync/src/modules/class-meta.php
@@ -64,7 +64,7 @@ class Meta extends Module {
 		$current_query_length = 0;
 
 		foreach ( $object_key_pairs as $object_id => $keys ) {
-			$keys_placeholders = implode( ',', array_fill( 0, is_countable( $keys ) ? count( $keys ) : 0, '%s' ) );
+			$keys_placeholders = implode( ',', array_fill( 0, count( $keys ), '%s' ) );
 			$where_condition   = trim(
 				$wpdb->prepare(
 					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/projects/packages/sync/src/modules/class-meta.php
+++ b/projects/packages/sync/src/modules/class-meta.php
@@ -38,6 +38,8 @@ class Meta extends Module {
 	 * @return array
 	 */
 	public function get_objects_by_id( $object_type, $config ) {
+		global $wpdb;
+
 		$table = _get_meta_table( $object_type );
 
 		if ( ! $table ) {
@@ -48,13 +50,64 @@ class Meta extends Module {
 			return array();
 		}
 
-		$meta_objects = array();
+		$object_id_column = $object_type . '_id';
+		$object_key_pairs = array();
+
 		foreach ( $config as $item ) {
-			$meta = null;
 			if ( isset( $item['id'] ) && isset( $item['meta_key'] ) ) {
-				$meta = $this->get_object_by_id( $object_type, (int) $item['id'], (string) $item['meta_key'] );
+				$object_key_pairs[ (int) $item['id'] ][] = (string) $item['meta_key'];
 			}
-			$meta_objects[ $item['id'] . '-' . $item['meta_key'] ] = $meta;
+		}
+
+		$conditionals         = array();
+		$where_sql            = '';
+		$current_query_length = 0;
+
+		foreach ( $object_key_pairs as $object_id => $keys ) {
+			$keys_placeholders = implode( ',', array_fill( 0, is_countable( $keys ) ? count( $keys ) : 0, '%s' ) );
+			$where_condition   = trim(
+				$wpdb->prepare(
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					"( `$object_id_column` = %d AND meta_key IN ( $keys_placeholders ) )",
+					array_merge( array( $object_id ), $keys )
+				)
+			);
+
+			$where_sql = empty( $where_sql ) ? $where_condition : $where_sql . ' OR ' . $where_condition;
+
+			$current_query_length += strlen( $where_sql );
+
+			if ( $current_query_length > self::MAX_DB_QUERY_LENGTH ) {
+				$conditionals[]       = $where_sql;
+				$where_sql            = '';
+				$current_query_length = 0;
+			}
+		}
+
+		$conditionals[] = $where_sql;
+
+		$meta_objects = array();
+
+		foreach ( $conditionals as $where ) {
+			$meta = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT * FROM {$table} WHERE {$where}",
+				ARRAY_A
+			);
+
+			if ( ! is_wp_error( $meta ) && ! empty( $meta ) ) {
+				foreach ( $meta as $meta_entry ) {
+					$object_id = $meta_entry[ $object_id_column ];
+					$meta_key  = $meta_entry['meta_key'];
+					$key       = $object_id . '-' . $meta_key;
+
+					if ( ! isset( $meta_objects[ $key ] ) ) {
+						$meta_objects[ $key ] = array();
+					}
+
+					$meta_objects[ $key ][] = $this->get_prepared_meta_object( $object_type, $meta_entry );
+				}
+			}
 		}
 
 		return $meta_objects;
@@ -94,19 +147,33 @@ class Meta extends Module {
 
 		if ( ! is_wp_error( $meta ) && ! empty( $meta ) ) {
 			foreach ( $meta as $meta_entry ) {
-				if ( 'post' === $object_type && strlen( $meta_entry['meta_value'] ) >= Posts::MAX_POST_META_LENGTH ) {
-					$meta_entry['meta_value'] = '';
-				}
-				$meta_objects[] = array(
-					'meta_type'  => $object_type,
-					'meta_id'    => $meta_entry['meta_id'],
-					'meta_key'   => $meta_key,
-					'meta_value' => $meta_entry['meta_value'],
-					'object_id'  => $meta_entry[ $object_id_column ],
-				);
+				$meta_objects[] = $this->get_prepared_meta_object( $object_type, $meta_entry );
 			}
 		}
 
 		return $meta_objects;
+	}
+
+	/**
+	 * Accepts a DB meta entry and returns it in a standard format.
+	 *
+	 * @param  string $object_type The meta object type, eg 'post', 'user' etc.
+	 * @param  array  $meta_entry  A meta array.
+	 * @return array
+	 */
+	private function get_prepared_meta_object( $object_type, $meta_entry ) {
+		$object_id_column = $object_type . '_id';
+
+		if ( 'post' === $object_type && strlen( $meta_entry['meta_value'] ) >= Posts::MAX_POST_META_LENGTH ) {
+			$meta_entry['meta_value'] = '';
+		}
+
+		return array(
+			'meta_type'  => $object_type,
+			'meta_id'    => $meta_entry['meta_id'],
+			'meta_key'   => $meta_entry['meta_key'],
+			'meta_value' => $meta_entry['meta_value'],
+			'object_id'  => $meta_entry[ $object_id_column ],
+		);
 	}
 }

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -30,6 +30,15 @@ abstract class Module {
 	const ARRAY_CHUNK_SIZE = 10;
 
 	/**
+	 * Max query length for DB queries.
+	 *
+	 * @access public
+	 *
+	 * @var int
+	 */
+	const MAX_DB_QUERY_LENGTH = 15 * 1024;
+
+	/**
 	 * Sync module name.
 	 *
 	 * @access public

--- a/projects/plugins/jetpack/changelog/update-sync-meta-module
+++ b/projects/plugins/jetpack/changelog/update-sync-meta-module
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated Sync related unit tests
+
+

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-meta.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-meta.php
@@ -300,6 +300,42 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	/**
+	 * Verify that get_object_by_id will return null for non existing meta.
+	 */
+	public function test_get_object_by_id_will_return_null_for_non_existing_meta() {
+		$module = Modules::get_module( 'meta' );
+		$this->assertNull( $module->get_object_by_id( 'post', $this->post_id, 'does_not_exist' ) );
+	}
+
+	/**
+	 * Test get_object_by_id with multiple meta for the same object_id and key.
+	 */
+	public function test_get_object_by_id_multiple_meta_same_object_id_and_key() {
+		$meta_id = add_post_meta( $this->post_id, $this->whitelisted_post_meta, 'bar' );
+		$module  = Modules::get_module( 'meta' );
+
+		$metas    = $module->get_object_by_id( 'post', $this->post_id, $this->whitelisted_post_meta );
+		$expected = array(
+			array(
+				'meta_type'  => 'post',
+				'meta_id'    => (string) $this->meta_id,
+				'meta_key'   => $this->whitelisted_post_meta,
+				'meta_value' => 'foo',
+				'object_id'  => (string) $this->post_id,
+			),
+			array(
+				'meta_type'  => 'post',
+				'meta_id'    => (string) $meta_id,
+				'meta_key'   => $this->whitelisted_post_meta,
+				'meta_value' => 'bar',
+				'object_id'  => (string) $this->post_id,
+			),
+		);
+
+		$this->assertSame( $expected, $metas );
+	}
+
+	/**
 	 * Verify that meta_values above size limit are truncated in get_object_by_id
 	 */
 	public function test_get_object_by_id_size_limit_exceeded() {

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-meta.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-meta.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Sync\Settings;
 
 class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 	protected $post_id;
+	protected $meta_id;
 	protected $meta_module;
 
 	protected $whitelisted_post_meta = 'foobar';
@@ -25,7 +26,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 		$this->meta_module = Modules::get_module( 'meta' );
 		Settings::update_settings( array( 'post_meta_whitelist' => array( 'foobar' ) ) );
 		$this->post_id = self::factory()->post->create();
-		add_post_meta( $this->post_id, $this->whitelisted_post_meta, 'foo' );
+		$this->meta_id = add_post_meta( $this->post_id, $this->whitelisted_post_meta, 'foo' );
 		$this->sender->do_sync();
 	}
 
@@ -320,5 +321,105 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 		$module = Modules::get_module( 'meta' );
 		$metas  = $module->get_object_by_id( 'post', $this->post_id, $this->whitelisted_post_meta );
 		$this->assertEquals( $meta_test_value, $metas[0]['meta_value'] );
+	}
+
+	/**
+	 * Tests get_objects_by_id
+	 */
+	public function test_get_objects_by_id() {
+		$module  = Modules::get_module( 'meta' );
+		$meta_id = add_post_meta( $this->post_id, $this->whitelisted_post_meta, 'bar' );
+		$config  = array(
+			array(
+				'id'       => $this->post_id,
+				'meta_key' => $this->whitelisted_post_meta,
+			),
+		);
+		$metas   = $module->get_objects_by_id( 'post', $config );
+
+		$expected = array(
+			$this->post_id . '-' . $this->whitelisted_post_meta => array(
+				array(
+					'meta_type'  => 'post',
+					'meta_id'    => (string) $this->meta_id,
+					'meta_key'   => $this->whitelisted_post_meta,
+					'meta_value' => 'foo',
+					'object_id'  => (string) $this->post_id,
+				),
+				array(
+					'meta_type'  => 'post',
+					'meta_id'    => (string) $meta_id,
+					'meta_key'   => $this->whitelisted_post_meta,
+					'meta_value' => 'bar',
+					'object_id'  => (string) $this->post_id,
+				),
+			),
+		);
+		$this->assertSame( $expected, $metas );
+	}
+
+	/**
+	 * Verify that meta_values above size limit are truncated in get_objects_by_id.
+	 */
+	public function test_get_objects_by_id_size_limit_exceeded() {
+		$meta_test_value = str_repeat( 'X', Posts::MAX_POST_META_LENGTH );
+		update_post_meta( $this->post_id, $this->whitelisted_post_meta, $meta_test_value );
+
+		$module = Modules::get_module( 'meta' );
+		$config = array(
+			array(
+				'id'       => $this->post_id,
+				'meta_key' => $this->whitelisted_post_meta,
+			),
+		);
+		$metas  = $module->get_objects_by_id( 'post', $config );
+
+		$expected = array(
+			$this->post_id . '-' . $this->whitelisted_post_meta => array(
+				array(
+					'meta_type'  => 'post',
+					'meta_id'    => (string) $this->meta_id,
+					'meta_key'   => $this->whitelisted_post_meta,
+					'meta_value' => '',
+					'object_id'  => (string) $this->post_id,
+				),
+			),
+		);
+		$this->assertSame( $expected, $metas );
+	}
+
+	/**
+	 * Tests get_objects_by_id when the max DB query length is exceeded.
+	 */
+	public function test_get_objects_by_id_max_query_length_exceeded() {
+		$module        = Modules::get_module( 'meta' );
+		$long_meta_key = str_repeat( 'X', $module::MAX_DB_QUERY_LENGTH );
+		// We are not actually adding the meta, only in $config so that it produces a long DB query.
+		$config = array(
+			array(
+				'id'       => 9999,
+				'meta_key' => $long_meta_key,
+			),
+			array(
+				'id'       => $this->post_id,
+				'meta_key' => $this->whitelisted_post_meta,
+			),
+		);
+
+		$metas = $module->get_objects_by_id( 'post', $config );
+
+		$expected = array(
+			$this->post_id . '-' . $this->whitelisted_post_meta => array(
+				array(
+					'meta_type'  => 'post',
+					'meta_id'    => (string) $this->meta_id,
+					'meta_key'   => $this->whitelisted_post_meta,
+					'meta_value' => 'foo',
+					'object_id'  => (string) $this->post_id,
+				),
+			),
+		);
+
+		$this->assertSame( $expected, $metas );
 	}
 }

--- a/tools/phpcs-excludelist.json
+++ b/tools/phpcs-excludelist.json
@@ -7,7 +7,6 @@
 	"projects/packages/sync/src/class-replicastore.php",
 	"projects/packages/sync/src/modules/class-full-sync-immediately.php",
 	"projects/packages/sync/src/modules/class-full-sync.php",
-	"projects/packages/sync/src/modules/class-meta.php",
 	"projects/packages/sync/src/modules/class-module.php",
 	"projects/packages/sync/src/modules/class-posts.php",
 	"projects/packages/sync/src/modules/class-term-relationships.php",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

During `meta` Fix Checksums, it's possible to call `Automattic\Jetpack\Sync\Modules\Metas::get_objects_by_id` with a config of max 1200 metas to fetch from the DB.
Up to know we used to fetch each one of them via a separate DB query.
This PR refactors `get_objects_by_id` so that we fetch those via a single query.
However, taking into account that the resulting DB query can be very long, we have incorporated a buffer logic that compares the resulting DB query length with a default max length to split the queries if needed.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Modules\Module`: Introduce `MAX_DB_QUERY_LENGTH` class constant, which holds the maximum allowed DB query length.
* `Automattic\Jetpack\Sync\Modules\Meta`: Refactor `get_objects_by_id` to fetch all metas via a single DB query
* `Automattic\Jetpack\Sync\Modules\Meta`: Introduce `get_prepared_meta_object` private method, used both by `get_object_by_id` and `get_objecst_by_id` in order to prepare the meta results in the same expected format.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pf5801-1mi-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* We'll need to test with `woocommerce_order_itemmeta` so make sure you have WooCommerce plugin active and a few orders too
* Wipe your `postmeta` table on your WPCOM Cache site
* Trigger a Fix Checksum for `postmeta`
* Confirm the `postmeta` table on your WPCOM Cache site is populated. Note the total count and some sample metas
* Repeat the same but on trunk
* Confirm the `postmeta` table on your WPCOM Cache site matches the total count from before and the sample metas you noted hold the same values
* Repeat with `commentmeta` and `woocommerce_order_itemmeta`