### PR TITLE
Use present tense in automated changelog entries

### DIFF
--- a/.github/files/renovate-post-upgrade.sh
+++ b/.github/files/renovate-post-upgrade.sh
@@ -58,7 +58,7 @@ for DIR in $(git -c core.quotepath=off diff --name-only HEAD | sed -nE 's!^(proj
 	echo "Adding change file for $SLUG"
 	cd "$DIR"
 
-	changelogger_add 'Updated package dependencies.' '' --filename="${CHANGEFILE}" --filename-auto-suffix
+	changelogger_add 'Update package dependencies.' '' --filename="${CHANGEFILE}" --filename-auto-suffix
 	cd "$BASE"
 done
 

--- a/tools/changelogger-release.sh
+++ b/tools/changelogger-release.sh
@@ -280,10 +280,10 @@ for DS in $( git -c core.quotepath=off diff --name-only projects | sed -E -e 's!
 		debug "  $DS already has an uncommitted change entry file, skipping"
 	elif ! git diff --quiet -- . ":!./composer.lock"; then
 		debug "  $DS has non-lockfile changes"
-		changelogger_add 'Updated package dependencies.'
+		changelogger_add 'Update package dependencies.'
 	else
 		debug "  $DS has lockfile changes only"
-		changelogger_add '' 'Updated composer.lock.'
+		changelogger_add '' 'Update composer.lock.'
 	fi
 done
 cd "$BASE"

--- a/tools/check-intra-monorepo-deps.sh
+++ b/tools/check-intra-monorepo-deps.sh
@@ -219,7 +219,7 @@ for SLUG in "${SLUGS[@]}"; do
 
 				if $DOCL; then
 					info "Creating changelog entry for $SLUG"
-					do_changelogger "$SLUG" 'Updated package dependencies.'
+					do_changelogger "$SLUG" 'Update package dependencies.'
 					DOCL=false
 				fi
 			fi
@@ -233,7 +233,7 @@ for SLUG in "${SLUGS[@]}"; do
 
 				if $DOCL; then
 					info "Creating changelog entry for $SLUG"
-					do_changelogger "$SLUG" 'Updated package dependencies.'
+					do_changelogger "$SLUG" 'Update package dependencies.'
 					DOCL=false
 				fi
 			fi

--- a/tools/check-intra-monorepo-deps.sh
+++ b/tools/check-intra-monorepo-deps.sh
@@ -249,7 +249,7 @@ for SLUG in "${SLUGS[@]}"; do
 				"$BASE/tools/composer-update-monorepo.sh" --quiet --no-install --no-scripts --no-audit "$PROJECTFOLDER"
 				if [[ "$OLD" != "$(<composer.lock)" ]] && $DOCL; then
 					info "Creating changelog entry for $SLUG composer.lock update"
-					do_changelogger "$SLUG" '' 'Updated composer.lock.'
+					do_changelogger "$SLUG" '' 'Update composer.lock.'
 				fi
 				debug "Done updating $SLUG composer.lock"
 			} &

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -363,7 +363,7 @@ async function addIndirectPlugins( argv, directProjects, changelogFiles ) {
 			continue;
 		}
 
-		// If it has a changelog file other than "Updated composer.lock" or "Updated dependencies", skip it.
+		// If it has a changelog file other than "Update composer.lock" or "Update dependencies", skip it.
 		// Either it's directly affected or we added an entry in a previous run.
 		if ( changelogFiles.has( proj ) ) {
 			for ( const file of changelogFiles.get( proj ) ) {

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -369,8 +369,8 @@ async function addIndirectPlugins( argv, directProjects, changelogFiles ) {
 			for ( const file of changelogFiles.get( proj ) ) {
 				const contents = fs.readFileSync( file, 'utf-8' );
 				if (
-					! contents.match( /^Comment: Updated composer\.lock\.$/m ) ||
-					contents.match( /\r?\n\r?\n(?!Updated package dependencies\.[\r\n]*$)\s*\S/ )
+					! contents.match( /^Comment: Updated? composer\.lock\.$/m ) ||
+					contents.match( /\r?\n\r?\n(?!Updated? package dependencies\.[\r\n]*$)\s*\S/ )
 				) {
 					continue projloop;
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This is a simple PR to make sure our automated changelog entries are put in present tense.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Should be pretty straight-forward...