### PR TITLE
Forms: Fix field widths and spacing in the editor

### DIFF
--- a/projects/packages/forms/changelog/fix-form-field-widths
+++ b/projects/packages/forms/changelog/fix-form-field-widths
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix field spacing and widths.

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -41,7 +41,7 @@
 		}
 	}
 
-	.block-editor-inner-blocks > .block-editor-block-list__layout {
+	.block-editor-block-list__layout {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: flex-start;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -581,10 +581,7 @@
 .block-editor-inserter__preview {
 	.jetpack-contact-form {
 		padding: 16px;
-
-		.block-editor-inner-blocks .block-editor-block-list__layout {
-			margin: 0;
-		}
+		margin: 0;
 	}
 }
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -577,14 +577,6 @@
 	}
 }
 
-// Overrides to make the preview look good
-.block-editor-inserter__preview {
-	.jetpack-contact-form {
-		padding: 16px;
-		margin: 0;
-	}
-}
-
 // Make sure form settings dropdown looks good on older Gutenberg versions
 .jetpack-contact-form__popover .components-popover__content {
 	min-width: 260px;

--- a/projects/plugins/jetpack/changelog/fix-form-field-widths
+++ b/projects/plugins/jetpack/changelog/fix-form-field-widths
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix field spacing and widths.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #41414

## Proposed changes:
The previously merged PR #41348, seems to have broken the form styles in the editor.

Lots of the styles target the `.block-editor-inner-blocks` classname, which is no longer present after the switch to `useInnerBlocksProps`.

The block's styles shouldn't really be targeting the block editor's own internal class names, and instead add its own class names (`jetpack-form-inner-blocks`), but this PR is a quick fix to get things working again rather than a full refactor.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Add a contact form in the editor
2. Set two neighbouring fields to 50% or 75/25 so that they're on the same row.
3. The forms should visually update their size (in trunk they stay at 100%)
4. Also note the fields have padding between them, in trunk they're very close together.