### PR TITLE
Revert file field changes

### DIFF
--- a/projects/packages/forms/changelog/add-file-upload-field
+++ b/projects/packages/forms/changelog/add-file-upload-field
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Forms: Add a new file upload field block to allow visitors to upload files through contact forms. 

--- a/projects/packages/forms/changelog/refine-file-upload-field
+++ b/projects/packages/forms/changelog/refine-file-upload-field
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Forms: Refine file upload field block to use WordPress upload icon and follow consistent field patterns. Make the block available in beta. 

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -2,7 +2,7 @@ import { InnerBlocks } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { Path, Icon } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
-import { globe, envelope, mobile, upload } from '@wordpress/icons';
+import { globe, envelope, mobile } from '@wordpress/icons';
 import { filter, isEmpty, map, startsWith, trim } from 'lodash';
 import JetpackField from './components/jetpack-field';
 import JetpackFieldCheckbox from './components/jetpack-field-checkbox';
@@ -521,7 +521,9 @@ export const childBlocks = [
 			description: __( 'Allow visitors to upload files through your form.', 'jetpack-forms' ),
 			icon: {
 				foreground: getIconColor(),
-				src: <Icon icon={ upload } />,
+				src: renderMaterialIcon(
+					<Path d="M11 14.5V6.33L8.5 8.83L7.67 8L12 3.67L16.33 8L15.5 8.83L13 6.33V14.5H11ZM12 20.33L7.67 16L8.5 15.17L11 17.67V15.5H13V17.67L15.5 15.17L16.33 16L12 20.33Z" />
+				),
 			},
 			edit: editField( 'file' ),
 			attributes: {
@@ -536,7 +538,7 @@ export const childBlocks = [
 					default: '',
 				},
 			},
-			isBeta: true,
+			isExperimental: true,
 		},
 	},
 	{

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -381,7 +381,7 @@ export const childBlocks = [
 		settings: {
 			...FieldDefaults,
 			title: __( 'Name Field', 'jetpack-forms' ),
-			description: __( "Collect the site visitor's name.", 'jetpack-forms' ),
+			description: __( 'Collect the site visitor’s name.', 'jetpack-forms' ),
 			icon: {
 				foreground: getIconColor(),
 				src: renderMaterialIcon(
@@ -506,39 +506,6 @@ export const childBlocks = [
 					role: 'content',
 				},
 			},
-		},
-	},
-	{
-		name: 'field-file',
-		settings: {
-			...FieldDefaults,
-			title: __( 'File Upload Field', 'jetpack-forms' ),
-			keywords: [
-				__( 'File', 'jetpack-forms' ),
-				__( 'Upload', 'jetpack-forms' ),
-				__( 'Attachment', 'jetpack-forms' ),
-			],
-			description: __( 'Allow visitors to upload files through your form.', 'jetpack-forms' ),
-			icon: {
-				foreground: getIconColor(),
-				src: renderMaterialIcon(
-					<Path d="M11 14.5V6.33L8.5 8.83L7.67 8L12 3.67L16.33 8L15.5 8.83L13 6.33V14.5H11ZM12 20.33L7.67 16L8.5 15.17L11 17.67V15.5H13V17.67L15.5 15.17L16.33 16L12 20.33Z" />
-				),
-			},
-			edit: editField( 'file' ),
-			attributes: {
-				...FieldDefaults.attributes,
-				label: {
-					type: 'string',
-					default: __( 'Upload a file', 'jetpack-forms' ),
-					role: 'content',
-				},
-				filetype: {
-					type: 'string',
-					default: '',
-				},
-			},
-			isExperimental: true,
 		},
 	},
 	{

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -162,15 +162,15 @@ class Contact_Form_Block {
 		);
 
 		$blocks_variation = apply_filters( 'jetpack_blocks_variation', \Automattic\Jetpack\Constants::get_constant( 'JETPACK_BLOCKS_VARIATION' ) );
-		if ( 'beta' === $blocks_variation ) {
-			self::register_beta_blocks();
+		if ( 'experimental' === $blocks_variation ) {
+			self::register_experimental_blocks();
 		}
 	}
 
 	/**
-	 * Register beta blocks
+	 * Register experimental blocks
 	 */
-	private static function register_beta_blocks() {
+	private static function register_experimental_blocks() {
 		Blocks::jetpack_register_block(
 			'jetpack/field-file',
 			array(

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -160,23 +160,6 @@ class Contact_Form_Block {
 				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_consent' ),
 			)
 		);
-
-		$blocks_variation = apply_filters( 'jetpack_blocks_variation', \Automattic\Jetpack\Constants::get_constant( 'JETPACK_BLOCKS_VARIATION' ) );
-		if ( 'experimental' === $blocks_variation ) {
-			self::register_experimental_blocks();
-		}
-	}
-
-	/**
-	 * Register experimental blocks
-	 */
-	private static function register_experimental_blocks() {
-		Blocks::jetpack_register_block(
-			'jetpack/field-file',
-			array(
-				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_file' ),
-			)
-		);
 	}
 
 	/**

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
@@ -47,20 +47,23 @@ const JetpackField = props => {
 					setAttributes={ setAttributes }
 					style={ formStyle }
 				/>
-				<input
-					className="jetpack-field__input"
-					onChange={ e => setAttributes( { placeholder: e.target.value } ) }
-					style={ fieldStyle }
-					type={ type }
-					value={ placeholder }
-					onClick={ event => type === 'file' && event.preventDefault() }
-					onKeyDown={ event => {
-						if ( event.defaultPrevented || event.key !== 'Enter' ) {
-							return;
-						}
-						insertBlocksAfter( createBlock( getDefaultBlockName() ) );
-					} }
-				/>
+				{ type === 'file' ? (
+					<input type="file" className="jetpack-field__input" />
+				) : (
+					<input
+						className="jetpack-field__input"
+						onChange={ e => setAttributes( { placeholder: e.target.value } ) }
+						style={ fieldStyle }
+						type="text"
+						value={ placeholder }
+						onKeyDown={ event => {
+							if ( event.defaultPrevented || event.key !== 'Enter' ) {
+								return;
+							}
+							insertBlocksAfter( createBlock( getDefaultBlockName() ) );
+						} }
+					/>
+				) }
 			</div>
 
 			<JetpackFieldControls

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
@@ -23,7 +23,6 @@ const JetpackField = props => {
 		placeholder,
 		width,
 		insertBlocksAfter,
-		type,
 	} = props;
 
 	const { blockStyle, fieldStyle } = useJetpackFieldStyles( attributes );
@@ -47,23 +46,19 @@ const JetpackField = props => {
 					setAttributes={ setAttributes }
 					style={ formStyle }
 				/>
-				{ type === 'file' ? (
-					<input type="file" className="jetpack-field__input" />
-				) : (
-					<input
-						className="jetpack-field__input"
-						onChange={ e => setAttributes( { placeholder: e.target.value } ) }
-						style={ fieldStyle }
-						type="text"
-						value={ placeholder }
-						onKeyDown={ event => {
-							if ( event.defaultPrevented || event.key !== 'Enter' ) {
-								return;
-							}
-							insertBlocksAfter( createBlock( getDefaultBlockName() ) );
-						} }
-					/>
-				) }
+				<input
+					className="jetpack-field__input"
+					onChange={ e => setAttributes( { placeholder: e.target.value } ) }
+					style={ fieldStyle }
+					type="text"
+					value={ placeholder }
+					onKeyDown={ event => {
+						if ( event.defaultPrevented || event.key !== 'Enter' ) {
+							return;
+						}
+						insertBlocksAfter( createBlock( getDefaultBlockName() ) );
+					} }
+				/>
 			</div>
 
 			<JetpackFieldControls

--- a/projects/packages/forms/src/blocks/contact-form/util/register-jetpack-block.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/register-jetpack-block.js
@@ -19,7 +19,7 @@ import { addFilter } from '@wordpress/hooks';
 export default function registerJetpackBlock( name, settings, childBlocks = [], prefix = true ) {
 	const { available, details, unavailableReason } = getJetpackExtensionAvailability( name );
 	const jetpackData = getJetpackData();
-	const isBeta = jetpackData?.blocks_variation === 'beta';
+	const isExperimental = jetpackData?.blocks_variation === 'experimental';
 
 	const requiredPlan = requiresPaidPlan( unavailableReason, details );
 	const jpPrefix = prefix ? 'jetpack/' : '';
@@ -48,8 +48,8 @@ export default function registerJetpackBlock( name, settings, childBlocks = [], 
 	// Register child blocks. Using `registerBlockType()` directly avoids availability checks -- if
 	// their parent is available, we register them all, without checking for their individual availability.
 	childBlocks.forEach( childBlock => {
-		// Skip beta blocks unless beta variation is enabled
-		if ( childBlock.settings?.isBeta && ! isBeta ) {
+		// Skip experimental blocks unless experimental variation is enabled
+		if ( childBlock.settings?.isExperimental && ! isExperimental ) {
 			return;
 		}
 		registerBlockType( jpPrefix + childBlock.name, childBlock.settings );

--- a/projects/packages/forms/src/blocks/contact-form/util/register-jetpack-block.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/register-jetpack-block.js
@@ -2,7 +2,6 @@ import {
 	getJetpackExtensionAvailability,
 	withHasWarningIsInteractiveClassNames,
 	requiresPaidPlan,
-	getJetpackData,
 } from '@automattic/jetpack-shared-extension-utils';
 import { registerBlockType } from '@wordpress/blocks';
 import { addFilter } from '@wordpress/hooks';
@@ -18,8 +17,6 @@ import { addFilter } from '@wordpress/hooks';
  */
 export default function registerJetpackBlock( name, settings, childBlocks = [], prefix = true ) {
 	const { available, details, unavailableReason } = getJetpackExtensionAvailability( name );
-	const jetpackData = getJetpackData();
-	const isExperimental = jetpackData?.blocks_variation === 'experimental';
 
 	const requiredPlan = requiresPaidPlan( unavailableReason, details );
 	const jpPrefix = prefix ? 'jetpack/' : '';
@@ -47,13 +44,9 @@ export default function registerJetpackBlock( name, settings, childBlocks = [], 
 
 	// Register child blocks. Using `registerBlockType()` directly avoids availability checks -- if
 	// their parent is available, we register them all, without checking for their individual availability.
-	childBlocks.forEach( childBlock => {
-		// Skip experimental blocks unless experimental variation is enabled
-		if ( childBlock.settings?.isExperimental && ! isExperimental ) {
-			return;
-		}
-		registerBlockType( jpPrefix + childBlock.name, childBlock.settings );
-	} );
+	childBlocks.forEach( childBlock =>
+		registerBlockType( jpPrefix + childBlock.name, childBlock.settings )
+	);
 
 	return result;
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -494,19 +494,6 @@ class Contact_Form_Plugin {
 	}
 
 	/**
-	 * Render the file upload field.
-	 *
-	 * @param array  $atts - the block attributes.
-	 * @param string $content - html content.
-	 *
-	 * @return string HTML for the file upload field.
-	 */
-	public static function gutenblock_render_field_file( $atts, $content ) {
-		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'file' );
-		return Contact_Form::parse_contact_field( $atts, $content );
-	}
-
-	/**
 	 * Add the 'Form Responses' menu item as a submenu of Feedback.
 	 */
 	public function admin_menu() {


### PR DESCRIPTION
## Proposed changes:
Proposes reverting  #41582 and #41586

From what I can see these PRs result in the file field block being available in production, while the PR implies they should be experimental/beta.

The main impact of this is that if a user has added this block, they'll see a message "Your site doesn't include support for the "jetpack/field-file" block" after this. The block won't appear in the frontend, but everything else (the editor, other blocks) works without issue

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Open the editor
2. Try adding the 'File Upload Field' block, it shouldn't be possible

