### PR TITLE
My Jetpack: Fix Current_Plan::get() not getting current/latest plan. Cache stuck.

### DIFF
--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-paid-plan-needs-plugin-install-activation-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-paid-plan-needs-plugin-install-activation-notice.tsx
@@ -57,13 +57,14 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 	} = getMyJetpackWindowInitialState();
 
 	const getPluginInfo = useCallback(
-		productSlug => ( {
+		( productSlug, action ) => ( {
 			productSlug: productSlug,
 			pluginSlug: products[ productSlug ].plugin_slug,
 			pluginName:
 				products[ productSlug ].plugin_slug === 'jetpack'
 					? 'Jetpack'
 					: products[ productSlug ].title,
+			action,
 			pluginUri: `https://wordpress.org/plugins/${ products[ productSlug ].plugin_slug }/`,
 		} ),
 		[ products ]
@@ -72,18 +73,25 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 	const pluginsList = useMemo( () => {
 		if ( needs_installed && needs_activated_only ) {
 			const slugs = new Set();
-			return [ ...needs_installed, ...needs_activated_only ]
-				.map( getPluginInfo )
-				.filter( ( { pluginSlug } ) => ! slugs.has( pluginSlug ) && slugs.add( pluginSlug ) ); // filters out duplicates
+			const needsInstalled = [ ...needs_installed ].map( productSlug =>
+				getPluginInfo( productSlug, 'install' )
+			);
+			const needsActivated = [ ...needs_activated_only ].map( productSlug =>
+				getPluginInfo( productSlug, 'activate' )
+			);
+			return [ ...needsInstalled, ...needsActivated ].filter(
+				// filters out duplicates
+				( { pluginSlug } ) => ! slugs.has( pluginSlug ) && slugs.add( pluginSlug )
+			);
 		} else if ( needs_installed ) {
 			const slugs = new Set();
 			return needs_installed
-				.map( getPluginInfo )
+				.map( productSlug => getPluginInfo( productSlug, 'install' ) )
 				.filter( ( { pluginSlug } ) => ! slugs.has( pluginSlug ) && slugs.add( pluginSlug ) );
 		}
 		const slugs = new Set();
 		return needs_activated_only
-			?.map( getPluginInfo )
+			?.map( productSlug => getPluginInfo( productSlug, 'activate' ) )
 			.filter( ( { pluginSlug } ) => ! slugs.has( pluginSlug ) && slugs.add( pluginSlug ) );
 	}, [ getPluginInfo, needs_activated_only, needs_installed ] );
 
@@ -184,18 +192,30 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 						) }
 					</Text>
 					<ul className="plugins-list">
-						{ pluginsList.map( ( pluginInfo, index ) => (
-							<li key={ index } className="plugin-item">
-								{ actionVerb === 'activate' ? (
-									<a href="/wp-admin/plugins.php">{ pluginInfo.pluginName }</a>
-								) : (
-									<ExternalLink href={ pluginInfo.pluginUri }>
-										{ pluginInfo.pluginName }
-									</ExternalLink>
-								) }
-								<span>(Needs { actionNoun })</span>
-							</li>
-						) ) }
+						{ pluginsList.map( ( pluginInfo, index ) => {
+							const pluginActionNoun =
+								pluginInfo.action === 'activate' ? 'activated' : 'installed and activated';
+							return (
+								<li key={ index } className="plugin-item">
+									{ pluginInfo.action === 'activate' ? (
+										<a href="/wp-admin/plugins.php">{ pluginInfo.pluginName }</a>
+									) : (
+										<ExternalLink href={ pluginInfo.pluginUri }>
+											{ pluginInfo.pluginName }
+										</ExternalLink>
+									) }
+									<span>
+										(
+										{ sprintf(
+											/* translators: %s is the word "activated" or words "installed and activated". */
+											__( 'Needs %s', 'jetpack-my-jetpack' ),
+											pluginActionNoun
+										) }
+										)
+									</span>
+								</li>
+							);
+						} ) }
 					</ul>
 				</Col>
 			</>

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-paid-plan-needs-plugin-install-activation-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-paid-plan-needs-plugin-install-activation-notice.tsx
@@ -57,14 +57,13 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 	} = getMyJetpackWindowInitialState();
 
 	const getPluginInfo = useCallback(
-		( productSlug, action ) => ( {
+		productSlug => ( {
 			productSlug: productSlug,
 			pluginSlug: products[ productSlug ].plugin_slug,
 			pluginName:
 				products[ productSlug ].plugin_slug === 'jetpack'
 					? 'Jetpack'
 					: products[ productSlug ].title,
-			action,
 			pluginUri: `https://wordpress.org/plugins/${ products[ productSlug ].plugin_slug }/`,
 		} ),
 		[ products ]
@@ -73,25 +72,18 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 	const pluginsList = useMemo( () => {
 		if ( needs_installed && needs_activated_only ) {
 			const slugs = new Set();
-			const needsInstalled = [ ...needs_installed ].map( productSlug =>
-				getPluginInfo( productSlug, 'install' )
-			);
-			const needsActivated = [ ...needs_activated_only ].map( productSlug =>
-				getPluginInfo( productSlug, 'activate' )
-			);
-			return [ ...needsInstalled, ...needsActivated ].filter(
-				// filters out duplicates
-				( { pluginSlug } ) => ! slugs.has( pluginSlug ) && slugs.add( pluginSlug )
-			);
+			return [ ...needs_installed, ...needs_activated_only ]
+				.map( getPluginInfo )
+				.filter( ( { pluginSlug } ) => ! slugs.has( pluginSlug ) && slugs.add( pluginSlug ) ); // filters out duplicates
 		} else if ( needs_installed ) {
 			const slugs = new Set();
 			return needs_installed
-				.map( productSlug => getPluginInfo( productSlug, 'install' ) )
+				.map( getPluginInfo )
 				.filter( ( { pluginSlug } ) => ! slugs.has( pluginSlug ) && slugs.add( pluginSlug ) );
 		}
 		const slugs = new Set();
 		return needs_activated_only
-			?.map( productSlug => getPluginInfo( productSlug, 'activate' ) )
+			?.map( getPluginInfo )
 			.filter( ( { pluginSlug } ) => ! slugs.has( pluginSlug ) && slugs.add( pluginSlug ) );
 	}, [ getPluginInfo, needs_activated_only, needs_installed ] );
 
@@ -192,30 +184,18 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 						) }
 					</Text>
 					<ul className="plugins-list">
-						{ pluginsList.map( ( pluginInfo, index ) => {
-							const pluginActionNoun =
-								pluginInfo.action === 'activate' ? 'activated' : 'installed and activated';
-							return (
-								<li key={ index } className="plugin-item">
-									{ pluginInfo.action === 'activate' ? (
-										<a href="/wp-admin/plugins.php">{ pluginInfo.pluginName }</a>
-									) : (
-										<ExternalLink href={ pluginInfo.pluginUri }>
-											{ pluginInfo.pluginName }
-										</ExternalLink>
-									) }
-									<span>
-										(
-										{ sprintf(
-											/* translators: %s is the word "activated" or words "installed and activated". */
-											__( 'Needs %s', 'jetpack-my-jetpack' ),
-											pluginActionNoun
-										) }
-										)
-									</span>
-								</li>
-							);
-						} ) }
+						{ pluginsList.map( ( pluginInfo, index ) => (
+							<li key={ index } className="plugin-item">
+								{ actionVerb === 'activate' ? (
+									<a href="/wp-admin/plugins.php">{ pluginInfo.pluginName }</a>
+								) : (
+									<ExternalLink href={ pluginInfo.pluginUri }>
+										{ pluginInfo.pluginName }
+									</ExternalLink>
+								) }
+								<span>(Needs { actionNoun })</span>
+							</li>
+						) ) }
 					</ul>
 				</Col>
 			</>

--- a/projects/packages/my-jetpack/changelog/fix-mj-current-plan-not-updated
+++ b/projects/packages/my-jetpack/changelog/fix-mj-current-plan-not-updated
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Change not visible or relevant to users
+
+

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -346,7 +346,7 @@ class Wpcom_Products {
 		$body      = wp_remote_retrieve_body( $response );
 		$purchases = json_decode( $body );
 		// Set short transient to help with repeated lookups on the same page load
-		set_transient( self::MY_JETPACK_PURCHASES_TRANSIENT_KEY, $purchases, 360 );
+		set_transient( self::MY_JETPACK_PURCHASES_TRANSIENT_KEY, $purchases, 5 );
 
 		return $purchases;
 	}
@@ -370,7 +370,7 @@ class Wpcom_Products {
 
 		Current_Plan::refresh_from_wpcom();
 		$current_plan = Current_Plan::get();
-		set_transient( self::MY_JETPACK_CURRENT_PLAN_TRANSIENT_KEY, $current_plan, 5 );
+		set_transient( self::MY_JETPACK_CURRENT_PLAN_TRANSIENT_KEY, $current_plan, 360 );
 
 		return $current_plan;
 	}

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -351,29 +351,19 @@ class Wpcom_Products {
 	}
 
 	/**
-	 * Check to see if the site supports a feature (using Current_Plan class)
-	 * This will check the features provided by the site plans and products (including free ones)
-	 *
-	 * @param string $feature - the feature to check for.
-	 * @return bool
-	 */
-	public static function current_plan_supports( $feature ) {
-		static $has_refreshed = null;
-
-		if ( $has_refreshed !== null ) {
-			return Current_Plan::supports( $feature );
-		}
-
-		$has_refreshed = true;
-		return Current_Plan::supports( $feature, true );
-	}
-
-	/**
 	 * Gets the site's currently active "plan" (bundle).
 	 *
+	 * @param bool $reload  Whether to refresh data from wpcom or not.
 	 * @return array
 	 */
-	public static function get_site_current_plan() {
+	public static function get_site_current_plan( $reload = false ) {
+		static $reloaded_already = false;
+
+		if ( $reload && ! $reloaded_already ) {
+			Current_Plan::refresh_from_wpcom();
+			$reloaded_already = true;
+		}
+
 		return Current_Plan::get();
 	}
 

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -34,8 +34,7 @@ class Wpcom_Products {
 
 	const CACHE_CHECK_HASH_NAME = 'my-jetpack-wpcom-product-check-hash';
 
-	const MY_JETPACK_PURCHASES_TRANSIENT_KEY    = 'my-jetpack-purchases';
-	const MY_JETPACK_CURRENT_PLAN_TRANSIENT_KEY = 'my-jetpack-current-plan';
+	const MY_JETPACK_PURCHASES_TRANSIENT_KEY = 'my-jetpack-purchases';
 
 	/**
 	 * Store the data on failed WPCOM requests.
@@ -354,25 +353,18 @@ class Wpcom_Products {
 	/**
 	 * Gets the site's currently active "plan" (bundle).
 	 *
+	 * @param bool $reload  Whether to refresh data from wpcom or not.
 	 * @return array
 	 */
-	public static function get_site_current_plan() {
-		static $current_plan = null;
+	public static function get_site_current_plan( $reload = false ) {
+		static $reloaded_already = false;
 
-		if ( $current_plan !== null ) {
-			return $current_plan;
+		if ( $reload && ! $reloaded_already ) {
+			Current_Plan::refresh_from_wpcom();
+			$reloaded_already = true;
 		}
 
-		$stored_plan = get_transient( self::MY_JETPACK_CURRENT_PLAN_TRANSIENT_KEY );
-		if ( $stored_plan !== false ) {
-			return $stored_plan;
-		}
-
-		Current_Plan::refresh_from_wpcom();
-		$current_plan = Current_Plan::get();
-		set_transient( self::MY_JETPACK_CURRENT_PLAN_TRANSIENT_KEY, $current_plan, 360 );
-
-		return $current_plan;
+		return Current_Plan::get();
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -351,6 +351,24 @@ class Wpcom_Products {
 	}
 
 	/**
+	 * Check to see if the site supports a feature (using Current_Plan class)
+	 * This will check the features provided by the site plans and products (including free ones)
+	 *
+	 * @param string $feature - the feature to check for.
+	 * @return bool
+	 */
+	public static function current_plan_supports( $feature ) {
+		static $has_refreshed = null;
+
+		if ( $has_refreshed !== null ) {
+			return Current_Plan::supports( $feature );
+		}
+
+		$has_refreshed = true;
+		return Current_Plan::supports( $feature, true );
+	}
+
+	/**
 	 * Gets the site's currently active "plan" (bundle).
 	 *
 	 * @return array

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -34,7 +34,8 @@ class Wpcom_Products {
 
 	const CACHE_CHECK_HASH_NAME = 'my-jetpack-wpcom-product-check-hash';
 
-	const MY_JETPACK_PURCHASES_TRANSIENT_KEY = 'my-jetpack-purchases';
+	const MY_JETPACK_PURCHASES_TRANSIENT_KEY    = 'my-jetpack-purchases';
+	const MY_JETPACK_CURRENT_PLAN_TRANSIENT_KEY = 'my-jetpack-current-plan';
 
 	/**
 	 * Store the data on failed WPCOM requests.
@@ -353,18 +354,25 @@ class Wpcom_Products {
 	/**
 	 * Gets the site's currently active "plan" (bundle).
 	 *
-	 * @param bool $reload  Whether to refresh data from wpcom or not.
 	 * @return array
 	 */
-	public static function get_site_current_plan( $reload = false ) {
-		static $reloaded_already = false;
+	public static function get_site_current_plan() {
+		static $current_plan = null;
 
-		if ( $reload && ! $reloaded_already ) {
-			Current_Plan::refresh_from_wpcom();
-			$reloaded_already = true;
+		if ( $current_plan !== null ) {
+			return $current_plan;
 		}
 
-		return Current_Plan::get();
+		$stored_plan = get_transient( self::MY_JETPACK_CURRENT_PLAN_TRANSIENT_KEY );
+		if ( $stored_plan !== false ) {
+			return $stored_plan;
+		}
+
+		Current_Plan::refresh_from_wpcom();
+		$current_plan = Current_Plan::get();
+		set_transient( self::MY_JETPACK_CURRENT_PLAN_TRANSIENT_KEY, $current_plan, 5 );
+
+		return $current_plan;
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -346,7 +346,7 @@ class Wpcom_Products {
 		$body      = wp_remote_retrieve_body( $response );
 		$purchases = json_decode( $body );
 		// Set short transient to help with repeated lookups on the same page load
-		set_transient( self::MY_JETPACK_PURCHASES_TRANSIENT_KEY, $purchases, 5 );
+		set_transient( self::MY_JETPACK_PURCHASES_TRANSIENT_KEY, $purchases, 360 );
 
 		return $purchases;
 	}

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -514,7 +514,7 @@ abstract class Product {
 			return array();
 		}
 		$paid_bundles   = $features['available']->$idendifying_feature ?? array();
-		$current_bundle = Wpcom_Products::get_site_current_plan();
+		$current_bundle = Wpcom_Products::get_site_current_plan( true );
 
 		if ( in_array( static::$feature_identifying_paid_plan, $current_bundle['features']['active'], true ) ) {
 			$paid_bundles[] = $current_bundle['product_slug'];

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -514,7 +514,7 @@ abstract class Product {
 			return array();
 		}
 		$paid_bundles   = $features['available']->$idendifying_feature ?? array();
-		$current_bundle = Wpcom_Products::get_site_current_plan( true );
+		$current_bundle = Wpcom_Products::get_site_current_plan();
 
 		if ( in_array( static::$feature_identifying_paid_plan, $current_bundle['features']['active'], true ) ) {
 			$paid_bundles[] = $current_bundle['product_slug'];

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -435,7 +435,7 @@ abstract class Product {
 	public static function has_paid_plan_for_product() {
 		// First check site features (if there's a feature that identifies the paid plan)
 		if ( static::$feature_identifying_paid_plan ) {
-			if ( static::does_site_have_feature( static::$feature_identifying_paid_plan ) ) {
+			if ( Wpcom_Products::current_plan_supports( static::$feature_identifying_paid_plan ) ) {
 				return true;
 			}
 		}

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -435,7 +435,7 @@ abstract class Product {
 	public static function has_paid_plan_for_product() {
 		// First check site features (if there's a feature that identifies the paid plan)
 		if ( static::$feature_identifying_paid_plan ) {
-			if ( Wpcom_Products::current_plan_supports( static::$feature_identifying_paid_plan ) ) {
+			if ( static::does_site_have_feature( static::$feature_identifying_paid_plan ) ) {
 				return true;
 			}
 		}
@@ -514,7 +514,7 @@ abstract class Product {
 			return array();
 		}
 		$paid_bundles   = $features['available']->$idendifying_feature ?? array();
-		$current_bundle = Wpcom_Products::get_site_current_plan();
+		$current_bundle = Wpcom_Products::get_site_current_plan( true );
 
 		if ( in_array( static::$feature_identifying_paid_plan, $current_bundle['features']['active'], true ) ) {
 			$paid_bundles[] = $current_bundle['product_slug'];


### PR DESCRIPTION
This PR fixes an issue in My Jetpack that is causing incorrect results in `[Product class]::get_paid_bundles_that_include_product()` which in turn produces the wrong result in `[Product class]:get_paid_purchase_for_product()`, which ultimately is affecting the red-bubble `alert_if_paid_plan_requires_plugin_install_or_activation()` causing the red-bubble notice/banner to report the incorrect plugins needing installed or activated (because `Current_Plan::get()` is stuck cached and always returning a stale result (See also: p1738167022814599/1738164593.019149-slack-C07RQ9B3UFK).

This bug/issue was first introduced in a bug-fix PR: [Package protect-status: Fix Current_Plan::supports from busting cache on every call](https://github.com/Automattic/jetpack/pull/41010), which prevents `Current_Plan::supports()` from pulling new wpcom api data on every call, basically allowing the result to be cached.  Issue discussion here: p1736794507070729-slack-C02LK1W8T4Z
The problem is, now `Current_Plan::supports()` is now over-aggressively cached and only always returning stale results (in My Jetpack) after purchasing (or removing) a new paid plan/bundle.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* In My Jetpack, update `static::get_site_current_plan(...)` to refresh the data from wpcom. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

It would be best to test this PR with your local Jetpack dev environment (via Docker), as opposed to Jurassic Ninja

1. Running the latest `trunk` branch (Bleeding edge).
2. Make sure only the VideoPress plugin is active. (Jetpack plugin **not** active, only VideoPress active).
3. Make sure Jetpack is connected (both site and user).
4. First make sure your site has no paid plans (only Jetpack Free).
5. From Jetpack root, run `jetpack docker wp option get jetpack_active_plan`
6. If the returned active plan is Not Jetpack Free, do the following steps:
    - Checkout this branch: `git checkout fix/mj-current-plan-not-updated`
    - Load/open the My Jetpack page.
    - Now checkout `trunk` branch again.
    - Run `jetpack docker wp option get jetpack_active_plan`, confirm Jetpack Free is the active plan
7. Purchase Jetpack Complete plan.
8. Open My Jetpack.
9. See/confirm that the plugin activation/installation notice is showing, and that it's saying only "CRM" needs activated. See screenshot:
10. ![Screen Shot 2025-01-30 at 13 38 00](https://github.com/user-attachments/assets/84163d28-21c3-42ff-9ec5-cc5071d1b4b4)
11. You can run `jetpack docker wp option get jetpack_active_plan` again, and confirm that the active plan is still Jetpack Free, even though you purchased Jetpack Complete. This is the bug. The `Current_Plan::get()` is stuck with stale data.
12. Now checkout this PR branch: `git checkout fix/mj-current-plan-not-updated`
13. Reload My Jetpack page.
14. See that the plugin activation/installation notice is now showing all the Jetpack plugins needing activated. See screenshot:
15. ![Screen Shot 2025-01-30 at 13 47 25](https://github.com/user-attachments/assets/7bba7413-7ff1-4a85-bc92-f30e54e317c4)
16. You can run `jetpack docker wp option get jetpack_active_plan` again, to confirm that the active plan is now refreshed to the correct plan, "Jetpack Complete".
17. Activate the "Jetpack" plugin. You should now see that only Akismet, Boost, and CRM are the required plugins needing activated for Jetpack Complete to function fully. See screenshot:
18. ![Screen Shot on 2025-01-30 at 13-57-26](https://github.com/user-attachments/assets/da03d019-c171-4db3-9c36-2bea7c3ec6af)

