### PR TITLE
Stats: Show stats widget to admins on Simple sites

### DIFF
--- a/projects/plugins/jetpack/changelog/test-stats_widget_check_connection
+++ b/projects/plugins/jetpack/changelog/test-stats_widget_check_connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Temporarily show the widget to administrators for Simple sites

--- a/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
@@ -53,7 +53,8 @@ class Jetpack_Stats_Dashboard_Widget {
 		 */
 		// Temporarily show the widget to administrators for Simple sites as the view_stats capability is not available.
 		// TODO: Grant the view_stats capability to corresponding users for Simple sites.
-		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'view_stats' ) ) {
+		$can_user_view_stats = current_user_can( 'manage_options' ) || current_user_can( 'view_stats' );
+		if ( ! apply_filters( 'jetpack_stats_dashboard_widget_show_to_user', $can_user_view_stats ) ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
@@ -51,7 +51,9 @@ class Jetpack_Stats_Dashboard_Widget {
 		 *
 		 * @param bool Whether to show the widget to the current user.
 		 */
-		if ( ! apply_filters( 'jetpack_stats_dashboard_widget_show_to_user', current_user_can( 'view_stats' ) ) ) {
+		// Temporarily show the widget to administrators for Simple sites as the view_stats capability is not available.
+		// TODO: Grant the view_stats capability to corresponding users for Simple sites.
+		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'view_stats' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1738610770056089-slack-C0299DMPG
Related to p1738685296472999/1734418687.010599-slack-C06DN6QQVAQ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Temporarily show the widget to administrators for Simple sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Login to a Simple site with an admin user.
* Navigate to the Simple site's `/wp-admin` without the a8c proxy.
* Ensure the Jetpack Stats widget is not shown.
* Run the following command on your sandbox:
```
bin/jetpack-downloader test jetpack test/stats_widget_check_connection
```
* Sandbox your Simple site.
* Navigate to the Simple site's `/wp-admin` without the a8c proxy.
* Ensure the Jetpack Stats widget is displayed.
* Login to the Simple site with a non-admin user.
* Navigate to the Simple site's `/wp-admin` without the a8c proxy.
* Ensure the Jetpack Stats widget is not shown.