### PR TITLE
Fix Site Visibility link for duplicated view experiment users

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-reading-settings-site-visibility-link
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-reading-settings-site-visibility-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Site Visibility link for duplicated view experiment users

--- a/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
@@ -26,6 +26,7 @@ function replace_site_visibility() {
 
 	$jetpack_status = new Automattic\Jetpack\Status();
 	$site_slug      = $jetpack_status->get_site_suffix();
+	$current_screen = wpcom_admin_get_current_screen();
 
 	if ( ! is_jetpack_connected() && $jetpack_status->is_private_site() ) {
 		$settings_url = esc_url_raw( sprintf( '/wp-admin/admin.php?page=jetpack' ) );
@@ -34,6 +35,13 @@ function replace_site_visibility() {
 		return;
 	} else {
 		$settings_url = esc_url_raw( sprintf( 'https://wordpress.com/settings/general/%s#site-privacy-settings', $site_slug ) );
+
+		// To prevent "Default + hold-out" users from redirecting to /wp-admin/options-general.php.
+		// p1738634823404529/1738634703.754159-slack-CRWCHQGUB
+		if ( in_array( $current_screen, WPCOM_DUPLICATED_VIEW, true ) && wpcom_is_duplicate_views_experiment_enabled() ) {
+			$settings_url = esc_url_raw( sprintf( 'https://wordpress.com/sites/settings/site/%s', $site_slug ) );
+		}
+
 		$manage_label = __( 'Manage your privacy settings', 'jetpack-mu-wpcom' );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Update the link since it will redundantly redirect users from options-reading.php to options-general.php for Default + hold-out users.
p7DVsv-mbN-p2#comment-52413  

<img width="494" alt="Screenshot 2025-02-04 at 12 27 19" src="https://github.com/user-attachments/assets/e1e64e4e-d539-40bb-9c4a-196a62a8c5ff" />

---
For reference, here are redirection logics from https://github.com/Automattic/wp-calypso/pull/98875:

- Classic view + hold out
	- `/settings/general` (Hosting > Site Settings) redirects to SMP since they are compatible feature-wise. 
	- Users can access options-general.php via Settings > General as before. 
- Default view + hold out 
	- `/settings/general` (Settings > General) redirects to `options-general.php`
 	- `/settings/reading` (Settings > General) redirects to `options-reading.php`
 	- `/settings/writing` (Settings > General) redirects to `options-writing.php`
 	- `/settings/discussion` (Settings > General) redirects to `options-discussion.php`


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add yourself to the treatment group via 22167-explat-experiment
* Patch this change to your sandbox
* Add `options-reading.php` to this list: https://github.com/Automattic/jetpack/blob/ca618eff5313eed31d236cd474b8f56054c3c843/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php#L119
* Go to /wp-admin/options-reading.php
* Observe the link is updated to /sites/settings/site/:site