### PR TITLE
Jetpack SEO: fix state effects and suspense prop

### DIFF
--- a/projects/plugins/jetpack/changelog/change-jetpack-seo-state-effects
+++ b/projects/plugins/jetpack/changelog/change-jetpack-seo-state-effects
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO: fix state inconsistencies, change effects and use global isBusy suspense flag

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/seo-assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/seo-assistant-wizard.tsx
@@ -1,5 +1,3 @@
-import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
 import './style.scss';
 import AssistantWizard from './assistant-wizard';
@@ -8,39 +6,5 @@ const debug = debugFactory( 'jetpack-ai:seo-assistant-wizard' );
 
 export default function SeoAssistantWizard( { close }: { close?: () => void } ) {
 	debug( 'render' );
-	return (
-		<AssistantWizard
-			close={ close }
-			tasks={ [
-				{
-					id: 'welcome',
-					title: __( 'Optimise for SEO', 'jetpack' ),
-					label: 'welcome',
-					type: 'welcome',
-					autoAdvance: 1500,
-					messages: [
-						{
-							content: createInterpolateElement(
-								__( "<b>Hi there! 👋 Let's optimise your blog post for SEO.</b>", 'jetpack' ),
-								{ b: <b /> }
-							),
-							showIcon: true,
-							id: '1',
-						},
-						{
-							content: createInterpolateElement(
-								__(
-									"Here's what we can improve:<br />1. Keywords<br />2. Title<br />3. Meta description",
-									'jetpack'
-								),
-								{ br: <br /> }
-							),
-							showIcon: false,
-							id: '2',
-						},
-					],
-				},
-			] }
-		/>
-	);
+	return <AssistantWizard close={ close } />;
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/style.scss
@@ -41,7 +41,7 @@
 			color: #1e1e1e;
 
 			&:hover {
-				color: #374151;
+				color:#3858E9;
 			}
 		}
 	}
