### PR TITLE
External Media: Add Import button in Media Library

### DIFF
--- a/projects/packages/external-media/changelog/feat-external-media-import-button
+++ b/projects/packages/external-media/changelog/feat-external-media-import-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+External Media: Add Import button in Media Library

--- a/projects/packages/external-media/src/features/admin/external-media-import-button.js
+++ b/projects/packages/external-media/src/features/admin/external-media-import-button.js
@@ -3,6 +3,9 @@ import { __ } from '@wordpress/i18n';
 document.addEventListener( 'DOMContentLoaded', function () {
 	const addNewButton = document.querySelector( 'a.page-title-action' );
 	if ( addNewButton ) {
+		const buttonContainer = document.createElement( 'div' );
+		buttonContainer.className = 'wpcom-media-library-action-buttons';
+
 		const importButton = document.createElement( 'a' );
 		importButton.className = 'page-title-action';
 		importButton.role = 'button';
@@ -10,6 +13,12 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		importButton.href = window.JETPACK_EXTERNAL_MEDIA_IMPORT_BUTTON?.href;
 		importButton.onclick = event => event.stopImmediatePropagation();
 
-		addNewButton.parentNode.insertBefore( importButton, addNewButton.nextSibling );
+		const parentNode = addNewButton.parentNode;
+		const nextSibling = addNewButton.nextSibling;
+
+		buttonContainer.appendChild( addNewButton );
+		buttonContainer.appendChild( importButton );
+
+		parentNode.insertBefore( buttonContainer, nextSibling );
 	}
 } );

--- a/projects/packages/external-media/src/features/admin/external-media-import-button.js
+++ b/projects/packages/external-media/src/features/admin/external-media-import-button.js
@@ -4,16 +4,11 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	const addNewButton = document.querySelector( 'a.page-title-action' );
 	if ( addNewButton ) {
 		const importButton = document.createElement( 'a' );
-		importButton.className = 'button';
+		importButton.className = 'page-title-action';
 		importButton.role = 'button';
 		importButton.innerHTML = __( 'Import Media', 'jetpack-external-media' );
 		importButton.href = window.JETPACK_EXTERNAL_MEDIA_IMPORT_BUTTON?.href;
-		importButton.style = `
-			position: relative;
-			top: -3px;
-			margin-left: 3px;
-			vertical-align: baseline;
-		`;
+		importButton.onclick = event => event.stopImmediatePropagation();
 
 		addNewButton.parentNode.insertBefore( importButton, addNewButton.nextSibling );
 	}

--- a/projects/packages/external-media/src/features/admin/external-media-import-button.js
+++ b/projects/packages/external-media/src/features/admin/external-media-import-button.js
@@ -1,0 +1,20 @@
+import { __ } from '@wordpress/i18n';
+
+document.addEventListener( 'DOMContentLoaded', function () {
+	const addNewButton = document.querySelector( 'a.page-title-action' );
+	if ( addNewButton ) {
+		const importButton = document.createElement( 'a' );
+		importButton.className = 'button';
+		importButton.role = 'button';
+		importButton.innerHTML = __( 'Import Media', 'jetpack-external-media' );
+		importButton.href = window.JETPACK_EXTERNAL_MEDIA_IMPORT_BUTTON?.href;
+		importButton.style = `
+			position: relative;
+			top: -3px;
+			margin-left: 3px;
+			vertical-align: baseline;
+		`;
+
+		addNewButton.parentNode.insertBefore( importButton, addNewButton.nextSibling );
+	}
+} );

--- a/projects/packages/external-media/src/features/admin/external-media-import-button.js
+++ b/projects/packages/external-media/src/features/admin/external-media-import-button.js
@@ -7,11 +7,10 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		buttonContainer.className = 'wpcom-media-library-action-buttons';
 
 		const importButton = document.createElement( 'a' );
-		importButton.className = 'page-title-action';
+		importButton.className = 'button';
 		importButton.role = 'button';
 		importButton.innerHTML = __( 'Import Media', 'jetpack-external-media' );
 		importButton.href = window.JETPACK_EXTERNAL_MEDIA_IMPORT_BUTTON?.href;
-		importButton.onclick = event => event.stopImmediatePropagation();
 
 		const parentNode = addNewButton.parentNode;
 		const nextSibling = addNewButton.nextSibling;

--- a/projects/packages/external-media/src/features/admin/external-media-import-button.scss
+++ b/projects/packages/external-media/src/features/admin/external-media-import-button.scss
@@ -3,8 +3,10 @@
 	flex-wrap: wrap;
 	gap: 4px;
 
-	.wrap & .page-title-action,
-	.wrap & .page-title-action:active {
+	> a {
+		position: relative;
+		top: -3px;
 		margin-left: 0;
+		vertical-align: baseline;
 	}
 }

--- a/projects/packages/external-media/src/features/admin/external-media-import-button.scss
+++ b/projects/packages/external-media/src/features/admin/external-media-import-button.scss
@@ -1,0 +1,9 @@
+.wpcom-media-library-action-buttons {
+	display: inline-flex;
+	flex-wrap: wrap;
+	gap: 4px;
+
+	.wrap & .page-title-action {
+		margin-left: 0;
+	}
+}

