### PR TITLE
Components: Add ScanReport and ShieldIcon Components

### DIFF
--- a/projects/js-packages/components/changelog/add-protect-meets-core-components
+++ b/projects/js-packages/components/changelog/add-protect-meets-core-components
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Components: add additional Protect components

--- a/projects/js-packages/components/components/scan-report/constants.ts
+++ b/projects/js-packages/components/components/scan-report/constants.ts
@@ -1,0 +1,36 @@
+import { __ } from '@wordpress/i18n';
+import {
+	code as fileIcon,
+	color as themeIcon,
+	plugins as pluginIcon,
+	shield as shieldIcon,
+	wordpress as coreIcon,
+} from '@wordpress/icons';
+
+export const STATUS_TYPES = [
+	{ value: 'checked', label: __( 'Checked', 'jetpack-components' ) },
+	{ value: 'unchecked', label: __( 'Unchecked', 'jetpack-components' ) },
+	{ value: 'threat', label: __( 'Threat', 'jetpack-components' ) },
+];
+
+export const TYPES = [
+	{ value: 'core', label: __( 'WordPress', 'jetpack-components' ) },
+	{ value: 'plugins', label: __( 'Plugin', 'jetpack-components' ) },
+	{ value: 'themes', label: __( 'Theme', 'jetpack-components' ) },
+	{ value: 'files', label: __( 'Files', 'jetpack-components' ) },
+];
+
+export const ICONS = {
+	plugins: pluginIcon,
+	themes: themeIcon,
+	core: coreIcon,
+	files: fileIcon,
+	default: shieldIcon,
+};
+
+export const FIELD_ICON = 'icon';
+export const FIELD_TYPE = 'type';
+export const FIELD_NAME = 'name';
+export const FIELD_STATUS = 'status';
+export const FIELD_UPDATE = 'update';
+export const FIELD_VERSION = 'version';

