### PR TITLE
Jetpack SEO: process assistant results summary

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-seo-assistant-results-summary
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-seo-assistant-results-summary
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO: add completion summary  step

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/style.scss
@@ -17,6 +17,15 @@
 		width: unset;
 	}
 
+	.components-button.is-primary {
+		background-color: #3858E9;
+	}
+
+	.components-button.is-secondary {
+		box-shadow: inset 0 0 0 1px #3858e9, 0 0 0 currentColor;
+		color: #3858e9;
+	}
+
 	&__header {
 		flex: 0 0 auto;
 		display: flex;
@@ -154,10 +163,6 @@
 			box-shadow: none;
 			outline: 0;
 		}
-
-		.components-button.is-primary {
-			background-color: #3858E9;
-		}
 	}
 
 	// submit and retry buttons
@@ -204,15 +209,6 @@
 		align-items: center;
 		gap: 16px;
 		animation: assistantInputAppear 0.3s ease-out;
-
-		.components-button.is-primary {
-			background-color: #3858E9;
-		}
-
-		.components-button.is-secondary {
-			box-shadow: inset 0 0 0 1px #3858e9, 0 0 0 currentColor;
-			color: #3858e9;
-		}
 	}
 
 	&__completion {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/types.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/types.tsx
@@ -11,13 +11,21 @@ export interface Message {
 
 export type OptionMessage = Pick< Message, 'id' | 'content' >;
 
+export interface Results {
+	[ key: string ]: {
+		value: string;
+		type: string;
+		label: string;
+	};
+}
+
 export interface Step {
 	id: string;
 	title: string;
 	label?: string;
 	messages: Message[];
 	type: StepType;
-	onStart?: ( options?: { fromSkip: boolean; stepValue: string } ) => void;
+	onStart?: ( options?: { fromSkip: boolean; stepValue: string; results: Results } ) => void;
 	onSubmit?: () => Promise< string >;
 	onSkip?: () => void;
 	value?: string;
@@ -27,6 +35,7 @@ export interface Step {
 	setCompleted?: React.Dispatch< React.SetStateAction< boolean > >;
 	completed?: boolean;
 	autoAdvance?: number;
+	includeInResults?: boolean;
 
 	// Input step properties
 	placeholder?: string;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/types.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/types.tsx
@@ -32,8 +32,6 @@ export interface Step {
 	setValue?:
 		| React.Dispatch< React.SetStateAction< string > >
 		| React.Dispatch< React.SetStateAction< Array< string > > >;
-	setCompleted?: React.Dispatch< React.SetStateAction< boolean > >;
-	completed?: boolean;
 	autoAdvance?: number;
 	includeInResults?: boolean;
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-completion-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-completion-step.tsx
@@ -1,16 +1,16 @@
 import { createInterpolateElement, useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useMessages } from './wizard-messages';
-import type { Step } from './types';
+import type { Step, Results } from './types';
 
 export const useCompletionStep = (): Step => {
-	const [ keywords, setKeywords ] = useState( '' );
-	const [ completed, setCompleted ] = useState( false );
+	const [ value, setValue ] = useState( '' );
 	const { messages, setMessages, addMessage } = useMessages();
 
 	const startHandler = useCallback(
-		async ( { fromSkip } ) => {
+		async ( { fromSkip, results } ) => {
 			const firstMessages = [];
+
 			if ( fromSkip ) {
 				firstMessages.push( {
 					content: __( 'Skipped!', 'jetpack' ),
@@ -19,32 +19,62 @@ export const useCompletionStep = (): Step => {
 				} );
 			}
 			setMessages( firstMessages );
-			await new Promise( resolve => setTimeout( resolve, 2000 ) );
+
+			await new Promise( resolve => setTimeout( resolve, 1500 ) );
+
+			const resultsString = Object.values( results )
+				.map( ( result: Results[ string ] ) => `${ result.value ? '✅' : '❌' } ${ result.label }` )
+				.join( '<br />' );
+
 			addMessage( {
 				content: createInterpolateElement(
-					"Here's your updated checklist:<br />✅ Title<br />✅ Meta description<br /><br />",
+					`Here's your updated checklist:<br />${ resultsString }<br /><br />`,
 					{
 						br: <br />,
 					}
 				),
 				id: '1',
 			} );
-			addMessage( {
-				content: createInterpolateElement(
-					__(
-						'<strong>SEO optimization complete! 🎉</strong><br/>Your blog post is now search-engine friendly.',
-						'jetpack'
+
+			const incomplete: { total: number; completed: number } = Object.values( results ).reduce(
+				( acc: { total: number; completed: number }, result: Results[ string ] ) => {
+					const total = acc.total + 1;
+					const completed = acc.completed + ( result.value ? 1 : 0 );
+					return { total, completed };
+				},
+				{ total: 0, completed: 0 }
+			) as { total: number; completed: number };
+
+			const incompleteString =
+				incomplete.completed === incomplete.total
+					? ''
+					: `${ incomplete.completed } out of ${ incomplete.total }`;
+
+			if ( incompleteString ) {
+				addMessage( {
+					content: createInterpolateElement(
+						`<strong>You've optimized ${ incompleteString } items! 🎉</strong><br />Your post is looking great! Come back anytime to complete the rest.`,
+						{
+							strong: <strong />,
+							br: <br />,
+						}
 					),
-					{ br: <br />, strong: <strong /> }
-				),
-				showIcon: false,
-				id: '3',
-			} );
-			addMessage( {
-				content: __( 'Happy blogging! 😊', 'jetpack' ),
-				showIcon: false,
-				id: '4',
-			} );
+					id: '2',
+				} );
+			} else {
+				addMessage( {
+					content: createInterpolateElement(
+						__(
+							'<strong>SEO optimization complete! 🎉</strong><br/>Your blog post is now search-engine friendly.<br />Happy blogging! 😊',
+							'jetpack'
+						),
+						{ br: <br />, strong: <strong /> }
+					),
+					showIcon: false,
+					id: '3',
+				} );
+			}
+
 			return 'completion';
 		},
 		[ setMessages, addMessage ]
@@ -58,9 +88,7 @@ export const useCompletionStep = (): Step => {
 		type: 'completion',
 		onStart: startHandler,
 		submitCtaLabel: __( 'Done!', 'jetpack' ),
-		completed,
-		setCompleted,
-		value: keywords,
-		setValue: setKeywords,
+		value,
+		setValue,
 	};
 };

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -54,7 +54,7 @@ export const useMetaDescriptionStep = (): Step => {
 										'Explore breathtaking flower and plant photography in our Flora Guide, featuring tips and inspiration for gardening and plant enthusiasts to enhance their outdoor spaces.',
 								},
 							] ),
-						3000
+						1500
 					)
 				);
 			}
@@ -90,7 +90,7 @@ export const useMetaDescriptionStep = (): Step => {
 								'Explore breathtaking flower and plant photography in our Flora Guide, featuring tips and inspiration for gardening and plant enthusiasts to enhance their outdoor spaces.',
 						},
 					] ),
-				3000
+				1500
 			)
 		);
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -9,7 +9,6 @@ export const useMetaDescriptionStep = (): Step => {
 	const [ metaDescriptionOptions, setMetaDescriptionOptions ] = useState< OptionMessage[] >( [] );
 	const { messages, setMessages, addMessage, editLastMessage, setSelectedMessage } = useMessages();
 	const { editPost } = useDispatch( 'core/editor' );
-	const [ completed, setCompleted ] = useState( false );
 
 	const handleMetaDescriptionSelect = useCallback(
 		( option: OptionMessage ) => {
@@ -22,7 +21,6 @@ export const useMetaDescriptionStep = (): Step => {
 	const handleMetaDescriptionSubmit = useCallback( async () => {
 		await editPost( { meta: { advanced_seo_description: selectedMetaDescription } } );
 		addMessage( { content: __( 'Meta description updated! ✅', 'jetpack' ) } );
-		setCompleted( true );
 		return selectedMetaDescription;
 	}, [ selectedMetaDescription, addMessage, editPost ] );
 
@@ -101,6 +99,7 @@ export const useMetaDescriptionStep = (): Step => {
 	return {
 		id: 'meta',
 		title: __( 'Add meta description', 'jetpack' ),
+		label: __( 'Meta description', 'jetpack' ),
 		messages: messages,
 		type: 'options',
 		options: metaDescriptionOptions,
@@ -112,7 +111,6 @@ export const useMetaDescriptionStep = (): Step => {
 		onStart: handleMetaDescriptionGenerate,
 		value: selectedMetaDescription,
 		setValue: setSelectedMetaDescription,
-		completed,
-		setCompleted,
+		includeInResults: true,
 	};
 };

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -57,7 +57,7 @@ export const useTitleStep = (): Step => {
 										'Flora Guide: Beautiful Photos of Flowers and Plants for Gardening Enthusiasts',
 								},
 							] ),
-						3000
+						1500
 					)
 				);
 			}
