### PR TITLE
Dev Docker: add php extensions needed for unit testing and code coverage

### DIFF
--- a/tools/docker/Dockerfile.monorepo
+++ b/tools/docker/Dockerfile.monorepo
@@ -41,10 +41,17 @@ RUN --mount=type=cache,target=/var/lib/apt/lists/,sharing=private \
         jq \
         "php${PHP_VERSION}" \
         "php${PHP_VERSION}-ast" \
+        "php${PHP_VERSION}-bcmath" \
         "php${PHP_VERSION}-cli" \
         "php${PHP_VERSION}-curl" \
         "php${PHP_VERSION}-dom" \
+        "php${PHP_VERSION}-gd" \
+        "php${PHP_VERSION}-igbinary" \
+        "php${PHP_VERSION}-imagick" \
+        "php${PHP_VERSION}-intl" \
         "php${PHP_VERSION}-mbstring" \
+        "php${PHP_VERSION}-mysqli" \
+        "php${PHP_VERSION}-pcov" \
         "php${PHP_VERSION}-xml" \
         "php${PHP_VERSION}-zip" \
         rsync \

--- a/tools/docker/Dockerfile.monorepo
+++ b/tools/docker/Dockerfile.monorepo
@@ -6,10 +6,11 @@ ARG COMPOSER_VERSION
 ARG NODE_VERSION
 ARG PNPM_VERSION
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     JETPACK_MONOREPO_ENV=1 \
-    DEBIAN_FRONTEND=noninteractive \
     PNPM_HOME=/usr/local/pnpm \
     PATH="/usr/local/pnpm:${PATH}" \
     npm_config_update_notifier=false
@@ -57,10 +58,6 @@ RUN --mount=type=cache,target=/var/lib/apt/lists/,sharing=private \
         "php${PHP_VERSION}-pcov" \
         "php${PHP_VERSION}-xml" \
         "php${PHP_VERSION}-zip" \
-        imagemagick \
-        libssl-dev \
-        libwebp-dev \
-        libavif-dev \
         rsync \
         locales \
         "nodejs$(apt-cache show nodejs | sed -n "/^Version: ${NODE_VERSION}-/ { s/^Version: /=/p; q }" )" \

--- a/tools/docker/Dockerfile.monorepo
+++ b/tools/docker/Dockerfile.monorepo
@@ -21,7 +21,7 @@ WORKDIR /app
 RUN --mount=type=cache,target=/var/lib/apt/lists/,sharing=private \
     # Setup repositories and keys
     apt-get update && apt-get install -y curl gpg language-pack-en-base ca-certificates \
-        --no-install-recommends software-properties-common \
+        software-properties-common \
     && add-apt-repository ppa:ondrej/php \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     # Add Docker's official GPG key

--- a/tools/docker/Dockerfile.monorepo
+++ b/tools/docker/Dockerfile.monorepo
@@ -54,10 +54,13 @@ RUN --mount=type=cache,target=/var/lib/apt/lists/,sharing=private \
         "php${PHP_VERSION}-pcov" \
         "php${PHP_VERSION}-xml" \
         "php${PHP_VERSION}-zip" \
-        rsync \
+        "imagemagick" \
+        "libssl-dev" \
+        "libwebp-dev" \
+        "libavif-dev" \
+        "rsync" \
     && apt-get remove --purge -y python3-apt \
     && apt-get remove --purge --auto-remove -y gpg software-properties-common \
-    && apt-get clean \
     && find /var/ -name '*-old' -delete && rm -rf /var/log/dpkg.log /var/log/alternatives.log /var/log/apt/ ~/.launchpadlib
 
 # Install Composer
@@ -73,7 +76,6 @@ RUN --mount=type=cache,target=/var/lib/apt/lists/,sharing=private \
     && apt-get -q update \
     && VER="$(apt-cache show nodejs | sed -n "/^Version: ${NODE_VERSION}-/ { s/^Version: /=/p; q }" )" \
     && apt-get install -y nodejs$VER \
