### PR TITLE
Form: Fix/radio and checkbox alignment

### DIFF
--- a/projects/packages/forms/changelog/fix-radio-and-checkbox-alignemnet
+++ b/projects/packages/forms/changelog/fix-radio-and-checkbox-alignemnet
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Minor fix
+
+

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -94,6 +94,7 @@
 	.block-editor-block-list__layout.wp-block-jetpack-field-option-radio,
 	.block-editor-block-list__layout.wp-block-jetpack-field-option-checkbox  {
 		gap: 0;
+		align-items: center;
 
 		> .wp-block {
 			flex: initial;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -91,6 +91,15 @@
 		}
 	}
 
+	.block-editor-block-list__layout.wp-block-jetpack-field-option-radio,
+	.block-editor-block-list__layout.wp-block-jetpack-field-option-checkbox  {
+		gap: 0;
+
+		> .wp-block {
+			flex: initial;
+		}
+	}
+
 	.block-list-appender {
 		flex: 0 0 100%;
 	}

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -478,7 +478,7 @@
 	.jetpack-field-option.field-option-radio,
 	.wp-block-jetpack-field-option-radio {
 		.jetpack-option__type {
-			transform: translateY(15%); /* Small offset to compensate the slightly odd perceived alignment that's due to the circular shape */
+			transform: translateY(5%); /* Small offset to compensate the slightly odd perceived alignment that's due to the circular shape */
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes a regression. 

Before:

![Screenshot 2025-01-30 at 6 25 28 AM](https://github.com/user-attachments/assets/206d992e-d748-4db5-b5c3-e7efdcf16ef7)

After:

![Screenshot 2025-01-30 at 6 25 38 AM](https://github.com/user-attachments/assets/84b2f1cc-388b-471a-8441-9558bbcba504)



## Proposed changes:
* Fixes the styling of the block 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:


* Load this PR. 
* Add a form block in the block editor. 
* Add the radio and the checkbox blocks, and the multi select checkbox. 
* Notice that the alignment works as expected. 


