### PR TITLE
keep both raw and formatted value on keywords step

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-seo-keywords-raw-formatted-value
+++ b/projects/plugins/jetpack/changelog/add-jetpack-seo-keywords-raw-formatted-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO Assistant: keep both raw and formatted value on keywords step, thus allowing for consistency on messages but also on provided value for later steps

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
@@ -214,8 +214,8 @@ export default function AssistantWizard( { close } ) {
 					<TextInput
 						ref={ keywordsInputRef }
 						placeholder={ steps[ currentStep ].placeholder }
-						value={ steps[ currentStep ].value }
-						setValue={ steps[ currentStep ].setValue }
+						value={ steps[ currentStep ].rawInput }
+						setValue={ steps[ currentStep ].setRawInput }
 						handleSubmit={ handleStepSubmit }
 					/>
 				) }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/types.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/types.tsx
@@ -37,7 +37,8 @@ export interface Step {
 
 	// Input step properties
 	placeholder?: string;
-
+	rawInput?: string;
+	setRawInput?: React.Dispatch< React.SetStateAction< string > >;
 	// Options step properties
 	options?: OptionMessage[];
 	onSelect?: ( option: OptionMessage ) => void;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-keywords-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-keywords-step.tsx
@@ -1,10 +1,11 @@
-import { createInterpolateElement, useCallback, useState } from '@wordpress/element';
+import { createInterpolateElement, useCallback, useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useMessages } from './wizard-messages';
 import type { Step } from './types';
 
 export const useKeywordsStep = (): Step => {
-	const [ keywords, setKeywords ] = useState( '' );
+	const [ value, setValue ] = useState< string >( '' );
+	const [ rawInput, setRawInput ] = useState( '' );
 	const { messages, addMessage } = useMessages();
 
 	const onStart = useCallback( async () => {
@@ -17,44 +18,56 @@ export const useKeywordsStep = (): Step => {
 		} );
 	}, [ addMessage ] );
 
+	useEffect( () => {
+		setValue(
+			rawInput
+				.split( ',' )
+				.map( k => k.trim() )
+				// remove empty entries
+				.filter( v => v )
+				// remove duped entries, inefficient but we don't expect a lot of entries here
+				.filter( ( v, i, arr ) => arr.indexOf( v ) === i )
+				.reduce( ( acc, curr, i, arr ) => {
+					if ( arr.length === 1 ) {
+						return curr;
+					}
+					return i === 0 ? curr : `${ acc },${ curr }`;
+				}, '' )
+		);
+	}, [ rawInput ] );
+
 	const handleKeywordsSubmit = useCallback( async () => {
-		if ( ! keywords.trim() ) {
+		if ( ! rawInput.trim() ) {
 			return '';
 		}
-		addMessage( { content: keywords, isUser: true } );
+		addMessage( { content: rawInput, isUser: true } );
 
-		const keywordlist = await new Promise( resolve =>
+		const keywordsString = await new Promise< string >( resolve =>
 			setTimeout( () => {
-				const commaSeparatedKeywords = keywords
-					.split( ',' )
-					.map( k => k.trim() )
-					// remove empty entries
-					.filter( v => v )
-					// remove duped entries, inefficient but we don't expect a lot of entries here
-					.filter( ( v, i, arr ) => arr.indexOf( v ) === i )
-					.reduce( ( acc, curr, i, arr ) => {
-						if ( arr.length === 1 ) {
-							return curr;
-						}
-						if ( i === arr.length - 1 ) {
-							return `${ acc } </b>&<b> ${ curr }`;
-						}
-						return i === 0 ? curr : `${ acc }, ${ curr }`;
-					}, '' );
-				resolve( commaSeparatedKeywords );
+				const formattedKeywords = value.split( ',' ).reduce( ( acc, curr, i, arr ) => {
+					if ( arr.length === 1 ) {
+						return curr;
+					}
+					if ( i === arr.length - 1 ) {
+						return `${ acc } </b>&<b> ${ curr }`;
+					}
+					return i === 0 ? curr : `${ acc }, ${ curr }`;
+				}, '' );
+
+				resolve( formattedKeywords );
 			}, 500 )
 		);
 
 		const message = createInterpolateElement(
 			/* Translators: wrapped string is list of keywords user has entered */
-			sprintf( __( `Got it! You're targeting <b>%s</b>. ✨✅`, 'jetpack' ), keywordlist ),
+			sprintf( __( `Got it! You're targeting <b>%s</b>. ✨✅`, 'jetpack' ), keywordsString ),
 			{
 				b: <b />,
 			}
 		);
 		addMessage( { content: message } );
-		return keywords;
-	}, [ addMessage, keywords ] );
+		return value;
+	}, [ addMessage, rawInput, value ] );
 
 	return {
 		id: 'keywords',
@@ -64,8 +77,10 @@ export const useKeywordsStep = (): Step => {
 		type: 'input',
 		placeholder: __( 'Photography, plants', 'jetpack' ),
 		onSubmit: handleKeywordsSubmit,
-		value: keywords,
-		setValue: setKeywords,
+		rawInput,
+		setRawInput,
+		value,
+		setValue,
 		onStart,
 	};
 };


### PR DESCRIPTION


## Proposed changes:
This PR splits the value on keywords step (input step) so to keep the value as the user entered but also the formatted version (cleaned up, comma separated string of keywords) to provide on later steps. This way, the steps don't have to perform the same cleanup, trusting the value will just be a string,with,values,separated,by,commas. It also makes for a single point of processing the user input string.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
As the state of things are right now, nothing should have changed. Both title and meta steps will receive the formatted value, but the keywords step will retain both.

You can enable debug (`setLocalStorage( 'debug', 'jetpack-seo:*' )`) and check the value vs the input text:

Input text: `,,dogs, , cats, some multi word keyword`

<img width="447" alt="image" src="https://github.com/user-attachments/assets/5f4a6c4c-6720-4b59-b009-949d35d344db" />