@@ -127,8 +127,7 @@
 		animation: assistantInputAppear 0.3s ease-out;
 
 		&:focus-within {
-			outline-width: 2px;
-			outline-color: var( --wp-components-color-accent, var( --wp-admin-theme-color, #007cba ) );
+			outline-color: #3858E9;
 		}
 
 
@@ -144,11 +143,14 @@
 
 		.components-text-control__input,
 		.components-text-control__input:focus {
-			padding: 8px;
 			border: 0;
 			border-radius: 12px;
 			box-shadow: none;
 			outline: 0;
+		}
+
+		.components-button.is-primary {
+			background-color: #3858E9;
 		}
 	}
 
@@ -179,7 +181,7 @@
 
 		&.is-selected {
 			background: #fff;
-			border-color: var( --wp-components-color-accent, var( --wp-admin-theme-color, #007cba ) );
+			border-color: #3858E9;
 		}
 
 		// target buttons only
@@ -198,6 +200,15 @@
 		align-items: center;
 		gap: 16px;
 		animation: assistantInputAppear 0.3s ease-out;
+
+		.components-button.is-primary {
+			background-color: #3858E9;
+		}
+
+		.components-button.is-secondary {
+			box-shadow: inset 0 0 0 1px #3858e9, 0 0 0 currentColor;
+			color: #3858e9;
+		}
 	}
 
 	&__completion {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/types.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/types.tsx
@@ -11,13 +11,13 @@ export interface Message {
 
 export type OptionMessage = Pick< Message, 'id' | 'content' >;
 
-interface BaseStep {
+export interface Step {
 	id: string;
 	title: string;
 	label?: string;
 	messages: Message[];
 	type: StepType;
-	onStart?: OnStartFunction;
+	onStart?: ( options?: { fromSkip: boolean; stepValue: string } ) => void;
 	onSubmit?: () => Promise< string >;
 	onSkip?: () => void;
 	value?: string;
@@ -26,27 +26,15 @@ interface BaseStep {
 		| React.Dispatch< React.SetStateAction< Array< string > > >;
 	setCompleted?: React.Dispatch< React.SetStateAction< boolean > >;
 	completed?: boolean;
-}
+	autoAdvance?: number;
 
-export interface InputStep extends BaseStep {
-	type: 'input';
-	placeholder: string;
-}
+	// Input step properties
+	placeholder?: string;
 
-interface OptionsStep extends BaseStep {
-	type: 'options';
-	options: OptionMessage[];
-	onSelect: ( option: OptionMessage ) => void;
+	// Options step properties
+	options?: OptionMessage[];
+	onSelect?: ( option: OptionMessage ) => void;
 	submitCtaLabel?: string;
 	onRetry?: () => void;
 	retryCtaLabel?: string;
 }
-
-export interface CompletionStep extends BaseStep {
-	type: 'completion';
-	submitCtaLabel?: string;
-}
-
-export type Step = BaseStep | InputStep | OptionsStep | CompletionStep;
-
-export type OnStartFunction = ( options?: { fromSkip: boolean; stepValue: string } ) => void;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-completion-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-completion-step.tsx
@@ -1,26 +1,18 @@
 import { createInterpolateElement, useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import TypingMessage from './typing-message';
 import { useMessages } from './wizard-messages';
 import type { Step } from './types';
 
 export const useCompletionStep = (): Step => {
 	const [ keywords, setKeywords ] = useState( '' );
 	const [ completed, setCompleted ] = useState( false );
-	const { messages, setMessages, addMessage, removeLastMessage } = useMessages();
+	const { messages, setMessages, addMessage } = useMessages();
 
 	const startHandler = useCallback(
 		async ( { fromSkip } ) => {
-			const firstMessages = [
-				{
-					content: <TypingMessage />,
-					showIcon: true,
-					id: '2',
-				},
-			];
+			const firstMessages = [];
 			if ( fromSkip ) {
-				firstMessages.unshift( {
-					// @ts-expect-error - type is properly defined, unsure why it's erroring
+				firstMessages.push( {
 					content: __( 'Skipped!', 'jetpack' ),
 					showIcon: true,
 					id: 'a',
@@ -28,8 +20,6 @@ export const useCompletionStep = (): Step => {
 			}
 			setMessages( firstMessages );
 			await new Promise( resolve => setTimeout( resolve, 2000 ) );
-			removeLastMessage();
-			// await new Promise( resolve => setTimeout( resolve, 1000 ) );
 			addMessage( {
 				content: createInterpolateElement(
 					"Here's your updated checklist:<br />✅ Title<br />✅ Meta description<br /><br />",
@@ -57,7 +47,7 @@ export const useCompletionStep = (): Step => {
 			} );
 			return 'completion';
 		},
-		[ setMessages, addMessage, removeLastMessage ]
+		[ setMessages, addMessage ]
 	);
 
 	return {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-completion-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-completion-step.tsx
@@ -2,9 +2,9 @@ import { createInterpolateElement, useCallback, useState } from '@wordpress/elem
 import { __ } from '@wordpress/i18n';
 import TypingMessage from './typing-message';
 import { useMessages } from './wizard-messages';
-import type { CompletionStep } from './types';
+import type { Step } from './types';
 
-export const useCompletionStep = (): CompletionStep => {
+export const useCompletionStep = (): Step => {
 	const [ keywords, setKeywords ] = useState( '' );
 	const [ completed, setCompleted ] = useState( false );
 	const { messages, setMessages, addMessage, removeLastMessage } = useMessages();

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-keywords-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-keywords-step.tsx
@@ -1,6 +1,5 @@
 import { createInterpolateElement, useCallback, useState, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import TypingMessage from './typing-message';
 import { useMessages } from './wizard-messages';
 import type { InputStep } from './types';
 
@@ -26,7 +25,6 @@ export const useKeywordsStep = (): InputStep => {
 			return '';
 		}
 		addMessage( { content: keywords, isUser: true } );
-		addMessage( { content: <TypingMessage /> } );
 
 		const keywordlist = await new Promise( resolve =>
 			setTimeout( () => {
@@ -49,7 +47,6 @@ export const useKeywordsStep = (): InputStep => {
 				resolve( commaSeparatedKeywords );
 			}, 500 )
 		);
-		removeLastMessage();
 
 		const message = createInterpolateElement(
 			/* Translators: wrapped string is list of keywords user has entered */
@@ -59,9 +56,8 @@ export const useKeywordsStep = (): InputStep => {
 			}
 		);
 		addMessage( { content: message } );
-		setCompleted( true );
 		return keywords;
-	}, [ addMessage, keywords, removeLastMessage ] );
+	}, [ addMessage, keywords ] );
 
 	return {
 		id: 'keywords',

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-keywords-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-keywords-step.tsx
@@ -1,24 +1,21 @@
-import { createInterpolateElement, useCallback, useState, useEffect } from '@wordpress/element';
+import { createInterpolateElement, useCallback, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useMessages } from './wizard-messages';
-import type { InputStep } from './types';
+import type { Step } from './types';
 
-export const useKeywordsStep = (): InputStep => {
+export const useKeywordsStep = (): Step => {
 	const [ keywords, setKeywords ] = useState( '' );
-	const [ completed, setCompleted ] = useState( false );
-	const { messages, setMessages, addMessage, removeLastMessage } = useMessages();
+	const { messages, addMessage } = useMessages();
 
-	useEffect( () => {
-		setMessages( [
-			{
-				content: __(
-					'To start, please enter 1–3 focus keywords that describe your blog post.',
-					'jetpack'
-				),
-				showIcon: true,
-			},
-		] );
-	}, [ setMessages ] );
+	const onStart = useCallback( async () => {
+		addMessage( {
+			content: __(
+				'To start, please enter 1–3 focus keywords that describe your blog post.',
+				'jetpack'
+			),
+			showIcon: true,
+		} );
+	}, [ addMessage ] );
 
 	const handleKeywordsSubmit = useCallback( async () => {
 		if ( ! keywords.trim() ) {
@@ -67,9 +64,8 @@ export const useKeywordsStep = (): InputStep => {
 		type: 'input',
 		placeholder: __( 'Photography, plants', 'jetpack' ),
 		onSubmit: handleKeywordsSubmit,
-		completed,
-		setCompleted,
 		value: keywords,
 		setValue: setKeywords,
+		onStart,
 	};
 };

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -1,21 +1,13 @@
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useState, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import TypingMessage from './typing-message';
 import { useMessages } from './wizard-messages';
 import type { Step, OptionMessage } from './types';
 
 export const useMetaDescriptionStep = (): Step => {
 	const [ selectedMetaDescription, setSelectedMetaDescription ] = useState< string >();
 	const [ metaDescriptionOptions, setMetaDescriptionOptions ] = useState< OptionMessage[] >( [] );
-	const {
-		messages,
-		setMessages,
-		addMessage,
-		removeLastMessage,
-		editLastMessage,
-		setSelectedMessage,
-	} = useMessages();
+	const { messages, setMessages, addMessage, editLastMessage, setSelectedMessage } = useMessages();
 	const { editPost } = useDispatch( 'core/editor' );
 	const [ completed, setCompleted ] = useState( false );
 
@@ -28,13 +20,11 @@ export const useMetaDescriptionStep = (): Step => {
 	);
 
 	const handleMetaDescriptionSubmit = useCallback( async () => {
-		addMessage( { content: <TypingMessage /> } );
 		await editPost( { meta: { advanced_seo_description: selectedMetaDescription } } );
-		removeLastMessage();
 		addMessage( { content: __( 'Meta description updated! ✅', 'jetpack' ) } );
 		setCompleted( true );
 		return selectedMetaDescription;
-	}, [ selectedMetaDescription, addMessage, editPost, removeLastMessage ] );
+	}, [ selectedMetaDescription, addMessage, editPost ] );
 
 	const handleMetaDescriptionGenerate = useCallback(
 		async ( { fromSkip } ) => {
@@ -54,7 +44,6 @@ export const useMetaDescriptionStep = (): Step => {
 			// we only generate if options are empty
 			setMessages( [ initialMessage ] );
 			if ( newMetaDescriptions.length === 0 ) {
-				addMessage( { content: <TypingMessage /> } );
 				newMetaDescriptions = await new Promise( resolve =>
 					setTimeout(
 						() =>
@@ -68,7 +57,6 @@ export const useMetaDescriptionStep = (): Step => {
 						3000
 					)
 				);
-				removeLastMessage();
 			}
 			setMetaDescriptionOptions( newMetaDescriptions );
 			const editedFirstMessage = fromSkip
@@ -88,7 +76,7 @@ export const useMetaDescriptionStep = (): Step => {
 				addMessage( { ...meta, type: 'option', isUser: true } )
 			);
 		},
-		[ metaDescriptionOptions, addMessage, removeLastMessage, setMessages, editLastMessage ]
+		[ metaDescriptionOptions, addMessage, setMessages, editLastMessage ]
 	);
 
 	const handleMetaDescriptionRegenerate = useCallback( async () => {
@@ -96,7 +84,6 @@ export const useMetaDescriptionStep = (): Step => {
 		setMessages( [
 			{ content: __( "Now, let's optimize your meta description.", 'jetpack' ), showIcon: true },
 		] );
-		addMessage( { content: <TypingMessage /> } );
 		const newMetaDescription = await new Promise< Array< OptionMessage > >( resolve =>
 			setTimeout(
 				() =>
@@ -110,7 +97,6 @@ export const useMetaDescriptionStep = (): Step => {
 				3000
 			)
 		);
-		removeLastMessage();
 		const editedFirstMessage = createInterpolateElement(
 			__( "Now, let's optimize your meta description.<br />Here's a suggestion:", 'jetpack' ),
 			{ br: <br /> }
@@ -118,7 +104,7 @@ export const useMetaDescriptionStep = (): Step => {
 		editLastMessage( editedFirstMessage );
 		setMetaDescriptionOptions( newMetaDescription );
 		newMetaDescription.forEach( meta => addMessage( { ...meta, type: 'option', isUser: true } ) );
-	}, [ addMessage, removeLastMessage, editLastMessage, setMessages ] );
+	}, [ addMessage, editLastMessage, setMessages ] );
 
 	return {
 		id: 'meta',

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -1,7 +1,6 @@
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useState, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import TypingMessage from './typing-message';
 import { useMessages } from './wizard-messages';
 import type { Step, OptionMessage } from './types';
 
@@ -9,14 +8,7 @@ export const useTitleStep = (): Step => {
 	const [ selectedTitle, setSelectedTitle ] = useState< string >( '' );
 	const [ titleOptions, setTitleOptions ] = useState< OptionMessage[] >( [] );
 	const { editPost } = useDispatch( 'core/editor' );
-	const {
-		messages,
-		setMessages,
-		addMessage,
-		removeLastMessage,
-		editLastMessage,
-		setSelectedMessage,
-	} = useMessages();
+	const { messages, setMessages, addMessage, editLastMessage, setSelectedMessage } = useMessages();
 	const [ completed, setCompleted ] = useState( false );
 	const [ prevStepValue, setPrevStepValue ] = useState();
 
@@ -51,7 +43,6 @@ export const useTitleStep = (): Step => {
 			let newTitles = [ ...titleOptions ];
 			// we only generate if options are empty
 			if ( newTitles.length === 0 || prevStepHasChanged ) {
-				addMessage( { content: <TypingMessage /> } );
 				newTitles = await new Promise( resolve =>
 					setTimeout(
 						() =>
@@ -69,7 +60,6 @@ export const useTitleStep = (): Step => {
 						3000
 					)
 				);
-				removeLastMessage();
 			}
 			let editedMessage;
 
@@ -99,11 +89,10 @@ export const useTitleStep = (): Step => {
 				newTitles.forEach( title => addMessage( { ...title, type: 'option', isUser: true } ) );
 			}
 		},
-		[ titleOptions, addMessage, removeLastMessage, setMessages, prevStepValue, editLastMessage ]
+		[ titleOptions, addMessage, setMessages, prevStepValue, editLastMessage ]
 	);
 
 	const handleTitleRegenerate = useCallback( async () => {
-		addMessage( { content: <TypingMessage /> } );
 		const newTitles = await new Promise< Array< OptionMessage > >( resolve =>
 			setTimeout(
 				() =>
@@ -121,19 +110,16 @@ export const useTitleStep = (): Step => {
 				2000
 			)
 		);
-		removeLastMessage();
 		setTitleOptions( [ ...titleOptions, ...newTitles ] );
 		newTitles.forEach( title => addMessage( { ...title, type: 'option', isUser: true } ) );
-	}, [ addMessage, removeLastMessage, titleOptions ] );
+	}, [ addMessage, titleOptions ] );
 
 	const handleTitleSubmit = useCallback( async () => {
-		addMessage( { content: <TypingMessage /> } );
 		await editPost( { title: selectedTitle, meta: { jetpack_seo_html_title: selectedTitle } } );
-		removeLastMessage();
 		addMessage( { content: __( 'Title updated! ✅', 'jetpack' ) } );
 		setCompleted( true );
 		return selectedTitle;
-	}, [ selectedTitle, addMessage, editPost, removeLastMessage ] );
+	}, [ selectedTitle, addMessage, editPost ] );
 
 	return {
 		id: 'title',

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-welcome-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-welcome-step.tsx
@@ -1,0 +1,31 @@
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import type { Step } from './types';
+
+export const useWelcomeStep = (): Step => {
+	return {
+		id: 'welcome',
+		title: __( 'Optimise for SEO', 'jetpack' ),
+		label: 'welcome',
+		type: 'welcome',
+		messages: [
+			{
+				content: createInterpolateElement(
+					__( "<b>Hi there! 👋 Let's optimise your blog post for SEO.</b>", 'jetpack' ),
+					{ b: <b /> }
+				),
+				showIcon: true,
+				id: '1',
+			},
+			{
+				content: createInterpolateElement(
+					__( "Here's what we can improve:<br />1. Title<br />2. Meta description", 'jetpack' ),
+					{ br: <br /> }
+				),
+				showIcon: false,
+				id: '2',
+			},
+		],
+		autoAdvance: 2000,
+	};
+};

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-input.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-input.tsx
@@ -32,7 +32,13 @@ function UnforwardedKeywordsInput( { placeholder, value, setValue, handleSubmit 
 	return (
 		<div ref={ ref } className="assistant-wizard__input">
 			<KeyboardShortcuts shortcuts={ { enter: handleSubmit } }>
-				<TextControl value={ value } onChange={ setValue } placeholder={ placeholder } />
+				<TextControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					value={ value }
+					onChange={ setValue }
+					placeholder={ placeholder }
+				/>
 			</KeyboardShortcuts>
 			<Button
 				variant="primary"

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-messages.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-messages.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import bigSkyIcon from './big-sky-icon.svg';
+import TypingMessage from './typing-message';
 import type { Message } from './types';
 
 const randomId = () => Math.random().toString( 32 ).substring( 2, 8 );
@@ -63,7 +64,7 @@ export const useMessages = () => {
 	};
 };
 
-export const MessageBubble = ( { message, onSelect } ) => {
+export const MessageBubble = ( { message, onSelect = ( m: Message ) => m } ) => {
 	return (
 		<div
 			className={ clsx( 'assistant-wizard__message', {
@@ -94,24 +95,15 @@ export const MessageBubble = ( { message, onSelect } ) => {
 	);
 };
 
-export default function Messages( { onSelect, messages } ) {
-	const messagesEndRef = useRef< HTMLDivElement >( null );
-	const scrollToBottom = () => {
-		messagesEndRef.current?.scrollIntoView( { behavior: 'smooth' } );
-	};
-
-	useEffect( () => {
-		scrollToBottom();
-	}, [ messages ] );
-
+export default function Messages( { onSelect, messages, isBusy } ) {
 	return (
 		<>
 			<div className="assistant-wizard__messages">
 				{ messages.map( message => (
 					<MessageBubble key={ message.id } onSelect={ onSelect } message={ message } />
 				) ) }
+				{ isBusy && <MessageBubble message={ { content: <TypingMessage />, showIcon: true } } /> }
 			</div>
-			<div ref={ messagesEndRef } />
 		</>
 	);
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-step.tsx
@@ -2,13 +2,22 @@ import { useRef } from '@wordpress/element';
 import clsx from 'clsx';
 import { default as WizardMessages } from './wizard-messages';
 
-export default function WizardStep( { className = '', messages, visible, onSelect } ) {
+export default function WizardStep( {
+	className = '',
+	messages,
+	visible,
+	onSelect,
+	isBusy,
+	current,
+} ) {
 	const stepRef = useRef( null );
 	const classes = clsx( 'assistant-wizard-step', className );
+	const stepIsBusy = isBusy && current;
+
 	return (
 		visible && (
 			<div ref={ stepRef } className={ classes }>
-				<WizardMessages messages={ messages } onSelect={ onSelect } />
+				<WizardMessages messages={ messages } onSelect={ onSelect } isBusy={ stepIsBusy } />
 			</div>
 		)
 	);


### PR DESCRIPTION


## Proposed changes:
This PR is yet another rearrange in the code. It addresses internal state inconsistencies derived from managing all the states from hooks. useEffect's are now split to hold better control.
There are a lot of debug calls, trying to understand when timed calls (`setTimeout`) start to degrade state consistency and when it's React.StrictMode just kicking in.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
We're still behind flags but the assistant should now handle "most" situations. There are still some unexpected behaviors and the completion step still doesn't give you an actual summary of what's done, but the interaction is quite fluent.

Open the editor and use the Jetpack sidebar to trigger the assistant. Follow steps and navigate back and forth, should work fine.