### PR TITLE
CRM: Fix companies API endpoint param mapping

### DIFF
--- a/projects/plugins/crm/.phan/baseline.php
+++ b/projects/plugins/crm/.phan/baseline.php
@@ -102,7 +102,6 @@ return [
     // PhanImpossibleTypeComparisonInLoop : 1 occurrence
     // PhanIncompatibleRealPropertyType : 1 occurrence
     // PhanNoopVariable : 1 occurrence
-    // PhanParamTooMany : 1 occurrence
     // PhanPluginDuplicateArrayKey : 1 occurrence
     // PhanPluginDuplicateCatchStatementBody : 1 occurrence
     // PhanPluginUseReturnValueInternalKnown : 1 occurrence
@@ -159,7 +158,7 @@ return [
         'admin/support/main.page.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanPossiblyUndeclaredGlobalVariable', 'PhanTypeMismatchArgumentNullable'],
         'admin/system/partials/title.block.php' => ['PhanUndeclaredGlobalVariable'],
         'admin/system/system-status.page.php' => ['PhanRedundantCondition', 'PhanTypePossiblyInvalidDimOffset'],
-        'api/companies.php' => ['PhanParamTooMany', 'PhanPluginSimplifyExpressionBool'],
+        'api/companies.php' => ['PhanPluginSimplifyExpressionBool'],
         'api/create_company.php' => ['PhanImpossibleTypeComparisonInGlobalScope', 'PhanPossiblyUndeclaredGlobalVariable', 'PhanRedundantConditionInGlobalScope'],
         'api/create_customer.php' => ['PhanImpossibleTypeComparisonInGlobalScope', 'PhanPossiblyUndeclaredGlobalVariable', 'PhanRedundantConditionInGlobalScope', 'PhanTypePossiblyInvalidDimOffset'],
         'api/create_event.php' => ['PhanImpossibleTypeComparisonInGlobalScope'],

--- a/projects/plugins/crm/api/companies.php
+++ b/projects/plugins/crm/api/companies.php
@@ -46,6 +46,10 @@ $search_phrase = '';
 if ( isset( $company_params['search'] ) ) {
 	$search_phrase = sanitize_text_field( $company_params['search'] );
 }
+$owned_by = -1;
+if ( isset( $company_params['owned'] ) ) {
+	$owned_by = (int) $company_params['owned'];
+}
 
 // ... this forces them from string of "true" or "false" into a bool
 $with_invoices     = $with_invoices === 'true' ? true : false;
@@ -56,6 +60,7 @@ $args = array(
 	'perPage'          => $items_per_page,
 	'page'             => $page_num,
 	'searchPhrase'     => $search_phrase,
+	'ownedBy'          => $owned_by,
 	'withQuotes'       => $with_quotes,
 	'withInvoices'     => $with_invoices,
 	'withTransactions' => $with_transactions,

--- a/projects/plugins/crm/api/companies.php
+++ b/projects/plugins/crm/api/companies.php
@@ -1,6 +1,5 @@
 <?php
-/*
-!
+/**
  * Jetpack CRM
  * https://jetpackcrm.com
  * V3.0
@@ -8,19 +7,13 @@
  * Copyright 2020 Automattic
  *
  * Date: 04/06/2019
+ *
+ * @package automattic/jetpack-crm
  */
 
-/*
-======================================================
-	Breaking Checks ( stops direct access )
-	====================================================== */
 if ( ! defined( 'ZEROBSCRM_PATH' ) ) {
 	exit( 0 );
 }
-/*
-======================================================
-	/ Breaking Checks
-	====================================================== */
 
 // Check the method
 // Ultimately this should be switched to GET, but the docs have it as POST, so best to wait for a rewrite
@@ -29,44 +22,40 @@ jpcrm_api_check_http_method( array( 'POST' ) );
 $json_params    = file_get_contents( 'php://input' );
 $company_params = json_decode( $json_params, true );
 
-$perPage = 10;
+$items_per_page = 10;
 if ( isset( $company_params['perpage'] ) ) {
-	$perPage = sanitize_text_field( $company_params['perpage'] );
+	$items_per_page = sanitize_text_field( $company_params['perpage'] );
 }
-$page = 0;
+$page_num = 0;
 if ( isset( $company_params['page'] ) ) {
-	$page = sanitize_text_field( $company_params['page'] );
+	$page_num = sanitize_text_field( $company_params['page'] );
 }
-$withInvoices = -1;
+$with_invoices = -1;
 if ( isset( $company_params['invoices'] ) ) {
-	$withInvoices = sanitize_text_field( $company_params['invoices'] );
+	$with_invoices = sanitize_text_field( $company_params['invoices'] );
 }
-$withQuotes = -1;
+$with_quotes = -1;
 if ( isset( $company_params['quotes'] ) ) {
-	$withQuotes = sanitize_text_field( $company_params['quotes'] );
+	$with_quotes = sanitize_text_field( $company_params['quotes'] );
 }
-$searchPhrase = '';
+$search_phrase = '';
 if ( isset( $company_params['search'] ) ) {
-	$searchPhrase = sanitize_text_field( $company_params['search'] );
+	$search_phrase = sanitize_text_field( $company_params['search'] );
 }
-$withTransactions = -1;
+$with_transactions = -1;
 if ( isset( $company_params['transactions'] ) ) {
-	$withTransactions = sanitize_text_field( $company_params['transactions'] );
-}
-$isOwned = -1;
-if ( isset( $company_params['owned'] ) ) {
-	$isOwned = (int) $company_params['owned'];
+	$with_transactions = sanitize_text_field( $company_params['transactions'] );
 }
 
 // #FORMIKENOTES -
 // These should be Bools - see https://stackoverflow.com/questions/7336861/how-to-convert-string-to-boolean-php
 // ... this forces them from string of "true" or "false" into a bool
-$withInvoices     = $withInvoices === 'true' ? true : false;
-$withQuotes       = $withQuotes === 'true' ? true : false;
-$withTransactions = $withTransactions === 'true' ? true : false;
-$isAssigned       = false; // ??
+$with_invoices     = $with_invoices === 'true' ? true : false;
+$with_quotes       = $with_quotes === 'true' ? true : false;
+$with_transactions = $with_transactions === 'true' ? true : false;
+$is_assigned       = false; // ??
 
 // needs moving to the $args version
-$companies = zeroBS_getCompanies( true, $perPage, $page, $withInvoices, $withQuotes, $searchPhrase, $withTransactions, false, false, '', '', false, false, false, 'ID', 'DESC', false, $isAssigned );
+$companies = zeroBS_getCompanies( true, $items_per_page, $page_num, $with_invoices, $with_quotes, $search_phrase, $with_transactions, false, false, '', '', false, false, false, 'ID', 'DESC', false, $is_assigned );
 
 wp_send_json( $companies );

--- a/projects/plugins/crm/api/companies.php
+++ b/projects/plugins/crm/api/companies.php
@@ -38,24 +38,32 @@ $with_quotes = -1;
 if ( isset( $company_params['quotes'] ) ) {
 	$with_quotes = sanitize_text_field( $company_params['quotes'] );
 }
-$search_phrase = '';
-if ( isset( $company_params['search'] ) ) {
-	$search_phrase = sanitize_text_field( $company_params['search'] );
-}
 $with_transactions = -1;
 if ( isset( $company_params['transactions'] ) ) {
 	$with_transactions = sanitize_text_field( $company_params['transactions'] );
 }
+$search_phrase = '';
+if ( isset( $company_params['search'] ) ) {
+	$search_phrase = sanitize_text_field( $company_params['search'] );
+}
 
-// #FORMIKENOTES -
-// These should be Bools - see https://stackoverflow.com/questions/7336861/how-to-convert-string-to-boolean-php
 // ... this forces them from string of "true" or "false" into a bool
 $with_invoices     = $with_invoices === 'true' ? true : false;
 $with_quotes       = $with_quotes === 'true' ? true : false;
 $with_transactions = $with_transactions === 'true' ? true : false;
-$is_assigned       = false; // ??
 
-// needs moving to the $args version
-$companies = zeroBS_getCompanies( true, $items_per_page, $page_num, $with_invoices, $with_quotes, $search_phrase, $with_transactions, false, false, '', '', false, false, false, 'ID', 'DESC', false, $is_assigned );
+$args = array(
+	'perPage'          => $items_per_page,
+	'page'             => $page_num,
+	'searchPhrase'     => $search_phrase,
+	'withQuotes'       => $with_quotes,
+	'withInvoices'     => $with_invoices,
+	'withTransactions' => $with_transactions,
+	'sortByField'      => 'ID',
+	'sortOrder'        => 'DESC',
+);
+
+global $zbs;
+$companies = $zbs->DAL->companies->getCompanies( $args ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable,WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 wp_send_json( $companies );

--- a/projects/plugins/crm/changelog/fix-crm-company_api_endpoint_params
+++ b/projects/plugins/crm/changelog/fix-crm-company_api_endpoint_params
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+API: Fix `companies` endpoint param mapping.

--- a/tools/phpcs-excludelist.json
+++ b/tools/phpcs-excludelist.json
@@ -57,7 +57,6 @@
 	"projects/plugins/crm/admin/user-profile/main.page.php",
 	"projects/plugins/crm/admin/user-profile/reminders.page.php",
 	"projects/plugins/crm/admin/user-profile/user-profile.page.php",
-	"projects/plugins/crm/api/companies.php",
 	"projects/plugins/crm/api/create_company.php",
 	"projects/plugins/crm/api/create_customer.php",
 	"projects/plugins/crm/api/create_event.php",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The param mapping for the `companies` endpoint was incorrect. This PR corrects the mapping so it does what it says it does, and does a direct DAL call.

There's a slight chance that this would affect end users that are using less common endpoint params, but the fact that no one reported the issue with params not doing what they were saying means it's likely no one noticed.

I also did some linting in the first commit.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When working through `PhanParamTooMany` instances (#41263) I noticed one instance in CRM that required more investigation.

The `companies` endpoint made a call to `zeroBS_getCompanies` with 18 params, whereas said function only has 12 params. Looking through the commit history, it seems the call was actually copied from `zeroBS_getCustomers()` (which had 18 params at the time but now has 19), and params were never adjusted.

This illustrates it best:

| Call Position | Endpoint call | zeroBS_getCompanies | zeroBS_getCustomers |
|---------------|-------------------------------|-------------------------------|-------------------------------|
| 1 | `true` | $withFullDetails | $withFullDetails |
| 2 | `$perPage` | $perPage | $perPage |
| 3 | `$page` | $page | $page |
| 4 | `$withInvoices` | $searchPhrase | $withInvoices |
| 5 | `$withQuotes` | $argsOverride | $withQuotes |
| 6 | `$searchPhrase` | $withInvoices | $searchPhrase |
| 7 | `$withTransactions` | $withQuotes | $withTransactions |
| 8 | `false` | $withTransactions | $argsOverride |
| 9 | `false` | $inCountry | $companyID |
| 10 | `''` | $ownedByID | $hasTagIDs |
| 11 | `''` | $withStatus | $inArr |
| 12 | `false` | $inArr | $withTags |
| 13 | `false` | (No parameter) | $withAssigned |
| 14 | `false` | (No parameter) | $withLastLog |
| 15 | `'ID'` | (No parameter) | $sortByField |
| 16 | `'DESC'` | (No parameter) | $sortOrder |
| 17 | `false` | (No parameter) | $quickFilters |
| 18 | `$isAssigned` | (No parameter) | $ownedByID |

Most of the params were passed through as defaults or not used, so they weren't passed through in the DAL call. I did not expose `sort` to the end user at this point, but it's available for easy implementation down the road.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Make sure the endpoint works as expected.