### PR TITLE
Boost: Add compatibility with Depay Payments for WooCommerce

### DIFF
--- a/projects/plugins/boost/changelog/fix-boost-compatibility-depay-woocommerce
+++ b/projects/plugins/boost/changelog/fix-boost-compatibility-depay-woocommerce
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Concatenate JS: Add compatibility with "Depay Payments for WooCommerce".

--- a/projects/plugins/boost/compatibility/js-concatenate.php
+++ b/projects/plugins/boost/compatibility/js-concatenate.php
@@ -12,6 +12,8 @@ function maybe_do_not_concat( $do_concat, $handle ) {
 		'tribe-tickets-provider',
 		// Plugin: `woocommerce-shipping`
 		'woocommerce-shipping-checkout-address-validation',
+		// Plugin: `depay-payments-for-woocommerce`
+		'DEPAY_WC_WIDGETS',
 	);
 
 	if ( in_array( $handle, $excluded_handles, true ) ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/jpop-issues/issues/9520

## Proposed changes:

* Exclude plugin JS asset from concatenation to avoid JS errors.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/jpop-issues/issues/9520

## Does this pull request change what data or activity we track or use?

n/a

## Testing instructions:

### Test that it breaks
* Use production version of Boost with WooCommerce and "Depay Checkout for WooCommerce";
* Open the front-page and make sure there are no JS errors;
* Now enable Concatenate JS;
* Visit the front-page again, and there should be a JS error similar to the one in the linked issue.

### Test that it works
* Use this PRs version of Boost with WooCommerce and "Depay Checkout for WooCommerce";
* Enable Concatenate JS;
* There should be no JS error.