### PR TITLE
CRM: Fix links in changelog

### DIFF
--- a/projects/plugins/crm/CHANGELOG.md
+++ b/projects/plugins/crm/CHANGELOG.md
@@ -3640,6 +3640,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [6.1.0]: https://github.com/Automattic/jetpack-crm/compare/6.0.0...6.1.0
 [6.0.0]: https://github.com/Automattic/jetpack-crm/compare/5.8.0...6.0.0
 [5.8.0]: https://github.com/Automattic/jetpack-crm/compare/5.7.0...5.8.0
-[5.7.0]: https://github.com/Automattic/jetpack-crm/compare/v5.6.0...v5.7.0
-[5.6.0]: https://github.com/Automattic/jetpack-crm/compare/v5.5.4-a.1...v5.6.0
-[5.5.4-a.1]: https://github.com/Automattic/jetpack-crm/compare/v5.5.3...v5.5.4-a.1
+[5.7.0]: https://github.com/Automattic/jetpack-crm/compare/5.6.0...5.7.0

--- a/projects/plugins/crm/CHANGELOG.md
+++ b/projects/plugins/crm/CHANGELOG.md
@@ -319,7 +319,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Onboarding: Usage tracking changed from opt-out to opt-in in the onboarding wizard [#29999]
 - WooSync: Tag existing contacts with new orders [#30107]
 
-## [5.6.0] - 2023-03-23
+## 5.6.0 - 2023-03-23
 ### Changed
 - Contacts: Change customer references to contact in all but Woo and commerce contexts [#29267]
 - Compatibility: Indicate full compatibility with the latest version of WordPress, 6.2 [#29341]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This addresses two issues:
* When writing the changelog, the order of the links was sorting oddly due to an old alpha tag that didn't exist.
* One of the links prefixed the tags with `v`, but the actual tags did not have `v`, so the link was broken.

This PR corrects both of the above. I also removed a different alpha release tag in the mirror repo.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The links at the bottom of `CHANGELOG.md` should no longer change order when running `jetpack changelogger write plugins/crm`.
