### PR TITLE
Add hint for outdated dependencies

### DIFF
--- a/tools/cli/bin/jetpack.js
+++ b/tools/cli/bin/jetpack.js
@@ -29,6 +29,18 @@ async function guardedImport( path ) {
 					'*** Something is missing from your install. Please run `pnpm install` and try again. ***'
 				)
 			);
+		} else if (
+			error.name === 'SyntaxError' &&
+			( error.stack.match(
+				/Named export '.+?' not found. The requested module '.+?' is a CommonJS module/
+			) ||
+				error.stack.match( /The requested module '.+?' does not provide an export named '.+?'/ ) )
+		) {
+			console.error(
+				bold(
+					'*** Perhaps you have outdated dependencies. Please run `pnpm install` and try again. ***'
+				)
+			);
 		} else {
 			console.error( bold( '*** Something unexpected happened. See error above. ***' ) );
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Sometimes we update dependencies that are critical to our tooling. This PR adds a hint to run `pnpm install` if an expected export is not found in an existing dependency.

We already catch scenarios where the module itself isn't present.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Ensure all three scenarios work (I edited `noop.js` so I could easily test with `jetpack noop`):

1. `import worldpeace from 'utopia';`
2. `import { boysenberry } from 'chalk';`
3. Downgrade chalk to v3 (`pnpm install chalk@3`) and run `jetpack noop`