### PR TITLE
Media Library: add track event to the Import Media button

### DIFF
--- a/projects/packages/external-media/changelog/media-library-tracks-2
+++ b/projects/packages/external-media/changelog/media-library-tracks-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Media Library: add track event to the Import Media button

--- a/projects/packages/external-media/src/features/admin/external-media-import-button.js
+++ b/projects/packages/external-media/src/features/admin/external-media-import-button.js
@@ -1,3 +1,4 @@
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { __ } from '@wordpress/i18n';
 
 document.addEventListener( 'DOMContentLoaded', function () {
@@ -11,6 +12,11 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		importButton.role = 'button';
 		importButton.innerHTML = __( 'Import Media', 'jetpack-external-media' );
 		importButton.href = window.JETPACK_EXTERNAL_MEDIA_IMPORT_BUTTON?.href;
+		importButton.onclick = function () {
+			jetpackAnalytics.tracks.recordEvent( 'jetpack_external_media_import_media_button_click', {
+				page: 'media-library',
+			} );
+		};
 
 		const parentNode = addNewButton.parentNode;
 		const nextSibling = addNewButton.nextSibling;


### PR DESCRIPTION
Part of:

- https://github.com/Automattic/dotcom-forge/issues/10412

## Proposed changes:

This PR adds the following track event when we click on the Media Library -> Import Media button:

<img width="517" alt="image" src="https://github.com/user-attachments/assets/8644a503-c998-425b-8594-783cde33e702" />
<img width="494" alt="image" src="https://github.com/user-attachments/assets/ae5c4952-f370-4fb4-a61e-1aec4fc567bb" />


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to `wp-admin/upload.php?untangling-media=true`
2. Click the Import Media button
3. Observe that the above Track event is fired

