### PR TITLE
My Jetpack: Needs plugins notice- Installation/activation fix & translations improvements.

### DIFF
--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/get-paid-plan-needs-plugins-content.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/get-paid-plan-needs-plugins-content.tsx
@@ -119,7 +119,7 @@ export const useGetPaidPlanNeedsPluginsContent = ( {
 			__( 'Install and/or activate %1$s in one click', 'jetpack-my-jetpack' ),
 			_n( 'plugin', 'plugins', numPluginsNeedingAction, 'jetpack-my-jetpack' )
 		),
-		inatall: sprintf(
+		install: sprintf(
 			/* translators: %1$s is "plugin" or "plugins" (singular/plural) */
 			__( 'Install and activate %1$s in one click', 'jetpack-my-jetpack' ),
 			_n( 'plugin', 'plugins', numPluginsNeedingAction, 'jetpack-my-jetpack' )

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/get-paid-plan-needs-plugins-content.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/get-paid-plan-needs-plugins-content.tsx
@@ -1,0 +1,148 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { useMemo } from 'react';
+import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
+
+type NeedsPluginsAlert =
+	Window[ 'myJetpackInitialState' ][ 'redBubbleAlerts' ][ `${ string }--plugins_needing_installed_activated` ];
+
+export const useGetPaidPlanNeedsPluginsContent = ( {
+	alert,
+	planName,
+	planPurchaseId,
+}: {
+	alert: NeedsPluginsAlert;
+	planName: string;
+	planPurchaseId: string;
+} ) => {
+	const { needs_installed, needs_activated_only } = alert || {};
+	const numPluginsNeedingAction =
+		( needs_installed?.length ?? 0 ) + ( needs_activated_only?.length ?? 0 );
+
+	const { siteSuffix } = getMyJetpackWindowInitialState();
+
+	const actionType = useMemo( () => {
+		if ( needs_installed && needs_activated_only ) {
+			return 'install_activate';
+		} else if ( needs_installed ) {
+			return 'install';
+		}
+		return 'activate';
+	}, [ needs_activated_only, needs_installed ] );
+
+	const noticeTitleSingular = {
+		install_activate: __( 'Plugin installation and activation needed', 'jetpack-my-jetpack' ),
+		install: __( 'Plugin installation needed', 'jetpack-my-jetpack' ),
+		activate: __( 'Plugin activation needed', 'jetpack-my-jetpack' ),
+	};
+
+	const noticeTitlePlural = {
+		install_activate: __(
+			'Some plugins need to be installed and/or activated',
+			'jetpack-my-jetpack'
+		),
+		install: __( 'Some plugins need to be installed', 'jetpack-my-jetpack' ),
+		activate: __( 'Some plugins need to be activated', 'jetpack-my-jetpack' ),
+	};
+
+	const noticeMessages = {
+		install_activate: createInterpolateElement(
+			sprintf(
+				// translators: %1$s is the name of the Jetpack paid plan, i.e.- "Jetpack Security", and %2$s word "plugin" as singular, or plural ("plugins").
+				__(
+					'To get the most out of your <link>%1$s paid subscription</link> and have access to all it’s features, we recommend you install and/or activate the following %2$s:',
+					'jetpack-my-jetpack'
+				),
+				planName,
+				_n( 'plugin', 'plugins', numPluginsNeedingAction, 'jetpack-my-jetpack' )
+			),
+			{
+				link: (
+					<ExternalLink
+						href={ getRedirectUrl( 'jetpack-subscription-renew', {
+							site: siteSuffix,
+							path: planPurchaseId,
+						} ) }
+					/>
+				),
+			}
+		),
+		install: createInterpolateElement(
+			sprintf(
+				// translators: %1$s is the name of the Jetpack paid plan, i.e.- "Jetpack Security", and %2$s word "plugin" as singular, or plural ("plugins").
+				__(
+					'To get the most out of your <link>%1$s paid subscription</link> and have access to all it’s features, we recommend you install and activate the following %2$s:',
+					'jetpack-my-jetpack'
+				),
+				planName,
+				_n( 'plugin', 'plugins', numPluginsNeedingAction, 'jetpack-my-jetpack' )
+			),
+			{
+				link: (
+					<ExternalLink
+						href={ getRedirectUrl( 'jetpack-subscription-renew', {
+							site: siteSuffix,
+							path: planPurchaseId,
+						} ) }
+					/>
+				),
+			}
+		),
+		activate: createInterpolateElement(
+			sprintf(
+				// translators: %1$s is the name of the Jetpack paid plan, i.e.- "Jetpack Security", and %2$s word "plugin" as singular, or plural ("plugins").
+				__(
+					'To get the most out of your <link>%1$s paid subscription</link> and have access to all it’s features, we recommend you activate the following %2$s:',
+					'jetpack-my-jetpack'
+				),
+				planName,
+				_n( 'plugin', 'plugins', numPluginsNeedingAction, 'jetpack-my-jetpack' )
+			),
+			{
+				link: (
+					<ExternalLink
+						href={ getRedirectUrl( 'jetpack-subscription-renew', {
+							site: siteSuffix,
+							path: planPurchaseId,
+						} ) }
+					/>
+				),
+			}
+		),
+	};
+
+	const buttonLabels = {
+		install_activate: sprintf(
+			/* translators: %1$s is "plugin" or "plugins" (singular/plural) */
+			__( 'Install and/or activate %1$s in one click', 'jetpack-my-jetpack' ),
+			_n( 'plugin', 'plugins', numPluginsNeedingAction, 'jetpack-my-jetpack' )
+		),
+		inatall: sprintf(
+			/* translators: %1$s is "plugin" or "plugins" (singular/plural) */
+			__( 'Install and activate %1$s in one click', 'jetpack-my-jetpack' ),
+			_n( 'plugin', 'plugins', numPluginsNeedingAction, 'jetpack-my-jetpack' )
+		),
+		activate: sprintf(
+			/* translators: %1$s is "plugin" or "plugins" (singular/plural) */
+			__( 'Activate %1$s in one click', 'jetpack-my-jetpack' ),
+			_n( 'plugin', 'plugins', numPluginsNeedingAction, 'jetpack-my-jetpack' )
+		),
+	};
+
+	const noticeTitle =
+		numPluginsNeedingAction === 1
+			? noticeTitleSingular[ actionType ]
+			: noticeTitlePlural[ actionType ];
+
+	const noticeMessage = noticeMessages[ actionType ];
+
+	const buttonLabel = buttonLabels[ actionType as keyof typeof buttonLabels ];
+
+	return {
+		noticeTitle,
+		noticeMessage,
+		buttonLabel,
+	};
+};

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-paid-plan-needs-plugin-install-activation-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-paid-plan-needs-plugin-install-activation-notice.tsx
@@ -115,23 +115,79 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 		planPurchaseId: planPurchase?.ID,
 	} );
 
+	const prepareProductsArray = useCallback(
+		productsArray => {
+			if ( ! productsArray ) {
+				return [];
+			}
+			const prepared = [ ...productsArray ]
+				.map( productSlug => ( { productSlug, pluginSlug: products[ productSlug ].plugin_slug } ) )
+				.sort( ( a, b ) => {
+					if ( a.pluginSlug === 'jetpack' ) {
+						return 1; // Move `jetpack` to the end
+					} else if ( b.pluginSlug === 'jetpack' ) {
+						return -1; // Keep others before `jetpack`
+					}
+					return a.productSlug - b.productSlug; // Otherwise sort ascending
+				} )
+				.map( ( { productSlug } ) => productSlug );
+			return prepared;
+		},
+		[ products ]
+	);
+
+	const needsInstalled = prepareProductsArray( needs_installed );
+	const needsActivated = prepareProductsArray( needs_activated_only );
+
+	const needsInstalledContainsJetpack = needsInstalled.find(
+		productSlug => products[ productSlug ].plugin_slug === 'jetpack'
+	);
+
 	const { install: installAndActivatePlugins, isPending: isInstalling } =
-		useInstallPlugins( needs_installed );
+		useInstallPlugins( needsInstalled );
 	const { activate: activatePlugins, isPending: isActivating } =
-		useActivatePlugins( needs_activated_only );
+		useActivatePlugins( needsActivated );
 
 	const handleInstallActivateInOneClick = useCallback( () => {
 		recordEvent( 'jetpack_my_jetpack_plugin_needs_installed_notice_cta_click' );
 
-		if ( needs_installed ) {
+		if ( needsInstalled.length && needsActivated.length ) {
+			if ( needsInstalledContainsJetpack ) {
+				activatePlugins( null, {
+					onSuccess: () => {
+						installAndActivatePlugins( null, {
+							onSuccess: () => {
+								delete redBubbleAlerts[ pluginsNeedingActionAlerts[ 0 ] ];
+								resetNotice();
+							},
+						} );
+					},
+				} );
+				return;
+			}
+			installAndActivatePlugins( null, {
+				onSuccess: () => {
+					activatePlugins( null, {
+						onSuccess: () => {
+							delete redBubbleAlerts[ pluginsNeedingActionAlerts[ 0 ] ];
+							resetNotice();
+						},
+					} );
+				},
+			} );
+			return;
+		}
+
+		if ( needsInstalled.length ) {
 			installAndActivatePlugins( null, {
 				onSuccess: () => {
 					delete redBubbleAlerts[ pluginsNeedingActionAlerts[ 0 ] ];
 					resetNotice();
 				},
 			} );
+			return;
 		}
-		if ( needs_activated_only ) {
+		if ( needsActivated.length ) {
 			activatePlugins( null, {
 				onSuccess: () => {
 					delete redBubbleAlerts[ pluginsNeedingActionAlerts[ 0 ] ];
@@ -141,13 +197,14 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 		}
 	}, [
 		recordEvent,
-		needs_installed,
-		needs_activated_only,
+		needsInstalled,
+		needsActivated,
+		needsInstalledContainsJetpack,
 		installAndActivatePlugins,
+		activatePlugins,
 		redBubbleAlerts,
 		pluginsNeedingActionAlerts,
 		resetNotice,
-		activatePlugins,
 	] );
 
 	useEffect( () => {

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-paid-plan-needs-plugin-install-activation-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-paid-plan-needs-plugin-install-activation-notice.tsx
@@ -1,6 +1,5 @@
-import { Col, Text, getRedirectUrl } from '@automattic/jetpack-components';
+import { Col, Text } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useContext, useEffect, useMemo, useCallback } from 'react';
 import { NOTICE_PRIORITY_MEDIUM } from '../../context/constants';
@@ -12,6 +11,7 @@ import useSimpleQuery from '../../data/use-simple-query';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import useAnalytics from '../use-analytics';
+import { useGetPaidPlanNeedsPluginsContent } from './get-paid-plan-needs-plugins-content';
 import type { NoticeOptions } from '../../context/notices/types';
 import type { MyJetpackInitialState } from '../../data/types';
 
@@ -52,9 +52,17 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 		( needs_installed?.length ?? 0 ) + ( needs_activated_only?.length ?? 0 );
 
 	const {
-		siteSuffix,
 		products: { items: products },
 	} = getMyJetpackWindowInitialState();
+
+	const actionType = useMemo( () => {
+		if ( needs_installed && needs_activated_only ) {
+			return 'install_activate';
+		} else if ( needs_installed ) {
+			return 'install';
+		}
+		return 'activate';
+	}, [ needs_activated_only, needs_installed ] );
 
 	const getPluginInfo = useCallback(
 		( productSlug, action ) => ( {
@@ -101,43 +109,11 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 		);
 	}, [ getPluginInfo, needs_activated_only, needs_installed ] );
 
-	const actionVerb = useMemo( () => {
-		if ( needs_installed && needs_activated_only ) {
-			return __( 'install and/or activate', 'jetpack-my-jetpack' );
-		} else if ( needs_installed ) {
-			return __( 'install and activate', 'jetpack-my-jetpack' );
-		}
-		return __( 'activate', 'jetpack-my-jetpack' );
-	}, [ needs_activated_only, needs_installed ] );
-
-	const actionType = useMemo( () => {
-		if ( needs_installed && needs_activated_only ) {
-			return 'install_activate';
-		} else if ( needs_installed ) {
-			return 'install';
-		}
-		return 'activate';
-	}, [ needs_activated_only, needs_installed ] );
-
-	const noticeTitleSingular = {
-		install_activate: __( 'Plugin installation and activation needed', 'jetpack-my-jetpack' ),
-		install: __( 'Plugin installation needed', 'jetpack-my-jetpack' ),
-		activate: __( 'Plugin activation needed', 'jetpack-my-jetpack' ),
-	};
-
-	const noticeTitlePlural = {
-		install_activate: __(
-			'Some plugins need to be installed and/or activated',
-			'jetpack-my-jetpack'
-		),
-		install: __( 'Some plugins need to be installed', 'jetpack-my-jetpack' ),
-		activate: __( 'Some plugins need to be activated', 'jetpack-my-jetpack' ),
-	};
-
-	const noticeTitle =
-		numPluginsNeedingAction === 1
-			? noticeTitleSingular[ actionType ]
-			: noticeTitlePlural[ actionType ];
+	const { noticeTitle, noticeMessage, buttonLabel } = useGetPaidPlanNeedsPluginsContent( {
+		alert,
+		planName,
+		planPurchaseId: planPurchase?.ID,
+	} );
 
 	const { install: installAndActivatePlugins, isPending: isInstalling } =
 		useInstallPlugins( needs_installed );
@@ -184,32 +160,11 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 			activate: __( 'Needs activation', 'jetpack-my-jetpack' ),
 		};
 
-		const noticeMessage = (
+		const noticeContent = (
 			<>
 				<Col>
 					<Text mt={ 2 } mb={ 2 }>
-						{ createInterpolateElement(
-							sprintf(
-								// translators: %1$s is the name of the Jetpack paid plan, i.e.- "Jetpack Security", %2$s is either "the [plugin name] plugin" or "the following plugins", and %3$s is a verb being either "installed", or "activated", or "installed and/or activated".
-								__(
-									'To get the most out of your <link>%1$s paid subscription</link> and have access to all it’s features, we recommend you %2$s the following %3$s:',
-									'jetpack-my-jetpack'
-								),
-								planName,
-								actionVerb,
-								_n( 'plugin', 'plugins', numPluginsNeedingAction, 'jetpack-my-jetpack' )
-							),
-							{
-								link: (
-									<ExternalLink
-										href={ getRedirectUrl( 'jetpack-subscription-renew', {
-											site: siteSuffix,
-											path: planPurchase.ID,
-										} ) }
-									/>
-								),
-							}
-						) }
+						{ noticeMessage }
 					</Text>
 					<ul className="plugins-list">
 						{ pluginsList.map( ( pluginInfo, index ) => {
@@ -231,14 +186,7 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 			</>
 		);
 
-		const buttonLabel = sprintf(
-			/* translators: %1$s is either "Install and activate", or "Install and/or activate", or "Activate"; And %2$s is "plugin" or "plugins" (singular/plural). */
-			__( '%1$s %2$s in one click', 'jetpack-my-jetpack' ),
-			actionVerb.charAt( 0 ).toUpperCase() + actionVerb.slice( 1 ),
-			_n( 'plugin', 'plugins', numPluginsNeedingAction, 'jetpack-my-jetpack' )
-		);
-
-		const isinstallingOrActivating = isActivating || isInstalling;
+		const isInstallingOrActivating = isActivating || isInstalling;
 
 		const noticeOptions: NoticeOptions = {
 			id: 'plugin_needs_installed_activated',
@@ -247,9 +195,9 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 				{
 					label: buttonLabel,
 					onClick: handleInstallActivateInOneClick,
-					isLoading: isinstallingOrActivating,
+					isLoading: isInstallingOrActivating,
 					loadingText:
-						actionVerb === 'activate'
+						actionType === 'activate'
 							? sprintf(
 									/* translators: %s is the singular or plural "plugin" or "plugins". */
 									__( 'Activating %s…', 'jetpack-my-jetpack' ),
@@ -263,18 +211,19 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 					noDefaultClasses: true,
 				},
 			],
-			priority: NOTICE_PRIORITY_MEDIUM + ( isinstallingOrActivating ? 1 : 0 ),
+			priority: NOTICE_PRIORITY_MEDIUM + ( isInstallingOrActivating ? 1 : 0 ),
 		};
 
 		setNotice( {
 			title: noticeTitle,
-			message: noticeMessage,
+			message: noticeContent,
 			options: noticeOptions,
 		} );
 	}, [
 		actionType,
-		actionVerb,
 		noticeTitle,
+		noticeMessage,
+		buttonLabel,
 		isPurchasesDataLoaded,
 		numPluginsNeedingAction,
 		handleInstallActivateInOneClick,
@@ -283,7 +232,6 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 		pluginsList,
 		pluginsNeedingActionAlerts.length,
 		setNotice,
-		siteSuffix,
 		isInstalling,
 		isActivating,
 	] );

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-paid-plan-needs-plugin-install-activation-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-paid-plan-needs-plugin-install-activation-notice.tsx
@@ -57,13 +57,14 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 	} = getMyJetpackWindowInitialState();
 
 	const getPluginInfo = useCallback(
-		productSlug => ( {
+		( productSlug, action ) => ( {
 			productSlug: productSlug,
 			pluginSlug: products[ productSlug ].plugin_slug,
 			pluginName:
 				products[ productSlug ].plugin_slug === 'jetpack'
 					? 'Jetpack'
 					: products[ productSlug ].title,
+			action,
 			pluginUri: `https://wordpress.org/plugins/${ products[ productSlug ].plugin_slug }/`,
 		} ),
 		[ products ]
@@ -72,37 +73,50 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 	const pluginsList = useMemo( () => {
 		if ( needs_installed && needs_activated_only ) {
 			const slugs = new Set();
-			return [ ...needs_installed, ...needs_activated_only ]
-				.map( getPluginInfo )
-				.filter( ( { pluginSlug } ) => ! slugs.has( pluginSlug ) && slugs.add( pluginSlug ) ); // filters out duplicates
+			const needsInstalled = [ ...needs_installed ].map( productSlug =>
+				getPluginInfo( productSlug, 'install' )
+			);
+			const needsActivated = [ ...needs_activated_only ].map( productSlug =>
+				getPluginInfo( productSlug, 'activate' )
+			);
+			return [ ...needsInstalled, ...needsActivated ].filter(
+				/* filters out duplicates */
+				( { pluginSlug } ) => ! slugs.has( pluginSlug ) && slugs.add( pluginSlug )
+			);
 		} else if ( needs_installed ) {
 			const slugs = new Set();
-			return needs_installed
-				.map( getPluginInfo )
-				.filter( ( { pluginSlug } ) => ! slugs.has( pluginSlug ) && slugs.add( pluginSlug ) );
+			return (
+				needs_installed
+					.map( productSlug => getPluginInfo( productSlug, 'install' ) )
+					/* filters out duplicates */
+					.filter( ( { pluginSlug } ) => ! slugs.has( pluginSlug ) && slugs.add( pluginSlug ) )
+			);
 		}
 		const slugs = new Set();
-		return needs_activated_only
-			?.map( getPluginInfo )
-			.filter( ( { pluginSlug } ) => ! slugs.has( pluginSlug ) && slugs.add( pluginSlug ) );
+		return (
+			needs_activated_only
+				?.map( productSlug => getPluginInfo( productSlug, 'activate' ) )
+				/* filters out duplicates */
+				.filter( ( { pluginSlug } ) => ! slugs.has( pluginSlug ) && slugs.add( pluginSlug ) )
+		);
 	}, [ getPluginInfo, needs_activated_only, needs_installed ] );
 
 	const actionNoun = useMemo( () => {
 		if ( needs_installed && needs_activated_only ) {
-			return 'installation and/or activation';
+			return __( 'installation and/or activation', 'jetpack-my-jetpack' );
 		} else if ( needs_installed ) {
-			return 'installation';
+			return __( 'installation', 'jetpack-my-jetpack' );
 		}
-		return 'activation';
+		return __( 'activation', 'jetpack-my-jetpack' );
 	}, [ needs_activated_only, needs_installed ] );
 
 	const actionVerb = useMemo( () => {
 		if ( needs_installed && needs_activated_only ) {
-			return 'install and/or activate';
+			return __( 'install and/or activate', 'jetpack-my-jetpack' );
 		} else if ( needs_installed ) {
-			return 'install and activate';
+			return __( 'install and activate', 'jetpack-my-jetpack' );
 		}
-		return 'activate';
+		return __( 'activate', 'jetpack-my-jetpack' );
 	}, [ needs_activated_only, needs_installed ] );
 
 	const { install: installAndActivatePlugins, isPending: isInstalling } =
@@ -156,6 +170,11 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 			actionNoun
 		);
 
+		const actionNounMap = {
+			install: __( 'Needs installation and activation', 'jetpack-my-jetpack' ),
+			activate: __( 'Needs activation', 'jetpack-my-jetpack' ),
+		};
+
 		const noticeMessage = (
 			<>
 				<Col>
@@ -184,18 +203,20 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 						) }
 					</Text>
 					<ul className="plugins-list">
-						{ pluginsList.map( ( pluginInfo, index ) => (
-							<li key={ index } className="plugin-item">
-								{ actionVerb === 'activate' ? (
-									<a href="/wp-admin/plugins.php">{ pluginInfo.pluginName }</a>
-								) : (
-									<ExternalLink href={ pluginInfo.pluginUri }>
-										{ pluginInfo.pluginName }
-									</ExternalLink>
-								) }
-								<span>(Needs { actionNoun })</span>
-							</li>
-						) ) }
+						{ pluginsList.map( ( pluginInfo, index ) => {
+							return (
+								<li key={ index } className="plugin-item">
+									{ pluginInfo.action === 'activate' ? (
+										<a href="/wp-admin/plugins.php">{ pluginInfo.pluginName }</a>
+									) : (
+										<ExternalLink href={ pluginInfo.pluginUri }>
+											{ pluginInfo.pluginName }
+										</ExternalLink>
+									) }
+									<span>({ actionNounMap[ pluginInfo.action ] })</span>
+								</li>
+							);
+						} ) }
 					</ul>
 				</Col>
 			</>

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-paid-plan-needs-plugin-install-activation-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-paid-plan-needs-plugin-install-activation-notice.tsx
@@ -101,15 +101,6 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 		);
 	}, [ getPluginInfo, needs_activated_only, needs_installed ] );
 
-	const actionNoun = useMemo( () => {
-		if ( needs_installed && needs_activated_only ) {
-			return __( 'installation and/or activation', 'jetpack-my-jetpack' );
-		} else if ( needs_installed ) {
-			return __( 'installation', 'jetpack-my-jetpack' );
-		}
-		return __( 'activation', 'jetpack-my-jetpack' );
-	}, [ needs_activated_only, needs_installed ] );
-
 	const actionVerb = useMemo( () => {
 		if ( needs_installed && needs_activated_only ) {
 			return __( 'install and/or activate', 'jetpack-my-jetpack' );
@@ -118,6 +109,35 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 		}
 		return __( 'activate', 'jetpack-my-jetpack' );
 	}, [ needs_activated_only, needs_installed ] );
+
+	const actionType = useMemo( () => {
+		if ( needs_installed && needs_activated_only ) {
+			return 'install_activate';
+		} else if ( needs_installed ) {
+			return 'install';
+		}
+		return 'activate';
+	}, [ needs_activated_only, needs_installed ] );
+
+	const noticeTitleSingular = {
+		install_activate: __( 'Plugin installation and activation needed', 'jetpack-my-jetpack' ),
+		install: __( 'Plugin installation needed', 'jetpack-my-jetpack' ),
+		activate: __( 'Plugin activation needed', 'jetpack-my-jetpack' ),
+	};
+
+	const noticeTitlePlural = {
+		install_activate: __(
+			'Some plugins need to be installed and/or activated',
+			'jetpack-my-jetpack'
+		),
+		install: __( 'Some plugins need to be installed', 'jetpack-my-jetpack' ),
+		activate: __( 'Some plugins need to be activated', 'jetpack-my-jetpack' ),
+	};
+
+	const noticeTitle =
+		numPluginsNeedingAction === 1
+			? noticeTitleSingular[ actionType ]
+			: noticeTitlePlural[ actionType ];
 
 	const { install: installAndActivatePlugins, isPending: isInstalling } =
 		useInstallPlugins( needs_installed );
@@ -158,17 +178,6 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 		if ( pluginsNeedingActionAlerts.length === 0 || ! isPurchasesDataLoaded ) {
 			return;
 		}
-
-		const noticeTitle = sprintf(
-			/* translators: %s is the word(s), "installation", or "activation", or "installation and/or activation". */
-			_n(
-				'Plugin %s needed',
-				'Some plugins need %s',
-				numPluginsNeedingAction,
-				'jetpack-my-jetpack'
-			),
-			actionNoun
-		);
 
 		const actionNounMap = {
 			install: __( 'Needs installation and activation', 'jetpack-my-jetpack' ),
@@ -263,8 +272,9 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 			options: noticeOptions,
 		} );
 	}, [
-		actionNoun,
+		actionType,
 		actionVerb,
+		noticeTitle,
 		isPurchasesDataLoaded,
 		numPluginsNeedingAction,
 		handleInstallActivateInOneClick,

--- a/projects/packages/my-jetpack/changelog/update-mj-needs-plugins-notice
+++ b/projects/packages/my-jetpack/changelog/update-mj-needs-plugins-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: My Jetpack: Needs plugin notice- minor bug fixes & enhancements.
+
+


### PR DESCRIPTION
Prior to this PR, some of the copy/content translations were resulting in production build errors. Also there was a bug where if the `jetpack` plugin was one of the plugins in the array of plugins needing installed, the plugin items occurring after `jetpack` in the array were not getting installed/activated.
This PR fixes up all the translations, and it makes `jetpack` be the very last plugin to be installed/activated, which fixes some plugins not getting installed previously.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move all the notice copy/translations into a separate `useGetPaidPlanNeedsPluginsContent()` hook (separate file).
* Sort the array of plugins needing installed/activated so that `jetpack` is the last plugin installed or activated.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Project thread: pbNhbs-bJN-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a Jurassic Ninja test site. In the options, un-check Jetpack (we don't want Jetpack installed) and add the Jetpack Beta plugin, running this PR branch on the VideoPress plugin.
* Go to the Plugins page. Make sure Jetpack is **not installed** (We only want VideoPress installed for now), and also de-activate Akismet Anti-spam.
* Make sure the site is connected (both site and user connection).
* In My Jetpack, click "Purchase a plan". Purchase the Complete plan (using credits).
* In My Jetpack you should now see the notice saying plugins need to be installed and/or activated. Notice that Akismet needs activated only and all the others need installed. (See screenshot:)
* ![Screen Shot on 2025-02-02 at 08-15-30](https://github.com/user-attachments/assets/afbd5c1e-0ce2-42a2-adec-dd65dca86653)
* Click the "Install and/or activate plugins in one click" button.
* Wait for all the plugins to install and activate and for the banner to disappear.
* Go to the Plugins page and confirm that Akismet was activated and the remaining plugins were all installed (and activated).
* You can deactivate and/or uninstall the plugins in other various combinations and test again if you like, to make sure they all get installed or activated in any combinations.