### PR TITLE
Jetpack AI: add default value for prompt on error response

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-featured-image-free-ver-range-error-handling
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-featured-image-free-ver-range-error-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: featured image will try to set a null prompt when quota is exceeded. This patch sets a default value (empty string) on those cases

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -185,7 +185,7 @@ export default function FeaturedImage( {
 		const response = await handleGenerate( { userPrompt: '', style: guessedStyle } );
 		if ( response ) {
 			debug( 'handleFirstGenerate', response.revisedPrompt );
-			setPrompt( response.revisedPrompt );
+			setPrompt( response.revisedPrompt || '' );
 		}
 	}, [ currentPointer, handleGenerate, handleGuessStyle ] );
 


### PR DESCRIPTION
## Proposed changes:
When featured image request comes back with error, the prompt is set to `revised_prompt` of the response. On cases where this is undefined the default value is no longer a string and causes an editor crash

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1738684202435209-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Use your sandbox to mock a free user exceeding requests quota:

```php
add_filter( 'jetpack_ai_current_period_requests_count', function() { return 21; } );
add_filter( 'jetpack_ai_all_time_requests_count', function() { return 21; } );
add_filter( 'jetpack_ai_tier_licensed_quantity', function() { return 0; } );
```

Load the editor and add some content to the post. Then look for the Featured Image button on the Post settings sidebar, click it and choose "Generate with AI".

Without the patch the request will fail and the editor will crash. Apply this PR (and build/watch plugins/jetpack). Repeat the test and see the error is handled (albeit ugly) and the editor doesn't crash.