### PR TITLE
Forms: Fixes date validation bug

### DIFF
--- a/projects/packages/forms/changelog/fix-date-validation-bug
+++ b/projects/packages/forms/changelog/fix-date-validation-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fixes the date format input if multiple date pickers are used with different date formats.

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -889,8 +889,6 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 		wp_enqueue_style( 'jp-jquery-ui-datepicker', plugins_url( '../../dist/contact-form/css/jquery-ui-datepicker.css', __FILE__ ), array( 'dashicons' ), '1.0' );
 
-		// Using Core's built-in datepicker localization routine
-		wp_localize_jquery_ui_datepicker();
 		return $field;
 	}
 

--- a/projects/packages/forms/src/contact-form/js/grunion-frontend.js
+++ b/projects/packages/forms/src/contact-form/js/grunion-frontend.js
@@ -1,13 +1,15 @@
 jQuery( function ( $ ) {
 	const $input = $( '.contact-form input.jp-contact-form-date' );
-	const dateFormat = $input.attr( 'data-format' ) || 'yy-mm-dd';
-
-	$input.datepicker( {
-		dateFormat,
-		constrainInput: false,
-		showOptions: { direction: 'down' },
-		onSelect: function () {
-			$( this ).focus();
-		},
+	$input.each( function () {
+		const el = $( this );
+		const dateFormat = el.attr( 'data-format' ) || 'yy-mm-dd';
+		el.datepicker( {
+			dateFormat,
+			constrainInput: false,
+			showOptions: { direction: 'down' },
+			onSelect: function () {
+				$( this ).focus();
+			},
+		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #41599

In this video you can see. 
1. The site is using a different locale. The calendar is translated into German. 
2. You are able to pick different formats and submit the form. 
3. If you enter wrong formats validate still works as expected. 

https://github.com/user-attachments/assets/5c544808-d592-4077-b846-12c9a0647ade

## Proposed changes:
* Make sure that we only include the date picker required js once on the page. 
* Make sure that we loop though the different date picker inputs and respect the date format if they are different. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Load this Pr. 
* Add 3 date pickers on the page. have different date picker formats. 
* As a visitor make sure that you can submit all the different date pickers as expected. 
