### PR TITLE
Map block: Prevent PHP fatal when content is empty

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-map_block_fatal
+++ b/projects/plugins/jetpack/changelog/fix-map_block_fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Map block: Catch error if content is empty.

--- a/projects/plugins/jetpack/extensions/blocks/map/map.php
+++ b/projects/plugins/jetpack/extensions/blocks/map/map.php
@@ -154,6 +154,10 @@ function render_single_block_page() {
 	/** This filter is already documented in core/wp-includes/post-template.php */
 	$content = apply_filters( 'the_content', $post->post_content );
 
+	if ( empty( $content ) ) {
+		return;
+	}
+
 	/* Suppress warnings */
 	libxml_use_internal_errors( true );
 	@$post_html->loadHTML( $content ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged

--- a/projects/plugins/jetpack/extensions/blocks/map/map.php
+++ b/projects/plugins/jetpack/extensions/blocks/map/map.php
@@ -154,6 +154,7 @@ function render_single_block_page() {
 	/** This filter is already documented in core/wp-includes/post-template.php */
 	$content = apply_filters( 'the_content', $post->post_content );
 
+	// Return early if empty to prevent DOMDocument::loadHTML fatal.
 	if ( empty( $content ) ) {
 		return;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

If the Map block receives empty content, it results in a PHP fatal. This PR returns early in that scenario.

## Proposed changes:
This was discovered while monitoring a deploy:
```
PHP Fatal error: Uncaught ValueError: DOMDocument::loadHTML(): Argument #1 ($source) must not be empty in /wordpress/plugins/jetpack/14.3-a.5/extensions/blocks/map/map.php:159 Stack trace: #0 /wordpress/plugins/jetpack/14.3-a.5/extensions/blocks/map/map.php(159): DOMDocument->loadHTML('')
```

Prior to PHP 8, `DOMDocument::loadHTML()` would throw a deprecation notice if the source string is empty; now it gives a fatal ([docs](https://www.php.net/manual/en/domdocument.loadhtml.php)).

There's no way to reliably prevent `$content` from being empty, given there's an `apply_filters()` just before which could be used by any third-party code.

At first I wasn't sure if it was safe to just return, but looking further in code that'd be precisely what it does if `$container` is not truthy, which would always be case since the `DOMXPath::query` would not find the path in question with empty content anyway. I believe another solution would be to throw a dummy `<div></div>` into `$content` should it be empty, but that seems more hackish.

Anyway, I'm fairly confident this restores the same behavior seen in PHP <8.

Note: the line in question did have a suppression before with `@` added in d9492d1aacd8bcc271d3fb0c1a6f85e6663d87f3, but it's unclear from the PR (#13405) or the commit message if this or some other scenario warranted it. As such, I'm leaving it in place for now. There are also some `libxml_use_internal_errors()` calls, but those would be applicable for normal parsing errors too, so should stay.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I'm not sure how to reproduce this best...check my logic above?