### PR TITLE
Forms: Update date picker input to improve accessibility and remove the jquery dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2258,6 +2258,9 @@ importers:
       '@wordpress/data':
         specifier: 10.16.0
         version: 10.16.0(react@18.3.1)
+      '@wordpress/dom-ready':
+        specifier: 4.17.0
+        version: 4.17.0
       '@wordpress/element':
         specifier: 6.16.0
         version: 6.16.0
@@ -8328,6 +8331,10 @@ packages:
 
   '@wordpress/dom-ready@4.16.0':
     resolution: {integrity: sha512-rlp7gZRRPsob8z+//tS8bHHRTlkRiOfbKA1SJmyfakU/p4fcEXskLfdq/0wGPZtoHnia6kLKUyFMWhIBe8SuYQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/dom-ready@4.17.0':
+    resolution: {integrity: sha512-u/ocyrPV4MJIKxM1OJg+Q6yOBD0pIYi1jcXE1HVYnc/9Mte0IFlfovYRJj6oGUc7u4dM6AVE2BUCQMJgmG406Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/dom@3.58.0':
@@ -19240,7 +19247,7 @@ snapshots:
   '@wordpress/a11y@4.16.0':
     dependencies:
       '@babel/runtime': 7.25.7
-      '@wordpress/dom-ready': 4.16.0
+      '@wordpress/dom-ready': 4.17.0
       '@wordpress/i18n': 5.16.0
 
   '@wordpress/annotations@3.16.0(react@18.3.1)':
@@ -20451,6 +20458,10 @@ snapshots:
       '@babel/runtime': 7.25.7
 
   '@wordpress/dom-ready@4.16.0':
+    dependencies:
+      '@babel/runtime': 7.25.7
+
+  '@wordpress/dom-ready@4.17.0':
     dependencies:
       '@babel/runtime': 7.25.7
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2306,6 +2306,9 @@ importers:
       semver:
         specifier: 7.6.3
         version: 7.6.3
+      vanillajs-datepicker:
+        specifier: 1.3.4
+        version: 1.3.4
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@6.0.1)
@@ -14886,6 +14889,9 @@ packages:
   validator@13.12.0:
     resolution: {integrity: sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==}
     engines: {node: '>= 0.10'}
+
+  vanillajs-datepicker@1.3.4:
+    resolution: {integrity: sha512-waOyp2Ay+K1VA/B5cNlFgSNzFR9efCVKaoyMyNEAhAwmKLzMB9nCJs6Vqmo6HuHWA98VEHXbgz5thZ7hH/uohA==}
 
   varint@6.0.0:
     resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==}
@@ -29254,6 +29260,8 @@ snapshots:
       convert-source-map: 2.0.0
 
   validator@13.12.0: {}
+
+  vanillajs-datepicker@1.3.4: {}
 
   varint@6.0.0: {}
 

--- a/projects/packages/forms/changelog/update-date-picker-input
+++ b/projects/packages/forms/changelog/update-date-picker-input
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: Update datepicker to remove the dependency on jquery

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -39,6 +39,7 @@
 		"@wordpress/compose": "7.16.0",
 		"@wordpress/core-data": "7.16.0",
 		"@wordpress/data": "10.16.0",
+		"@wordpress/dom-ready": "4.17.0",
 		"@wordpress/element": "6.16.0",
 		"@wordpress/hooks": "4.16.0",
 		"@wordpress/i18n": "5.16.0",

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -55,6 +55,7 @@
 		"redux-thunk": "2.3.0",
 		"sass": "1.64.1",
 		"semver": "7.6.3",
