### PR TITLE
Update broken PHPDoc blocks.

### DIFF
--- a/projects/packages/classic-theme-helper/changelog/update-broken-phpdoc
+++ b/projects/packages/classic-theme-helper/changelog/update-broken-phpdoc
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Updated a comment, not changing any logic.
+
+

--- a/projects/packages/classic-theme-helper/src/social-menu.php
+++ b/projects/packages/classic-theme-helper/src/social-menu.php
@@ -23,17 +23,17 @@ if ( ! function_exists( 'jetpack_social_menu_init' ) ) {
 			return;
 		}
 
-		/*
-		* Social Menu description.
-		*
-		* Rename the social menu description.
-		*
-		* @module theme-tools
-		*
-		* @since 3.9.0
-		*
-		* @param string $social_menu_description Social Menu description
-		*/
+		/**
+		 * Social Menu description.
+		 *
+		 * Rename the social menu description.
+		 *
+		 * @module theme-tools
+		 *
+		 * @since 3.9.0
+		 *
+		 * @param string $social_menu_description Social Menu description
+		 */
 		$social_menu_description = apply_filters( 'jetpack_social_menu_description', __( 'Social Menu', 'jetpack-classic-theme-helper' ) );
 
 		// Register a new menu location

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -1204,6 +1204,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			|| ( Jetpack::is_plugin_active( 'under-construction-page/under-construction.php' ) && isset( $ucp_options['status'] ) && 1 == $ucp_options['status'] ) // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 			|| ( Jetpack::is_plugin_active( 'ultimate-under-construction/ultimate-under-construction.php' ) && isset( $uuc_settings['enable'] ) && 1 == $uuc_settings['enable'] ) // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 			|| ( Jetpack::is_plugin_active( 'coming-soon/coming-soon.php' ) && isset( $csp4['status'] ) && ( 1 == $csp4['status'] || 2 == $csp4['status'] ) ) // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+			||
 			/**
 			 * Allow plugins to mark a site as "under construction".
 			 *
@@ -1211,7 +1212,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			 *
 			 * @param false bool Is the site under construction? Default to false.
 			 */
-			|| true === apply_filters( 'jetpack_is_under_construction_plugin', false )
+			true === apply_filters( 'jetpack_is_under_construction_plugin', false )
 		) {
 			return new WP_Error( 'forbidden', __( 'Site is under construction and cannot be verified', 'jetpack' ) );
 		}

--- a/projects/plugins/jetpack/changelog/update-broken-phpdoc
+++ b/projects/plugins/jetpack/changelog/update-broken-phpdoc
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated a comment, not changing any logic.
+
+

--- a/projects/plugins/jetpack/modules/shortcodes/youtube.php
+++ b/projects/plugins/jetpack/modules/shortcodes/youtube.php
@@ -623,6 +623,7 @@ add_filter( 'oembed_fetch_url', 'wpcom_youtube_oembed_fetch_url', 10, 2 );
 
 if (
 	! is_admin()
+	&&
 	/**
 	 * Allow oEmbeds in Jetpack's Comment form.
 	 *
@@ -632,7 +633,7 @@ if (
 	 *
 	 * @param int $allow_oembed Option to automatically embed all plain text URLs.
 	 */
-	&& apply_filters( 'jetpack_comments_allow_oembed', true )
+	apply_filters( 'jetpack_comments_allow_oembed', true )
 	// No need for this on WordPress.com, this is done for multiple shortcodes at a time there.
 	&& ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM )
 ) {

--- a/projects/plugins/jetpack/modules/theme-tools/social-menu.php
+++ b/projects/plugins/jetpack/modules/theme-tools/social-menu.php
@@ -25,17 +25,17 @@ if ( ! class_exists( '\Automattic\Jetpack\Classic_Theme_Helper\Main' ) ) {
 				return;
 			}
 
-			/*
-			* Social Menu description.
-			*
-			* Rename the social menu description.
-			*
-			* @module theme-tools
-			*
-			* @since 3.9.0
-			*
-			* @param string $social_menu_description Social Menu description
-			*/
+			/**
+			 * Social Menu description.
+			 *
+			 * Rename the social menu description.
+			 *
+			 * @module theme-tools
+			 *
+			 * @since 3.9.0
+			 *
+			 * @param string $social_menu_description Social Menu description
+			 */
 			$social_menu_description = apply_filters( 'jetpack_social_menu_description', __( 'Social Menu', 'jetpack' ) );
 
 			// Register a new menu location


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
* Updates several PHPDoc blocks to be properly picked up by the Jetpack CLI `docs` command.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
* No logic change in this PR, so shouldn't require any testing.
