### PR TITLE
Media Library: add track events for upload from URL feature

### DIFF
--- a/projects/packages/external-media/changelog/media-tracks
+++ b/projects/packages/external-media/changelog/media-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Media Library: add track events for upload from URL feature

--- a/projects/packages/external-media/src/shared/media-browser/index.js
+++ b/projects/packages/external-media/src/shared/media-browser/index.js
@@ -72,8 +72,8 @@ function MediaBrowser( {
 	);
 
 	const onCopyAndInsert = useCallback( () => {
-		tracks.recordEvent( 'jetpack_external_media_modal_cta_click', {
-			page_source: pageSource,
+		tracks.recordEvent( 'jetpack_external_media_modal_submit', {
+			page: pageSource,
 			media_source: mediaSource,
 			media_count: selected.length,
 			multiple: !! multiple,

--- a/projects/packages/external-media/src/shared/media-browser/use-page-source.js
+++ b/projects/packages/external-media/src/shared/media-browser/use-page-source.js
@@ -1,18 +1,12 @@
 import { useSelect } from '@wordpress/data';
 
 const usePageSource = () => {
-	const isSiteEditor = useSelect( select => !! select( 'core/edit-site' ), [] );
-	const postType = useSelect( select => select( 'core/editor' )?.getCurrentPostType(), [] );
+	const isEditor = useSelect( select => !! select( 'core/editor' ), [] );
 
-	if ( ! postType ) {
-		return 'jetpack-external-media-import-page';
+	if ( isEditor ) {
+		return 'editor';
 	}
-
-	if ( isSiteEditor ) {
-		return 'site-editor';
-	}
-
-	return postType === 'page' ? 'page-editor' : 'post-editor';
+	return 'media-library';
 };
 
 export default usePageSource;

--- a/projects/packages/jetpack-mu-wpcom/changelog/media-tracks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/media-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Media Library: add track events for upload from URL feature

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
@@ -1,10 +1,11 @@
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useState } from 'react';
+import { wpcomTrackEvent } from '../../../common/tracks';
 
 import './style.scss';
 
-const WpcomMediaUrlUploadForm = ( { ajaxUrl, action, nonce, isEditor } ) => {
+const WpcomMediaUrlUploadForm = ( { ajaxUrl, action, nonce, page } ) => {
 	const [ url, setUrl ] = useState( '' );
 
 	const [ show, setShow ] = useState( false );
@@ -24,6 +25,10 @@ const WpcomMediaUrlUploadForm = ( { ajaxUrl, action, nonce, isEditor } ) => {
 			return false;
 		}
 		e.preventDefault();
+
+		wpcomTrackEvent( 'wpcom_media_upload_from_url_submit', {
+			page,
+		} );
 
 		const formData = new FormData();
 		formData.append( 'action', action );
@@ -48,7 +53,7 @@ const WpcomMediaUrlUploadForm = ( { ajaxUrl, action, nonce, isEditor } ) => {
 							.collection.add( attachmentToAdd );
 					};
 
-					if ( isEditor ) {
+					if ( page === 'editor' ) {
 						const mediaLibraryTab = window.wp.media.frame.state( 'library' );
 						mediaLibraryTab.trigger( 'open' );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.php
@@ -23,10 +23,10 @@ function wpcom_media_url_upload() {
 
 	$data = wp_json_encode(
 		array(
-			'ajaxUrl'  => admin_url( 'admin-ajax.php' ),
-			'action'   => 'wpcom_media_url_upload',
-			'nonce'    => wp_create_nonce( 'wpcom_media_url_upload' ),
-			'isEditor' => $pagenow !== 'upload.php',
+			'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+			'action'  => 'wpcom_media_url_upload',
+			'nonce'   => wp_create_nonce( 'wpcom_media_url_upload' ),
+			'page'    => $pagenow === 'upload.php' ? 'media-library' : 'editor',
 		)
 	);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of https://github.com/Automattic/dotcom-forge/issues/10412

## Proposed changes:

This PR adds a track event to track the usage of "upload from URL" feature in Media Library:

<img width="703" alt="image" src="https://github.com/user-attachments/assets/98ad9346-11bb-4f30-9f39-3c18d6352745" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to `wp-admin/upload.php?untangling-media=true`
2. Click "Add New Media File"
3. Click "Upload from URL"
4. Enter a valid media URL
5. Click Upload button
6. Verify that the event is fired as above.
7. Go to Site Editor, try again, and verify that the event is fired with 'page': 'editor' props.

