### PR TITLE
Tag Boost milestones

### DIFF
--- a/.github/workflows/tag-boost-milestone.yml
+++ b/.github/workflows/tag-boost-milestone.yml
@@ -1,0 +1,35 @@
+name: Tag PRs with Milestone
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  tag-prs:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, '[Plugin] Boost')
+    env:
+      MILESTONE_NAME: "boost/next"
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Check and set milestone
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # First check if milestone exists
+        if ! gh api repos/${{ github.repository }}/milestones --jq '.[] | select(.title=="'"$MILESTONE_NAME"'")' | grep -q "$MILESTONE_NAME"; then
+          # Create milestone if it doesn't exist
+          gh api repos/${{ github.repository }}/milestones -F title="$MILESTONE_NAME" -F state="open"
+        fi
+        
+        # Check if PR has a milestone
+        if ! gh pr view ${{ github.event.pull_request.number }} --json milestone | grep -q '"milestone":.*[^null]'; then
+          # If no milestone, set it to the default milestone
+          gh pr edit ${{ github.event.pull_request.number }} --milestone "$MILESTONE_NAME"
+        fi
+

--- a/.github/workflows/tag-boost-milestone.yml
+++ b/.github/workflows/tag-boost-milestone.yml
@@ -17,19 +17,25 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Check and set milestone
+    - name: Create the milestone if it doesn't exist
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        # First check if milestone exists
         if ! gh api repos/${{ github.repository }}/milestones --jq '.[] | select(.title=="'"$MILESTONE_NAME"'")' | grep -q "$MILESTONE_NAME"; then
-          # Create milestone if it doesn't exist
+          echo "Creating milestone $MILESTONE_NAME"
           gh api repos/${{ github.repository }}/milestones -F title="$MILESTONE_NAME" -F state="open"
+        else
+          echo "Milestone $MILESTONE_NAME already exists"
         fi
-        
-        # Check if PR has a milestone
+
+    - name: Set milestone on PR if none is set
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
         if ! gh pr view ${{ github.event.pull_request.number }} --json milestone | grep -q '"milestone":.*[^null]'; then
-          # If no milestone, set it to the default milestone
+          echo "Setting milestone $MILESTONE_NAME on PR #${{ github.event.pull_request.number }}"
           gh pr edit ${{ github.event.pull_request.number }} --milestone "$MILESTONE_NAME"
+        else
+          echo "PR already has a milestone set"
         fi
 

--- a/.github/workflows/tag-boost-milestone.yml
+++ b/.github/workflows/tag-boost-milestone.yml
@@ -20,10 +20,11 @@ jobs:
     - name: Create the milestone if it doesn't exist
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
       run: |
-        if ! gh api repos/${{ github.repository }}/milestones --jq '.[] | select(.title=="'"$MILESTONE_NAME"'")' | grep -q "$MILESTONE_NAME"; then
+        if ! gh api repos/${REPO}/milestones --jq '.[] | select(.title=="'"$MILESTONE_NAME"'")' | grep -q "$MILESTONE_NAME"; then
           echo "Creating milestone $MILESTONE_NAME"
-          gh api repos/${{ github.repository }}/milestones -F title="$MILESTONE_NAME" -F state="open"
+          gh api repos/${REPO}/milestones -F title="$MILESTONE_NAME" -F state="open"
         else
           echo "Milestone $MILESTONE_NAME already exists"
         fi
@@ -31,11 +32,12 @@ jobs:
     - name: Set milestone on PR if none is set
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
-        milestone=$(gh pr view ${{ github.event.pull_request.number }} --json milestone --jq '.milestone.title')
+        milestone=$(gh pr view ${PR_NUMBER} --json milestone --jq '.milestone.title')
         if [ "$milestone" = "null" ] || [ -z "$milestone" ]; then
-          echo "Setting milestone $MILESTONE_NAME on PR #${{ github.event.pull_request.number }}"
-          gh pr edit ${{ github.event.pull_request.number }} --milestone "$MILESTONE_NAME"
+          echo "Setting milestone $MILESTONE_NAME on PR #${PR_NUMBER}"
+          gh pr edit ${PR_NUMBER} --milestone "$MILESTONE_NAME"
         else
           echo "PR already has milestone: $milestone"
         fi

--- a/.github/workflows/tag-boost-milestone.yml
+++ b/.github/workflows/tag-boost-milestone.yml
@@ -5,7 +5,7 @@ on:
     types: [closed]
 
 jobs:
-  tag-prs:
+  tag-pr:
     runs-on: ubuntu-latest
     if: |
       github.event.pull_request.merged == true &&
@@ -32,10 +32,11 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        if ! gh pr view ${{ github.event.pull_request.number }} --json milestone | grep -q '"milestone":.*[^null]'; then
-          echo "Setting milestone $MILESTONE_NAME on PR #${{ github.event.pull_request.number }}"
-          gh pr edit ${{ github.event.pull_request.number }} --milestone "$MILESTONE_NAME"
+        milestone=$(gh pr view 3 --json milestone --jq '.milestone.title')
+        if [ "$milestone" = "null" ] || [ -z "$milestone" ]; then
+          echo "Setting milestone $MILESTONE_NAME on PR #3"
+          gh pr edit 3 --milestone "$MILESTONE_NAME"
         else
-          echo "PR already has a milestone set"
+          echo "PR already has milestone: $milestone"
         fi
 

--- a/.github/workflows/tag-boost-milestone.yml
+++ b/.github/workflows/tag-boost-milestone.yml
@@ -1,4 +1,4 @@
-name: Tag PRs with Milestone
+name: Tag Boost PRs with milestone
 
 on:
   pull_request:

--- a/.github/workflows/tag-boost-milestone.yml
+++ b/.github/workflows/tag-boost-milestone.yml
@@ -32,10 +32,10 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        milestone=$(gh pr view 3 --json milestone --jq '.milestone.title')
+        milestone=$(gh pr view ${{ github.event.pull_request.number }} --json milestone --jq '.milestone.title')
         if [ "$milestone" = "null" ] || [ -z "$milestone" ]; then
-          echo "Setting milestone $MILESTONE_NAME on PR #3"
-          gh pr edit 3 --milestone "$MILESTONE_NAME"
+          echo "Setting milestone $MILESTONE_NAME on PR #${{ github.event.pull_request.number }}"
+          gh pr edit ${{ github.event.pull_request.number }} --milestone "$MILESTONE_NAME"
         else
           echo "PR already has milestone: $milestone"
         fi


### PR DESCRIPTION
## Proposed changes:
* This is a github workflow specifically for Boost. Tag any PR that doesn't have a milestone with "boost/next" on merge.

The intended use for this is to include maintenance PRs in the milestone which may only be included if the PR is merged before a release. While releasing, the milestone is renamed to `boost/x.y.z`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
Since it's a github workflow, the only way to test it would be either after this is merged or on a forked repository. I have tested it in a fork: https://github.com/haqadn/jetpack/actions/runs/13077207694/job/36492217161?pr=5

