### PR TITLE
Jetpack: add connection owner info to dashboard

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/connections.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/connections.jsx
@@ -10,6 +10,7 @@ import Gridicon from 'components/gridicon';
 import {
 	getSiteConnectionStatus,
 	isConnectionOwner,
+	isConnectionOwnerName,
 	isCurrentUserLinked,
 	isOfflineMode,
 	isFetchingUserData as _isFetchingUserData,
@@ -77,9 +78,23 @@ export class DashConnections extends Component {
 								</span>
 							) }
 
-							{ this.props.userCanDisconnectSite && (
+							{ ! this.props.isConnectionOwner && this.props.isConnectionOwnerName && (
+								<span className="jp-connection-settings__is-owner">
+									{ sprintf(
+										/* translators: Placeholder is the WordPress user login name. */
+										__( 'The connection owner is %s.', 'jetpack' ),
+										this.props.isConnectionOwnerName
+									) }
+								</span>
+							) }
+
+							{ this.props.userCanDisconnectSite ? (
 								<div className="jp-connection-settings__actions">
 									<ConnectButton asLink autoOpenInDisconnectRoute={ true } />
+								</div>
+							) : (
+								<div className="jp-connection-settings__actions">
+									<span>{ __( 'This site is connected to WordPress.com.', 'jetpack' ) }</span>
 								</div>
 							) }
 						</div>
@@ -232,6 +247,7 @@ export default connect( state => {
 		userGravatar: getUserGravatar( state ),
 		username: getUsername( state ),
 		isConnectionOwner: isConnectionOwner( state ),
+		isConnectionOwnerName: isConnectionOwnerName( state ),
 		isLinked: isCurrentUserLinked( state ),
 		siteIcon: getSiteIcon( state ),
 		isFetchingUserData: _isFetchingUserData( state ),

--- a/projects/plugins/jetpack/_inc/client/state/connection/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/connection/reducer.js
@@ -349,6 +349,16 @@ export function isConnectionOwner( state ) {
 }
 
 /**
+ * Returns connection owner name.
+ *
+ * @param {object} state - Global state tree
+ * @return {string} Return connection owner name.
+ */
+export function isConnectionOwnerName( state ) {
+	return state.jetpack.connection.user?.connectionOwner;
+}
+
+/**
  * Returns true if the site has a connected owner.
  *
  * @param {object} state - Global state tree

--- a/projects/plugins/jetpack/_inc/client/state/connection/test/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/connection/test/reducer.js
@@ -5,6 +5,7 @@ import {
 	requests as requestsReducer,
 	connectionRequests,
 	hasSeenWCConnectionModal,
+	isConnectionOwnerName,
 } from '../reducer';
 
 describe( 'status reducer', () => {
@@ -234,5 +235,30 @@ describe( '#hasSeenWCConnectionModal', () => {
 		};
 		const stateOut = hasSeenWCConnectionModal( stateIn, action );
 		expect( stateOut ).toBe( true );
+	} );
+} );
+describe( 'isConnectionOwnerName Selector', () => {
+	test( 'returns the connection owner name if it exists', () => {
+		const state = {
+			jetpack: {
+				connection: {
+					user: {
+						connectionOwner: 'John Doe',
+					},
+				},
+			},
+		};
+		expect( isConnectionOwnerName( state ) ).toBe( 'John Doe' );
+	} );
+
+	test( 'returns undefined if connection owner name does not exist', () => {
+		const state = {
+			jetpack: {
+				connection: {
+					user: {},
+				},
+			},
+		};
+		expect( isConnectionOwnerName( state ) ).toBeUndefined();
 	} );
 } );

--- a/projects/plugins/jetpack/changelog/fix-dashboard-connection-info
+++ b/projects/plugins/jetpack/changelog/fix-dashboard-connection-info
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Dashboard: Display connection owner to all users.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR matches some of the work done for connection information in My Jetpack in https://github.com/Automattic/jetpack/pull/41520

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Non-admin users will see "This site is connected to WordPress.com" notice instead of a blank Site Connection card when the site is connected. They won't see the Manage connection button.
* All users will see the username of the connection owner when one exists.

<img width="783" alt="Screenshot 2025-02-06 at 18 15 08" src="https://github.com/user-attachments/assets/c6d570e1-e71e-4568-be85-15bbcd5ad56b" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pghT6q-4b-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You will need a JN site and two WPcom accounts.
* Create a secondary WP account with an admin role, but don't connect it.
* Connect only the site and check what the secondary admin sees.
* Switch the role for secondary admin to non-admin role and recheck the dashboard.
* Connect the primary account and check what the non-admin sees. It should be as in the image above.
* Connect the non-admin. Everything should work.
* Switch back the non-admin role to admin one. Recheck the dashboard. The owner info should be there along with the Manage connection button.
