### PR TITLE
Jetpack SEO: persist selected option

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-seo-persist-selected-option
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-seo-persist-selected-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO assistant: persist selected options if they haven't changed

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
@@ -221,7 +221,7 @@ export default function AssistantWizard( { close } ) {
 				) }
 				{ currentStep === 2 && steps[ currentStep ].type === 'options' && (
 					<OptionsInput
-						disabled={ ! steps[ currentStep ].value }
+						disabled={ ! steps[ currentStep ].hasSelection }
 						submitCtaLabel={ steps[ currentStep ].submitCtaLabel }
 						retryCtaLabel={ steps[ currentStep ].retryCtaLabel }
 						handleRetry={ handleRetry }
@@ -230,7 +230,7 @@ export default function AssistantWizard( { close } ) {
 				) }
 				{ currentStep === 3 && steps[ currentStep ].type === 'options' && (
 					<OptionsInput
-						disabled={ ! steps[ currentStep ].value }
+						disabled={ ! steps[ currentStep ].hasSelection }
 						submitCtaLabel={ steps[ currentStep ].submitCtaLabel }
 						retryCtaLabel={ steps[ currentStep ].retryCtaLabel }
 						handleRetry={ handleRetry }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/types.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/types.tsx
@@ -9,7 +9,7 @@ export interface Message {
 	selected?: boolean;
 }
 
-export type OptionMessage = Pick< Message, 'id' | 'content' >;
+export type OptionMessage = Pick< Message, 'id' | 'content' | 'selected' >;
 
 export interface Results {
 	[ key: string ]: {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/types.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/types.tsx
@@ -44,4 +44,5 @@ export interface Step {
 	submitCtaLabel?: string;
 	onRetry?: () => void;
 	retryCtaLabel?: string;
+	hasSelection?: boolean;
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-completion-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-completion-step.tsx
@@ -20,7 +20,7 @@ export const useCompletionStep = (): Step => {
 			}
 			setMessages( firstMessages );
 
-			await new Promise( resolve => setTimeout( resolve, 1500 ) );
+			await new Promise( resolve => setTimeout( resolve, 1000 ) );
 
 			const resultsString = Object.values( results )
 				.map( ( result: Results[ string ] ) => `${ result.value ? '✅' : '❌' } ${ result.label }` )

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -13,6 +13,7 @@ import { useMessages } from './wizard-messages';
 import type { Step, OptionMessage } from './types';
 
 export const useMetaDescriptionStep = ( { keywords }: { keywords: string } ): Step => {
+	const [ value, setValue ] = useState< string >();
 	const [ selectedMetaDescription, setSelectedMetaDescription ] = useState< string >();
 	const [ metaDescriptionOptions, setMetaDescriptionOptions ] = useState< OptionMessage[] >( [] );
 	const { messages, setMessages, addMessage, editLastMessage, setSelectedMessage } = useMessages();
@@ -47,6 +48,9 @@ export const useMetaDescriptionStep = ( { keywords }: { keywords: string } ): St
 		( option: OptionMessage ) => {
 			setSelectedMetaDescription( option.content as string );
 			setSelectedMessage( option );
+			setMetaDescriptionOptions( prev =>
+				prev.map( o => ( { ...o, selected: o.id === option.id } ) )
+			);
 		},
 		[ setSelectedMessage ]
 	);
@@ -67,6 +71,7 @@ export const useMetaDescriptionStep = ( { keywords }: { keywords: string } ): St
 	}, [ generatedCount, request ] );
 
 	const handleMetaDescriptionSubmit = useCallback( async () => {
+		setValue( selectedMetaDescription );
 		await editPost( { meta: { advanced_seo_description: selectedMetaDescription } } );
 		addMessage( { content: __( 'Meta description updated! ✅', 'jetpack' ) } );
 		return selectedMetaDescription;
@@ -87,8 +92,8 @@ export const useMetaDescriptionStep = ( { keywords }: { keywords: string } ): St
 						showIcon: true,
 				  };
 			let newMetaDescriptions = [ ...metaDescriptionOptions ];
-			// we only generate if options are empty
 			setMessages( [ initialMessage ] );
+			// we only generate if options are empty
 			if ( newMetaDescriptions.length === 0 ) {
 				newMetaDescriptions = await getMetaDescriptions();
 			}
@@ -133,8 +138,9 @@ export const useMetaDescriptionStep = ( { keywords }: { keywords: string } ): St
 		onRetry: handleMetaDescriptionRegenerate,
 		retryCtaLabel: __( 'Regenerate', 'jetpack' ),
 		onStart: handleMetaDescriptionGenerate,
-		value: selectedMetaDescription,
-		setValue: setSelectedMetaDescription,
+		value,
+		setValue,
 		includeInResults: true,
+		hasSelection: !! selectedMetaDescription,
 	};
 };

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -13,6 +13,7 @@ import { useMessages } from './wizard-messages';
 import type { Step, OptionMessage } from './types';
 
 export const useTitleStep = ( { keywords }: { keywords: string } ): Step => {
+	const [ value, setValue ] = useState< string >( '' );
 	const [ selectedTitle, setSelectedTitle ] = useState< string >( '' );
 	const [ titleOptions, setTitleOptions ] = useState< OptionMessage[] >( [] );
 	const { editPost } = useDispatch( 'core/editor' );
@@ -47,6 +48,7 @@ export const useTitleStep = ( { keywords }: { keywords: string } ): Step => {
 		( option: OptionMessage ) => {
 			setSelectedTitle( option.content as string );
 			setSelectedMessage( option );
+			setTitleOptions( prev => prev.map( o => ( { ...o, selected: o.id === option.id } ) ) );
 		},
 		[ setSelectedMessage ]
 	);
@@ -135,6 +137,7 @@ export const useTitleStep = ( { keywords }: { keywords: string } ): Step => {
 	}, [ addMessage, getTitles, titleOptions ] );
 
 	const handleTitleSubmit = useCallback( async () => {
+		setValue( selectedTitle );
 		await editPost( { title: selectedTitle, meta: { jetpack_seo_html_title: selectedTitle } } );
 		addMessage( { content: __( 'Title updated! ✅', 'jetpack' ) } );
 		return selectedTitle;
@@ -153,8 +156,9 @@ export const useTitleStep = ( { keywords }: { keywords: string } ): Step => {
 		onRetry: handleTitleRegenerate,
 		retryCtaLabel: __( 'Regenerate', 'jetpack' ),
 		onStart: handleTitleGenerate,
-		value: selectedTitle,
-		setValue: setSelectedTitle,
+		value,
+		setValue,
 		includeInResults: true,
+		hasSelection: !! selectedTitle,
 	};
 };


### PR DESCRIPTION


## Proposed changes:
Split the `selected` and `value` states on the steps to keep track of them separately. This allows for the submit buttons to be enabled on selection without considering that selection the value for the step. The value needs to only be set on submission.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Open the assistant from the Jetpack sidebar. Navigate back and forth on option steps (title and meta), see that a selected option persists through navigation unless it had to be generated again (steps still co-depend on their values, so they'd trigger a new generation when another step changes)