### PR TITLE
Admin bar: Track clicks on the launch button

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-track-launch-button
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-track-launch-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Tracking clicks on the admin bar launch button

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.js
@@ -1,0 +1,11 @@
+import { wpcomTrackEvent } from '../../common/tracks';
+
+document.addEventListener( 'DOMContentLoaded', () => {
+	const launchButton = document.querySelector( '#wpadminbar .launch-site' );
+	if ( ! launchButton ) {
+		return;
+	}
+	launchButton.addEventListener( 'click', () => {
+		wpcomTrackEvent( 'wpcom_adminbar_launch_site' );
+	} );
+} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -1,12 +1,11 @@
 <?php
-
-use Automattic\Jetpack\Jetpack_Mu_Wpcom;
-
 /**
  * Adds a "launch site" button to the admin bar.
  *
  * @package automattic/jetpack-mu-wpcom
  */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 
 /**
  * Adds a "launch site" button to the admin bar.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -1,4 +1,7 @@
 <?php
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
 /**
  * Adds a "launch site" button to the admin bar.
  *
@@ -58,6 +61,14 @@ function wpcom_enqueue_launch_button_styles() {
 	}
 	$version = filemtime( __DIR__ . '/style.css' );
 	wp_enqueue_style( 'launch-banner', plugins_url( 'style.css', __FILE__ ), array(), $version );
+	$asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/adminbar-launch-button/adminbar-launch-button.asset.php';
+	wp_enqueue_script(
+		'adminbar-launch-button',
+		plugins_url( 'build/adminbar-launch-button/adminbar-launch-button.js', Jetpack_Mu_Wpcom::BASE_FILE ),
+		$asset_file['dependencies'] ?? array(),
+		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/adminbar-launch-button/adminbar-launch-button.js' ),
+		true
+	);
 }
 
 add_action( 'admin_bar_menu', 'wpcom_add_launch_button_to_admin_bar', 500 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Common;
 
 /**
  * Adds a "launch site" button to the admin bar.
@@ -68,6 +69,7 @@ function wpcom_enqueue_launch_button_styles() {
 		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/adminbar-launch-button/adminbar-launch-button.js' ),
 		true
 	);
+	Common\wpcom_enqueue_tracking_scripts( 'adminbar-launch-button' );
 }
 
 add_action( 'admin_bar_menu', 'wpcom_add_launch_button_to_admin_bar', 500 );

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -59,6 +59,7 @@ module.exports = [
 			'starter-page-templates': './src/features/starter-page-templates/index.tsx',
 			'removed-calypso-screen-notice':
 				'./src/features/wpcom-admin-interface/removed-calypso-screen-notice.tsx',
+			'adminbar-launch-button': './src/features/launch-button/index.js',
 		},
 		mode: jetpackWebpackConfig.mode,
 		devtool: jetpackWebpackConfig.devtool,


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/98860

## Proposed changes:

Tracks `calypso_masterbar_launch_site` event when the user clicks on the "launch button" of the Calypso master bar.
In a different PR I4m going to add an event to track clicks on the admin bar button as well.

## Does this pull request change what data or activity we track or use?

Yes, this tracks clicks on the launch button.

## Testing instructions:

Nothing really, this just adds a small track event. You can try launching a site from the "launch button" in the admin bar.
