### PR TITLE
Jetpack Sync: fix extracting UTF-8 characters from image alt text

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-media-extractor-image-alt-text-encoding
+++ b/projects/plugins/jetpack/changelog/fix-media-extractor-image-alt-text-encoding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack Sync: Fixed extracting UTF-8 characters from image alt-text

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -495,10 +495,18 @@ class Jetpack_PostImages {
 		// Let's grab all image tags from the HTML.
 		$dom_doc = new DOMDocument();
 
+		// DOMDocument defaults to ISO-8859 because we're loading only the post content, without head tag.
+		// Fix: Enforce encoding with meta tag.
+		$charset = get_option( 'blog_charset' );
+		if ( empty( $charset ) || ! preg_match( '/^[a-zA-Z0-9_-]+$/', $charset ) ) {
+			$charset = 'UTF-8';
+		}
+		$html_prefix = sprintf( '<meta http-equiv="Content-Type" content="text/html; charset=%s">', esc_attr( $charset ) );
+
 		// The @ is not enough to suppress errors when dealing with libxml,
 		// we have to tell it directly how we want to handle errors.
 		libxml_use_internal_errors( true );
-		@$dom_doc->loadHTML( $html_info['html'] ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		@$dom_doc->loadHTML( $html_prefix . $html_info['html'] ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		libxml_use_internal_errors( false );
 
 		$image_tags = $dom_doc->getElementsByTagName( 'img' );

--- a/projects/plugins/jetpack/tests/php/media/test-class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/tests/php/media/test-class.jetpack-post-images.php
@@ -84,6 +84,19 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers Jetpack_PostImages::from_html
+	 */
+	public function test_from_html_alt_utf8() {
+		$s = '<img src="bob.jpg" width="200" height="200" alt="Ḽơᶉëᶆ ȋṕšᶙṁ ḍỡḽǭᵳ ʂǐť ӓṁệẗ" />';
+
+		$result = Jetpack_PostImages::from_html( $s );
+
+		$this->assertIsArray( $result );
+		$this->assertNotEmpty( $result );
+		$this->assertEquals( 'Ḽơᶉëᶆ ȋṕšᶙṁ ḍỡḽǭᵳ ʂǐť ӓṁệẗ', $result[0]['alt_text'] );
+	}
+
+	/**
 	 * @author scotchfield
 	 * @covers Jetpack_PostImages::from_slideshow
 	 * @since 3.2


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/33480

## Proposed changes:
* Prepend the blog encoding to HTML when parsing post content to extract images and their alt texts

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/jetpack/issues/33480

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

I've added an automated test. Additionally, we can test it on wpcom: 36d89-pb/#plain