### PR TITLE
Forms: Make file upload field block available in beta and refine its behavior

### DIFF
--- a/projects/packages/forms/changelog/add-experimental-file-upload-field
+++ b/projects/packages/forms/changelog/add-experimental-file-upload-field
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Forms: Add experimental file upload field block to allow visitors to upload files through contact forms. 

--- a/projects/packages/forms/changelog/add-experimental-file-upload-field
+++ b/projects/packages/forms/changelog/add-experimental-file-upload-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Add experimental file upload field block to allow visitors to upload files through contact forms. 

--- a/projects/packages/forms/changelog/refine-file-upload-field
+++ b/projects/packages/forms/changelog/refine-file-upload-field
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Forms: Refine file upload field block to use WordPress upload icon and follow consistent field patterns. 
+Forms: Refine file upload field block to use WordPress upload icon and follow consistent field patterns. Make the block available in beta. 

--- a/projects/packages/forms/changelog/refine-file-upload-field
+++ b/projects/packages/forms/changelog/refine-file-upload-field
@@ -1,4 +1,4 @@
 Significance: patch
-Type: enhancement
+Type: changed
 
 Forms: Refine file upload field block to use WordPress upload icon and follow consistent field patterns. Make the block available in beta. 

--- a/projects/packages/forms/changelog/refine-file-upload-field
+++ b/projects/packages/forms/changelog/refine-file-upload-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Forms: Refine file upload field block to use WordPress upload icon and follow consistent field patterns. 

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -2,7 +2,7 @@ import { InnerBlocks } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { Path, Icon } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
-import { globe, envelope, mobile } from '@wordpress/icons';
+import { globe, envelope, mobile, upload } from '@wordpress/icons';
 import { filter, isEmpty, map, startsWith, trim } from 'lodash';
 import JetpackField from './components/jetpack-field';
 import JetpackFieldCheckbox from './components/jetpack-field-checkbox';
