### PR TITLE
Boost: Run the 404 tester when concatenate modules are enabled

### DIFF
--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -72,6 +72,10 @@ function jetpack_boost_check_404_handler( $request_uri ) {
  * This function is called when the Minify_CSS or Minify_JS module is activated.
  */
 function jetpack_boost_404_tester() {
+	if ( defined( 'JETPACK_BOOST_DISABLE_404_TESTER' ) && JETPACK_BOOST_DISABLE_404_TESTER ) {
+		return;
+	}
+
 	wp_remote_get( home_url( '/wp-content/boost-cache/static/testing_404' ) );
 	if ( file_exists( Config::get_static_cache_dir_path() . '/404' ) ) {
 		wp_delete_file( Config::get_static_cache_dir_path() . '/404' );

--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -68,8 +68,9 @@ function jetpack_boost_check_404_handler( $request_uri ) {
  * This function is used to test if is_404() is working in wp-content/
  * It sends a request to a non-existent URL, that will execute the 404 handler
  * in jetpack_boost_check_404_handler().
+ * Define the constant JETPACK_BOOST_DISABLE_404_TESTER to disable this.
  *
- * This function is called when the Minify_CSS or Minify_JS module is activated.
+ * This function is called when the Minify_CSS or Minify_JS module is activated, and once per day.
  */
 function jetpack_boost_404_tester() {
 	if ( defined( 'JETPACK_BOOST_DISABLE_404_TESTER' ) && JETPACK_BOOST_DISABLE_404_TESTER ) {

--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -77,7 +77,7 @@ function jetpack_boost_404_tester() {
 		return;
 	}
 
-	$minification_enabled = 0;
+	$minification_enabled = '';
 	wp_remote_get( home_url( '/wp-content/boost-cache/static/testing_404' ) );
 	if ( file_exists( Config::get_static_cache_dir_path() . '/404' ) ) {
 		wp_delete_file( Config::get_static_cache_dir_path() . '/404' );

--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -77,13 +77,17 @@ function jetpack_boost_404_tester() {
 		return;
 	}
 
+	$minification_enabled = 0;
 	wp_remote_get( home_url( '/wp-content/boost-cache/static/testing_404' ) );
 	if ( file_exists( Config::get_static_cache_dir_path() . '/404' ) ) {
 		wp_delete_file( Config::get_static_cache_dir_path() . '/404' );
-		update_site_option( 'jetpack_boost_static_minification', 1 );
+		$minification_enabled = 1;
 	} else {
-		update_site_option( 'jetpack_boost_static_minification', 0 );
+		$minification_enabled = 0;
 	}
+	update_site_option( 'jetpack_boost_static_minification', $minification_enabled );
+
+	return $minification_enabled;
 }
 add_action( 'jetpack_boost_404_tester_cron', 'jetpack_boost_404_tester' );
 

--- a/projects/plugins/boost/app/modules/optimizations/minify/class-minify-css.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/class-minify-css.php
@@ -3,12 +3,13 @@
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Minify;
 
 use Automattic\Jetpack_Boost\Contracts\Changes_Page_Output;
+use Automattic\Jetpack_Boost\Contracts\Has_Activate;
 use Automattic\Jetpack_Boost\Contracts\Has_Deactivate;
 use Automattic\Jetpack_Boost\Contracts\Optimization;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Minify\Concatenate_CSS;
 
-class Minify_CSS implements Pluggable, Changes_Page_Output, Optimization, Has_Deactivate {
+class Minify_CSS implements Pluggable, Changes_Page_Output, Optimization, Has_Activate, Has_Deactivate {
 
 	public static $default_excludes = array( 'admin-bar', 'dashicons', 'elementor-app' );
 
@@ -47,6 +48,10 @@ class Minify_CSS implements Pluggable, Changes_Page_Output, Optimization, Has_De
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wp_styles                         = new Concatenate_CSS( $wp_styles );
 		$wp_styles->allow_gzip_compression = true; // @todo - used constant ALLOW_GZIP_COMPRESSION = true if not defined.
+	}
+
+	public static function activate() {
+		jetpack_boost_404_tester();
 	}
 
 	public static function deactivate() {

--- a/projects/plugins/boost/app/modules/optimizations/minify/class-minify-js.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/class-minify-js.php
@@ -3,12 +3,13 @@
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Minify;
 
 use Automattic\Jetpack_Boost\Contracts\Changes_Page_Output;
+use Automattic\Jetpack_Boost\Contracts\Has_Activate;
 use Automattic\Jetpack_Boost\Contracts\Has_Deactivate;
 use Automattic\Jetpack_Boost\Contracts\Optimization;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Minify\Concatenate_JS;
 
-class Minify_JS implements Pluggable, Changes_Page_Output, Optimization, Has_Deactivate {
+class Minify_JS implements Pluggable, Changes_Page_Output, Optimization, Has_Activate, Has_Deactivate {
 
 	public static $default_excludes = array( 'jquery', 'jquery-core', 'underscore', 'backbone' );
 
@@ -47,6 +48,10 @@ class Minify_JS implements Pluggable, Changes_Page_Output, Optimization, Has_Dea
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wp_scripts                         = new Concatenate_JS( $wp_scripts );
 		$wp_scripts->allow_gzip_compression = true; // @todo - used constant ALLOW_GZIP_COMPRESSION = true if not defined.
+	}
+
+	public static function activate() {
+		jetpack_boost_404_tester();
 	}
 
 	public static function deactivate() {

--- a/projects/plugins/boost/changelog/update-boost-404-test-activate
+++ b/projects/plugins/boost/changelog/update-boost-404-test-activate
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Minification: run the 404 tester when activating either of the minification/concatenation modules.
+
+

--- a/projects/plugins/boost/tests/php/lib/minify/test-functions-service.php
+++ b/projects/plugins/boost/tests/php/lib/minify/test-functions-service.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Tests\Lib\Minify;
+
+use Automattic\Jetpack_Boost\Lib\Minify\Config;
+use Automattic\Jetpack_Boost\Tests\Base_Test_Case;
+use Brain\Monkey\Functions;
+
+class Test_Functions_Service extends Base_Test_Case {
+	protected function set_up() {
+		parent::set_up();
+
+		if ( ! defined( 'WP_CONTENT_DIR' ) ) {
+			define( 'WP_CONTENT_DIR', '/tmp/wordpress/wp-content' );
+		}
+
+		// Mock add_action
+		Functions\expect( 'add_action' )->andReturn( true );
+
+		// Clean up any test files before each test
+		if ( file_exists( Config::get_static_cache_dir_path() . '/404' ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_exists
+			unlink( Config::get_static_cache_dir_path() . '/404' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+		}
+		require_once __DIR__ . '/../../../../app/lib/minify/loader.php';
+	}
+
+	public function test_404_tester_when_404_file_exists() {
+		// Create mock 404 file
+		$cache_dir = Config::get_static_cache_dir_path();
+		if ( ! is_dir( $cache_dir ) ) {
+			mkdir( $cache_dir, 0775, true ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+		}
+		file_put_contents( $cache_dir . '/404', '1' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+
+		Functions\expect( 'home_url' )
+			->once()
+			->with( '/wp-content/boost-cache/static/testing_404' )
+			->andReturn( 'http://example.com/wp-content/boost-cache/static/testing_404' );
+
+		Functions\expect( 'wp_remote_get' )
+			->once()
+			->with( 'http://example.com/wp-content/boost-cache/static/testing_404' );
+
+		Functions\expect( 'wp_delete_file' )
+			->once()
+			->with( $cache_dir . '/404' );
+
+		Functions\expect( 'update_site_option' )
+			->once()
+			->with( 'jetpack_boost_static_minification', 1 );
+
+		$this->assertEquals( 1, jetpack_boost_404_tester() );
+	}
+
+	public function test_404_tester_when_404_file_does_not_exist() {
+		Functions\expect( 'home_url' )
+			->once()
+			->with( '/wp-content/boost-cache/static/testing_404' )
+			->andReturn( 'http://example.com/wp-content/boost-cache/static/testing_404' );
+
+		Functions\expect( 'wp_remote_get' )
+			->once()
+			->with( 'http://example.com/wp-content/boost-cache/static/testing_404' );
+
+		Functions\expect( 'update_site_option' )
+			->once()
+			->with( 'jetpack_boost_static_minification', 0 );
+
+		$this->assertEquals( 0, jetpack_boost_404_tester() );
+	}
+
+	public function test_404_tester_disabled_by_constant() {
+		if ( ! defined( 'JETPACK_BOOST_DISABLE_404_TESTER' ) ) {
+			define( 'JETPACK_BOOST_DISABLE_404_TESTER', true );
+		}
+
+		Functions\expect( 'wp_remote_get' )->never();
+		Functions\expect( 'update_site_option' )->never();
+
+		$this->assertEquals( '', jetpack_boost_404_tester() );
+	}
+
+	protected function tear_down() {
+		parent::tear_down();
+
+		// Clean up any test files after each test
+		if ( file_exists( Config::get_static_cache_dir_path() . '/404' ) ) {
+			unlink( Config::get_static_cache_dir_path() . '/404' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+		}
+
+		$path = '/tmp/wordpress/wp-content/boost-cache/static/';
+		while ( $path !== '/tmp' ) {
+			if ( is_dir( $path ) ) {
+				rmdir( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
+			}
+			$path = dirname( $path );
+		}
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Make sure to run the 404 tester each time either of the concatenate modules is enabled. This lets the plugin react more quickly to changes in wp-content/ in case mod_rewrite support has changed.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added Activate trait to concatenate classes


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pc9hqz-3kc-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Apply the PR
* Add an error_log to the activate functions added to confirm they're called.
* Toggle both concatenate modules off and on again.
* Run tests with `composer phpunit` from projects/plugins/boost/