### PR TITLE
Development tools: add Cursor rules

### DIFF
--- a/.cursor/rules/adding-changelog.mdc
+++ b/.cursor/rules/adding-changelog.mdc
@@ -1,0 +1,20 @@
+---
+description: How changelog entries must be structured for each change
+globs: 
+---
+Every change in the `/projects` directory will need to add a specially-formatted file to the project's specified `changelog` directory.
+
+The change file is a text file with a header-and-body format, like HTTP or email. A change file might look like this:
+
+```
+Significance: patch
+Type: compat
+
+Block Editor: update all blocks to be fully compatible with WordPress 5.7.
+```
+
+The “Significance” header specifies the significance of change in the style of semantic versioning: patch, minor, or major.
+
+The “Type” header categorizes the change in the changelog. In Jetpack, for example, our changelog divides changes into “Major Enhancements”, “Enhancements”, “Improved compatibility”, and “Bugfixes”.
+
+The body is separated from the headers by a blank line, and is the text that actually goes into the changelog. This should follow our recommendations at [writing-a-good-changelog-entry.md](mdc:jetpack/jetpack/jetpack/docs/writing-a-good-changelog-entry.md).

--- a/.cursor/rules/code-style-structure.mdc
+++ b/.cursor/rules/code-style-structure.mdc
@@ -1,0 +1,13 @@
+---
+description: General guidelines on code style and structure
+globs: 
+---
+General guidelines are defined in [coding-guidelines.md](mdc:jetpack/jetpack/jetpack/jetpack/jetpack/jetpack/jetpack/jetpack/jetpack/jetpack/docs/coding-guidelines.md).
+
+### Naming Conventions
+
+- Use WordPress naming conventions for functions and classes
+- Prefix any global php functions or hooks with `jetpack_`
+- Use lowercase with underscores for PHP functions
+- Follow WordPress React component naming patterns
+- Use BEM-like naming for SCSS

--- a/.cursor/rules/development-guidelines.mdc
+++ b/.cursor/rules/development-guidelines.mdc
@@ -1,0 +1,42 @@
+---
+description: General development guidelines
+globs: 
+---
+You are an expert WordPress plugin developer specializing in site building tools, with deep expertise in WordPress core, React, PHP, and modern frontend development. You prioritize WordPress coding standards while delivering maintainable, accessible solutions.
+
+## Short codes
+
+Check the start of any user message for the following short codes and act appropriately:
+
+- ddc - short for `discuss don't code` so do not make any code changes only discuss the options until given the go ahead to make changes.
+- jdi - short for `just do it` so this is giving approval to go ahead and make the changes that have been discussed.
+
+## Analysis Process
+
+Before responding to any request, follow these steps:
+
+1. Request Analysis
+
+- Determine if task involves plugin core (PHP) or frontend (JS/React)
+- Identify WordPress hooks and filters needed
+- Note compatibility requirements (WordPress version, PHP version), based on the different versions specified in [versions.sh](mdc:jetpack/jetpack/jetpack/jetpack/jetpack/.github/versions.sh)
+- Define core functionality and user experience goals
+- Consider WordPress coding standards compliance
+
+2. Solution Planning
+
+- Break down solution into WordPress-compatible components
+- Consider plugin activation/deactivation hooks
+- Identify necessary WordPress API integrations
+- Plan for internationalization (i18n)
+- Evaluate security implications
+
+3. Implementation Strategy
+
+- Choose appropriate WordPress design patterns
+- Consider performance impact on WordPress site
+- Plan for WordPress error handling conventions
+- Ensure WordPress coding standards compliance
+- Verify accessibility requirements
+
+Always prioritize WordPress coding standards and best practices while delivering functionality that enhances the WordPress site-building experience.

--- a/.cursor/rules/js-react-standards.mdc
+++ b/.cursor/rules/js-react-standards.mdc
@@ -1,0 +1,26 @@
+---
+description: JavaScript/React Standards
+globs: *.js, *.jsx, *.ts, *.tsx
+---
+## General guidelines
+
+- Write modern ES6+ code following WordPress JS standards
+- Use WordPress data store for state management
+- Follow WordPress component patterns
+- Implement proper WordPress hooks system
+- Structure components using WordPress conventions
+- Where it applies, make strings available for translation.
+- Use Gutenberg's `@wordpress/i18n` package to handle translations.
+- Use an appropriate unique text domain in your JS code.
+
+## React Components
+
+- Use WordPress `@wordpress/element` instead of direct React import
+- Implement WordPress hooks system
+- Follow WordPress component lifecycle patterns
+- Use the WordPress block editor data stores for state management of WordPress block editor components
+- Follow WordPress accessibility guidelines
+
+## TypeScript
+
+- When using TypeScript in Webpack, use `@babel/preset-typescript` rather than `ts-loader`.

--- a/.cursor/rules/js-testing.mdc
+++ b/.cursor/rules/js-testing.mdc
@@ -1,0 +1,14 @@
+---
+description: Guidelines to write JavaScript tests
+globs: 
+---
+- Use Jest with WordPress test utilities
+- Follow WordPress testing patterns
+- Test React components with `@testing-library/react`
+- Implement proper async testing
+- Use WordPress mocking patterns
+
+
+Check [component.tsx](mdc:jetpack/jetpack/jetpack/jetpack/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.tsx) for an example.
+
+Find out more about how to develop tests at [automated-testing.md](mdc:jetpack/jetpack/docs/automated-testing.md)

--- a/.cursor/rules/php-standards.mdc
+++ b/.cursor/rules/php-standards.mdc
@@ -1,0 +1,20 @@
+---
+description: PHP coding standards
+globs: *.php
+---
+- Follow WordPress PHP Coding Standards
+- Use proper WordPress prefix for functions and classes
+- Implement WordPress nonce verification
+- Follow WordPress database operations best practices
+- Structure plugin hooks logically
+
+## Package Version Annotations
+
+When needing to add a package version number inside a DocBlock, please use `$$next-version$$` as such:
+
+- `@since $$next-version$$`
+- `@deprecated $$next-version$$`
+- `@deprecated since $$next-version$$`
+- `_deprecated_function( __METHOD__, 'package-$$next-version$$' );` (other WordPress deprecation functions also work, but note it must be all on one line).
+
+The `$$next-version$$` specifier will be automatically replaced with the correct package version number the next time a new version of that package is released.

--- a/.cursor/rules/php-testing.mdc
+++ b/.cursor/rules/php-testing.mdc
@@ -1,0 +1,14 @@
+---
+description: Guidelines when testing PHP
+globs: 
+---
+When developing Unit Tests in PHP, follow these guidelines:
+
+- Use PHPUnit with WordPress test framework
+- Follow WordPress testing conventions
+- Use WordPress fixtures and mocks
+- Test WordPress hooks and filters
+
+Check [test_Manager_integration.php](mdc:jetpack/jetpack/jetpack/jetpack/projects/packages/connection/tests/php/test_Manager_integration.php) for an example.
+
+Find out more rules on how to write tests at [automated-testing.md](mdc:jetpack/jetpack/docs/automated-testing.md)


### PR DESCRIPTION
## Proposed changes:

This adds a first set of rules to be used by folks using Cursor as their IDE.
The different rules are mostly sourced from other Automattic repos, as well as existing documentation in the monorepo. I also referenced some of our other docs to add more context.

The rules follow the format expected by the IDE:
https://docs.cursor.com/context/rules-for-ai#project-rules-recommended

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

It is hard to test it right away. I believe we'll need to iterate on it as we go, to get better and better suggestions.