--- a/projects/js-packages/components/components/scan-report/index.tsx
+++ b/projects/js-packages/components/components/scan-report/index.tsx
@@ -1,0 +1,250 @@
+import { type Threat } from '@automattic/jetpack-scan';
+import { Tooltip } from '@wordpress/components';
+import {
+	type SupportedLayouts,
+	type View,
+	type Field,
+	DataViews,
+	filterSortAndPaginate,
+} from '@wordpress/dataviews';
+import { __, _n } from '@wordpress/i18n';
+import { Icon } from '@wordpress/icons';
+import { useCallback, useMemo, useState } from 'react';
+import ShieldIcon from '../shield-icon';
+import {
+	FIELD_NAME,
+	FIELD_VERSION,
+	FIELD_ICON,
+	FIELD_STATUS,
+	FIELD_TYPE,
+	STATUS_TYPES,
+	TYPES,
+	ICONS,
+} from './constants';
+import styles from './styles.module.scss';
+
+type ScanReportExtension = {
+	id: number;
+	checked: boolean;
+	slug?: string;
+	name?: string;
+	version?: string;
+	threats: Threat[];
+	type: 'plugins' | 'themes' | 'core' | 'files';
+};
+
+/**
+ * DataViews component for displaying a scan report.
+ *
+ * @param {object}   props                   - Component props.
+ * @param {string}   props.dataSource        - Data source.
+ * @param {Array}    props.data              - Scan report data.
+ * @param {Function} props.onChangeSelection - Callback function run when an item is selected.
+ *
+ * @return {JSX.Element} The ScanReport component.
+ */
+export default function ScanReport( { dataSource, data, onChangeSelection } ): JSX.Element {
+	const baseView = {
+		search: '',
+		filters: [],
+		page: 1,
+		perPage: 20,
+	};
+
+	/**
+	 * DataView default layouts.
+	 *
+	 * This property provides layout information about the view types that are active. If empty, enables all layout types (see “Layout Types”) with empty layout data.
+	 *
+	 * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dataviews/#defaultlayouts-record-string-view
+	 */
+	const defaultLayouts: SupportedLayouts = {
+		table: {
+			...baseView,
+			fields: [ FIELD_TYPE, FIELD_NAME, FIELD_VERSION ],
+			titleField: FIELD_STATUS,
+			showMedia: false,
+		},
+		list: {
+			...baseView,
+			fields: [ FIELD_STATUS, FIELD_VERSION, FIELD_TYPE ],
+			titleField: FIELD_NAME,
+			mediaField: FIELD_ICON,
+			showMedia: true,
+		},
+	};
+
+	/**
+	 * DataView view object - configures how the dataset is visible to the user.
+	 *
+	 * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dataviews/#view-object
+	 */
+	const [ view, setView ] = useState< View >( {
+		type: 'table',
+		...defaultLayouts.table,
+	} );
+
+	/**
+	 * DataView fields - describes the visible items for each record in the dataset.
+	 *
+	 * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dataviews/#fields-object
+	 */
+	const fields = useMemo( () => {
+		const iconHeight = 20;
+		const result: Field< ScanReportExtension >[] = [
+			{
+				id: FIELD_STATUS,
+				elements: STATUS_TYPES,
+				label: __( 'Status', 'jetpack-components' ),
+				enableHiding: false,
+				getValue( { item } ) {
+					if ( item.checked ) {
+						if ( item.threats.length > 0 ) {
+							return 'threat';
+						}
+						return 'checked';
+					}
+					return 'unchecked';
+				},
+				render( { item }: { item: ScanReportExtension } ) {
+					const scanApi = 'scan_api' === dataSource;
+					let variant: 'info' | 'error' | 'success' = 'info';
+					let text = __(
+						'This item was added to your site after the most recent scan. We will check for threats during the next scheduled one.',
+						'jetpack-components'
+					);
+
+					if ( item.checked ) {
+						if ( item.threats.length > 0 ) {
+							variant = 'error';
+							text = _n(
+								'Vulnerability detected.',
+								'Vulnerabilities detected.',
+								item.threats.length,
+								'jetpack-components'
+							);
+
+							if ( scanApi ) {
+								text = _n(
+									'Threat detected.',
+									'Threats detected.',
+									item.threats.length,
+									'jetpack-components'
+								);
+							}
+						} else {
+							variant = 'success';
+							text = __(
+								'No known vulnerabilities found that affect this version.',
+								'jetpack-components'
+							);
+
+							if ( scanApi ) {
+								text = __(
+									'No known threats found that affect this version.',
+									'jetpack-components'
+								);
+							}
+						}
+					}
+
+					return (
+						<Tooltip className={ styles.tooltip } text={ text }>
+							<div className={ styles.icon }>
+								<ShieldIcon variant={ variant } height={ iconHeight } />
+							</div>
+						</Tooltip>
+					);
+				},
+			},
+			{
+				id: FIELD_TYPE,
+				label: __( 'Type', 'jetpack-components' ),
+				elements: TYPES,
+				enableHiding: false,
+			},
+			{
+				id: FIELD_NAME,
+				label: __( 'Name', 'jetpack-components' ),
+				enableHiding: false,
+				enableGlobalSearch: true,
+				getValue( { item }: { item: ScanReportExtension } ) {
+					return item.name ? item.name : '';
+				},
+			},
+			{
+				id: FIELD_VERSION,
+				label: __( 'Version', 'jetpack-components' ),
+				enableHiding: false,
+				enableSorting: false,
+				enableGlobalSearch: true,
+				getValue( { item }: { item: ScanReportExtension } ) {
+					return item.version ? item.version : '';
+				},
+			},
+			...( view.type === 'list'
+				? [
+						{
+							id: FIELD_ICON,
+							label: __( 'Icon', 'jetpack-components' ),
+							enableSorting: false,
+							enableHiding: false,
+							getValue( { item }: { item: ScanReportExtension } ) {
+								return ICONS[ item.type ] || '';
+							},
+							render( { item }: { item: ScanReportExtension } ) {
+								return (
+									<div className={ styles.threat__media }>
+										<Icon icon={ ICONS[ item.type ] } />
+									</div>
+								);
+							},
+						},
+				  ]
+				: [] ),
+		];
+
+		return result;
+	}, [ view, dataSource ] );
+
+	/**
+	 * Apply the view settings (i.e. filters, sorting, pagination) to the dataset.
+	 *
+	 * @see https://github.com/WordPress/gutenberg/blob/trunk/packages/dataviews/src/filter-and-sort-data-view.ts
+	 */
+	const { data: processedData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( data, view, fields );
+	}, [ data, view, fields ] );
+
+	/**
+	 * Callback function to update the view state.
+	 *
+	 * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dataviews/#onchangeview-function
+	 */
+	const onChangeView = useCallback( ( newView: View ) => {
+		setView( newView );
+	}, [] );
+
+	/**
+	 * DataView getItemId function - returns the unique ID for each record in the dataset.
+	 *
+	 * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dataviews/#getitemid-function
+	 */
+	const getItemId = useCallback(
+		( item: ScanReportExtension ) => `${ item.type }_${ item.slug }_${ item.version }`,
+		[]
+	);
+
+	return (
+		<DataViews
+			data={ processedData }
+			defaultLayouts={ defaultLayouts }
+			fields={ fields }
+			getItemId={ getItemId }
+			onChangeSelection={ onChangeSelection }
+			onChangeView={ onChangeView }
+			paginationInfo={ paginationInfo }
+			view={ view }
+		/>
+	);
+}

