### PR TITLE
Add/transient to cache backup api calls

### DIFF
--- a/projects/packages/my-jetpack/changelog/add-transient-to-cache-backup-api-calls
+++ b/projects/packages/my-jetpack/changelog/add-transient-to-cache-backup-api-calls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Cache calls to backup API in My Jetpack

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -65,7 +65,6 @@ class Initializer {
 	const VIDEOPRESS_STATS_KEY                           = 'my-jetpack-videopress-stats';
 	const VIDEOPRESS_PERIOD_KEY                          = 'my-jetpack-videopress-period';
 	const MY_JETPACK_RED_BUBBLE_TRANSIENT_KEY            = 'my-jetpack-red-bubble-transient';
-	const BACKUP_STATUS_TRANSIENT_KEY                    = 'my-jetpack-backup-status';
 
 	/**
 	 * Holds info/data about the site (from the /sites/%d endpoint)

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -65,6 +65,7 @@ class Initializer {
 	const VIDEOPRESS_STATS_KEY                           = 'my-jetpack-videopress-stats';
 	const VIDEOPRESS_PERIOD_KEY                          = 'my-jetpack-videopress-period';
 	const MY_JETPACK_RED_BUBBLE_TRANSIENT_KEY            = 'my-jetpack-red-bubble-transient';
+	const BACKUP_STATUS_TRANSIENT_KEY                    = 'my-jetpack-backup-status';
 
 	/**
 	 * Holds info/data about the site (from the /sites/%d endpoint)

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -71,6 +71,8 @@ class Backup extends Hybrid_Product {
 	 */
 	public static $feature_identifying_paid_plan = 'backups';
 
+	public const BACKUP_STATUS_TRANSIENT_KEY = 'my-jetpack-backup-status';
+
 	/**
 	 * Get the product name
 	 *
@@ -243,6 +245,13 @@ class Backup extends Hybrid_Product {
 	 * @return boolean|array
 	 */
 	public static function does_module_need_attention() {
+		$previous_backup_status = get_transient( self::BACKUP_STATUS_TRANSIENT_KEY );
+
+		// If we have a previous backup status, show it.
+		if ( ! empty( $previous_backup_status ) ) {
+			return $previous_backup_status;
+		}
+
 		$backup_failed_status = false;
 		// First check the status of Rewind for failure.
 		$rewind_state = self::get_state_from_wpcom();
@@ -282,6 +291,12 @@ class Backup extends Hybrid_Product {
 					);
 				}
 			}
+		}
+
+		if ( is_array( $backup_failed_status ) && $backup_failed_status['type'] === 'error' ) {
+			set_transient( self::BACKUP_STATUS_TRANSIENT_KEY, $backup_failed_status, 5 * MINUTE_IN_SECONDS );
+		} else {
+			set_transient( self::BACKUP_STATUS_TRANSIENT_KEY, 'successful', HOUR_IN_SECONDS );
 		}
 
 		return $backup_failed_status;

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -249,7 +249,7 @@ class Backup extends Hybrid_Product {
 
 		// If we have a previous backup status, show it.
 		if ( ! empty( $previous_backup_status ) ) {
-			return $previous_backup_status;
+			return $previous_backup_status === 'no_errors' ? false : $previous_backup_status;
 		}
 
 		$backup_failed_status = false;
@@ -296,7 +296,7 @@ class Backup extends Hybrid_Product {
 		if ( is_array( $backup_failed_status ) && $backup_failed_status['type'] === 'error' ) {
 			set_transient( self::BACKUP_STATUS_TRANSIENT_KEY, $backup_failed_status, 5 * MINUTE_IN_SECONDS );
 		} else {
-			set_transient( self::BACKUP_STATUS_TRANSIENT_KEY, 'successful', HOUR_IN_SECONDS );
+			set_transient( self::BACKUP_STATUS_TRANSIENT_KEY, 'no_errors', HOUR_IN_SECONDS );
 		}
 
 		return $backup_failed_status;


### PR DESCRIPTION
## Proposed changes:

Currently we are making 2 API calls to WPCOM for the backup card (if a backup plan is active) on every page load

* Cache Backup API calls in My Jetpack to avoid calling them on every page load
* Cache for 5 minutes if there was an error with their last backup, that way they can check to see if it was fixed if they try troubleshooting it
* Cache for 1 hour if the previous backup was successful so that, if there is a backup with an error, they'll know about it within an hour if they go to My Jetpack

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment (local environment is preferred here so you can delete the transient if you need to)
2. If you go to My Jetpack before the backup has errors, you'll have to delete the transient. You can do this by putting the following line of code above [this line](https://github.com/Automattic/jetpack/pull/41608/files#diff-0f5b867186de1fe5907ea282632cd26b682e52d6df22611b4e897a9ce6a9697aR248)
```php
delete_transient( self::BACKUP_STATUS_TRANSIENT_KEY );
```
3. Connect your site and user account
4. Purchase a VaultPress Backup plan for your site
5. Go to `/wp-admin/admin.php?page=jetpack-backup` and trigger a backup
6. Right after doing that, disconnect your site so that the backup will fail
7. Go to My Jetpack and ensure you see the error
![image](https://github.com/user-attachments/assets/3527311b-06f2-4952-ab54-46ce7054a95a)
8. Open up the query monitor and see that a request to `/rewind` and `/rewind/backup` were made
![Screenshot 2025-02-06 at 11 22 04 AM](https://github.com/user-attachments/assets/5dfb10ab-22cb-4aea-b39e-8ed77069ead2)
9. Refresh the page, and ensure those requests were not made again (as long as you didn't wait 5 minutes to refresh)
10. If you'd like, you can re-trigger the backup to ensure it was successful, wait 5 minutes from the last time you went to My Jetpack and ensure the request is made again, and the error is gone
![image](https://github.com/user-attachments/assets/f8d076fd-3b3c-482c-903c-bb833978b5ee)

If you'd like to check the transient values, you can run this locally and add the following line to `projects/packages/my-jetpack/src/products/class-backup.php` line 249
```php
l( $previous_backup_status );
```

