### PR TITLE
Verbum: fix nonce bug

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-nonce-bug
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-nonce-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Verbum: wp_die if nonce check fails

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
@@ -461,12 +461,12 @@ HTML;
 		// Check for Highlander Nonce.
 		if (
 			isset( $_POST['highlander_comment_nonce'] ) &&
-			wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['highlander_comment_nonce'] ), 'highlander_comment' ) )
+			wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['highlander_comment_nonce'] ) ), 'highlander_comment' )
 		) {
 			return;
 		}
 
-		return new WP_Error( 'verbum', __( 'Error: please try commenting again.', 'jetpack-mu-wpcom' ) );
+		wp_die( esc_html__( 'Sorry, this comment could not be posted.', 'jetpack-mu-wpcom' ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/loop/issues/356

## Proposed changes:

* Fix typo in `wp_verify_nonce`. The ending parenthesis should be on the other side of the nonce name.
* `wp_die` instead of returning an error.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p3btAN-2ZA-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

To be continued...