### PR TITLE
Social | Use feature flag for social admin page

### DIFF
--- a/projects/packages/publicize/changelog/update-social-use-feature-flag-for-social-admin-page
+++ b/projects/packages/publicize/changelog/update-social-use-feature-flag-for-social-admin-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Use feature flag for social admin page

--- a/projects/packages/publicize/src/class-social-admin-page.php
+++ b/projects/packages/publicize/src/class-social-admin-page.php
@@ -80,9 +80,7 @@ class Social_Admin_Page {
 	 */
 	public function add_menu() {
 
-		$show_admin_page = class_exists( \Jetpack_Social::class ) || Publicize_Script_Data::has_feature_flag( 'admin-page' );
-
-		if ( ! $show_admin_page ) {
+		if ( ! Publicize_Script_Data::has_feature_flag( 'admin-page' ) ) {
 			return;
 		}
 

--- a/projects/packages/publicize/src/class-social-admin-page.php
+++ b/projects/packages/publicize/src/class-social-admin-page.php
@@ -80,7 +80,9 @@ class Social_Admin_Page {
 	 */
 	public function add_menu() {
 
-		if ( ! Publicize_Script_Data::has_feature_flag( 'admin-page' ) ) {
+		$show_admin_page = class_exists( \Jetpack_Social::class ) || Publicize_Script_Data::has_feature_flag( 'admin-page' );
+
+		if ( ! $show_admin_page ) {
 			return;
 		}
 

--- a/projects/packages/publicize/src/class-social-admin-page.php
+++ b/projects/packages/publicize/src/class-social-admin-page.php
@@ -80,9 +80,7 @@ class Social_Admin_Page {
 	 */
 	public function add_menu() {
 
-		// TODO Remove this check once we are ready to always have the menu/page.
-		if ( ! defined( 'JETPACK_SOCIAL_PLUGIN_DIR' ) ) {
-			// For now, the menu/page is added only if the Social plugin is active.
+		if ( ! Publicize_Script_Data::has_feature_flag( 'admin-page' ) ) {
 			return;
 		}
 

--- a/projects/plugins/wpcomsh/changelog/update-social-use-feature-flag-for-social-admin-page
+++ b/projects/plugins/wpcomsh/changelog/update-social-use-feature-flag-for-social-admin-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Use feature flag for social admin page

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -416,6 +416,7 @@ class WPCOM_Features {
 	public const SFTP                              = 'sftp';
 	public const SIMPLE_PAYMENTS                   = 'simple-payments';
 	public const SITE_PREVIEW_LINKS                = 'site-preview-links';
+	public const SOCIAL_ADMIN_PAGE                 = 'social-admin-page';
 	public const SOCIAL_IMAGE_GENERATOR            = 'social-image-generator';
 	public const SOCIAL_PREVIEWS                   = 'social-previews';
 	public const SOCIAL_SHARES_1000                = 'social-shares-1000';

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -1069,6 +1069,14 @@ class WPCOM_Features {
 			self::JETPACK_SOCIAL_PLANS,
 			self::JETPACK_GROWTH_PLANS,
 		),
+		self::SOCIAL_ADMIN_PAGE                 => array(
+			array(
+				// This feature isn't launched yet, so we're ensuring that it's not available on any plans.
+				'before' => '1900-01-01',
+				self::WPCOM_ALL_SITES,
+				self::JETPACK_ALL_SITES,
+			),
+		),
 		self::SOCIAL_MASTODON_CONNECTION        => array(
 			array(
 				// This feature isn't launched yet, so we're ensuring that it's not available on any plans.

--- a/tools/docker/jetpack-docker-config-default.yml
+++ b/tools/docker/jetpack-docker-config-default.yml
@@ -66,3 +66,4 @@ e2e:
     projects/plugins/boost/tests/e2e/plugins/e2e-mock-speed-score-api.php: /var/www/html/wp-content/plugins/e2e-mock-speed-score-api.php
     tools/e2e-commons/plugins/e2e-search-test-helper.php: /var/www/html/wp-content/plugins/e2e-search-test-helper.php
     tools/e2e-commons/plugins/e2e-wpcom-request-interceptor.php: /var/www/html/wp-content/plugins/e2e-wpcom-request-interceptor.php
+    tools/e2e-commons/plugins/e2e-social-config.php: /var/www/html/wp-content/plugins/e2e-social-config.php

--- a/tools/e2e-commons/bin/e2e-env.sh
+++ b/tools/e2e-commons/bin/e2e-env.sh
@@ -62,6 +62,7 @@ configure_wp_env() {
 	$BASE_CMD wp plugin activate e2e-waf-data-interceptor
 	$BASE_CMD wp plugin activate e2e-search-test-helper
 	$BASE_CMD wp plugin activate e2e-wpcom-request-interceptor
+	$BASE_CMD wp plugin activate e2e-social-config
 	if [ "${1}" == "--activate-plugins" ]; then
 		shift
 		for var in "$@"; do

--- a/tools/e2e-commons/plugins/e2e-social-config.php
+++ b/tools/e2e-commons/plugins/e2e-social-config.php
@@ -9,7 +9,11 @@
  * @package automattic/jetpack
  */
 
-// Define feature flags.
+/**
+ * Define feature flags.
+ *
+ * @see https://github.com/Automattic/jetpack/blob/58853303c0175fb95823ad3b892295091324b8d6/projects/packages/publicize/src/class-publicize-script-data.php#L257-L272
+ */
 if ( ! defined( 'JETPACK_SOCIAL_HAS_ADMIN_PAGE' ) ) {
 	define( 'JETPACK_SOCIAL_HAS_ADMIN_PAGE', true );
 }

--- a/tools/e2e-commons/plugins/e2e-social-config.php
+++ b/tools/e2e-commons/plugins/e2e-social-config.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Plugin Name: Social E2E config
+ * Plugin URI: https://github.com/automattic/jetpack
+ * Author: Jetpack Team
+ * Version: 1.0.0
+ * Text Domain: jetpack
+ *
+ * @package automattic/jetpack
+ */
+
+// Define feature flags.
+if ( ! defined( 'JETPACK_SOCIAL_HAS_ADMIN_PAGE' ) ) {
+	define( 'JETPACK_SOCIAL_HAS_ADMIN_PAGE', true );
+}


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use feature flag to display the Social admin page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply 171564-ghe-Automattic/wpcom to your sandbox
* Apply this PR to your sandbox on top of the above PR instead of on trunk
* Activate Social and deactivate Jetpack
* Goto Social admin page
* Confirm that it's accessible when Social plugin is active
* Now deactivate Social plugin and activate Jetpack plugin
* Confirm that the social admin page is not accessible
* Add the blog sticker to your site
    - `wpsh`
    - `add_blog_sticker( 'jetpack-social-admin-page', null, null, blog-id-here );`
* Goto **My Plan** page to refresh the feature set - `wp-admin/admin.php?page=jetpack#/my-plan`
* Goto Social admin page
* Confirm that it's now accessible
* Remove the feature flag and refresh the feature set
* Confirm that the page is not accessible
* Test that the feature flag works for WPCOM sites as well.