### PR TITLE
Boost: Add a redirect for plugin rating

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/speed-score/pop-out/pop-out.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/speed-score/pop-out/pop-out.tsx
@@ -28,7 +28,7 @@ const fasterMessage: ScoreChangeMessage = {
 	title: __( 'Your site got faster', 'jetpack-boost' ),
 	body: <p>{ __( `That's great! If you’re happy, why not rate Boost?`, 'jetpack-boost' ) }</p>,
 	cta: __( 'Rate the Plugin', 'jetpack-boost' ),
-	ctaLink: 'https://wordpress.org/support/plugin/jetpack-boost/reviews/#new-post',
+	ctaLink: getRedirectUrl( 'boost-rate-plugin' ),
 };
 
 const slowerMessage: ScoreChangeMessage = {

--- a/projects/plugins/boost/app/assets/src/js/features/speed-score/pop-out/pop-out.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/speed-score/pop-out/pop-out.tsx
@@ -77,13 +77,23 @@ function PopOut( { scoreChange }: Props ) {
 
 	const hideAlert = () => setClose( true );
 
+	const scoreDirection = scoreChange && scoreChange > 0 ? 'up' : 'down';
+
 	useEffect( () => {
 		if ( hasScoreChanged && ! isDismissed && ! isClosed ) {
 			recordBoostEvent( 'speed_score_alert_shown', {
-				score_direction: scoreChange > 0 ? 'up' : 'down',
+				score_direction: scoreDirection,
 			} );
 		}
-	}, [ hasScoreChanged, scoreChange, isDismissed, isClosed ] );
+	}, [ hasScoreChanged, isDismissed, isClosed, scoreDirection ] );
+
+	const handleCtaClick = () => {
+		recordBoostEvent( 'speed_score_alert_cta_clicked', {
+			score_direction: scoreDirection,
+		} );
+
+		dismissAlert();
+	};
 
 	const animationStyles = useSpring( {
 		from: {
@@ -113,7 +123,7 @@ function PopOut( { scoreChange }: Props ) {
 					href={ message?.ctaLink }
 					target="_blank"
 					rel="noreferrer"
-					onClick={ dismissAlert }
+					onClick={ handleCtaClick }
 				>
 					{ message.cta }
 				</a>
@@ -122,7 +132,7 @@ function PopOut( { scoreChange }: Props ) {
 					variant="link"
 					size="small"
 					className={ styles[ 'dismiss-button' ] }
-					onClick={ dismissAlert }
+					onClick={ handleCtaClick }
 				>
 					{ __( 'Do not show me again', 'jetpack-boost' ) }
 				</Button>

--- a/projects/plugins/boost/changelog/add-review-click-tracking
+++ b/projects/plugins/boost/changelog/add-review-click-tracking
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Speed Scores: add tracking for speed score pop-out CTA.


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use a jetpack-redirect for review link on the score change pop-out.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
none

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
none

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

You can use chrome's [response content override](https://www.michalspacek.com/overriding-http-response-content-in-chrome) to test this easily.

* When you see the boost score change popout, check to make sure the url to review is a redirect URL and it correctly redirects to the review page of Boost.
* Make sure `speed_score_alert_cta_clicked` is tracked for both positive and negative outcomes of score change.