### PR TITLE
Forms: Prevent empty form submission client side

### DIFF
--- a/projects/packages/forms/changelog/forms-prevent-emtpy-form-submission-client-side
+++ b/projects/packages/forms/changelog/forms-prevent-emtpy-form-submission-client-side
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Prevent empty form submission client side

--- a/projects/packages/forms/src/contact-form/js/accessible-form.js
+++ b/projects/packages/forms/src/contact-form/js/accessible-form.js
@@ -935,6 +935,10 @@ const setFormError = ( form, invalidFields, opts = {} ) => {
 	}
 
 	const count = invalidFields.length;
+	// This is essentially a way to add a single error styled message when we
+	// have no field validation errors. We have to pass no invalid fields and
+	// `opts.type` to match a translatable message. We should extract it when
+	// we refactor the error handling.
 	if ( ! count && !! L10N[ opts.type ] ) {
 		error.appendChild( createError( L10N[ opts.type ] ) );
 		return;

--- a/projects/packages/forms/src/contact-form/js/accessible-form.js
+++ b/projects/packages/forms/src/contact-form/js/accessible-form.js
@@ -49,18 +49,13 @@ const initAllForms = () => {
 		.forEach( initForm );
 };
 
-const IgnoredFieldsForEmptyForm = [
-	'_wpnonce',
-	'_wp_http_referer',
-	'contact-form-id',
-	'action',
-	'contact-form-hash',
-];
 function isFormEmpty( form ) {
-	const formData = new FormData( form );
-	return ! Array.from( formData.entries() ).some(
-		( [ key, value ] ) => ! IgnoredFieldsForEmptyForm.includes( key ) && !! value?.trim()
+	const clonedForm = form.cloneNode( true );
+	Array.from( clonedForm.querySelectorAll( 'input[type="hidden"]' ) ).forEach( input =>
+		input.remove()
 	);
+	const formData = new FormData( clonedForm );
+	return ! Array.from( formData.values() ).some( value => !! value?.trim() );
 }
 
 /**

--- a/projects/packages/forms/src/contact-form/js/accessible-form.js
+++ b/projects/packages/forms/src/contact-form/js/accessible-form.js
@@ -55,7 +55,9 @@ function isFormEmpty( form ) {
 		input.remove()
 	);
 	const formData = new FormData( clonedForm );
-	return ! Array.from( formData.values() ).some( value => !! value?.trim() );
+	return ! Array.from( formData.values() ).some( value =>
+		value instanceof File ? !! value.size : !! value.trim?.()
+	);
 }
 
 /**

--- a/projects/packages/forms/src/contact-form/js/accessible-form.js
+++ b/projects/packages/forms/src/contact-form/js/accessible-form.js
@@ -29,6 +29,8 @@ const L10N = {
 	submittingForm: __( 'Submitting form', 'jetpack-forms' ),
 	/* translators: generic error message */
 	genericError: __( 'Please correct this field', 'jetpack-forms' ),
+	/* translators: error message shown when no field has been filled out */
+	emptyForm: __( 'The form you are trying to submit is emtpy.', 'jetpack-forms' ),
 	errorCount: d =>
 		/* translators: message displayed when errors need to be fixed. %d is the number of errors. */
 		_n( 'You need to fix %d error.', 'You need to fix %d errors.', d, 'jetpack-forms' ),
@@ -46,6 +48,20 @@ const initAllForms = () => {
 		.querySelectorAll( '.wp-block-jetpack-contact-form-container form.contact-form' )
 		.forEach( initForm );
 };
+
+const IgnoredFieldsForEmptyForm = [
+	'_wpnonce',
+	'_wp_http_referer',
+	'contact-form-id',
+	'action',
+	'contact-form-hash',
+];
+function isFormEmpty( form ) {
+	const formData = new FormData( form );
+	return ! Array.from( formData.entries() ).some(
+		( [ key, value ] ) => ! IgnoredFieldsForEmptyForm.includes( key ) && !! value?.trim()
+	);
+}
 
 /**
  * Implement a form custom validation.
@@ -75,7 +91,15 @@ const initForm = form => {
 
 		clearForm( form, inputListenerMap, opts );
 
-		if ( isFormValid( form ) ) {
+		const isValid = isFormValid( form );
+		// If a form is invalid proceed with the usual validation process, even if it's empty.
+		// This indicates that some fields are required.
+		if ( isFormEmpty( form ) && isValid ) {
+			setFormError( form, [], { disableLiveRegion: true, type: 'emptyForm' } );
+			return;
+		}
+
+		if ( isValid ) {
 			inputListenerMap = {};
 
 			form.removeEventListener( 'submit', onSubmit );
@@ -914,6 +938,10 @@ const setFormError = ( form, invalidFields, opts = {} ) => {
 	}
 
 	const count = invalidFields.length;
+	if ( ! count && !! L10N[ opts.type ] ) {
+		error.appendChild( createError( L10N[ opts.type ] ) );
+		return;
+	}
 	const errors = [ L10N.invalidForm ];
 
 	if ( count > 0 ) {

--- a/projects/packages/forms/src/contact-form/js/accessible-form.js
+++ b/projects/packages/forms/src/contact-form/js/accessible-form.js
@@ -56,7 +56,7 @@ function isFormEmpty( form ) {
 	);
 	const formData = new FormData( clonedForm );
 	return ! Array.from( formData.values() ).some( value =>
-		value instanceof File ? !! value.size : !! value.trim?.()
+		value instanceof File ? !! value.size : !! value?.trim?.()
 	);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/11886

Alternative of: https://github.com/Automattic/jetpack/pull/41356

Currently a user can submit an empty form, which creates a `feedback` entity and unnecessary noise. This PR handles the client side part that I had suggested [here](https://github.com/Automattic/jetpack/issues/11886#issuecomment-2579809356). A follow up should handle server side checks.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
1. Insert a form with different fields.
2. Try to submit it empty and observe that a message is displayed.
3. Try combinations with required fields. For example add one required and leave everything empty. It should show the validation message and not the `empty form` error.
4. Try with checkboxes and default values used. In that case a form shouldn't be considered empty, as it has values, and should be submitted.

