### PR TITLE
Implement Verbum Block Editor darkmode

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-dark-mode
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-dark-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Dark mode in Verbum Comments

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
@@ -187,6 +187,7 @@ class Verbum_Comments {
 		$css_mtime        = filemtime( ABSPATH . '/widgets.wp.com/verbum-block-editor/block-editor.css' );
 		$js_mtime         = filemtime( ABSPATH . '/widgets.wp.com/verbum-block-editor/block-editor.min.js' );
 		$vbe_cache_buster = max( $js_mtime, $css_mtime );
+		$color_scheme     = get_blog_option( $this->blog_id, 'jetpack_comment_form_color_scheme' );
 
 		wp_add_inline_script(
 			'verbum-settings',
@@ -259,6 +260,7 @@ class Verbum_Comments {
 					'isRTL'                              => is_rtl(),
 					'vbeCacheBuster'                     => $vbe_cache_buster,
 					'iframeUniqueId'                     => $iframe_unique_id,
+					'colorScheme'                        => $color_scheme,
 				)
 			),
 			'before'

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/comment-input-field.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/comment-input-field.tsx
@@ -71,7 +71,8 @@ export const CommentInputField = forwardRef(
 						handleOnKeyUp();
 					},
 					VerbumComments.isRTL,
-					embedContentCallback
+					embedContentCallback,
+					VerbumComments.colorScheme === 'dark'
 				);
 				// Wait fro the block editor to render.
 				setTimeout( () => setEditorState( 'LOADED' ), 100 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/types.d.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/types.d.ts
@@ -11,7 +11,8 @@ declare global {
 			textarea: HTMLTextAreaElement,
 			content: ( embedUrl: string ) => void,
 			isRtl: boolean,
-			onEmbedContent: ( embedUrl: string ) => void
+			onEmbedContent: ( embedUrl: string ) => void,
+			isDarkMode: boolean
 		) => void;
 	};
 	const vbeCacheBuster: string;

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/types.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/types.tsx
@@ -72,6 +72,7 @@ export interface VerbumComments {
 	 */
 	fullyLoadedTime: number;
 	vbeCacheBuster: string;
+	colorScheme: string;
 }
 
 export type EmailSubscriptionResponse = {


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/40380

## Proposed changes:
This passes the color scheme value to Verbum Block Editor.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Apply this.
2. Sandbox sdfsfdsf344f443f.wordpress.com.
3. Go to https://sdfsfdsf344f443f.wordpress.com/2025/01/09/hello-world/
4. Text should be white. 
