### PR TITLE
Fix my jetpack protect card shield inconsistency

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/auto-firewall-status.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/auto-firewall-status.tsx
@@ -19,10 +19,11 @@ export const AutoFirewallStatus = () => {
 	const {
 		protect: { wafConfig: wafData },
 	} = getMyJetpackWindowInitialState();
-	const { jetpack_waf_automatic_rules: isAutoFirewallEnabled } = wafData || {};
+	const { jetpack_waf_automatic_rules: isAutoFirewallEnabled, waf_enabled: isWafEnabled } =
+		wafData || {};
 
 	if ( isPluginActive && isSiteConnected ) {
-		if ( isAutoFirewallEnabled ) {
+		if ( isAutoFirewallEnabled && isWafEnabled ) {
 			return <WafStatus status="active" />;
 		}
 

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/use-protect-tooltip-copy.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/use-protect-tooltip-copy.ts
@@ -50,6 +50,7 @@ export function useProtectTooltipCopy(): TooltipContent {
 		blocked_logins: blockedLoginsCount,
 		brute_force_protection: hasBruteForceProtection,
 		waf_supported: wafSupported,
+		waf_enabled: isWafEnabled,
 	} = wafData || {};
 
 	const pluginsCount = fromScanPlugins.length || Object.keys( plugins ).length;
@@ -247,7 +248,7 @@ export function useProtectTooltipCopy(): TooltipContent {
 						),
 				  },
 		autoFirewallTooltip:
-			( hasProtectPaidPlan && ! isAutoFirewallEnabled ) || ! wafSupported
+			( hasProtectPaidPlan && ( ! isAutoFirewallEnabled || ! isWafEnabled ) ) || ! wafSupported
 				? {
 						title: __( 'Auto-Firewall: Inactive', 'jetpack-my-jetpack' ),
 						text: wafSupported

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-protect-card-shield-inconsistency
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-protect-card-shield-inconsistency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix bug where firewall was displayed as active if automatic rules were enabled but firewall was off

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -288,6 +288,7 @@ interface Window {
 				jetpack_waf_share_debug_data: boolean;
 				standalone_mode: boolean;
 				waf_supported: boolean;
+				waf_enabled: boolean;
 			};
 		};
 		videopress: {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -248,8 +248,9 @@ class Initializer {
 		}
 
 		if ( class_exists( 'Automattic\Jetpack\Waf\Waf_Runner' ) ) {
-			$waf_config    = Waf_Runner::get_config();
-			$waf_supported = Waf_Runner::is_supported_environment();
+			$waf_config     = Waf_Runner::get_config();
+			$is_waf_enabled = Waf_Runner::is_enabled();
+			$waf_supported  = Waf_Runner::is_supported_environment();
 		}
 
 		wp_localize_script(
@@ -313,6 +314,7 @@ class Initializer {
 						$waf_config,
 						array(
 							'waf_supported' => $waf_supported,
+							'waf_enabled'   => $is_waf_enabled,
 						),
 						array( 'blocked_logins' => (int) get_site_option( 'jetpack_protect_blocked_attempts', 0 ) )
 					),

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -237,8 +237,9 @@ class Initializer {
 		$scan_data                      = Products\Protect::get_protect_data();
 		self::update_historically_active_jetpack_modules();
 
-		$waf_config    = array();
-		$waf_supported = false;
+		$waf_config     = array();
+		$waf_supported  = false;
+		$is_waf_enabled = false;
 
 		$sandboxed_domain = '';
 		$is_dev_version   = false;


### PR DESCRIPTION
## Proposed changes:

* Fix bug where the firewall was displayed in My Jetpack as "active" when automatic rules were enabled before disabling the firewall

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Issue: https://github.com/Automattic/jetpack/issues/41366

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Connect your site and user account
3. Purchase a Protect plan and attach it to the site however you'd like
4. Go to `/wp-admin/admin.php?page=jetpack#/settings` and enable the Firewall on the site. Also turn on Automatic rules
![image](https://github.com/user-attachments/assets/19665539-1f80-4d4e-906f-bf730c11a239)
5. Go back to My Jetpack and ensure the Firewall is displaying as active on the Protect card
![image](https://github.com/user-attachments/assets/7c00b97c-d3e5-4290-816d-527e6d8dbeaa)
6. Now go back to `/wp-admin/admin.php?page=jetpack#/settings` and disable Firewall without specifically disabling the automatic rules
![image](https://github.com/user-attachments/assets/fce8d439-2ac4-4438-9290-071f79798d69)
7. Go back to My Jetpack and ensure the card shows Firewall as inactive and that the tooltip leads back to the settings to enable the Firewall
![image](https://github.com/user-attachments/assets/3aff857d-1047-4982-a59a-c587329e1b2f)

Bonus: Test this out with only the Protect standalone plugin to ensure everything still works as expected
