### PR TITLE
Jetpack: Fix order of `Jetpack_Gutenberg` function calls.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-order-of-block-calls
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-order-of-block-calls
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix order of `Jetpack_Gutenberg` function calls from #39734.
+
+

--- a/projects/plugins/jetpack/modules/blocks.php
+++ b/projects/plugins/jetpack/modules/blocks.php
@@ -29,8 +29,9 @@ function jetpack_blocks_activate_module() {
 	delete_option( 'jetpack_blocks_disabled' ); // The function will check and return early if not present.
 }
 
-Jetpack_Gutenberg::load_independent_blocks();
 Jetpack_Gutenberg::load_block_editor_extensions();
+Jetpack_Gutenberg::load_independent_blocks();
+Jetpack_Gutenberg::register_block_metadata_collection();
 
 /**
  * We've switched from enqueue_block_editor_assets to enqueue_block_assets in WP-Admin because the assets with the former are loaded on the main site-editor.php.
@@ -43,4 +44,3 @@ if ( is_admin() ) {
 	add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
 }
 add_filter( 'render_block', array( 'Jetpack_Gutenberg', 'display_deprecated_block_message' ), 10, 2 );
-add_action( 'plugins_loaded', array( 'Jetpack_Gutenberg', 'register_block_metadata_collection' ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PR #39734 accidentally swapped the order of the calls to `Jetpack_Gutenberg::load_block_editor_extensions()` and `Jetpack_Gutenberg::load_independent_blocks()`, which somehow broke the Paid Content block from being correctly registered.

It also accidentally removed the call to
`Jetpack_Gutenberg::register_block_metadata_collection()`, which had no visible effect (just removed an optimization).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1738263698408899-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See if the Paid Content block shows up in the block selector sidebar.