### PR TITLE
Launchpad in My Home: Do not show First post modal if coming from the Launchpad

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/do-not-show-first-post-modal-if-publish-first-post-hash
+++ b/projects/packages/jetpack-mu-wpcom/changelog/do-not-show-first-post-modal-if-publish-first-post-hash
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Block Editor Nux: Do not show first post modal when the publish-first-post hash is present.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-first-post-modal-redirect-to-home
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-first-post-modal-redirect-to-home
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Block Editor Nux: Return to my home when hash to idenifify first publish post is present.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-first-post-modal-redirect-to-home
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-first-post-modal-redirect-to-home
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Block Editor Nux: Return to my home when hash to idenifify first publish post is present.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/first-post-published-modal/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/first-post-published-modal/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { isURL } from '@wordpress/url';
+import { getQueryArg, isURL } from '@wordpress/url';
 import React from 'react';
 import postPublishedImage from '../../../../assets/images/post-published.svg';
 import { useSiteIntent, useShouldShowFirstPostPublishedModal } from '../../../../common/tour-kit';
@@ -48,6 +48,8 @@ const FirstPostPublishedModalInner: React.FC = () => {
 		siteUrl = new URL( siteUrlOption ).hostname;
 	}
 
+	const isLaunchpadHomeTask = window.location.hash === '#publish-first-post';
+	const siteOriginParam = getQueryArg( window.location.search, 'origin' );
 	useEffect( () => {
 		// If the user is set to see the first post modal and current post status changes to publish,
 		// open the post publish modal
@@ -75,9 +77,11 @@ const FirstPostPublishedModalInner: React.FC = () => {
 
 	const handleNextStepsClick = ( event: React.MouseEvent ) => {
 		event.preventDefault();
-		(
-			window.top as Window
-		 ).location.href = `https://wordpress.com/setup/write/launchpad?siteSlug=${ siteUrl }`;
+		const siteOrigin = siteOriginParam || 'https://wordpress.com';
+		const redirectUrl = isLaunchpadHomeTask
+			? `${ siteOrigin }/home/${ siteUrl }`
+			: `${ siteOrigin }/setup/write/launchpad?siteSlug=${ siteUrl }`;
+		( window.top as Window ).location.href = redirectUrl;
 	};
 	return (
 		<NuxModal

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/first-post-published-modal/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/first-post-published-modal/index.tsx
@@ -35,10 +35,14 @@ const FirstPostPublishedModalInner: React.FC = () => {
 		select => ( select( 'core/editor' ) as CoreEditorPlaceholder ).isCurrentPostPublished(),
 		[]
 	);
-	const previousIsCurrentPostPublished = useRef( isCurrentPostPublished );
-	const shouldShowFirstPostPublishedModal = useShouldShowFirstPostPublishedModal();
-	const [ isOpen, setIsOpen ] = useState( false );
+
 	const initialHash = useRef( window.location.hash );
+	const isLaunchpadHomeTask = initialHash.current === '#publish-first-post';
+
+	const shouldShowFirstPostPublishedModal =
+		useShouldShowFirstPostPublishedModal() && ! isLaunchpadHomeTask;
+
+	const [ isOpen, setIsOpen ] = useState( false );
 	const closeModal = () => setIsOpen( false );
 
 	const { siteUrlOption, launchpadScreenOption, siteIntentOption } = window?.launchpadOptions || {};
@@ -49,7 +53,8 @@ const FirstPostPublishedModalInner: React.FC = () => {
 		siteUrl = new URL( siteUrlOption ).hostname;
 	}
 
-	const isLaunchpadHomeTask = initialHash.current === '#publish-first-post';
+	const previousIsCurrentPostPublished = useRef( isCurrentPostPublished );
+
 	useEffect( () => {
 		// If the user is set to see the first post modal and current post status changes to publish,
 		// open the post publish modal

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/first-post-published-modal/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/first-post-published-modal/index.tsx
@@ -82,10 +82,8 @@ const FirstPostPublishedModalInner: React.FC = () => {
 
 	const handleNextStepsClick = ( event: React.MouseEvent ) => {
 		event.preventDefault();
-		const siteOrigin = 'https://wordpress.com';
-		const redirectUrl = isLaunchpadHomeTask
-			? `${ siteOrigin }/home/${ siteUrl }`
-			: `${ siteOrigin }/setup/write/launchpad?siteSlug=${ siteUrl }`;
+		const redirectUrl = `https://wordpress.com/setup/write/launchpad?siteSlug=${ siteUrl }`;
+
 		( window.top as Window ).location.href = redirectUrl;
 	};
 	return (

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/first-post-published-modal/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/first-post-published-modal/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { getQueryArg, isURL } from '@wordpress/url';
+import { isURL } from '@wordpress/url';
 import React from 'react';
 import postPublishedImage from '../../../../assets/images/post-published.svg';
 import { useSiteIntent, useShouldShowFirstPostPublishedModal } from '../../../../common/tour-kit';
@@ -38,6 +38,7 @@ const FirstPostPublishedModalInner: React.FC = () => {
 	const previousIsCurrentPostPublished = useRef( isCurrentPostPublished );
 	const shouldShowFirstPostPublishedModal = useShouldShowFirstPostPublishedModal();
 	const [ isOpen, setIsOpen ] = useState( false );
+	const initialHash = useRef( window.location.hash );
 	const closeModal = () => setIsOpen( false );
 
 	const { siteUrlOption, launchpadScreenOption, siteIntentOption } = window?.launchpadOptions || {};
@@ -48,8 +49,7 @@ const FirstPostPublishedModalInner: React.FC = () => {
 		siteUrl = new URL( siteUrlOption ).hostname;
 	}
 
-	const isLaunchpadHomeTask = window.location.hash === '#publish-first-post';
-	const siteOriginParam = getQueryArg( window.location.search, 'origin' );
+	const isLaunchpadHomeTask = initialHash.current === '#publish-first-post';
 	useEffect( () => {
 		// If the user is set to see the first post modal and current post status changes to publish,
 		// open the post publish modal
@@ -77,7 +77,7 @@ const FirstPostPublishedModalInner: React.FC = () => {
 
 	const handleNextStepsClick = ( event: React.MouseEvent ) => {
 		event.preventDefault();
-		const siteOrigin = siteOriginParam || 'https://wordpress.com';
+		const siteOrigin = 'https://wordpress.com';
 		const redirectUrl = isLaunchpadHomeTask
 			? `${ siteOrigin }/home/${ siteUrl }`
 			: `${ siteOrigin }/setup/write/launchpad?siteSlug=${ siteUrl }`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/98839

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds prevents the first post modal from appearing if the `#publish-first-post` hash exists in the URL.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use the [provided information ](https://github.com/Automattic/jetpack/pull/41618#issuecomment-2641800726)to apply changes to your sandbox 
* Go to `/setup/onboarding` and create a site with `publish blog` goal
* You might need to sandbox the test site
* Skip to `My Home` and choose `Write first post` task
* in the editor append `#publish-first-post` to the url
* Publish first post then click the `Next step` CTA and it should bring you back to the site home.

