### PR TITLE
Forms: vertically align submit button in single row

### DIFF
--- a/projects/packages/forms/changelog/fix-form-submit-btn-valign
+++ b/projects/packages/forms/changelog/fix-form-submit-btn-valign
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Vertically align submit button in single row

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -318,6 +318,7 @@
 }
 
 .jetpack-field__textarea {
+	display: block;
 	min-height: 200px;
 }
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -55,6 +55,7 @@
 
 			&.wp-block-jetpack-button {
 				flex-basis: auto;
+				align-self: flex-end; // Ensure button is aligned with the bottom of the previous field when on a same row
 			}
 
 			&.jetpack-field__width-25,

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -243,6 +243,7 @@
 
 .wp-block-jetpack-contact-form .wp-block-jetpack-button {
 	width: fit-content;
+	align-self: flex-end;
 }
 
 .wp-block-jetpack-contact-form .wp-block-jetpack-button.aligncenter {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -44,6 +44,7 @@
 }
 
 :where(.contact-form textarea) {
+	display: block;
 	height: 200px;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/vulcan/issues/687

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In a Jetpack form, when the submit button is on the same row as the preceding field, it is not properly aligned/sized.
| Before | After |
|-|-|
|<img width="400" alt="Screenshot 2025-02-05 at 10 10 40 AM" src="https://github.com/user-attachments/assets/047a2a8b-75a4-4695-a9cf-da1efd0411aa" />|<img width="400" alt="Screenshot 2025-02-05 at 10 30 29 AM" src="https://github.com/user-attachments/assets/c4f8f669-e451-438c-a155-0b97989c7032" />|

This PR ensures the bottom of the button and field are aligned.

_Note: it could make sense to have the button the same height as the field but I don't see a foolproof way of achieving this, especially with all themes._

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a Jetpack site
- Create a new post
- Add a form
- Verify the submit button still looks as expected
- Reduce the width of the field preceding the submit button, so the field and button are on the same row
- Notice the bottom of both elements are aligned (there could be a slight offset, depending on the theme and if borders and margins are applied)
- Open the preview
- Do the same verification
- Optionally, test with different themes

