### PR TITLE
Fix/crm/js issue welcome wizard - WIP

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-js-issue-welcome-wizard
+++ b/projects/plugins/crm/changelog/fix-crm-js-issue-welcome-wizard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Small fix to welcome wizard

--- a/projects/plugins/crm/js/welcome-to-zbs/wizard2.js
+++ b/projects/plugins/crm/js/welcome-to-zbs/wizard2.js
@@ -69,7 +69,6 @@ jQuery( function () {
 		if ( isValid ) {
 			nextStepWizard.prop( 'disabled', false ).trigger( 'click' );
 		}
-		//console.log(window.zbsOptions);
 	} );
 	jQuery( 'div.setup-panel div a.btn-primary' ).trigger( 'click' );
 	jQuery( '.zbs-gogogo' )
@@ -83,7 +82,7 @@ jQuery( function () {
 			}
 			jQuery( this ).addClass( 'disabled' );
 
-			const t = window.zbsOptions;
+			const t = zbsOptions;
 			t.action = 'zbs_wizard_fin';
 			t.security = jQuery( '#zbswf-ajax-nonce' ).val();
 			/*
@@ -201,25 +200,23 @@ function zbs_crm_js_updatePage2() {
 	}
 }
 function zbsJS_welcomeWizard_update_deets() {
-	window.zbsOptions.zbs_crm_name = jQuery( '#zbs_crm_name' ).val();
-	window.zbsOptions.zbs_crm_other = jQuery( '#zbs_other_details' ).val();
-	window.zbsOptions.zbs_crm_curr = jQuery( '#zbs_crm_curr' ).val();
-	window.zbsOptions.zbs_crm_menu_style = jQuery(
-		'input[name="zbs-menu-opt-choice"]:checked'
-	).val();
-	window.zbsOptions.zbs_b2b = jQuery( '#zbs_b2b' ).is( ':checked' ) ? 1 : 0;
-	window.zbsOptions.zbs_crm_share_essentials = jQuery( '#zbs_ess' ).is( ':checked' ) ? 1 : 0;
+	zbsOptions.zbs_crm_name = jQuery( '#zbs_crm_name' ).val();
+	zbsOptions.zbs_crm_other = jQuery( '#zbs_other_details' ).val();
+	zbsOptions.zbs_crm_curr = jQuery( '#zbs_crm_curr' ).val();
+	zbsOptions.zbs_crm_menu_style = jQuery( 'input[name="zbs-menu-opt-choice"]:checked' ).val();
+	zbsOptions.zbs_b2b = jQuery( '#zbs_b2b' ).is( ':checked' ) ? 1 : 0;
+	zbsOptions.zbs_crm_share_essentials = jQuery( '#zbs_ess' ).is( ':checked' ) ? 1 : 0;
 
-	window.zbsOptions.zbs_quotes = jQuery( '#zbs_quotes' ).is( ':checked' ) ? 1 : 0;
-	window.zbsOptions.zbs_invoicing = jQuery( '#zbs_invoicing' ).is( ':checked' ) ? 1 : 0;
-	window.zbsOptions.jpcrm_woo_module = jQuery( '#jpcrm_woo_module' ).is( ':checked' ) ? 1 : 0;
-	window.zbsOptions.zbs_forms = 1;
+	zbsOptions.zbs_quotes = jQuery( '#zbs_quotes' ).is( ':checked' ) ? 1 : 0;
+	zbsOptions.zbs_invoicing = jQuery( '#zbs_invoicing' ).is( ':checked' ) ? 1 : 0;
+	zbsOptions.jpcrm_woo_module = jQuery( '#jpcrm_woo_module' ).is( ':checked' ) ? 1 : 0;
+	zbsOptions.zbs_forms = 1;
 
-	window.zbsOptions.zbs_crm_subblogname = jQuery( '#zbs_crm_subblogname' ).val();
-	window.zbsOptions.zbs_crm_first_name = jQuery( '#zbs_crm_first_name' ).val();
-	window.zbsOptions.zbs_crm_last_name = jQuery( '#zbs_crm_last_name' ).val();
-	window.zbsOptions.zbs_crm_email = jQuery( '#zbs_crm_email' ).val();
-	window.zbsOptions.zbs_crm_subscribed = jQuery( '#zbs_sub' ).is( ':checked' ) ? 1 : 0;
+	zbsOptions.zbs_crm_subblogname = jQuery( '#zbs_crm_subblogname' ).val();
+	zbsOptions.zbs_crm_first_name = jQuery( '#zbs_crm_first_name' ).val();
+	zbsOptions.zbs_crm_last_name = jQuery( '#zbs_crm_last_name' ).val();
+	zbsOptions.zbs_crm_email = jQuery( '#zbs_crm_email' ).val();
+	zbsOptions.zbs_crm_subscribed = jQuery( '#zbs_sub' ).is( ':checked' ) ? 1 : 0;
 }
 
 if ( typeof module !== 'undefined' ) {

--- a/projects/plugins/crm/js/welcome-to-zbs/wizard2.js
+++ b/projects/plugins/crm/js/welcome-to-zbs/wizard2.js
@@ -220,5 +220,5 @@ function zbsJS_welcomeWizard_update_deets() {
 }
 
 if ( typeof module !== 'undefined' ) {
-	module.exports = { zbsOptions, zbs_biz_select, zbs_crm_name_change, zbs_crm_js_updatePage2 };
+	module.exports = { zbs_biz_select, zbs_crm_name_change, zbs_crm_js_updatePage2 };
 }


### PR DESCRIPTION
Fixes Automattic/zero-bs-crm#3531

## Proposed changes:
Some of the variables in the JS were set like so `window.variable = { }` and these were changed to be `const variable = { }` however in some places the `window.variable` references remained. 

This causes some JS errors in local installs. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable? N/A
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them? N/A
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)? N/A

## Jetpack product discussion
Discussed via p1738254853764999-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- [ ] Git pull the trunk 
- [ ] Going to a page like this `wp-admin/admin.php?page=zerobscrm-dash&jpcrm_force_wizard=true` will force the wizard to show (in case you have already run it)
- [ ] Run through the welcome wizard. The "finish" step will be broken
- [ ] Pull this branch, the "finish" step works again

It does not impact the live version, likely because of the minimisation step