### PR TITLE
Media Library: don't show storage info on Atomic upload.php's uploader

### DIFF
--- a/projects/plugins/wpcomsh/changelog/wpcomsh-update-media-notice
+++ b/projects/plugins/wpcomsh/changelog/wpcomsh-update-media-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Media Library: don't show storage info on Atomic upload.php's uploader

--- a/projects/plugins/wpcomsh/notices/storage-notices.php
+++ b/projects/plugins/wpcomsh/notices/storage-notices.php
@@ -59,9 +59,15 @@ function wpcomsh_storage_notices() {
 add_action( 'admin_notices', 'wpcomsh_storage_notices' );
 
 /**
- * Display disk space usage on /wp-admin/upload.php
+ * Display disk space usage on the uploader
  */
 function wpcomsh_display_disk_space_usage() {
+	global $pagenow;
+
+	if ( $pagenow === 'upload.php' ) {
+		return;
+	}
+
 	$site_info = wpcomsh_get_at_site_info();
 
 	if ( empty( $site_info['space_used'] ) || empty( $site_info['space_quota'] ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of https://github.com/Automattic/wp-calypso/issues/98080

## Proposed changes:

This PR removes the redundant storage information on Atomic's Media Library uploader:

|Before|After|
|-|-|
|<img width="736" alt="image" src="https://github.com/user-attachments/assets/d33578e3-dd3d-4b27-b04e-deea1c509f4b" />|<img width="734" alt="image" src="https://github.com/user-attachments/assets/2d22448a-a47e-4a01-a488-71424993d286" />|

(Note that it's not easy to change the admin notice into a simple paragraph, to match 172488-ghe-Automattic/wpcom. There's simply no hooks to do that...)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Patch this PR.
2. Go to /wp-admin/upload.php.
3. Click Add New Media File
4. Observe the uploader does not show the storage info
5. Go to Editor
6. Insertan Image block and click Select Media
7. Click the Upload file tab
8. Observe that the storage info is still shown there.