### PR TITLE
Update/my jetpack dataview mobile row click

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/products-table-view/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/products-table-view/index.tsx
@@ -34,7 +34,7 @@ import type {
 	Operator,
 	Option,
 } from '@wordpress/dataviews';
-import type { FC, MouseEvent } from 'react';
+import type { FC } from 'react';
 
 import './style.scss';
 
@@ -102,7 +102,6 @@ const ProductsTableView: FC< ProductsTableViewProps > = ( { products } ) => {
 	const onChangeView = useCallback( ( newView: View ) => {
 		setView( newView );
 	}, [] );
-	const isItemClickable = useCallback( () => false, [] );
 	const allProductData = useAllProducts();
 	const isMobileViewport: boolean = useViewportMatch( 'medium', '<' );
 	const navigate = useNavigate();
@@ -135,12 +134,22 @@ const ProductsTableView: FC< ProductsTableViewProps > = ( { products } ) => {
 	);
 
 	const navigateToInterstitial = useCallback(
-		( slug: string ) => ( event: MouseEvent< HTMLButtonElement > ) => {
-			event.preventDefault();
+		( slug: string ) => {
 			recordEvent( `jetpack_myjetpack_product_list_item_${ slug }_learnmore_mobile_click` );
 			navigate( `add-${ slug }` );
 		},
 		[ navigate, recordEvent ]
+	);
+
+	const onChangeSelection = useCallback(
+		( items: JetpackModule[] ) => {
+			if ( isMobileViewport ) {
+				const slug = items[ 0 ];
+
+				navigateToInterstitial( slug );
+			}
+		},
+		[ navigateToInterstitial, isMobileViewport ]
 	);
 
 	const fields = useMemo( () => {
@@ -211,10 +220,7 @@ const ProductsTableView: FC< ProductsTableViewProps > = ( { products } ) => {
 
 					if ( isMobileViewport ) {
 						return (
-							<button
-								onClick={ navigateToInterstitial( slug ) }
-								className="product-list-item-chevron"
-							>
+							<button className="product-list-item-chevron">
 								<Icon icon={ chevronRight } size={ 24 } />
 							</button>
 						);
@@ -261,7 +267,7 @@ const ProductsTableView: FC< ProductsTableViewProps > = ( { products } ) => {
 			paginationInfo={ paginationInfo }
 			onChangeView={ onChangeView }
 			defaultLayouts={ defaultLayouts }
-			isItemClickable={ isItemClickable }
+			onChangeSelection={ onChangeSelection }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/products-table-view/style.scss
+++ b/projects/packages/my-jetpack/_inc/components/products-table-view/style.scss
@@ -6,10 +6,6 @@
 }
 
 div.dataviews-wrapper {
-    button.dataviews-view-list__item {
-        display: none;
-    }
-
     div.dataviews-filters__container {
         padding-left: 24px;
     }
@@ -59,6 +55,14 @@ div.dataviews-wrapper {
             .dataviews-view-list__fields {
                 justify-content: space-between;
                 flex-wrap: nowrap;
+                margin-right: 30px;
+            }
+
+            @media ( min-width: 783px ) {
+                .dataviews-view-list__fields {
+                    flex-wrap: wrap;
+                    margin-right: 0;
+                }
             }
     
             &:not(.is-selected).is-hovered,
@@ -69,6 +73,12 @@ div.dataviews-wrapper {
                     color: #757575;
                 }
             }
+        }
+    }
+
+    @media ( min-width: 783px ) {
+        button.dataviews-view-list__item {
+            display: none;
         }
     }
 }
@@ -101,6 +111,10 @@ div.dataviews-filters__summary-chip-container button.dataviews-filters__summary-
 }
 
 button.product-list-item-chevron {
+    position: absolute;
+    right: 30px;
+    top: calc( 50% - 12px );
+
     display: flex;
     align-items: center;
     justify-content: center;

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-dataview-mobile-row-click
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-dataview-mobile-row-click
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Make entire row of dataview clickable when on mobile


### PR DESCRIPTION
## Proposed changes:

* On mobile sizes, make entire row on products list clickable to go to Learn More

That way we aren't expecting the user to hit the chevron right on when they try to navigate

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: pghfsA-2S-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Go to My Jetpack
3. Change your screen width to less than 783px and scroll down to the "Discover More" section
![image](https://github.com/user-attachments/assets/e29bb8a4-5ef3-406e-9c68-f125d3671c74)
4. Click anywhere on the product you want to see more about and ensure it takes you to the correct interstitial
![image](https://github.com/user-attachments/assets/c483e076-715e-42d7-98cb-0dc28baf6286)
