### PR TITLE
Jetpack Search: hide module toggle on wpcom

### DIFF
--- a/projects/packages/search/changelog/fix-disable-search-toggle-on-wpcom
+++ b/projects/packages/search/changelog/fix-disable-search-toggle-on-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+

--- a/projects/packages/search/src/dashboard/components/module-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/module-control/index.jsx
@@ -279,25 +279,28 @@ const SearchToggle = ( {
 	const isSearchToggleChecked = isModuleEnabled && supportsSearch && ! isDisabledFromOverLimit;
 	const isSearchToggleDisabled =
 		isSavingEitherOption || ! supportsSearch || isDisabledFromOverLimit;
+	const isWpcom = useSelect( select => select( STORE_ID ).isWpcom(), [] );
 
 	return (
 		<div className="jp-form-search-settings-group__toggle is-search jp-search-dashboard-wrap">
-			<div className="jp-search-dashboard-row">
-				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
-				<CompactFormToggle
-					checked={ isSearchToggleChecked }
-					disabled={ isSearchToggleDisabled }
-					onChange={ toggleSearchModule }
-					toggling={ isTogglingModule }
-					className="is-search-admin"
-					switchClassNames="lg-col-span-1 md-col-span-1 sm-col-span-1"
-					labelClassNames=" lg-col-span-7 md-col-span-5 sm-col-span-3"
-					aria-label={ __( 'Enable Jetpack Search', 'jetpack-search-pkg' ) }
-				>
-					{ __( 'Enable Jetpack Search', 'jetpack-search-pkg' ) }
-				</CompactFormToggle>
-				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
-			</div>
+			{ ! isWpcom && (
+				<div className="jp-search-dashboard-row">
+					<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
+					<CompactFormToggle
+						checked={ isSearchToggleChecked }
+						disabled={ isSearchToggleDisabled }
+						onChange={ toggleSearchModule }
+						toggling={ isTogglingModule }
+						className="is-search-admin"
+						switchClassNames="lg-col-span-1 md-col-span-1 sm-col-span-1"
+						labelClassNames=" lg-col-span-7 md-col-span-5 sm-col-span-3"
+						aria-label={ __( 'Enable Jetpack Search', 'jetpack-search-pkg' ) }
+					>
+						{ __( 'Enable Jetpack Search', 'jetpack-search-pkg' ) }
+					</CompactFormToggle>
+					<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
+				</div>
+			) }
 			<div className="jp-search-dashboard-row">
 				<div className="lg-col-span-3 md-col-span-2 sm-col-span-1"></div>
 				<div className="jp-form-search-settings-group__toggle-description lg-col-span-7 md-col-span-5 sm-col-span-3">


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/52543

## Proposed changes:
* Hide the Jetpack Search toggle on Simple sites

![image](https://github.com/user-attachments/assets/dfe656c4-b0c4-44af-91c5-1d2f8c636cdd)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Run `bin/jetpack-downloader test jetpack fix/disable-search-toggle-on-wpcom` on your sandbox
* Sandbox a simple site with Jetpack Search or Classic Search
* Go to wp-admin/admin.php?page=jetpack-search
* Verify that the toggle "Enable Jetpack Search" isn't shown
* Additionally, verify that it is visible on an Atomic or external Jetpack site

