### PR TITLE
Wpcom settings: Duplicate view pop up copy changes

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-settings-popup-copy
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-settings-popup-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated copy on the wpcom duplicate view pop ups to include link to learn more.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/removed-calypso-screen-notice.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/removed-calypso-screen-notice.tsx
@@ -242,7 +242,16 @@ const Notice = () => {
 					content: (
 						<>
 							<h1>{ config[ removedCalypsoScreenNoticeConfig.screen ].title }</h1>
-							<p>{ config[ removedCalypsoScreenNoticeConfig.screen ].description }</p>
+							<p>
+								{ config[ removedCalypsoScreenNoticeConfig.screen ].description }&nbsp;
+								<a
+									href="https://wordpress.com/blog/2025/01/22/interface-update/"
+									target="_blank"
+									rel="noreferrer"
+								>
+									{ __( 'Learn more ↗', 'jetpack-mu-wpcom' ) }
+								</a>
+							</p>
 						</>
 					),
 				},

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/removed-calypso-screen-notice.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/removed-calypso-screen-notice.tsx
@@ -148,8 +148,8 @@ const Notice = () => {
 		},
 		'options-general.php': {
 			icon: settings,
-			title: hasTranslation( 'The General Settings view just got an update' )
-				? __( 'The General Settings view just got an update', 'jetpack-mu-wpcom' )
+			title: hasTranslation( 'General Settings just got an update' )
+				? __( 'General Settings just got an update', 'jetpack-mu-wpcom' )
 				: titleFallback,
 			description: hasTranslation(
 				"We've adopted WordPress' main General Settings view to bring improvements to you and millions of WordPress users worldwide."
@@ -162,8 +162,8 @@ const Notice = () => {
 		},
 		'options-writing.php': {
 			icon: verse,
-			title: hasTranslation( 'The Writing Settings view just got an update' )
-				? __( 'The Writing Settings view just got an update', 'jetpack-mu-wpcom' )
+			title: hasTranslation( 'Writing Settings just got an update' )
+				? __( 'Writing Settings just got an update', 'jetpack-mu-wpcom' )
 				: titleFallback,
 			description: hasTranslation(
 				"We've adopted WordPress' main Writing Settings view to bring improvements to you and millions of WordPress users worldwide."
@@ -176,8 +176,8 @@ const Notice = () => {
 		},
 		'options-reading.php': {
 			icon: page,
-			title: hasTranslation( 'The Reading Settings view just got an update' )
-				? __( 'The Reading Settings view just got an update', 'jetpack-mu-wpcom' )
+			title: hasTranslation( 'Reading Settings just got an update' )
+				? __( 'Reading Settings just got an update', 'jetpack-mu-wpcom' )
 				: titleFallback,
 			description: hasTranslation(
 				"We've adopted WordPress' main Reading Settings view to bring improvements to you and millions of WordPress users worldwide."
@@ -190,8 +190,8 @@ const Notice = () => {
 		},
 		'options-discussion.php': {
 			icon: postComments,
-			title: hasTranslation( 'The Discussion Settings view just got an update' )
-				? __( 'The Discussion Settings view just got an update', 'jetpack-mu-wpcom' )
+			title: hasTranslation( 'Discussion Settings just got an update' )
+				? __( 'Discussion Settings just got an update', 'jetpack-mu-wpcom' )
 				: titleFallback,
 			description: hasTranslation(
 				"We've adopted WordPress' main Discussion Settings view to bring improvements to you and millions of WordPress users worldwide."
@@ -223,20 +223,6 @@ const Notice = () => {
 		);
 	};
 
-	let title = sprintf(
-		// translators: %s: page name
-		__( 'The %s view just got better', 'jetpack-mu-wpcom' ),
-		removedCalypsoScreenNoticeConfig.title
-	);
-
-	if ( hasTranslation( 'The %s view just got an update' ) ) {
-		title = sprintf(
-			// translators: %s: page name
-			__( 'The %s view just got an update', 'jetpack-mu-wpcom' ),
-			removedCalypsoScreenNoticeConfig.title
-		);
-	}
-
 	return (
 		<Guide
 			className="removed-calypso-screen-notice"
@@ -255,7 +241,7 @@ const Notice = () => {
 					),
 					content: (
 						<>
-							<h1>{ title }</h1>
+							<h1>{ config[ removedCalypsoScreenNoticeConfig.screen ].title }</h1>
 							<p>{ config[ removedCalypsoScreenNoticeConfig.screen ].description }</p>
 						</>
 					),


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/99255

| Before | After |
|---|---|
|![Screenshot 2025-02-07 at 17-11-41 General Settings ‹ Site Title — WordPress](https://github.com/user-attachments/assets/16fb4bf9-d95f-4817-b958-9a856b05aedd)|![Screenshot 2025-02-07 at 17-11-08 General Settings ‹ Site Title — WordPress](https://github.com/user-attachments/assets/5c3b6584-00ad-4cad-aeca-bf4646cb17ce)|

## Proposed changes:

* Updates titles per issue / figma
* Adds learn more link to announcement post: https://wordpress.com/blog/2025/01/22/interface-update/

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

```
# Build
jetpack build plugins/jetpack plugins/mu-wpcom-plugin packages/jetpack-mu-wpcom

# Sandbox
jetpack rsync mu-wpcom-plugin wpcom:~/public_html/wp-content/mu-plugins/jetpack-mu-wpcom-plugin/dev --watch

# Woa
jetpack rsync mu-wpcom-plugin woa:~/htdocs/wp-content/plugins/jetpack-mu-wpcom-plugin-dev --watch
```

* Sandbox your test site domain
* Assign yourself to the experiment 22129-explat-experiment
* Site settings menu items should now be wp-admin versions
* Note: you can use [this line](https://github.com/Automattic/jetpack/blob/5f6e41063c8a83e4eac2417064202f9631523611/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php#L622C4-L622C10) commented out to trigger the pop ups for testing.
* Repeat test for atomic using Jetpack beta and applying the `update/wpcom-duplicate-views-settings` branch for WordPress.com Features