### PR TITLE
Fix/social media section spacing

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-media-section-spacing
+++ b/projects/js-packages/publicize-components/changelog/fix-social-media-section-spacing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Minor UI fix
+
+

--- a/projects/js-packages/publicize-components/src/components/form/share-post-form.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/share-post-form.tsx
@@ -3,6 +3,7 @@ import useSocialMediaMessage from '../../hooks/use-social-media-message';
 import { features } from '../../utils/constants';
 import MediaSection from '../media-section';
 import MessageBoxControl from '../message-box-control';
+import styles from './styles.module.scss';
 
 type SharePostFormProps = {
 	analyticsData?: object;
@@ -26,7 +27,9 @@ export const SharePostForm: React.FC< SharePostFormProps > = ( { analyticsData =
 				analyticsData={ analyticsData }
 			/>
 			{ siteHasFeature( features.ENHANCED_PUBLISHING ) && (
-				<MediaSection analyticsData={ analyticsData } />
+				<div className={ styles[ 'share-post-form__media-section' ] }>
+					<MediaSection analyticsData={ analyticsData } />
+				</div>
 			) }
 		</>
 	);

--- a/projects/js-packages/publicize-components/src/components/form/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/form/styles.module.scss
@@ -61,3 +61,7 @@
 	display: block;
 	margin-bottom: 0.5rem;
 }
+
+.share-post-form__media-section {
+	margin-top: 1rem;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/787

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added spacing

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor and check the spacing between the message box and the media section
* Check in the social preview modal too

| Before | After |
|--------|--------|
| ![Image](https://github.com/user-attachments/assets/7f8b645c-e062-472d-a26f-7bab963437b7) | ![CleanShot 2025-02-04 at 14 06 55 png](https://github.com/user-attachments/assets/116b39fd-f3df-4e3e-ae48-e1fbfda64c98) | 

