### PR TITLE
Forms: update form field and button blocks to support content only mode

### DIFF
--- a/projects/packages/forms/changelog/update-form-blocks-for-content-only-mode
+++ b/projects/packages/forms/changelog/update-form-blocks-for-content-only-mode
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Update fields and button blocks to support contentOnly editing.

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -31,6 +31,7 @@ const FieldDefaults = {
 		label: {
 			type: 'string',
 			default: null,
+			role: 'content',
 		},
 		required: {
 			type: 'boolean',
@@ -38,18 +39,22 @@ const FieldDefaults = {
 		},
 		requiredText: {
 			type: 'string',
+			role: 'content',
 		},
 		options: {
 			type: 'array',
 			default: [],
+			role: 'content',
 		},
 		defaultValue: {
 			type: 'string',
 			default: '',
+			role: 'content',
 		},
 		placeholder: {
 			type: 'string',
 			default: '',
+			role: 'content',
 		},
 		id: {
 			type: 'string',
@@ -366,6 +371,7 @@ export const childBlocks = [
 				label: {
 					type: 'string',
 					default: 'Text',
+					role: 'content',
 				},
 			},
 		},
@@ -388,6 +394,7 @@ export const childBlocks = [
 				label: {
 					type: 'string',
 					default: 'Name',
+					role: 'content',
 				},
 			},
 		},
@@ -409,6 +416,7 @@ export const childBlocks = [
 				label: {
 					type: 'string',
 					default: 'Email',
+					role: 'content',
 				},
 			},
 		},
@@ -435,6 +443,7 @@ export const childBlocks = [
 				label: {
 					type: 'string',
 					default: __( 'Website', 'jetpack-forms' ),
+					role: 'content',
 				},
 			},
 		},
@@ -464,6 +473,7 @@ export const childBlocks = [
 				label: {
 					type: 'string',
 					default: 'Date',
+					role: 'content',
 				},
 				dateFormat: {
 					type: 'string',
@@ -493,6 +503,7 @@ export const childBlocks = [
 				label: {
 					type: 'string',
 					default: 'Phone',
+					role: 'content',
 				},
 			},
 		},
@@ -542,6 +553,7 @@ export const childBlocks = [
 				label: {
 					type: 'string',
 					default: '',
+					role: 'content',
 				},
 			},
 		},
@@ -649,10 +661,12 @@ export const childBlocks = [
 				toggleLabel: {
 					type: 'string',
 					default: null,
+					role: 'content',
 				},
 				options: {
 					type: 'array',
 					default: [ '' ],
+					role: 'content',
 				},
 			},
 		},

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-choice/item/settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-choice/item/settings.js
@@ -4,6 +4,7 @@ export default {
 	attributes: {
 		label: {
 			type: 'string',
+			role: 'content',
 		},
 		fieldType: {
 			enum: [ 'checkbox', 'radio' ],

--- a/projects/plugins/jetpack/changelog/update-form-blocks-for-content-only-mode
+++ b/projects/plugins/jetpack/changelog/update-form-blocks-for-content-only-mode
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Update field and button blocks to support contentOnly editing.

--- a/projects/plugins/jetpack/extensions/blocks/button/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/button/attributes.js
@@ -17,12 +17,15 @@ export default {
 	},
 	text: {
 		type: 'string',
+		role: 'content',
 	},
 	placeholder: {
 		type: 'string',
+		role: 'content',
 	},
 	url: {
 		type: 'string',
+		role: 'content',
 	},
 	textColor: {
 		type: 'string',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #40955, see also #40040

## Proposed changes:
Makes the field and button blocks editable when using `contentOnly` editing.

To achieve this, certain block attributes (ones that are considered 'content') now have the `role: content` property added to them. This allows contentOnly mode to identify which blocks contain content, and make them editable (but with a pared back interface).

This is useful for a couple of different editing modes:
- If a form is within a group that has `templateLock: 'contentOnly'` set on it.
- If the experimental Write Mode feature is enabled and active, form fields are now editable.

At the moment, this is about all that can be achieved with the APIs currently available in Gutenberg and WordPress core.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
The main thing to check is that every field block type works as expected.
### `templateLock: contentOnly`
1. For this test you need a group block inserted with the `"templateLock": "contentOnly"` attribute. That group should contain a form, and that form should have pretty much every field type added. I've included the block markup for you so that you can copy/paste it into the 'Code Editor' within the block editor. Expand below to view and copy it: 
<details><summary>Expand here to view/copy block markup</summary>

```html
<!-- wp:group {"layout":{"type":"constrained"},"templateLock":"contentOnly"} -->
<div class="wp-block-group">
<!-- wp:jetpack/contact-form {"style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}}} -->
<div class="wp-block-jetpack-contact-form" style="padding-top:16px;padding-right:16px;padding-bottom:16px;padding-left:16px">
<!-- wp:jetpack/field-text /-->
<!-- wp:jetpack/field-name /-->
<!-- wp:jetpack/field-email /-->
<!-- wp:jetpack/field-url /-->
<!-- wp:jetpack/field-date /-->
<!-- wp:jetpack/field-telephone /-->
<!-- wp:jetpack/field-textarea {"label":""} /-->
<!-- wp:jetpack/field-checkbox /-->
<!-- wp:jetpack/field-consent /-->
<!-- wp:jetpack/field-radio -->
<div class="wp-block-jetpack-field-radio">
<!-- wp:jetpack/field-option-radio /-->
</div>
<!-- /wp:jetpack/field-radio -->
<!-- wp:jetpack/field-checkbox-multiple -->
<div class="wp-block-jetpack-field-checkbox-multiple">
<!-- wp:jetpack/field-option-checkbox /-->
</div>
<!-- /wp:jetpack/field-checkbox-multiple -->
<!-- wp:jetpack/field-select {"label":"","toggleLabel":"Select one option"} /-->
<!-- wp:jetpack/button {"element":"button","text":"Contact Us","lock":{"remove":true}} /--></div>
<!-- /wp:jetpack/contact-form -->
</div>
<!-- /wp:group -->
```

</details>

2. Click the fields and try to edit each one. Pretty much every field should be updatable, with a few minor exceptions:
- The block inspector for each field can't be reached (which is currently by design). 
- New single-choice radio or multi-choice checkboxes can't be added/removed. This is a limitation in core that's also present with blocks like List as well.
- The form block itself is not selectable (another limitation). We can technically also add `role: content` to the form block, but the UI ends up a bit buggy, as contentOnly doesn't properly support parent blocks that have this role.

### Write Mode
1. For this you need to enable a Gutenberg experiment, so a local dev environment that has the Gutenberg plugin installed is probably the best place to test. From wp-admin, navigate to `Gutenberg > Experiments` and toggle on the 'Simplified site editing' experiment.
2. Open the Site Editor and edit a template like the Homepage/Blog Home.
3. On the top bar, between the `+` button and the 'Undo' button, you should see a 'Tools' dropdown. Open this and ensure 'Design' is selected.
4. Open List View. If you're in a template, in most themes you'll have a Header, Group, and Footer as the top level blocks. Insert a Form into the Group, and add every type of field and a button to the form.
5. Open the tools dropdown again and switch to 'Design'
6. Now try editing the form, you should see it works similarly to the 'contentOnly' template lock test above. For this test, the Form block should be selectable if it was inserted in the write place (this is because it's considered a 'section', and it's a little hard to explain!).