--- a/projects/packages/external-media/src/features/admin/external-media-import-button.scss
+++ b/projects/packages/external-media/src/features/admin/external-media-import-button.scss
@@ -3,7 +3,8 @@
 	flex-wrap: wrap;
 	gap: 4px;
 
-	.wrap & .page-title-action {
+	.wrap & .page-title-action,
+	.wrap & .page-title-action:active {
 		margin-left: 0;
 	}
 }

--- a/projects/packages/external-media/src/features/admin/external-media-import.php
+++ b/projects/packages/external-media/src/features/admin/external-media-import.php
@@ -75,7 +75,7 @@ function enqueue_jetpack_external_media_import_button() {
 		$asset_name,
 		'JETPACK_EXTERNAL_MEDIA_IMPORT_BUTTON',
 		array(
-			'href' => admin_url( 'upload.php?page=jetpack_external_media_import_page&jetpack_external_media_import_page=true' ),
+			'href' => admin_url( 'upload.php?page=jetpack_external_media_import_page&untangling-media=true' ),
 		)
 	);
 }

--- a/projects/packages/external-media/src/features/admin/external-media-import.php
+++ b/projects/packages/external-media/src/features/admin/external-media-import.php
@@ -66,6 +66,7 @@ function enqueue_jetpack_external_media_import_button() {
 		array(
 			'in_footer'  => true,
 			'textdomain' => 'jetpack-external-media',
+			'css_path'   => $assets_base_path . "$asset_name/$asset_name.css",
 		)
 	);
 

--- a/projects/packages/external-media/src/features/admin/external-media-import.php
+++ b/projects/packages/external-media/src/features/admin/external-media-import.php
@@ -47,9 +47,37 @@ function add_jetpack_external_media_import_page() {
 		__NAMESPACE__ . '\render_jetpack_external_media_import_page'
 	);
 
+	add_action( 'load-upload.php', __NAMESPACE__ . '\enqueue_jetpack_external_media_import_button' );
 	add_action( "load-$external_media_import_page_hook", __NAMESPACE__ . '\enqueue_jetpack_external_media_import_page' );
 }
 add_action( 'admin_menu', __NAMESPACE__ . '\add_jetpack_external_media_import_page' );
+
+/**
+ * Enqueue the assets of the Jetpack external media import button.
+ */
+function enqueue_jetpack_external_media_import_button() {
+	$assets_base_path = 'build/';
+	$asset_name       = 'jetpack-external-media-import-button';
+
+	Assets::register_script(
+		$asset_name,
+		$assets_base_path . "$asset_name/$asset_name.js",
+		External_Media::BASE_FILE,
+		array(
+			'in_footer'  => true,
+			'textdomain' => 'jetpack-external-media',
+		)
+	);
+
+	Assets::enqueue_script( $asset_name );
+	wp_localize_script(
+		$asset_name,
+		'JETPACK_EXTERNAL_MEDIA_IMPORT_BUTTON',
+		array(
+			'href' => admin_url( 'upload.php?page=jetpack_external_media_import_page&jetpack_external_media_import_page=true' ),
+		)
+	);
+}
 
 /**
  * Enqueue the assets of the Jetpack external media page.

--- a/projects/packages/external-media/webpack.config.js
+++ b/projects/packages/external-media/webpack.config.js
@@ -5,8 +5,10 @@ module.exports = [
 	{
 		entry: {
 			'jetpack-external-media-editor': './src/features/editor/index.js',
-			'jetpack-external-media-import-button':
+			'jetpack-external-media-import-button': [
 				'./src/features/admin/external-media-import-button.js',
+				'./src/features/admin/external-media-import-button.scss',
+			],
 			'jetpack-external-media-import-page': './src/features/admin/external-media-import.js',
 		},
 		mode: jetpackWebpackConfig.mode,

--- a/projects/packages/external-media/webpack.config.js
+++ b/projects/packages/external-media/webpack.config.js
@@ -5,6 +5,8 @@ module.exports = [
 	{
 		entry: {
 			'jetpack-external-media-editor': './src/features/editor/index.js',
+			'jetpack-external-media-import-button':
+				'./src/features/admin/external-media-import-button.js',
 			'jetpack-external-media-import-page': './src/features/admin/external-media-import.js',
 		},
 		mode: jetpackWebpackConfig.mode,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/10253

## Proposed changes:

This PR adds the following Import Media button in Media -> Library:

<img width="555" alt="image" src="https://github.com/user-attachments/assets/27d73f10-46a3-4f6c-ad86-9df8ce1809b7" />

This button takes us to the new Import Media page.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Apply this patch.
2. Go to `/wp-admin/upload.php?jetpack_external_media_import_page=true`
3. Verify you can see the `Import Media` button at the top of the page.
4. Click it.
5. Verify it takes you to the new Import Media page.
