### PR TITLE
Repo Gardening: Add <plugin>/next for milestone tagging

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/add-next-milestone-tagging
+++ b/projects/github-actions/repo-gardening/changelog/add-next-milestone-tagging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Milestone: Add support for `<plugin>/next` milestone names.

--- a/projects/github-actions/repo-gardening/src/utils/get-next-valid-milestone.js
+++ b/projects/github-actions/repo-gardening/src/utils/get-next-valid-milestone.js
@@ -49,7 +49,7 @@ async function getOpenMilestones( octokit, owner, repo ) {
  */
 async function getNextValidMilestone( octokit, owner, repo, plugin = 'jetpack' ) {
 	// Find all valid milestones for the specified plugin.
-	const reg = new RegExp( '^' + plugin + '\\/\\d+\\.\\d' );
+	const reg = new RegExp( '^' + plugin + '\\/(\\d+\\.\\d|next)' );
 	const milestones = ( await getOpenMilestones( octokit, owner, repo ) )
 		.filter( m => m.title.match( reg ) )
 		.filter( m => {
@@ -61,9 +61,18 @@ async function getNextValidMilestone( octokit, owner, repo, plugin = 'jetpack' )
 			const match = m.description?.match( /(?:Code Freeze|Branch Cut): (\d{4}-\d{2}-\d{2})/ );
 			return ! ( match && moment( match[ 1 ] ) < moment() );
 		} )
-		.sort( ( m1, m2 ) =>
-			compareVersions( m1.title.split( '/' )[ 1 ], m2.title.split( '/' )[ 1 ] )
-		);
+		.sort( ( m1, m2 ) => {
+			const v1 = m1.title.split( '/' )[ 1 ];
+			const v2 = m2.title.split( '/' )[ 1 ];
+
+			// `next` is placeholder version name that represents the immediate next version.
+			// It should be the first item in the list.
+			if ( v1 === 'next' ) return -1;
+			if ( v2 === 'next' ) return 1;
+
+			// Otherwise compare versions normally
+			return compareVersions( v1, v2 );
+		} );
 
 	// Return the first milestone with a future due date,
 	// or failing that the first milestone with no due date.


### PR DESCRIPTION
## Proposed changes:
* Add auto-tagging support for <plugin>/next milestone

**Context**
It's hard to predict the next version number with Semver as the version number can be different depending on the change. So Heart of Gold has adopted a workflow where the current milestone for boost is always called `boost/next` which get's renamed to `boost/x.y.z` upon release with the appropriate version number. This was skipped by the existing milestone tagging workflow. This PR adds support for those `boost/next` milestones.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
To test this, a PR having a label for a single plugin needs to be merged. If there is an open milestone named `<plugin>/next`, the PR will be tagged with that milestone.

I [tested this in a fork](https://github.com/haqadn/jetpack/actions/runs/13188438448/job/36816022650#step:7:17).