### PR TITLE
Fix search fiter type key warning.

### DIFF
--- a/projects/packages/search/changelog/fix-search-fiter-type-offset-warning
+++ b/projects/packages/search/changelog/fix-search-fiter-type-offset-warning
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Added a safeguard for unset array item warnings.
+
+

--- a/projects/packages/search/src/class-template-tags.php
+++ b/projects/packages/search/src/class-template-tags.php
@@ -63,7 +63,7 @@ class Template_Tags {
 		}
 
 		foreach ( (array) $filters as $filter ) {
-			if ( 'post_type' === $filter['type'] ) {
+			if ( isset( $filter['type'] ) && 'post_type' === $filter['type'] ) {
 				self::render_filter( $filter, $post_types );
 			} else {
 				self::render_filter( $filter, $active_post_types );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a warning that's caused by non-existent array key `type`:

```
PHP Warning:  Undefined array key "type" in /wordpress/plugins/jetpack/14.3/jetpack_vendor/automattic/jetpack-search/src/class-template-tags.php on line 66
```

## Proposed changes:
* Add an `isset` check in the condition where we get the warning.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Not sure how to test this, or where the filter without an expected key might come from.

