### PR TITLE
Account Protection: Add tests for newly added code

### DIFF
--- a/projects/packages/account-protection/changelog/add-account-protection-tests
+++ b/projects/packages/account-protection/changelog/add-account-protection-tests
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Account Protection: Added unit tests for the package functionality.

--- a/projects/packages/account-protection/src/class-account-protection.php
+++ b/projects/packages/account-protection/src/class-account-protection.php
@@ -59,7 +59,7 @@ class Account_Protection {
 	 *
 	 * @return void
 	 */
-	private function register_hooks(): void {
+	protected function register_hooks(): void {
 		// Account protection activation/deactivation hooks
 		add_action( 'jetpack_activate_module_' . self::ACCOUNT_PROTECTION_MODULE_NAME, array( $this, 'on_account_protection_activation' ) );
 		add_action( 'jetpack_deactivate_module_' . self::ACCOUNT_PROTECTION_MODULE_NAME, array( $this, 'on_account_protection_deactivation' ) );
@@ -74,7 +74,7 @@ class Account_Protection {
 	 *
 	 * @return void
 	 */
-	private function register_runtime_hooks(): void {
+	protected function register_runtime_hooks(): void {
 		// Validate password after successful login
 		add_action( 'wp_authenticate_user', array( $this->password_detection, 'login_form_password_detection' ), 10, 2 );
 

--- a/projects/packages/account-protection/src/class-email-service.php
+++ b/projects/packages/account-protection/src/class-email-service.php
@@ -16,6 +16,24 @@ use Jetpack_Options;
  */
 class Email_Service {
 	/**
+	 * Connection manager dependency.
+	 *
+	 * @var Connection_Manager
+	 */
+	private $connection_manager;
+
+	/**
+	 * Constructor for dependency injection.
+	 *
+	 * @param Connection_Manager|null $connection_manager Connection manager dependency.
+	 */
+	public function __construct(
+		?Connection_Manager $connection_manager = null
+	) {
+		$this->connection_manager = $connection_manager ?? new Connection_Manager();
+	}
+
+	/**
 	 * Send the email using the API.
 	 *
 	 * @param \WP_User $user The user.
@@ -24,10 +42,9 @@ class Email_Service {
 	 * @return bool True if the email was sent successfully, false otherwise.
 	 */
 	public function api_send_auth_email( \WP_User $user, string $auth_code ): bool {
-		$blog_id      = Jetpack_Options::get_option( 'id' );
-		$is_connected = ( new Connection_Manager() )->is_connected();
+		$blog_id = Jetpack_Options::get_option( 'id' );
 
-		if ( ! $blog_id || ! $is_connected ) {
+		if ( ! $blog_id || ! $this->connection_manager->is_connected() ) {
 			return false;
 		}
 
@@ -37,15 +54,7 @@ class Email_Service {
 			'code'       => $auth_code,
 		);
 
-		$response = Client::wpcom_json_api_request_as_blog(
-			sprintf( '/sites/%d/jetpack-protect-send-verification-code', $blog_id ),
-			'2',
-			array(
-				'method' => 'POST',
-			),
-			$body,
-			'wpcom'
-		);
+		$response = $this->send_email_request( (int) $blog_id, $body );
 
 		$response_code = wp_remote_retrieve_response_code( $response );
 		if ( is_wp_error( $response ) || 200 !== $response_code || empty( $response['body'] ) ) {
@@ -55,6 +64,25 @@ class Email_Service {
 		$body = json_decode( wp_remote_retrieve_body( $response ), true );
 
 		return $body['email_sent'] ?? false;
+	}
+
+	/**
+	 * Dependency decoupling for the static call to the client.
+	 *
+	 * @param int   $blog_id Blog ID.
+	 * @param array $body The request body.
+	 * @return array|\WP_Error Response data or error.
+	 */
+	protected function send_email_request( int $blog_id, array $body ) {
+		return Client::wpcom_json_api_request_as_blog(
+			sprintf( '/sites/%d/jetpack-protect-send-verification-code', $blog_id ),
+			'2',
+			array(
+				'method' => 'POST',
+			),
+			$body,
+			'wpcom'
+		);
 	}
 
 	/**
@@ -109,6 +137,9 @@ class Email_Service {
 		$domain_parts = explode( '.', $parts[1] );
 		$domain       = substr( $domain_parts[0], 0, 1 ) . str_repeat( '*', strlen( $domain_parts[0] ) - 1 );
 
-		return "{$name}@{$domain}.{$domain_parts[1]}";
+		// Join all domain parts except the first one with dots
+		$tld = implode( '.', array_slice( $domain_parts, 1 ) );
+
+		return "{$name}@{$domain}.{$tld}";
 	}
 }

--- a/projects/packages/account-protection/src/class-password-detection.php
+++ b/projects/packages/account-protection/src/class-password-detection.php
@@ -69,6 +69,27 @@ class Password_Detection {
 	}
 
 	/**
+	 * Redirect and exit.
+	 *
+	 * @param string $redirect_location The redirect location.
+	 *
+	 * @return never
+	 */
+	protected function redirect_and_exit( string $redirect_location ) {
+		wp_safe_redirect( $redirect_location );
+		$this->exit();
+	}
+
+	/**
+	 * Exit decoupling.
+	 *
+	 * @return never
+	 */
+	protected function exit() {
+		exit;
+	}
+
+	/**
 	 * Handle password detection validation error.
 	 *
 	 * @param string    $username The username.
@@ -79,9 +100,19 @@ class Password_Detection {
 	public function handle_password_detection_validation_error( string $username, \WP_Error $error ): void {
 		if ( isset( $error->errors['password_detection_validation_error'] ) ) {
 			$token = $error->get_error_data()['token'];
-			wp_safe_redirect( $this->get_redirect_url( $token ) );
-			exit;
+			$this->redirect_and_exit( $this->get_redirect_url( $token ) );
 		}
+	}
+
+	/**
+	 * Load user by ID. Dependency decoupling.
+	 *
+	 * @param int $user_id The user ID.
+	 *
+	 * @return \WP_User|null The user object.
+	 */
+	protected function load_user( int $user_id ) {
+		return get_user_by( 'ID', $user_id );
 	}
 
 	/**
@@ -91,20 +122,22 @@ class Password_Detection {
 	 */
 	public function render_page() {
 		if ( is_user_logged_in() ) {
-			wp_safe_redirect( admin_url() );
-			exit;
+			$this->redirect_and_exit( admin_url() );
+			return;
 		}
 
 		$token          = isset( $_GET['token'] ) ? sanitize_text_field( wp_unslash( $_GET['token'] ) ) : null;
 		$transient_data = get_transient( Config::TRANSIENT_PREFIX . "_{$token}" );
 		if ( ! $transient_data ) {
 			$this->redirect_to_login();
+			return;
 		}
 
 		$user_id = $transient_data['user_id'] ?? null;
-		$user    = $user_id ? get_user_by( 'ID', $user_id ) : null;
+		$user    = $user_id ? $this->load_user( (int) $user_id ) : null;
 		if ( ! $user instanceof \WP_User ) {
 			$this->redirect_to_login();
+			return;
 		}
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ) );
@@ -125,8 +158,8 @@ class Password_Detection {
 					$this->set_transient_error( $user->ID, $message );
 				}
 
-				wp_safe_redirect( $this->get_redirect_url( $token ) );
-				exit;
+				$this->redirect_and_exit( $this->get_redirect_url( $token ) );
+				return;
 			} else {
 				$this->set_transient_error( $user->ID, __( 'Resend nonce verification failed. Please try again.', 'jetpack-account-protection' ) );
 			}
@@ -138,13 +171,13 @@ class Password_Detection {
 				$user_input = isset( $_POST['user_input'] ) ? sanitize_text_field( wp_unslash( $_POST['user_input'] ) ) : null;
 
 				$this->handle_auth_form_submission( $user, $token, $transient_data['auth_code'] ?? null, $user_input );
+				return;
 			} else {
 				$this->set_transient_error( $user->ID, __( 'Verify nonce verification failed. Please try again.', 'jetpack-account-protection' ) );
 			}
 		}
 
 		$this->render_content( $user, $token );
-		exit;
 	}
 
 	/**
@@ -188,15 +221,15 @@ class Password_Detection {
 							<form method="post">
 								<?php wp_nonce_field( 'verify_action', '_wpnonce_verify' ); ?>
 								<input
-									type="text" 
-									name="user_input" 
-									class="action-input" 
-									placeholder="<?php esc_attr_e( 'Enter verification code', 'jetpack-account-protection' ); ?>" 
-									required 
-									pattern="\d{6}" 
-									minlength="6" 
-									maxlength="6" 
-									inputmode="numeric" 
+									type="text"
+									name="user_input"
+									class="action-input"
+									placeholder="<?php esc_attr_e( 'Enter verification code', 'jetpack-account-protection' ); ?>"
+									required
+									pattern="\d{6}"
+									minlength="6"
+									maxlength="6"
+									inputmode="numeric"
 									oninput="this.value = this.value.replace(/\D/g, '');"
 								/>
 								<button class="action action-verify" type="submit" name="verify"><?php esc_html_e( 'Verify', 'jetpack-account-protection' ); ?></button>
@@ -216,6 +249,7 @@ class Password_Detection {
 			</body>
 		</html>
 		<?php
+		$this->exit();
 	}
 
 	/**
@@ -268,8 +302,7 @@ class Password_Detection {
 	 * @return never
 	 */
 	private function redirect_to_login() {
-		wp_safe_redirect( wp_login_url() );
-		exit;
+		$this->redirect_and_exit( wp_login_url() );
 	}
 
 	/**
@@ -299,8 +332,7 @@ class Password_Detection {
 			delete_transient( Config::TRANSIENT_PREFIX . "_{$token}" );
 			wp_set_auth_cookie( $user->ID, true );
 			// TODO: Notify user to update their password/redirect to password update page
-			wp_safe_redirect( admin_url() );
-			exit;
+			$this->redirect_and_exit( admin_url() );
 		} else {
 			$this->set_transient_error( $user->ID, __( 'Authentication code verification failed. Please try again.', 'jetpack-account-protection' ) );
 		}
@@ -316,7 +348,7 @@ class Password_Detection {
 	 * @return void
 	 */
 	private function set_transient_error( int $user_id, string $message, int $expiration = 60 ): void {
-		set_transient( Config::TRANSIENT_PREFIX . "_error_{$user_id}", esc_html( $message ), $expiration );
+		set_transient( Config::TRANSIENT_PREFIX . "_error_{$user_id}", $message, $expiration );
 	}
 
 	/**

--- a/projects/packages/account-protection/src/class-password-detection.php
+++ b/projects/packages/account-protection/src/class-password-detection.php
@@ -117,12 +117,11 @@ class Password_Detection {
 
 	/**
 	 * Render password detection page.
-	 *
-	 * @return never
 	 */
 	public function render_page() {
 		if ( is_user_logged_in() ) {
 			$this->redirect_and_exit( admin_url() );
+			// @phan-suppress-next-line PhanPluginUnreachableCode This would fall through in unit tests otherwise.
 			return;
 		}
 
@@ -130,6 +129,7 @@ class Password_Detection {
 		$transient_data = get_transient( Config::TRANSIENT_PREFIX . "_{$token}" );
 		if ( ! $transient_data ) {
 			$this->redirect_to_login();
+			// @phan-suppress-next-line PhanPluginUnreachableCode This would fall through in unit tests otherwise.
 			return;
 		}
 
@@ -137,6 +137,7 @@ class Password_Detection {
 		$user    = $user_id ? $this->load_user( (int) $user_id ) : null;
 		if ( ! $user instanceof \WP_User ) {
 			$this->redirect_to_login();
+			// @phan-suppress-next-line PhanPluginUnreachableCode This would fall through in unit tests otherwise.
 			return;
 		}
 
@@ -159,6 +160,7 @@ class Password_Detection {
 				}
 
 				$this->redirect_and_exit( $this->get_redirect_url( $token ) );
+				// @phan-suppress-next-line PhanPluginUnreachableCode This would fall through in unit tests otherwise.
 				return;
 			} else {
 				$this->set_transient_error( $user->ID, __( 'Resend nonce verification failed. Please try again.', 'jetpack-account-protection' ) );

--- a/projects/packages/account-protection/src/class-validation-service.php
+++ b/projects/packages/account-protection/src/class-validation-service.php
@@ -28,7 +28,7 @@ class Validation_Service {
 	 * @param Connection_Manager|null $connection_manager Connection manager dependency.
 	 */
 	public function __construct(
-		?Connection_Manager $connection_manager,
+		?Connection_Manager $connection_manager = null
 	) {
 		$this->connection_manager = $connection_manager ?? new Connection_Manager();
 	}

--- a/projects/packages/account-protection/src/class-validation-service.php
+++ b/projects/packages/account-protection/src/class-validation-service.php
@@ -14,6 +14,41 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
  * Class Validation_Service
  */
 class Validation_Service {
+
+	/**
+	 * Connection manager dependency.
+	 *
+	 * @var Connection_Manager
+	 */
+	private $connection_manager;
+
+	/**
+	 * Constructor for dependency injection.
+	 *
+	 * @param Connection_Manager|null $connection_manager Connection manager dependency.
+	 */
+	public function __construct(
+		?Connection_Manager $connection_manager,
+	) {
+		$this->connection_manager = $connection_manager ?? new Connection_Manager();
+	}
+
+	/**
+	 * Dependency decoupling so we can test this class.
+	 *
+	 * @param string $password_prefix The password prefix to be checked.
+	 * @return array|\WP_Error
+	 */
+	protected function request_suffixes( string $password_prefix ) {
+		return Client::wpcom_json_api_request_as_blog(
+			'/jetpack-protect-weak-password/' . $password_prefix,
+			'2',
+			array( 'method' => 'GET' ),
+			null,
+			'wpcom'
+		);
+	}
+
 	/**
 	 * Check if the password is in the list of compromised/common passwords.
 	 *
@@ -22,23 +57,14 @@ class Validation_Service {
 	 * @return bool True if the password is in the list of compromised/common passwords, false otherwise.
 	 */
 	public function is_weak_password( string $password ): bool {
-		$api_url = '/jetpack-protect-weak-password';
-
-		$is_connected = ( new Connection_Manager() )->is_connected();
-		if ( ! $is_connected ) {
+		if ( ! $this->connection_manager->is_connected() ) {
 			return false;
 		}
 
 		$hashed_password = sha1( $password );
 		$password_prefix = substr( $hashed_password, 0, 5 );
 
-		$response = Client::wpcom_json_api_request_as_blog(
-			$api_url . '/' . $password_prefix,
-			'2',
-			array( 'method' => 'GET' ),
-			null,
-			'wpcom'
-		);
+		$response = $this->request_suffixes( $password_prefix );
 
 		$response_code = wp_remote_retrieve_response_code( $response );
 

--- a/projects/packages/account-protection/tests/php/bootstrap.php
+++ b/projects/packages/account-protection/tests/php/bootstrap.php
@@ -9,3 +9,5 @@
  * Include the composer autoloader.
  */
 require_once __DIR__ . '/../../vendor/autoload.php';
+
+\WorDBless\Load::load();

--- a/projects/packages/account-protection/tests/php/test-account-protection.php
+++ b/projects/packages/account-protection/tests/php/test-account-protection.php
@@ -1,0 +1,141 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\Account_Protection;
+
+use Automattic\Jetpack\Modules;
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for the Account_Protection module class.
+ */
+class Account_Protection_Test extends BaseTestCase {
+
+	public function test_is_enabled_proxies_to_modules_dependency(): void {
+		$modules_mock = $this->createMock( Modules::class );
+		$modules_mock->expects( $this->once() )
+			->method( 'is_active' )
+			->with( Account_Protection::ACCOUNT_PROTECTION_MODULE_NAME )
+			->willReturn( true );
+
+		$sut = new Account_Protection( $modules_mock );
+		$this->assertTrue( $sut->is_enabled(), 'Module should be enabled.' );
+	}
+
+	public function test_init_registers_hooks_and_runtime_hooks_if_module_enabled(): void {
+		$sut = $this->createPartialMock( Account_Protection::class, array( 'is_enabled', 'register_hooks', 'register_runtime_hooks' ) );
+		$sut->expects( $this->once() )
+			->method( 'is_enabled' )
+			->willReturn( true );
+
+		$sut->expects( $this->once() )
+			->method( 'register_hooks' );
+
+		$sut->expects( $this->once() )
+			->method( 'register_runtime_hooks' );
+
+		$sut->init();
+	}
+
+	public function test_init_registers_hooks_but_not_runtime_hooks_if_module_disabled(): void {
+		$sut = $this->createPartialMock( Account_Protection::class, array( 'is_enabled', 'register_hooks', 'register_runtime_hooks' ) );
+		$sut->expects( $this->once() )
+			->method( 'is_enabled' )
+			->willReturn( false );
+
+		$sut->expects( $this->once() )
+			->method( 'register_hooks' );
+
+		$sut->expects( $this->never() )
+			->method( 'register_runtime_hooks' );
+
+		$sut->init();
+	}
+
+	public function test_enable_activates_module_if_not_activated_yet(): void {
+		$modules_mock = $this->createMock( Modules::class );
+		$modules_mock->expects( $this->once() )
+			->method( 'is_active' )
+			->willReturn( false );
+
+		$modules_mock->expects( $this->once() )
+			->method( 'activate' )
+			->with( Account_Protection::ACCOUNT_PROTECTION_MODULE_NAME, false, false )
+			->willReturn( true );
+
+		$sut = new Account_Protection( $modules_mock );
+		$this->assertTrue( $sut->enable(), 'Module should be enabled successfully.' );
+	}
+
+	public function test_enable_does_nothing_if_module_already_activated(): void {
+		$modules_mock = $this->createMock( Modules::class );
+		$modules_mock->expects( $this->once() )
+			->method( 'is_active' )
+			->willReturn( true );
+
+		$modules_mock->expects( $this->never() )
+			->method( 'activate' );
+
+		$sut = new Account_Protection( $modules_mock );
+		$this->assertTrue( $sut->enable(), 'Module should be enabled successfully.' );
+	}
+
+	public function test_disable_deactivates_module_if_active(): void {
+		$modules_mock = $this->createMock( Modules::class );
+		$modules_mock->expects( $this->once() )
+			->method( 'is_active' )
+			->willReturn( true );
+
+		$modules_mock->expects( $this->once() )
+			->method( 'deactivate' )
+			->with( Account_Protection::ACCOUNT_PROTECTION_MODULE_NAME )
+			->willReturn( true );
+
+		$sut = new Account_Protection( $modules_mock );
+		$this->assertTrue( $sut->disable(), 'Module should be disabled successfully.' );
+	}
+
+	public function test_disable_does_nothing_if_module_already_inactive(): void {
+		$modules_mock = $this->createMock( Modules::class );
+		$modules_mock->expects( $this->once() )
+			->method( 'is_active' )
+			->willReturn( false );
+
+		$modules_mock->expects( $this->never() )
+			->method( 'deactivate' );
+
+		$sut = new Account_Protection( $modules_mock );
+		$this->assertTrue( $sut->disable(), 'Module should be disabled successfully.' );
+	}
+
+	public function test_remove_module_on_unsupported_environments_removes_itself_correctly(): void {
+		$sut = $this->createPartialMock( Account_Protection::class, array( 'is_supported_environment' ) );
+		$sut->expects( $this->once() )
+			->method( 'is_supported_environment' )
+			->willReturn( false );
+
+		$all_modules = array(
+			'something-else' => 'should_remain',
+			Account_Protection::ACCOUNT_PROTECTION_MODULE_NAME => 'should_be_removed',
+		);
+
+		$all_modules = $sut->remove_module_on_unsupported_environments( $all_modules );
+
+		$this->assertArrayNotHasKey( Account_Protection::ACCOUNT_PROTECTION_MODULE_NAME, $all_modules, 'The module should have removed itself.' );
+	}
+
+	public function test_remove_standalone_module_on_unsupported_environments_removes_itself_correctly(): void {
+		$sut = $this->createPartialMock( Account_Protection::class, array( 'is_supported_environment' ) );
+		$sut->expects( $this->once() )
+			->method( 'is_supported_environment' )
+			->willReturn( false );
+
+		$all_modules = array(
+			'some_other_module',
+			Account_Protection::ACCOUNT_PROTECTION_MODULE_NAME,
+		);
+
+		$all_modules = $sut->remove_standalone_module_on_unsupported_environments( $all_modules );
+
+		$this->assertNotContains( Account_Protection::ACCOUNT_PROTECTION_MODULE_NAME, $all_modules, 'The module should have removed itself.' );
+	}
+}

--- a/projects/packages/account-protection/tests/php/test-email-service.php
+++ b/projects/packages/account-protection/tests/php/test-email-service.php
@@ -1,0 +1,214 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\Account_Protection;
+
+use Jetpack_Options;
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for the Validation_Service class.
+ */
+class Email_Service_Test extends BaseTestCase {
+
+	public function test_generate_auth_code_returns_valid_code(): void {
+		$sut = new Email_Service();
+		$this->assertMatchesRegularExpression( '/^[0-9]{6}$/', $sut->generate_auth_code() );
+	}
+
+	/**
+	 * @dataProvider email_masking_data_provider
+	 */
+	public function test_mask_email_address_masks_correctly( $plain_email, $expected_masked_email ): void {
+		$sut = new Email_Service();
+		$this->assertEquals( $expected_masked_email, $sut->mask_email_address( $plain_email ) );
+	}
+
+	public function email_masking_data_provider(): array {
+		return array(
+			'john.doe@example.com'    => array( 'john.doe@example.com', 'j*******@e******.com' ),
+			'mary.smith@gmail.com'    => array( 'mary.smith@gmail.com', 'm*********@g****.com' ),
+			'support@company.co.uk'   => array( 'support@company.co.uk', 's******@c******.co.uk' ),
+			'test.user123@domain.org' => array( 'test.user123@domain.org', 't***********@d*****.org' ),
+		);
+	}
+
+	public function test_resend_auth_mail_does_not_resend_if_too_many_attempts(): void {
+		$sut = new Email_Service();
+
+		$this->assertFalse(
+			$sut->resend_auth_email(
+				new \WP_User(),
+				array(
+					'resend_attempts' => 5,
+				),
+				''
+			)
+		);
+	}
+
+	public function test_resend_auth_mail_sends_mail_and_remembers_2fa_token_successfully(): void {
+		$user = new \WP_User();
+
+		$sut = $this->createPartialMock( Email_Service::class, array( 'api_send_auth_email' ) );
+		$sut->expects( $this->once() )->method( 'api_send_auth_email' )
+			->with( $user, $this->matchesRegularExpression( '/^[0-9]{6}$/' ) )
+			->willReturn( true );
+
+		$transient_data = array(
+			'resend_attempts' => 0,
+		);
+
+		$my_token = 'my_token';
+
+		$result = $sut->resend_auth_email( $user, $transient_data, $my_token );
+
+		// Verify the mail was sent
+		$this->assertTrue( $result, 'Resending auth mail should return true as success indicator.' );
+
+		// Verify the transient has the expected data
+		$new_transient = get_transient( Config::TRANSIENT_PREFIX . "_{$my_token}" );
+		$this->assertSame( 1, $new_transient['resend_attempts'], 'Resend attempts should be 1.' );
+		$this->assertMatchesRegularExpression( '/^[0-9]{6}$/', $new_transient['auth_code'], 'Auth code should be 6 digits.' );
+	}
+
+	public function test_api_send_auth_email_returns_false_if_blog_id_not_available(): void {
+		Jetpack_Options::delete_option( 'id' );
+		$sut = new Email_Service();
+		$this->assertFalse( $sut->api_send_auth_email( new \WP_User(), '123456' ) );
+	}
+
+	public function test_api_send_auth_email_returns_false_if_not_connected(): void {
+		Jetpack_Options::update_option( 'id', 123 );
+
+		$connection = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Manager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'is_connected' )
+			->willReturn( false );
+
+		$sut = new Email_Service( $connection );
+		$this->assertFalse( $sut->api_send_auth_email( new \WP_User(), '123456' ) );
+	}
+
+	private function get_connected_connection_manager() {
+		$connection = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Manager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'is_connected' )
+			->willReturn( true );
+
+		return $connection;
+	}
+
+	public function test_api_send_auth_email_sends_email_successfully(): void {
+		Jetpack_Options::update_option( 'id', 123 );
+
+		$sut = $this->getMockBuilder( Email_Service::class )
+			->onlyMethods( array( 'send_email_request' ) )
+			->setConstructorArgs( array( $this->get_connected_connection_manager() ) )
+			->getMock();
+
+		$sut->expects( $this->once() )
+			->method( 'send_email_request' )
+			->with(
+				123,
+				$this->callback(
+					function ( $body ) {
+						return $body['user_login'] === 'john.doe'
+						&& $body['user_email'] === 'john.doe@example.com'
+						&& $body['code'] === '123456';
+					}
+				)
+			)->willReturn(
+				array(
+					'response' => array( 'code' => 200 ),
+					'body'     => json_encode( array( 'email_sent' => true ) ),
+				)
+			);
+
+		$user             = new \WP_User();
+		$user->user_login = 'john.doe';
+		$user->user_email = 'john.doe@example.com';
+
+		$this->assertTrue( $sut->api_send_auth_email( $user, '123456' ), 'Email should have been sent.' );
+	}
+
+	public function test_api_send_auth_email_returns_false_if_response_is_error(): void {
+		Jetpack_Options::update_option( 'id', 123 );
+
+		$sut = $this->getMockBuilder( Email_Service::class )
+			->onlyMethods( array( 'send_email_request' ) )
+			->setConstructorArgs( array( $this->get_connected_connection_manager() ) )
+			->getMock();
+
+		$sut->expects( $this->once() )
+			->method( 'send_email_request' )
+			->willReturn( new \WP_Error( 'some_error' ) );
+
+		$this->assertFalse( $sut->api_send_auth_email( new \WP_User(), '123456' ) );
+	}
+
+	public function test_api_send_auth_email_returns_false_if_response_code_is_not_200(): void {
+		Jetpack_Options::update_option( 'id', 123 );
+
+		$sut = $this->getMockBuilder( Email_Service::class )
+			->onlyMethods( array( 'send_email_request' ) )
+			->setConstructorArgs( array( $this->get_connected_connection_manager() ) )
+			->getMock();
+
+		$sut->expects( $this->once() )
+			->method( 'send_email_request' )
+			->willReturn(
+				array(
+					'response' => array( 'code' => 404 ),
+					'body'     => json_encode( array( 'email_sent' => true ) ),
+				)
+			);
+
+		$this->assertFalse( $sut->api_send_auth_email( new \WP_User(), '123456' ) );
+	}
+
+	public function test_api_send_auth_email_returns_false_if_response_body_is_empty(): void {
+		Jetpack_Options::update_option( 'id', 123 );
+
+		$sut = $this->getMockBuilder( Email_Service::class )
+			->onlyMethods( array( 'send_email_request' ) )
+			->setConstructorArgs( array( $this->get_connected_connection_manager() ) )
+			->getMock();
+
+		$sut->expects( $this->once() )
+			->method( 'send_email_request' )
+			->willReturn(
+				array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '',
+				)
+			);
+
+		$this->assertFalse( $sut->api_send_auth_email( new \WP_User(), '123456' ) );
+	}
+
+	public function test_api_send_auth_email_returns_false_if_response_from_api_is_false(): void {
+		Jetpack_Options::update_option( 'id', 123 );
+
+		$sut = $this->getMockBuilder( Email_Service::class )
+			->onlyMethods( array( 'send_email_request' ) )
+			->setConstructorArgs( array( $this->get_connected_connection_manager() ) )
+			->getMock();
+
+		$sut->expects( $this->once() )
+			->method( 'send_email_request' )
+			->willReturn(
+				array(
+					'response' => array( 'code' => 200 ),
+					'body'     => json_encode( array( 'email_sent' => false ) ),
+				)
+			);
+
+		$this->assertFalse( $sut->api_send_auth_email( new \WP_User(), '123456' ) );
+	}
+}

--- a/projects/packages/account-protection/tests/php/test-email-service.php
+++ b/projects/packages/account-protection/tests/php/test-email-service.php
@@ -6,7 +6,7 @@ use Jetpack_Options;
 use WorDBless\BaseTestCase;
 
 /**
- * Tests for the Validation_Service class.
+ * Tests for the Account_Protection class.
  */
 class Email_Service_Test extends BaseTestCase {
 

--- a/projects/packages/account-protection/tests/php/test-password-detection.php
+++ b/projects/packages/account-protection/tests/php/test-password-detection.php
@@ -367,7 +367,10 @@ class Password_Detection_Test extends BaseTestCase {
 		$sut->expects( $this->once() )
 			->method( 'exit' );
 
-		$sentence = htmlentities( 'We\'ve noticed that your current password may have been compromised in a public leak. To keep your account safe, we\'ve added an extra layer of security.' );
+		$sentence = htmlentities(
+			'We\'ve noticed that your current password may have been compromised in a public leak. To keep your account safe, we\'ve added an extra layer of security.',
+			ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401
+		);
 
 		$this->expectOutputRegex( '@' . $sentence . '@' );
 		$sut->render_content( $user, 'my_cool_token' );

--- a/projects/packages/account-protection/tests/php/test-password-detection.php
+++ b/projects/packages/account-protection/tests/php/test-password-detection.php
@@ -1,0 +1,395 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\Account_Protection;
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for the Password_Detection class.
+ */
+class Password_Detection_Test extends BaseTestCase {
+
+	public function test_handle_password_detection_validation_error_redirects_to_login(): void {
+		$error = new \WP_Error( Config::ERROR_CODE, Config::ERROR_MESSAGE, array( 'token' => 'my-token' ) );
+
+		$sut = $this->createPartialMock( Password_Detection::class, array( 'redirect_and_exit' ) );
+		$sut->expects( $this->once() )
+			->method( 'redirect_and_exit' )
+			->with( 'http://example.org/wp-login.php?action=password-detection&token=my-token' );
+
+		$sut->handle_password_detection_validation_error( 'username', $error );
+	}
+
+	public function test_login_form_password_detection_does_not_ask_validation_service_if_user_doesnt_require_protection(): void {
+		$validation_service_mock = $this->createMock( Validation_Service::class );
+		$validation_service_mock->expects( $this->never() )
+			->method( 'is_weak_password' );
+
+		$sut = new Password_Detection( null, $validation_service_mock );
+
+		$user   = new \WP_User();
+		$return = $sut->login_form_password_detection( $user, 'pw' );
+		$this->assertSame( $user, $return, 'User should be returned.' );
+	}
+
+	public function test_login_form_password_detection_does_not_ask_validation_service_if_user_has_wrong_password(): void {
+		$validation_service_mock = $this->createMock( Validation_Service::class );
+		$validation_service_mock->expects( $this->never() )
+			->method( 'is_weak_password' );
+
+		$sut = new Password_Detection( null, $validation_service_mock );
+
+		$user            = new \WP_User();
+		$user->user_pass = 'pw';
+		$user->add_cap( 'publish_posts' );
+		$return = $sut->login_form_password_detection( $user, 'pw' );
+		$this->assertSame( $user, $return, 'User should be returned.' );
+	}
+
+	public function test_login_form_password_detection_asks_validation_service_if_user_has_correct_password(): void {
+		add_filter( 'check_password', '__return_true' );
+
+		$validation_service_mock = $this->createMock( Validation_Service::class );
+		$validation_service_mock->expects( $this->once() )
+			->method( 'is_weak_password' )
+			->with( 'pw' )
+			->willReturn( false );
+
+		$sut = new Password_Detection( null, $validation_service_mock );
+
+		$user            = new \WP_User();
+		$user->user_pass = 'pw';
+		$user->add_cap( 'publish_posts' );
+		$return = $sut->login_form_password_detection( $user, 'pw' );
+
+		$this->assertSame( $user, $return, 'User should be returned.' );
+
+		remove_filter( 'check_password', '__return_true' );
+	}
+
+	public function test_login_form_password_detection_sends_email_and_returns_error_for_weak_password(): void {
+		add_filter( 'check_password', '__return_true' );
+
+		$validation_service_mock = $this->createMock( Validation_Service::class );
+		$validation_service_mock->expects( $this->once() )
+			->method( 'is_weak_password' )
+			->with( 'pw' )
+			->willReturn( true );
+
+		$auth_code = '123456';
+
+		$user            = new \WP_User();
+		$user->user_pass = 'pw';
+		$user->add_cap( 'publish_posts' );
+
+		$email_service_mock = $this->createMock( Email_Service::class );
+		$email_service_mock->expects( $this->once() )
+			->method( 'generate_auth_code' )
+			->willReturn( $auth_code );
+		$email_service_mock->expects( $this->once() )
+			->method( 'api_send_auth_email' )
+			->with( $user, $auth_code )
+			->willReturn( true );
+
+		$sut = new Password_Detection( $email_service_mock, $validation_service_mock );
+
+		$error = $sut->login_form_password_detection( $user, 'pw' );
+
+		$this->assertInstanceOf( \WP_Error::class, $error, 'Should return a WP_Error object.' );
+		$this->assertSame( Config::ERROR_MESSAGE, $error->get_error_message( Config::ERROR_CODE ), 'Should return the correct error message.' );
+		$token = $error->get_error_data( Config::ERROR_CODE )['token'];
+		$this->assertSame( 32, strlen( $token ), 'Token should be 32 characters long.' );
+
+		remove_filter( 'check_password', '__return_true' );
+	}
+
+	public function test_login_form_password_detection_sets_transient_error_if_unable_to_send_mail(): void {
+		add_filter( 'check_password', '__return_true' );
+
+		$validation_service_mock = $this->createMock( Validation_Service::class );
+		$validation_service_mock->expects( $this->once() )
+			->method( 'is_weak_password' )
+			->with( 'pw' )
+			->willReturn( true );
+
+		$user            = new \WP_User();
+		$user->user_pass = 'pw';
+		$user->add_cap( 'publish_posts' );
+
+		$email_service_mock = $this->createMock( Email_Service::class );
+		$email_service_mock->expects( $this->once() )
+			->method( 'generate_auth_code' )
+			->willReturn( '123456' );
+		$email_service_mock->expects( $this->once() )
+			->method( 'api_send_auth_email' )
+			->with( $user, '123456' )
+			->willReturn( false );
+
+		$sut = new Password_Detection( $email_service_mock, $validation_service_mock );
+
+		$sut->login_form_password_detection( $user, 'pw' );
+
+		$transient_data = get_transient( Config::TRANSIENT_PREFIX . "_error_{$user->ID}" );
+		$this->assertSame( 'Failed to send authentication email. Please try again.', $transient_data, 'Should have set the correct error message.' );
+
+		remove_filter( 'check_password', '__return_true' );
+	}
+
+	public function test_render_page_redirects_to_admin_page_if_user_already_logged_in(): void {
+		$sut = $this->createPartialMock( Password_Detection::class, array( 'redirect_and_exit' ) );
+		$sut->expects( $this->once() )
+			->method( 'redirect_and_exit' )
+			->with( 'http://example.org/wp-admin/' );
+
+		$mock_user = $this->createMock( \WP_User::class );
+		$mock_user->expects( $this->once() )
+			->method( 'exists' )
+			->willReturn( true );
+
+		global $current_user;
+		$previous_current_user   = $current_user;
+		$GLOBALS['current_user'] = $mock_user;
+
+		$sut->render_page();
+
+		$GLOBALS['current_user'] = $previous_current_user;
+	}
+
+	public function test_render_page_redirects_to_login_if_transient_data_is_not_available(): void {
+		$sut = $this->createPartialMock( Password_Detection::class, array( 'redirect_and_exit' ) );
+		$sut->expects( $this->once() )
+			->method( 'redirect_and_exit' )
+			->with( 'http://example.org/wp-login.php' );
+
+		$sut->render_page();
+	}
+
+	public function test_render_page_redirects_to_login_if_user_with_id_from_transient_does_not_exist(): void {
+		$_GET['token'] = 'my_cool_token';
+		set_transient( Config::TRANSIENT_PREFIX . '_my_cool_token', array( 'user_id' => 123 ) );
+
+		$sut = $this->createPartialMock( Password_Detection::class, array( 'redirect_and_exit', 'load_user' ) );
+		$sut->expects( $this->once() )
+			->method( 'load_user' )
+			->with( 123 )
+			->willReturn( false );
+		$sut->expects( $this->once() )
+			->method( 'redirect_and_exit' )
+			->with( 'http://example.org/wp-login.php' );
+
+		$sut->render_page();
+
+		unset( $_GET['token'] );
+	}
+
+	public function test_render_page_checks_2fa_code_successfully(): void {
+		$_GET['token']            = 'my_cool_token';
+		$_POST['verify']          = '1';
+		$_POST['user_input']      = '123456';
+		$_POST['_wpnonce_verify'] = wp_create_nonce( 'verify_action' );
+
+		set_transient(
+			Config::TRANSIENT_PREFIX . '_my_cool_token',
+			array(
+				'user_id'   => 123,
+				'auth_code' => '123456',
+			)
+		);
+
+		$user            = new \WP_User();
+		$user->ID        = 123;
+		$user->user_pass = 'pw';
+		$user->add_cap( 'publish_posts' );
+
+		$sut = $this->createPartialMock( Password_Detection::class, array( 'redirect_and_exit', 'load_user' ) );
+		$sut->expects( $this->once() )
+			->method( 'load_user' )
+			->with( 123 )
+			->willReturn( $user );
+		$sut->expects( $this->once() )
+			->method( 'redirect_and_exit' )
+			->with( 'http://example.org/wp-admin/' );
+
+		$calls        = 0;
+		$call_counter = function () use ( &$calls ) {
+			++$calls;
+			return false;
+		};
+
+		add_filter( 'send_auth_cookies', $call_counter );
+
+		$sut->render_page();
+
+		remove_filter( 'send_auth_cookies', $call_counter );
+
+		$this->assertSame( 1, $calls, 'send_auth_cookies filter should have been called once' );
+
+		unset( $_GET['token'] );
+		unset( $_POST['verify'] );
+		unset( $_POST['user_input'] );
+		unset( $_POST['_wpnonce_verify'] );
+	}
+
+	public function test_render_page_sets_transient_error_if_2fa_code_is_wrong(): void {
+		$_GET['token']            = 'my_cool_token';
+		$_POST['verify']          = '1';
+		$_POST['user_input']      = '837467'; // intentionally wrong
+		$_POST['_wpnonce_verify'] = wp_create_nonce( 'verify_action' );
+
+		set_transient(
+			Config::TRANSIENT_PREFIX . '_my_cool_token',
+			array(
+				'user_id'   => 123,
+				'auth_code' => '123456',
+			)
+		);
+
+		$user            = new \WP_User();
+		$user->ID        = 123;
+		$user->user_pass = 'pw';
+		$user->add_cap( 'publish_posts' );
+
+		$sut = $this->createPartialMock( Password_Detection::class, array( 'load_user' ) );
+		$sut->expects( $this->once() )
+			->method( 'load_user' )
+			->with( 123 )
+			->willReturn( $user );
+
+		$sut->render_page();
+
+		$error = get_transient( Config::TRANSIENT_PREFIX . '_error_123' );
+
+		$this->assertSame( 'Authentication code verification failed. Please try again.', $error, 'Error message is not as expected.' );
+
+		unset( $_GET['token'] );
+		unset( $_POST['verify'] );
+		unset( $_POST['user_input'] );
+		unset( $_POST['_wpnonce_verify'] );
+	}
+
+	public function test_render_page_sets_transient_error_if_2fa_nonce_is_wrong(): void {
+		$_GET['token']            = 'my_cool_token';
+		$_POST['verify']          = '1';
+		$_POST['_wpnonce_verify'] = 'wrong nonce'; // intentionally wrong
+
+		set_transient(
+			Config::TRANSIENT_PREFIX . '_my_cool_token',
+			array(
+				'user_id'   => 123,
+				'auth_code' => '123456',
+			)
+		);
+
+		$user            = new \WP_User();
+		$user->ID        = 123;
+		$user->user_pass = 'pw';
+		$user->add_cap( 'publish_posts' );
+
+		$sut = $this->createPartialMock( Password_Detection::class, array( 'load_user', 'render_content' ) );
+		$sut->expects( $this->once() )
+			->method( 'load_user' )
+			->with( 123 )
+			->willReturn( $user );
+		$sut->expects( $this->once() )
+			->method( 'render_content' )
+			->with( $user, 'my_cool_token' );
+
+		$sut->render_page();
+
+		$error = get_transient( Config::TRANSIENT_PREFIX . '_error_123' );
+
+		$this->assertSame( 'Verify nonce verification failed. Please try again.', $error, 'Error message is not as expected.' );
+
+		unset( $_GET['token'] );
+		unset( $_POST['verify'] );
+		unset( $_POST['_wpnonce_verify'] );
+	}
+
+	public function test_render_page_resends_mail_successfully(): void {
+		$_GET['token']        = 'my_cool_token';
+		$_GET['resend_email'] = '1';
+		$_GET['_wpnonce']     = wp_create_nonce( 'resend_email_nonce' );
+
+		set_transient(
+			Config::TRANSIENT_PREFIX . '_my_cool_token',
+			array(
+				'user_id'   => 123,
+				'auth_code' => '123456',
+			)
+		);
+
+		$user            = new \WP_User();
+		$user->ID        = 123;
+		$user->user_pass = 'pw';
+		$user->add_cap( 'publish_posts' );
+
+		$email_service_mock = $this->createMock( Email_Service::class );
+		$email_service_mock->expects( $this->once() )
+			->method( 'resend_auth_email' )
+			->with(
+				$user,
+				array(
+					'user_id'   => 123,
+					'auth_code' => '123456',
+				),
+				'my_cool_token'
+			)
+			->willReturn( true );
+
+		$sut = $this->getMockBuilder( Password_Detection::class )
+			->setConstructorArgs( array( $email_service_mock ) )
+			->onlyMethods( array( 'load_user', 'redirect_and_exit' ) )
+			->getMock();
+		$sut->expects( $this->once() )
+			->method( 'load_user' )
+			->with( 123 )
+			->willReturn( $user );
+		$sut->expects( $this->once() )
+			->method( 'redirect_and_exit' )
+			->with( 'http://example.org/wp-login.php?action=password-detection&token=my_cool_token' );
+
+		$sut->render_page();
+
+		unset( $_GET['token'] );
+		unset( $_GET['resend_email'] );
+		unset( $_GET['_wpnonce'] );
+	}
+
+	public function test_render_content_explains_the_2fa_form(): void {
+		$user             = new \WP_User();
+		$user->ID         = 123;
+		$user->user_email = 'john.doe@example.com';
+
+		$sut = $this->getMockBuilder( Password_Detection::class )
+			->onlyMethods( array( 'exit' ) )
+			->getMock();
+
+		$sut->expects( $this->once() )
+			->method( 'exit' );
+
+		$sentence = htmlentities( 'We\'ve noticed that your current password may have been compromised in a public leak. To keep your account safe, we\'ve added an extra layer of security.' );
+
+		$this->expectOutputRegex( '@' . $sentence . '@' );
+		$sut->render_content( $user, 'my_cool_token' );
+	}
+
+	public function test_render_content_shows_transient_error_if_set(): void {
+		$error_message = 'This is a error message to test things with.';
+
+		set_transient( Config::TRANSIENT_PREFIX . '_error_123', $error_message );
+
+		$user             = new \WP_User();
+		$user->ID         = 123;
+		$user->user_email = 'john.doe@example.com';
+
+		$sut = $this->getMockBuilder( Password_Detection::class )
+			->onlyMethods( array( 'exit' ) )
+			->getMock();
+
+		$sut->expects( $this->once() )
+			->method( 'exit' );
+
+		$this->expectOutputRegex( '@' . $error_message . '@' );
+		$sut->render_content( $user, 'my_cool_token' );
+	}
+}

--- a/projects/packages/account-protection/tests/php/test-validation-service.php
+++ b/projects/packages/account-protection/tests/php/test-validation-service.php
@@ -1,8 +1,7 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
-namespace Automattic\Jetpack\AccountProtection;
+namespace Automattic\Jetpack\Account_Protection;
 
-use Automattic\Jetpack\Account_Protection\Validation_Service;
 use WorDBless\BaseTestCase;
 
 /**

--- a/projects/packages/account-protection/tests/php/test-validation-service.php
+++ b/projects/packages/account-protection/tests/php/test-validation-service.php
@@ -1,0 +1,164 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\AccountProtection;
+
+use Automattic\Jetpack\Account_Protection\Validation_Service;
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for the Validation_Service class.
+ */
+class Validation_Service_Test extends BaseTestCase {
+
+	public function test_returns_false_if_not_connected() {
+		$connection = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Manager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'is_connected' )
+			->willReturn( false );
+
+		$validation_service = new Validation_Service( $connection );
+		$this->assertFalse( $validation_service->is_weak_password( 'somepassword' ) );
+	}
+
+	private function get_connected_connection_manager() {
+		$connection = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Manager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'is_connected' )
+			->willReturn( true );
+
+		return $connection;
+	}
+
+	public function test_returns_false_if_remote_request_fails() {
+
+		$validation_service = $this->getMockBuilder( Validation_Service::class )
+			->setConstructorArgs( array( $this->get_connected_connection_manager() ) )
+			->onlyMethods( array( 'request_suffixes' ) )
+			->getMock();
+
+		$validation_service->expects( $this->once() )
+			->method( 'request_suffixes' )
+			->willReturn( new \WP_Error( 'something went wrong' ) );
+
+		$this->assertFalse( $validation_service->is_weak_password( 'somepassword' ) );
+	}
+
+	public function test_returns_false_if_response_code_is_not_200() {
+
+		$validation_service = $this->getMockBuilder( Validation_Service::class )
+			->setConstructorArgs( array( $this->get_connected_connection_manager() ) )
+			->onlyMethods( array( 'request_suffixes' ) )
+			->getMock();
+
+		$validation_service->expects( $this->once() )
+			->method( 'request_suffixes' )
+			->willReturn(
+				array(
+					'response' => array(
+						'code' => 404,
+					),
+				)
+			);
+
+		$this->assertFalse( $validation_service->is_weak_password( 'somepassword' ) );
+	}
+
+	public function test_returns_false_if_response_code_is_empty_body() {
+		$validation_service = $this->getMockBuilder( Validation_Service::class )
+			->setConstructorArgs( array( $this->get_connected_connection_manager() ) )
+			->onlyMethods( array( 'request_suffixes' ) )
+			->getMock();
+
+		$validation_service->expects( $this->once() )
+			->method( 'request_suffixes' )
+			->willReturn(
+				array(
+					'response' => array(
+						'code' => 200,
+					),
+					'body'     => '',
+				)
+			);
+
+		$this->assertFalse( $validation_service->is_weak_password( 'somepassword' ) );
+	}
+
+	public function test_returns_true_if_password_is_compromised() {
+		$validation_service = $this->getMockBuilder( Validation_Service::class )
+			->setConstructorArgs( array( $this->get_connected_connection_manager() ) )
+			->onlyMethods( array( 'request_suffixes' ) )
+			->getMock();
+
+		$validation_service->expects( $this->once() )
+			->method( 'request_suffixes' )
+			->willReturn(
+				array(
+					'response' => array(
+						'code' => 200,
+					),
+					'body'     => json_encode(
+						array(
+							'compromised' => array( 'c90fcfd699f0ddbdcb30c2c9183d2d933ea' ),
+						)
+					),
+				)
+			);
+
+		$this->assertTrue( $validation_service->is_weak_password( 'somepassword' ) );
+	}
+
+	public function test_returns_true_if_password_is_common() {
+		$validation_service = $this->getMockBuilder( Validation_Service::class )
+			->setConstructorArgs( array( $this->get_connected_connection_manager() ) )
+			->onlyMethods( array( 'request_suffixes' ) )
+			->getMock();
+
+		$validation_service->expects( $this->once() )
+			->method( 'request_suffixes' )
+			->willReturn(
+				array(
+					'response' => array(
+						'code' => 200,
+					),
+					'body'     => json_encode(
+						array(
+							'common' => array( 'c90fcfd699f0ddbdcb30c2c9183d2d933ea' ),
+						)
+					),
+				)
+			);
+
+		$this->assertTrue( $validation_service->is_weak_password( 'somepassword' ) );
+	}
+
+	public function test_returns_false_if_password_is_not_weak() {
+		$validation_service = $this->getMockBuilder( Validation_Service::class )
+			->setConstructorArgs( array( $this->get_connected_connection_manager() ) )
+			->onlyMethods( array( 'request_suffixes' ) )
+			->getMock();
+
+		$validation_service->expects( $this->once() )
+			->method( 'request_suffixes' )
+			->willReturn(
+				array(
+					'response' => array(
+						'code' => 200,
+					),
+					'body'     => json_encode(
+						array(
+							'compromised' => array( '1234' ),
+							'common'      => array(),
+						)
+					),
+				)
+			);
+
+		$this->assertFalse( $validation_service->is_weak_password( 'somepassword' ) );
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add PHP unit test coverage for the new account protection module, as we're lacking test coverage at all so far.

After this PR, test coverage looks as follows:

![image](https://github.com/user-attachments/assets/30f50f7e-86b4-42a5-8f4a-84892e405558)

Which means we still have room for improvement. It has to be said though, that some of the methods are for decoupling dependencies, like exiting the script, or doing a static call to the Jetpack Client for the connection API call. It is sad that it is a static method call, but nothing we can easily change in this PR.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack-scan-team/issues/1669

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* The tests run automatically against this PR: https://github.com/Automattic/jetpack/actions/runs/13079317642/job/36498994151?pr=41463#step:10:408
* However, since I also changed some of the functional code, it would be good to also manually test the flow again, as described in this PR: https://github.com/Automattic/jetpack/pull/41365

As an aside, I think this whole thing might also warrant some E2E tests, but these need to go into the jetpack and protect plugins, and are not part of this PR.
