### PR TITLE
Protect Status: Fixed a bug where it can happen that the core version data is not interpreted correctly from the report data response.

### DIFF
--- a/projects/packages/protect-status/changelog/fix-protect-status-core-version-check
+++ b/projects/packages/protect-status/changelog/fix-protect-status-core-version-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Protect Status: Fixed a bug where it can happen that the core version data is not interpreted correctly from the report data response.

--- a/projects/packages/protect-status/src/class-protect-status.php
+++ b/projects/packages/protect-status/src/class-protect-status.php
@@ -258,8 +258,10 @@ class Protect_Status extends Status {
 		global $wp_version;
 
 		// Ensure the report data has the core property.
-		if ( ! $report_data->core || ! $report_data->core->version ) {
-			$report_data->core = new \stdClass();
+		if ( ! isset( $report_data->core ) || ! $report_data->core
+			|| ! isset( $report_data->core->version ) || ! $report_data->core->version ) {
+			$report_data->core          = new \stdClass();
+			$report_data->core->version = new \stdClass();
 		}
 
 		$core = new Extension_Model(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In some cases (presumably sync lags and not-yet-finished reports), it can happen that a protect report comes back without core and/or core version data.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Reliably check if the core and version data is actually around before checking it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jpop-issues/issues/9512 
See also p1738569743255219-slack-CDLH4C1UZ


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

To test on a JT site:
- To reproduce, before the changed if block, add these lines (on trunk):
```php
error_reporting(E_ALL);
ini_set('display_errors', 'on');
unset($report_data->core);
```

- If you also have a jetpack scan plan, you'll also need to change line `projects/packages/protect-status/src/class-status.php:72` to 
```php
self::$status = Protect_Status::get_status( $refresh_from_wpcom );
```

This ensures that you actually see the free scan report instead of the paid scan report.

- Then, verify the warnings do not come up anymore.