### PR TITLE
Social: Enable the new admin page for the Social plugin.

### DIFF
--- a/projects/plugins/social/changelog/update-social-new-admin
+++ b/projects/plugins/social/changelog/update-social-new-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social: Enable new admin page for the Social plugn

--- a/projects/plugins/social/jetpack-social.php
+++ b/projects/plugins/social/jetpack-social.php
@@ -40,6 +40,7 @@ define( 'JETPACK_SOCIAL_PLUGIN_SLUG', 'jetpack-social' );
 define( 'JETPACK_SOCIAL_PLUGIN_NAME', 'Jetpack Social' );
 define( 'JETPACK_SOCIAL_PLUGIN_URI', 'https://jetpack.com/jetpack-social' );
 define( 'JETPACK_SOCIAL_PLUGIN_FOLDER', dirname( plugin_basename( __FILE__ ) ) );
+define( 'JETPACK_SOCIAL_HAS_ADMIN_PAGE', true );
 
 // Jetpack Autoloader.
 $jetpack_autoloader = JETPACK_SOCIAL_PLUGIN_DIR . 'vendor/autoload_packages.php';


### PR DESCRIPTION
Currently we have a feature check that is enabling the feature if the Social plugin is active. That is causing some problems where the admin page doesn't show up until the feature information is updated for the site, after the site is connected etc.)

This change sets the constant in the Social plugin, so the feature is always enabled from now on with the Social plugin active. We can then remove the version check from the feature check in WPCOM.

Fixes: Automattic/jetpack-reach#792

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Enable the social admin feature with the constant

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* If not merged, sandbox the API and checkout 171978-ghe-Automattic/wpcom
* Activate the trunk version of the Social plugin only
* Notice the Social Admin page is inaccessible - You might need to visit My Jetpack in order to update the plan information
* With this PR, the Social admin page should be accessible again.