### PR TITLE
jetpack: Move `executionLock.release()` into `finally`

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-membership-products-resolvers-coverage-thing
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-membership-products-resolvers-coverage-thing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Move `executionLock.release()` into `finally`.
+
+

--- a/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
@@ -222,8 +222,9 @@ export const getProducts =
 			dispatch( setConnectUrl( null ) );
 			dispatch( setApiState( API_STATE_NOTCONNECTED ) );
 			onError( error.message, registry );
+		} finally {
+			executionLock.release( lock );
 		}
-		executionLock.release( lock );
 	};
 
 export const getSubscriberCounts =
@@ -244,8 +245,9 @@ export const getSubscriberCounts =
 		} catch ( error ) {
 			dispatch( setApiState( API_STATE_NOTCONNECTED ) );
 			onError( error.message, registry );
+		} finally {
+			executionLock.release( lock );
 		}
-		executionLock.release( lock );
 	};
 
 export const getNewsletterCategories =
@@ -266,8 +268,9 @@ export const getNewsletterCategories =
 		} catch ( error ) {
 			dispatch( setApiState( API_STATE_NOTCONNECTED ) );
 			onError( error.message, registry );
+		} finally {
+			executionLock.release( lock );
 		}
-		executionLock.release( lock );
 	};
 
 export const getNewsletterCategoriesSubscriptionsCount =
@@ -287,6 +290,7 @@ export const getNewsletterCategoriesSubscriptionsCount =
 		} catch ( error ) {
 			dispatch( setApiState( API_STATE_NOTCONNECTED ) );
 			onError( error.message, registry );
+		} finally {
+			executionLock.release( lock );
 		}
-		executionLock.release( lock );
 	};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Even if something in the `catch` block throws (as seems to usually, but not always, happen in testing), the `release()` should probably still happen. So put it in a `finally` block.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1738162466193509/1738152583.829339-slack-C05Q5HSS013 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy? And does the coverage reliably show that one line being covered?
  * [x] Don't know about "reliably", but it's covered: https://jetpackcodecoverage.atomicsites.blog/prs/41405/js/extensions/store/membership-products/resolvers.js.html#L249