### PR TITLE
Update form block to use block.json for server-side block registration

### DIFF
--- a/projects/packages/forms/changelog/update-contact-form-block-to-use-block-json-on-server
+++ b/projects/packages/forms/changelog/update-contact-form-block-to-use-block-json-on-server
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Update form block to use block.json in server side block registration.

--- a/projects/packages/forms/src/blocks/contact-form/block.json
+++ b/projects/packages/forms/src/blocks/contact-form/block.json
@@ -21,6 +21,46 @@
 		},
 		"align": [ "wide", "full" ]
 	},
-	"attributes": {},
+	"attributes": {
+		"subject": {
+			"type": "string",
+			"default": ""
+		},
+		"to": {
+			"type": "string",
+			"default": ""
+		},
+		"customThankyou": {
+			"type": "string",
+			"default": ""
+		},
+		"customThankyouHeading": {
+			"type": "string",
+			"default": "Your message has been sent"
+		},
+		"customThankyouMessage": {
+			"type": "string",
+			"default": ""
+		},
+		"customThankyouRedirect": {
+			"type": "string",
+			"default": ""
+		},
+		"jetpackCRM": {
+			"type": "boolean",
+			"default": true
+		},
+		"formTitle": {
+			"type": "string",
+			"default": ""
+		},
+		"salesforceData": {
+			"type": "object",
+			"default": {
+				"organizationId": "",
+				"sendToSalesforce": false
+			}
+		}
+	},
 	"editorScript": "file:./editor.js"
 }

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -25,7 +25,7 @@ class Contact_Form_Block {
 	 */
 	public static function register_block() {
 		Blocks::jetpack_register_block(
-			'jetpack/contact-form',
+			__DIR__,
 			array(
 				'render_callback' => array( __CLASS__, 'gutenblock_render_form' ),
 			)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
Proposes using the block.json for the contact form block's PHP block registration.

Currently for the contact form block:
1. There's a JavaScript declaration of the block type settings/metadata - https://github.com/Automattic/jetpack/blob/4967a2f99c7c1499c1b21f2767ea7bdd0bf6bce2/projects/packages/forms/src/blocks/contact-form/index.js#L37-L107
2. There's a block.json with block type settings/metadata, where many of the settings are copied, but this is unused by the jetpack codebase. I think it's probably there for the plugin directory - 
https://github.com/Automattic/jetpack/blob/4967a2f99c7c1499c1b21f2767ea7bdd0bf6bce2/projects/packages/forms/src/blocks/contact-form/block.json#L1-L26
3. There's a PHP registration, and the same block type settings/metadata can also be provided in the array, but there are none declared - https://github.com/Automattic/jetpack/blob/4967a2f99c7c1499c1b21f2767ea7bdd0bf6bce2/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php#L26-L32

The impact of the third one is that the block doesn't declare any of its block `supports` properties or `attribute` definitions (no default values) for the server side implementation of the block. It hasn't caused an issue right now, but for #41428, layout support would have to be triplicated across all three places.

Looking at other blocks in the jetpack codebase, it seems the PHP registration (3) can use the values from the block.json by passing an absolute path with the location of the file to `jetpack_register_block` method instead of the block name. This PR uses the `__DIR__` constant to do that, just like other blocks do.

I'm not sure if there are any unwanted side effects from doing this, but I thought I'd make a PR to propose it ... I still need to test it on WPCOM, but hopefully it works there too.

In the future, it might be nice to be able to import the JSON values into the JS block registration code too so that there's a single source of truth, but perhaps that will require some updates to the jetpack build code.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Add different types of form blocks to a post
2. Check that the block appears on the frontend as expected
