### PR TITLE
External Media: Fix the button size in the editor for GB 18 or below

### DIFF
--- a/projects/packages/external-media/changelog/fix-external-media-button-size
+++ b/projects/packages/external-media/changelog/fix-external-media-button-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+External Media: Fix the button size in the editor for GB 18 or below

--- a/projects/packages/external-media/src/class-external-media.php
+++ b/projects/packages/external-media/src/class-external-media.php
@@ -110,11 +110,8 @@ class External_Media {
 		}
 
 		// Let's now check if the Gutenberg plugin is installed on the site.
-		if (
-			defined( 'GUTENBERG_VERSION' )
-			&& version_compare( (string) GUTENBERG_VERSION, '19.4', '>=' )
-		) {
-			return true;
+		if ( defined( 'GUTENBERG_VERSION' ) ) {
+			return version_compare( (string) GUTENBERG_VERSION, '19.4', '>=' );
 		}
 
 		// Finally, let's check for the WordPress version.

--- a/projects/packages/external-media/src/class-external-media.php
+++ b/projects/packages/external-media/src/class-external-media.php
@@ -92,7 +92,7 @@ class External_Media {
 	/**
 	 * Check whether the environment supports the newer default size of elements, gradually introduced starting with WP 6.4.
 	 *
-	 * @since 14.0
+	 * @since jetpack-14.0
 	 *
 	 * @see https://make.wordpress.org/core/2023/10/16/editor-components-updates-in-wordpress-6-4/#improving-size-consistency-for-ui-components
 	 *

--- a/projects/packages/external-media/src/class-external-media.php
+++ b/projects/packages/external-media/src/class-external-media.php
@@ -112,7 +112,7 @@ class External_Media {
 		// Let's now check if the Gutenberg plugin is installed on the site.
 		if (
 			defined( 'GUTENBERG_VERSION' )
-			&& version_compare( GUTENBERG_VERSION, '19.4', '>=' )
+			&& version_compare( (string) GUTENBERG_VERSION, '19.4', '>=' )
 		) {
 			return true;
 		}

--- a/projects/packages/external-media/src/class-external-media.php
+++ b/projects/packages/external-media/src/class-external-media.php
@@ -80,11 +80,50 @@ class External_Media {
 		}
 
 		return array(
-			'wpcomBlogId'    => $blog_id,
-			'pluginBasePath' => plugins_url( '', Constants::get_constant( 'JETPACK__PLUGIN_FILE' ) ),
-			'ai-assistant'   => array(
+			'wpcomBlogId'         => $blog_id,
+			'pluginBasePath'      => plugins_url( '', Constants::get_constant( 'JETPACK__PLUGIN_FILE' ) ),
+			'ai-assistant'        => array(
 				'is-enabled' => apply_filters( 'jetpack_ai_enabled', $jetpack_ai_enabled ),
 			),
+			'next40pxDefaultSize' => self::site_supports_next_default_size(),
 		);
+	}
+
+	/**
+	 * Check whether the environment supports the newer default size of elements, gradually introduced starting with WP 6.4.
+	 *
+	 * @since 14.0
+	 *
+	 * @see https://make.wordpress.org/core/2023/10/16/editor-components-updates-in-wordpress-6-4/#improving-size-consistency-for-ui-components
+	 *
+	 * @to-do: Deprecate this method and the logic around it when Jetpack requires WordPress 6.7.
+	 *
+	 * @return bool
+	 */
+	public static function site_supports_next_default_size() {
+		/*
+		 * If running a local dev build of gutenberg,
+		 * let's assume it supports the newest changes included in Gutenberg.
+		 */
+		if ( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) && GUTENBERG_DEVELOPMENT_MODE ) {
+			return true;
+		}
+
+		// Let's now check if the Gutenberg plugin is installed on the site.
+		if (
+			defined( 'GUTENBERG_VERSION' )
+			&& version_compare( GUTENBERG_VERSION, '19.4', '>=' )
+		) {
+			return true;
+		}
+
+		// Finally, let's check for the WordPress version.
+		global $wp_version;
+		if ( version_compare( $wp_version, '6.7', '>=' ) ) {
+			return true;
+		}
+
+		// Final fallback.
+		return false;
 	}
 }

--- a/projects/packages/external-media/src/features/editor/editor.scss
+++ b/projects/packages/external-media/src/features/editor/editor.scss
@@ -41,6 +41,16 @@
 
 .jetpack-external-media-button-wrapper {
 	display: contents;
+
+	&:not(.is-support-next-40px-default-button) {
+		display: flex;
+		flex-direction: row;
+		gap: 12px;
+
+		.components-placeholder.is-medium .components-placeholder__fieldset & {
+			flex-direction: column;
+		}
+	}
 }
 
 // Reset placeholder button margin.

