### PR TITLE
Team assignment: update GitHub issue mapping for Newsletter to Loop team

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-newsletter-issue-team-mapping
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-newsletter-issue-team-mapping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Team assignment: update issue mapping for Newsletter to Loop team

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/automattic-label-team-assignments.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/automattic-label-team-assignments.js
@@ -138,10 +138,15 @@ export const automatticAssignments = {
 		board_id: 'https://github.com/orgs/Automattic/projects/724',
 	},
 	Newsletter: {
-		team: 'Zap',
-		labels: [ '[Block] Subscriptions', '[Block] Paywall' ],
-		slack_id: 'C02NQ4HMJKV',
-		board_id: 'https://github.com/orgs/Automattic/projects/657',
+		team: 'Loop',
+		labels: [
+			'[Block] Subscriptions',
+			'[Block] Paywall',
+			'[Block] Subscriber Login',
+			'[Feature] Subscriptions',
+		],
+		slack_id: 'C083ZPVVDTK',
+		board_id: 'https://github.com/orgs/Automattic/projects/443/views/13',
 	},
 	Photon: {
 		team: 'Heart of Gold',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the GitHub issue mapping between teams and labels so that Newsletter maps to the Loop team

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1738665051284949-slack-C083ZPVVDTK

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

 I don't think we can't really test this until it's merged so just double-check the values are correct. Refer to the Slack discussion. 

* You can test the Slack channel id is correct by using the web Slack client and changing the URL.
* Visit the GitHub board to verify it's correct.

Once merged, we can validate things are working correctly by using these steps:

* Create a test GH issue for the Newsletter feature 
  * Add a "[Block] Subscriber Login" or a "[Feature] Subscriptions" label
  * Make it high priority or blocker
* The test issue should appear on the Loop board -> Newsletter tab
* The creator newsletter slack should get a ping

