### PR TITLE
Tracks: add site type to all events

### DIFF
--- a/projects/packages/connection/changelog/add-tracks-site-type
+++ b/projects/packages/connection/changelog/add-tracks-site-type
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Tracks: add site type to all events

--- a/projects/packages/connection/src/class-tracking.php
+++ b/projects/packages/connection/src/class-tracking.php
@@ -250,6 +250,11 @@ class Tracking {
 
 		$properties['user_lang'] = $user->get( 'WPLANG' );
 
+		if ( ! isset( $properties['site_type'] ) && class_exists( '\Automattic\Jetpack\Status\Host' ) ) {
+			$host                    = new \Automattic\Jetpack\Status\Host();
+			$properties['site_type'] = $host->get_known_host_guess();
+		}
+
 		$blog_details = array(
 			'blog_lang' => isset( $properties['blog_lang'] ) ? $properties['blog_lang'] : get_bloginfo( 'language' ),
 			'blog_id'   => \Jetpack_Options::get_option( 'id' ),


### PR DESCRIPTION
Would it be useful to include hosting information in all tracks events?