### PR TITLE
MU COM: add is_user_member_of_blog check for launch button

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-bar-launch-2
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-bar-launch-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+add is_user_member_of_blog check for launch button

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -17,6 +17,10 @@ function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
 		return false;
 	}
 
+	if ( ! is_user_member_of_blog( get_current_user_id(), $current_blog_id ) ) {
+		return;
+	}
+
 	if ( ! current_user_can( 'manage_options' ) ) {
 		return;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

See #41340.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Restore the is_user_member_of_blog check for the launch button in the admin bar. It seems this will remove the button for wp.com, not the grey listed check.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

