### PR TITLE
Forms: Tests: Shouldn't submit if empty

### DIFF
--- a/projects/packages/forms/changelog/add-forms-test
+++ b/projects/packages/forms/changelog/add-forms-test
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Tests: An empty form shouldn't submit test

--- a/projects/packages/forms/tests/js/contact-form/contact-form.test.js
+++ b/projects/packages/forms/tests/js/contact-form/contact-form.test.js
@@ -106,7 +106,7 @@ describe( 'Contact Form', () => {
 			expect( spy ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		it( "shouldn't submit an invalid form", () => {
+		it( "shouldn't submit form with missing required fields", () => {
 			const form = screen.getByRole( 'form' );
 			const input = screen.getByLabelText( 'Name' );
 			input.setAttribute( 'required', '' );

--- a/projects/packages/forms/tests/js/contact-form/contact-form.test.js
+++ b/projects/packages/forms/tests/js/contact-form/contact-form.test.js
@@ -76,9 +76,15 @@ describe( 'Contact Form', () => {
 		beforeEach( () => {
 			setFormContent( `
 				<label for="name">Name</label>
-				<input id="name" name="name" required />
+				<input id="name" name="name">
 				<button type="submit">Submit</button>
 			` );
+			// Mock offsetParent for all elements
+			Object.defineProperty( HTMLElement.prototype, 'offsetParent', {
+				get() {
+					return {};
+				}, // Return a truthy value
+			} );
 			fireDomReadyEvent();
 		} );
 
@@ -101,6 +107,17 @@ describe( 'Contact Form', () => {
 		} );
 
 		it( "shouldn't submit an invalid form", () => {
+			const form = screen.getByRole( 'form' );
+			const input = screen.getByLabelText( 'Name' );
+			input.setAttribute( 'required', '' );
+			const spy = jest.spyOn( form, 'submit' ).mockImplementation( () => {} );
+
+			fireEvent.submit( form );
+
+			expect( spy ).not.toHaveBeenCalled();
+		} );
+
+		it( "shouldn't submit when all fields are empty", () => {
 			const form = screen.getByRole( 'form' );
 			const spy = jest.spyOn( form, 'submit' ).mockImplementation( () => {} );
 


### PR DESCRIPTION
Extracted from https://github.com/Automattic/jetpack/pull/41356 

## Proposed changes:
* Add test to verify that contact forms don't submit when all fields are empty
* This test was originally part of PR #41356 but has been extracted since we went with PR #41464 for the main implementation
* The test helps ensure proper form validation behavior

## Jetpack product discussion
N/A - This is a test-only change extracted from a previously discussed PR

## Does this pull request change what data or activity we track or use?
No - This PR only adds test coverage

## Testing instructions:

* run the `js` tests `jetpack test` for the `form` `package`
* Verify that the new test `shouldn't submit when all fields are empty` passes
* The test should confirm that a form with empty fields does not submit
