### PR TITLE
Jetpack Search: Fix infinite loading at purchase flow

### DIFF
--- a/projects/packages/search/changelog/fix-search-checkout-flow
+++ b/projects/packages/search/changelog/fix-search-checkout-flow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
@@ -1,3 +1,4 @@
+import restApi from '@automattic/jetpack-api';
 import {
 	AdminPage,
 	Container,
@@ -39,6 +40,7 @@ const JETPACK_SEARCH__LINK = 'https://jetpack.com/upgrade/search';
  */
 export default function UpsellPage( { isLoading = false } ) {
 	// Introduce the gate for new pricing with URL parameter `new_pricing_202208=1`
+	const APINonce = useSelect( select => select( STORE_ID ).getAPINonce(), [] );
 	const isNewPricing = useSelect( select => select( STORE_ID ).isNewPricing202208(), [] );
 	useSelect( select => select( STORE_ID ).getSearchPricing(), [] );
 	const domain = useSelect( select => select( STORE_ID ).getCalypsoSlug(), [] );
@@ -47,10 +49,10 @@ export default function UpsellPage( { isLoading = false } ) {
 	const isWpcom = useSelect( select => select( STORE_ID ).isWpcom(), [] );
 
 	const { fetchSearchPlanInfo } = useDispatch( STORE_ID );
-	const checkSiteHasSearchProduct = useCallback(
-		() => fetchSearchPlanInfo().then( response => response?.supports_search ),
-		[ fetchSearchPlanInfo ]
-	);
+	const checkSiteHasSearchProduct = useCallback( () => {
+		restApi.setApiNonce( APINonce );
+		fetchSearchPlanInfo().then( response => response?.supports_search );
+	}, [ APINonce, fetchSearchPlanInfo ] );
 
 	const { run: sendToCartPaid, hasCheckoutStarted: hasCheckoutStartedPaid } =
 		useProductCheckoutWorkflow( {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #https://github.com/Automattic/wp-calypso/issues/98722

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes the Search purchase error when loading available plans 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync branch using Jetpack Beta Plugin for `Jetpack Search`
* Go to `Jetpack` from the left Navbar and then go to `Search` and click either `Get Search` or `Start for free`
* You should be able to activate your plan successfully

