### PR TITLE
UPDATE: Reader urls from /read to /reader

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/reader-update-url-from-read-to-reader
+++ b/projects/packages/jetpack-mu-wpcom/changelog/reader-update-url-from-read-to-reader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Reader: Update url from /read to /reader

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -224,7 +224,7 @@ function wpcom_add_reader_menu( $wp_admin_bar ) {
 						/* translators: Hidden accessibility text. */
 						__( 'Reader', 'jetpack-mu-wpcom' ) .
 						'</span>',
-			'href'   => maybe_add_origin_site_id_to_url( 'https://wordpress.com/read' ),
+			'href'   => maybe_add_origin_site_id_to_url( 'https://wordpress.com/reader' ),
 			'meta'   => array(
 				'class' => 'wp-admin-bar-reader',
 			),

--- a/projects/plugins/jetpack/changelog/reader-update-url-from-read-to-reader
+++ b/projects/plugins/jetpack/changelog/reader-update-url-from-read-to-reader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Reader: Update url from /read to /reader

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
@@ -141,7 +141,7 @@ function render_block( $attributes ) {
 		return sprintf(
 			$block_template,
 			get_block_wrapper_attributes(),
-			'https://wordpress.com/read/site/subscription/' . Jetpack_Memberships::get_blog_id(),
+			'https://wordpress.com/reader/site/subscription/' . Jetpack_Memberships::get_blog_id(),
 			$manage_subscriptions_label
 		);
 	}

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
@@ -128,7 +128,7 @@ function render_block( $attributes ) {
 	$show_manage_link           = ! empty( $attributes['showManageSubscriptionsLink'] );
 	$manage_subscriptions_label = ! empty( $attributes['manageSubscriptionsLabel'] ) ? sanitize_text_field( $attributes['manageSubscriptionsLabel'] ) : esc_html__( 'Manage subscription', 'jetpack' );
 
-	if ( false ) {
+	if ( ! is_subscriber_logged_in() ) {
 		return sprintf(
 			$block_template,
 			get_block_wrapper_attributes(),
@@ -137,7 +137,7 @@ function render_block( $attributes ) {
 		);
 	}
 
-	if ( true ) {
+	if ( $show_manage_link && Jetpack_Memberships::is_current_user_subscribed() ) {
 		return sprintf(
 			$block_template,
 			get_block_wrapper_attributes(),

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
@@ -128,7 +128,7 @@ function render_block( $attributes ) {
 	$show_manage_link           = ! empty( $attributes['showManageSubscriptionsLink'] );
 	$manage_subscriptions_label = ! empty( $attributes['manageSubscriptionsLabel'] ) ? sanitize_text_field( $attributes['manageSubscriptionsLabel'] ) : esc_html__( 'Manage subscription', 'jetpack' );
 
-	if ( ! is_subscriber_logged_in() ) {
+	if ( false ) {
 		return sprintf(
 			$block_template,
 			get_block_wrapper_attributes(),
@@ -137,7 +137,7 @@ function render_block( $attributes ) {
 		);
 	}
 
-	if ( $show_manage_link && Jetpack_Memberships::is_current_user_subscribed() ) {
+	if ( true ) {
 		return sprintf(
 			$block_template,
 			get_block_wrapper_attributes(),

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -765,7 +765,7 @@ function render_for_website( $data, $classes, $styles ) {
 					<?php endif; ?>
 				>
 						<a
-							href="<?php echo esc_url( 'https://wordpress.com/read/site/subscription/' . $blog_id ); ?>"
+							href="<?php echo esc_url( 'https://wordpress.com/reader/site/subscription/' . $blog_id ); ?>"
 							<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
 								class="<?php echo esc_attr( $classes['submit_button'] ); ?>"
 							<?php endif; ?>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -758,7 +758,7 @@ function render_for_website( $data, $classes, $styles ) {
 	?>
 	<div <?php echo wp_kses_data( $data['wrapper_attributes'] ); ?>>
 		<div class="wp-block-jetpack-subscriptions__container<?php echo ! $is_subscribed ? ' is-not-subscriber' : ''; ?>">
-			<?php if ( is_top_subscription() ) : ?>
+			<?php if ( true ) : ?>
 				<p id="subscribe-submit" class="is-link"
 					<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
 						style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -758,7 +758,7 @@ function render_for_website( $data, $classes, $styles ) {
 	?>
 	<div <?php echo wp_kses_data( $data['wrapper_attributes'] ); ?>>
 		<div class="wp-block-jetpack-subscriptions__container<?php echo ! $is_subscribed ? ' is-not-subscriber' : ''; ?>">
-			<?php if ( true ) : ?>
+			<?php if ( is_top_subscription() ) : ?>
 				<p id="subscribe-submit" class="is-link"
 					<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
 						style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to #https://github.com/Automattic/loop/issues/338

## Proposed changes:

- Updated all `/read/*` routes to `/reader/*`

### Dependencies

- [x] Merge https://github.com/Automattic/wp-calypso/pull/99038

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:

* Choose a simple site (example: `mehmoodak2.wordpress.com`).
* Sandbox the site and `s0.wp.com`. 

* Verify Reader link of admin bar:
    * Download the branch to your sandbox with `bin/jetpack-downloader test jetpack-mu-wpcom-plugin loop-338/update-reader-url-to-reader`
    * Go to [https://mehmoodak2.wordpress.com](https://mehmoodak2.wordpress.com) and verify that the reader url is changed.
    * Reset `jetpack-downloader reset jetpack-mu-wpcom-plugin`

* Verify Jetpack block changes:
    * Download the branch to your sandbox with `bin/jetpack-downloader test jetpack loop-338/update-reader-url-to-reader`
    * Go to test site and create a post.
    * Add "Subscribe" and "Subscriber Login" blocks.
    * View Post.
    * Manually changed conditions to show state of the block that have reader url (af8dd1670620c37fd4c8e2685dfc0b7010909b2a) ..... tried multiple times but didn't found a way to trigger the needed state via UI.
    * Verify that the blocks on frontend are showing `/reader` urls (subscribe if necessary)
    * Reset `jetpack-downloader reset jetpack`
