### PR TITLE
WP Super Cache: Minimum WP version is 6.6 again

### DIFF
--- a/projects/plugins/super-cache/changelog/update-super-cache-min-wp-version-6-6
+++ b/projects/plugins/super-cache/changelog/update-super-cache-min-wp-version-6-6
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: WP compatibility: bump min WP version to 6.6 again because of polyfills.
+
+

--- a/projects/plugins/super-cache/readme.txt
+++ b/projects/plugins/super-cache/readme.txt
@@ -1,7 +1,7 @@
 === WP Super Cache ===
 Contributors: donncha, automattic, adnan007, dilirity, mikemayhem3030, pyronaur, thingalon
 Tags: performance, caching, wp-cache, wp-super-cache, cache
-Requires at least: 6.2
+Requires at least: 6.6
 Requires PHP: 7.2
 Tested up to: 6.7.1
 Stable tag: 2.0.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Bump the minimum required WP version to 6.6 because the polyfills weren't loaded early enough for caching to work in 6.2.

Fixes #41441

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

None required.
