### PR TITLE
Full sync: Set chunk size of Woo modules dynamically

### DIFF
--- a/projects/packages/sync/changelog/update-full-sync-woo-dynamic
+++ b/projects/packages/sync/changelog/update-full-sync-woo-dynamic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Sync: Full-sync chunking logic dynamic for Woo modules

--- a/projects/packages/sync/src/modules/class-comments.php
+++ b/projects/packages/sync/src/modules/class-comments.php
@@ -16,24 +16,6 @@ use Automattic\Jetpack\Sync\Settings;
 class Comments extends Module {
 
 	/**
-	 * Max bytes allowed for full sync upload.
-	 * Current Setting : 7MB.
-	 *
-	 * @access public
-	 *
-	 * @var int
-	 */
-	const MAX_SIZE_FULL_SYNC = 7000000;
-	/**
-	 * Max bytes allowed for post meta_value => length.
-	 * Current Setting : 2MB.
-	 *
-	 * @access public
-	 *
-	 * @var int
-	 */
-	const MAX_COMMENT_META_LENGTH = 2000000;
-	/**
 	 * Sync module name.
 	 *
 	 * @access public
@@ -599,7 +581,7 @@ class Comments extends Module {
 			'comment',
 			$comments,
 			$metadata,
-			self::MAX_COMMENT_META_LENGTH, // Replace with appropriate comment meta length constant.
+			self::MAX_META_LENGTH, // Replace with appropriate comment meta length constant.
 			self::MAX_SIZE_FULL_SYNC
 		);
 
@@ -608,23 +590,5 @@ class Comments extends Module {
 			'objects'    => $filtered_comments,
 			'meta'       => $filtered_comments_metadata,
 		);
-	}
-
-	/**
-	 * Set the status of the full sync action based on the objects that were sent.
-	 *
-	 * @access public
-	 *
-	 * @param array $status This module Full Sync status.
-	 * @param array $objects This module Full Sync objects.
-	 *
-	 * @return array The updated status.
-	 */
-	public function set_send_full_sync_actions_status( $status, $objects ) {
-
-		$object_ids          = $objects['object_ids'];
-		$status['last_sent'] = end( $object_ids );
-		$status['sent']     += count( $object_ids );
-		return $status;
 	}
 }

