### PR TITLE
Docker: do not fatal if test data is not symlinked

### DIFF
--- a/tools/docker/bin/run.sh
+++ b/tools/docker/bin/run.sh
@@ -100,7 +100,11 @@ if [ "$COMPOSE_PROJECT_NAME" == "jetpack_dev" ] ; then
 	# Symlink jetpack into wordpress-develop for WP >= 5.6-beta1
 	WP_TESTS_JP_DIR="/tmp/wordpress-develop/tests/phpunit/data/plugins/jetpack"
 	if [ ! -L $WP_TESTS_JP_DIR ] || [ ! -e $WP_TESTS_JP_DIR ]; then
-		ln -s /var/www/html/wp-content/plugins/jetpack $WP_TESTS_JP_DIR
+		mkdir -p "$(dirname "$WP_TESTS_JP_DIR")" || true
+		ln -s /var/www/html/wp-content/plugins/jetpack $WP_TESTS_JP_DIR || {
+			echo "Warning: Failed to create symlink for test environment. This is non-fatal."
+			echo "Jetpack plugin PHPUnit tests will not run until this is resolved."
+		}
 	fi
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

I've ran into an issue that sometimes the WordPress container can't load because the symlink for the Jetpack test data fails. While I do need to figure out why that's happening, it seems extreme to totally fatal the WordPress container when that fails. That data is only used for Jetpack PHPUnit tests, yet the error stops any Docker usage.

This would have it fail with a message, but the rest of the script continues.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* I'm not 100% sure how to duplicate. It seems that my Docker run will fail to fully checkout the WP SVN and then, on the next run, it'll move past that and fail on the symlink for it not being there.
* You'll need to run `{jetpack|jp} docker build` to get the modified `run.sh` into the container.

Again, I want to figure out the larger issue, but in any event, the symlink failing shouldn't be a fatal IMO.

