### PR TITLE
Jetpack SEO: add mock requests

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-seo-mock-requests
+++ b/projects/plugins/jetpack/changelog/add-jetpack-seo-mock-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO: add request mocking function for development

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
@@ -31,8 +31,11 @@ export default function AssistantWizard( { close } ) {
 
 	// Keywords
 	const keywordsStepData = useKeywordsStep();
-	const titleStepData = useTitleStep( { keywords: keywordsStepData.value } );
-	const metaStepData = useMetaDescriptionStep( { keywords: keywordsStepData.value } );
+	const titleStepData = useTitleStep( { keywords: keywordsStepData.value, mockRequests: true } );
+	const metaStepData = useMetaDescriptionStep( {
+		keywords: keywordsStepData.value,
+		mockRequests: true,
+	} );
 	const completionStepData = useCompletionStep();
 	const welcomeStepData = useWelcomeStep();
 	// Memoize steps array to prevent unnecessary recreations

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -12,7 +12,29 @@ import { __ } from '@wordpress/i18n';
 import { useMessages } from './wizard-messages';
 import type { Step, OptionMessage } from './types';
 
-export const useMetaDescriptionStep = ( { keywords }: { keywords: string } ): Step => {
+const mockMetaDescriptionRequest = ( keywords: string ) => {
+	return new Promise< string >( resolve => {
+		setTimeout( () => {
+			resolve(
+				JSON.stringify( {
+					descriptions: [
+						'Discover everything you need to know about ' +
+							keywords +
+							'. Our comprehensive guide covers essential tips, expert advice and practical techniques for success.',
+					],
+				} )
+			);
+		}, 1000 );
+	} );
+};
+
+export const useMetaDescriptionStep = ( {
+	keywords,
+	mockRequests = false,
+}: {
+	keywords: string;
+	mockRequests?: boolean;
+} ): Step => {
 	const [ value, setValue ] = useState< string >();
 	const [ selectedMetaDescription, setSelectedMetaDescription ] = useState< string >();
 	const [ metaDescriptionOptions, setMetaDescriptionOptions ] = useState< OptionMessage[] >( [] );
@@ -23,7 +45,10 @@ export const useMetaDescriptionStep = ( { keywords }: { keywords: string } ): St
 	const [ generatedCount, setGeneratedCount ] = useState( 0 );
 
 	const request = useCallback( async () => {
-		const response = await askQuestionSync(
+		if ( mockRequests ) {
+			return mockMetaDescriptionRequest( keywords );
+		}
+		return askQuestionSync(
 			[
 				{
 					role: 'jetpack-ai' as const,
@@ -40,9 +65,7 @@ export const useMetaDescriptionStep = ( { keywords }: { keywords: string } ): St
 				feature: 'seo-meta-description',
 			}
 		);
-
-		return response;
-	}, [ keywords, postContent, postId ] );
+	}, [ keywords, postContent, postId, mockRequests ] );
 
 	const handleMetaDescriptionSelect = useCallback(
 		( option: OptionMessage ) => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -12,7 +12,23 @@ import { __ } from '@wordpress/i18n';
 import { useMessages } from './wizard-messages';
 import type { Step, OptionMessage } from './types';
 
-export const useTitleStep = ( { keywords }: { keywords: string } ): Step => {
+const mockTitleRequest = ( keywords: string ) => {
+	return new Promise< string >( resolve => {
+		setTimeout( () => {
+			resolve(
+				JSON.stringify( { titles: [ 'Title 1 about ' + keywords, 'Title 2 about ' + keywords ] } )
+			);
+		}, 1000 );
+	} );
+};
+
+export const useTitleStep = ( {
+	keywords,
+	mockRequests = false,
+}: {
+	keywords: string;
+	mockRequests?: boolean;
+} ): Step => {
 	const [ value, setValue ] = useState< string >( '' );
 	const [ selectedTitle, setSelectedTitle ] = useState< string >( '' );
 	const [ titleOptions, setTitleOptions ] = useState< OptionMessage[] >( [] );
@@ -24,7 +40,10 @@ export const useTitleStep = ( { keywords }: { keywords: string } ): Step => {
 	const [ generatedCount, setGeneratedCount ] = useState( 0 );
 
 	const request = useCallback( async () => {
-		const response = await askQuestionSync(
+		if ( mockRequests ) {
+			return mockTitleRequest( keywords );
+		}
+		return askQuestionSync(
 			[
 				{
 					role: 'jetpack-ai' as const,
@@ -40,9 +59,7 @@ export const useTitleStep = ( { keywords }: { keywords: string } ): Step => {
 				feature: 'seo-title',
 			}
 		);
-
-		return response;
-	}, [ keywords, postContent, postId ] );
+	}, [ keywords, postContent, postId, mockRequests ] );
 
 	const handleTitleSelect = useCallback(
 		( option: OptionMessage ) => {


### PR DESCRIPTION
## Proposed changes:
This PR adds mocking functions to deal with backend requests while developing the feature. It will simulate a 1s delayed request and provide usable data for title and meta steps

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1738945766324189-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Open the SEO assistant and proceed with steps. See that title and meta steps always return fixed values, including keywords. Change the value for `mockRequests` to false on assistant-wizard.tsx lines 34-36 and reload. Now the assistant should actually perform the requests to backend.