### PR TITLE
Optimize scan data by ensuring we only call it once per page load

### DIFF
--- a/projects/packages/my-jetpack/changelog/add-transient-to-cache-protect-api-calls
+++ b/projects/packages/my-jetpack/changelog/add-transient-to-cache-protect-api-calls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Cache scan calls if no threats are found to improve performance

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -234,7 +234,10 @@ class Initializer {
 			$previous_score = $speed_score_history->latest( 1 );
 		}
 		$latest_score['previousScores'] = $previous_score['scores'] ?? array();
-		$scan_data                      = Products\Protect::get_protect_data();
+
+		Products\Protect::initialize();
+		$scan_data = Products\Protect::get_protect_data();
+
 		self::update_historically_active_jetpack_modules();
 
 		$waf_config    = array();

--- a/projects/packages/my-jetpack/src/products/class-protect.php
+++ b/projects/packages/my-jetpack/src/products/class-protect.php
@@ -7,13 +7,11 @@
 
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
-use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\My_Jetpack\Hybrid_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
+use Automattic\Jetpack\Protect_Models\Status_Model;
 use Automattic\Jetpack\Protect_Status\Status as Protect_Status;
 use Automattic\Jetpack\Redirect;
-use Jetpack_Options;
-use WP_Error;
 
 /**
  * Class responsible for handling the Protect product
@@ -24,8 +22,9 @@ class Protect extends Hybrid_Product {
 	const UPGRADED_TIER_SLUG         = 'upgraded';
 	const UPGRADED_TIER_PRODUCT_SLUG = 'jetpack_scan';
 
-	const SCAN_FEATURE_SLUG     = 'scan';
-	const FIREWALL_FEATURE_SLUG = 'firewall';
+	const SCAN_FEATURE_SLUG                  = 'scan';
+	const FIREWALL_FEATURE_SLUG              = 'firewall';
+	const PROTECT_THREAT_COUNT_TRANSIENT_KEY = 'protect_threat_count';
 
 	/**
 	 * The product slug
@@ -131,36 +130,9 @@ class Protect extends Hybrid_Product {
 	}
 
 	/**
-	 * Hits the wpcom api to check scan status.
-	 *
-	 * @todo Maybe add caching.
-	 *
-	 * @return Object|WP_Error
-	 */
-	private static function get_state_from_wpcom() {
-		static $status = null;
-
-		if ( $status !== null ) {
-			return $status;
-		}
-
-		$site_id = Jetpack_Options::get_option( 'id' );
-
-		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/scan', $site_id ) . '?force=wpcom', '2', array( 'timeout' => 2 ), null, 'wpcom' );
-
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return new WP_Error( 'scan_state_fetch_failed' );
-		}
-
-		$body   = wp_remote_retrieve_body( $response );
-		$status = json_decode( $body );
-		return $status;
-	}
-
-	/**
 	 * Get the normalized protect/scan data
 	 *
-	 * @return Object|WP_Error
+	 * @return Status_Model
 	 */
 	public static function get_protect_data() {
 		return Protect_Status::get_status();
@@ -289,6 +261,12 @@ class Protect extends Hybrid_Product {
 	 * @return boolean|array
 	 */
 	public static function does_module_need_attention() {
+		$previous_critical_threat_count = get_transient( self::PROTECT_THREAT_COUNT_TRANSIENT_KEY );
+
+		if ( 'no_threats' === $previous_critical_threat_count ) {
+			return false;
+		}
+
 		$protect_threat_status = false;
 
 		// Check if there are scan threats.
@@ -314,6 +292,11 @@ class Protect extends Hybrid_Product {
 					'fixable_threat_ids'    => $protect_data->fixable_threat_ids,
 				),
 			);
+		}
+
+		// If no threats were found, cache results for an hour so we aren't hitting the API on every page load.
+		if ( $critical_threat_count === false ) {
+			set_transient( self::PROTECT_THREAT_COUNT_TRANSIENT_KEY, 'no_threats', HOUR_IN_SECONDS );
 		}
 
 		return $protect_threat_status;

--- a/projects/packages/my-jetpack/src/products/class-protect.php
+++ b/projects/packages/my-jetpack/src/products/class-protect.php
@@ -22,9 +22,8 @@ class Protect extends Hybrid_Product {
 	const UPGRADED_TIER_SLUG         = 'upgraded';
 	const UPGRADED_TIER_PRODUCT_SLUG = 'jetpack_scan';
 
-	const SCAN_FEATURE_SLUG                  = 'scan';
-	const FIREWALL_FEATURE_SLUG              = 'firewall';
-	const PROTECT_THREAT_COUNT_TRANSIENT_KEY = 'protect_threat_count';
+	const SCAN_FEATURE_SLUG     = 'scan';
+	const FIREWALL_FEATURE_SLUG = 'firewall';
 
 	/**
 	 * The product slug

--- a/projects/packages/my-jetpack/src/products/class-protect.php
+++ b/projects/packages/my-jetpack/src/products/class-protect.php
@@ -80,6 +80,20 @@ class Protect extends Hybrid_Product {
 	public static $feature_identifying_paid_plan = 'scan';
 
 	/**
+	 * Holds the scan data
+	 *
+	 * @var Status_Model
+	 */
+	private static $scan_data;
+
+	/**
+	 * Protect constructor.
+	 */
+	public static function initialize() {
+		self::$scan_data = Protect_Status::get_status();
+	}
+
+	/**
 	 * Get the product name
 	 *
 	 * @return string
@@ -130,15 +144,6 @@ class Protect extends Hybrid_Product {
 	}
 
 	/**
-	 * Get the normalized protect/scan data
-	 *
-	 * @return Status_Model
-	 */
-	public static function get_protect_data() {
-		return Protect_Status::get_status();
-	}
-
-	/**
 	 * Get the product's available tiers
 	 *
 	 * @return string[] Slugs of the available tiers
@@ -148,6 +153,15 @@ class Protect extends Hybrid_Product {
 			self::UPGRADED_TIER_SLUG,
 			self::FREE_TIER_SLUG,
 		);
+	}
+
+	/**
+	 * Get the normalized protect/scan data
+	 *
+	 * @return Status_Model
+	 */
+	public static function get_protect_data() {
+		return self::$scan_data;
 	}
 
 	/**
@@ -261,16 +275,10 @@ class Protect extends Hybrid_Product {
 	 * @return boolean|array
 	 */
 	public static function does_module_need_attention() {
-		$previous_critical_threat_count = get_transient( self::PROTECT_THREAT_COUNT_TRANSIENT_KEY );
-
-		if ( 'no_threats' === $previous_critical_threat_count ) {
-			return false;
-		}
-
 		$protect_threat_status = false;
 
 		// Check if there are scan threats.
-		$protect_data = self::get_protect_data();
+		$protect_data = self::$scan_data;
 		if ( is_wp_error( $protect_data ) ) {
 			return $protect_threat_status; // false
 		}
@@ -292,11 +300,6 @@ class Protect extends Hybrid_Product {
 					'fixable_threat_ids'    => $protect_data->fixable_threat_ids,
 				),
 			);
-		}
-
-		// If no threats were found, cache results for an hour so we aren't hitting the API on every page load.
-		if ( $critical_threat_count === false ) {
-			set_transient( self::PROTECT_THREAT_COUNT_TRANSIENT_KEY, 'no_threats', HOUR_IN_SECONDS );
 		}
 
 		return $protect_threat_status;

--- a/projects/packages/my-jetpack/src/products/class-scan.php
+++ b/projects/packages/my-jetpack/src/products/class-scan.php
@@ -7,11 +7,9 @@
 
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
-use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\My_Jetpack\Module_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 use Automattic\Jetpack\Redirect;
-use Jetpack_Options;
 use WP_Error;
 
 /**
@@ -115,47 +113,6 @@ class Scan extends Module_Product {
 	}
 
 	/**
-	 * Hits the wpcom api to check scan status.
-	 *
-	 * @todo Maybe add caching.
-	 *
-	 * @return object|WP_Error
-	 */
-	private static function get_state_from_wpcom() {
-		static $status = null;
-
-		if ( $status !== null ) {
-			return $status;
-		}
-
-		$site_id = Jetpack_Options::get_option( 'id' );
-
-		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/scan', $site_id ) . '?force=wpcom', '2', array( 'timeout' => 2 ), null, 'wpcom' );
-
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			$status = new WP_Error( 'scan_state_fetch_failed' );
-			return $status;
-		}
-
-		$body   = wp_remote_retrieve_body( $response );
-		$status = json_decode( $body );
-		return $status;
-	}
-
-	/**
-	 * Checks whether the current plan (or purchases) of the site already supports the product
-	 *
-	 * @return boolean
-	 */
-	public static function has_required_plan() {
-		$scan_data = static::get_state_from_wpcom();
-		if ( is_wp_error( $scan_data ) ) {
-			return false;
-		}
-		return is_object( $scan_data ) && isset( $scan_data->state ) && 'unavailable' !== $scan_data->state;
-	}
-
-	/**
 	 * Checks whether the Product is active
 	 *
 	 * Scan is not actually a module. Activation takes place on WPCOM. So lets consider it active if jetpack is active and has the plan.
@@ -163,7 +120,7 @@ class Scan extends Module_Product {
 	 * @return boolean
 	 */
 	public static function is_active() {
-		return static::is_jetpack_plugin_active() && static::has_required_plan();
+		return static::is_jetpack_plugin_active();
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-scan.php
+++ b/projects/packages/my-jetpack/src/products/class-scan.php
@@ -119,7 +119,7 @@ class Scan extends Module_Product {
 	 *
 	 * @todo Maybe add caching.
 	 *
-	 * @return Object|WP_Error
+	 * @return object|WP_Error
 	 */
 	private static function get_state_from_wpcom() {
 		static $status = null;

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -13,7 +13,6 @@ use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\My_Jetpack\Hybrid_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 use Automattic\Jetpack\Search\Module_Control as Search_Module_Control;
-use Jetpack_Options;
 use WP_Error;
 
 /**
@@ -270,39 +269,6 @@ class Search extends Hybrid_Product {
 		$body                      = wp_remote_retrieve_body( $response );
 		$pricings[ $record_count ] = json_decode( $body, true );
 		return $pricings[ $record_count ];
-	}
-
-	/**
-	 * Hits the wpcom api to check Search status.
-	 *
-	 * @todo Maybe add caching.
-	 *
-	 * @return Object|WP_Error
-	 */
-	private static function get_state_from_wpcom() {
-		static $status = null;
-
-		if ( $status !== null ) {
-			return $status;
-		}
-
-		$blog_id = Jetpack_Options::get_option( 'id' );
-
-		$response = Client::wpcom_json_api_request_as_blog(
-			'/sites/' . $blog_id . '/jetpack-search/plan',
-			'2',
-			array( 'timeout' => 5 ),
-			null,
-			'wpcom'
-		);
-
-		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return new WP_Error( 'search_state_fetch_failed' );
-		}
-
-		$body   = wp_remote_retrieve_body( $response );
-		$status = json_decode( $body );
-		return $status;
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:
Right now we are calling the Scan API multiple times. Once when we are gathering scan data for the card, and once when checking for scan threats. 

* Add an initializer class to the Protect class that calls the Scan endpoint and populates a `$scan_data` variable
* Update uses of scan data to get the data from this variable instead of calling the same endpoint for different uses of the data

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Install/activate Jetpack Protect with a paid Scan upgrade/plan
3. Go to My Jetpack and, using the Query Monitor, ensure that we are only making one http request to the Scan endpoint
![Screenshot 2025-02-06 at 1 53 25 PM](https://github.com/user-attachments/assets/dde75e93-3c48-49a0-8993-f3424671f27b)

