### PR TITLE
My Jetpack > AI: fix admin URL used for product interstitial

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-ai-interstitial-url
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-ai-interstitial-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI: avoid using relative URLs in admin URLs, to support sites where WordPress is installed in a subdirectory.

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -501,7 +501,7 @@ class Jetpack_Ai extends Product {
 	 * @return ?string
 	 */
 	public static function get_post_checkout_url() {
-		return 'admin.php?page=my-jetpack#/jetpack-ai';
+		return self::get_manage_url();
 	}
 
 	/**
@@ -510,7 +510,7 @@ class Jetpack_Ai extends Product {
 	 * @return ?string
 	 */
 	public static function get_post_activation_url() {
-		return '/wp-admin/admin.php?page=my-jetpack#/jetpack-ai';
+		return self::get_manage_url();
 	}
 
 	/**
@@ -519,7 +519,7 @@ class Jetpack_Ai extends Product {
 	 * @return ?string
 	 */
 	public static function get_manage_url() {
-		return '/wp-admin/admin.php?page=my-jetpack#/jetpack-ai';
+		return admin_url( 'admin.php?page=my-jetpack#/jetpack-ai' );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

On sites where WordPress is installed in a subdirectory, the URL was not correct.
https://developer.wordpress.org/advanced-administration/server/wordpress-in-directory/

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

> [!NOTE]
> First, you'll need to set up a test site where WordPress is installed in a subdirectory. The alternative would be to use one of our common test sites set up that way: P8oabR-1n-p2

* Connect your site to your WordPress.com account.
* Go to Jetpack > My Jetpack
* Click on the "View" button in the AI card
    * You'll see you'll be redirected to a 404, because the URL does not include the subdirectory.
* Now check out this branch.
* Visit My Jetpack again and click on the button agai.
    * It should now load properly.
    
