### PR TITLE
Stats: Fix stats role checks

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -3398,6 +3398,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool|WP_Error
 	 */
 	public static function validate_stats_roles( $value, $request, $param ) {
+		if ( ! function_exists( 'get_editable_roles' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/user.php';
+		}
 		$editable_roles = array_keys( get_editable_roles() );
 		if ( ! empty( $value ) && ! array_intersect( $editable_roles, $value ) ) {
 			return new WP_Error(

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -3398,14 +3398,15 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool|WP_Error
 	 */
 	public static function validate_stats_roles( $value, $request, $param ) {
-		if ( ! empty( $value ) && ! array_intersect( self::$stats_roles, $value ) ) {
+		$editable_roles = array_keys( get_editable_roles() );
+		if ( ! empty( $value ) && ! array_intersect( $editable_roles, $value ) ) {
 			return new WP_Error(
 				'invalid_param',
 				sprintf(
 					/* Translators: first variable is the name of a parameter passed to endpoint holding the role that will be checked, the second is a list of roles allowed to see stats. The parameter is checked against this list. */
 					esc_html__( '%1$s must be %2$s.', 'jetpack' ),
 					$param,
-					implode( ', ', self::$stats_roles )
+					implode( ', ', $editable_roles )
 				)
 			);
 		}

--- a/projects/plugins/jetpack/changelog/fix-stats-role-checks
+++ b/projects/plugins/jetpack/changelog/fix-stats-role-checks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix count roles not able to be updated


### PR DESCRIPTION
Fixes: https://github.com/Automattic/jpop-issues/issues/9511
Related: p1738628099736259-slack-CDD9LQRSN

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Test for custom roles as well as default roles

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1738628099736259-slack-CDD9LQRSN
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open an Atomic blog with beta tester
* Install the branch for Jetpack
* Open `/wp-admin/admin.php?page=jetpack#traffic`
* Expand Jetpack Stats section
* Toggle the roles
* Ensure there's no error
* Ensure the toggles stick