### PR TITLE
Forms: Fix block style variations not appearing in the editor

### DIFF
--- a/projects/packages/forms/changelog/fix-form-style-variations-in-editor
+++ b/projects/packages/forms/changelog/fix-form-style-variations-in-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix block style variations not showing in the editor.

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -711,13 +711,13 @@
 		}
 	}
 
-	&.is-style-outlined, &.is-style-animated {
+	.is-style-outlined &, .is-style-animated & {
 		.jetpack-field {
 			position: relative;
 		}
 	}
 
-	&.is-style-outlined {
+	.is-style-outlined & {
 		.block-editor-block-list__block:not([contenteditable]):focus:after {
 			top: -10px;
 			left: -10px;
@@ -869,7 +869,7 @@
 		}
 	}
 
-	&.is-style-animated {
+	.is-style-animated & {
 		.jetpack-field {
 			--left-offset: calc(var(--jetpack--contact-form--input-padding-left, 16px) + var(--jetpack--contact-form--border-size));
 			--label-left: max(var(--left-offset), var(--jetpack--contact-form--border-radius));

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -728,7 +728,7 @@
 		.jetpack-field {
 			--notch-width: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));
 			margin-top: 8px;
-			display: flex;
+			box-sizing: border-box;
 
 			.notched-label {
 				position: absolute;

--- a/projects/plugins/jetpack/changelog/fix-form-style-variations-in-editor
+++ b/projects/plugins/jetpack/changelog/fix-form-style-variations-in-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix block style variations not showing in the editor.


### PR DESCRIPTION
Fixes #41119

## Proposed changes:
Fixes the form block's style variations not appearing in the editor.

The issue seems to be caused by the class names in the stylesheet being the wrong way around. They expect the element with `.jetpack-contact-form` to be parent of `.is-style-outlined`, but it's the other way around, `.is-style-outlined` is set on the block wrapper, and `.jetpack-contact-form` is an inner element.

I've fixed it by updating the CSS. I expect this needs some thorough testing, as these style may have been dormant for a while.

This could be a more radical fix that does some more restructuring to the CSS and block markup, but I think this is a good change to tread lightly with. Separately it might be worth reconsidering a lot of the CSS for the form block. It should be possible to make the editor styles more closely match the front-end markup and not require so much duplication, but then I don't know much of the history of this block.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Add a contact form block.
2. Ensure the contact form block is selected, and from the block inspector select the 'Styles' tab and choose either the 'Animated' or 'Outlined' block styles
3. Observe that the block style visually updates in the editor to match the frontend. In trunk it doesn't change.
