### PR TITLE
Jetpack SEO: fix assistant chat options

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-seo-assistant-chat-spacings
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-seo-assistant-chat-spacings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO: fix gap/spacing between chat bubbles and options

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/style.scss
@@ -63,6 +63,7 @@
 
 	&__content {
 		flex: 1 1 auto;
+		gap: 8px;
 		display: flex;
 		flex-direction: column;
 		height: 100%;
@@ -78,11 +79,24 @@
 		flex: 1 1 auto;
 		display: flex;
 		flex-direction: column;
-		gap: 16px;
-		padding: 8px 8px 8px 0;
+		gap: 8px;
+		padding: 0 8px;
 		overflow-y: auto;
 		scroll-behavior: smooth;
 		align-items: flex-start;
+
+		// weirdly placed here, this makes the first option have a top margin
+		& > .assistant-wizard__message.is-option {
+			margin-top: 8px;
+		}
+
+		& > .assistant-wizard__message.is-option ~ .assistant-wizard__message.is-option {
+			margin-top: 0px;
+		}
+
+		& > .assistant-wizard__message.is-option:last-of-type {
+			margin-bottom: 8px;
+		}
 	}
 
 	&__message {
@@ -93,6 +107,11 @@
 		display: flex;
 		align-items: center;
 		max-width: 255px;
+
+		&:not( .is-option ) {
+			margin-top: 8px;
+			margin-bottom: 8px;
+		}
 
 		.assistant-wizard__message-icon {
 			flex-shrink: 0;
@@ -121,6 +140,10 @@
 			.assistant-wizard__message-icon {
 				display: none;
 			}
+		}
+
+		&.is-option {
+			align-self: flex-start;
 		}
 	}
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-messages.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-messages.tsx
@@ -69,6 +69,7 @@ export const MessageBubble = ( { message, onSelect = ( m: Message ) => m } ) => 
 		<div
 			className={ clsx( 'assistant-wizard__message', {
 				'is-user': message.isUser,
+				'is-option': message.type === 'option',
 			} ) }
 		>
 			<div className="assistant-wizard__message-icon">


### PR DESCRIPTION
Fixes #41573

## Proposed changes:
This PR addresses a design issue affecting option messages alignment and spacings

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
EKpTaLNcT89FyM3GWu69dr-fi-4504_32787

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Open the SEO assistant and advance to the title step. See that the spacing between the options is less (8px) than regular message spacing (8 margin + 8 gap).
See the options are now aligned to the left