### PR TITLE
Blogger Launchpad - add add_first_subscribers and verify_email tasks.

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-subscribers-task-to-blogger-launchpad
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-subscribers-task-to-blogger-launchpad
@@ -1,4 +1,5 @@
 Significance: minor
 Type: added
 
-Adds the add first subscribers task to the blogger launchpad ('write' intent).
+Defines a new launchpad task: add_first_subscribers.
+Adds the add_first_subscribers task and verify_email taskto the blogger launchpad ('write' intent).

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-subscribers-task-to-blogger-launchpad
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-subscribers-task-to-blogger-launchpad
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Adds the subscribers modal task to the blogger launchpad ('write' intent).
+Adds the add first subscribers task to the blogger launchpad ('write' intent).

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-subscribers-task-to-blogger-launchpad
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-subscribers-task-to-blogger-launchpad
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adds the subscribers modal task to the blogger launchpad ('write' intent).

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-subscribers-task-to-blogger-launchpad
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-subscribers-task-to-blogger-launchpad
@@ -2,4 +2,4 @@ Significance: minor
 Type: added
 
 Defines a new launchpad task: add_first_subscribers.
-Adds the add_first_subscribers task and verify_email taskto the blogger launchpad ('write' intent).
+Adds the add_first_subscribers task and verify_email task to the blogger launchpad ('write' intent).

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -663,9 +663,8 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 		),
 		'add_first_subscribers'           => array(
-			// Note, we do not want this mapped to the 'subscribers_added' task. This is intended as
-			// a nudge and is marked complete after the user visits the subscribers interfaces,
-			// regardless of whether or not they actually added subscribers.
+			// We do not want this mapped to the 'subscribers_added' task, since this task supports
+			// being marked as complete in situations where subscribers are not added.
 			'get_title'            => function () {
 				return __( 'Add your first subscribers', 'jetpack-mu-wpcom' );
 			},

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -663,10 +663,12 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 		),
 		'add_first_subscribers'           => array(
+			// Note, we do not want this mapped to the 'subscribers_added' task. This is intended as
+			// a nudge and is marked complete after the user visits the subscribers interfaces,
+			// regardless of whether or not they actually added subscribers.
 			'get_title'            => function () {
 				return __( 'Add your first subscribers', 'jetpack-mu-wpcom' );
 			},
-			'id_map'               => 'subscribers_added',
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => '__return_true',
 			'get_calypso_path'     => function ( $task, $default, $data ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -669,7 +669,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Add your first subscribers', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_add_first_subscribers_completed',
 			'is_visible_callback'  => '__return_true',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/subscribers/' . $data['site_slug_encoded'] . '#add-subscribers';
@@ -2710,6 +2710,25 @@ function wpcom_launchpad_is_domain_customize_completed( $task, $default ) {
 
 	// For everyone else, show the task as incomplete.
 	return $default;
+}
+
+/**
+ * Determines whether the add_first_subscribers task is complete by checking both the task option
+ * and related tasks like subscribers_added and import_subscribers.
+ *
+ * This exists because we need a 1-way relationship between these tasks: completion of other
+ * subscriber tasks implies add_first_subscribers is completed, but completion of
+ * add_first_subscribers does not imply completion of other subscriber tasks. This is because
+ * add_first_subscribers is allowed to be marked complete at times when no subscribers are actually
+ * added, and why using id_map here will not work since it creates a 2-way relationship.
+ *
+ * @param Task $task    The Task object.
+ * @return bool True if either condition is met.
+ */
+function wpcom_launchpad_is_add_first_subscribers_completed( $task ) {
+	return wpcom_launchpad_is_task_option_completed( $task )
+		|| wpcom_is_checklist_task_complete( 'subscribers_added' )
+		|| wpcom_is_checklist_task_complete( 'import_subscribers' );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -662,6 +662,17 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/subscribers/' . $data['site_slug_encoded'] . '#add-subscribers';
 			},
 		),
+		'add_first_subscribers'           => array(
+			'get_title'            => function () {
+				return __( 'Add your first subscribers', 'jetpack-mu-wpcom' );
+			},
+			'id_map'               => 'subscribers_added',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => '__return_true',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/subscribers/' . $data['site_slug_encoded'] . '#add-subscribers';
+			},
+		),
 		'add_subscribe_block'             => array(
 			'get_title'            => function () {
 				return __( 'Add the Subscribe Block to your site', 'jetpack-mu-wpcom' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -136,6 +136,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'setup_write',
 				'design_completed',
 				'plan_selected',
+				'verify_email',
 				'add_first_subscribers',
 				'first_post_published',
 				'site_launched',

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -136,6 +136,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'setup_write',
 				'design_completed',
 				'plan_selected',
+				'enable_subscribers_modal',
 				'first_post_published',
 				'site_launched',
 			),

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -136,7 +136,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'setup_write',
 				'design_completed',
 				'plan_selected',
-				'enable_subscribers_modal',
+				'add_first_subscribers',
 				'first_post_published',
 				'site_launched',
 			),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes # Automattic/loop#252 

related to https://github.com/Automattic/wp-calypso/pull/99207

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a `add_first_subscribers` launchpad task definition. 
    * This task is intended to be marked complete when engaged with on the front-end, and not to depend on whether or not subscribers were actually added (noted in Automattic/loop#253). Because of this, we don't want to use or map to the `subscribers_added` task which requires adding subscribers for completion, but we check other subscribers tasks in the completion callback for this new task. (e.g. `subscribers_added` completion implies `add_first_subscribers` completion, but not the other way around).
* Adds the `add_first_subscribers` task and the `verify_email` task to the `write` intent launchpad task list.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Patch this branch to your sandbox: `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/subscribers-task-to-blogger-launchpad`  (taken from [instructions below](https://github.com/Automattic/jetpack/pull/41502#issuecomment-2630735041))
* Sandbox the public-api.
* Test alongside instructions in https://github.com/Automattic/wp-calypso/pull/99207