--- a/projects/packages/sync/src/modules/class-meta.php
+++ b/projects/packages/sync/src/modules/class-meta.php
@@ -177,7 +177,7 @@ class Meta extends Module {
 	private function get_prepared_meta_object( $object_type, $meta_entry ) {
 		$object_id_column = $object_type . '_id';
 
-		if ( 'post' === $object_type && strlen( $meta_entry['meta_value'] ) >= Posts::MAX_POST_META_LENGTH ) {
+		if ( 'post' === $object_type && strlen( $meta_entry['meta_value'] ) >= Posts::MAX_META_LENGTH ) {
 			$meta_entry['meta_value'] = '';
 		}
 

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -472,8 +472,7 @@ abstract class Module {
 	 */
 	protected function set_send_full_sync_actions_status( $status, $objects ) {
 
-		$object_ids = $objects['object_ids'] ?? $objects;
-		rsort( $object_ids );
+		$object_ids          = $objects['object_ids'] ?? $objects;
 		$status['last_sent'] = end( $object_ids );
 		$status['sent']     += count( $object_ids );
 		return $status;

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -741,9 +741,11 @@ abstract class Module {
 			$object_size      = strlen( maybe_serialize( $object ) );
 			$current_metadata = array();
 			$metadata_size    = 0;
+			$id_field         = $this->id_field();
+			$object_id        = (int) ( is_object( $object ) ? $object->{$id_field} : $object[ $id_field ] );
 
 			foreach ( $metadata as $key => $metadata_item ) {
-				if ( (int) $metadata_item->{$type . '_id'} === (int) $object->{$this->id_field()} ) {
+				if ( (int) $metadata_item->{$type . '_id'} === $object_id ) {
 					$metadata_item_size = strlen( maybe_serialize( $metadata_item->meta_value ) );
 					if ( $metadata_item_size >= $max_meta_size ) {
 						$metadata_item->meta_value = ''; // Trim metadata if too large.
@@ -760,7 +762,6 @@ abstract class Module {
 
 			// Always allow the first object with metadata.
 			if ( empty( $filtered_object_ids ) || ( $current_size + $object_size + $metadata_size ) <= $max_total_size ) {
-				$id_field              = $this->id_field();
 				$filtered_object_ids[] = strval( is_object( $object ) ? $object->{$id_field} : $object[ $id_field ] );
 				$filtered_objects[]    = $object;
 				$filtered_metadata     = array_merge( $filtered_metadata, $current_metadata );

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -39,6 +39,26 @@ abstract class Module {
 	const MAX_DB_QUERY_LENGTH = 15 * 1024;
 
 	/**
+	 * Max bytes allowed for full sync upload for the module.
+	 * Default Setting : 7MB.
+	 *
+	 * @access public
+	 *
+	 * @var int
+	 */
+	const MAX_SIZE_FULL_SYNC = 7000000;
+
+	/**
+	 * Max bytes allowed for post meta_value => length.
+	 * Default Setting : 2MB.
+	 *
+	 * @access public
+	 *
+	 * @var int
+	 */
+	const MAX_META_LENGTH = 2000000;
+
+	/**
 	 * Sync module name.
 	 *
 	 * @access public
@@ -439,6 +459,9 @@ abstract class Module {
 
 	/**
 	 * Set the status of the full sync action based on the objects that were sent.
+	 * Used to update the status of the module after sending a chunk of objects.
+	 * Since Full Sync logic chunking relies on order of items being processed in descending order, we need to sort
+	 * due to some modules (e.g. WooCommerce) changing the order while getting the objects.
 	 *
 	 * @access protected
 	 *
@@ -448,8 +471,11 @@ abstract class Module {
 	 * @return array The updated status.
 	 */
 	protected function set_send_full_sync_actions_status( $status, $objects ) {
-		$status['last_sent'] = end( $objects );
-		$status['sent']     += count( $objects );
+
+		$object_ids = isset( $objects['object_ids'] ) ? $objects['object_ids'] : $objects;
+		rsort( $object_ids );
+		$status['last_sent'] = end( $object_ids );
+		$status['sent']     += count( $object_ids );
 		return $status;
 	}
 
@@ -734,7 +760,8 @@ abstract class Module {
 
 			// Always allow the first object with metadata.
 			if ( empty( $filtered_object_ids ) || ( $current_size + $object_size + $metadata_size ) <= $max_total_size ) {
-				$filtered_object_ids[] = strval( $object->{$this->id_field()} );
+				$id_field              = $this->id_field();
+				$filtered_object_ids[] = strval( is_object( $object ) ? $object->{$id_field} : $object[ $id_field ] );
 				$filtered_objects[]    = $object;
 				$filtered_metadata     = array_merge( $filtered_metadata, $current_metadata );
 				$current_size         += $object_size + $metadata_size;

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -472,7 +472,7 @@ abstract class Module {
 	 */
 	protected function set_send_full_sync_actions_status( $status, $objects ) {
 
-		$object_ids = isset( $objects['object_ids'] ) ? $objects['object_ids'] : $objects;
+		$object_ids = $objects['object_ids'] ?? $objects;
 		rsort( $object_ids );
 		$status['last_sent'] = end( $object_ids );
 		$status['sent']     += count( $object_ids );

--- a/projects/packages/sync/src/modules/class-posts.php
+++ b/projects/packages/sync/src/modules/class-posts.php
@@ -312,7 +312,7 @@ class Posts extends Module {
 		// Explicitly truncate meta_value when it exceeds limit.
 		// Large content will cause OOM issues and break Sync.
 		$serialized_value = maybe_serialize( $meta_value );
-		if ( strlen( $serialized_value ) >= self::MAX_POST_LENGTH ) {
+		if ( strlen( $serialized_value ) >= self::MAX_META_LENGTH ) {
 			$meta_value = '';
 		}
 		return array( $meta_id, $object_id, $meta_key, $meta_value );

--- a/projects/packages/sync/src/modules/class-posts.php
+++ b/projects/packages/sync/src/modules/class-posts.php
@@ -65,26 +65,6 @@ class Posts extends Module {
 	const MAX_POST_CONTENT_LENGTH = 5000000;
 
 	/**
-	 * Max bytes allowed for post meta_value => length.
-	 * Current Setting : 2MB.
-	 *
-	 * @access public
-	 *
-	 * @var int
-	 */
-	const MAX_POST_META_LENGTH = 2000000;
-
-	/**
-	 * Max bytes allowed for full sync upload.
-	 * Current Setting : 7MB.
-	 *
-	 * @access public
-	 *
-	 * @var int
-	 */
-	const MAX_SIZE_FULL_SYNC = 7000000;
-
-	/**
 	 * Default previous post state.
 	 * Used for default previous post status.
 	 *
@@ -321,7 +301,7 @@ class Posts extends Module {
 	}
 
 	/**
-	 * Filter meta arguments so that we don't sync meta_values over MAX_POST_META_LENGTH.
+	 * Filter meta arguments so that we don't sync meta_values over MAX_META_LENGTH.
 	 *
 	 * @param array $args action arguments.
 	 *
@@ -332,7 +312,7 @@ class Posts extends Module {
 		// Explicitly truncate meta_value when it exceeds limit.
 		// Large content will cause OOM issues and break Sync.
 		$serialized_value = maybe_serialize( $meta_value );
-		if ( strlen( $serialized_value ) >= self::MAX_POST_META_LENGTH ) {
+		if ( strlen( $serialized_value ) >= self::MAX_POST_LENGTH ) {
 			$meta_value = '';
 		}
 		return array( $meta_id, $object_id, $meta_key, $meta_value );
@@ -894,7 +874,7 @@ class Posts extends Module {
 			'post',
 			$posts,
 			$metadata,
-			self::MAX_POST_META_LENGTH,
+			self::MAX_META_LENGTH,
 			self::MAX_SIZE_FULL_SYNC
 		);
 
@@ -917,23 +897,5 @@ class Posts extends Module {
 		$posts = array_map( array( $this, 'filter_post_content_and_add_links' ), $posts );
 		$posts = array_values( $posts ); // Reindex in case posts were deleted.
 		return $posts;
-	}
-
-	/**
-	 * Set the status of the full sync action based on the objects that were sent.
-	 *
-	 * @access public
-	 *
-	 * @param array $status This module Full Sync status.
-	 * @param array $objects This module Full Sync objects.
-	 *
-	 * @return array The updated status.
-	 */
-	public function set_send_full_sync_actions_status( $status, $objects ) {
-
-		$object_ids          = $objects['object_ids'];
-		$status['last_sent'] = end( $object_ids );
-		$status['sent']     += count( $object_ids );
-		return $status;
 	}
 }

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -145,7 +145,7 @@ class WooCommerce_HPOS_Orders extends Module {
 	 */
 	public function init_before_send() {
 		// Full sync.
-		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_woocommerce_hpos_orders', array( $this, 'expand_order_objects' ) );
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_woocommerce_hpos_orders', array( $this, 'build_full_sync_action_object' ) );
 	}
 
 	/**
@@ -229,10 +229,10 @@ class WooCommerce_HPOS_Orders extends Module {
 	 *
 	 * @return array
 	 */
-	public function expand_order_objects( $args ) {
-		list( $order_ids, $previous_end ) = $args;
+	public function build_full_sync_action_object( $args ) {
+		list( $filtered_orders, $previous_end ) = $args;
 		return array(
-			'orders'       => $this->get_objects_by_id( 'order', $order_ids ),
+			'orders'       => $filtered_orders['objects'],
 			'previous_end' => $previous_end,
 		);
 	}
@@ -502,5 +502,48 @@ class WooCommerce_HPOS_Orders extends Module {
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Query is prepared.
 		$where_sql = $wpdb->prepare( "type IN ( $order_type_placeholder )", $order_types );
 		return "{$parent_where} AND {$where_sql}";
+	}
+
+	/**
+	 * Given the Module Configuration and Status return the next chunk of items to send.
+	 * This function also expands the posts and metadata and filters them based on the maximum size constraints.
+	 *
+	 * @param array $config This module Full Sync configuration.
+	 * @param array $status This module Full Sync status.
+	 * @param int   $chunk_size Chunk size.
+	 *
+	 * @return array
+	 */
+	public function get_next_chunk( $config, $status, $chunk_size ) {
+
+		$order_ids = parent::get_next_chunk( $config, $status, $chunk_size );
+
+		if ( empty( $order_ids ) ) {
+			return array();
+		}
+
+		$orders = $this->get_objects_by_id( 'order', $order_ids );
+
+		// If no orders were fetched, make sure to return the expected structure so that status is updated correctly.
+		if ( empty( $orders ) ) {
+			return array(
+				'object_ids' => $order_ids,
+				'objects'    => array(),
+			);
+		}
+
+		// Filter the orders based on the maximum size constraints. We don't need to filter metadata here since we don't sync it for hpos.
+		list( $filtered_order_ids, $filtered_orders, ) = $this->filter_objects_and_metadata_by_size(
+			'order',
+			$orders,
+			array(),
+			0,
+			self::MAX_SIZE_FULL_SYNC
+		);
+
+		return array(
+			'object_ids' => $filtered_order_ids,
+			'objects'    => $filtered_orders,
+		);
 	}
 }

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -228,6 +228,25 @@ class WooCommerce_HPOS_Orders extends Module {
 	 * @param array $args List of order IDs.
 	 *
 	 * @return array
+	 * @deprecated since $$next-version$$
+	 */
+	public function expand_order_objects( $args ) {
+		_deprecated_function( __METHOD__, 'next-version' );
+		list( $order_ids, $previous_end ) = $args;
+		return array(
+			'orders'       => $this->get_objects_by_id( 'order', $order_ids ),
+			'previous_end' => $previous_end,
+		);
+	}
+
+	/**
+	 * Build the full sync action object.
+	 *
+	 * @access public
+	 *
+	 * @param array $args An array with filtered objects and previous end.
+	 *
+	 * @return array
 	 */
 	public function build_full_sync_action_object( $args ) {
 		list( $filtered_orders, $previous_end ) = $args;

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -145,7 +145,7 @@ class WooCommerce_HPOS_Orders extends Module {
 	 */
 	public function init_before_send() {
 		// Full sync.
-		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_woocommerce_hpos_orders', array( $this, 'build_full_sync_action_object' ) );
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_woocommerce_hpos_orders', array( $this, 'build_full_sync_action_array' ) );
 	}
 
 	/**
@@ -246,9 +246,9 @@ class WooCommerce_HPOS_Orders extends Module {
 	 *
 	 * @param array $args An array with filtered objects and previous end.
 	 *
-	 * @return array
+	 * @return array An array with orders and previous end.
 	 */
-	public function build_full_sync_action_object( $args ) {
+	public function build_full_sync_action_array( $args ) {
 		list( $filtered_orders, $previous_end ) = $args;
 		return array(
 			'orders'       => $filtered_orders['objects'],

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -655,11 +655,11 @@ class WooCommerce extends Module {
 	 * @return array
 	 */
 	public function build_full_sync_action_object( $args ) {
-		list( $filtered_orders, $previous_end ) = $args;
+		list( $filtered_order_items, $previous_end ) = $args;
 		return array(
-			'orders'       => $filtered_orders['objects'],
-			'order_meta'   => $filtered_orders['meta'],
-			'previous_end' => $previous_end,
+			'order_items'     => $filtered_order_items['objects'],
+			'order_item_meta' => $filtered_order_items['meta'],
+			'previous_end'    => $previous_end,
 		);
 	}
 
@@ -675,39 +675,39 @@ class WooCommerce extends Module {
 	 */
 	public function get_next_chunk( $config, $status, $chunk_size ) {
 
-		$order_ids = parent::get_next_chunk( $config, $status, $chunk_size );
+		$order_item_ids = parent::get_next_chunk( $config, $status, $chunk_size );
 
-		if ( empty( $order_ids ) ) {
+		if ( empty( $order_item_ids ) ) {
 			return array();
 		}
 
-		$orders = $this->get_objects_by_id( 'order_item', $order_ids );
+		$order_items = $this->get_objects_by_id( 'order_item', $order_item_ids );
 
 		// If no orders were fetched, make sure to return the expected structure so that status is updated correctly.
-		if ( empty( $orders ) ) {
+		if ( empty( $order_items ) ) {
 			return array(
-				'object_ids' => $order_ids,
+				'object_ids' => $order_item_ids,
 				'objects'    => array(),
 			);
 		}
 
 		// Get the order IDs from the orders that were fetched.
-		$fetched_orders_ids = wp_list_pluck( $orders, 'order_item_id' );
-		$metadata           = $this->get_metadata( $fetched_orders_ids, 'order_item', static::$order_item_meta_whitelist );
+		$fetched_order_item_ids = wp_list_pluck( $order_items, 'order_item_id' );
+		$metadata               = $this->get_metadata( $fetched_order_item_ids, 'order_item', static::$order_item_meta_whitelist );
 
 		// Filter the orders and metadata based on the maximum size constraints.
-		list( $filtered_order_ids, $filtered_orders, $filtered_orders_metadata ) = $this->filter_objects_and_metadata_by_size(
+		list( $filtered_order_item_ids, $filtered_order_items, $filtered_order_items_metadata ) = $this->filter_objects_and_metadata_by_size(
 			'order_item',
-			$orders,
+			$order_items,
 			$metadata,
 			self::MAX_META_LENGTH,
 			self::MAX_SIZE_FULL_SYNC
 		);
 
 		return array(
-			'object_ids' => $filtered_order_ids,
-			'objects'    => $filtered_orders,
-			'meta'       => $filtered_orders_metadata,
+			'object_ids' => $filtered_order_item_ids,
+			'objects'    => $filtered_order_items,
+			'meta'       => $filtered_order_items_metadata,
 		);
 	}
 }

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -630,7 +630,7 @@ class WooCommerce extends Module {
 	 * @param string $object_type Object type.
 	 * @param array  $ids IDs of objects to return.
 	 *
-	 * @access publicbuild_full_sync_action_array
+	 * @access public
 	 *
 	 * @return array|object|WP_Error|null
 	 */

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -616,13 +616,14 @@ class WooCommerce extends Module {
 	/**
 	 * Returns a list of order_item objects by their IDs.
 	 *
-	 * @param array $ids List of order_item IDs to fetch.
+	 * @param array  $ids List of order_item IDs to fetch.
+	 * @param string $order Order of the results.
 	 *
 	 * @access public
 	 *
 	 * @return array|object|null
 	 */
-	public function get_order_item_by_ids( $ids ) {
+	public function get_order_item_by_ids( $ids, $order = '' ) {
 		global $wpdb;
 
 		if ( ! is_array( $ids ) ) {
@@ -640,6 +641,9 @@ class WooCommerce extends Module {
 		$placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
 
 		$query = "SELECT * FROM {$this->order_item_table_name} WHERE order_item_id IN ( $placeholders )";
+		if ( ! empty( $order ) ) {
+			$query .= " ORDER BY order_item_id $order";
+		}
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		return $wpdb->get_results( $wpdb->prepare( $query, $ids ), ARRAY_A );
@@ -680,8 +684,8 @@ class WooCommerce extends Module {
 		if ( empty( $order_item_ids ) ) {
 			return array();
 		}
-
-		$order_items = $this->get_objects_by_id( 'order_item', $order_item_ids );
+		// Fetch the order items in DESC order for the next chunk logic to work.
+		$order_items = $this->get_order_item_by_ids( $order_item_ids, 'DESC' );
 
 		// If no orders were fetched, make sure to return the expected structure so that status is updated correctly.
 		if ( empty( $order_items ) ) {

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -671,7 +671,7 @@ class WooCommerce extends Module {
 		$placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
 
 		$query = "SELECT * FROM {$this->order_item_table_name} WHERE order_item_id IN ( $placeholders )";
-		if ( ! empty( $order ) ) {
+		if ( ! empty( $order ) && in_array( $order, array( 'ASC', 'DESC' ), true ) ) {
 			$query .= " ORDER BY order_item_id $order";
 		}
 

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -221,7 +221,7 @@ class WooCommerce extends Module {
 	 */
 	public function init_before_send() {
 		// Full sync.
-		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_woocommerce_order_items', array( $this, 'expand_order_item_ids' ) );
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_woocommerce_order_items', array( $this, 'build_full_sync_action_object' ) );
 	}
 
 	/**
@@ -255,34 +255,6 @@ class WooCommerce extends Module {
 		if ( $order_item_ids ) {
 			do_action( 'woocommerce_remove_order_item_ids', $order_item_ids );
 		}
-	}
-
-	/**
-	 * Expand order item IDs to order items and their meta.
-	 *
-	 * @access public
-	 *
-	 * @todo Refactor table name to use a $wpdb->prepare placeholder.
-	 *
-	 * @param array $args The hook arguments.
-	 * @return array $args Expanded order items with meta.
-	 */
-	public function expand_order_item_ids( $args ) {
-		$order_item_ids = $args[0];
-
-		global $wpdb;
-
-		$order_item_ids_sql = implode( ', ', array_map( 'intval', $order_item_ids ) );
-
-		$order_items = $wpdb->get_results(
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			"SELECT * FROM $this->order_item_table_name WHERE order_item_id IN ( $order_item_ids_sql )"
-		);
-
-		return array(
-			$order_items,
-			$this->get_metadata( $order_item_ids, 'order_item', static::$order_item_meta_whitelist ),
-		);
 	}
 
 	/**
@@ -671,5 +643,71 @@ class WooCommerce extends Module {
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		return $wpdb->get_results( $wpdb->prepare( $query, $ids ), ARRAY_A );
+	}
+
+	/**
+	 * Retrieves multiple orders data by their ID.
+	 *
+	 * @access public
+	 *
+	 * @param array $args List of order IDs.
+	 *
+	 * @return array
+	 */
+	public function build_full_sync_action_object( $args ) {
+		list( $filtered_orders, $previous_end ) = $args;
+		return array(
+			'orders'       => $filtered_orders['objects'],
+			'order_meta'   => $filtered_orders['meta'],
+			'previous_end' => $previous_end,
+		);
+	}
+
+	/**
+	 * Given the Module Configuration and Status return the next chunk of items to send.
+	 * This function also expands the posts and metadata and filters them based on the maximum size constraints.
+	 *
+	 * @param array $config This module Full Sync configuration.
+	 * @param array $status This module Full Sync status.
+	 * @param int   $chunk_size Chunk size.
+	 *
+	 * @return array
+	 */
+	public function get_next_chunk( $config, $status, $chunk_size ) {
+
+		$order_ids = parent::get_next_chunk( $config, $status, $chunk_size );
+
+		if ( empty( $order_ids ) ) {
+			return array();
+		}
+
+		$orders = $this->get_objects_by_id( 'order_item', $order_ids );
+
+		// If no orders were fetched, make sure to return the expected structure so that status is updated correctly.
+		if ( empty( $orders ) ) {
+			return array(
+				'object_ids' => $order_ids,
+				'objects'    => array(),
+			);
+		}
+
+		// Get the order IDs from the orders that were fetched.
+		$fetched_orders_ids = wp_list_pluck( $orders, 'order_item_id' );
+		$metadata           = $this->get_metadata( $fetched_orders_ids, 'order_item', static::$order_item_meta_whitelist );
+
+		// Filter the orders and metadata based on the maximum size constraints.
+		list( $filtered_order_ids, $filtered_orders, $filtered_orders_metadata ) = $this->filter_objects_and_metadata_by_size(
+			'order_item',
+			$orders,
+			$metadata,
+			self::MAX_META_LENGTH,
+			self::MAX_SIZE_FULL_SYNC
+		);
+
+		return array(
+			'object_ids' => $filtered_order_ids,
+			'objects'    => $filtered_orders,
+			'meta'       => $filtered_orders_metadata,
+		);
 	}
 }

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -647,7 +647,7 @@ class WooCommerce extends Module {
 	 * Returns a list of order_item objects by their IDs.
 	 *
 	 * @param array  $ids List of order_item IDs to fetch.
-	 * @param string $order Order of the results.
+	 * @param string $order Either 'ASC' or 'DESC'.
 	 *
 	 * @access public
 	 *

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -221,7 +221,7 @@ class WooCommerce extends Module {
 	 */
 	public function init_before_send() {
 		// Full sync.
-		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_woocommerce_order_items', array( $this, 'build_full_sync_action_object' ) );
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_woocommerce_order_items', array( $this, 'build_full_sync_action_array' ) );
 	}
 
 	/**
@@ -630,7 +630,7 @@ class WooCommerce extends Module {
 	 * @param string $object_type Object type.
 	 * @param array  $ids IDs of objects to return.
 	 *
-	 * @access public
+	 * @access publicbuild_full_sync_action_array
 	 *
 	 * @return array|object|WP_Error|null
 	 */
@@ -686,9 +686,9 @@ class WooCommerce extends Module {
 	 *
 	 * @param array $args An array with the order items and the previous end.
 	 *
-	 * @return array
+	 * @return array An array with the order items, order item meta and the previous end.
 	 */
-	public function build_full_sync_action_object( $args ) {
+	public function build_full_sync_action_array( $args ) {
 		list( $filtered_order_items, $previous_end ) = $args;
 		return array(
 			'order_items'     => $filtered_order_items['objects'],

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -258,6 +258,36 @@ class WooCommerce extends Module {
 	}
 
 	/**
+	 * Expand order item IDs to order items and their meta.
+	 *
+	 * @access public
+	 *
+	 * @todo Refactor table name to use a $wpdb->prepare placeholder.
+	 *
+	 * @param array $args The hook arguments.
+	 * @return array $args Expanded order items with meta.
+	 * @deprecated since $$next-version$$
+	 */
+	public function expand_order_item_ids( $args ) {
+		_deprecated_function( __METHOD__, '$$next-version$$' );
+		$order_item_ids = $args[0];
+
+		global $wpdb;
+
+		$order_item_ids_sql = implode( ', ', array_map( 'intval', $order_item_ids ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$order_items = $wpdb->get_results(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"SELECT * FROM $this->order_item_table_name WHERE order_item_id IN ( $order_item_ids_sql )"
+		);
+
+		return array(
+			$order_items,
+			$this->get_metadata( $order_item_ids, 'order_item', static::$order_item_meta_whitelist ),
+		);
+	}
+	/**
 	 * Extract the full order item from the database by its ID.
 	 *
 	 * @access public
@@ -650,11 +680,11 @@ class WooCommerce extends Module {
 	}
 
 	/**
-	 * Retrieves multiple orders data by their ID.
+	 * Build the full sync action object for WooCommerce order items.
 	 *
 	 * @access public
 	 *
-	 * @param array $args List of order IDs.
+	 * @param array $args An array with the order items and the previous end.
 	 *
 	 * @return array
 	 */

--- a/projects/packages/sync/tests/php/modules/test-module.php
+++ b/projects/packages/sync/tests/php/modules/test-module.php
@@ -38,11 +38,15 @@ class Test_Module extends BaseTestCase {
 	/**
 	 * Test filter_objects_and_metadata_by_size with no constraints of size
 	 */
-	public function filter_objects_and_metadata_by_size_no_constraints() {
+	public function test_filter_objects_and_metadata_by_size_no_constraints() {
 		$objects  = array(
 			(object) array(
 				'ID'           => 1,
 				'module_title' => 'Post 1',
+			),
+			(object) array(
+				'ID'           => 2,
+				'module_title' => 'Post 2',
 			),
 		);
 		$metadata = array(
@@ -54,9 +58,42 @@ class Test_Module extends BaseTestCase {
 
 		$result = $this->module_instance->filter_objects_and_metadata_by_size( 'module', $objects, $metadata, PHP_INT_MAX, PHP_INT_MAX );
 
-		$this->assertCount( 1, $result[0] );
-		$this->assertCount( 1, $result[1] );
+		$this->assertCount( 2, $result[0] );
+		$this->assertCount( 2, $result[1] );
 		$this->assertCount( 1, $result[2] );
+		$this->assertSame( array( '1', '2' ), $result[0] );
+		$this->assertSame( $objects, $result[1] );
+		$this->assertSame( $metadata, $result[2] );
+	}
+
+	/**
+	 * Test filter_objects_and_metadata_by_size with no constraints of size objects being an array
+	 */
+	public function test_filter_objects_and_metadata_by_size_no_constraints_object_being_array() {
+		$objects  = array(
+			array(
+				'ID'           => 1,
+				'module_title' => 'Element 1',
+			),
+			array(
+				'ID'           => 2,
+				'module_title' => 'Element 2',
+			),
+		);
+		$metadata = array(
+			(object) array(
+				'module_id'  => 1,
+				'meta_value' => 'meta1',
+			),
+		);
+
+		$result = $this->module_instance->filter_objects_and_metadata_by_size( 'module', $objects, $metadata, PHP_INT_MAX, PHP_INT_MAX );
+		$this->assertCount( 2, $result[0] );
+		$this->assertCount( 2, $result[1] );
+		$this->assertCount( 1, $result[2] );
+		$this->assertSame( array( '1', '2' ), $result[0] );
+		$this->assertSame( $objects, $result[1] );
+		$this->assertSame( $metadata, $result[2] );
 	}
 	/**
 	 * Test filter_objects_and_metadata_by_size with constraints of size for metadata

--- a/projects/plugins/jetpack/changelog/update-full-sync-woo-dynamic
+++ b/projects/plugins/jetpack/changelog/update-full-sync-woo-dynamic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Sync: Full-sync chunking logic dynamic for Woo modules

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -634,7 +634,7 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	/**
-	 * Verify metadata meta_value is limited based on MAX_COMMENT_META_LENGTH.
+	 * Verify metadata meta_value is limited based on MAX_META_LENGTH.
 	 */
 	public function test_metadata_limit() {
 
@@ -642,13 +642,13 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 			(object) array(
 				'comment_id' => $this->comment->comment_ID,
 				'meta_key'   => 'test_key',
-				'meta_value' => str_repeat( 'X', Automattic\Jetpack\Sync\Modules\Comments::MAX_COMMENT_META_LENGTH - 1 ),
+				'meta_value' => str_repeat( 'X', Automattic\Jetpack\Sync\Modules\Comments::MAX_META_LENGTH - 1 ),
 				'meta_id'    => 1,
 			),
 			(object) array(
 				'comment_id' => $this->comment->comment_ID,
 				'meta_key'   => 'test_key',
-				'meta_value' => str_repeat( 'X', Automattic\Jetpack\Sync\Modules\Comments::MAX_COMMENT_META_LENGTH ),
+				'meta_value' => str_repeat( 'X', Automattic\Jetpack\Sync\Modules\Comments::MAX_META_LENGTH ),
 				'meta_id'    => 2,
 			),
 
@@ -660,7 +660,7 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 			'comment',
 			array( $this->comment ),
 			$metadata,
-			Automattic\Jetpack\Sync\Modules\Posts::MAX_POST_META_LENGTH,
+			Automattic\Jetpack\Sync\Modules\Posts::MAX_META_LENGTH,
 			Automattic\Jetpack\Sync\Modules\Posts::MAX_SIZE_FULL_SYNC
 		);
 
@@ -723,7 +723,7 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 			'comment',
 			$comments,
 			$metadata,
-			Automattic\Jetpack\Sync\Modules\Comments::MAX_COMMENT_META_LENGTH,
+			Automattic\Jetpack\Sync\Modules\Comments::MAX_META_LENGTH,
 			Automattic\Jetpack\Sync\Modules\Posts::MAX_SIZE_FULL_SYNC
 		);
 
@@ -745,13 +745,13 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 
 		$comments = array( $comment_1, $comment_2 );
 
-		$metadata_items_number = Automattic\Jetpack\Sync\Modules\Posts::MAX_SIZE_FULL_SYNC / Automattic\Jetpack\Sync\Modules\Comments::MAX_COMMENT_META_LENGTH;
+		$metadata_items_number = Automattic\Jetpack\Sync\Modules\Posts::MAX_SIZE_FULL_SYNC / Automattic\Jetpack\Sync\Modules\Comments::MAX_META_LENGTH;
 		$comment_metadata_1    = array_map(
 			function ( $x ) use ( $comment_id_1 ) {
 				return (object) array(
 					'comment_id' => $comment_id_1,
 					'meta_key'   => 'test_key',
-					'meta_value' => str_repeat( 'X', Automattic\Jetpack\Sync\Modules\Comments::MAX_COMMENT_META_LENGTH - 1 ),
+					'meta_value' => str_repeat( 'X', Automattic\Jetpack\Sync\Modules\Comments::MAX_META_LENGTH - 1 ),
 					'meta_id'    => $x,
 				);
 			},
@@ -775,7 +775,7 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 			'comment',
 			$comments,
 			$metadata,
-			Automattic\Jetpack\Sync\Modules\Comments::MAX_COMMENT_META_LENGTH,
+			Automattic\Jetpack\Sync\Modules\Comments::MAX_META_LENGTH,
 			Automattic\Jetpack\Sync\Modules\Posts::MAX_SIZE_FULL_SYNC
 		);
 

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-meta.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-meta.php
@@ -34,7 +34,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 	 * Verify that meta_values below size limit are not tuncated.
 	 */
 	public function test_meta_adheres_size_limit_max() {
-		$meta_test_value = str_repeat( 'X', Posts::MAX_POST_META_LENGTH - 1 );
+		$meta_test_value = str_repeat( 'X', Posts::MAX_META_LENGTH - 1 );
 		update_post_meta( $this->post_id, $this->whitelisted_post_meta, $meta_test_value );
 
 		$this->sender->do_sync();
@@ -47,7 +47,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 	 * Verify that meta_values above size limit are truncated.
 	 */
 	public function test_meta_adheres_size_limit_exceeded() {
-		$meta_test_value = str_repeat( 'X', Posts::MAX_POST_META_LENGTH );
+		$meta_test_value = str_repeat( 'X', Posts::MAX_META_LENGTH );
 		update_post_meta( $this->post_id, $this->whitelisted_post_meta, $meta_test_value );
 
 		$this->sender->do_sync();
@@ -339,7 +339,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 	 * Verify that meta_values above size limit are truncated in get_object_by_id
 	 */
 	public function test_get_object_by_id_size_limit_exceeded() {
-		$meta_test_value = str_repeat( 'X', Posts::MAX_POST_META_LENGTH );
+		$meta_test_value = str_repeat( 'X', Posts::MAX_META_LENGTH );
 		update_post_meta( $this->post_id, $this->whitelisted_post_meta, $meta_test_value );
 
 		$module = Modules::get_module( 'meta' );
@@ -351,7 +351,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 	 * Verify that meta_values below size limit are not truncated in get_object_by_id
 	 */
 	public function test_get_object_by_id_size_limit_max() {
-		$meta_test_value = str_repeat( 'X', Posts::MAX_POST_META_LENGTH - 1 );
+		$meta_test_value = str_repeat( 'X', Posts::MAX_META_LENGTH - 1 );
 		update_post_meta( $this->post_id, $this->whitelisted_post_meta, $meta_test_value );
 
 		$module = Modules::get_module( 'meta' );

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-meta.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-meta.php
@@ -398,7 +398,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 	 * Verify that meta_values above size limit are truncated in get_objects_by_id.
 	 */
 	public function test_get_objects_by_id_size_limit_exceeded() {
-		$meta_test_value = str_repeat( 'X', Posts::MAX_POST_META_LENGTH );
+		$meta_test_value = str_repeat( 'X', Posts::MAX_META_LENGTH );
 		update_post_meta( $this->post_id, $this->whitelisted_post_meta, $meta_test_value );
 
 		$module = Modules::get_module( 'meta' );

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -1519,7 +1519,7 @@ That was a cool video.';
 	}
 
 	/**
-	 * Verify metadata meta_value is limited based on MAX_POST_META_LENGTH.
+	 * Verify metadata meta_value is limited based on MAX_META_LENGTH.
 	 */
 	public function test_metadata_limit() {
 
@@ -1527,13 +1527,13 @@ That was a cool video.';
 			(object) array(
 				'post_id'    => $this->post_id,
 				'meta_key'   => 'test_key',
-				'meta_value' => str_repeat( 'X', Automattic\Jetpack\Sync\Modules\Posts::MAX_POST_META_LENGTH - 1 ),
+				'meta_value' => str_repeat( 'X', Automattic\Jetpack\Sync\Modules\Posts::MAX_META_LENGTH - 1 ),
 				'meta_id'    => 1,
 			),
 			(object) array(
 				'post_id'    => $this->post_id,
 				'meta_key'   => 'test_key',
-				'meta_value' => str_repeat( 'X', Automattic\Jetpack\Sync\Modules\Posts::MAX_POST_META_LENGTH ),
+				'meta_value' => str_repeat( 'X', Automattic\Jetpack\Sync\Modules\Posts::MAX_META_LENGTH ),
 				'meta_id'    => 2,
 			),
 
@@ -1545,7 +1545,7 @@ That was a cool video.';
 			'post',
 			array( $this->post ),
 			$metadata,
-			Automattic\Jetpack\Sync\Modules\Posts::MAX_POST_META_LENGTH,
+			Automattic\Jetpack\Sync\Modules\Posts::MAX_META_LENGTH,
 			Automattic\Jetpack\Sync\Modules\Posts::MAX_SIZE_FULL_SYNC
 		);
 
@@ -1609,7 +1609,7 @@ That was a cool video.';
 			'post',
 			$posts,
 			$metadata,
-			Automattic\Jetpack\Sync\Modules\Posts::MAX_POST_META_LENGTH,
+			Automattic\Jetpack\Sync\Modules\Posts::MAX_META_LENGTH,
 			Automattic\Jetpack\Sync\Modules\Posts::MAX_SIZE_FULL_SYNC
 		);
 
@@ -1631,13 +1631,13 @@ That was a cool video.';
 
 		$posts = array( $post_1, $post_2 );
 
-		$metadata_items_number = Automattic\Jetpack\Sync\Modules\Posts::MAX_SIZE_FULL_SYNC / Automattic\Jetpack\Sync\Modules\Posts::MAX_POST_META_LENGTH;
+		$metadata_items_number = Automattic\Jetpack\Sync\Modules\Posts::MAX_SIZE_FULL_SYNC / Automattic\Jetpack\Sync\Modules\Posts::MAX_META_LENGTH;
 		$post_metadata_1       = array_map(
 			function ( $x ) use ( $post_id_1 ) {
 				return (object) array(
 					'post_id'    => $post_id_1,
 					'meta_key'   => 'test_key',
-					'meta_value' => str_repeat( 'X', Automattic\Jetpack\Sync\Modules\Posts::MAX_POST_META_LENGTH - 1 ),
+					'meta_value' => str_repeat( 'X', Automattic\Jetpack\Sync\Modules\Posts::MAX_META_LENGTH - 1 ),
 					'meta_id'    => $x,
 				);
 			},
@@ -1662,7 +1662,7 @@ That was a cool video.';
 			'post',
 			$posts,
 			$metadata,
-			Automattic\Jetpack\Sync\Modules\Posts::MAX_POST_META_LENGTH,
+			Automattic\Jetpack\Sync\Modules\Posts::MAX_META_LENGTH,
 			Automattic\Jetpack\Sync\Modules\Posts::MAX_SIZE_FULL_SYNC
 		);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Part of https://github.com/Automattic/vulcan/issues/661

https://github.com/Automattic/jetpack/pull/34390 created the ability to have a dynamic number of items sent for posts. The final number of items sent will be determined by reaching the MAX_SIZE for a number of items or if we reach the chunk_size in `full_sync_limits`.
Same work as the one done in https://github.com/Automattic/jetpack/pull/41350 now for the Woo modules living in the Sync package. ( `woocommerce` and `woocommerce-hpos-orders`)
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Re-use the `filter_objects_and_metadata_by_size` method written in the [Module](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/modules/class-module.php#L22) parent class.
* Abstract some of the constants and functions to the parent class to keep things tidy. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Repeat the instructions in https://github.com/Automattic/jetpack/pull/41350 but do them for `woocommerce` and `woocommerce-hpos-orders` modules instead.

