### PR TITLE
Blocks: Add get_variation method

### DIFF
--- a/projects/packages/blocks/changelog/add-blocks-get_variation-method
+++ b/projects/packages/blocks/changelog/add-blocks-get_variation-method
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Blocks: added get_variation method

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -510,8 +510,8 @@ class Blocks {
 		/**
 		* Alternative to `JETPACK_EXPERIMENTAL_BLOCKS`, set to `true` to load Experimental Blocks.
 		*
-		* @since 6.9.0
-		* @deprecated 11.8.0 Use jetpack_blocks_variation filter instead.
+		* @since jetpack-6.9.0
+		* @deprecated jetpack-11.8.0 Use jetpack_blocks_variation filter instead.
 		*
 		* @param boolean
 		*/

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -455,4 +455,95 @@ class Blocks {
 
 		return false === $result ? $block_src_dir : $result;
 	}
+
+	/**
+	 * Determine whether a site should use the default set of blocks, or a custom set.
+	 * Possible variations are currently beta, experimental, and production.
+	 *
+	 * @since $$next_version$$
+	 *
+	 * @return string $block_varation production|beta|experimental
+	 */
+	public static function get_variation() {
+		// Default to production blocks.
+		$block_varation = 'production';
+
+		/*
+		 * Prefer to use this JETPACK_BLOCKS_VARIATION constant
+		 * or the jetpack_blocks_variation filter
+		 * to set the block variation in your code.
+		 */
+		$default = Constants::get_constant( 'JETPACK_BLOCKS_VARIATION' );
+		if ( ! empty( $default ) && in_array( $default, array( 'beta', 'experimental', 'production' ), true ) ) {
+			$block_varation = $default;
+		}
+
+		/**
+		* Alternative to `JETPACK_BETA_BLOCKS`, set to `true` to load Beta Blocks.
+		*
+		* @since 6.9.0
+		* @deprecated 11.8.0 Use jetpack_blocks_variation filter instead.
+		*
+		* @param boolean
+		*/
+		$is_beta = apply_filters_deprecated(
+			'jetpack_load_beta_blocks',
+			array( false ),
+			'jetpack-11.8.0',
+			'jetpack_blocks_variation'
+		);
+
+		/*
+		 * Switch to beta blocks if you use the JETPACK_BETA_BLOCKS constant
+		 * or the deprecated jetpack_load_beta_blocks filter.
+		 * This only applies when not using the newer JETPACK_BLOCKS_VARIATION constant.
+		 */
+		if ( empty( $default )
+				&& (
+					$is_beta
+					|| Constants::is_true( 'JETPACK_BETA_BLOCKS' )
+				)
+			) {
+			$block_varation = 'beta';
+		}
+
+		/**
+		* Alternative to `JETPACK_EXPERIMENTAL_BLOCKS`, set to `true` to load Experimental Blocks.
+		*
+		* @since 6.9.0
+		* @deprecated 11.8.0 Use jetpack_blocks_variation filter instead.
+		*
+		* @param boolean
+		*/
+		$is_experimental = apply_filters_deprecated(
+			'jetpack_load_experimental_blocks',
+			array( false ),
+			'jetpack-11.8.0',
+			'jetpack_blocks_variation'
+		);
+
+		/*
+		 * Switch to experimental blocks if you use the JETPACK_EXPERIMENTAL_BLOCKS constant
+		 * or the deprecated jetpack_load_experimental_blocks filter.
+		 * This only applies when not using the newer JETPACK_BLOCKS_VARIATION constant.
+		 */
+		if ( empty( $default )
+			&& (
+				$is_experimental
+				|| Constants::is_true( 'JETPACK_EXPERIMENTAL_BLOCKS' )
+			)
+			) {
+			$block_varation = 'experimental';
+		}
+
+		/**
+		 * Allow customizing the variation of blocks in use on a site.
+		 * Overwrites any previously set values, whether by constant or filter.
+		 *
+		 * @since 8.1.0
+		 *
+		 * @param string $block_variation Can be beta, experimental, and production. Defaults to production.
+		 */
+		return apply_filters( 'jetpack_blocks_variation', $block_varation );
+	}
 }

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -540,7 +540,7 @@ class Blocks {
 		 * Allow customizing the variation of blocks in use on a site.
 		 * Overwrites any previously set values, whether by constant or filter.
 		 *
-		 * @since 8.1.0
+		 * @since jetpack-8.1.0
 		 *
 		 * @param string $block_variation Can be beta, experimental, and production. Defaults to production.
 		 */

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -460,7 +460,7 @@ class Blocks {
 	 * Determine whether a site should use the default set of blocks, or a custom set.
 	 * Possible variations are currently beta, experimental, and production.
 	 *
-	 * @since $$next_version$$
+	 * @since $$next-version$$
 	 *
 	 * @return string $block_varation production|beta|experimental
 	 */

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -481,8 +481,8 @@ class Blocks {
 		/**
 		* Alternative to `JETPACK_BETA_BLOCKS`, set to `true` to load Beta Blocks.
 		*
-		* @since 6.9.0
-		* @deprecated 11.8.0 Use jetpack_blocks_variation filter instead.
+		* @since jetpack-6.9.0
+		* @deprecated jetpack-11.8.0 Use jetpack_blocks_variation filter instead.
 		*
 		* @param boolean
 		*/

--- a/projects/packages/blocks/tests/php/Blocks_Test.php
+++ b/projects/packages/blocks/tests/php/Blocks_Test.php
@@ -520,7 +520,7 @@ class Blocks_Test extends TestCase {
 	 *
 	 * @return array[] Test parameters
 	 */
-	public function get_variation_constants() {
+	public static function get_variation_constants() {
 		return array(
 			'default'                          => array(
 				'expected'      => 'production',
@@ -577,7 +577,7 @@ class Blocks_Test extends TestCase {
 	 *
 	 * @return array[] Test parameters
 	 */
-	public function get_variation_deprecated_filters() {
+	public static function get_variation_deprecated_filters() {
 		return array(
 			'deprecated beta filter'         => array(
 				'expected'    => 'beta',

--- a/projects/packages/blocks/tests/php/Blocks_Test.php
+++ b/projects/packages/blocks/tests/php/Blocks_Test.php
@@ -486,4 +486,128 @@ class Blocks_Test extends TestCase {
 			$this->assertEquals( $expected, $result, "Failed for path: $path" );
 		}
 	}
+
+	/**
+	 * Test getting block variation with various constants.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @dataProvider get_variation_constants
+	 *
+	 * @param string      $expected      Expected variation value.
+	 * @param string|null $constant_name Name of the constant to set, if any.
+	 * @param mixed|null  $constant_val  Value of the constant to set, if any.
+	 *
+	 * @covers Automattic\Jetpack\Blocks::get_variation
+	 */
+	public function test_get_variation_with_constants( $expected, $constant_name, $constant_val ) {
+		if ( $constant_name ) {
+			Jetpack_Constants::set_constant( $constant_name, $constant_val );
+		}
+
+		try {
+			$this->assertEquals( $expected, Blocks::get_variation() );
+		} finally {
+			if ( $constant_name ) {
+				Jetpack_Constants::clear_constants();
+			}
+		}
+	}
+
+	/**
+	 * Data provider for testing block variations with constants.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return array[] Test parameters
+	 */
+	public function get_variation_constants() {
+		return array(
+			'default'                          => array(
+				'expected'      => 'production',
+				'constant_name' => null,
+				'constant_val'  => null,
+			),
+			'valid constant'                   => array(
+				'expected'      => 'beta',
+				'constant_name' => 'JETPACK_BLOCKS_VARIATION',
+				'constant_val'  => 'beta',
+			),
+			'invalid constant'                 => array(
+				'expected'      => 'production',
+				'constant_name' => 'JETPACK_BLOCKS_VARIATION',
+				'constant_val'  => 'invalid',
+			),
+			'old beta blocks constant'         => array(
+				'expected'      => 'beta',
+				'constant_name' => 'JETPACK_BETA_BLOCKS',
+				'constant_val'  => true,
+			),
+			'old experimental blocks constant' => array(
+				'expected'      => 'experimental',
+				'constant_name' => 'JETPACK_EXPERIMENTAL_BLOCKS',
+				'constant_val'  => true,
+			),
+		);
+	}
+
+	/**
+	 * Test getting block variation with various filters.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @dataProvider get_variation_deprecated_filters
+	 *
+	 * @param string $expected    Expected variation value.
+	 * @param string $filter_name Name of the filter to add.
+	 *
+	 * @covers Automattic\Jetpack\Blocks::get_variation
+	 */
+	public function test_get_variation_with_filters( $expected, $filter_name ) {
+		add_filter( $filter_name, '__return_true' );
+		try {
+			$this->assertEquals( $expected, Blocks::get_variation() );
+		} finally {
+			remove_filter( $filter_name, '__return_true' );
+		}
+	}
+
+	/**
+	 * Data provider for testing block variations with filters.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return array[] Test parameters
+	 */
+	public function get_variation_deprecated_filters() {
+		return array(
+			'deprecated beta filter'         => array(
+				'expected'    => 'beta',
+				'filter_name' => 'jetpack_load_beta_blocks',
+			),
+			'deprecated experimental filter' => array(
+				'expected'    => 'experimental',
+				'filter_name' => 'jetpack_load_experimental_blocks',
+			),
+		);
+	}
+
+	/**
+	 * Test getting block variation with jetpack_blocks_variation filter.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @covers Automattic\Jetpack\Blocks::get_variation
+	 */
+	public function test_get_variation_with_new_filter() {
+		$filter = function () {
+			return 'beta';
+		};
+		add_filter( 'jetpack_blocks_variation', $filter );
+		try {
+			$this->assertEquals( 'beta', Blocks::get_variation() );
+		} finally {
+			remove_filter( 'jetpack_blocks_variation', $filter );
+		}
+	}
 }

--- a/projects/packages/blocks/tests/php/Blocks_Test.php
+++ b/projects/packages/blocks/tests/php/Blocks_Test.php
@@ -497,9 +497,8 @@ class Blocks_Test extends TestCase {
 	 * @param string      $expected      Expected variation value.
 	 * @param string|null $constant_name Name of the constant to set, if any.
 	 * @param mixed|null  $constant_val  Value of the constant to set, if any.
-	 *
-	 * @covers Automattic\Jetpack\Blocks::get_variation
 	 */
+	#[DataProvider( 'get_variation_constants' )]
 	public function test_get_variation_with_constants( $expected, $constant_name, $constant_val ) {
 		if ( $constant_name ) {
 			Jetpack_Constants::set_constant( $constant_name, $constant_val );
@@ -560,9 +559,8 @@ class Blocks_Test extends TestCase {
 	 *
 	 * @param string $expected    Expected variation value.
 	 * @param string $filter_name Name of the filter to add.
-	 *
-	 * @covers Automattic\Jetpack\Blocks::get_variation
 	 */
+	#[DataProvider( 'get_variation_deprecated_filters' )]
 	public function test_get_variation_with_filters( $expected, $filter_name ) {
 		add_filter( $filter_name, '__return_true' );
 		try {
@@ -596,8 +594,6 @@ class Blocks_Test extends TestCase {
 	 * Test getting block variation with jetpack_blocks_variation filter.
 	 *
 	 * @since $$next-version$$
-	 *
-	 * @covers Automattic\Jetpack\Blocks::get_variation
 	 */
 	public function test_get_variation_with_new_filter() {
 		$filter = function () {

--- a/projects/packages/forms/changelog/add-blocks-get_variation-method
+++ b/projects/packages/forms/changelog/add-blocks-get_variation-method
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Blocks: added get_variation method

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -185,8 +185,7 @@ class Contact_Form_Block {
 			)
 		);
 
-		$blocks_variation = apply_filters( 'jetpack_blocks_variation', \Automattic\Jetpack\Constants::get_constant( 'JETPACK_BLOCKS_VARIATION' ) );
-		if ( 'beta' === $blocks_variation ) {
+		if ( 'beta' === Blocks::get_variation() ) {
 			self::register_beta_blocks();
 		}
 	}

--- a/projects/plugins/jetpack/changelog/add-blocks-get_variation-method
+++ b/projects/plugins/jetpack/changelog/add-blocks-get_variation-method
@@ -1,5 +1,5 @@
 Significance: patch
 Type: other
-Comment: not useful
+Comment: deprecated Jetpack_Gutenberg::blocks_variation() method for Blocks::get_variation. 
 
 

--- a/projects/plugins/jetpack/changelog/add-blocks-get_variation-method
+++ b/projects/plugins/jetpack/changelog/add-blocks-get_variation-method
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: not useful
+
+

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -856,6 +856,8 @@ class Jetpack_Gutenberg {
 	 *
 	 * @since 8.1.0
 	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Blocks::get_variation instead. Requires the blocks pacakge.
+	 *
 	 * @return string $block_varation production|beta|experimental
 	 */
 	public static function blocks_variation() {

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -298,7 +298,7 @@ class Jetpack_Gutenberg {
 	 */
 	public static function get_jetpack_gutenberg_extensions_allowed_list() {
 		$preset_extensions_manifest = ( defined( 'TESTING_IN_JETPACK' ) && TESTING_IN_JETPACK ) ? array() : self::get_preset();
-		$blocks_variation           = Blocks::blocks_variation();
+		$blocks_variation           = Blocks::get_variation();
 
 		return self::get_extensions_preset_for_variation( $preset_extensions_manifest, $blocks_variation );
 	}

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -671,7 +671,7 @@ class Jetpack_Gutenberg {
 		}
 
 		$blocks_dir       = self::get_blocks_directory();
-		$blocks_variation = self::blocks_variation();
+		$blocks_variation = Blocks::get_variation();
 
 		if ( 'production' !== $blocks_variation ) {
 			$blocks_env = '-' . esc_attr( $blocks_variation );
@@ -859,88 +859,7 @@ class Jetpack_Gutenberg {
 	 * @return string $block_varation production|beta|experimental
 	 */
 	public static function blocks_variation() {
-		// Default to production blocks.
-		$block_varation = 'production';
-
-		/*
-		 * Prefer to use this JETPACK_BLOCKS_VARIATION constant
-		 * or the jetpack_blocks_variation filter
-		 * to set the block variation in your code.
-		 */
-		$default = Constants::get_constant( 'JETPACK_BLOCKS_VARIATION' );
-		if ( ! empty( $default ) && in_array( $default, array( 'beta', 'experimental', 'production' ), true ) ) {
-			$block_varation = $default;
-		}
-
-		/**
-		* Alternative to `JETPACK_BETA_BLOCKS`, set to `true` to load Beta Blocks.
-		*
-		* @since 6.9.0
-		* @deprecated 11.8.0 Use jetpack_blocks_variation filter instead.
-		*
-		* @param boolean
-		*/
-		$is_beta = apply_filters_deprecated(
-			'jetpack_load_beta_blocks',
-			array( false ),
-			'jetpack-11.8.0',
-			'jetpack_blocks_variation'
-		);
-
-		/*
-		 * Switch to beta blocks if you use the JETPACK_BETA_BLOCKS constant
-		 * or the deprecated jetpack_load_beta_blocks filter.
-		 * This only applies when not using the newer JETPACK_BLOCKS_VARIATION constant.
-		 */
-		if (
-			empty( $default )
-			&& (
-				$is_beta
-				|| Constants::is_true( 'JETPACK_BETA_BLOCKS' )
-			)
-		) {
-			$block_varation = 'beta';
-		}
-
-		/**
-		* Alternative to `JETPACK_EXPERIMENTAL_BLOCKS`, set to `true` to load Experimental Blocks.
-		*
-		* @since 6.9.0
-		* @deprecated 11.8.0 Use jetpack_blocks_variation filter instead.
-		*
-		* @param boolean
-		*/
-		$is_experimental = apply_filters_deprecated(
-			'jetpack_load_experimental_blocks',
-			array( false ),
-			'jetpack-11.8.0',
-			'jetpack_blocks_variation'
-		);
-
-		/*
-		 * Switch to experimental blocks if you use the JETPACK_EXPERIMENTAL_BLOCKS constant
-		 * or the deprecated jetpack_load_experimental_blocks filter.
-		 * This only applies when not using the newer JETPACK_BLOCKS_VARIATION constant.
-		 */
-		if (
-			empty( $default )
-			&& (
-				$is_experimental
-				|| Constants::is_true( 'JETPACK_EXPERIMENTAL_BLOCKS' )
-			)
-		) {
-			$block_varation = 'experimental';
-		}
-
-		/**
-		 * Allow customizing the variation of blocks in use on a site.
-		 * Overwrites any previously set values, whether by constant or filter.
-		 *
-		 * @since 8.1.0
-		 *
-		 * @param string $block_variation Can be beta, experimental, and production. Defaults to production.
-		 */
-		return apply_filters( 'jetpack_blocks_variation', $block_varation );
+		return Blocks::get_variation();
 	}
 
 	/**

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -298,7 +298,7 @@ class Jetpack_Gutenberg {
 	 */
 	public static function get_jetpack_gutenberg_extensions_allowed_list() {
 		$preset_extensions_manifest = ( defined( 'TESTING_IN_JETPACK' ) && TESTING_IN_JETPACK ) ? array() : self::get_preset();
-		$blocks_variation           = self::blocks_variation();
+		$blocks_variation           = Blocks::blocks_variation();
 
 		return self::get_extensions_preset_for_variation( $preset_extensions_manifest, $blocks_variation );
 	}

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -859,7 +859,7 @@ class Jetpack_Gutenberg {
 	 * @return string $block_varation production|beta|experimental
 	 */
 	public static function blocks_variation() {
-		_deprecated_function( __METHOD__, $$next-version$$, 'Automattic\\Jetpack\\Blocks::get_variation' );
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\\Jetpack\\Blocks::get_variation' );
 		return Blocks::get_variation();
 	}
 

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -859,6 +859,7 @@ class Jetpack_Gutenberg {
 	 * @return string $block_varation production|beta|experimental
 	 */
 	public static function blocks_variation() {
+		_deprecated_function( __METHOD__, $$next-version$$, 'Automattic\\Jetpack\\Blocks::get_variation' );
 		return Blocks::get_variation();
 	}
 


### PR DESCRIPTION
This Pr adds a helper method for getting the variation that you want to use. 

Note:
The new method could also be used in the videopress package but I wasn't sure how I would go about testing this. 
Also currently the package doesn't have the blocks dependency. 

@jeherve How should I deprecate the jetpack method. Should I add the `_doing_it_wrong` ? 

## Proposed changes:
* Adds new method.
* use the new method in jetpack and the forms package.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Load the PR. 
* Go to the block editor. 
* Notice that if you have the variation 'beta' set that you see some beta blocks. 

* Notice that you see some experiments blocks as well if you have the experimental variation set. 


