### PR TITLE
Add Site Management Panel link to General Settings page

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-add-smp-link
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-add-smp-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Site Management Panel link to General Settings page

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -18,7 +18,7 @@ use Automattic\Jetpack\Status\Host;
  * The setting is displayed only if the has the wp-admin interface selected.
  */
 function wpcomsh_wpcom_admin_interface_settings_field() {
-	add_settings_field( 'wpcom_admin_interface', '', 'wpcom_admin_interface_display', 'general', 'default' );
+	add_settings_field( 'wpcom_admin_interface', __( 'Admin Interface Style', 'jetpack-mu-wpcom' ), 'wpcom_admin_interface_display', 'general', 'default' );
 
 	register_setting( 'general', 'wpcom_admin_interface', array( 'sanitize_callback' => 'esc_attr' ) );
 }
@@ -29,7 +29,6 @@ function wpcomsh_wpcom_admin_interface_settings_field() {
 function wpcom_admin_interface_display() {
 	$value = get_option( 'wpcom_admin_interface' );
 
-	echo '<tr valign="top"><th scope="row"><label for="wpcom_admin_interface">' . esc_html__( 'Admin Interface Style', 'jetpack-mu-wpcom' ) . '</label></th><td>';
 	echo '<fieldset>';
 	echo '<label><input type="radio" name="wpcom_admin_interface" value="wp-admin" ' . checked( 'wp-admin', $value, false ) . '/> <span>' . esc_html__( 'Classic style', 'jetpack-mu-wpcom' ) . '</span></label><p>' . esc_html__( 'Use WP-Admin to manage your site.', 'jetpack-mu-wpcom' ) . '</p><br>';
 	echo '<label><input type="radio" name="wpcom_admin_interface" value="calypso" ' . checked( 'calypso', $value, false ) . '/> <span>' . esc_html__( 'Default style', 'jetpack-mu-wpcom' ) . '</span></label><p>' . esc_html__( 'Use WordPress.com’s native dashboard to manage your site.', 'jetpack-mu-wpcom' ) . '</p><br>';

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -125,6 +125,7 @@ const WPCOM_DUPLICATED_VIEW = array(
 	'edit-comments.php',
 	'edit-tags.php?taxonomy=category',
 	'edit-tags.php?taxonomy=post_tag',
+	'options-general.php',
 );
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -49,7 +49,10 @@ function wpcom_site_management_panel_link() {
  * Add the link to the Site Management Panel on WordPress.com to the general settings page.
  */
 function wpcom_site_management_panel() {
-	add_settings_field( 'wpcom_site_management_panel_link', '', 'wpcom_site_management_panel_link', 'general', 'default' );
+	$current_screen = wpcom_admin_get_current_screen();
+	if ( in_array( $current_screen, WPCOM_DUPLICATED_VIEW, true ) && wpcom_is_duplicate_views_experiment_enabled() ) {
+		add_settings_field( 'wpcom_site_management_panel_link', __( 'WordPress.com Site Settings', 'jetpack-mu-wpcom' ), 'wpcom_site_management_panel_link', 'general', 'default' );
+	}
 }
 add_action( 'load-options-general.php', 'wpcom_site_management_panel' );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -12,22 +12,17 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom;
  */
 function wpcom_fiverr_cta() {
 	?>
-	<tr class="wpcom-fiverr-cta">
-		<th>
-			<?php esc_html_e( 'Site Logo', 'jetpack-mu-wpcom' ); ?>
-		</th>
-		<td>
-			<p><b><?php esc_html_e( 'Make an incredible logo in minutes', 'jetpack-mu-wpcom' ); ?></b></p>
-			<p><?php esc_html_e( 'Pre-designed by top talent. Just add your touch.', 'jetpack-mu-wpcom' ); ?></p>
-			<button class="wpcom-fiverr-cta-button button">
-				<svg width="20" height="20" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
-					<circle cx="250" cy="250" r="177" fill="white"/>
-					<path d="M500 250C500 111.93 388.07 0 250 0C111.93 0 0 111.93 0 250C0 388.07 111.93 500 250 500C388.07 500 500 388.07 500 250ZM360.42 382.5H294.77V237.2H231.94V382.5H165.9V237.2H128.45V183.45H165.9V167.13C165.9 124.54 198.12 95.48 246.05 95.48H294.78V149.22H256.93C241.62 149.22 231.95 157.58 231.95 171.12V183.45H360.43V382.5H360.42Z" fill="#1DBF73"/>
-				</svg>
-				<?php esc_html_e( 'Try Fiverr Logo Maker', 'jetpack-mu-wpcom' ); ?>
-			</button>
-		</td>
-	</tr>
+	<div id="wpcom-fiverr-cta">
+		<p><b><?php esc_html_e( 'Make an incredible logo in minutes', 'jetpack-mu-wpcom' ); ?></b></p>
+		<p><?php esc_html_e( 'Pre-designed by top talent. Just add your touch.', 'jetpack-mu-wpcom' ); ?></p>
+		<button class="wpcom-fiverr-cta-button button">
+			<svg width="20" height="20" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<circle cx="250" cy="250" r="177" fill="white"/>
+				<path d="M500 250C500 111.93 388.07 0 250 0C111.93 0 0 111.93 0 250C0 388.07 111.93 500 250 500C388.07 500 500 388.07 500 250ZM360.42 382.5H294.77V237.2H231.94V382.5H165.9V237.2H128.45V183.45H165.9V167.13C165.9 124.54 198.12 95.48 246.05 95.48H294.78V149.22H256.93C241.62 149.22 231.95 157.58 231.95 171.12V183.45H360.43V382.5H360.42Z" fill="#1DBF73"/>
+			</svg>
+			<?php esc_html_e( 'Try Fiverr Logo Maker', 'jetpack-mu-wpcom' ); ?>
+		</button>
+	</div>
 	<?php
 }
 
@@ -35,7 +30,7 @@ function wpcom_fiverr_cta() {
  * Add the fiverr cta to the general settings page.
  */
 function wpcom_fiverr() {
-	add_settings_field( 'wpcom_fiverr_cta', '', 'wpcom_fiverr_cta', 'general', 'default' );
+	add_settings_field( 'wpcom_fiverr_cta', __( 'Site Logo', 'jetpack-mu-wpcom' ), 'wpcom_fiverr_cta', 'general', 'default' );
 }
 add_action( 'load-options-general.php', 'wpcom_fiverr' );
 
@@ -44,16 +39,9 @@ add_action( 'load-options-general.php', 'wpcom_fiverr' );
  */
 function wpcom_site_management_panel_link() {
 	?>
-	<tr class="wpcom-site-management-panel-link">
-		<th>
-			<?php esc_html_e( 'Site Management Panel', 'jetpack-mu-wpcom' ); ?>
-		</th>
-		<td>
-			<a href="https://wordpress.com/sites/<?php echo esc_attr( wpcom_get_site_slug() ); ?>">
-				<?php esc_html_e( 'Manage your WordPress.com site settings, including site visibility, and more.', 'jetpack-mu-wpcom' ); ?>
-			</a>
-		</td>
-	</tr>
+	<a href="https://wordpress.com/sites/settings/site/<?php echo esc_attr( wpcom_get_site_slug() ); ?>">
+		<?php esc_html_e( 'Manage your WordPress.com site settings, including site visibility, and more.', 'jetpack-mu-wpcom' ); ?>
+	</a>
 	<?php
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -40,6 +40,32 @@ function wpcom_fiverr() {
 add_action( 'load-options-general.php', 'wpcom_fiverr' );
 
 /**
+ * DOM for the link to the Site Management Panel on WordPress.com.
+ */
+function wpcom_site_management_panel_link() {
+	?>
+	<tr class="wpcom-site-management-panel-link">
+		<th>
+			<?php esc_html_e( 'Site Management Panel', 'jetpack-mu-wpcom' ); ?>
+		</th>
+		<td>
+			<a href="https://wordpress.com/sites/<?php echo esc_attr( wpcom_get_site_slug() ); ?>">
+				<?php esc_html_e( 'Manage your WordPress.com site settings, including site visibility, and more.', 'jetpack-mu-wpcom' ); ?>
+			</a>
+		</td>
+	</tr>
+	<?php
+}
+
+/**
+ * Add the link to the Site Management Panel on WordPress.com to the general settings page.
+ */
+function wpcom_site_management_panel() {
+	add_settings_field( 'wpcom_site_management_panel_link', '', 'wpcom_site_management_panel_link', 'general', 'default' );
+}
+add_action( 'load-options-general.php', 'wpcom_site_management_panel' );
+
+/**
  * Display the site URL in General Settings on Simple Classic sites.
  */
 function wpcom_enqueue_options_general_assets() {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
@@ -1,9 +1,7 @@
-.wpcom-fiverr-cta {
-	.wpcom-fiverr-cta-button {
-		margin-top: 1em;
+.wpcom-fiverr-cta-button {
+	margin-top: 1em;
 
-		svg {
-			vertical-align: middle;
-		}
+	svg {
+		vertical-align: middle;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.ts
@@ -6,7 +6,7 @@ import { wpcomTrackEvent } from '../../common/tracks';
  * @param fragment - The document fragment for options general.
  */
 const _wpcomBuildFiverrCta = ( fragment: DocumentFragment ) => {
-	const fiverrCtaRow = document.querySelector( '.wpcom-fiverr-cta' );
+	const fiverrCtaRow = document.getElementById( 'wpcom-fiverr-cta' )?.closest( 'tr' );
 	if ( fiverrCtaRow ) {
 		fragment.appendChild( fiverrCtaRow );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/99157

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

> [!WARNING]  
> https://github.com/Automattic/jetpack/pull/41497/commits/8a2269baeffc233e39fbe2077bd428ae2045820d needs to be reverted before merging.

- This PR adds Site Management Panel link to General Settings page.
- Removing redundant `tr`s by using `add_settings_field` properly.

| before | after |
|--------|--------|
| <img width="1436" alt="Screenshot 2025-02-03 at 17 14 56" src="https://github.com/user-attachments/assets/65613020-9b71-4fac-9131-4275e55be35b" /> | <img width="1434" alt="Screenshot 2025-02-03 at 17 16 29" src="https://github.com/user-attachments/assets/047b6e6c-aa85-4a2e-b4c4-b3a348cd992d" /> | 

---
I decided on the wording based on the following UI, but I'm open to any suggestions.

- The links to Dotcom in Users > Profile
	- <img width="627" alt="Screenshot 2025-02-03 at 17 21 51" src="https://github.com/user-attachments/assets/e2055f26-bc23-42df-ba93-27fc1a443f5e" />
- The copy in /sites/settings/site/:site (https://github.com/Automattic/wp-calypso/pull/98875/)
	- <img width="742" alt="Screenshot 2025-02-03 at 17 22 27" src="https://github.com/user-attachments/assets/0d439bdb-a027-4b73-bda1-a681f4967acc" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Patch this change https://github.com/Automattic/jetpack/pull/41497#issuecomment-2630173833
* Go to /wp-admin/options-general.php
* Observe the link to SMP

