### PR TITLE
Try sorting users list by email or username

### DIFF
--- a/projects/plugins/jetpack/changelog/try-order-with-viewers-in-users-list-endpoint
+++ b/projects/plugins/jetpack/changelog/try-order-with-viewers-in-users-list-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sort users by email or username when some of those users are viewers.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -240,21 +240,13 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 					if ( $include_viewers ) {
 						// First we need to be sure to obtain the viewer emails and logins.
 						foreach ( $combined_users as &$user ) {
-							$user = new WP_User( $user->ID );
+							$wp_user     = new WP_User( $user->ID );
+							$user->email = $wp_user->user_email;
+							$user->login = $wp_user->user_login;
 						}
 
-						$order = $args['order'] ?? 'asc';
-
-						switch ( $args['order_by'] ) {
-							case 'email':
-								$orderby = 'user_email';
-								break;
-							case 'login':
-								$orderby = 'user_login';
-								break;
-							default:
-								$orderby = 'display_name';
-						}
+						$order   = $args['order'] ?? 'asc';
+						$orderby = $args['order_by'] ?? 'name';
 
 						usort(
 							$combined_users,

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -245,16 +245,14 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 							$user->login = $wp_user->user_login;
 						}
 
-						$order   = $args['order'] ?? 'asc';
-						$orderby = $args['order_by'] ?? 'name';
+						$order   = strtolower( $args['order'] ) ?? 'asc';
+						$orderby = strtolower( $args['order_by'] ) ?? 'name';
 
 						usort(
 							$combined_users,
 							function ( $a, $b ) use ( $order, $orderby ) {
-								if ( 'desc' === strtolower( $order ) ) {
-									return gmp_neg( strcmp( strtolower( $a->{$orderby} ), strtolower( $b->{$orderby} ) ) );
-								}
-								return strcmp( strtolower( $a->{$orderby} ), strtolower( $b->{$orderby} ) );
+								$result = strcmp( $a->{$orderby}, $b->{$orderby} );
+								return 'desc' === $order ? - $result : $result;
 							}
 						);
 					}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -245,8 +245,8 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 							$user->login = $wp_user->user_login;
 						}
 
-						$order   = strtolower( $args['order'] ) ?? 'asc';
-						$orderby = strtolower( $args['order_by'] ) ?? 'name';
+						$order   = ! empty( $args['order'] ) ? strtolower( $args['order'] ) : 'asc';
+						$orderby = ! empty( $args['order_by'] ) ? strtolower( $args['order_by'] ) : 'name';
 
 						usort(
 							$combined_users,

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -243,46 +243,28 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 							$user = new WP_User( $user->ID );
 						}
 
-						if ( 'email' === $args['order_by'] ) {
-							if ( 'asc' === strtolower( $args['order'] ) ) {
-								usort(
-									$combined_users,
-									function ( $a, $b ) {
-										return strcmp( strtolower( $a->user_email ), strtolower( $b->user_email ) );
-									}
-								);
-							} else {
-								usort(
-									$combined_users,
-									function ( $a, $b ) {
-										return gmp_neg( strcmp( strtolower( $a->user_email ), strtolower( $b->user_email ) ) );
-									}
-								);
-							}
-						} elseif ( 'login' === $args['order_by'] ) {
-							if ( 'asc' === strtolower( $args['order'] ) ) {
-								usort(
-									$combined_users,
-									function ( $a, $b ) {
-										return strcmp( strtolower( $a->user_login ), strtolower( $b->user_login ) );
-									}
-								);
-							} else {
-								usort(
-									$combined_users,
-									function ( $a, $b ) {
-										return gmp_neg( strcmp( strtolower( $a->user_login ), strtolower( $b->user_login ) ) );
-									}
-								);
-							}
-						} else {
-							usort(
-								$combined_users,
-								function ( $a, $b ) {
-									return strcmp( strtolower( $a->display_name ), strtolower( $b->display_name ) );
-								}
-							);
+						$order = $args['order'] ?? 'asc';
+
+						switch ( $args['order_by'] ) {
+							case 'email':
+								$orderby = 'user_email';
+								break;
+							case 'login':
+								$orderby = 'user_login';
+								break;
+							default:
+								$orderby = 'display_name';
 						}
+
+						usort(
+							$combined_users,
+							function ( $a, $b ) use ( $order, $orderby ) {
+								if ( 'desc' === strtolower( $order ) ) {
+									return gmp_neg( strcmp( strtolower( $a->{$orderby} ), strtolower( $b->{$orderby} ) ) );
+								}
+								return strcmp( strtolower( $a->{$orderby} ), strtolower( $b->{$orderby} ) );
+							}
+						);
 					}
 
 					$return[ $key ] = $combined_users;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -236,14 +236,53 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 					$combined_users = array_merge( $users, $viewers );
 
