### PR TITLE
Update/dont sync set object terms action for blacklisted taxonomies

### DIFF
--- a/projects/packages/sync/changelog/update-dont-sync-set-object-terms-action-for-blacklisted-taxonomies
+++ b/projects/packages/sync/changelog/update-dont-sync-set-object-terms-action-for-blacklisted-taxonomies
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Sync: Full sync for posts not sending term relationships

--- a/projects/packages/sync/src/modules/class-posts.php
+++ b/projects/packages/sync/src/modules/class-posts.php
@@ -809,7 +809,7 @@ class Posts extends Module {
 	 * @deprecated since $$next-version$$
 	 */
 	public function add_term_relationships( $args ) {
-		_deprecated_function( __METHOD__, 'next-version' );
+		_deprecated_function( __METHOD__, '$$next-version$$' );
 		list( $filtered_posts, $previous_interval_end ) = $args;
 
 		return array(

--- a/projects/packages/sync/src/modules/class-posts.php
+++ b/projects/packages/sync/src/modules/class-posts.php
@@ -228,7 +228,7 @@ class Posts extends Module {
 		// Full sync.
 		$sync_module = Modules::get_module( 'full-sync' );
 		if ( $sync_module instanceof Full_Sync_Immediately ) {
-			add_filter( 'jetpack_sync_before_send_jetpack_full_sync_posts', array( $this, 'add_term_relationships' ) );
+			add_filter( 'jetpack_sync_before_send_jetpack_full_sync_posts', array( $this, 'build_full_sync_action_array' ) );
 		} else {
 			add_filter( 'jetpack_sync_before_send_jetpack_full_sync_posts', array( $this, 'expand_posts_with_metadata_and_terms' ) );
 		}
@@ -780,6 +780,25 @@ class Posts extends Module {
 	}
 
 	/**
+	 * Build the full sync action object for Posts.
+	 *
+	 * @access public
+	 *
+	 * @param array $args An array with the posts and the previous end.
+	 *
+	 * @return array An array with the posts, postmeta and the previous end.
+	 */
+	public function build_full_sync_action_array( $args ) {
+		list( $filtered_posts, $previous_end ) = $args;
+		return array(
+			$filtered_posts['objects'],
+			$filtered_posts['meta'],
+			array(), // WPCOM does not process term relationships in full sync posts actions for a while now, let's skip them.
+			$previous_end,
+		);
+	}
+
+	/**
 	 * Add term relationships to post objects within a hook before they are serialized and sent to the server.
 	 * This is used in Full Sync Immediately
 	 *
@@ -787,8 +806,10 @@ class Posts extends Module {
 	 *
 	 * @param array $args The hook parameters.
 	 * @return array $args The expanded hook parameters.
+	 * @deprecated since $$next-version$$
 	 */
 	public function add_term_relationships( $args ) {
+		_deprecated_function( __METHOD__, 'next-version' );
 		list( $filtered_posts, $previous_interval_end ) = $args;
 
 		return array(

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -231,7 +231,7 @@ class WooCommerce_HPOS_Orders extends Module {
 	 * @deprecated since $$next-version$$
 	 */
 	public function expand_order_objects( $args ) {
-		_deprecated_function( __METHOD__, 'next-version' );
+		_deprecated_function( __METHOD__, '$$next-version$$' );
 		list( $order_ids, $previous_end ) = $args;
 		return array(
 			'orders'       => $this->get_objects_by_id( 'order', $order_ids ),

--- a/projects/plugins/jetpack/changelog/update-dont-sync-set-object-terms-action-for-blacklisted-taxonomies
+++ b/projects/plugins/jetpack/changelog/update-dont-sync-set-object-terms-action-for-blacklisted-taxonomies
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Sync: Full sync for posts not sending term relationships

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
@@ -679,24 +679,6 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 'foo5', $this->server_replica_storage->get_metadata( 'post', $post_id, 'a_public_meta', true ) );
 	}
 
-	public function test_full_sync_sends_all_post_terms() {
-		$post_id = self::factory()->post->create();
-		wp_set_object_terms( $post_id, 'tag', 'post_tag' );
-
-		$this->sender->do_sync();
-		$terms = get_the_terms( $post_id, 'post_tag' );
-
-		$this->assertEqualsObject( $terms, $this->server_replica_storage->get_the_terms( $post_id, 'post_tag' ), 'Initial sync doesn\'t work' );
-		// reset the storage, check value, and do full sync - storage should be set!
-		$this->server_replica_storage->reset();
-
-		$this->assertFalse( $this->server_replica_storage->get_the_terms( $post_id, 'post_tag' ), 'Not empty' );
-		$this->full_sync->start();
-		$this->sender->do_full_sync();
-
-		$this->assertEqualsObject( $terms, $this->server_replica_storage->get_the_terms( $post_id, 'post_tag' ), 'Full sync doesn\'t work' );
-	}
-
 	public function test_full_sync_sends_all_comment_meta() {
 		$post_id     = self::factory()->post->create();
 		$comment_ids = self::factory()->comment->create_post_comments( $post_id );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/vulcan/issues/668
Full sync for post actions is not using the terms since D37014-code, we should not fetch it and send it.
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Send an empty array but keep the structure intact so that we don't need to change wpcom processing.
* Changed the name of the hook since `add_term_relationships` is not correct anymore and also used the same name as other modules the same we did in https://github.com/Automattic/jetpack/pull/41433. Ideally `build_full_sync_action_array` should be moved to the parent class (module)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* After deleting posts in your wpcom cached site, run a full sync for posts and check that things are working as expected.