### PR TITLE
Hide the welcome flow and recommendations for non admins

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -174,7 +174,7 @@ export default function MyJetpackScreen() {
 					</Col>
 				</Container>
 			) }
-			{ isWelcomeBannerVisible ? (
+			{ isWelcomeBannerVisible && userIsAdmin ? (
 				<WelcomeFlow
 					welcomeFlowExperiment={ welcomeFlowExperiment }
 					setWelcomeFlowExperiment={ setWelcomeFlowExperiment }
@@ -202,7 +202,9 @@ export default function MyJetpackScreen() {
 					</Container>
 				)
 			) }
-			{ ! isWelcomeBannerVisible && isSectionVisible && <EvaluationRecommendations /> }
+			{ ! isWelcomeBannerVisible && isSectionVisible && userIsAdmin && (
+				<EvaluationRecommendations />
+			) }
 
 			<ProductCardsSection />
 


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This diff prevents the My Jetpack Welcome flow or onboarding recommendations from showing to non-admins (non-admins cannot install plugins or enable features)

It should be noted that, since they cannot see My Jetpack without a site connection, non-admins would never see the welcome banner anyway. The checks added in the PR just make this intent more clear in the code.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up a new test site with an admin and non-admin user
* Make sure the non-admin user cannot see the Jetpack page before the site is connected and, after the site is connected, that they don't see any product recommendations produced by the welcome flow (these actually don't show for any users at the moment anyway 😃)

