### PR TITLE
Boost: Prioritized Cloud CSS regeneration for cornerstone pages

### DIFF
--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -24,7 +24,7 @@ use Automattic\Jetpack_Boost\Data_Sync\Getting_Started_Entry;
 use Automattic\Jetpack_Boost\Lib\Analytics;
 use Automattic\Jetpack_Boost\Lib\CLI;
 use Automattic\Jetpack_Boost\Lib\Connection;
-use Automattic\Jetpack_Boost\Lib\Cornerstone_Pages;
+use Automattic\Jetpack_Boost\Lib\Cornerstone\Cornerstone_Pages;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Storage;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Generator;

--- a/projects/plugins/boost/app/lib/Environment_Change_Detector.php
+++ b/projects/plugins/boost/app/lib/Environment_Change_Detector.php
@@ -9,6 +9,8 @@
 
 namespace Automattic\Jetpack_Boost\Lib;
 
+use Automattic\Jetpack_Boost\Lib\Cornerstone\Cornerstone_Utils;
+
 /**
  * Class Environment_Change_Detector
  */
@@ -109,13 +111,8 @@ class Environment_Change_Detector {
 	 * @return string The change type.
 	 */
 	private function get_post_change_type( $post ) {
-		$cornerstone_pages = ( new Cornerstone_Pages() )->get_pages();
-		if ( $cornerstone_pages ) {
-			$cornerstone_pages_sanitized = array_map( 'untrailingslashit', $cornerstone_pages );
-			$current_url                 = untrailingslashit( get_permalink( $post ) );
-			if ( in_array( $current_url, $cornerstone_pages_sanitized, true ) ) {
-				return $this::ENV_CHANGE_CORNERSTONE_PAGE_SAVED;
-			}
+		if ( Cornerstone_Utils::is_cornerstone_page( $post->ID ) ) {
+			return $this::ENV_CHANGE_CORNERSTONE_PAGE_SAVED;
 		}
 
 		if ( 'page' === $post->post_type ) {

--- a/projects/plugins/boost/app/lib/Environment_Change_Detector.php
+++ b/projects/plugins/boost/app/lib/Environment_Change_Detector.php
@@ -66,7 +66,7 @@ class Environment_Change_Detector {
 	/**
 	 * Fire the environment change action.
 	 *
-	 * @param bool   $is_major_change Whether the change is major.
+	 * @param bool   $is_major_change Whether the change is such that we should stop serving existing critical CSS immediately unless refreshed.
 	 * @param string $change_type The change type.
 	 */
 	public function do_action( $is_major_change, $change_type ) {

--- a/projects/plugins/boost/app/lib/cornerstone/Cornerstone_Pages.php
+++ b/projects/plugins/boost/app/lib/cornerstone/Cornerstone_Pages.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace Automattic\Jetpack_Boost\Lib;
+namespace Automattic\Jetpack_Boost\Lib\Cornerstone;
 
 use Automattic\Jetpack\Schema\Schema;
 use Automattic\Jetpack_Boost\Contracts\Has_Setup;
 use Automattic\Jetpack_Boost\Data_Sync\Cornerstone_Pages_Entry;
+use Automattic\Jetpack_Boost\Lib\Premium_Features;
 
 class Cornerstone_Pages implements Has_Setup {
 
@@ -113,19 +114,6 @@ class Cornerstone_Pages implements Has_Setup {
 		return $url;
 	}
 
-	public function get_pages() {
-		$pages = jetpack_boost_ds_get( 'cornerstone_pages_list' );
-
-		$permalink_structure = get_option( 'permalink_structure' );
-
-		// If permalink structure ends with slash, add trailing slashes
-		if ( $permalink_structure && substr( $permalink_structure, -1 ) === '/' ) {
-			$pages = array_map( 'trailingslashit', $pages );
-		}
-
-		return $pages;
-	}
-
 	public function get_properties() {
 		return array(
 			'max_pages'         => $this->get_max_pages(),
@@ -135,14 +123,8 @@ class Cornerstone_Pages implements Has_Setup {
 	}
 
 	public function add_display_post_states( $post_states, $post ) {
-		$cornerstone_pages = $this->get_pages();
-		if ( ! empty( $cornerstone_pages ) ) {
-			$post_url          = untrailingslashit( get_permalink( $post ) );
-			$cornerstone_pages = array_map( 'untrailingslashit', $cornerstone_pages );
-
-			if ( in_array( $post_url, $cornerstone_pages, true ) ) {
-				$post_states[] = __( 'Cornerstone Page', 'jetpack-boost' );
-			}
+		if ( Cornerstone_Utils::is_cornerstone_page( $post->ID ) ) {
+			$post_states[] = __( 'Cornerstone Page', 'jetpack-boost' );
 		}
 
 		return $post_states;

--- a/projects/plugins/boost/app/lib/cornerstone/Cornerstone_Utils.php
+++ b/projects/plugins/boost/app/lib/cornerstone/Cornerstone_Utils.php
@@ -30,11 +30,12 @@ class Cornerstone_Utils {
 	 */
 	public static function is_cornerstone_page( $post_id ) {
 		$cornerstone_pages = self::get_list();
-
-		if ( ! empty( $cornerstone_pages ) ) {
-			$post_url          = untrailingslashit( get_permalink( $post_id ) );
-			$cornerstone_pages = array_map( 'untrailingslashit', $cornerstone_pages );
+		if ( empty( $cornerstone_pages ) ) {
+			return false;
 		}
+
+		$post_url          = untrailingslashit( get_permalink( $post_id ) );
+		$cornerstone_pages = array_map( 'untrailingslashit', $cornerstone_pages );
 
 		return in_array( $post_url, $cornerstone_pages, true );
 	}

--- a/projects/plugins/boost/app/lib/cornerstone/Cornerstone_Utils.php
+++ b/projects/plugins/boost/app/lib/cornerstone/Cornerstone_Utils.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Lib\Cornerstone;
+
+class Cornerstone_Utils {
+
+	/**
+	 * Get the list of cornerstone pages.
+	 *
+	 * @return string[] The relative URLs of the cornerstone pages.
+	 */
+	public static function get_list() {
+		$pages = jetpack_boost_ds_get( 'cornerstone_pages_list' );
+
+		$permalink_structure = get_option( 'permalink_structure' );
+
+		// If permalink structure ends with slash, add trailing slashes
+		if ( $permalink_structure && substr( $permalink_structure, -1 ) === '/' ) {
+			$pages = array_map( 'trailingslashit', $pages );
+		}
+
+		return $pages;
+	}
+
+	/**
+	 * Check if a post is a cornerstone page.
+	 *
+	 * @param int $post_id The ID of the post to check.
+	 * @return bool True if the post is a cornerstone page, false otherwise.
+	 */
+	public static function is_cornerstone_page( $post_id ) {
+		$cornerstone_pages = self::get_list();
+
+		if ( ! empty( $cornerstone_pages ) ) {
+			$post_url          = untrailingslashit( get_permalink( $post_id ) );
+			$cornerstone_pages = array_map( 'untrailingslashit', $cornerstone_pages );
+		}
+
+		return in_array( $post_url, $cornerstone_pages, true );
+	}
+}

--- a/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Cornerstone_Provider.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Cornerstone_Provider.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack_Boost\Lib\Critical_CSS\Source_Providers\Providers;
 
-use Automattic\Jetpack_Boost\Lib\Cornerstone_Pages;
+use Automattic\Jetpack_Boost\Lib\Cornerstone\Cornerstone_Utils;
 
 /**
  * Class Cornerstone_Provider
@@ -28,9 +28,7 @@ class Cornerstone_Provider extends Provider {
 	 * @return array
 	 */
 	public static function get_critical_source_urls( $_context_posts = array() ) {
-		$cornerstone_pages = new Cornerstone_Pages();
-
-		$urls = $cornerstone_pages->get_pages();
+		$urls = Cornerstone_Utils::get_list();
 
 		$groups = array();
 		foreach ( $urls as $url ) {
@@ -67,8 +65,7 @@ class Cornerstone_Provider extends Provider {
 	 * @return array
 	 */
 	public static function get_keys() {
-		$cornerstone_pages = new Cornerstone_Pages();
-		$urls              = $cornerstone_pages->get_pages();
+		$urls = Cornerstone_Utils::get_list();
 
 		return array_map( array( __CLASS__, 'get_hash_for_url' ), $urls );
 	}

--- a/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
@@ -14,6 +14,7 @@ use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Storage;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Display_Critical_CSS;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Generator;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Source_Providers\Source_Providers;
+use Automattic\Jetpack_Boost\Lib\Environment_Change_Detector;
 use Automattic\Jetpack_Boost\Lib\Premium_Features;
 use Automattic\Jetpack_Boost\REST_API\Contracts\Has_Always_Available_Endpoints;
 use Automattic\Jetpack_Boost\REST_API\Endpoints\Update_Cloud_CSS;
@@ -179,6 +180,18 @@ class Cloud_CSS implements Pluggable, Has_Always_Available_Endpoints, Changes_Pa
 		// the Cloud CSS.
 		if ( $this->is_post_in_latest_providers_list( $post ) ) {
 			$this->regenerate_cloud_css( self::REGENERATE_REASON_SAVE_POST, $this->get_all_providers( array( $post ) ) );
+		}
+	}
+
+	/**
+	 * Handle when a critical CSS environment change is detected.
+	 */
+	public function handle_environment_change( $is_major_change, $change_type ) {
+		/*
+		 * Regenerate Cloud CSS when the list of cornerstone pages is updated.
+		 */
+		if ( $change_type === Environment_Change_Detector::ENV_CHANGE_CORNERSTONE_PAGES_LIST_UPDATED ) {
+			$this->regenerate_cloud_css( self::REGENERATE_REASON_CORNERSTONE_UPDATE, $this->get_all_providers() );
 		}
 	}
 

--- a/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
@@ -6,6 +6,7 @@ use Automattic\Jetpack\Boost_Core\Lib\Boost_API;
 use Automattic\Jetpack_Boost\Contracts\Changes_Page_Output;
 use Automattic\Jetpack_Boost\Contracts\Optimization;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
+use Automattic\Jetpack_Boost\Lib\Cornerstone\Cornerstone_Utils;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Admin_Bar_Compatibility;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Invalidator;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
@@ -24,6 +25,9 @@ class Cloud_CSS implements Pluggable, Has_Always_Available_Endpoints, Changes_Pa
 
 	/** A post was updated/created. */
 	const REGENERATE_REASON_SAVE_POST = 'save_post';
+
+	/** A cornerstone page or the list of cornerstone pages was updated. */
+	const REGENERATE_REASON_CORNERSTONE_UPDATE = 'cornerstone_update';
 
 	/** Existing critical CSS invalidated because of a significant change, e.g. Theme changed. */
 	const REGENERATE_REASON_INVALIDATED = 'invalidated';
@@ -161,6 +165,11 @@ class Cloud_CSS implements Pluggable, Has_Always_Available_Endpoints, Changes_Pa
 	 */
 	public function handle_save_post( $post_id, $post ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		if ( ! $post || ! isset( $post->post_type ) || ! is_post_publicly_viewable( $post ) ) {
+			return;
+		}
+
+		if ( Cornerstone_Utils::is_cornerstone_page( $post_id ) ) {
+			$this->regenerate_cloud_css( self::REGENERATE_REASON_CORNERSTONE_UPDATE, $this->get_all_providers() );
 			return;
 		}
 

--- a/projects/plugins/boost/app/rest-api/endpoints/List_Cornerstone_Pages.php
+++ b/projects/plugins/boost/app/rest-api/endpoints/List_Cornerstone_Pages.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack_Boost\REST_API\Endpoints;
 
-use Automattic\Jetpack_Boost\Lib\Cornerstone_Pages;
+use Automattic\Jetpack_Boost\Lib\Cornerstone\Cornerstone_Utils;
 use Automattic\Jetpack_Boost\REST_API\Contracts\Endpoint;
 use Automattic\Jetpack_Boost\REST_API\Permissions\Signed_With_Blog_Token;
 
@@ -18,8 +18,7 @@ class List_Cornerstone_Pages implements Endpoint {
 	}
 
 	public function response( $_request ) {
-		$cornerstone_pages = new Cornerstone_Pages();
-		return rest_ensure_response( $cornerstone_pages->get_pages() );
+		return rest_ensure_response( Cornerstone_Utils::get_list() );
 	}
 
 	public function permissions() {

--- a/projects/plugins/boost/changelog/update-ccss-regeneration
+++ b/projects/plugins/boost/changelog/update-ccss-regeneration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Cloud CSS: Handle prioritized cloud CSS regeneration for cornerstone pages updates.


### PR DESCRIPTION
## Proposed changes:
* Specify C.CSS regeneration reason when a cornerstone page is updated
* Regenerate cloud CSS if the cornerstone pages list is updated

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
* Upgrade Boost.
* Update the cornerstone pages list.
* Update one of the cornerstone pages.
* Make sure cloud CSS is requested with reason `cornerstone_update`