-					// When viewers are included, we ignore the order & orderby parameters.
+					// When viewers are included, we try to respect orderby if it's login or email.
 					if ( $include_viewers ) {
-						usort(
-							$combined_users,
-							function ( $a, $b ) {
-								return strcmp( strtolower( $a->name ), strtolower( $b->name ) );
+						// First we need to be sure to obtain the viewer emails and logins.
+						foreach ( $combined_users as &$user ) {
+							$user = new WP_User( $user->ID );
+						}
+
+						if ( 'email' === $args['order_by'] ) {
+							if ( 'asc' === strtolower( $args['order'] ) ) {
+								usort(
+									$combined_users,
+									function ( $a, $b ) {
+										return strcmp( strtolower( $a->user_email ), strtolower( $b->user_email ) );
+									}
+								);
+							} else {
+								usort(
+									$combined_users,
+									function ( $a, $b ) {
+										return gmp_neg( strcmp( strtolower( $a->user_email ), strtolower( $b->user_email ) ) );
+									}
+								);
 							}
-						);
+						} elseif ( 'login' === $args['order_by'] ) {
+							if ( 'asc' === strtolower( $args['order'] ) ) {
+								usort(
+									$combined_users,
+									function ( $a, $b ) {
+										return strcmp( strtolower( $a->user_login ), strtolower( $b->user_login ) );
+									}
+								);
+							} else {
+								usort(
+									$combined_users,
+									function ( $a, $b ) {
+										return gmp_neg( strcmp( strtolower( $a->user_login ), strtolower( $b->user_login ) ) );
+									}
+								);
+							}
+						} else {
+							usort(
+								$combined_users,
+								function ( $a, $b ) {
+									return strcmp( strtolower( $a->display_name ), strtolower( $b->display_name ) );
+								}
+							);
+						}
 					}
 
 					$return[ $key ] = $combined_users;

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.wpcom-json-api-list-users-endpoint.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Jetpack WPCOM JSON API `sites/%s/users` endpoint unit tests.
+ * Run this test with command: jetpack docker phpunit -- --filter=WP_Test_WPCOM_JSON_API_List_Users_Endpoint
+ *
+ * @package automattic/jetpack
+ */
+
+require_once JETPACK__PLUGIN_DIR . 'class.json-api-endpoints.php';
+
+/**
+ * Jetpack `sites/%s/users` endpoint unit tests.
+ */
+class WP_Test_WPCOM_JSON_API_List_Users_Endpoint extends WP_UnitTestCase {
+	/**
+	 * Mock user ID with administrator permissions.
+	 *
+	 * @var int
+	 */
+	private static $user_admin_id = 0;
+
+	/**
+	 * Mock user ID with editor permissions.
+	 *
+	 * @var int
+	 */
+	private static $user_editor_id = 0;
+
+	/**
+	 * Prepare the environment for the test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		static::$user_admin_id  = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		static::$user_editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( static::$user_admin_id );
+	}
+
+	/**
+	 * Reset the environment to its original state after the test.
+	 */
+	public function tear_down() {
+		wp_delete_user( static::$user_admin_id );
+		wp_delete_user( static::$user_editor_id );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Returns the response of a successful GET request to `sites/%s/users`.
+	 */
+	public function make_get_request( $query_args = array() ) {
+		global $blog_id;
+
+		$endpoint = new WPCOM_JSON_API_List_Users_Endpoint(
+			array(
+				'description'          => 'List the users of a site.',
+				'group'                => 'users',
+				'stat'                 => 'users:list',
+				'method'               => 'GET',
+				'path'                 => '/sites/%s/users',
+				'path_labels'          => array(
+					'$site' => '(int|string) Site ID or domain',
+				),
+				'query_parameters'     => array(
+					'number'          => '(int=20) Limit the total number of authors returned.',
+					'offset'          => '(int=0) The first n authors to be skipped in the returned array.',
+					'order'           => array(
+						'DESC' => 'Return authors in descending order.',
+						'ASC'  => 'Return authors in ascending order.',
+					),
+					'order_by'        => array(
+						'ID'           => 'Order by ID (default).',
+						'login'        => 'Order by username.',
+						'nicename'     => 'Order by nicename.',
+						'email'        => 'Order by author email address.',
+						'url'          => 'Order by author URL.',
+						'registered'   => 'Order by registered date.',
+						'display_name' => 'Order by display name.',
+						'post_count'   => 'Order by number of posts published.',
+					),
+					'authors_only'    => '(bool) Set to true to fetch authors only',
+					'include_viewers' => '(bool) Set to true to include viewers for Simple sites. When you pass in this parameter, order, order_by and search_columns are ignored. Currently, `search` is limited to the first page of results.',
+					'type'            => "(string) Specify the post type to query authors for. Only works when combined with the `authors_only` flag. Defaults to 'post'. Post types besides post and page need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
+					'search'          => '(string) Find matching users.',
+					'search_columns'  => "(array) Specify which columns to check for matching users. Can be any of 'ID', 'user_login', 'user_email', 'user_url', 'user_nicename', and 'display_name'. Only works when combined with `search` parameter.",
+					'role'            => '(string) Specify a specific user role to fetch.',
+					'capability'      => '(string) Specify a specific capability to fetch. You can specify multiple by comma separating them, in which case the user needs to match all capabilities provided.',
+				),
+				'response_format'      => array(
+					'found'   => '(int) The total number of authors found that match the request (ignoring limits and offsets).',
+					'authors' => '(array:author) Array of author objects.',
+				),
+				'example_response'     => '{
+				"found": 1,
+				"users": [
+					{
+						"ID": 78972699,
+						"login": "apiexamples",
+						"email": "justin+apiexamples@a8c.com",
+						"name": "apiexamples",
+						"first_name": "",
+						"last_name": "",
+						"nice_name": "apiexamples",
+						"URL": "http://apiexamples.wordpress.com",
+						"avatar_URL": "https://1.gravatar.com/avatar/a2afb7b6c0e23e5d363d8612fb1bd5ad?s=96&d=identicon&r=G",
+						"profile_URL": "https://gravatar.com/apiexamples",
+						"site_ID": 82974409,
+						"roles": [
+							"administrator"
+						],
+						"is_super_admin": false
+					}
+				]
+			}',
+				'example_request'      => 'https://public-api.wordpress.com/rest/v1/sites/82974409/users',
+				'example_request_data' => array(
+					'headers' => array(
+						'authorization' => 'Bearer YOUR_API_TOKEN',
+					),
+				),
+			)
+		);
+
+		$endpoint->api->query = $query_args;
+
+		return $endpoint->callback( '/sites/%s/users', $blog_id );
+	}
+
+	/**
+	 * Test GET `sites/%s/users` returns correct users.
+	 */
+	public function test_get_users_returns_correct_users() {
+		$response = $this->make_get_request();
+		$users    = $response['users'];
+
+		// Find admin user.
+		$admin_user = array_filter(
+			$users,
+			function ( $user ) {
+				return static::$user_admin_id === $user->ID;
+			}
+		);
+		$admin_user = reset( $admin_user );
+
+		// Find editor user.
+		$editor_user = array_filter(
+			$users,
+			function ( $user ) {
+				return static::$user_editor_id === $user->ID;
+			}
+		);
+		$editor_user = reset( $editor_user );
+
+		// Assert user IDs and roles.
+		$this->assertNotNull( $admin_user, 'Admin user not found' );
+		$this->assertEquals( static::$user_admin_id, $admin_user->ID, 'Admin user ID is not correct' );
+		$this->assertContains( 'administrator', $admin_user->roles, 'Admin user roles are not correct' );
+
+		$this->assertNotNull( $editor_user, 'Editor user not found' );
+		$this->assertEquals( static::$user_editor_id, $editor_user->ID, 'Editor user ID is not correct' );
+		$this->assertContains( 'editor', $editor_user->roles, 'Editor user roles are not correct' );
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->

When the output of the users list endpoint includes viewers, make it possible to sort by login or email. 

This is needed to display viewers in the `wp-admin/users.php` view, as part of https://github.com/Automattic/wp-calypso/issues/98386.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Should be tested in conjunction with 171239-ghe-Automattic/wpcom 
* Go to `/wp-admin/users.php` on a simple site. Make sure classic view is enabled!
* Try clicking on "username" and "email" buttons at the top of the users table:
<img width="658" alt="Screenshot 2025-02-12 at 11 33 25 am" src="https://github.com/user-attachments/assets/fbd15196-bf4a-4f37-80f7-c1ed2fc57f6a" />

* Verify that list of users is reordered accordingly.