--- a/projects/js-packages/components/components/scan-report/stories/index.stories.tsx
+++ b/projects/js-packages/components/components/scan-report/stories/index.stories.tsx
@@ -1,0 +1,79 @@
+import ScanReport from '..';
+
+export default {
+	title: 'JS Packages/Components/Scan Report',
+	component: ScanReport,
+	parameters: {
+		backgrounds: {
+			default: 'light',
+			values: [ { name: 'light', value: 'white' } ],
+		},
+	},
+	decorators: [
+		Story => (
+			<div style={ { maxWidth: '100%', backgroundColor: 'white' } }>
+				<Story />
+			</div>
+		),
+	],
+};
+
+export const Default = args => <ScanReport { ...args } />;
+Default.args = {
+	dataSource: 'scan_api',
+	data: [
+		{
+			id: 1,
+			name: 'WordPress',
+			slug: null,
+			version: '6.7.1',
+			threats: [],
+			checked: true,
+			type: 'core',
+		},
+		{
+			id: 2,
+			name: 'Jetpack',
+			slug: 'jetpack/jetpack.php',
+			version: '14.1-a.7',
+			threats: [],
+			checked: false,
+			type: 'plugins',
+		},
+		{
+			id: 3,
+			name: 'Twenty Fifteen',
+			slug: 'twentyfifteen',
+			version: '1.1',
+			threats: [
+				{
+					id: 198352527,
+					signature: 'Vulnerable.WP.Extension',
+					description: 'Vulnerable WordPress extension',
+					severity: 3,
+				},
+			],
+			checked: true,
+			type: 'themes',
+		},
+		{
+			id: 4,
+			threats: [
+				{
+					id: 198352406,
+					signature: 'EICAR_AV_Test_Suspicious',
+					title: 'Malicious code found in file: jptt_eicar.php',
+					severity: 1,
+				},
+				{
+					id: 198352407,
+					signature: 'EICAR_AV_Test_Suspicious',
+					title: 'Malicious code found in file: jptt_eicar.php',
+					severity: 1,
+				},
+			],
+			checked: true,
+			type: 'files',
+		},
+	],
+};

--- a/projects/js-packages/components/components/scan-report/styles.module.scss
+++ b/projects/js-packages/components/components/scan-report/styles.module.scss
@@ -1,0 +1,27 @@
+@import '@wordpress/dataviews/build-style/style.css';
+
+.threat__media {
+	width: 100%;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background-color: #EDFFEE;
+	border-color: #EDFFEE;
+
+	svg {
+		fill: var( --jp-black );
+	}
+}
+
+.tooltip {
+	max-width: 240px;
+	border-radius: 4px;
+	text-align: left;
+}
+
+.icon {
+	min-width: 32px;
+	display: flex;
+	justify-content: center;
+}