+		"vanillajs-datepicker": "1.3.4",
 		"webpack": "5.94.0",
 		"webpack-cli": "6.0.1"
 	},

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -847,21 +847,24 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			'mm/dd/yy' => array(
 				/* translators: date format. DD is the day of the month, MM the month, and YYYY the year (e.g., 12/31/2023). */
 				'label' => __( 'MM/DD/YYYY', 'jetpack-forms' ),
+				'js'    => 'mm/dd/yyyy',
 			),
 			'dd/mm/yy' => array(
 				/* translators: date format. DD is the day of the month, MM the month, and YYYY the year (e.g., 31/12/2023). */
 				'label' => __( 'DD/MM/YYYY', 'jetpack-forms' ),
+				'js'    => 'dd/mm/yyyy',
 			),
 			'yy-mm-dd' => array(
 				/* translators: date format. DD is the day of the month, MM the month, and YYYY the year (e.g., 2023-12-31). */
 				'label' => __( 'YYYY-MM-DD', 'jetpack-forms' ),
+				'js'    => 'yyyy-mm-dd',
 			),
 		);
 
 		$date_format = $this->get_attribute( 'dateformat' );
 		$date_format = isset( $date_format ) && ! empty( $date_format ) ? $date_format : 'yy-mm-dd';
 		$label       = isset( $formats[ $date_format ] ) ? $label . ' (' . $formats[ $date_format ]['label'] . ')' : $label;
-		$extra_attrs = array( 'data-format' => $date_format );
+		$extra_attrs = array( 'data-format' => $formats[ $date_format ]['js'] );
 
 		$field  = $this->render_label( 'date', $id, $label, $required, $required_field_text );
 		$field .= $this->render_input_field( 'text', $id, $value, $class, $placeholder, $required, $extra_attrs );
@@ -886,8 +889,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'version'      => \JETPACK__VERSION,
 			)
 		);
-		// Using Core's built-in datepicker localization routine
-		wp_localize_jquery_ui_datepicker();
+
 		return $field;
 	}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -877,18 +877,15 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		}
 
 		Assets::register_script(
-			'grunion-frontend',
-			'../../dist/contact-form/js/grunion-frontend.js',
+			'datepicker-frontend',
+			'../../dist/contact-form/js/date-picker.js',
 			__FILE__,
 			array(
 				'enqueue'      => true,
-				'dependencies' => array( 'jquery', 'jquery-ui-datepicker' ),
+				'dependencies' => array(),
 				'version'      => \JETPACK__VERSION,
 			)
 		);
-
-		wp_enqueue_style( 'jp-jquery-ui-datepicker', plugins_url( '../../dist/contact-form/css/jquery-ui-datepicker.css', __FILE__ ), array( 'dashicons' ), '1.0' );
-
 		// Using Core's built-in datepicker localization routine
 		wp_localize_jquery_ui_datepicker();
 		return $field;

--- a/projects/packages/forms/src/contact-form/js/date-picker.js
+++ b/projects/packages/forms/src/contact-form/js/date-picker.js
@@ -1,6 +1,12 @@
+import domReady from '@wordpress/dom-ready';
 import Datepicker from 'vanillajs-datepicker/Datepicker';
 
 import 'vanillajs-datepicker/css/datepicker.css';
 
-const elem = document.querySelector( 'input.jp-contact-form-date' );
-new Datepicker( elem );
+domReady( () => {
+	const collection = document.getElementsByClassName( 'jp-contact-form-date' );
+	for ( let i = 0; i < collection.length; i++ ) {
+		const dateFormat = collection[ i ].getAttribute( 'data-format' );
+		new Datepicker( collection[ i ], { format: dateFormat } );
+	}
+} );

--- a/projects/packages/forms/src/contact-form/js/date-picker.js
+++ b/projects/packages/forms/src/contact-form/js/date-picker.js
@@ -1,0 +1,6 @@
+import Datepicker from 'vanillajs-datepicker/Datepicker';
+
+import 'vanillajs-datepicker/css/datepicker.css';
+
+const elem = document.querySelector( 'input.jp-contact-form-date' );
+new Datepicker( elem );

--- a/projects/plugins/jetpack/changelog/update-date-picker-input
+++ b/projects/plugins/jetpack/changelog/update-date-picker-input
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Update the date picker to be more accessible and not reply on jquery datepicker


### PR DESCRIPTION
⚠️  - WIP: Do not merge. 

Resolves https://github.com/Automattic/jetpack/issues/41081

![Screenshot 2025-01-29 at 8 23 44 PM](https://github.com/user-attachments/assets/7a19ad20-649d-4be5-852f-8e4c517f3272)

## Proposed changes:
* Update the date picker to be more accessible. Adds keyboard navigation
* Update to use less depenencies. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Load this PR. 
* Add the form block. 
* Add the date field. 
* Go to add the front end Notice that you can now use the keyboard to navigate to a particular date. 

