### PR TITLE
Jetpack SEO: set mockRequests to false

### DIFF
--- a/projects/plugins/jetpack/changelog/change-jetpack-seo-switch-mock-requests
+++ b/projects/plugins/jetpack/changelog/change-jetpack-seo-switch-mock-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO: switch mockRequests flag to false so it defaults to make requests to backend

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
@@ -31,10 +31,10 @@ export default function AssistantWizard( { close } ) {
 
 	// Keywords
 	const keywordsStepData = useKeywordsStep();
-	const titleStepData = useTitleStep( { keywords: keywordsStepData.value, mockRequests: true } );
+	const titleStepData = useTitleStep( { keywords: keywordsStepData.value, mockRequests: false } );
 	const metaStepData = useMetaDescriptionStep( {
 		keywords: keywordsStepData.value,
-		mockRequests: true,
+		mockRequests: false,
 	} );
 	const completionStepData = useCompletionStep();
 	const welcomeStepData = useWelcomeStep();


### PR DESCRIPTION
## Proposed changes:
This PR switches mockRequests flag to false so it defaults to make requests to backend. This is just a maintenance PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1738958550819329-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Use the SEO assistant, by default is should perform requests to our backend AI endpoint