### PR TITLE
Make sure Viewers are searchable by username and email.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-search-viewers-by-email
+++ b/projects/plugins/jetpack/changelog/fix-search-viewers-by-email
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Ensure Viewers are searchable by username and email.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -190,7 +190,7 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$wp_viewer = new WP_User( $viewer->ID );
 					// remove special database search characters from search term
 					$search_term = str_replace( '*', '', $args['search'] );
-					return ( strpos( $wp_viewer->user_login, $search_term ) !== false || strpos( $wp_viewer->user_email, $search_term ) !== false );
+					return ( strpos( $wp_viewer->user_login, $search_term ) !== false || strpos( $wp_viewer->user_email, $search_term ) !== false || strpos( $wp_viewer->display_name, $search_term ) !== false );
 				}
 			);
 		}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -181,14 +181,16 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 		) : array();
 		$viewers = array_map( array( $this, 'get_author' ), $viewers );
 
-		// we restrict search field to name when include_viewers is true.
+		// When include_viewers is true, search by username or email.
 		if ( $include_viewers && ! empty( $args['search'] ) ) {
 			$viewers = array_filter(
 				$viewers,
 				function ( $viewer ) use ( $args ) {
+					// Convert to WP_User so expected fields are available.
+					$wp_viewer = new WP_User( $viewer->ID );
 					// remove special database search characters from search term
 					$search_term = str_replace( '*', '', $args['search'] );
-					return strpos( $viewer->name, $search_term ) !== false;
+					return ( strpos( $wp_viewer->user_login, $search_term ) !== false || strpos( $wp_viewer->user_email, $search_term ) !== false );
 				}
 			);
 		}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -190,7 +190,7 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$wp_viewer = new WP_User( $viewer->ID );
 					// remove special database search characters from search term
 					$search_term = str_replace( '*', '', $args['search'] );
-					return ( strpos( $wp_viewer->user_login, $search_term ) !== false || strpos( $wp_viewer->user_email, $search_term ) !== false || strpos( $wp_viewer->display_name, $search_term ) !== false );
+					return ( str_contains( $wp_viewer->user_login, $search_term ) || str_contains( $wp_viewer->user_email, $search_term ) || str_contains( $wp_viewer->display_name, $search_term ) );
 				}
 			);
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/77814.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

When queried with a search parameter and `include_viewers` set to true, `WPCOM_JSON_API_List_Users_Endpoint` only compares the search string with the name field for Viewer role users. 

This PR replaces the name field with username and email fields, so querying by either of those returns any relevant Viewer users.
In order to access the correct fields, we're converting the users to `WP_User` objects before comparing the search string.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* This needs to be tested on a wp.com simple site, with one or more Viewer type users available.
* To create a Viewer user, first set your site to Private under general settings.
* Then go to "Add new user" (must be the Calypso view!) and select "Viewer" from the roles dropdown.
* Go to the Calypso version of the All Users page and search for a Viewer by username or by email; check the correct Viewer pops up in the results.