--- a/projects/js-packages/components/components/shield-icon/index.tsx
+++ b/projects/js-packages/components/components/shield-icon/index.tsx
@@ -1,0 +1,81 @@
+const COLORS = {
+	default: '#1d2327',
+	info: '#A7AAAD',
+	success: '#069E08',
+	warning: '#F0B849',
+	error: '#D63638',
+};
+
+/**
+ * Protect Shield SVG Icon
+ *
+ * @param {object}  props           - Component props.
+ * @param {string}  props.className - Additional class names.
+ * @param {string}  props.contrast  - Icon contrast color. Overrides variant.
+ * @param {string}  props.fill      - Icon fill color (default, success, warning, error, or a custom color code string). Overrides variant.
+ * @param {number}  props.height    - Icon height (px). Width is calculated based on height.
+ * @param {string}  props.icon      - Icon variant (success, error). Overrides variant.
+ * @param {boolean} props.outline   - When enabled, the icon will use an outline style.
+ * @param {string}  props.variant   - Icon variant (default, success, error).
+ *
+ * @return {React.ReactElement} Protect Shield SVG Icon
+ */
+export default function ShieldIcon( {
+	className,
+	contrast = '#fff',
+	fill,
+	height = 32,
+	icon,
+	outline = false,
+	variant = 'default',
+}: {
+	className?: string;
+	contrast?: string;
+	fill?: 'default' | 'info' | 'success' | 'warning' | 'error' | string;
+	height?: number;
+	icon?: 'success' | 'error' | 'warning';
+	outline?: boolean;
+	variant?: 'default' | 'info' | 'success' | 'warning' | 'error';
+} ): JSX.Element {
+	const shieldFill = COLORS[ fill ] || fill || COLORS[ variant ];
+	const iconFill = outline ? shieldFill : contrast;
+	const iconVariant = icon || variant;
+
+	return (
+		<svg
+			height={ height }
+			width={ ( height * 76 ) / 93 }
+			viewBox="0 0 76 93"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			className={ className }
+		>
+			<path
+				d={
+					'M37.5652 0.980293L75.1304 18.0554V43.5097C75.1304 65.2086 61.1942 85.753 41.5427 92.2343C38.9604 93.0862 36.1701 93.0862 33.5878 92.2343C13.9362 85.753 0 65.2086 0 43.5097V18.0554L37.5652 0.980293Z' +
+					( outline
+						? ' M8.34783 23.4307V43.5097C8.34783 61.9471 20.286 79.0573 36.2024 84.3068C37.0866 84.5981 38.0438 84.5981 38.928 84.3068C54.8444 79.0573 66.7826 61.9471 66.7826 43.5097V23.4307L37.5652 10.15L8.34783 23.4307Z'
+						: '' )
+				}
+				fill={ shieldFill }
+			/>
+			{ 'info' === iconVariant && (
+				<path d="M33.7 69H41.5V45.6H33.7V69ZM33.7 37.8H41.5V30H33.7V37.8Z" fill={ iconFill } />
+			) }
+			{ 'success' === iconVariant && (
+				<path
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M55.6042 37.0675L34.3578 65.2656L20.898 55.3892L23.878 51.4342L33.33 58.3698L51.5965 34.1267L55.6042 37.0675Z"
+					fill={ iconFill }
+				/>
+			) }
+			{ [ 'warning', 'error' ].includes( iconVariant ) && (
+				<path
+					d="M41.7474 54.1614L43.0546 30H32L33.3071 54.1614H41.7474ZM41.4113 66.7283C42.3076 65.8681 42.7931 64.6713 42.7931 63.1378C42.7931 61.5669 42.345 60.3701 41.4487 59.5098C40.5523 58.6496 39.2452 58.2008 37.4899 58.2008C35.7346 58.2008 34.4275 58.6496 33.4939 59.5098C32.5602 60.3701 32.112 61.5669 32.112 63.1378C32.112 64.6713 32.5975 65.8681 33.5312 66.7283C34.5022 67.5886 35.8093 68 37.4899 68C39.1705 68 40.4776 67.5886 41.4113 66.7283Z"
+					fill={ iconFill }
+				/>
+			) }
+		</svg>
+	);
+}

