### PR TITLE
Tooling: Call nvm use on pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,6 @@
+#!/bin/sh
+if [ -f ~/.nvm/nvm.sh ]; then
+  . ~/.nvm/nvm.sh
+  nvm use
+fi
 node tools/js-tools/git-hooks/pre-commit-hook.mjs


### PR DESCRIPTION
Lately, when using GitHub Desktop, I’ve been getting errors related to environment versions when trying to commit from the app. This fixes it, but I’m not sure it’s the most reliable solution.

