### PR TITLE
Stat Card: add "hideValue" property

### DIFF
--- a/projects/js-packages/components/changelog/add-hide-value-prop-to-stat-card
+++ b/projects/js-packages/components/changelog/add-hide-value-prop-to-stat-card
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stat Card: add hideValue prop.

--- a/projects/js-packages/components/components/stat-card/index.tsx
+++ b/projects/js-packages/components/components/stat-card/index.tsx
@@ -18,7 +18,14 @@ import type React from 'react';
  * @param {StatCardProps} props - Component props.
  * @return {React.ReactNode} - StatCard react component.
  */
-const StatCard = ( { className, icon, label, value, variant = 'square' }: StatCardProps ) => {
+const StatCard = ( {
+	className,
+	hideValue,
+	icon,
+	label,
+	value,
+	variant = 'square',
+}: StatCardProps ) => {
 	const formattedValue = numberFormat( value );
 	const compactValue = numberFormat( value, {
 		notation: 'compact',
@@ -33,12 +40,12 @@ const StatCard = ( { className, icon, label, value, variant = 'square' }: StatCa
 				{ variant === 'square' ? (
 					<Tooltip text={ formattedValue } placement="top">
 						<Text variant="headline-small" className={ clsx( styles.value ) }>
-							{ compactValue }
+							{ hideValue ? '-' : compactValue }
 						</Text>
 					</Tooltip>
 				) : (
 					<Text variant="title-medium-semi-bold" className={ clsx( styles.value ) }>
-						{ formattedValue }
+						{ hideValue ? '-' : formattedValue }
 					</Text>
 				) }
 			</div>

--- a/projects/js-packages/components/components/stat-card/stories/index.stories.tsx
+++ b/projects/js-packages/components/components/stat-card/stories/index.stories.tsx
@@ -21,6 +21,9 @@ export default {
 				disable: true,
 			},
 		},
+		hideValue: {
+			control: { type: 'boolean' },
+		},
 	},
 } as Meta< typeof StatCard >;
 

--- a/projects/js-packages/components/components/stat-card/types.ts
+++ b/projects/js-packages/components/components/stat-card/types.ts
@@ -5,6 +5,11 @@ export type StatCardProps = {
 	className?: string;
 
 	/**
+	 * Whether to hide the value.
+	 */
+	hideValue?: boolean;
+
+	/**
 	 * The stat card icon.
 	 */
 	icon: React.JSX.Element;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Extracted from https://github.com/Automattic/jetpack/pull/40191

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a `hideValue` prop to the `StatCard` component, to enable intentionally displaying a "-" character instead of a zero when a stat value is unavailable.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1HpG7-v1n-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test the StatCard Storybook: `cd projects/js-packages/storybook && pnpm storybook:dev`

## Screenshots:

<img width="914" alt="Screenshot 2025-02-09 at 4 45 48 PM" src="https://github.com/user-attachments/assets/5c3dc933-ff36-4cb8-9be4-4185706a736e" />

<img width="874" alt="Screenshot 2025-02-09 at 4 46 00 PM" src="https://github.com/user-attachments/assets/9bed791c-09e4-48ed-a830-342acd7ddce0" />