--- a/projects/js-packages/components/components/shield-icon/stories/index.stories.tsx
+++ b/projects/js-packages/components/components/shield-icon/stories/index.stories.tsx
@@ -1,0 +1,56 @@
+import ShieldIcon from '../index';
+
+export default {
+	title: 'JS Packages/Components/Sheild Icon',
+	component: ShieldIcon,
+	parameters: {
+		layout: 'centered',
+	},
+	argTypes: {
+		variant: {
+			control: {
+				type: 'select',
+			},
+			options: [ 'default', 'info', 'success', 'warning', 'error' ],
+		},
+		icon: {
+			control: {
+				type: 'select',
+			},
+			options: [ 'info', 'success', 'error' ],
+		},
+		fill: {
+			control: 'color',
+		},
+		outline: {
+			control: 'boolean',
+		},
+	},
+};
+
+export const Default = args => <ShieldIcon { ...args } />;
+Default.args = {
+	variant: 'success',
+	outline: false,
+};
+
+export const Variants = () => {
+	return (
+		<div style={ { display: 'flex', flexDirection: 'column', gap: '8px' } }>
+			<div style={ { display: 'flex', gap: '8px' } }>
+				<ShieldIcon variant="default" />
+				<ShieldIcon variant="info" />
+				<ShieldIcon variant="success" />
+				<ShieldIcon variant="warning" />
+				<ShieldIcon variant="error" />
+			</div>
+			<div style={ { display: 'flex', gap: '8px' } }>
+				<ShieldIcon variant="default" outline />
+				<ShieldIcon variant="info" outline />
+				<ShieldIcon variant="success" outline />
+				<ShieldIcon variant="warning" outline />
+				<ShieldIcon variant="error" outline />
+			</div>
+		</div>
+	);
+};

--- a/projects/js-packages/components/components/threat-severity-badge/index.tsx
+++ b/projects/js-packages/components/components/threat-severity-badge/index.tsx
@@ -1,25 +1,40 @@
-import { _x } from '@wordpress/i18n';
+import {
+	getSeverityLabel,
+	getSeverityLevel,
+	SEVERITY_LEVEL_CRITICAL,
+	SEVERITY_LEVEL_HIGH,
+	SEVERITY_LEVEL_LOW,
+} from '@automattic/jetpack-scan';
+import { __, sprintf } from '@wordpress/i18n';
 import Badge from '../badge';
 
