### PR TITLE
Launchpad: verifying email sends appropriate launchpad track event

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-send-wpcom_launchpad_mark_task_complete-when-email-verified
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-send-wpcom_launchpad_mark_task_complete-when-email-verified
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+verify_email task sends appropriate tracks event

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -946,12 +946,13 @@ function wpcom_launchpad_is_woocommerce_task_completed( $task, $is_complete ) {
 /**
  * Record completion event in Tracks if we're running on WP.com.
  *
- * @param string $task_id The task ID.
- * @param array  $extra_props Optional extra arguments to pass to the Tracks event.
+ * @param string       $task_id The task ID.
+ * @param array        $extra_props Optional extra arguments to pass to the Tracks event.
+ * @param WP_User|null $user Optional user to use instead of the current user.
  *
  * @return void
  */
-function wpcom_launchpad_track_completed_task( $task_id, $extra_props = array() ) {
+function wpcom_launchpad_track_completed_task( $task_id, $extra_props = array(), $user = null ) {
 	if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
 		return;
 	}
@@ -959,7 +960,7 @@ function wpcom_launchpad_track_completed_task( $task_id, $extra_props = array() 
 	require_lib( 'tracks/client' );
 
 	tracks_record_event(
-		wp_get_current_user(),
+		$user ?? wp_get_current_user(),
 		'wpcom_launchpad_mark_task_complete',
 		array_merge(
 			array( 'task_id' => $task_id ),
@@ -1886,6 +1887,20 @@ function wpcom_launchpad_is_email_verified() {
 
 	return ! Email_Verification::is_email_unverified();
 }
+
+/**
+ * Handles WPCOM action fired when email verification is completed.
+ *
+ * @param int $user_id The user ID.
+ */
+function wpcom_launchpad_mark_verify_email_complete( $user_id ) {
+	$user = get_user_by( 'id', $user_id );
+	if ( empty( $user ) ) {
+		return;
+	}
+	wpcom_launchpad_track_completed_task( 'verify_email', array(), $user );
+}
+add_action( 'wpcom_email_verification_complete', 'wpcom_launchpad_mark_verify_email_complete' );
 
 /**
  * If the site has a paid-subscriber goal.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/99456

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Other tasks record a `wpcom_launchpad_mark_task_complete` event when
a task is detected as completed. Nothing is recording this for email
verification though. We should record an event for this just like
every other task.

WPCOM fires a `wpcom_email_verification_complete` action when the
user verifies. We hook into that action here in Jetpack.

Email verification links send users to `signup.wordpress.com` not
`public-api.wordpress.com`. So it must use a different authentication
mechanism which is why I'm not trusting the `wp_get_current_user()`
function call like the other tracks events do. Using the user ID
from the action parameter is how other action handlers in WPCOM do
it too. See this example 36e9b-pb


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Tracking email verification task is the same sort of data we already track for other tasks. No changes
to our existing data usage.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox
* Sandbox `signup.wordpress.com`
* Create a new user
* Copy the verification link sent to your inbox
* Use this JavaScript snippet to extract the `redirect_to` URL out of the link
   * `new URLSearchParams(new URL(' ... ').search).get('redirect_to')` (substituting the link for the ...)
* Use your Tracks Live View and wait 10m for your event to appear. Filter by your new user's id and the `wpcom_launchpad_mark_task_complete` event
   * Alternatively you can add some logging to the line which records the track event