--- a/projects/packages/external-media/src/features/editor/editor.scss
+++ b/projects/packages/external-media/src/features/editor/editor.scss
@@ -49,6 +49,7 @@
 
 		.components-placeholder.is-medium .components-placeholder__fieldset & {
 			flex-direction: column;
+			align-items: flex-start;
 		}
 	}
 }

--- a/projects/packages/external-media/src/shared/media-button/index.js
+++ b/projects/packages/external-media/src/shared/media-button/index.js
@@ -1,8 +1,10 @@
 import { useBlockEditContext } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
+import clsx from 'clsx';
 import React from 'react';
 import { getExternalLibrary, getExternalSource } from '../sources';
 import { isGeneralPurposeImageGeneratorBetaEnabled } from '../utils/is-general-purpose-image-generator-beta-enabled';
+import { isSupportNext40pxDefaultSize } from '../utils/is-support-next-40px-default-size';
 import MediaAiButton from './media-ai-button';
 import MediaButtonMenu from './media-menu';
 
@@ -46,7 +48,10 @@ function MediaButton( props ) {
 		// eslint-disable-next-line  jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
 		<div
 			onClick={ event => event.stopPropagation() }
-			className="jetpack-external-media-button-wrapper"
+			className={ clsx( {
+				'jetpack-external-media-button-wrapper': true,
+				'is-support-next-40px-default-button': isSupportNext40pxDefaultSize(),
+			} ) }
 		>
 			<MediaButtonMenu
 				{ ...props }

--- a/projects/packages/external-media/src/shared/media-button/media-ai-button.js
+++ b/projects/packages/external-media/src/shared/media-button/media-ai-button.js
@@ -2,6 +2,7 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import React from 'react';
 import { SOURCE_JETPACK_AI_GENERAL_PURPOSE_IMAGE_FOR_BLOCK } from '../constants';
+import { isSupportNext40pxDefaultSize } from '../utils/is-support-next-40px-default-size';
 
 /**
  * MediaAiButton component
@@ -13,7 +14,7 @@ function MediaAiButton( props ) {
 
 	return (
 		<Button
-			__next40pxDefaultSize
+			__next40pxDefaultSize={ isSupportNext40pxDefaultSize() }
 			variant="secondary"
 			className="jetpack-external-media-button-menu"
 			aria-haspopup="false"

--- a/projects/packages/external-media/src/shared/media-button/media-menu.js
+++ b/projects/packages/external-media/src/shared/media-button/media-menu.js
@@ -2,6 +2,7 @@ import { Button, MenuItem, MenuGroup, Dropdown, NavigableMenu } from '@wordpress
 import { __ } from '@wordpress/i18n';
 import { Icon, media } from '@wordpress/icons';
 import React from 'react';
+import { isSupportNext40pxDefaultSize } from '../utils/is-support-next-40px-default-size';
 import MediaSources from './media-sources';
 
 /**
@@ -54,7 +55,7 @@ function MediaButtonMenu( props ) {
 					}
 					return (
 						<Button
-							__next40pxDefaultSize
+							__next40pxDefaultSize={ isSupportNext40pxDefaultSize() }
 							variant="secondary"
 							className="jetpack-external-media-button-menu"
 							aria-haspopup="true"

--- a/projects/packages/external-media/src/shared/utils/is-support-next-40px-default-size.js
+++ b/projects/packages/external-media/src/shared/utils/is-support-next-40px-default-size.js
@@ -1,0 +1,12 @@
+// to-do: Remove when Jetpack requires WordPress 6.7.
+// See https://github.com/Automattic/jetpack/issues/41609.
+export const isSupportNext40pxDefaultSize = () => {
+	if (
+		window?.JetpackExternalMediaData &&
+		Object.prototype.hasOwnProperty.call( window?.JetpackExternalMediaData, 'next40pxDefaultSize' )
+	) {
+		return window?.JetpackExternalMediaData?.next40pxDefaultSize;
+	}
+
+	return true;
+};

--- a/projects/plugins/jetpack/changelog/fix-external-media-button-size
+++ b/projects/plugins/jetpack/changelog/fix-external-media-button-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+External Media: Fix the button size in the editor for GB 18 or below

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -740,10 +740,10 @@ class Jetpack_Gutenberg {
 
 		$jetpack_plan  = Jetpack_Plan::get();
 		$initial_state = array(
-			'available_blocks'    => self::get_availability(),
-			'blocks_variation'    => $blocks_variation,
-			'modules'             => $modules,
-			'jetpack'             => array(
+			'available_blocks' => self::get_availability(),
+			'blocks_variation' => $blocks_variation,
+			'modules'          => $modules,
+			'jetpack'          => array(
 				'is_active'                     => Jetpack::is_connection_ready(),
 				'is_current_user_connected'     => $is_current_user_connected,
 				/** This filter is documented in class.jetpack-gutenberg.php */
@@ -770,16 +770,15 @@ class Jetpack_Gutenberg {
 				 */
 				'republicize_enabled'           => apply_filters( 'jetpack_block_editor_republicize_feature', true ),
 			),
-			'siteFragment'        => $status->get_site_suffix(),
-			'adminUrl'            => esc_url( admin_url() ),
-			'tracksUserData'      => $user_data,
-			'wpcomBlogId'         => $blog_id,
-			'allowedMimeTypes'    => wp_get_mime_types(),
-			'siteLocale'          => str_replace( '_', '-', get_locale() ),
-			'ai-assistant'        => $ai_assistant_state,
-			'screenBase'          => $screen_base,
-			'pluginBasePath'      => plugins_url( '', Constants::get_constant( 'JETPACK__PLUGIN_FILE' ) ),
-			'next40pxDefaultSize' => self::site_supports_next_default_size(),
+			'siteFragment'     => $status->get_site_suffix(),
+			'adminUrl'         => esc_url( admin_url() ),
+			'tracksUserData'   => $user_data,
+			'wpcomBlogId'      => $blog_id,
+			'allowedMimeTypes' => wp_get_mime_types(),
+			'siteLocale'       => str_replace( '_', '-', get_locale() ),
+			'ai-assistant'     => $ai_assistant_state,
+			'screenBase'       => $screen_base,
+			'pluginBasePath'   => plugins_url( '', Constants::get_constant( 'JETPACK__PLUGIN_FILE' ) ),
 		);
 
 		if ( Jetpack::is_module_active( 'publicize' ) && function_exists( 'publicize_init' ) ) {
@@ -1319,44 +1318,6 @@ class Jetpack_Gutenberg {
 		}
 
 		return $block_content;
-	}
-
-	/**
-	 * Check whether the environment supports the newer default size of elements, gradually introduced starting with WP 6.4.
-	 *
-	 * @since 14.0
-	 *
-	 * @see https://make.wordpress.org/core/2023/10/16/editor-components-updates-in-wordpress-6-4/#improving-size-consistency-for-ui-components
-	 *
-	 * @to-do: Deprecate this method and the logic around it when Jetpack requires WordPress 6.7.
-	 *
-	 * @return bool
-	 */
-	public static function site_supports_next_default_size() {
-		/*
-		 * If running a local dev build of gutenberg,
-		 * let's assume it supports the newest changes included in Gutenberg.
-		 */
-		if ( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) && GUTENBERG_DEVELOPMENT_MODE ) {
-			return true;
-		}
-
-		// Let's now check if the Gutenberg plugin is installed on the site.
-		if (
-			defined( 'GUTENBERG_VERSION' )
-			&& version_compare( GUTENBERG_VERSION, '19.4', '>=' )
-		) {
-			return true;
-		}
-
-		// Finally, let's check for the WordPress version.
-		global $wp_version;
-		if ( version_compare( $wp_version, '6.7', '>=' ) ) {
-			return true;
-		}
-
-		// Final fallback.
-		return false;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/41609

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Some of sites still use GB 18 or below so that the media button didn't align with other buttons inside the block (e.g.: Image). As a result, this PR brought the check back to resolve the issue.

| | Before | After |
| - | - | - |
| P2 | ![image](https://github.com/user-attachments/assets/f46357c9-77da-4442-b062-f3cf1ad6ffab) | ![image](https://github.com/user-attachments/assets/071a3569-b95a-45c3-8dc6-2853a3e32a9c) |
| Forum |  ![image](https://github.com/user-attachments/assets/6114c9ae-1bd3-4a30-a0f2-5f98f3ec01e8) | ![image](https://github.com/user-attachments/assets/fd154e5f-fffa-48fc-8d0b-165f0c00384b) |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your sandbox
* Sandbox a p2 site
* Create a new post
* Insert a image block
* Ensure the "Select Image" button & the "Generate with AI" button align with other buttons
* Sandbox a forum, https://wordpress.com/forums
* Repeat the above steps
* Ensure the styles look as expected
