### PR TITLE
Prevent PHP error when error log retrieved from database is an unexpected type

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-log_fatal
+++ b/projects/plugins/jetpack/changelog/fix-log_fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Prevent PHP error when error log retrieved from database is an unexpected type. 

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -2910,8 +2910,15 @@ p {
 	 * @param mixed $data Data to log.
 	 */
 	public static function log( $code, $data = null ) {
+
+		$raw_log = Jetpack_Options::get_option( 'log', array() );
+		// This can be modified by the `jetpack_options` filter, so make sure we have an array.
+		if ( ! is_array( $raw_log ) ) {
+			$raw_log = array();
+		}
+
 		// only grab the latest 200 entries.
-		$log = array_slice( Jetpack_Options::get_option( 'log', array() ), -199, 199 );
+		$log = array_slice( $raw_log, -199, 199 );
 
 		// Append our event to the log.
 		$log_entry = array(

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -2912,9 +2912,9 @@ p {
 	public static function log( $code, $data = null ) {
 
 		$raw_log = Jetpack_Options::get_option( 'log', array() );
-		// This can be modified by the `jetpack_options` filter, so make sure we have an array.
+		// This can be modified by the `jetpack_options` filter, so abort if we don't have an array.
 		if ( ! is_array( $raw_log ) ) {
-			$raw_log = array();
+			return;
 		}
 
 		// only grab the latest 200 entries.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

If `Jetpack_Options::get_option( 'log' )` returns an unexpected value in `Jetpack::log()`, we get a fatal when processing it. This PR ensures we have an array to process.

## Proposed changes:
Discovered while monitoring a deploy:
```
PHP Fatal error: Uncaught TypeError: array_slice(): Argument #1 ($array) must be of type array, bool given in /wordpress/plugins/jetpack/14.3-a.5/class.jetpack.php:2925 Stack trace: #0 /wordpress/plugins/jetpack/14.3-a.5/class.jetpack.php(2925): array_slice(false, -199, 199)
```

While we technically pass a default value in case there's no current value, there are two ways I could think of this being ignored:
1. The `jetpack_options` filter can manipulate the value.
2. The value in the database could be bad.

Since this was seen in the wild, I just make sure we have an array before trying to `array_slice` it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Option 1 is to add the following to the end of `jetpack.php`:
```
function some_function_that_returns_junk( $value, $name ) {
	if ( $name === 'log' ) {
		return false;
	}
	return $value;
}
add_filter( 'jetpack_options', 'some_function_that_returns_junk', 10, 2 );
Jetpack::log(123);
```

Option 2 is to change the value in the database:
```
UPDATE wp_options SET option_value = 0 WHERE option_name = 'jetpack_log';
```