-    && apt-get clean \
     && find /var/ -name '*-old' -delete && rm -rf /var/log/dpkg.log /var/log/alternatives.log /var/log/apt/ ~/.launchpadlib
 
 # Install pnpm
@@ -90,7 +92,6 @@ RUN chmod +x /usr/local/bin/monorepo-entrypoint.sh
 RUN apt-get update && apt-get install -y locales \
     && locale-gen en_US.UTF-8 \
     && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 \
-    && apt-get clean \
     && find /var/ -name '*-old' -delete && rm -rf /var/log/dpkg.log /var/log/alternatives.log /var/log/apt/ ~/.launchpadlib
 
 ENV LANG=en_US.UTF-8

--- a/tools/docker/Dockerfile.monorepo
+++ b/tools/docker/Dockerfile.monorepo
@@ -9,7 +9,10 @@ ARG PNPM_VERSION
 ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     JETPACK_MONOREPO_ENV=1 \
-    DEBIAN_FRONTEND=noninteractive
+    DEBIAN_FRONTEND=noninteractive \
+    PNPM_HOME=/usr/local/pnpm \
+    PATH="/usr/local/pnpm:${PATH}" \
+    npm_config_update_notifier=false
 
 WORKDIR /app
 
@@ -72,10 +75,9 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
     && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=$COMPOSER_VERSION \
     && php -r "unlink('composer-setup.php');"
 
-# Install PNPM and setup directories
-ENV PNPM_HOME=/usr/local/pnpm \
-    PATH="${PNPM_HOME}:${PATH}" \
-    npm_config_update_notifier=false
+# Set up PNPM global directory
+RUN mkdir -p "${PNPM_HOME}" \
+    && chmod 777 "${PNPM_HOME}"
 
 RUN npm install --global pnpm@$PNPM_VERSION \
     && SHELL=/bin/bash pnpm setup
@@ -91,10 +93,6 @@ RUN locale-gen en_US.UTF-8 \
     && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 \
     && find /var/ -name '*-old' -delete \
     && rm -rf /var/log/dpkg.log /var/log/alternatives.log /var/log/apt/ ~/.launchpadlib
-
-# Set up PNPM global directory
-RUN mkdir -p "$PNPM_HOME" \
-    && chmod 777 "$PNPM_HOME"
 
 ENTRYPOINT ["/usr/local/bin/monorepo-entrypoint.sh"]
 CMD ["bash"]

--- a/tools/docker/Dockerfile.monorepo
+++ b/tools/docker/Dockerfile.monorepo
@@ -8,28 +8,28 @@ ARG PNPM_VERSION
 
 ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
-    JETPACK_MONOREPO_ENV=1
+    JETPACK_MONOREPO_ENV=1 \
+    DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /app
 
-# Install basic packages and PHP
+# Combine all repository setup, package installation, and cleanup into one layer
 RUN --mount=type=cache,target=/var/lib/apt/lists/,sharing=private \
-    export DEBIAN_FRONTEND=noninteractive \
-    && apt-get update \
-    && apt-get install -y curl gpg language-pack-en-base ca-certificates \
-    # Install software-properties-common without recommended packages to avoid Python issues
-    && apt-get install -y --no-install-recommends software-properties-common \
+    # Setup repositories and keys
+    apt-get update && apt-get install -y curl gpg language-pack-en-base ca-certificates \
+        --no-install-recommends software-properties-common \
     && add-apt-repository ppa:ondrej/php \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     # Add Docker's official GPG key
     && install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
     && chmod a+r /etc/apt/keyrings/docker.asc \
-    # Add Docker repository
-    && echo \
-      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-      $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-      tee /etc/apt/sources.list.d/docker.list > /dev/null \
+    # Add repositories
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+       $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
+    && N=${NODE_VERSION%%.*} \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$N.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
+    # Install all packages
     && apt-get update \
     && apt-get --purge install -y \
         git \
