### PR TITLE
Admin UI | Add remove_menu to Admin_Menu class

### DIFF
--- a/projects/packages/admin-ui/changelog/add-remove_menu-to-admin_menu-class
+++ b/projects/packages/admin-ui/changelog/add-remove_menu-to-admin_menu-class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added remove_menu method to Admin_Menu class

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -174,6 +174,26 @@ class Admin_Menu {
 	}
 
 	/**
+	 * Removes an already added submenu
+	 *
+	 * @param string $menu_slug   The slug of the submenu to remove.
+	 *
+	 * @return array|false The removed submenu on success, false if not found.
+	 */
+	public static function remove_menu( $menu_slug ) {
+
+		foreach ( self::$menu_items as $index => $menu_item ) {
+			if ( $menu_item['menu_slug'] === $menu_slug ) {
+				unset( self::$menu_items[ $index ] );
+
+				return $menu_item;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Gets the slug for the first item under the Jetpack top level menu
 	 *
 	 * @return string|null

--- a/projects/packages/publicize/changelog/add-remove_menu-to-admin_menu-class
+++ b/projects/packages/publicize/changelog/add-remove_menu-to-admin_menu-class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use Admin_Menu::remove_menu to handle old Social menu item

--- a/projects/packages/publicize/src/class-social-admin-page.php
+++ b/projects/packages/publicize/src/class-social-admin-page.php
@@ -40,39 +40,6 @@ class Social_Admin_Page {
 	 */
 	private function __construct() {
 		add_action( 'admin_menu', array( $this, 'add_menu' ) );
-
-		/**
-		 * Admin_Menu::add_menu uses 1000, so we use 2000
-		 * to ensure we remove the old Social menu item after it has been added.
-		 */
-		add_action( 'admin_menu', array( $this, 'remove_old_social_menu_item' ), 2000 );
-	}
-
-	/**
-	 * Remove the page added by old versions of Social.
-	 */
-	public function remove_old_social_menu_item() {
-
-		$social_version = Publicize_Script_Data::get_plugin_info()['social']['version'];
-
-		// If it's the old social version, remove the submenu page.
-		// TODO Update the version and operator before next Social release.
-		if ( $social_version && version_compare( $social_version, '6.1.0', '<' ) ) {
-			/**
-			 * `add_submenu_page` allows multiple submenus with the same slug,
-			 * but `remove_submenu_page` only removes the first one it finds with the given slug.
-			 *
-			 * We add the menu using `admin_menu` hook unlike the old Social plugin,
-			 * which used the `init` hook, which runs before `admin_menu`.
-			 * So, the old Social plugin's menu is before the new one in $submenu global.
-			 *
-			 * So, `remove_submenu_page` should remove the menu added by the old Social plugin.
-			 *
-			 * @see https://developer.wordpress.org/reference/functions/add_submenu_page
-			 * @see https://developer.wordpress.org/reference/functions/remove_submenu_page
-			 */
-			remove_submenu_page( 'jetpack', 'jetpack-social' );
-		}
 	}
 
 	/**
@@ -85,6 +52,9 @@ class Social_Admin_Page {
 			// For now, the menu/page is added only if the Social plugin is active.
 			return;
 		}
+
+		// Remove the old Social menu item, if it exists.
+		Admin_Menu::remove_menu( 'jetpack-social' );
 
 		$page_suffix = Admin_Menu::add_menu(
 			__( 'Jetpack Social', 'jetpack-publicize-pkg' ),


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `remove_menu` method to `Admin_Menu` class
* Use `Admin_Menu::remove_menu` to handle old Social menu item

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate Jetpack bleeding edge and Social latest stable (`v6.1.0`)
* You should see Social menu item twice under Jetpack
* Switch Jetpack to this PR
* Confirm that the Social menu item is now only once
* Switch Social to this PR
* Confirm that the item is still added once
* Deactivate Social plugin
* Confirm that the Social menu is not added under Jetpack
