### PR TITLE
Social | Move settings endpoint to publicize package

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-move-settings-endpoint-to-publicize
+++ b/projects/js-packages/publicize-components/changelog/update-social-move-settings-endpoint-to-publicize
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Move settings endpoint to publicize package

--- a/projects/js-packages/publicize-components/src/social-store/selectors/social-settings.ts
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/social-settings.ts
@@ -17,21 +17,34 @@ export const isSavingSiteSettings = createRegistrySelector( select => () => {
 export const getSocialSettings = createRegistrySelector( select => () => {
 	const data = select( coreStore ).getEntityRecord< SocialSettingsFields >( 'root', 'site' );
 
+	const { settings } = getSocialScriptData();
+
 	// If we don't have the data yet,
 	// return the default settings from the initial state.
 	if ( ! data ) {
-		return getSocialScriptData().settings;
+		return settings;
 	}
 
+	// Add safe fallbacks for cases when the REST API doesn't return the expected data.
+	// For example when publicize module is disabled, the API doesn't return the settings.
 	return {
-		showPricingPage: data[ 'jetpack-social_show_pricing_page' ],
-		socialImageGenerator: data.jetpack_social_image_generator_settings,
-		utmSettings: data.jetpack_social_utm_settings,
+		showPricingPage: data[ 'jetpack-social_show_pricing_page' ] ?? settings.showPricingPage,
+		socialImageGenerator: {
+			...settings.socialImageGenerator,
+			...data.jetpack_social_image_generator_settings,
+		},
+		utmSettings: {
+			...settings.utmSettings,
+			...data.jetpack_social_utm_settings,
+		},
 		socialNotes: {
 			// When it's OFF, the API sometimes returns null,
 			// So, to avoid controlled vs uncrontrolled warning, we convert it to false
 			enabled: Boolean( data[ 'jetpack-social-note' ] ),
-			config: data.jetpack_social_notes_config,
+			config: {
+				...settings.socialNotes.config,
+				...data.jetpack_social_notes_config,
+			},
 		},
 	} satisfies SocialSettings;
 } );

--- a/projects/packages/publicize/changelog/update-social-move-settings-endpoint-to-publicize
+++ b/projects/packages/publicize/changelog/update-social-move-settings-endpoint-to-publicize
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Move settings endpoint to publicize package

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -51,6 +51,9 @@ class Publicize_Setup {
 			}
 		}
 
+		// This doesn't need to be active on WPCOM.
+		new REST_API\Settings_Controller();
+
 		Social_Admin_Page::init();
 	}
 

