### PR TITLE
Forms: Fix submission if date field had errored

### DIFF
--- a/projects/packages/forms/changelog/form-fix-submit-if-date-had-errored
+++ b/projects/packages/forms/changelog/form-fix-submit-if-date-had-errored
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix submission if date field had errored

--- a/projects/packages/forms/src/contact-form/js/accessible-form.js
+++ b/projects/packages/forms/src/contact-form/js/accessible-form.js
@@ -269,6 +269,7 @@ const isDateFieldValid = input => {
 	if ( value && format && typeof $ !== 'undefined' ) {
 		try {
 			$.datepicker.parseDate( format, value );
+			input.setCustomValidity( '' );
 		} catch {
 			input.setCustomValidity( L10N.invalidDate );
 

--- a/projects/packages/forms/src/contact-form/js/grunion-frontend.js
+++ b/projects/packages/forms/src/contact-form/js/grunion-frontend.js
@@ -6,5 +6,8 @@ jQuery( function ( $ ) {
 		dateFormat,
 		constrainInput: false,
 		showOptions: { direction: 'down' },
+		onSelect: function () {
+			$( this ).focus();
+		},
 	} );
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes: https://github.com/Automattic/jetpack/issues/41478

Currently if you submit a form with an invalid date field there is no way to recover from that. This PR fixes that.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Create a form with a date field.
2. On the front end type `1` in the date field ( or something else invalid) and submit the form.
3. You should see an invalid field error.
4. Now select the a date via the date picker. and submit the form.
5. The form submission should be successful 

