### PR TITLE
Forms: Fix form submissions across pages that have pagination applied

### DIFF
--- a/projects/packages/forms/changelog/fix-form-submit-miulti-page
+++ b/projects/packages/forms/changelog/fix-form-submit-miulti-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Add support for having multiple forms accross paginated pages

--- a/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
+++ b/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
@@ -159,13 +159,7 @@ class WPCOM_REST_API_V2_Endpoint_Forms extends WP_REST_Controller {
 			array_diff_key( $filter_args, array( 'post_parent' => '' ) )
 		);
 
-		$base_fields = array(
-			'email_marketing_consent' => '',
-			'entry_title'             => '',
-			'entry_permalink'         => '',
-			'feedback_id'             => '',
-		);
-
+		$base_fields   = Contact_Form_Plugin::NON_PRINTABLE_FIELDS;
 		$data_defaults = array(
 			'_feedback_author'       => '',
 			'_feedback_author_email' => '',

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -702,13 +702,6 @@ class Admin {
 	 * @return void
 	 */
 	public function grunion_manage_post_column_response( $post ) {
-		$non_printable_keys = array(
-			'email_marketing_consent',
-			'entry_title',
-			'entry_permalink',
-			'entry_page',
-			'feedback_id',
-		);
 
 		$post_content = get_post_field( 'post_content', $post->ID );
 		$content      = explode( '<!--more-->', $post_content );
@@ -756,7 +749,7 @@ class Admin {
 			$url = add_query_arg( 'page', $response_fields['entry_page'], $url );
 		}
 
-		$response_fields = array_diff_key( $response_fields, array_flip( $non_printable_keys ) );
+		$response_fields = array_diff_key( $response_fields, array_flip( array_keys( Contact_Form_Plugin::NON_PRINTABLE_FIELDS ) ) );
 
 		echo '<hr class="feedback_response__mobile-separator" />';
 		echo '<div class="feedback_response__item">';

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -706,6 +706,7 @@ class Admin {
 			'email_marketing_consent',
 			'entry_title',
 			'entry_permalink',
+			'entry_page',
 			'feedback_id',
 		);
 
@@ -750,6 +751,11 @@ class Admin {
 			}
 		}
 
+		$url = get_permalink( $post->post_parent );
+		if ( isset( $response_fields['entry_page'] ) ) {
+			$url = add_query_arg( 'page', $response_fields['entry_page'], $url );
+		}
+
 		$response_fields = array_diff_key( $response_fields, array_flip( $non_printable_keys ) );
 
 		echo '<hr class="feedback_response__mobile-separator" />';
@@ -774,7 +780,7 @@ class Admin {
 			echo '<div class="feedback_response__item-value">' . esc_html( $content_fields['_feedback_ip'] ) . '</div>';
 		}
 		echo '<div class="feedback_response__item-key">' . esc_html__( 'Source', 'jetpack-forms' ) . '</div>';
-		echo '<div class="feedback_response__item-value"><a href="' . esc_url( get_permalink( $post->post_parent ) ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( get_permalink( $post->post_parent ) ) . '</a></div>';
+		echo '<div class="feedback_response__item-value"><a href="' . esc_url( $url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $url ) . '</a></div>';
 		echo '</div>';
 	}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -703,7 +703,7 @@ class Contact_Form_Plugin {
 					$postdata = generate_postdata( $post );
 					$page     = isset( $_POST['page'] ) ? absint( wp_unslash( $_POST['page'] ) ) : null; // phpcs:Ignore WordPress.Security.NonceVerification.Missing
 					$paged    = isset( $page ) ? $page : 1;
-					$content  = $postdata['pages'][ $paged - 1 ];
+					$content  = isset( $postdata['pages'][ $paged - 1 ] ) ? $postdata['pages'][ $paged - 1 ] : $post->post_content;
 				} else {
 					$content = $post->post_content;
 				}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -52,6 +52,20 @@ class Contact_Form_Plugin {
 	 */
 	private $pde_email_address = '';
 
+	/*
+	 * Field keys that might be present in the entry json but we don't want to show to the admin
+	 * since they not something that the visitor entered into the form.
+	 *
+	 * @var array
+	 */
+	const NON_PRINTABLE_FIELDS = array(
+		'entry_title'             => '',
+		'email_marketing_consent' => '',
+		'entry_permalink'         => '',
+		'entry_page'              => '',
+		'feedback_id'             => '',
+	);
+
 	/**
 	 * Initializing function.
 	 */
@@ -1143,7 +1157,7 @@ class Contact_Form_Plugin {
 		$content_fields = self::parse_fields_from_content( $post_id );
 		$all_fields     = isset( $content_fields['_feedback_all_fields'] ) ? $content_fields['_feedback_all_fields'] : array();
 		$md             = $has_json_data
-			? array_diff_key( $all_fields, array_flip( array( 'entry_title', 'email_marketing_consent', 'entry_permalink', 'feedback_id' ) ) )
+			? array_diff_key( $all_fields, array_flip( array_keys( self::NON_PRINTABLE_FIELDS ) ) )
 			: (array) get_post_meta( $post_id, '_feedback_extra_fields', true );
 
 		$md['-3_response_date'] = get_the_date( 'Y-m-d H:i:s', $post_id );

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -699,8 +699,16 @@ class Contact_Form_Plugin {
 
 			// Process the content to populate Contact_Form::$last
 			if ( $post ) {
+				if ( str_contains( $post->post_content, '<!--nextpage-->' ) ) {
+					$postdata = generate_postdata( $post );
+					$page     = isset( $_POST['page'] ) ? sanitize_text_field( wp_unslash( $_POST['page'] ) ) : null; // phpcs:Ignore WordPress.Security.NonceVerification.Missing
+					$paged    = isset( $page ) ? $page : 1;
+					$content  = $postdata['pages'][ $paged - 1 ];
+				} else {
+					$content = $post->post_content;
+				}
 				/** This filter is already documented in core. wp-includes/post-template.php */
-				apply_filters( 'the_content', $post->post_content );
+				apply_filters( 'the_content', $content );
 			}
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -701,7 +701,7 @@ class Contact_Form_Plugin {
 			if ( $post ) {
 				if ( str_contains( $post->post_content, '<!--nextpage-->' ) ) {
 					$postdata = generate_postdata( $post );
-					$page     = isset( $_POST['page'] ) ? sanitize_text_field( wp_unslash( $_POST['page'] ) ) : null; // phpcs:Ignore WordPress.Security.NonceVerification.Missing
+					$page     = isset( $_POST['page'] ) ? absint( wp_unslash( $_POST['page'] ) ) : null; // phpcs:Ignore WordPress.Security.NonceVerification.Missing
 					$paged    = isset( $page ) ? $page : 1;
 					$content  = $postdata['pages'][ $paged - 1 ];
 				} else {

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1660,7 +1660,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 */
 	public static function get_permalink( $post_id ) {
 		$url  = get_permalink( $post_id );
-		$page = isset( $_POST['page'] ) ? sanitize_text_field( wp_unslash( $_POST['page'] ) ) : null; // phpcs:Ignore WordPress.Security.NonceVerification.Missing
+		$page = isset( $_POST['page'] ) ? absint( wp_unslash( $_POST['page'] ) ) : null; // phpcs:Ignore WordPress.Security.NonceVerification.Missing
 		if ( $page ) {
 			return add_query_arg( 'page', $page, $url );
 		}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -82,7 +82,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @param string $content - the content.
 	 */
 	public function __construct( $attributes, $content = null ) {
-		global $post;
+		global $post, $page;
 
 		// Set up the default subject and recipient for this form.
 		$default_to      = '';
@@ -123,7 +123,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			if ( ! isset( $attributes['id'] ) ) {
 				$attributes['id'] = '';
 			}
-			$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 );
+			$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 ) . '-' . $page;
 		}
 
 		$this->hash                 = sha1( wp_json_encode( $attributes ) );
@@ -249,8 +249,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return string HTML for the concat form.
 	 */
 	public static function parse( $attributes, $content ) {
-		global $post;
-
+		global $post, $page; // $page is used in the contact-form submission redirect
 		if ( Settings::is_syncing() ) {
 			return '';
 		}
@@ -347,6 +346,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 			} else {
 				// Submit form to the post permalink
 				$url = get_permalink();
+				if ( $page ) {
+					$url = add_query_arg( 'page', $page, $url );
+				}
 			}
 
 			// For SSL/TLS page. See RFC 3986 Section 4.2
@@ -364,7 +366,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			 * @param $post $GLOBALS['post'] Post global variable.
 			 * @param int $id Contact Form ID.
 			 */
-			$url                     = apply_filters( 'grunion_contact_form_form_action', "{$url}#contact-form-{$id}", $GLOBALS['post'], $id );
+			$url                     = apply_filters( 'grunion_contact_form_form_action', "{$url}#contact-form-{$id}", $GLOBALS['post'], $id, $page );
 			$has_submit_button_block = str_contains( $content, 'wp-block-jetpack-button' );
 			$form_classes            = 'contact-form commentsblock';
 			$post_title              = $post->post_title ?? '';
@@ -433,6 +435,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$r .= "\t\t<input type='hidden' name='contact-form-id' value='$id' />\n";
 			$r .= "\t\t<input type='hidden' name='action' value='grunion-contact-form' />\n";
 			$r .= "\t\t<input type='hidden' name='contact-form-hash' value='" . esc_attr( $form->hash ) . "' />\n";
+
+			if ( $page ) {
+				$r .= "\t\t<input type='hidden' name='page' value='$page' />\n";
+			}
 
 			if ( ! $has_submit_button_block ) {
 				$r .= "\t</p>\n";
@@ -1323,7 +1329,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		$entry_values = array(
 			'entry_title'     => the_title_attribute( 'echo=0' ),
-			'entry_permalink' => esc_url( get_permalink( get_the_ID() ) ),
+			'entry_permalink' => esc_url( self::get_permalink( get_the_ID() ) ),
 			'feedback_id'     => $feedback_id,
 		);
 
@@ -1338,7 +1344,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		if ( $block_template || $block_template_part || $widget ) {
 			$url = home_url( '/' );
 		} else {
-			$url = get_permalink( $post->ID );
+			$url = self::get_permalink( $post->ID );
 		}
 
 		// translators: the time of the form submission.
@@ -1644,6 +1650,21 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- We intentially allow external redirects here.
 		wp_redirect( $redirect );
 		exit( 0 );
+	}
+	/**
+	 * Get the permalink for the post ID that include the page query parameter if it was set.
+	 *
+	 * @param int $post_id The post ID.
+	 *
+	 * return string The permalink for the post ID.
+	 */
+	public static function get_permalink( $post_id ) {
+		$url  = get_permalink( $post_id );
+		$page = isset( $_POST['page'] ) ? sanitize_text_field( wp_unslash( $_POST['page'] ) ) : null; // phpcs:Ignore WordPress.Security.NonceVerification.Missing
+		if ( $page ) {
+			return add_query_arg( 'page', $page, $url );
+		}
+		return $url;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -436,7 +436,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$r .= "\t\t<input type='hidden' name='action' value='grunion-contact-form' />\n";
 			$r .= "\t\t<input type='hidden' name='contact-form-hash' value='" . esc_attr( $form->hash ) . "' />\n";
 
-			if ( $page ) {
+			if ( $page && $page > 1 ) {
 				$r .= "\t\t<input type='hidden' name='page' value='$page' />\n";
 			}
 
@@ -1332,6 +1332,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'entry_permalink' => esc_url( self::get_permalink( get_the_ID() ) ),
 			'feedback_id'     => $feedback_id,
 		);
+
+		if ( isset( $_POST['page'] ) ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing
+			$entry_values['entry_page'] = absint( wp_unslash( $_POST['page'] ) ); // phpcs:Ignore WordPress.Security.NonceVerification.Missing
+		}
 
 		$all_values = array_merge( $all_values, $entry_values );
 

--- a/projects/plugins/jetpack/changelog/fix-form-submit-miulti-page
+++ b/projects/plugins/jetpack/changelog/fix-form-submit-miulti-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+ Forms: Add support for having multiple forms accross paginated pages.


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/41334


Currently if you create a page and split it up using the <!--nextpage--> block or code. 
Forms on pages other then the first one will not work. See issue #41334. 


## Proposed changes:
* Add a hidden page field that lets the form know what page we are on. 
* Update the links that appear in the email as well as the form reponses linking to the correct page form. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no 

## Testing instructions:

* Load this PR. 
* Create a page with multiple pages.
* Place forms across multiple pages. 
* Notice that you are able to submit each of the posts across the different pages. 

