### PR TITLE
Media Library: Support Upload from URL on media-new page

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/feat-media-url-upload-form-on-media-new-page
+++ b/projects/packages/jetpack-mu-wpcom/changelog/feat-media-url-upload-form-on-media-new-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Media Library: Support Upload from URL on media-new page

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { wpcomTrackEvent } from '../../../common/tracks';
 
 import './style.scss';
@@ -11,38 +11,54 @@ const WpcomMediaUrlUploadForm = ( { ajaxUrl, action, nonce, page } ) => {
 	const [ show, setShow ] = useState( false );
 	const [ isUploading, setIsUploading ] = useState( false );
 
+	const hasMediaItemsForm = useMemo( () => {
+		return (
+			page === 'media-new' &&
+			!! document.getElementById( 'media-items' ) &&
+			!! window.fileQueued &&
+			!! window.uploadSuccess &&
+			!! window.uploadError
+		);
+	}, [ page ] );
+
 	const handleUrlChange = e => {
 		setUrl( e.target.value );
 	};
 
-	const handleSubmit = async e => {
-		if ( isUploading ) {
-			return false;
-		}
-		try {
-			new URL( url ); // eslint-disable-line no-new
-		} catch {
-			return false;
-		}
-		e.preventDefault();
+	const handleBeforeUpload = fileObj => {
+		setIsUploading( true );
 
-		wpcomTrackEvent( 'wpcom_media_upload_from_url_submit', {
-			page,
-		} );
+		if ( hasMediaItemsForm ) {
+			window.fileQueued( fileObj );
+		}
+	};
 
+	const handleUpload = async () => {
 		const formData = new FormData();
 		formData.append( 'action', action );
 		formData.append( 'url', url );
 		formData.append( '_ajax_nonce', nonce );
-
-		setIsUploading( true );
 
 		const response = await fetch( ajaxUrl, {
 			method: 'POST',
 			body: formData,
 		} );
 
-		const { success, data } = await response.json();
+		return await response.json();
+	};
+
+	const handlePostUpload = ( fileObj, { success, data } ) => {
+		if ( hasMediaItemsForm ) {
+			if ( success ) {
+				window.uploadSuccess( fileObj, data.attachment_id );
+				setIsUploading( false );
+				setUrl( '' );
+			} else {
+				window.uploadError( fileObj );
+				setIsUploading( false );
+			}
+			return;
+		}
 
 		if ( success ) {
 			window.wp.media.model.Attachment.get( data.attachment_id ).fetch( {
@@ -74,6 +90,33 @@ const WpcomMediaUrlUploadForm = ( { ajaxUrl, action, nonce, page } ) => {
 			setIsUploading( false );
 			window.wp.Uploader.errors.add( { file: { name: url }, message: data[ 0 ].message } );
 		}
+	};
+
+	const handleSubmit = async e => {
+		if ( isUploading ) {
+			return false;
+		}
+		try {
+			new URL( url ); // eslint-disable-line no-new
+		} catch {
+			return false;
+		}
+		e.preventDefault();
+
+		wpcomTrackEvent( 'wpcom_media_upload_from_url_submit', {
+			page,
+		} );
+
+		const fileObj = {
+			id: Date.now(),
+			name: new URL( url ).pathname.split( '/' ).pop(),
+		};
+
+		handleBeforeUpload( fileObj );
+
+		const response = await handleUpload();
+
+		handlePostUpload( fileObj, response );
 
 		return false;
 	};

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
@@ -154,7 +154,10 @@ const WpcomMediaUrlUploadForm = ( { ajaxUrl, action, nonce, page } ) => {
 			<a
 				className="wpcom-media-url-upload-form__link"
 				href="#"
-				onClick={ () => setShow( value => ! value ) }
+				onClick={ event => {
+					event.preventDefault();
+					setShow( value => ! value );
+				} }
 			>
 				{ __( 'Upload from URL', 'jetpack-mu-wpcom' ) }
 			</a>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
@@ -123,12 +123,9 @@ const WpcomMediaUrlUploadForm = ( { ajaxUrl, action, nonce, page } ) => {
 
 	const renderLink = () => {
 		return (
-			<button
-				className="button wpcom-media-url-upload-form__pre-upload-button"
-				onClick={ () => setShow( true ) }
-			>
+			<a href="#" onClick={ () => setShow( true ) }>
 				{ __( 'Upload from URL', 'jetpack-mu-wpcom' ) }
-			</button>
+			</a>
 		);
 	};
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/index.jsx
@@ -121,14 +121,6 @@ const WpcomMediaUrlUploadForm = ( { ajaxUrl, action, nonce, page } ) => {
 		return false;
 	};
 
-	const renderLink = () => {
-		return (
-			<a href="#" onClick={ () => setShow( true ) }>
-				{ __( 'Upload from URL', 'jetpack-mu-wpcom' ) }
-			</a>
-		);
-	};
-
 	const renderForm = () => {
 		let buttonText = __( 'Upload', 'jetpack-mu-wpcom' );
 		if ( isUploading ) {
@@ -157,7 +149,18 @@ const WpcomMediaUrlUploadForm = ( { ajaxUrl, action, nonce, page } ) => {
 		);
 	};
 
-	return <div className="wpcom-media-url-upload-form">{ show ? renderForm() : renderLink() }</div>;
+	return (
+		<div className="wpcom-media-url-upload-form">
+			<a
+				className="wpcom-media-url-upload-form__link"
+				href="#"
+				onClick={ () => setShow( value => ! value ) }
+			>
+				{ __( 'Upload from URL', 'jetpack-mu-wpcom' ) }
+			</a>
+			{ show && renderForm() }
+		</div>
+	);
 };
 
 export default WpcomMediaUrlUploadForm;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/style.scss
@@ -1,6 +1,7 @@
 .wpcom-media-url-upload-form {
 	min-height: 30px;
 	margin: -15px 30px 0;
+	font-size: 12px;
 
 	form {
 		display: flex;
@@ -8,13 +9,13 @@
 		justify-content: center;
 		gap: 6px;
 		flex-wrap: wrap;
-		margin-bottom: 6px;
+		margin: 12px 0 6px;
 	}
 
 	input {
 		flex: 1;
 		height: 30px;
-		max-width: 600px;
+		max-width: 300px;
 	}
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/style.scss
@@ -1,16 +1,20 @@
 .wpcom-media-url-upload-form {
-	margin: -15px 30px 15px;
+	min-height: 30px;
+	margin: -15px 30px 0;
 
-	button#{&}__pre-upload-button {
-		padding: 0 21px;
+	form {
+		display: flex;
+		align-items: flex-start;
+		justify-content: center;
+		gap: 6px;
+		flex-wrap: wrap;
+		margin-bottom: 6px;
 	}
 
 	input {
+		flex: 1;
 		height: 30px;
-		width: 100%;
 		max-width: 600px;
-		margin-inline-end: 6px;
-		margin-bottom: 6px;
 	}
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/style.scss
@@ -1,5 +1,4 @@
 .wpcom-media-url-upload-form {
-	min-height: 30px;
 	margin: -15px 30px 0;
 	font-size: 12px;
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/style.scss
@@ -34,3 +34,14 @@
 		margin-top: 15px;
 	}
 }
+
+/**
+ * To align the styles with Core.
+ *
+ * Another way is to avoid concat the `media-views` styles with the `css_do_concat` filter
+ * since the styles should not be loaded on the `media-new.php`. But this one seems to be
+ * relatively safe.
+ */
+.media-upload-form .attachment-details .copy-to-clipboard-container {
+	margin-left: 0;
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload-form/style.scss
@@ -1,15 +1,32 @@
 .wpcom-media-url-upload-form {
-	margin-top: -15px;
-	margin-bottom: 15px;
-	height: 30px;
+	margin: -15px 30px 15px;
 
 	button#{&}__pre-upload-button {
 		padding: 0 21px;
 	}
 
 	input {
+		height: 30px;
 		width: 100%;
 		max-width: 600px;
-		margin-right: 6px;
+		margin-inline-end: 6px;
+		margin-bottom: 6px;
+	}
+}
+
+#plupload-upload-ui.has-wpcom-media-url-upload {
+	#drag-drop-area {
+		min-height: 200px;
+		height: auto;
+	}
+
+	.drag-drop-inside {
+		min-width: 250px;
+		width: auto;
+		margin-bottom: 60px;
+	}
+
+	.wpcom-media-url-upload-form {
+		margin-top: 15px;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.js
@@ -18,6 +18,13 @@ const insertWpcomMediaUrlUploadForm = () => {
 	}
 };
 
+const removeWpcomMediaUrlUploadForm = () => {
+	const container = document.getElementById( selectors.WPCOM_MEDIA_URL_UPLOAD_CONTAINER );
+	if ( container ) {
+		container.innerHTML = '';
+	}
+};
+
 document.addEventListener( 'DOMContentLoaded', function () {
 	const pluploadUploadUI = document.getElementById( selectors.PLUPLOAD_UPLOAD_UI );
 	const selectFilesButton = document.getElementById( selectors.PLUPLOAD_BROWSE_BUTTON );
@@ -39,9 +46,13 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		const originalUploaderInline = window.wp.media.view.UploaderInline;
 
 		window.wp.media.view.UploaderInline = originalUploaderInline.extend( {
-			ready: function () {
-				originalUploaderInline.prototype.ready.apply( this, arguments );
+			show: function () {
+				originalUploaderInline.prototype.show.apply( this, arguments );
 				insertWpcomMediaUrlUploadForm();
+			},
+			hide: function () {
+				originalUploaderInline.prototype.hide.apply( this, arguments );
+				removeWpcomMediaUrlUploadForm();
 			},
 		} );
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.js
@@ -4,19 +4,44 @@ import WpcomMediaUrlUploadForm from './wpcom-media-url-upload-form';
 
 const props = typeof window === 'object' ? window.JETPACK_MU_WPCOM_MEDIA_URL_UPLOAD : {};
 
+const selectors = {
+	PLUPLOAD_UPLOAD_UI: 'plupload-upload-ui',
+	PLUPLOAD_BROWSE_BUTTON: 'plupload-browse-button',
+	WPCOM_MEDIA_URL_UPLOAD_CONTAINER: 'wpcom-media-url-upload',
+};
+
+const insertWpcomMediaUrlUploadForm = () => {
+	const container = document.getElementById( selectors.WPCOM_MEDIA_URL_UPLOAD_CONTAINER );
+	if ( container ) {
+		const root = ReactDOM.createRoot( container );
+		root.render( <WpcomMediaUrlUploadForm { ...props } /> );
+	}
+};
+
 document.addEventListener( 'DOMContentLoaded', function () {
+	const pluploadUploadUI = document.getElementById( selectors.PLUPLOAD_UPLOAD_UI );
+	const selectFilesButton = document.getElementById( selectors.PLUPLOAD_BROWSE_BUTTON );
+	if ( pluploadUploadUI && selectFilesButton ) {
+		// Add the class to the outer container.
+		if ( ! pluploadUploadUI.classList.contains( 'has-wpcom-media-url-upload' ) ) {
+			pluploadUploadUI.classList.add( 'has-wpcom-media-url-upload' );
+		}
+
+		// Insert the container for the wpcom media url upload form.
+		const container = document.createElement( 'div' );
+		container.id = selectors.WPCOM_MEDIA_URL_UPLOAD_CONTAINER;
+		selectFilesButton.parentNode.insertBefore( container, selectFilesButton.nextSibling );
+		insertWpcomMediaUrlUploadForm();
+		return;
+	}
+
 	if ( window.wp?.media?.view?.UploaderInline ) {
 		const originalUploaderInline = window.wp.media.view.UploaderInline;
 
 		window.wp.media.view.UploaderInline = originalUploaderInline.extend( {
 			ready: function () {
 				originalUploaderInline.prototype.ready.apply( this, arguments );
-
-				const container = document.getElementById( 'wpcom-media-url-upload' );
-				if ( container ) {
-					const root = ReactDOM.createRoot( container );
-					root.render( <WpcomMediaUrlUploadForm { ...props } /> );
-				}
+				insertWpcomMediaUrlUploadForm();
 			},
 		} );
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.php
@@ -25,7 +25,7 @@ function enqueue_wpcom_media_url_upload_form() {
 	$page = 'editor';
 	if ( $pagenow === 'upload.php' ) {
 		$page = 'media-library';
-	} else if ( $pagenow === 'media-new.php' ) {
+	} elseif ( $pagenow === 'media-new.php' ) {
 		$page = 'media-new';
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.php
@@ -8,25 +8,33 @@
 /**
  * Appends the wpcom media URL upload form.
  */
-function wpcom_media_url_upload() {
-	global $pagenow;
-
-	if ( empty( $_GET['untangling-media'] ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
-		return;
-	}
-
+function append_wpcom_media_url_upload() {
 	?>
 	<div id="wpcom-media-url-upload"></div>
 	<?php
+}
+
+/**
+ * Enqueue the assets of the wpcom media URL upload form
+ */
+function enqueue_wpcom_media_url_upload_form() {
+	global $pagenow;
 
 	$handle = jetpack_mu_wpcom_enqueue_assets( 'wpcom-media-url-upload', array( 'js', 'css' ) );
+
+	$page = 'editor';
+	if ( $pagenow === 'upload.php' ) {
+		$page = 'media-library';
+	} else if ( $pagenow === 'media-new.php' ) {
+		$page = 'media-new';
+	}
 
 	$data = wp_json_encode(
 		array(
 			'ajaxUrl' => admin_url( 'admin-ajax.php' ),
 			'action'  => 'wpcom_media_url_upload',
 			'nonce'   => wp_create_nonce( 'wpcom_media_url_upload' ),
-			'page'    => $pagenow === 'upload.php' ? 'media-library' : 'editor',
+			'page'    => $page,
 		)
 	);
 
@@ -76,7 +84,25 @@ function wpcom_handle_media_url_upload() {
 	}
 }
 
-if ( current_user_can( 'upload_files' ) ) {
-	add_action( 'pre-upload-ui', 'wpcom_media_url_upload', 9 );
+/**
+ * Load the wpcom media URL upload form.
+ */
+function load_wpcom_media_url_upload_form() {
+	if ( ! current_user_can( 'upload_files' ) ) {
+		return;
+	}
+
 	add_action( 'wp_ajax_wpcom_media_url_upload', 'wpcom_handle_media_url_upload' );
+
+	if ( empty( $_GET['untangling-media'] ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
+		return;
+	}
+
+	global $pagenow;
+	if ( $pagenow !== 'media-new.php' ) {
+		add_action( 'pre-upload-ui', 'append_wpcom_media_url_upload', 9 );
+	}
+
+	add_action( 'post-plupload-upload-ui', 'enqueue_wpcom_media_url_upload_form' );
 }
+load_wpcom_media_url_upload_form();

--- a/projects/plugins/mu-wpcom-plugin/changelog/feat-media-url-upload-form-on-media-new-page
+++ b/projects/plugins/mu-wpcom-plugin/changelog/feat-media-url-upload-form-on-media-new-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Media Library: Support Upload from URL on media-new page

--- a/projects/plugins/wpcomsh/changelog/feat-media-url-upload-form-on-media-new-page
+++ b/projects/plugins/wpcomsh/changelog/feat-media-url-upload-form-on-media-new-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Media Library: Support Upload from URL on media-new page


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to p1738900618822769/1738898875.646109-slack-CRWCHQGUB

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Add the `Upload from URL` button on the media-new page. It's a little hacky to display the upload status 🙈
* Change the button back to the link as suggested https://github.com/Automattic/jetpack/pull/41627#discussion_r1946358946
* Keep the `Upload from URL` link and allow users to toggle the form to align with the [design](https://github.com/Automattic/dotcom-forge/issues/10180#issuecomment-2572909885)
* Reset the status of the upload from URL form when the inline uploader is closed

**Screenshots**

| Media Library | Media New |
| - | - |
| ![image](https://github.com/user-attachments/assets/bf90441c-2c67-4cea-84d3-0846bd85fd63) | ![image](https://github.com/user-attachments/assets/bcddc325-a39d-4830-b0d6-30aa5547f1df) |

**Demo**

https://github.com/user-attachments/assets/a4a2e201-3532-4601-be3d-9877307845fe

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your site
* Go to /wp-admin/media-new.php?untangling-media=true
* Ensure you can upload media from URL
* Go to /wp-admin/upload.php?untangling-media=true
* Ensure you can still upload media from URL
* Go to Editor
* Ensure you can still upload media from URL by `Image Block > Media Library > Upload from UR`