### PR TITLE
Repo Gardening > Team triage: update VideoPress assignment

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-videopress-slack
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-videopress-slack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Team assignments: update Slack channel where VideoPress issues get posted.
+
+

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/automattic-label-team-assignments.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/automattic-label-team-assignments.js
@@ -207,7 +207,7 @@ export const automatticAssignments = {
 	VideoPress: {
 		team: 'Nexus',
 		labels: [ '[Package] VideoPress', '[Feature] VideoPress', '[Plugin] VideoPress' ],
-		slack_id: 'C02TQF5VAJD',
+		slack_id: 'C02LT75D3',
 		board_id: 'https://github.com/orgs/Automattic/projects/460',
 	},
 	// Let this be the last item. It will act as a catch-all for any issues that haven't been matched until now.


### PR DESCRIPTION
## Proposed changes:

VideoPress issues should get posted in the VideoPress channel from now on.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No 

## Testing instructions:

Not much to test on this one.
