### PR TITLE
Social: Update `social/settings` route registration

### DIFF
--- a/projects/packages/publicize/changelog/update-social-settings-route-registration
+++ b/projects/packages/publicize/changelog/update-social-settings-route-registration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Only register social/settings endpoint if Jetpack version does not have it

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -306,7 +306,7 @@ class Publicize_Script_Data {
 		$commom_paths = array(
 			'refreshConnections' => '/wpcom/v2/publicize/connections?test_connections=1',
 			// The complete path will be like `/jetpack/v4/social/settings`.
-			'socialToggleBase'   => Utils::has_new_module_endpoint() ? 'settings' : 'social/settings',
+			'socialToggleBase'   => Utils::should_use_jetpack_module_endpoint() ? 'settings' : 'social/settings',
 		);
 
 		$specific_paths = array();

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -306,7 +306,7 @@ class Publicize_Script_Data {
 		$commom_paths = array(
 			'refreshConnections' => '/wpcom/v2/publicize/connections?test_connections=1',
 			// The complete path will be like `/jetpack/v4/social/settings`.
-			'socialToggleBase'   => class_exists( 'Jetpack' ) ? 'settings' : 'social/settings',
+			'socialToggleBase'   => Utils::has_new_module_endpoint() ? 'settings' : 'social/settings',
 		);
 
 		$specific_paths = array();

--- a/projects/packages/publicize/src/class-publicize-utils.php
+++ b/projects/packages/publicize/src/class-publicize-utils.php
@@ -109,4 +109,13 @@ class Publicize_Utils {
 			throw new \Exception( esc_html( "Method $method can only be called on WordPress.com." ) );
 		}
 	}
+
+	/**
+	 * Check if the new module endpoint is available in the used Jetpack version.
+	 *
+	 * @return bool
+	 */
+	public static function has_new_module_endpoint() {
+		return class_exists( 'Jetpack' ) && defined( 'JETPACK__VERSION' ) && ( version_compare( JETPACK__VERSION, '13.4', '>=' ) );
+	}
 }