-const ThreatSeverityBadge = ( { severity } ) => {
-	if ( severity >= 5 ) {
-		return (
-			<Badge variant="danger">
-				{ _x( 'Critical', 'Severity label for issues rated 5 or higher.', 'jetpack-components' ) }
-			</Badge>
-		);
-	}
+const ThreatSeverityBadge = ( { severity, showLabel = false } ) => {
+	const title = getSeverityLabel( severity );
 
-	if ( severity >= 3 && severity < 5 ) {
-		return (
-			<Badge variant="warning">
-				{ _x( 'High', 'Severity label for issues rated between 3 and 5.', 'jetpack-components' ) }
-			</Badge>
-		);
+	let variant: 'danger' | 'warning';
+	switch ( getSeverityLevel( severity ) ) {
+		case SEVERITY_LEVEL_CRITICAL:
+			variant = 'danger';
+			break;
+		case SEVERITY_LEVEL_HIGH:
+			variant = 'warning';
+			break;
+		case SEVERITY_LEVEL_LOW:
+		default:
+			// Default variant.
+			break;
 	}
 
 	return (
-		<Badge>{ _x( 'Low', 'Severity label for issues rated below 3.', 'jetpack-components' ) }</Badge>
+		<Badge variant={ variant }>
+			{ showLabel
+				? sprintf(
+						// translators: placeholder is the severity title, i.e. "Critical Severity".
+						__( '%s Severity', 'jetpack-components' ),
+						title
+				  )
+				: title }
+		</Badge>
 	);
 };
 

--- a/projects/js-packages/components/index.ts
+++ b/projects/js-packages/components/index.ts
@@ -47,6 +47,8 @@ export { default as ThemeProvider } from './components/theme-provider';
 export { default as ThreatFixerButton } from './components/threat-fixer-button';
 export { default as ThreatSeverityBadge } from './components/threat-severity-badge';
 export { default as ThreatsDataViews } from './components/threats-data-views';
+export { default as ScanReport } from './components/scan-report';
+export { default as ShieldIcon } from './components/shield-icon';
 export { default as Text, H2, H3, Title } from './components/text';
 export { default as ToggleControl } from './components/toggle-control';
 export { default as numberFormat } from './components/number-format';

--- a/projects/js-packages/scan/changelog/add-severity-utils
+++ b/projects/js-packages/scan/changelog/add-severity-utils
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add severity utils

--- a/projects/js-packages/scan/src/utils/index.ts
+++ b/projects/js-packages/scan/src/utils/index.ts
@@ -3,6 +3,8 @@ import { FIXER_IS_STALE_THRESHOLD } from '../constants/index.js';
 import { type ThreatFixStatus } from '../types/fixers.js';
 import { type Threat } from '../types/threats.js';
 
+export * from './severity.js';
+
 export const getThreatType = ( threat: Threat ) => {
 	if ( threat.signature === 'Vulnerable.WP.Core' ) {
 		return 'core';

--- a/projects/js-packages/scan/src/utils/severity.ts
+++ b/projects/js-packages/scan/src/utils/severity.ts
@@ -1,0 +1,52 @@
+import { _x } from '@wordpress/i18n';
+
+export const SEVERITY_LEVEL_CRITICAL = 'critical';
+export const SEVERITY_LEVEL_HIGH = 'high';
+export const SEVERITY_LEVEL_LOW = 'low';
+
+export type SeverityLevel =
+	| typeof SEVERITY_LEVEL_CRITICAL
+	| typeof SEVERITY_LEVEL_HIGH
+	| typeof SEVERITY_LEVEL_LOW;
+
+/**
+ * Get Severity Level based on CVSS score.
+ *
+ * @param {number} severity - The severity score, i.e. 5.4.
+ *
+ * @return {string} The severity type, i.e. SEVERITY_LEVEL_CRITICAL.
+ */
+export function getSeverityLevel( severity: number ): SeverityLevel {
+	if ( severity >= 5 ) {
+		return SEVERITY_LEVEL_CRITICAL;
+	}
+
+	if ( severity >= 3 && severity < 5 ) {
+		return SEVERITY_LEVEL_HIGH;
+	}
+
+	return SEVERITY_LEVEL_LOW;
+}
+
+/**
+ * Get Severity Label based on CVSS score.
+ *
+ * @param {number} severity - The severity score, i.e. 5.4.
+ *
+ * @return {string} The severity label, i.e. "Critical".
+ */
+export function getSeverityLabel( severity: number ): string {
+	switch ( getSeverityLevel( severity ) ) {
+		case SEVERITY_LEVEL_CRITICAL:
+			return _x(
+				'Critical',
+				'Severity label for threats with CVSS of 5 or greater.',
+				'jetpack-scan'
+			);
+		case SEVERITY_LEVEL_HIGH:
+			return _x( 'High', 'Severity label for threats with CVSS between 3 and 5.', 'jetpack-scan' );
+		case SEVERITY_LEVEL_LOW:
+		default:
+			return _x( 'Low', 'Severity label for threats with a CVSS lower than 3.', 'jetpack-scan' );
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `ScanReport` component
* Adds `ShieldIcon` component
* Updates `ThreatSeverityBadge` with new severity utils in the scan package.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

TBD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* TBD