@@ -54,31 +54,29 @@ RUN --mount=type=cache,target=/var/lib/apt/lists/,sharing=private \
         "php${PHP_VERSION}-pcov" \
         "php${PHP_VERSION}-xml" \
         "php${PHP_VERSION}-zip" \
-        "imagemagick" \
-        "libssl-dev" \
-        "libwebp-dev" \
-        "libavif-dev" \
-        "rsync" \
+        imagemagick \
+        libssl-dev \
+        libwebp-dev \
+        libavif-dev \
+        rsync \
+        locales \
+        "nodejs$(apt-cache show nodejs | sed -n "/^Version: ${NODE_VERSION}-/ { s/^Version: /=/p; q }" )" \
+    # Cleanup
     && apt-get remove --purge -y python3-apt \
     && apt-get remove --purge --auto-remove -y gpg software-properties-common \
-    && find /var/ -name '*-old' -delete && rm -rf /var/log/dpkg.log /var/log/alternatives.log /var/log/apt/ ~/.launchpadlib
+    && find /var/ -name '*-old' -delete \
+    && rm -rf /var/log/dpkg.log /var/log/alternatives.log /var/log/apt/ ~/.launchpadlib
 
 # Install Composer
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
     && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=$COMPOSER_VERSION \
     && php -r "unlink('composer-setup.php');"
 
-# Install Node.js
-RUN --mount=type=cache,target=/var/lib/apt/lists/,sharing=private \
-    export DEBIAN_FRONTEND=noninteractive \
-    && N=${NODE_VERSION%%.*} \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$N.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
-    && apt-get -q update \
-    && VER="$(apt-cache show nodejs | sed -n "/^Version: ${NODE_VERSION}-/ { s/^Version: /=/p; q }" )" \
-    && apt-get install -y nodejs$VER \
-    && find /var/ -name '*-old' -delete && rm -rf /var/log/dpkg.log /var/log/alternatives.log /var/log/apt/ ~/.launchpadlib
+# Install PNPM and setup directories
+ENV PNPM_HOME=/usr/local/pnpm \
+    PATH="${PNPM_HOME}:${PATH}" \
+    npm_config_update_notifier=false
 
-# Install pnpm
 RUN npm install --global pnpm@$PNPM_VERSION \
     && SHELL=/bin/bash pnpm setup
 
@@ -88,19 +86,13 @@ WORKDIR /workspace
 COPY bin/monorepo-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/monorepo-entrypoint.sh
 
-# Set up locale properly
-RUN apt-get update && apt-get install -y locales \
-    && locale-gen en_US.UTF-8 \
+# Set up locale
+RUN locale-gen en_US.UTF-8 \
     && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 \
-    && find /var/ -name '*-old' -delete && rm -rf /var/log/dpkg.log /var/log/alternatives.log /var/log/apt/ ~/.launchpadlib
-
-ENV LANG=en_US.UTF-8
-ENV LC_ALL=en_US.UTF-8
+    && find /var/ -name '*-old' -delete \
+    && rm -rf /var/log/dpkg.log /var/log/alternatives.log /var/log/apt/ ~/.launchpadlib
 
 # Set up PNPM global directory
-ENV PNPM_HOME=/usr/local/pnpm
-ENV PATH="${PNPM_HOME}:${PATH}"
-
 RUN mkdir -p "$PNPM_HOME" \
     && chmod 777 "$PNPM_HOME"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The new Dev Docker container need additional php extensions for WordPress (for unit testing/WorDBless) and code coverage.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add various PHP extensions.
* Adds a `npm_config_update_notifier` env var to prevent PNPM from alerting to update the in-docker pnpm version.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/41057#discussion_r1934703155

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `BUILD_LOCAL=1 jp test php packages/image-cdn -v`
* `BUILD_LOCAL=1 jp test coverage packages/image-cdn` (or any other package with PHP code coverage.
* Note: may need to delete local copies of the image within Docker to force the new build.