--- a/projects/packages/publicize/src/class-publicize-utils.php
+++ b/projects/packages/publicize/src/class-publicize-utils.php
@@ -112,11 +112,12 @@ class Publicize_Utils {
 
 	/**
 	 * Check if the new module endpoint is available in the used Jetpack version.
+	 * More: https://github.com/Automattic/jetpack-reach/issues/794
 	 *
 	 * @return bool
 	 */
-	public static function has_new_module_endpoint() {
+	public static function should_use_jetpack_module_endpoint() {
 		// @phan-suppress-next-line PhanTypeMismatchArgumentNullableInternal - Phan thinks JETPACK__VERSION is not a string (it is).
-		return class_exists( 'Jetpack' ) && defined( 'JETPACK__VERSION' ) && ( version_compare( JETPACK__VERSION, '14.3', '>=' ) );
+		return class_exists( 'Jetpack' ) && defined( 'JETPACK__VERSION' ) && ( version_compare( (string) JETPACK__VERSION, '14.3', '>=' ) );
 	}
 }

--- a/projects/packages/publicize/src/class-publicize-utils.php
+++ b/projects/packages/publicize/src/class-publicize-utils.php
@@ -106,14 +106,14 @@ class Publicize_Utils {
 	 */
 	public static function assert_is_wpcom( $method ) {
 		if ( ! self::is_wpcom() ) {
-			throw new \Exception( esc_html( "Method $method can only b`e called on WordPress.com." ) );
+			throw new \Exception( esc_html( "Method $method can only be called on WordPress.com." ) );
 		}
 	}
 
 	/**
 	 * Check if the new module endpoint is available in the used Jetpack version.
 	 * We need the module status in response that's why we do the version check https://github.com/Automattic/jetpack/pull/41461/files#diff-f8e5ef1115599de750b64143dd1901554254eddd95ab4371b6b6b3b2a5914224R638-R642.
-	 * More: https://github.com/Automattic/jetpack-reach/issues/794
+	 * More: https://github.com/Automattic/jetpack/pull/41596.
 	 *
 	 * @return bool
 	 */

--- a/projects/packages/publicize/src/class-publicize-utils.php
+++ b/projects/packages/publicize/src/class-publicize-utils.php
@@ -116,6 +116,6 @@ class Publicize_Utils {
 	 * @return bool
 	 */
 	public static function has_new_module_endpoint() {
-		return class_exists( 'Jetpack' ) && defined( 'JETPACK__VERSION' ) && ( version_compare( JETPACK__VERSION, '13.4', '>=' ) );
+		return class_exists( 'Jetpack' ) && defined( 'JETPACK__VERSION' ) && ( version_compare( JETPACK__VERSION, '14.3', '>=' ) );
 	}
 }

--- a/projects/packages/publicize/src/class-publicize-utils.php
+++ b/projects/packages/publicize/src/class-publicize-utils.php
@@ -106,18 +106,18 @@ class Publicize_Utils {
 	 */
 	public static function assert_is_wpcom( $method ) {
 		if ( ! self::is_wpcom() ) {
-			throw new \Exception( esc_html( "Method $method can only be called on WordPress.com." ) );
+			throw new \Exception( esc_html( "Method $method can only b`e called on WordPress.com." ) );
 		}
 	}
 
 	/**
 	 * Check if the new module endpoint is available in the used Jetpack version.
+	 * We need the module status in response that's why we do the version check https://github.com/Automattic/jetpack/pull/41461/files#diff-f8e5ef1115599de750b64143dd1901554254eddd95ab4371b6b6b3b2a5914224R638-R642.
 	 * More: https://github.com/Automattic/jetpack-reach/issues/794
 	 *
 	 * @return bool
 	 */
 	public static function should_use_jetpack_module_endpoint() {
-		// @phan-suppress-next-line PhanTypeMismatchArgumentNullableInternal - Phan thinks JETPACK__VERSION is not a string (it is).
 		return class_exists( 'Jetpack' ) && defined( 'JETPACK__VERSION' ) && ( version_compare( (string) JETPACK__VERSION, '14.3', '>=' ) );
 	}
 }

--- a/projects/packages/publicize/src/class-publicize-utils.php
+++ b/projects/packages/publicize/src/class-publicize-utils.php
@@ -116,6 +116,7 @@ class Publicize_Utils {
 	 * @return bool
 	 */
 	public static function has_new_module_endpoint() {
+		// @phan-suppress-next-line PhanTypeMismatchArgumentNullableInternal - Phan thinks JETPACK__VERSION is not a string (it is).
 		return class_exists( 'Jetpack' ) && defined( 'JETPACK__VERSION' ) && ( version_compare( JETPACK__VERSION, '14.3', '>=' ) );
 	}
 }

--- a/projects/plugins/social/changelog/update-social-settings-route-registration
+++ b/projects/plugins/social/changelog/update-social-settings-route-registration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Only register social/settings endpoint if Jetpack version does not have it

--- a/projects/plugins/social/src/class-rest-settings-controller.php
+++ b/projects/plugins/social/src/class-rest-settings-controller.php
@@ -9,6 +9,7 @@
 namespace Automattic\Jetpack\Social;
 
 use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\Publicize\Publicize_Utils;
 use Jetpack_Social;
 use WP_Error;
 use WP_REST_Controller;
@@ -26,24 +27,28 @@ class REST_Settings_Controller extends WP_REST_Controller {
 	 * @static
 	 */
 	public function register_rest_routes() {
-		register_rest_route(
-			'jetpack/v4',
-			'/social/settings',
-			array(
+		// If the site has an older version of Jetpack we still need to register the route.
+		if ( ! Publicize_Utils::has_new_module_endpoint() ) {
+			register_rest_route(
+				'jetpack/v4',
+				'/social/settings',
 				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_item' ),
-					'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
-					'args'                => $this->get_endpoint_args_for_item_schema(),
-				),
-				array(
-					'methods'             => WP_REST_Server::EDITABLE,
-					'callback'            => array( $this, 'update_item' ),
-					'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
-					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
-				),
-			)
-		);
+					array(
+						'methods'             => WP_REST_Server::READABLE,
+						'callback'            => array( $this, 'get_item' ),
+						'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
+						'args'                => $this->get_endpoint_args_for_item_schema(),
+					),
+					array(
+						'methods'             => WP_REST_Server::EDITABLE,
+						'callback'            => array( $this, 'update_item' ),
+						'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
+						'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+					),
+				)
+			);
+		}
+
 		register_rest_route(
 			'jetpack/v4',
 			'/social/review-dismiss',

--- a/projects/plugins/social/src/class-rest-settings-controller.php
+++ b/projects/plugins/social/src/class-rest-settings-controller.php
@@ -27,28 +27,6 @@ class REST_Settings_Controller extends WP_REST_Controller {
 	 * @static
 	 */
 	public function register_rest_routes() {
-		// If the site has an older version of Jetpack we still need to register the route.
-		if ( ! Publicize_Utils::has_new_module_endpoint() ) {
-			register_rest_route(
-				'jetpack/v4',
-				'/social/settings',
-				array(
-					array(
-						'methods'             => WP_REST_Server::READABLE,
-						'callback'            => array( $this, 'get_item' ),
-						'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
-						'args'                => $this->get_endpoint_args_for_item_schema(),
-					),
-					array(
-						'methods'             => WP_REST_Server::EDITABLE,
-						'callback'            => array( $this, 'update_item' ),
-						'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
-						'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
-					),
-				)
-			);
-		}
-
 		register_rest_route(
 			'jetpack/v4',
 			'/social/review-dismiss',
@@ -57,6 +35,30 @@ class REST_Settings_Controller extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => array( $this, 'update_review_dismissed' ),
 					'permission_callback' => array( $this, 'require_publish_posts_permission_callback' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				),
+			)
+		);
+
+		if ( Publicize_Utils::should_use_jetpack_module_endpoint() ) {
+			return;
+		}
+
+		// If the site has an older version of Jetpack we still need to register the route.
+		register_rest_route(
+			'jetpack/v4',
+			'/social/settings',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
+					'args'                => $this->get_endpoint_args_for_item_schema(),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
 					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 				),
 			)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/790
Fixes https://github.com/Automattic/jetpack-reach/issues/794

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Only register `social/settings` endpoint if the current Jetpack version does not have it
* Use the available endpoint based on the same check.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You need to test different versions for this change.
* Check trunk social with Jetpack at least 13.4 - The module toggle should use the JP settings endpoint
* Check trunk social with older Jetpack - the `social/settings` route should get registered and used on the module toggle
* Toggle path for Jetpack new versions: `wp-json/jetpack/v4/settings?_locale=user`
* Toggle path for Jetpack older versions: `wp-json/jetpack/v4/social/settings?_locale=user`

