### PR TITLE
Forms: Add File Upload Field Skeleton (Experimental)

### DIFF
--- a/projects/packages/forms/changelog/add-file-upload-field
+++ b/projects/packages/forms/changelog/add-file-upload-field
@@ -1,4 +1,4 @@
 Significance: minor
-Type: enhancement
+Type: added
 
 Forms: Add a new file upload field block to allow visitors to upload files through contact forms. 

--- a/projects/packages/forms/changelog/add-file-upload-field
+++ b/projects/packages/forms/changelog/add-file-upload-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Add a new file upload field block to allow visitors to upload files through contact forms. 

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -509,6 +509,39 @@ export const childBlocks = [
 		},
 	},
 	{
+		name: 'field-file',
+		settings: {
+			...FieldDefaults,
+			title: __( 'File Upload Field', 'jetpack-forms' ),
+			keywords: [
+				__( 'File', 'jetpack-forms' ),
+				__( 'Upload', 'jetpack-forms' ),
+				__( 'Attachment', 'jetpack-forms' ),
+			],
+			description: __( 'Allow visitors to upload files through your form.', 'jetpack-forms' ),
+			icon: {
+				foreground: getIconColor(),
+				src: renderMaterialIcon(
+					<Path d="M11 14.5V6.33L8.5 8.83L7.67 8L12 3.67L16.33 8L15.5 8.83L13 6.33V14.5H11ZM12 20.33L7.67 16L8.5 15.17L11 17.67V15.5H13V17.67L15.5 15.17L16.33 16L12 20.33Z" />
+				),
+			},
+			edit: editField( 'file' ),
+			attributes: {
+				...FieldDefaults.attributes,
+				label: {
+					type: 'string',
+					default: __( 'Upload a file', 'jetpack-forms' ),
+					role: 'content',
+				},
+				filetype: {
+					type: 'string',
+					default: '',
+				},
+			},
+			isExperimental: true,
+		},
+	},
+	{
 		name: 'field-textarea',
 		settings: {
 			...FieldDefaults,
@@ -553,34 +586,6 @@ export const childBlocks = [
 				label: {
 					type: 'string',
 					default: '',
-					role: 'content',
-				},
-			},
-		},
-	},
-	{
-		name: 'field-upload',
-		settings: {
-			...FieldDefaults,
-			title: __( 'File Upload Field', 'jetpack-forms' ),
-			keywords: [
-				__( 'File', 'jetpack-forms' ),
-				__( 'Upload', 'jetpack-forms' ),
-				__( 'Attachment', 'jetpack-forms' ),
-			],
-			description: __( 'Allow visitors to upload files through your form.', 'jetpack-forms' ),
-			icon: {
-				foreground: getIconColor(),
-				src: renderMaterialIcon(
-					<Path d="M11 14.5V6.33L8.5 8.83L7.67 8L12 3.67L16.33 8L15.5 8.83L13 6.33V14.5H11ZM12 20.33L7.67 16L8.5 15.17L11 17.67V15.5H13V17.67L15.5 15.17L16.33 16L12 20.33Z" />
-				),
-			},
-			edit: editField( 'file' ),
-			attributes: {
-				...FieldDefaults.attributes,
-				label: {
-					type: 'string',
-					default: __( 'Upload a file', 'jetpack-forms' ),
 					role: 'content',
 				},
 			},

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -381,7 +381,7 @@ export const childBlocks = [
 		settings: {
 			...FieldDefaults,
 			title: __( 'Name Field', 'jetpack-forms' ),
-			description: __( 'Collect the site visitor’s name.', 'jetpack-forms' ),
+			description: __( "Collect the site visitor's name.", 'jetpack-forms' ),
 			icon: {
 				foreground: getIconColor(),
 				src: renderMaterialIcon(
@@ -553,6 +553,34 @@ export const childBlocks = [
 				label: {
 					type: 'string',
 					default: '',
+					role: 'content',
+				},
+			},
+		},
+	},
+	{
+		name: 'field-upload',
+		settings: {
+			...FieldDefaults,
+			title: __( 'File Upload Field', 'jetpack-forms' ),
+			keywords: [
+				__( 'File', 'jetpack-forms' ),
+				__( 'Upload', 'jetpack-forms' ),
+				__( 'Attachment', 'jetpack-forms' ),
+			],
+			description: __( 'Allow visitors to upload files through your form.', 'jetpack-forms' ),
+			icon: {
+				foreground: getIconColor(),
+				src: renderMaterialIcon(
+					<Path d="M11 14.5V6.33L8.5 8.83L7.67 8L12 3.67L16.33 8L15.5 8.83L13 6.33V14.5H11ZM12 20.33L7.67 16L8.5 15.17L11 17.67V15.5H13V17.67L15.5 15.17L16.33 16L12 20.33Z" />
+				),
+			},
+			edit: editField( 'file' ),
+			attributes: {
+				...FieldDefaults.attributes,
+				label: {
+					type: 'string',
+					default: __( 'Upload a file', 'jetpack-forms' ),
 					role: 'content',
 				},
 			},

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -160,6 +160,23 @@ class Contact_Form_Block {
 				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_consent' ),
 			)
 		);
+
+		$blocks_variation = apply_filters( 'jetpack_blocks_variation', \Automattic\Jetpack\Constants::get_constant( 'JETPACK_BLOCKS_VARIATION' ) );
+		if ( 'experimental' === $blocks_variation ) {
+			self::register_experimental_blocks();
+		}
+	}
+
+	/**
+	 * Register experimental blocks
+	 */
+	private static function register_experimental_blocks() {
+		Blocks::jetpack_register_block(
+			'jetpack/field-file',
+			array(
+				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_file' ),
+			)
+		);
 	}
 
 	/**

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
@@ -23,6 +23,7 @@ const JetpackField = props => {
 		placeholder,
 		width,
 		insertBlocksAfter,
+		type,
 	} = props;
 
 	const { blockStyle, fieldStyle } = useJetpackFieldStyles( attributes );
@@ -46,19 +47,23 @@ const JetpackField = props => {
 					setAttributes={ setAttributes }
 					style={ formStyle }
 				/>
-				<input
-					className="jetpack-field__input"
-					onChange={ e => setAttributes( { placeholder: e.target.value } ) }
-					style={ fieldStyle }
-					type="text"
-					value={ placeholder }
-					onKeyDown={ event => {
-						if ( event.defaultPrevented || event.key !== 'Enter' ) {
-							return;
-						}
-						insertBlocksAfter( createBlock( getDefaultBlockName() ) );
-					} }
-				/>
+				{ type === 'file' ? (
+					<input type="file" className="jetpack-field__input" />
+				) : (
+					<input
+						className="jetpack-field__input"
+						onChange={ e => setAttributes( { placeholder: e.target.value } ) }
+						style={ fieldStyle }
+						type="text"
+						value={ placeholder }
+						onKeyDown={ event => {
+							if ( event.defaultPrevented || event.key !== 'Enter' ) {
+								return;
+							}
+							insertBlocksAfter( createBlock( getDefaultBlockName() ) );
+						} }
+					/>
+				) }
 			</div>
 
 			<JetpackFieldControls

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -494,6 +494,19 @@ class Contact_Form_Plugin {
 	}
 
 	/**
+	 * Render the file upload field.
+	 *
+	 * @param array  $atts - the block attributes.
+	 * @param string $content - html content.
+	 *
+	 * @return string HTML for the file upload field.
+	 */
+	public static function gutenblock_render_field_file( $atts, $content ) {
+		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'file' );
+		return Contact_Form::parse_contact_field( $atts, $content );
+	}
+
+	/**
 	 * Add the 'Form Responses' menu item as a submenu of Feedback.
 	 */
 	public function admin_menu() {


### PR DESCRIPTION
## Proposed changes:
* Adds the skeleton/structure for a new File Upload field block in Jetpack Forms
* Implements the basic block registration as an experimental feature
* Sets up the foundation for future file upload functionality

### Implementation Details:
* Added new `field-file` block definition with experimental flag
* Added basic PHP rendering structure for file upload fields
* Implemented experimental blocks registration system
* No file upload functionality is implemented yet - this PR only adds the structural foundation

## Testing instructions:

### Testing the Block Structure:
1. Set `JETPACK_BLOCKS_VARIATION` to 'experimental'
2. Go to a page/post editor
3. Add a Contact Form block
4. Verify that the File Upload field is available in the field selector
5. Add a File Upload field and verify it shows a basic file input element

### Verifying Experimental Gate:
1. Set `JETPACK_BLOCKS_VARIATION` to anything other than 'experimental'
2. Go to a page/post editor
3. Add a Contact Form block
4. Verify that the File Upload field is NOT available in the field selector