--- a/projects/packages/publicize/src/rest-api/class-settings-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-settings-controller.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * The settings controller class.
+ *
+ * @package automattic/jetpack-publicize
+ */
+
+namespace Automattic\Jetpack\Publicize\REST_API;
+
+use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\Publicize\Publicize_Utils;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Registers the REST routes for Social.
+ */
+class Settings_Controller extends WP_REST_Controller {
+	const JETPACK_PUBLICIZE_MODULE_SLUG = 'publicize';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Registers the REST routes.
+	 *
+	 * @access public
+	 * @static
+	 */
+	public function register_routes() {
+		register_rest_route(
+			'jetpack/v4',
+			'/social/settings',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
+					'args'                => $this->get_endpoint_args_for_item_schema(),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Only administrators can access the API.
+	 *
+	 * @return bool|WP_Error True if a blog token was used to sign the request, WP_Error otherwise.
+	 */
+	public function require_admin_privilege_callback() {
+		if ( current_user_can( 'manage_options' ) ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'rest_forbidden',
+			esc_html__( 'You are not allowed to perform this action.', 'jetpack-publicize-pkg' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	/**
+	 * Updates the settings.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return array|WP_Error Array on success, or error object on failure.
+	 */
+	public function get_item( $request ) {
+		$fields = $this->get_fields_for_response( $request );
+		$data   = array();
+
+		if ( rest_is_field_included( 'publicize_active', $fields ) ) {
+			$data['publicize_active'] = Publicize_Utils::is_publicize_active();
+		}
+
+		return $this->prepare_item_for_response( $data, $request );
+	}
+
+	/**
+	 * POST `jetpack/v4/social/settings`
+	 *
+	 * @param WP_REST_Request $request - REST request.
+	 */
+	public function update_item( $request ) {
+		$params   = $request->get_params();
+		$settings = $this->get_endpoint_args_for_item_schema( $request->get_method() );
+
+		foreach ( array_keys( $settings ) as $name ) {
+			if ( ! array_key_exists( $name, $params ) ) {
+				continue;
+			}
+
+			switch ( $name ) {
+				case 'publicize_active':
+					$updated = ( new Modules() )->update_status( self::JETPACK_PUBLICIZE_MODULE_SLUG, (bool) $params[ $name ], false, false );
+					if ( is_wp_error( $updated ) ) {
+						return $updated;
+					}
+					break;
+			}
+		}
+
+		return $this->get_item( $request );
+	}
+
+	/**
+	 * Prepares the settings data to return from the endpoint.
+	 * Includes checking the values against the schema.
+	 *
+	 * @param array           $settings  The settings data to prepare.
+	 * @param WP_REST_Request $request   REST request.
+	 * @return array|WP_Error The prepared settings or a WP_Error on failure.
+	 */
+	public function prepare_item_for_response( $settings, $request ) {
+		$args   = $this->get_endpoint_args_for_item_schema( $request->get_method() );
+		$return = array();
+		foreach ( $settings as $name => $value ) {
+			if ( empty( $args[ $name ] ) ) {
+				// This setting shouldn't be returned.
+				continue;
+			}
+			$is_valid = rest_validate_value_from_schema( $value, $args[ $name ], $name );
+			if ( is_wp_error( $is_valid ) ) {
+				return $is_valid;
+			}
+			$sanitized = rest_sanitize_value_from_schema( $value, $args[ $name ] );
+			if ( is_wp_error( $sanitized ) ) {
+				return $sanitized;
+			}
+			$return[ $name ] = $sanitized;
+		}
+		return rest_ensure_response( $return );
+	}
+
+	/**
+	 * Get the settings schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'system_status',
+			'type'       => 'object',
+			'properties' => array(
+				'publicize_active' => array(
+					'description' => __( 'Is the publicize module enabled?', 'jetpack-publicize-pkg' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+				),
+			),
+		);
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/projects/plugins/social/changelog/update-social-move-settings-endpoint-to-publicize
+++ b/projects/plugins/social/changelog/update-social-move-settings-endpoint-to-publicize
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Move settings endpoint to publicize package

--- a/projects/plugins/social/src/class-rest-settings-controller.php
+++ b/projects/plugins/social/src/class-rest-settings-controller.php
@@ -8,7 +8,6 @@
 
 namespace Automattic\Jetpack\Social;
 
-use Automattic\Jetpack\Modules;
 use Jetpack_Social;
 use WP_Error;
 use WP_REST_Controller;
@@ -26,24 +25,6 @@ class REST_Settings_Controller extends WP_REST_Controller {
 	 * @static
 	 */
 	public function register_rest_routes() {
-		register_rest_route(
-			'jetpack/v4',
-			'/social/settings',
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_item' ),
-					'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
-					'args'                => $this->get_endpoint_args_for_item_schema(),
-				),
-				array(
-					'methods'             => WP_REST_Server::EDITABLE,
-					'callback'            => array( $this, 'update_item' ),
-					'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
-					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
-				),
-			)
-		);
 		register_rest_route(
 			'jetpack/v4',
 			'/social/review-dismiss',
@@ -90,50 +71,6 @@ class REST_Settings_Controller extends WP_REST_Controller {
 			esc_html__( 'You are not allowed to perform this action.', 'jetpack-social' ),
 			array( 'status' => rest_authorization_required_code() )
 		);
-	}
-
-	/**
-	 * Updates the settings.
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return array|WP_Error Array on success, or error object on failure.
-	 */
-	public function get_item( $request ) {
-		$fields = $this->get_fields_for_response( $request );
-		$data   = array();
-
-		if ( rest_is_field_included( 'publicize_active', $fields ) ) {
-			$data['publicize_active'] = Jetpack_Social::is_publicize_active();
-		}
-
-		return $this->prepare_item_for_response( $data, $request );
-	}
-
-	/**
-	 * POST `jetpack/v4/social/settings`
-	 *
-	 * @param WP_REST_Request $request - REST request.
-	 */
-	public function update_item( $request ) {
-		$params   = $request->get_params();
-		$settings = $this->get_endpoint_args_for_item_schema( $request->get_method() );
-
-		foreach ( array_keys( $settings ) as $name ) {
-			if ( ! array_key_exists( $name, $params ) ) {
-				continue;
-			}
-
-			switch ( $name ) {
-				case 'publicize_active':
-					$updated = ( new Modules() )->update_status( \Jetpack_Social::JETPACK_PUBLICIZE_MODULE_SLUG, (bool) $params[ $name ], false, false );
-					if ( is_wp_error( $updated ) ) {
-						return $updated;
-					}
-					break;
-			}
-		}
-
-		return $this->get_item( $request );
 	}
 
 	/**
@@ -184,26 +121,5 @@ class REST_Settings_Controller extends WP_REST_Controller {
 			$return[ $name ] = $sanitized;
 		}
 		return rest_ensure_response( $return );
-	}
-
-	/**
-	 * Get the settings schema, conforming to JSON Schema.
-	 *
-	 * @return array
-	 */
-	public function get_item_schema() {
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'system_status',
-			'type'       => 'object',
-			'properties' => array(
-				'publicize_active' => array(
-					'description' => __( 'Is the publicize module enabled?', 'jetpack-social' ),
-					'type'        => 'boolean',
-					'context'     => array( 'view', 'edit' ),
-				),
-			),
-		);
-		return $this->add_additional_fields_schema( $schema );
 	}
 }


### PR DESCRIPTION
Since the Social settings API is available only in Social plugin, we can't use that in a shared settings page between Jetpack and Social. Also, there is no such endpoint that can be used in Standalone plugins. Thus, this PR.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move the social settings endpoint to publicize package

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Deactivate Social and activate Jetpack
* Goto Social admin page
* Toggle Social ON/OFF
* Confirm that it works as expected
* Confirm that the value is retained on page reload
* Now activate both Social and Jetpack
* Confirm that the above steps still work fine
* Now activate only Social
* Confirm that the above steps still work fine

