### PR TITLE
My Jetpack: hide card actions for non-admins

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/action-button/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/action-button/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@automattic/jetpack-components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Icon, chevronDown, external, check } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useCallback, useState, useEffect, useMemo, useRef } from 'react';
@@ -36,7 +36,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 	className,
 	tracksIdentifier,
 } ) => {
-	const { userIsAdmin, lifecycleStats } = getMyJetpackWindowInitialState();
+	const { lifecycleStats } = getMyJetpackWindowInitialState();
 	const { ownedProducts } = lifecycleStats;
 
 	const [ isDropdownOpen, setIsDropdownOpen ] = useState( false );
@@ -49,7 +49,6 @@ const ActionButton: FC< ActionButtonProps > = ( {
 		managePaidPlanPurchaseUrl,
 		renewPaidPlanPurchaseUrl,
 		status,
-		name,
 		requiresUserConnection,
 	} = detail;
 	const { siteIsRegistering, isRegistered, isUserConnected } = useMyJetpackConnection();
@@ -68,7 +67,6 @@ const ActionButton: FC< ActionButtonProps > = ( {
 		( siteIsRegistering && status === PRODUCT_STATUSES.SITE_CONNECTION_ERROR );
 	const hasAdditionalActions = additionalActions?.length > 0;
 	const isOwned = ownedProducts?.includes( slug );
-	const admin = !! userIsAdmin;
 	const troubleshootBackupsUrl =
 		'https://jetpack.com/support/backup/troubleshooting-jetpack-backup/';
 
@@ -358,17 +356,6 @@ const ActionButton: FC< ActionButtonProps > = ( {
 			recordDropdownStateChange();
 		}
 	} );
-
-	if ( ! admin ) {
-		return (
-			<Button { ...buttonState } size="small" variant="link" weight="regular">
-				{
-					/* translators: placeholder is product name. */
-					sprintf( __( 'Learn about %s', 'jetpack-my-jetpack' ), name )
-				}
-			</Button>
-		);
-	}
 
 	const dropdown = hasAdditionalActions && (
 		<div ref={ dropdownRef } className={ styles[ 'action-button-dropdown' ] }>

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
@@ -43,6 +43,7 @@ const ProductCard: FC< ProductCardProps > = props => {
 		name,
 		Description,
 		status,
+		admin,
 		isDataLoading,
 		slug,
 		additionalActions,
@@ -149,22 +150,29 @@ const ProductCard: FC< ProductCardProps > = props => {
 				<RecommendationActions slug={ slug } />
 			) : (
 				<div className={ styles.actions }>
-					<div className={ styles.buttons }>
-						{ secondaryAction && secondaryAction?.positionFirst && (
-							<SecondaryButton { ...secondaryAction } />
-						) }
-						<ActionButton
-							slug={ slug }
-							additionalActions={ additionalActions }
-							primaryActionOverride={ primaryActionOverride }
-							fixSiteConnectionHandler={ fixSiteConnectionHandler }
-							setIsActionLoading={ setIsActionLoading }
-							tracksIdentifier="product_card"
-						/>
-						{ secondaryAction && ! secondaryAction?.positionFirst && (
-							<SecondaryButton { ...secondaryAction } />
-						) }
-					</div>
+					{
+						// TODO: only some products (social connections for example) have settings for non-admins
+						// Each product needs to specify this separately and provide a destination to link to for management by non-admins
+						// Until then, we don't show any action buttons or links on product cards for non-admins
+					 }
+					{ admin && (
+						<div className={ styles.buttons }>
+							{ secondaryAction && secondaryAction?.positionFirst && (
+								<SecondaryButton { ...secondaryAction } />
+							) }
+							<ActionButton
+								slug={ slug }
+								additionalActions={ additionalActions }
+								primaryActionOverride={ primaryActionOverride }
+								fixSiteConnectionHandler={ fixSiteConnectionHandler }
+								setIsActionLoading={ setIsActionLoading }
+								tracksIdentifier="product_card"
+							/>
+							{ secondaryAction && ! secondaryAction?.positionFirst && admin && (
+								<SecondaryButton { ...secondaryAction } />
+							) }
+						</div>
+					) }
 					<Status
 						status={ status }
 						isFetching={ isLoading }


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
My Jetpack typically shows action buttons on the product cards:
![Screenshot 2025-02-07 at 3 21 48 PM](https://github.com/user-attachments/assets/846995a4-21c0-49a6-bf50-2d44968daa1e)

These action buttons and links are not relevant for non-admins as they currently cannot view or manage the settings for any products. This PR hides any action buttons or links on the product cards for non-admin users:
![Screenshot 2025-02-07 at 3 21 40 PM](https://github.com/user-attachments/assets/45ca775b-1692-4d6a-9557-cd5319e9a021)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test this PR as a non-admin, confirm that you do not see any action buttons or links on the cards in My Jetpack

