### PR TITLE
Tools: Show warning when using rsync with untracked files

### DIFF
--- a/tools/cli/commands/rsync.js
+++ b/tools/cli/commands/rsync.js
@@ -107,6 +107,7 @@ export async function rsyncInit( argv ) {
 			// Warn but don't fail if file was intentionally not synced. We still want to sync
 			// if a change event occurs, as other change events could have been debounced.
 			if (
+				argv.v &&
 				event === 'change' &&
 				! paths.has( eventfile ) &&
 				! [ '../../../.git/index', '.gitignore', '.gitattributes' ].includes( eventfile ) // ignore some specific files
@@ -119,10 +120,10 @@ export async function rsyncInit( argv ) {
 				} else {
 					unsync_reason = 'something odd 🤷';
 				}
-				console.warn(
+				console.debug(
 					`Sync was triggered by a change to '${ eventfile }', but it was not synced.`
 				);
-				console.warn( `Reason: ${ unsync_reason }` );
+				console.debug( `Reason: ${ unsync_reason }` );
 			}
 
 			// On some systems, using multiple 'watcher.add()' calls breaks the firing of the 'ready' event.

--- a/tools/cli/commands/rsync.js
+++ b/tools/cli/commands/rsync.js
@@ -104,8 +104,13 @@ export async function rsyncInit( argv ) {
 
 			const paths = await rsyncToDest( sourcePluginPath, finalDest );
 
-			// Warn but don't fail if file was intentionally not synced.
-			if ( event === 'change' && ! paths.has( eventfile ) ) {
+			// Warn but don't fail if file was intentionally not synced. We still want to sync
+			// if a change event occurs, as other change events could have been debounced.
+			if (
+				event === 'change' &&
+				! paths.has( eventfile ) &&
+				! [ '../../../.git/index', '.gitignore', '.gitattributes' ].includes( eventfile ) // ignore some specific files
+			) {
 				let unsync_reason;
 				if ( ! ( await isFileTracked( sourcePluginPath + eventfile ) ) ) {
 					unsync_reason = 'not tracked by git';

--- a/tools/cli/commands/rsync.js
+++ b/tools/cli/commands/rsync.js
@@ -76,6 +76,24 @@ export async function rsyncInit( argv ) {
 		finalDest = path.join( argv.dest, '/' );
 	}
 
+	const untrackedFiles = await getUntrackedFiles( sourcePluginPath );
+	if ( untrackedFiles ) {
+		console.log( 'The below untracked files were detected in your plugin path:\n' );
+		console.log( untrackedFiles.replace( /^/gm, '  ' ) + '\n' );
+		await enquirer
+			.prompt( {
+				type: 'confirm',
+				name: 'ignoreUntracked',
+				message: 'Untracked files will not be synced. Proceed?',
+				initial: false,
+			} )
+			.then( answer => {
+				if ( ! answer.ignoreUntracked ) {
+					process.exit( 0 );
+				}
+			} );
+	}
+
 	if ( argv.watch ) {
 		await tracks( 'rsync_watch' );
 		let watcher;
@@ -85,6 +103,22 @@ export async function rsyncInit( argv ) {
 			}
 
 			const paths = await rsyncToDest( sourcePluginPath, finalDest );
+
+			// Warn but don't fail if file was intentionally not synced.
+			if ( event === 'change' && ! paths.has( eventfile ) ) {
+				let unsync_reason;
+				if ( ! ( await isFileTracked( sourcePluginPath + eventfile ) ) ) {
+					unsync_reason = 'not tracked by git';
+				} else if ( await isFileExcluded( sourcePluginPath + eventfile ) ) {
+					unsync_reason = 'excluded from production';
+				} else {
+					unsync_reason = 'something odd 🤷';
+				}
+				console.warn(
+					`Sync was triggered by a change to '${ eventfile }', but it was not synced.`
+				);
+				console.warn( `Reason: ${ unsync_reason }` );
+			}
 
 			// On some systems, using multiple 'watcher.add()' calls breaks the firing of the 'ready' event.
 			// Instead, we add all the paths to an array and call add() once.
@@ -385,6 +419,57 @@ async function createFilterFile( paths ) {
 	await util.promisify( tmpStream.close ).call( tmpStream );
 
 	return tmpFile;
+}
+
+/**
+ * Checks if file is tracked by git.
+ *
+ * @param {string} filePath - file path.
+ * @return {boolean} true if tracked, otherwise false.
+ */
+async function isFileTracked( filePath ) {
+	try {
+		await execa( 'git', [ 'ls-files', '--error-unmatch', filePath ] );
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Checks if file attribute is set to production-exclude by `.gitattributes`.
+ *
+ * @param {string} filePath - file path.
+ * @return {boolean} true if excluded, otherwise false.
+ */
+async function isFileExcluded( filePath ) {
+	try {
+		const { stdout } = await execa( 'git', [ 'check-attr', 'production-exclude', '--', filePath ] );
+		return stdout.split( ': ' )[ 2 ] === 'set';
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Get all untracked files in the plugin directory.
+ *
+ * @param {string} pluginPath - Path to plugin.
+ * @return {string} Files that aren't tracked.
+ */
+async function getUntrackedFiles( pluginPath ) {
+	try {
+		const { stdout } = await execa( 'git', [
+			'ls-files',
+			'--others',
+			'--exclude-standard',
+			pluginPath,
+		] );
+		return stdout;
+	} catch ( e ) {
+		console.log( e );
+		console.error( chalk.red( 'Uh oh! ' + e.message ) );
+	}
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

By design `jetpack rsync` only syncs files that are expected to be in production. This means untracked files are not synced. However, this has caused confusion in the past (e.g. p1737037284874559-slack-CDLH4C1UZ).

This PR adds a warning prompt prior to running the rsync:

```
$ jetpack rsync --watch jetpack somedest
Alias found, using dest: somedest:htdocs/wp-content/mu-plugins
The below untracked files were detected in your plugin path:

  projects/plugins/jetpack/asdf asdf copy.asdf
  projects/plugins/jetpack/asdf asdf.asdf
  projects/plugins/jetpack/asdf.asdf

✔ Untracked files will not be synced. Proceed? (y/N) · false
```

Also, when `jetpack rsync --watch` is used, it will output a notice if a sync is triggered by a file that will not be synced itself for one of the following reasons:

* Untracked
* Excluded from production
* Some unknown other reason

It's still good to trigger the sync in these cases, as more than one file might have changed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Try `jetpack rsync` and `jetpack rsync --watch` with various combinations:

* From the monorepo root as well as other folders
* With untracked files and files excluded from production