### PR TITLE
VideoPress: Fix VideoPress stdclass property warning.

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-stdclass-property-warning
+++ b/projects/packages/videopress/changelog/fix-videopress-stdclass-property-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix warnnings for videos with no prior metadata.

--- a/projects/packages/videopress/src/utility-functions.php
+++ b/projects/packages/videopress/src/utility-functions.php
@@ -500,6 +500,7 @@ function video_get_info_by_blogpostid( $blog_id, $post_id ) {
 	$video_info->description     = $post->post_content;
 	$video_info->title           = $post->post_title;
 	$video_info->caption         = $post->post_excerpt;
+	$video_info->privacy_setting = VIDEOPRESS_PRIVACY::SITE_DEFAULT;
 
 	if ( is_wp_error( $post ) ) {
 		return $video_info;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a warning that is caused by a missing property access attempt:

```
PHP Warning:  Undefined property: stdClass::$privacy_setting in /wordpress/plugins/jetpack/14.3/jetpack_vendor/automattic/jetpack-videopress/src/utility-functions.php on line 529
```

## Proposed changes:
* Defines a property and adds a default value to it to avoid warnings.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
* I don't know how the meta could be empty in this case, so it would be great if we could have a review on this.

