### PR TITLE
MU WPCOM: fix admin menu upsell layout shift

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-menu-notice-jank
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-menu-notice-jank
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix admin menu jank

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.js
@@ -1,4 +1,4 @@
-/* global wp, wpcomSidebarNoticeConfig */
+/* global wp, wpcomSidebarNoticeData */
 import { wpcomTrackEvent } from '../../common/tracks';
 
 import './wpcom-sidebar-notice.scss';
@@ -15,50 +15,15 @@ const wpcomSidebarNoticeRecordEvent = ( event, wpcomSidebarNoticeData ) => {
 	);
 };
 
-const wpcomShowSidebarNotice = wpcomSidebarNoticeData => {
-	const adminMenu = document.querySelector( '#adminmenu' );
-	if ( ! adminMenu || ! wpcomSidebarNoticeData ) {
+const wpcomShowSidebarNotice = () => {
+	const sidebarNotice = document.querySelector( '#toplevel_page_site-notices' );
+	if ( ! sidebarNotice || ! wpcomSidebarNoticeData ) {
 		return;
 	}
 
-	// Render notice.
-	adminMenu.insertAdjacentHTML(
-		'afterbegin',
-		`
-			<li
-				id="toplevel_page_site-notices"
-				class="wp-not-current-submenu menu-top menu-icon-generic toplevel_page_site-notices"
-				data-id="${ wpcomSidebarNoticeData.id }"
-				data-feature-class="${ wpcomSidebarNoticeData.featureClass }"
-			>
-				<a href="${
-					wpcomSidebarNoticeData.url
-				}" class="wp-not-current-submenu menu-top menu-icon-generic toplevel_page_site-notices">
-					<div class="wp-menu-name">
-						<div class="upsell_banner">
-							<div class="upsell_banner__icon dashicons" aria-hidden="true"></div>
-							<div class="upsell_banner__text">${ wpcomSidebarNoticeData.text }</div>
-							<button type="button" class="upsell_banner__action button">${
-								wpcomSidebarNoticeData.action
-							}</button>
-							${
-								wpcomSidebarNoticeData.dismissible
-									? '<button type="button" class="upsell_banner__dismiss button button-link">' +
-									  wpcomSidebarNoticeData.dismissLabel +
-									  '</button>'
-									: ''
-							}
-						</div>
-					</div>
-				</a>
-			</li>
-		`
-	);
-
 	// Record impression event in Tracks.
-	wpcomSidebarNoticeRecordEvent( wpcomSidebarNoticeData.tracks?.display );
+	wpcomSidebarNoticeRecordEvent( wpcomSidebarNoticeData.tracks?.display, wpcomSidebarNoticeData );
 
-	const sidebarNotice = adminMenu.firstElementChild;
 	sidebarNotice.addEventListener( 'click', event => {
 		if (
 			event.target.classList.contains( 'upsell_banner__dismiss' ) ||
@@ -74,32 +39,15 @@ const wpcomShowSidebarNotice = wpcomSidebarNoticeData => {
 			sidebarNotice.remove();
 
 			// Record dismiss event in Tracks.
-			wpcomSidebarNoticeRecordEvent( wpcomSidebarNoticeData.tracks?.dismiss );
+			wpcomSidebarNoticeRecordEvent(
+				wpcomSidebarNoticeData.tracks?.dismiss,
+				wpcomSidebarNoticeData
+			);
 		} else {
 			// Record click event in Tracks.
-			wpcomSidebarNoticeRecordEvent( wpcomSidebarNoticeData.tracks?.click );
+			wpcomSidebarNoticeRecordEvent( wpcomSidebarNoticeData.tracks?.click, wpcomSidebarNoticeData );
 		}
 	} );
 };
 
-const wpcomFetchSidebarNotice = async () => {
-	try {
-		const response = await fetch(
-			`${ wpcomSidebarNoticeConfig.ajaxUrl }?action=wpcom_fetch_sidebar_notice&nonce=${ wpcomSidebarNoticeConfig.nonce }`
-		);
-
-		if ( response.status !== 200 ) {
-			return;
-		}
-
-		const res = await response.json();
-
-		if ( res.success && res.data ) {
-			wpcomShowSidebarNotice( res.data );
-		}
-	} catch {
-		// End silently
-	}
-};
-
-document.addEventListener( 'DOMContentLoaded', wpcomFetchSidebarNotice );
+document.addEventListener( 'DOMContentLoaded', wpcomShowSidebarNotice );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.scss
@@ -38,15 +38,8 @@
 /**
  * Sidebar notice
  */
-#adminmenu li.menu-top.toplevel_page_site-notices {
-	&:hover,
-	&:focus {
-		background-color: inherit;
-	}
-
+#adminmenu li.toplevel_page_site-notices {
 	a {
-		cursor: default;
-
 		&:hover,
 		&:focus {
 			box-shadow: none;
@@ -54,9 +47,7 @@
 		}
 	}
 
-	.wp-menu-name {
-		padding: 0 8px 8px 8px;
-	}
+	padding: 0 8px 8px 8px;
 
 	.upsell_banner {
 		border-radius: 2px;
@@ -66,34 +57,17 @@
 		gap: 6px;
 	}
 
-	.upsell_banner__icon {
-		display: none;
-
-		&:before {
-			content: '\f534';
-			font-family: 'dashicons';
-			background-color: #a7aaad;
-			color: white;
-			border-radius: 50%;
-		}
-	}
-
 	.upsell_banner__text {
 		font-size: 12px;
 		line-height: 16px;
 	}
 
 	.upsell_banner__action {
-		width: 100%;
-		font-size: 13px;
-		line-height: 20px;
-		cursor: pointer;
-		min-height: 32px;
-		margin-bottom: 0;
-		border: 0;
+		text-align: center;
+		line-height: 2;
 	}
 
-	.upsell_banner__dismiss {
+	.upsell_banner__dismiss.button-link {
 		background-color: transparent;
 		color: inherit;
 		min-height: 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/87509 for wp-admin


https://github.com/user-attachments/assets/d9edbc1f-fa4f-481d-bd83-2e6d3e8302d5



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Let's avoid JS and render it in good old PHP.
* Gets rid of a network request.
* Here's the trick: I'm using the `adminmenu` hook which allows us to insert random HTML _after_ the admin menu. With the help of a tiny little inline script that instantly executes we can move it to the top before the browser can even render it. `(function(el){el.parentNode.prepend(el)})(document.getElementById( "toplevel_page_site-notices" ))`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Click admin menu links. The upsell notice shouldn't insert itself with a delay.

