### PR TITLE
Recipe block: switch to strings for all block descriptions

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-non-string-block-description
+++ b/projects/plugins/jetpack/changelog/fix-non-string-block-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Recipe Block: switch to strings for all block descriptions

--- a/projects/plugins/jetpack/extensions/blocks/recipe/details/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/details/index.js
@@ -1,5 +1,4 @@
 import { getBlockIconProp } from '@automattic/jetpack-shared-extension-utils';
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import metadata from '../block.json';
 import attributes from './attributes';
@@ -12,11 +11,7 @@ export const name = 'recipe-details';
 
 export const settings = {
 	title: __( 'Recipe Details', 'jetpack' ),
-	description: (
-		<Fragment>
-			<p>{ __( 'Recipe Details', 'jetpack' ) }</p>
-		</Fragment>
-	),
+	description: __( 'Recipe Details', 'jetpack' ),
 	keywords: [],
 	supports: {
 		align: [ 'left', 'right', 'center' ],

--- a/projects/plugins/jetpack/extensions/blocks/recipe/hero/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/hero/index.js
@@ -1,5 +1,4 @@
 import { getBlockIconProp } from '@automattic/jetpack-shared-extension-utils';
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import metadata from '../block.json';
 import edit from './edit';
@@ -9,11 +8,7 @@ export const name = 'recipe-hero';
 export const title = __( 'Recipe Hero', 'jetpack' );
 export const settings = {
 	title,
-	description: (
-		<Fragment>
-			<p>{ __( 'Image area for the recipe.', 'jetpack' ) }</p>
-		</Fragment>
-	),
+	description: __( 'Image area for the recipe.', 'jetpack' ),
 	keywords: [],
 	icon: getBlockIconProp( metadata ),
 	category: 'widgets',

--- a/projects/plugins/jetpack/extensions/blocks/recipe/ingredient-item/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/ingredient-item/index.js
@@ -1,5 +1,4 @@
 import { getBlockIconProp } from '@automattic/jetpack-shared-extension-utils';
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import metadata from '../block.json';
 import attributes from './attributes';
@@ -10,11 +9,7 @@ export const name = 'recipe-ingredient-item';
 export const title = __( 'Recipe Ingredient Item', 'jetpack' );
 export const settings = {
 	title,
-	description: (
-		<Fragment>
-			<p>{ __( 'A single ingredient associated with a recipe.', 'jetpack' ) }</p>
-		</Fragment>
-	),
+	description: __( 'A single ingredient associated with a recipe.', 'jetpack' ),
 	keywords: [],
 	icon: getBlockIconProp( metadata ),
 	category: 'widgets',

--- a/projects/plugins/jetpack/extensions/blocks/recipe/ingredients-list/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/ingredients-list/index.js
@@ -1,5 +1,4 @@
 import { getBlockIconProp } from '@automattic/jetpack-shared-extension-utils';
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import metadata from '../block.json';
 import attributes from './attributes';
@@ -12,11 +11,7 @@ export const name = 'recipe-ingredients-list';
 export const title = __( 'Recipe Ingredients List', 'jetpack' );
 export const settings = {
 	title,
-	description: (
-		<Fragment>
-			<p>{ __( 'Recipe ingredient list', 'jetpack' ) }</p>
-		</Fragment>
-	),
+	description: __( 'Recipe ingredient list', 'jetpack' ),
 	icon: getBlockIconProp( metadata ),
 	category: 'widgets',
 	keywords: [],

--- a/projects/plugins/jetpack/extensions/blocks/recipe/step/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/step/index.js
@@ -1,5 +1,4 @@
 import { getBlockIconProp } from '@automattic/jetpack-shared-extension-utils';
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import metadata from '../block.json';
 import edit from './edit';
@@ -9,11 +8,7 @@ export const name = 'recipe-step';
 export const title = __( 'Recipe Step', 'jetpack' );
 export const settings = {
 	title,
-	description: (
-		<Fragment>
-			<p>{ __( 'A single recipe step.', 'jetpack' ) }</p>
-		</Fragment>
-	),
+	description: __( 'A single recipe step.', 'jetpack' ),
 	keywords: [],
 	icon: getBlockIconProp( metadata ),
 	category: 'widgets',

--- a/projects/plugins/jetpack/extensions/blocks/recipe/steps/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/steps/index.js
@@ -1,5 +1,4 @@
 import { getBlockIconProp } from '@automattic/jetpack-shared-extension-utils';
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import metadata from '../block.json';
 import attributes from './attributes';
@@ -11,11 +10,7 @@ export const name = 'recipe-steps';
 export const title = __( 'Recipe Steps', 'jetpack' );
 export const settings = {
 	title,
-	description: (
-		<Fragment>
-			<p>{ __( 'Step by step instructions for the recipe.', 'jetpack' ) }</p>
-		</Fragment>
-	),
+	description: __( 'Step by step instructions for the recipe.', 'jetpack' ),
 	keywords: [],
 	icon: getBlockIconProp( metadata ),
 	category: 'widgets',


### PR DESCRIPTION
Fixes #26792

## Proposed changes:

These should be the last Jetpack blocks that use non-strings for block descriptions. Switching to string for those should get rid of the warning for good.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Enable beta blocks on your site, with
```php
add_filter(
	'jetpack_blocks_variation',
	function () {
		return 'beta';
	}
);
```
* Connect your site to your WordPress.com account
* Go to Posts > Add New
* Open your browser console
    * You should **not** see the following warning: `Declaring non-string block descriptions is deprecated since version 6.2`