@@ -521,9 +521,7 @@ export const childBlocks = [
 			description: __( 'Allow visitors to upload files through your form.', 'jetpack-forms' ),
 			icon: {
 				foreground: getIconColor(),
-				src: renderMaterialIcon(
-					<Path d="M11 14.5V6.33L8.5 8.83L7.67 8L12 3.67L16.33 8L15.5 8.83L13 6.33V14.5H11ZM12 20.33L7.67 16L8.5 15.17L11 17.67V15.5H13V17.67L15.5 15.17L16.33 16L12 20.33Z" />
-				),
+				src: <Icon icon={ upload } />,
 			},
 			edit: editField( 'file' ),
 			attributes: {

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -536,7 +536,7 @@ export const childBlocks = [
 					default: '',
 				},
 			},
-			isExperimental: true,
+			isBeta: true,
 		},
 	},
 	{

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -171,16 +171,12 @@ class Contact_Form_Block {
 	 * Register beta blocks
 	 */
 	private static function register_beta_blocks() {
-		$blocks_variation = apply_filters( 'jetpack_blocks_variation', \Automattic\Jetpack\Constants::get_constant( 'JETPACK_BLOCKS_VARIATION' ) );
-
-		if ( 'beta' === $blocks_variation ) {
-			Blocks::jetpack_register_block(
-				'jetpack/field-file',
-				array(
-					'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_file' ),
-				)
-			);
-		}
+		Blocks::jetpack_register_block(
+			'jetpack/field-file',
+			array(
+				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_file' ),
+			)
+		);
 	}
 
 	/**

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -162,21 +162,25 @@ class Contact_Form_Block {
 		);
 
 		$blocks_variation = apply_filters( 'jetpack_blocks_variation', \Automattic\Jetpack\Constants::get_constant( 'JETPACK_BLOCKS_VARIATION' ) );
-		if ( 'experimental' === $blocks_variation ) {
-			self::register_experimental_blocks();
+		if ( 'beta' === $blocks_variation ) {
+			self::register_beta_blocks();
 		}
 	}
 
 	/**
-	 * Register experimental blocks
+	 * Register beta blocks
 	 */
-	private static function register_experimental_blocks() {
-		Blocks::jetpack_register_block(
-			'jetpack/field-file',
-			array(
-				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_file' ),
-			)
-		);
+	private static function register_beta_blocks() {
+		$blocks_variation = apply_filters( 'jetpack_blocks_variation', \Automattic\Jetpack\Constants::get_constant( 'JETPACK_BLOCKS_VARIATION' ) );
+
+		if ( 'beta' === $blocks_variation ) {
+			Blocks::jetpack_register_block(
+				'jetpack/field-file',
+				array(
+					'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_file' ),
+				)
+			);
+		}
 	}
 
 	/**

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
@@ -47,23 +47,19 @@ const JetpackField = props => {
 					setAttributes={ setAttributes }
 					style={ formStyle }
 				/>
-				{ type === 'file' ? (
-					<input type="file" className="jetpack-field__input" />
-				) : (
-					<input
-						className="jetpack-field__input"
-						onChange={ e => setAttributes( { placeholder: e.target.value } ) }
-						style={ fieldStyle }
-						type="text"
-						value={ placeholder }
-						onKeyDown={ event => {
-							if ( event.defaultPrevented || event.key !== 'Enter' ) {
-								return;
-							}
-							insertBlocksAfter( createBlock( getDefaultBlockName() ) );
-						} }
-					/>
-				) }
+				<input
+					className="jetpack-field__input"
+					onChange={ e => setAttributes( { placeholder: e.target.value } ) }
+					style={ fieldStyle }
+					type={ type }
+					value={ placeholder }
+					onKeyDown={ event => {
+						if ( event.defaultPrevented || event.key !== 'Enter' ) {
+							return;
+						}
+						insertBlocksAfter( createBlock( getDefaultBlockName() ) );
+					} }
+				/>
 			</div>
 
 			<JetpackFieldControls

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
@@ -53,6 +53,7 @@ const JetpackField = props => {
 					style={ fieldStyle }
 					type={ type }
 					value={ placeholder }
+					onClick={ event => type === 'file' && event.preventDefault() }
 					onKeyDown={ event => {
 						if ( event.defaultPrevented || event.key !== 'Enter' ) {
 							return;

--- a/projects/packages/forms/src/blocks/contact-form/util/register-jetpack-block.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/register-jetpack-block.js
@@ -19,7 +19,7 @@ import { addFilter } from '@wordpress/hooks';
 export default function registerJetpackBlock( name, settings, childBlocks = [], prefix = true ) {
 	const { available, details, unavailableReason } = getJetpackExtensionAvailability( name );
 	const jetpackData = getJetpackData();
-	const isExperimental = jetpackData?.blocks_variation === 'experimental';
+	const isBeta = jetpackData?.blocks_variation === 'beta';
 
 	const requiredPlan = requiresPaidPlan( unavailableReason, details );
 	const jpPrefix = prefix ? 'jetpack/' : '';
@@ -48,8 +48,8 @@ export default function registerJetpackBlock( name, settings, childBlocks = [], 
 	// Register child blocks. Using `registerBlockType()` directly avoids availability checks -- if
 	// their parent is available, we register them all, without checking for their individual availability.
 	childBlocks.forEach( childBlock => {
-		// Skip experimental blocks unless experimental variation is enabled
-		if ( childBlock.settings?.isExperimental && ! isExperimental ) {
+		// Skip beta blocks unless beta variation is enabled
+		if ( childBlock.settings?.isBeta && ! isBeta ) {
 			return;
 		}
 		registerBlockType( jpPrefix + childBlock.name, childBlock.settings );


### PR DESCRIPTION
Fixes #

## Proposed changes:
* Updates the file upload field block from experimental to beta status
* Uses the WordPress upload icon for better visual consistency
* Prevents the file dialog from opening when clicking the field in the editor
* Simplifies block registration to only handle beta blocks, removing experimental block handling
* Updates PHP registration to match JavaScript block registration
* Improves code organization by keeping the file upload field in the childBlocks array

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable?

## Testing instructions:

1. Enable beta blocks by adding this to your `0-sandbox.php`:
   ```php
   define( 'JETPACK_BLOCKS_VARIATION', 'beta' );
   ```
   Or by using the filter:
   ```php
   add_filter( 'jetpack_blocks_variation', function () { return 'beta'; } );
   ```

2. Create or edit a post with the Jetpack Form block
3. Add a new field to the form
4. Verify that:
   - The File Upload field is available in the field options
   - The field uses the WordPress upload icon (instead of a custom icon)
   - The field appears correctly in the editor
   - Clicking the field in the editor does not trigger the file dialog (it should only be interactive on the frontend)
   - The field preview behaves consistently with other form fields

This PR builds upon the work done in #41582, which introduced the initial file upload field implementation. The main changes are moving the block from experimental to beta status and refining its behavior in the editor to be more consistent with WordPress patterns.