### PR TITLE
Newsletter: Add setting to hide category selection modal

### DIFF
--- a/projects/packages/sync/changelog/add-newsletter-modal-setting
+++ b/projects/packages/sync/changelog/add-newsletter-modal-setting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add setting to hide newsletter category modal

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -195,6 +195,7 @@ class Defaults {
 		'wpcom_locked_mode',
 		'wpcom_newsletter_categories',
 		'wpcom_newsletter_categories_enabled',
+		'wpcom_newsletter_categories_modal_hidden',
 		'wpcom_publish_comments_with_markdown',
 		'wpcom_publish_posts_with_markdown',
 		'wpcom_reader_views_enabled',

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2668,7 +2668,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'subscriptions',
 			),
-			'wpcom_newsletter_categories_modal_hidden'       => array(
+			'wpcom_newsletter_categories_modal_hidden'  => array(
 				'description'       => esc_html__( 'Whether the newsletter categories modal is hidden or not', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2668,6 +2668,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'subscriptions',
 			),
+			'wpcom_newsletter_categories_modal_hidden'       => array(
+				'description'       => esc_html__( 'Whether the newsletter categories modal is hidden or not', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'subscriptions',
+			),
 			'wpcom_featured_image_in_email'             => array(
 				'description'       => esc_html__( 'Whether to include the featured image in the email or not', 'jetpack' ),
 				'type'              => 'boolean',

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -973,6 +973,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 				case 'jetpack_subscribe_overlay_enabled':
 				case 'jetpack_subscribe_floating_button_enabled':
 				case 'wpcom_newsletter_categories_enabled':
+				case 'wpcom_newsletter_categories_modal_hidden':
 				case 'wpcom_featured_image_in_email':
 				case 'jetpack_gravatar_in_email':
 				case 'jetpack_author_in_email':

--- a/projects/plugins/jetpack/changelog/add-newsletter-modal-setting
+++ b/projects/plugins/jetpack/changelog/add-newsletter-modal-setting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Newsletter: add setting to hide category selection modal

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -468,7 +468,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'jetpack_post_date_in_email'       => (bool) get_option( 'jetpack_post_date_in_email', true ),
 						'wpcom_newsletter_categories'      => $newsletter_category_ids,
 						'wpcom_newsletter_categories_enabled' => (bool) get_option( 'wpcom_newsletter_categories_enabled' ),
-						'wpcom_newsletter_categories_modal_hidden_enabled' => (bool) get_option( 'wpcom_newsletter_categories_modal_hidden_enabled', false ),
+						'wpcom_newsletter_categories_modal_hidden' => (bool) get_option( 'wpcom_newsletter_categories_modal_hidden', false ),
 						'sm_enabled'                       => (bool) get_option( 'sm_enabled' ),
 						'jetpack_subscribe_overlay_enabled' => (bool) get_option( 'jetpack_subscribe_overlay_enabled' ),
 						'jetpack_subscribe_floating_button_enabled' => (bool) get_option( 'jetpack_subscribe_floating_button_enabled' ),

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -468,6 +468,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'jetpack_post_date_in_email'       => (bool) get_option( 'jetpack_post_date_in_email', true ),
 						'wpcom_newsletter_categories'      => $newsletter_category_ids,
 						'wpcom_newsletter_categories_enabled' => (bool) get_option( 'wpcom_newsletter_categories_enabled' ),
+						'wpcom_newsletter_categories_modal_hidden_enabled' => (bool) get_option( 'wpcom_newsletter_categories_modal_hidden_enabled', false ),
 						'sm_enabled'                       => (bool) get_option( 'sm_enabled' ),
 						'jetpack_subscribe_overlay_enabled' => (bool) get_option( 'jetpack_subscribe_overlay_enabled' ),
 						'jetpack_subscribe_floating_button_enabled' => (bool) get_option( 'jetpack_subscribe_floating_button_enabled' ),
@@ -1083,6 +1084,11 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				case 'wpcom_newsletter_categories_enabled':
 					update_option( 'wpcom_newsletter_categories_enabled', (int) (bool) $value );
+					$updated[ $key ] = (int) (bool) $value;
+					break;
+
+				case 'wpcom_newsletter_categories_modal_hidden':
+					update_option( 'wpcom_newsletter_categories_modal_hidden', (int) (bool) $value );
 					$updated[ $key ] = (int) (bool) $value;
 					break;
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -125,6 +125,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'jetpack_post_date_in_email'                => '(bool) Whether to show date in the email byline',
 			'wpcom_newsletter_categories'               => '(array) Array of post category ids that are marked as newsletter categories',
 			'wpcom_newsletter_categories_enabled'       => '(bool) Whether the newsletter categories are enabled or not',
+			'wpcom_newsletter_categories_modal_hidden'  => '(bool) Whether the newsletter categories modal is hidden or not',
 			'sm_enabled'                                => '(bool) Whether the newsletter Subscribe Modal is enabled or not',
 			'jetpack_subscribe_overlay_enabled'         => '(bool) Whether the newsletter Subscribe Overlay is enabled or not',
 			'jetpack_subscribe_floating_button_enabled' => '(bool) Whether the newsletter floating subscribe button is enabled or not',

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -256,6 +256,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'jetpack_post_date_in_email'                   => false,
 			'wpcom_newsletter_categories'                  => array(),
 			'wpcom_newsletter_categories_enabled'          => false,
+			'wpcom_newsletter_categories_modal_hidden'     => false,
 			'wpcom_gifting_subscription'                   => true,
 			'launch-status'                                => 'unlaunched',
 			'wpcom_subscription_emails_use_excerpt'        => false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `wpcom_newsletter_categories_modal_hidden` to Jetpack settings

<img width="759" alt="Screenshot 2025-02-05 at 15 13 36" src="https://github.com/user-attachments/assets/51125031-cf91-4c79-a53f-260cef115983" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the PR to your sandbox (see how to: PCYsg-eg0-p2)
* Sandbox `public-api.wordpress.com`
* Make a GET request to `https://public-api.wordpress.com/rest/v1.4/sites/{site-id}/settings`
* The `wpcom_newsletter_categories_modal_hidden` should be present on the response body under `settings`

