### PR TITLE
Dont show stats module on my Jetpack if user does not have permissions

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.tsx
@@ -109,6 +109,8 @@ const ProductCardsSection: FC< ProductCardsSectionProps > = ( { noticeMessage } 
 		data: { ownedProducts, unownedProducts },
 	} = useProductsByOwnership();
 
+	const { canUserViewStats } = getMyJetpackWindowInitialState();
+
 	const unownedSectionTitle = useMemo( () => {
 		return ownedProducts.length > 0
 			? __( 'Discover more', 'jetpack-my-jetpack' )
@@ -117,6 +119,10 @@ const ProductCardsSection: FC< ProductCardsSectionProps > = ( { noticeMessage } 
 
 	const filterProducts = ( products: JetpackModule[] ) => {
 		const productsWithNoCard = [ 'scan', 'security', 'growth', 'extras', 'complete' ];
+		// If the user cannot view stats, filter out the stats card
+		if ( ! canUserViewStats ) {
+			productsWithNoCard.push( 'stats' );
+		}
 		return products.filter( product => {
 			if ( productsWithNoCard.includes( product ) ) {
 				return false;

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.tsx
@@ -124,10 +124,7 @@ const ProductCardsSection: FC< ProductCardsSectionProps > = ( { noticeMessage } 
 			productsWithNoCard.push( 'stats' );
 		}
 		return products.filter( product => {
-			if ( productsWithNoCard.includes( product ) ) {
-				return false;
-			}
-			return true;
+			return ! productsWithNoCard.includes( product );
 		} );
 	};
 

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -120,6 +120,7 @@ interface Window {
 		blogID: string;
 		fileSystemWriteAccess: 'yes' | 'no';
 		isStatsModuleActive: string;
+		canUserViewStats: string;
 		isUserFromKnownHost: string;
 		jetpackManage: {
 			isAgencyAccount: boolean;

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -120,7 +120,7 @@ interface Window {
 		blogID: string;
 		fileSystemWriteAccess: 'yes' | 'no';
 		isStatsModuleActive: string;
-		canUserViewStats: string;
+		canUserViewStats: boolean;
 		isUserFromKnownHost: string;
 		jetpackManage: {
 			isAgencyAccount: boolean;

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -297,6 +297,7 @@ class Initializer {
 					'dismissed'  => \Jetpack_Options::get_option( 'dismissed_recommendations', false ),
 				),
 				'isStatsModuleActive'    => $modules->is_active( 'stats' ),
+				'canUserViewStats'       => current_user_can( 'manage_options' ) || current_user_can( 'view_stats' ),
 				'isUserFromKnownHost'    => self::is_user_from_known_host(),
 				'isCommercial'           => self::is_commercial_site(),
 				'sandboxedDomain'        => $sandboxed_domain,


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This diff hides the stats module output on My Jetpack if the user does not have the proper permissions to see stats

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Obtain a Jetpack test site with the main Jetpack plugin installed and connected
* If you run this branch locally, you will need to rebuild `packages/my-jeptack` for testing this change
* As an admin, you will see the Stats card showing on the My Jetpack page
* Log into the site as a non-admin user who does not have permissions for stats (by default, only admins can see stats unless permissions are granted to other roles in settings)
* The Stats card should no longer show in My Jetpack

