### PR TITLE
wpcomsh: Update wc-calypso-bridge to 2.8.2 

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-bridge-to-2.8.2
+++ b/projects/plugins/wpcomsh/changelog/update-bridge-to-2.8.2
@@ -1,0 +1,4 @@
+Significance: path
+Type: changed
+
+Update wc-calypso-bridge dependency to 2.8.2

--- a/projects/plugins/wpcomsh/changelog/update-bridge-to-2.8.2
+++ b/projects/plugins/wpcomsh/changelog/update-bridge-to-2.8.2
@@ -1,4 +1,4 @@
-Significance: path
+Significance: patch
 Type: changed
 
 Update wc-calypso-bridge dependency to 2.8.2

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -9,7 +9,7 @@
 		"automattic/custom-fonts": "^3.0",
 		"automattic/custom-fonts-typekit": "^2.0",
 		"automattic/text-media-widget-styles": "^2.0",
-		"automattic/wc-calypso-bridge": "2.8.1",
+		"automattic/wc-calypso-bridge": "2.8.2",
 		"wordpress/classic-editor-plugin": "1.6.7",
 		"automattic/jetpack-composer-plugin": "@dev",
 		"automattic/jetpack-config": "@dev",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "61f98aeaa724ef3b6c8460aa67a09223",
+    "content-hash": "9f3ce7d5ead6179da04a6e8b9db4da67",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
@@ -2012,16 +2012,16 @@
         },
         {
             "name": "automattic/wc-calypso-bridge",
-            "version": "v2.8.1",
+            "version": "v2.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/wc-calypso-bridge.git",
-                "reference": "32ecd472f1f4e8b6ea9ee817167255ccb4974811"
+                "reference": "7592a687a9a36afa49cd25557fac8f6a6d4e899c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/32ecd472f1f4e8b6ea9ee817167255ccb4974811",
-                "reference": "32ecd472f1f4e8b6ea9ee817167255ccb4974811",
+                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/7592a687a9a36afa49cd25557fac8f6a6d4e899c",
+                "reference": "7592a687a9a36afa49cd25557fac8f6a6d4e899c",
                 "shasum": ""
             },
             "require-dev": {
@@ -2060,7 +2060,7 @@
                     "phpcbf -p"
                 ]
             },
-            "time": "2024-10-29T15:32:13+00:00"
+            "time": "2025-01-31T03:41:01+00:00"
         },
         {
             "name": "scssphp/scssphp",
@@ -4865,11 +4865,11 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "automattic/jetpack-changelogger": 20,
         "automattic/jetpack-composer-plugin": 20,
         "automattic/jetpack-config": 20,
+        "automattic/jetpack-post-list": 20,
         "automattic/jetpack-mu-wpcom": 20,
-        "automattic/jetpack-post-list": 20
+        "automattic/jetpack-changelogger": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4876,6 +4876,6 @@
     "platform": {
         "php": ">=7.4"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4865,11 +4865,11 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "automattic/jetpack-changelogger": 20,
         "automattic/jetpack-composer-plugin": 20,
         "automattic/jetpack-config": 20,
-        "automattic/jetpack-post-list": 20,
         "automattic/jetpack-mu-wpcom": 20,
-        "automattic/jetpack-changelogger": 20
+        "automattic/jetpack-post-list": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,
@@ -4877,5 +4877,5 @@
         "php": ">=7.4"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4876,6 +4876,6 @@
     "platform": {
         "php": ">=7.4"
     },
-    "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This PR bumps the version of `wc-calypso-bridge` to `2.8.2`, which includes the following change:

- [Do not adjust header width for RTL languages](https://github.com/Automattic/wc-calypso-bridge/pull/1533#top)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

The changes related to the wc-calypso-bridge were already tested in the linked PRs. Testing instructions can be found on the linked PRs above.

