### PR TITLE
Boost: Cleanup minify modules

### DIFF
--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -94,7 +94,7 @@ add_action( 'jetpack_boost_404_tester_cron', 'jetpack_boost_404_tester' );
 /**
  * Setup the 404 tester.
  *
- * Schedule the 404 tester in three seconds if the concatenation modules
+ * Schedule the 404 tester if the concatenation modules
  * haven't been toggled since this feature was released.
  * Only run this in wp-admin to avoid excessive updates to the option.
  */

--- a/projects/plugins/boost/app/modules/optimizations/dist/inline-script.asset.php
+++ b/projects/plugins/boost/app/modules/optimizations/dist/inline-script.asset.php
@@ -1,4 +1,0 @@
-<?php return array(
-	'dependencies' => array(),
-	'version'      => 'c62f4cf4887d19aef4e4',
-);

--- a/projects/plugins/boost/app/modules/optimizations/minify/class-minify-css.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/class-minify-css.php
@@ -16,7 +16,7 @@ class Minify_CSS implements Pluggable, Changes_Page_Output, Optimization, Has_Ac
 	public function setup() {
 		require_once JETPACK_BOOST_DIR_PATH . '/app/lib/minify/functions-helpers.php';
 
-		jetpack_boost_minify_setup();
+		jetpack_boost_minify_init();
 
 		if ( jetpack_boost_page_optimize_bail() ) {
 			return;
@@ -51,6 +51,7 @@ class Minify_CSS implements Pluggable, Changes_Page_Output, Optimization, Has_Ac
 	}
 
 	public static function activate() {
+		jetpack_boost_minify_activation();
 		jetpack_boost_404_tester();
 	}
 

--- a/projects/plugins/boost/app/modules/optimizations/minify/class-minify-js.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/class-minify-js.php
@@ -16,7 +16,7 @@ class Minify_JS implements Pluggable, Changes_Page_Output, Optimization, Has_Act
 	public function setup() {
 		require_once JETPACK_BOOST_DIR_PATH . '/app/lib/minify/functions-helpers.php';
 
-		jetpack_boost_minify_setup();
+		jetpack_boost_minify_init();
 
 		if ( jetpack_boost_page_optimize_bail() ) {
 			return;
@@ -51,6 +51,7 @@ class Minify_JS implements Pluggable, Changes_Page_Output, Optimization, Has_Act
 	}
 
 	public static function activate() {
+		jetpack_boost_minify_activation();
 		jetpack_boost_404_tester();
 	}
 

--- a/projects/plugins/boost/changelog/update-minify-concat
+++ b/projects/plugins/boost/changelog/update-minify-concat
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Cleanup around minify features
+
+


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Cleanup activation and per-page-load code for minify static file service.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1738942777652179-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Make sure static minify files still serve correctly
* Make sure the garbage collection for minify works