### PR TITLE
Forms: Hide fields without options

### DIFF
--- a/projects/packages/forms/changelog/fix-hide-form-fields-no-options
+++ b/projects/packages/forms/changelog/fix-hide-form-fields-no-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Hide fields without options.

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1157,8 +1157,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return bool
 	 */
 	public function is_field_renderable( $type ) {
-		// Check for valid radio field.
-		if ( $type === 'radio' ) {
+		// Check that radio, select, and multiple choice
+		// fields have at leaast one valid option.
+		if ( $type === 'radio' || $type === 'checkbox-multiple' || $type === 'select' ) {
 			$options           = (array) $this->get_attribute( 'options' );
 			$non_empty_options = array_filter(
 				$options,

--- a/projects/plugins/jetpack/changelog/fix-hide-form-fields-no-options
+++ b/projects/plugins/jetpack/changelog/fix-hide-form-fields-no-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Hide fields without options.


### PR DESCRIPTION
## Proposed changes:
This is a follow up to #41379, which hid radio form fields that have no options. This PR does the same for multiple choice (checkbox) fields and select fields. As with radios, if those field types have no options, and the fields are required, you can never submit a form.

I thought there would be more work involved, but the logic and structure of the fields is the same as radios, so we just need to include those in the same check. Simple PR.

**EXAMPLE: The form below shows radio, multiple choice, and select fields with no options. Following this PR, none of them should display on the frontend or block form submission.**

<img width="1293" alt="forms-hide-fields-no-options" src="https://github.com/user-attachments/assets/522eff8f-26cb-4d81-addd-aa0049203aa8" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form to a page. When presented with form templates, choose RSVP. The RSVP form contains a radio field. 
* Add a multiple choice field and a select field to the form. For all of these fields, do not add any options. 
* Publish the page. On the frontend, confirm that none of the radio, select, or multiple choice fields appear, and that you can submit the form. 