@@ -107,7 +107,7 @@ export const useTitleStep = (): Step => {
 								'Flora Guide: Beautiful Photos of Flowers and Plants for Gardening Enthusiasts',
 						},
 					] ),
-				2000
+				1500
 			)
 		);
 		setTitleOptions( [ ...titleOptions, ...newTitles ] );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -9,7 +9,6 @@ export const useTitleStep = (): Step => {
 	const [ titleOptions, setTitleOptions ] = useState< OptionMessage[] >( [] );
 	const { editPost } = useDispatch( 'core/editor' );
 	const { messages, setMessages, addMessage, editLastMessage, setSelectedMessage } = useMessages();
-	const [ completed, setCompleted ] = useState( false );
 	const [ prevStepValue, setPrevStepValue ] = useState();
 
 	const handleTitleSelect = useCallback(
@@ -117,13 +116,13 @@ export const useTitleStep = (): Step => {
 	const handleTitleSubmit = useCallback( async () => {
 		await editPost( { title: selectedTitle, meta: { jetpack_seo_html_title: selectedTitle } } );
 		addMessage( { content: __( 'Title updated! ✅', 'jetpack' ) } );
-		setCompleted( true );
 		return selectedTitle;
 	}, [ selectedTitle, addMessage, editPost ] );
 
 	return {
 		id: 'title',
 		title: __( 'Optimise Title', 'jetpack' ),
+		label: __( 'Title', 'jetpack' ),
 		messages,
 		type: 'options',
 		options: titleOptions,
@@ -135,7 +134,6 @@ export const useTitleStep = (): Step => {
 		onStart: handleTitleGenerate,
 		value: selectedTitle,
 		setValue: setSelectedTitle,
-		completed,
-		setCompleted,
+		includeInResults: true,
 	};
 };

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-welcome-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-welcome-step.tsx
@@ -26,6 +26,6 @@ export const useWelcomeStep = (): Step => {
 				id: '2',
 			},
 		],
-		autoAdvance: 2000,
+		autoAdvance: 1500,
 	};
 };


### PR DESCRIPTION
Fixes #41046 

## Proposed changes:
This PR adds the process needed on the completion step to show a summary of actions. See the design file for reference.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
EKpTaLNcT89FyM3GWu69dr-fi-4504_32787

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Open the SEO assistant from the Jetpack sidebar, follow the steps all the way to the end, confirm the results summary reflects the actions taken.
NOTE: a step that has produced a change can NO LONGER be considered as "skipped". Even if you navigate back and then skip the step, the step has already produced changes and we reflect it on the summary (end) step.