### PR TITLE
Forms: Update date picker input to use a accessible standalone date picker

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2443,11 +2443,6 @@ importers:
         specifier: 7.19.0
         version: 7.19.0(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.94.0)
       '@wordpress/data':
-        specifier: 10.17.0
-        version: 10.17.0(react@18.3.1)
-      '@wordpress/dom-ready':
-        specifier: 4.17.0
-        version: 4.17.0
         specifier: 10.19.0
         version: 10.19.0(react@18.3.1)
       '@wordpress/dataviews':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29117,6 +29117,8 @@ snapshots:
 
   text-hex@1.0.0: {}
 
+  third-party-web@0.26.5: {}
+
   thread-loader@3.0.4(webpack@5.94.0):
     dependencies:
       json-parse-better-errors: 1.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2443,6 +2443,11 @@ importers:
         specifier: 7.19.0
         version: 7.19.0(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.94.0)
       '@wordpress/data':
+        specifier: 10.17.0
+        version: 10.17.0(react@18.3.1)
+      '@wordpress/dom-ready':
+        specifier: 4.17.0
+        version: 4.17.0
         specifier: 10.19.0
         version: 10.19.0(react@18.3.1)
       '@wordpress/dataviews':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29117,8 +29117,6 @@ snapshots:
 
   text-hex@1.0.0: {}
 
-  third-party-web@0.26.5: {}
-
   thread-loader@3.0.4(webpack@5.94.0):
     dependencies:
       json-parse-better-errors: 1.0.2

--- a/projects/packages/forms/changelog/update-date-picker-input-try-2
+++ b/projects/packages/forms/changelog/update-date-picker-input-try-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: update the datepicker to be a more accessible and not use jquery

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -916,17 +916,64 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		}
 
 		Assets::register_script(
-			'grunion-frontend',
-			'../../dist/contact-form/js/grunion-frontend.js',
+			'jp-date-picker',
+			'../../dist/contact-form/js/date-picker.js',
 			__FILE__,
 			array(
 				'enqueue'      => true,
-				'dependencies' => array( 'jquery', 'jquery-ui-datepicker' ),
+				'dependencies' => array(),
 				'version'      => \JETPACK__VERSION,
 			)
 		);
 
-		wp_enqueue_style( 'jp-jquery-ui-datepicker', plugins_url( '../../dist/contact-form/css/jquery-ui-datepicker.css', __FILE__ ), array( 'dashicons' ), '1.0' );
+		/**
+		 * Filter the localized date picker script.
+		 */
+		if ( ! apply_filters( 'jetpack_has_localized_date_picker', false ) ) {
+			\wp_localize_script(
+				'jp-date-picker',
+				'jpDatePicker',
+				array(
+					'offset' => intval( get_option( 'start_of_week', 1 ) ),
+					'lang'   => array(
+						'days'      => array( __( 'Sun', 'jetpack-forms' ), __( 'Mon', 'jetpack-forms' ), __( 'Tue', 'jetpack-forms' ), __( 'Wed', 'jetpack-forms' ), __( 'Thu', 'jetpack-forms' ), __( 'Fri', 'jetpack-forms' ), __( 'Sat', 'jetpack-forms' ) ),
+						'months'    => array(
+							__( 'January', 'jetpack-forms' ),
+							__( 'February', 'jetpack-forms' ),
+							__( 'March', 'jetpack-forms' ),
+							__( 'April', 'jetpack-forms' ),
+							__( 'May', 'jetpack-forms' ),
+							__( 'June', 'jetpack-forms' ),
+							__( 'July', 'jetpack-forms' ),
+							__( 'August', 'jetpack-forms' ),
+							__( 'September', 'jetpack-forms' ),
+							__( 'October', 'jetpack-forms' ),
+							__( 'November', 'jetpack-forms' ),
+							__( 'December', 'jetpack-forms' ),
+						),
+						'today'     => __( 'Today', 'jetpack-forms' ),
+						'clear'     => __( 'Clear', 'jetpack-forms' ),
+						'close'     => __( 'Close', 'jetpack-forms' ),
+						'ariaLabel' => array(
+							'enterPicker'       => __( 'You are on a date picker input. Use the down key to focus into the date picker. Or type the date in the format MM/DD/YYYY', 'jetpack-forms' ),
+							'dayPicker'         => __( 'You are currently inside the date picker, use the arrow keys to navigate between the dates. Use tab key to jump to more controls.', 'jetpack-forms' ),
+							'monthPicker'       => __( 'You are currently inside the month picker, use the arrow keys to navigate between the months. Use the space key to select it.', 'jetpack-forms' ),
+							'yearPicker'        => __( 'You are currently inside the year picker, use the up and down arrow keys to navigate between the years. Use the space key to select it.', 'jetpack-forms' ),
+							'monthPickerButton' => __( 'Month picker. Use the space key to enter the month picker.', 'jetpack-forms' ),
+							'yearPickerButton'  => __( 'Year picker. Use the space key to enter the month picker.', 'jetpack-forms' ),
+							'dayButton'         => __( 'Use the space key to select the date.', 'jetpack-forms' ),
+							'todayButton'       => __( 'Today button. Use the space key to select the current date.', 'jetpack-forms' ),
+							'clearButton'       => __( 'Clear button. Use the space key to clear the date picker.', 'jetpack-forms' ),
+							'closeButton'       => __( 'Close button. Use the space key to close the date picker.', 'jetpack-forms' ),
+						),
+					),
+				)
+			);
+			// Only include the localized script once.
+			add_filter( 'jetpack_has_localized_date_picker', '__return_true' );
+		}
+
+		\wp_enqueue_style( 'jp-date-picker', plugins_url( '../../dist/contact-form/js/date-picker.css', __FILE__ ), array(), \JETPACK__VERSION );
 
 		return $field;
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -936,7 +936,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				array(
 					'offset' => intval( get_option( 'start_of_week', 1 ) ),
 					'lang'   => array(
-						'days'      => array( __( 'Sun', 'jetpack-forms' ), __( 'Mon', 'jetpack-forms' ), __( 'Tue', 'jetpack-forms' ), __( 'Wed', 'jetpack-forms' ), __( 'Thu', 'jetpack-forms' ), __( 'Fri', 'jetpack-forms' ), __( 'Sat', 'jetpack-forms' ) ),
+						'days'      => array( __( 'Su', 'jetpack-forms' ), __( 'Mo', 'jetpack-forms' ), __( 'Tu', 'jetpack-forms' ), __( 'We', 'jetpack-forms' ), __( 'Th', 'jetpack-forms' ), __( 'Fr', 'jetpack-forms' ), __( 'Sa', 'jetpack-forms' ) ),
 						'months'    => array(
 							__( 'January', 'jetpack-forms' ),
 							__( 'February', 'jetpack-forms' ),

--- a/projects/packages/forms/src/contact-form/js/accessible-form.js
+++ b/projects/packages/forms/src/contact-form/js/accessible-form.js
@@ -317,8 +317,7 @@ const isDateFieldValid = input => {
 			return false;
 		}
 	}
-	input.setCustomValidity( L10N.invalidDate );
-	return false;
+	return true;
 };
 
 /**

--- a/projects/packages/forms/src/contact-form/js/accessible-form.js
+++ b/projects/packages/forms/src/contact-form/js/accessible-form.js
@@ -264,41 +264,6 @@ const isMultipleChoiceFieldValid = fieldset => {
 
 	return false;
 };
-/**
- * Check if a Date Picker field is valid.
- *
- * @param {string} value  Date value
- * @param {string} format Date format
- *
- * @returns {boolean}
- */
-const validateDate = ( value, format ) => {
-	let year, month, day;
-
-	switch ( format ) {
-		case 'mm/dd/yy':
-			[ month, day, year ] = value.split( '/' ).map( Number );
-			break;
-
-		case 'dd/mm/yy':
-			[ day, month, year ] = value.split( '/' ).map( Number );
-			break;
-
-		case 'yy-mm-dd':
-			[ year, month, day ] = value.split( '-' ).map( Number );
-			break;
-
-		default:
-			return false;
-	}
-	if ( isNaN( year ) || isNaN( month ) || isNaN( day ) ) {
-		return false;
-	}
-
-	const date = new Date( year, month - 1, day );
-
-	return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
-};
 
 /**
  * Check if a Date Picker field is valid.

--- a/projects/packages/forms/src/contact-form/js/accessible-form.js
+++ b/projects/packages/forms/src/contact-form/js/accessible-form.js
@@ -264,6 +264,41 @@ const isMultipleChoiceFieldValid = fieldset => {
 
 	return false;
 };
+/**
+ * Check if a Date Picker field is valid.
+ *
+ * @param {string} value  Date value
+ * @param {string} format Date format
+ *
+ * @returns {boolean}
+ */
+const validateDate = ( value, format ) => {
+	let year, month, day;
+
+	switch ( format ) {
+		case 'mm/dd/yy':
+			[ month, day, year ] = value.split( '/' ).map( Number );
+			break;
+
+		case 'dd/mm/yy':
+			[ day, month, year ] = value.split( '/' ).map( Number );
+			break;
+
+		case 'yy-mm-dd':
+			[ year, month, day ] = value.split( '-' ).map( Number );
+			break;
+
+		default:
+			return false;
+	}
+	if ( isNaN( year ) || isNaN( month ) || isNaN( day ) ) {
+		return false;
+	}
+
+	const date = new Date( year, month - 1, day );
+
+	return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
+};
 
 /**
  * Check if a Date Picker field is valid.
@@ -282,8 +317,8 @@ const isDateFieldValid = input => {
 			return false;
 		}
 	}
-
-	return true;
+	input.setCustomValidity( L10N.invalidDate );
+	return false;
 };
 
 /**

--- a/projects/packages/forms/src/contact-form/js/date-picker.js
+++ b/projects/packages/forms/src/contact-form/js/date-picker.js
@@ -1,9 +1,8 @@
-import domReady from '@wordpress/dom-ready';
 import { DatePicker } from './../libs/date-picker/date-picker';
 
 import './../libs/date-picker/date-picker.css';
 
-domReady( () => {
+document.addEventListener( 'DOMContentLoaded', () => {
 	document.querySelectorAll( '.jp-contact-form-date' ).forEach( function ( node ) {
 		DatePicker( node, {
 			lang: window.jpDatePicker.lang,

--- a/projects/packages/forms/src/contact-form/js/date-picker.js
+++ b/projects/packages/forms/src/contact-form/js/date-picker.js
@@ -8,6 +8,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			lang: window.jpDatePicker.lang,
 			dayOffset: Number( window.jpDatePicker.offset ),
 			dateFormat: node.dataset.format,
+			hasFooter: false,
 		} );
 	} );
 } );

--- a/projects/packages/forms/src/contact-form/js/date-picker.js
+++ b/projects/packages/forms/src/contact-form/js/date-picker.js
@@ -1,0 +1,14 @@
+import domReady from '@wordpress/dom-ready';
+import { DatePicker } from './../libs/date-picker/date-picker';
+
+import './../libs/date-picker/date-picker.css';
+
+domReady( () => {
+	document.querySelectorAll( '.jp-contact-form-date' ).forEach( function ( node ) {
+		DatePicker( node, {
+			lang: window.jpDatePicker.lang,
+			dayOffset: Number( window.jpDatePicker.offset ),
+			dateFormat: node.dataset.format,
+		} );
+	} );
+} );

--- a/projects/packages/forms/src/contact-form/libs/date-picker/date-picker-options.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/date-picker-options.ts
@@ -6,7 +6,7 @@ import { now, shiftYear, dateOrParse } from './lib/date';
 import { cp } from './lib/fns';
 
 const english = {
-	days: [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ],
+	days: [ 'Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa' ],
 	months: [
 		'January',
 		'February',

--- a/projects/packages/forms/src/contact-form/libs/date-picker/date-picker-options.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/date-picker-options.ts
@@ -1,0 +1,149 @@
+/**
+ * @file Responsible for sanitizing and creating date picker options.
+ */
+import { IDatePicker, IDatePickerOptions } from './interfaces';
+import { now, shiftYear, dateOrParse } from './lib/date';
+import { cp } from './lib/fns';
+
+const english = {
+	days: [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ],
+	months: [
+		'January',
+		'February',
+		'March',
+		'April',
+		'May',
+		'June',
+		'July',
+		'August',
+		'September',
+		'October',
+		'November',
+		'December',
+	],
+	today: 'Today',
+	clear: 'Clear',
+	close: 'Close',
+	ariaLabel: {
+		enterPicker:
+			'You are on a date picker input. Use the down key to focus into the date picker. Or type the date in the format MM/DD/YYYY',
+		dayPicker:
+			'You are currently inside the date picker, use the arrow keys to navigate between the dates. Use tab key to jump to more controls.',
+		monthPicker:
+			'You are currently inside the month picker, use the arrow keys to navigate between the months. Use the space key to select it.',
+		yearPicker:
+			'You are currently inside the year picker, use the up and down arrow keys to navigate between the years. Use the space key to select it.',
+		monthPickerButton: 'Month picker. Use the space key to enter the month picker.',
+		yearPickerButton: 'Year picker. Use the space key to enter the month picker.',
+		dayButton: 'Use the space key to select the date.',
+		todayButton: 'Today button. Use the space key to select the current date.',
+		clearButton: 'Clear button. Use the space key to clear the date picker.',
+		closeButton: 'Close button. Use the space key to close the date picker.',
+	},
+};
+
+/**
+ * DatePickerOptions constructs a new date picker options object, overriding
+ * default values with any values specified in opts.
+ *
+ * @param  _options
+ *
+ * @returns {IDatePickerOptions}
+ */
+export function DatePickerOptions( _options: Partial< IDatePickerOptions > = {} ) {
+	const options = cp( defaults(), _options );
+	const parse = dateOrParse( options.parse, options.dateFormat );
+
+	options.lang = cp( english, options.lang );
+	options.parse = parse;
+	options.inRange = makeInRangeFn( options );
+	options.min = parse( options.min || shiftYear( now(), -100 ), options.dateFormat );
+	options.max = parse( options.max || shiftYear( now(), 100 ), options.dateFormat );
+	options.highlightedDate = options.parse( options.highlightedDate, options.dateFormat );
+	options.alignment = options.alignment || 'left';
+
+	return options;
+}
+/**
+ *
+ * @returns {IDatePickerOptions}
+ */
+function defaults(): IDatePickerOptions {
+	return {
+		lang: english,
+
+		// Possible values: dp-modal, dp-below, dp-permanent
+		mode: 'dp-below',
+
+		// The date to hilight initially if the date picker has no
+		// initial value.
+		highlightedDate: now(),
+
+		format: function ( dt: Date, dateFormat: string ) {
+			const month = ( '0' + ( dt.getMonth() + 1 ) ).slice( -2 );
+			const day = ( '0' + dt.getDate() ).slice( -2 );
+			const year = dt.getFullYear();
+
+			if ( dateFormat === 'yy-mm-dd' ) {
+				return year + '-' + month + '-' + day;
+			}
+			if ( dateFormat === 'dd/mm/yy' ) {
+				return day + '/' + month + '/' + year;
+			}
+			if ( dateFormat === 'mm/dd/yy' ) {
+				return month + '/' + day + '/' + year;
+			}
+			return month + '/' + day + '/' + year;
+		},
+
+		dateFormat: 'mm/dd/yy',
+
+		parse: function ( candidate: Date | string, dateFormat: string ): Date {
+			if ( ! candidate ) {
+				return now();
+			}
+
+			let [ parsedYear, parsedMonth, parsedDay ] = [ NaN, NaN, NaN ];
+			switch ( dateFormat ) {
+				case 'yy-mm-dd':
+					[ parsedYear, parsedMonth, parsedDay ] = candidate.split( '-' ).map( Number );
+					break;
+				case 'dd/mm/yy':
+					[ parsedDay, parsedMonth, parsedYear ] = candidate.split( '/' ).map( Number );
+					break;
+				case 'mm/dd/yy':
+					[ parsedMonth, parsedDay, parsedYear ] = candidate.split( '/' ).map( Number );
+					break;
+			}
+
+			const today = now();
+			const year = isNaN( parsedYear ) || parsedYear === 0 ? today.getFullYear() : parsedYear;
+			const month = isNaN( parsedMonth ) || parsedMonth === 0 ? today.getMonth() : parsedMonth - 1;
+			const day = isNaN( parsedDay ) || parsedDay === 0 ? today.getDate() : parsedDay;
+			const date = new Date( year, month, day );
+
+			return isNaN( date.valueOf() ) ? now() : date;
+		},
+
+		dateClass: function () {
+			return '';
+		},
+
+		inRange: function () {
+			return true;
+		},
+
+		appendTo: document.body,
+		alignment: 'left',
+	};
+}
+
+function makeInRangeFn( opts: IDatePickerOptions ) {
+	const inRange = opts.inRange; // Cache this version, and return a variant
+
+	return function ( dt: Date, dp: IDatePicker ) {
+		const earlierThanMin = opts.min ? opts.min <= dt : true;
+		const laterThanMax = opts.max ? opts.max >= dt : true;
+		return inRange( dt, dp ) && earlierThanMin && laterThanMax;
+	};
+}

--- a/projects/packages/forms/src/contact-form/libs/date-picker/date-picker-options.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/date-picker-options.ts
@@ -2,7 +2,7 @@
  * @file Responsible for sanitizing and creating date picker options.
  */
 import { IDatePicker, IDatePickerOptions } from './interfaces';
-import { now, shiftYear, dateOrParse } from './lib/date';
+import { now, shiftYear, dateOrParse, Dec31st, Jan1st } from './lib/date';
 import { cp } from './lib/fns';
 
 const english = {
@@ -57,8 +57,8 @@ export function DatePickerOptions( _options: Partial< IDatePickerOptions > = {} 
 	options.lang = cp( english, options.lang );
 	options.parse = parse;
 	options.inRange = makeInRangeFn( options );
-	options.min = parse( options.min || shiftYear( now(), -100 ), options.dateFormat );
-	options.max = parse( options.max || shiftYear( now(), 100 ), options.dateFormat );
+	options.min = parse( options.min || shiftYear( Jan1st(), -100 ), options.dateFormat );
+	options.max = parse( options.max || shiftYear( Dec31st(), 100 ), options.dateFormat );
 	options.highlightedDate = options.parse( options.highlightedDate, options.dateFormat );
 	options.alignment = options.alignment || 'left';
 

--- a/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
@@ -48,7 +48,7 @@
 	--dp-date-background-disabled: transparent;
 	--dp-date-color-disabled: #8c8f94;
 
-	--dp-today-color:#1f3286;
+	--dp-today-color: #2a46ce;
 	--dp-date-edge-color: #787c82;
 
 	--dp-text-color: #3c434a;
@@ -137,17 +137,29 @@
 	align-items: center;
 }
 
+.dp .dp-day,
+.dp .dp-month,
+.dp .dp-year,
+.dp .dp-cal-dropdown,
+.dp .dp-cal-nav {
+	color: var( --dp-ui-color ); /* Higher specificigy than the default */
+	border: none;
+	letter-spacing: 0;
+}
+
 .dp-cal-nav {
 	position: absolute;
 	width: 36px;
 	height: 36px;
-	overflow: hidden;
-	color: var( --dp-ui-color );
+	overflow: hidden !important; /* We don't want to show this ever */
 	border-radius: var( --dp-nav-radius );
 	box-shadow: none;
 	border: 0;
 	background: var( --dp-ui-background );
 	padding: 0;
+	font-size: 12px;
+	text-align: center;
+	line-height: 12px;
 }
 
 .dp-cal-nav:focus,
@@ -185,7 +197,7 @@
 	border-left: 0;
 	border-top: 0;
 	margin-left: 0;
-	margin-right: -26px;
+	margin-right: -22px;
 }
 
 .dp-cal-dropdown:after {
@@ -322,18 +334,11 @@
 }
 
 .dp-edge-day {
-	color: var(--dp-date-edge-color);
 	cursor: default;
 }
 
-.dp-selected {
-	background: var(--dp-date-background-selected);
-	color: var(--dp-date-color-selected);
-}
-
-.dp-current {
-	background: var(--dp-date-background-selected);
-	color: var(--dp-date-color-selected);
+.dp .dp-edge-day {
+	color: var(--dp-date-edge-color);
 }
 
 .dp-current:focus,
@@ -342,21 +347,44 @@
 .dp-selected:focus,
 .dp-year:focus {
 	outline: none;
+	box-shadow: none;
+}
+
+.dp .dp-current:focus,
+.dp .dp-day:focus,
+.dp .dp-month:focus,
+.dp .dp-selected:focus,
+.dp .dp-year:focus {
 	background: var(--dp-date-background-focus);
 	color: var(--dp-date-color-focus);
-	box-shadow: none;
 }
 
 .dp-day:hover,
 .dp-month:hover,
 .dp-year:hover,
 .dp-selected:hover {
-	background: var(--dp-date-background-hover);
-	color: var(--dp-date-color-hover);
 	box-shadow: none;
 }
 
-.dp-day-disabled {
+.dp .dp-selected {
+	background: var(--dp-date-background-selected);
+	color: var(--dp-date-color-selected);
+}
+
+.dp .dp-current {
+	background: var(--dp-date-background-selected);
+	color: var(--dp-date-color-selected);
+}
+
+.dp .dp-day:hover,
+.dp .dp-month:hover,
+.dp .dp-year:hover,
+.dp .dp-selected:hover {
+	background: var(--dp-date-background-hover);
+	color: var(--dp-date-color-hover);
+}
+
+.dp .dp-day-disabled {
 	background: var(--dp-date-background-disabled);
 	color: var(--dp-date-color-disabled);
 }

--- a/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
@@ -265,6 +265,7 @@
 	border-radius: 50%;
 	width: 36px;
 }
+.dp-focusable,
 .dp-day {
 	cursor: pointer;
 }

--- a/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
@@ -184,7 +184,7 @@
 	border-left: 0;
 	border-top: 0;
 	margin-left: 0;
-	margin-right: -32px;
+	margin-right: -26px;
 }
 
 .dp-cal-dropdown:after {

--- a/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
@@ -12,16 +12,16 @@
 	background: #FFF;
 	border: 1px solid rgba(0, 0, 0, 0.1);
 	box-shadow: 0 4px 10px 0 rgba(0, 0, 0, 0.1);
-
+	padding: 16px;
 	line-height: 1.4;
 	border-radius: 4px;
 	max-height: 400px;
 	z-index: 1000;
 	overflow: hidden;
 	font-family: sans-serif;
-	padding: 2px 5px;
 
 	--dp-min-height: 300px;
+	--dp-bold: 600;
 
 	--dp-ui-background: transparent;
 	--dp-ui-color: #333;
@@ -69,15 +69,15 @@
 
 .dp-below {
 	position: absolute;
-	font-size: 0.8em;
-	width: 400px;
+	font-size: 0.75em;
+	width: 320px;
 	max-width: 100vw;
 }
 
 .dp-permanent {
 	position: relative;
-	font-size: 0.8em;
-	width: 400px;
+	font-size: 0.75em;
+	width: 320px;
 	max-width: 100vw;
 }
 
@@ -97,7 +97,7 @@
 
 .dp-months {
 	min-height: var( --dp-min-height );
-	padding: 8px;
+	padding: 0;
 	display: grid;
 	grid-template-columns: auto auto auto;
 	grid-template-rows: auto auto auto auto;
@@ -108,8 +108,9 @@
 .dp-years {
 	box-sizing: border-box;
 	max-height: calc( var( --dp-min-height ) + 16px);
-	padding: 8px 5px;
-  overflow: auto !important; /* HACK for Chrome on Android */
+	padding: 8px 16px 8px 0;
+	margin-right: -16px;
+  	overflow: auto !important; /* HACK for Chrome on Android */
 }
 
 .dp-cal-month,
@@ -129,20 +130,22 @@
 
 .dp-cal-header {
 	position: relative;
-	padding: 0 8px 13px;
+	padding: 0 0 8px;
+	display: flex;
+	align-items: center;
 }
 
 .dp-next,
 .dp-prev {
 	position: absolute;
-	width: 30px;
-	height: 30px;
+	width: 36px;
+	height: 36px;
 	overflow: hidden;
-	top: 10px;
 	color: var( --dp-ui-color );
-	border-radius: 2px;
+	border-radius: 50%;
 	border: 0;
 	background: var( --dp-ui-background );
+	padding: 0;
 }
 
 .dp-next:focus,
@@ -154,23 +157,23 @@
 }
 
 .dp-prev {
-	right: 54px;
+	right: 46px;
 }
 
 .dp-next {
-	right: 8px;
+	right: 3px;
 }
 
 .dp-prev:before,
 .dp-next:before {
 	content: '';
 	border: 2px solid;
-	width: 10px;
-	height: 10px;
+	width: 6px;
+	height: 6px;
 	display: inline-block;
 	transform: rotate(-45deg);
 	transition: border-color 0.2s;
-	margin: 9px 0 40px 4px;
+	margin: 14px 0 40px 2px;
 }
 
 .dp-prev:before {
@@ -189,26 +192,21 @@
 .dp-cal-year {
 	display: inline-block;
 	font-size: 1.4em;
+	font-weight: var( --dp-bold);
 	padding: 8px 8px;
-	margin-top: 8px;
-	}
+}
 
 .dp-cal-footer {
 	text-align: center;
 }
 
-.dp-day-today:after {
-	content: '';
-	height: 0;
-	width: 0;
-	border: 7px solid var( --dp-today-color );
-	border-bottom-color: transparent;
-	border-left-color: transparent;
-	position: absolute;
-	top: 0;
-	right: 0;
+.dp-day-today {
+	outline: 1px solid var( --dp-today-color );
 }
-
+.dp-current.dp-day-today,
+.dp-selected.dp-day-today {
+	outline-offset: 2px;
+}
 .dp-close,
 .dp-clear,
 .dp-today {
@@ -260,16 +258,30 @@
 
 .dp-col-header,
 .dp-day {
-	width: 14.28571429%;
 	display: inline-block;
-	padding: 8px;
+	padding: 0;
 	text-align: center;
+	height: 36px;
+	border-radius: 50%;
+	width: 36px;
+}
+.dp-day {
+	cursor: pointer;
+}
+.dp-days {
+	display: grid;
+	align-content: space-between;
+	grid-template-columns: repeat(7, 1fr);
+	grid-template-rows: auto auto auto auto auto auto auto;
+	column-gap: 1px;
+	row-gap: 1px;
 }
 
 .dp-col-header {
 	text-transform: uppercase;
-	padding: 8px 0;
 	color: var(--dp-text-color);
+	font-weight: var(--dp-bold);
+	line-height: 36px;
 }
 
 .dp-month {
@@ -285,6 +297,7 @@
 
 .dp-edge-day {
 	color: var(--dp-date-edge-color);
+	cursor: default;
 }
 
 .dp-selected {

--- a/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
@@ -20,7 +20,7 @@
 	overflow: hidden;
 	font-family: sans-serif;
 
-	--dp-min-height: 300px;
+	--dp-min-height: 274px;
 	--dp-bold: 600;
 
 	--dp-ui-background: transparent;

--- a/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
@@ -207,7 +207,7 @@
 .dp-cal-dropdown {
 	position: relative;
 	display: inline-block;
-	font-size: 1.3em;
+	font-size: 16px;
 	font-weight: var( --dp-bold);
 	padding: 8px 22px 8px 8px;
 }

--- a/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
@@ -1,0 +1,354 @@
+.dp-modal {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background: rgba(255, 255, 255, 0.75);
+}
+
+.dp {
+	position: relative;
+	background: #FFF;
+	box-shadow: 2px 2px 16px rgba(0, 0, 0, 0.25);
+	line-height: 1.4;
+	border-radius: 4px;
+	max-height: 400px;
+	z-index: 1000;
+	overflow: hidden;
+	font-family: sans-serif;
+	padding: 2px 5px;
+
+	--dp-min-height: 300px;
+
+	--dp-ui-background: transparent;
+	--dp-ui-color: #333;
+
+	--dp-ui-background-selected: #EEE;
+	--dp-ui-color-selected: #111;
+
+	--dp-ui-background-focus: transparent;
+	--dp-ui-color-focus: #111;
+
+	--dp-date-background: transparent;
+	--dp-date-color: #2c3338;
+
+	--dp-date-background-selected: #2a46ce;
+	--dp-date-color-selected: #FFF;
+
+	--dp-date-background-focus: #c3c4c7;
+	--dp-date-color-focus: #1d2327;
+
+	--dp-date-background-hover: #dcdcde;
+	--dp-date-color-hover: #1d2327;
+
+	--dp-date-background-disabled: transparent;
+	--dp-date-color-disabled: #8c8f94;
+
+	--dp-today-color:#1f3286;
+	--dp-date-edge-color: #787c82;
+
+	--dp-text-color: #3c434a;
+}
+
+.dp-permanent .dp {
+	padding-top: 0;
+	border: 1px solid var( --db-border-color );
+	box-shadow: none;
+}
+
+.dp-permanent .dp:before {
+	display: none;
+}
+
+.dp-cal {
+	min-height: var( --dp-min-height );
+}
+
+.dp-below {
+	position: absolute;
+	font-size: 0.8em;
+	width: 400px;
+	max-width: 100vw;
+}
+
+.dp-permanent {
+	position: relative;
+	font-size: 0.8em;
+	width: 400px;
+	max-width: 100vw;
+}
+
+.dp-permanent .dp{
+	z-index: 0;
+}
+
+.dp-modal .dp {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	max-width: 600px;
+	width: calc(100% - 4em);
+	transform: translate(-50%, -50%);
+	animation: slide-up 0.3s forwards;
+}
+
+.dp-months {
+	min-height: var( --dp-min-height );
+	padding: 8px;
+	display: grid;
+	grid-template-columns: auto auto auto;
+	grid-template-rows: auto auto auto auto;
+	column-gap: 8px;
+	row-gap: 8px;
+}
+
+.dp-years {
+	box-sizing: border-box;
+	max-height: calc( var( --dp-min-height ) + 16px);
+	padding: 8px 5px;
+  overflow: auto !important; /* HACK for Chrome on Android */
+}
+
+.dp-cal-month,
+.dp-cal-year,
+.dp-day,
+.dp-month,
+.dp-year {
+	box-sizing: border-box;
+	text-align: center;
+	text-decoration: none;
+	position: relative;
+	color: var( --dp-date-color );
+	border-radius: 2px;
+	border: 0;
+	background: var( --dp-date-background );
+}
+
+.dp-cal-header {
+	position: relative;
+	padding: 0 8px 13px;
+}
+
+.dp-next,
+.dp-prev {
+	position: absolute;
+	width: 30px;
+	height: 30px;
+	overflow: hidden;
+	top: 10px;
+	color: var( --dp-ui-color );
+	border-radius: 2px;
+	border: 0;
+	background: var( --dp-ui-background );
+}
+
+.dp-next:focus,
+.dp-prev:focus,
+.dp-next:hover,
+.dp-prev:hover {
+	background: var( --dp-ui-background-focus );
+	color: var( --dp-ui-color-focus );
+}
+
+.dp-prev {
+	right: 54px;
+}
+
+.dp-next {
+	right: 8px;
+}
+
+.dp-prev:before,
+.dp-next:before {
+	content: '';
+	border: 2px solid;
+	width: 10px;
+	height: 10px;
+	display: inline-block;
+	transform: rotate(-45deg);
+	transition: border-color 0.2s;
+	margin: 9px 0 40px 4px;
+}
+
+.dp-prev:before {
+	border-right: 0;
+	border-bottom: 0;
+	}
+
+.dp-next:before {
+	border-left: 0;
+	border-top: 0;
+	margin-left: 0;
+	margin-right: 4px;
+}
+
+.dp-cal-month,
+.dp-cal-year {
+	display: inline-block;
+	font-size: 1.4em;
+	padding: 8px 8px;
+	margin-top: 8px;
+	}
+
+.dp-cal-footer {
+	text-align: center;
+}
+
+.dp-day-today:after {
+	content: '';
+	height: 0;
+	width: 0;
+	border: 7px solid var( --dp-today-color );
+	border-bottom-color: transparent;
+	border-left-color: transparent;
+	position: absolute;
+	top: 0;
+	right: 0;
+}
+
+.dp-close,
+.dp-clear,
+.dp-today {
+	box-sizing: border-box;
+	display: inline-block;
+	width: 33%;
+	padding: 8px;
+	text-decoration: none;
+	border: 0;
+	background: var( --dp-ui-background );
+	color: var( --dp-ui-color );
+}
+
+.dp-permanent .dp-close,
+.dp-permanent .dp-clear {
+	display: none;
+}
+
+.dp-close:active,
+.dp-clear:active,
+.dp-today:active,
+.dp-next:active,
+.dp-prev:active,
+.dp-cal-month:active,
+.dp-cal-year:active {
+	background: var( --dp-ui-background-selected);
+	color: var( --dp-ui-color-selected );
+}
+
+@media screen and (min-device-width: 1200px) {
+	.dp-close:hover,
+	.dp-close:focus,
+	.dp-clear:hover,
+	.dp-clear:focus,
+	.dp-today:hover,
+	.dp-today:focus,
+	.dp-next:hover,
+	.dp-next:focus,
+	.dp-prev:hover,
+	.dp-prev:focus,
+	.dp-cal-month:focus,
+	.dp-cal-month:hover,
+	.dp-cal-year:hover,
+	.dp-cal-year:focus {
+		background: var( --dp-ui-background-selected);
+		color: var( --dp-ui-color-selected );
+	}
+}
+
+.dp-col-header,
+.dp-day {
+	width: 14.28571429%;
+	display: inline-block;
+	padding: 8px;
+	text-align: center;
+}
+
+.dp-col-header {
+	text-transform: uppercase;
+	padding: 8px 0;
+	color: var(--dp-text-color);
+}
+
+.dp-month {
+	font-size: 1.4em;
+}
+
+.dp-year {
+	display: block;
+	padding: 8px 40px;
+	width: 100%;
+	font-size: 1.4em;
+}
+
+.dp-edge-day {
+	color: var(--dp-date-edge-color);
+}
+
+.dp-selected {
+	background: var(--dp-date-background-selected);
+	color: var(--dp-date-color-selected);
+}
+
+.dp-current {
+	background: var(--dp-date-background-selected);
+	color: var(--dp-date-color-selected);
+}
+
+.dp-current:focus,
+.dp-day:focus,
+.dp-month:focus,
+.dp-selected:focus,
+.dp-year:focus {
+	outline: none;
+	background: var(--dp-date-background-focus);
+	color: var(--dp-date-color-focus);
+}
+
+.dp-day:hover,
+.dp-month:hover,
+.dp-year:hover,
+.dp-selected:hover {
+	background: var(--dp-date-background-hover);
+	color: var(--dp-date-color-hover);
+}
+
+.dp-day-disabled {
+	background: var(--dp-date-background-disabled);
+	color: var(--dp-date-color-disabled);
+}
+
+.dp-day-disabled:focus,
+.dp-day-disabled:hover {
+	background: var(--dp-date-background-disabled);
+}
+
+.dp-focuser {
+	position: absolute;
+	z-index: 0;
+	top: 50%;
+	left: 50%;
+}
+
+/* Responsive overrides */
+@media (max-width: 480px), (max-height: 480px) {
+	.dp-modal .dp {
+		font-size: 0.9em;
+		width: auto;
+		width: 100%;
+	}
+
+	.dp-day-of-week,
+	.dp-day {
+		padding: 8px;
+	}
+}
+
+@keyframes slide-up {
+	0% {
+		transform: translate(-50%, 100%);
+	}
+	100% {
+		transform: translate(-50%, -50%);
+	}
+}

--- a/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
@@ -20,7 +20,7 @@
 	overflow: hidden;
 	font-family: sans-serif;
 
-	--dp-min-height: 274px;
+	--dp-min-height: 300px;
 	--dp-bold: 600;
 	--dp-nav-radius: 2px;
 
@@ -154,6 +154,7 @@
 .dp-cal-nav:hover {
 	background: var( --dp-ui-background-focus );
 	color: var( --dp-ui-color-focus );
+	box-shadow: none;
 }
 
 .dp-prev {
@@ -201,6 +202,7 @@
 	margin: 0;
 	margin-top: -6px;
 	right: -8px;
+	font-size: 16px;
 	vertical-align: middle;
 }
 
@@ -208,8 +210,14 @@
 	position: relative;
 	display: inline-block;
 	font-size: 16px;
+	line-height: 20px;
 	font-weight: var( --dp-bold);
 	padding: 8px 22px 8px 8px;
+}
+
+.dp-cal-dropdown:focus,
+.dp-cal-dropdown:hover {
+	box-shadow: none;
 }
 
 .dp-cal-footer {
@@ -302,7 +310,7 @@
 }
 
 .dp-month {
-	font-size: 1.3em;
+	font-size: 16px;
 	padding: 0;
 }
 
@@ -310,7 +318,7 @@
 	display: block;
 	padding: 8px 40px;
 	width: 100%;
-	font-size: 1.3em;
+	font-size: 16px;
 }
 
 .dp-edge-day {
@@ -336,6 +344,7 @@
 	outline: none;
 	background: var(--dp-date-background-focus);
 	color: var(--dp-date-color-focus);
+	box-shadow: none;
 }
 
 .dp-day:hover,
@@ -344,6 +353,7 @@
 .dp-selected:hover {
 	background: var(--dp-date-background-hover);
 	color: var(--dp-date-color-hover);
+	box-shadow: none;
 }
 
 .dp-day-disabled {

--- a/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
@@ -71,14 +71,14 @@
 .dp-below {
 	position: absolute;
 	font-size: 0.75em;
-	width: 320px;
+	width: 340px;
 	max-width: 100vw;
 }
 
 .dp-permanent {
 	position: relative;
 	font-size: 0.75em;
-	width: 320px;
+	width: 340px;
 	max-width: 100vw;
 }
 
@@ -125,6 +125,7 @@
 	position: relative;
 	color: var( --dp-date-color );
 	border-radius: var( --dp-nav-radius );
+	box-shadow: none;
 	border: 0;
 	background: var( --dp-date-background );
 }
@@ -143,6 +144,7 @@
 	overflow: hidden;
 	color: var( --dp-ui-color );
 	border-radius: var( --dp-nav-radius );
+	box-shadow: none;
 	border: 0;
 	background: var( --dp-ui-background );
 	padding: 0;
@@ -155,11 +157,11 @@
 }
 
 .dp-prev {
-	right: 46px;
+	right: 50px;
 }
 
 .dp-next {
-	right: 3px;
+	right: 5px;
 }
 
 .dp-cal-nav:before {
@@ -182,7 +184,7 @@
 	border-left: 0;
 	border-top: 0;
 	margin-left: 0;
-	margin-right: -20px;
+	margin-right: -23px;
 }
 
 .dp-cal-dropdown:after {
@@ -205,7 +207,7 @@
 .dp-cal-dropdown {
 	position: relative;
 	display: inline-block;
-	font-size: 1.4em;
+	font-size: 1.3em;
 	font-weight: var( --dp-bold);
 	padding: 8px 22px 8px 8px;
 }
@@ -300,7 +302,7 @@
 }
 
 .dp-month {
-	font-size: 1.4em;
+	font-size: 1.3em;
 	padding: 0;
 }
 
@@ -308,7 +310,7 @@
 	display: block;
 	padding: 8px 40px;
 	width: 100%;
-	font-size: 1.4em;
+	font-size: 1.3em;
 }
 
 .dp-edge-day {

--- a/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
@@ -184,7 +184,7 @@
 	border-left: 0;
 	border-top: 0;
 	margin-left: 0;
-	margin-right: -28px;
+	margin-right: -32px;
 }
 
 .dp-cal-dropdown:after {

--- a/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
@@ -22,6 +22,7 @@
 
 	--dp-min-height: 274px;
 	--dp-bold: 600;
+	--dp-nav-radius: 2px;
 
 	--dp-ui-background: transparent;
 	--dp-ui-color: #333;
@@ -123,7 +124,7 @@
 	text-decoration: none;
 	position: relative;
 	color: var( --dp-date-color );
-	border-radius: 2px;
+	border-radius: var( --dp-nav-radius );
 	border: 0;
 	background: var( --dp-date-background );
 }
@@ -135,23 +136,20 @@
 	align-items: center;
 }
 
-.dp-next,
-.dp-prev {
+.dp-cal-nav {
 	position: absolute;
 	width: 36px;
 	height: 36px;
 	overflow: hidden;
 	color: var( --dp-ui-color );
-	border-radius: 50%;
+	border-radius: var( --dp-nav-radius );
 	border: 0;
 	background: var( --dp-ui-background );
 	padding: 0;
 }
 
-.dp-next:focus,
-.dp-prev:focus,
-.dp-next:hover,
-.dp-prev:hover {
+.dp-cal-nav:focus,
+.dp-cal-nav:hover {
 	background: var( --dp-ui-background-focus );
 	color: var( --dp-ui-color-focus );
 }
@@ -164,8 +162,7 @@
 	right: 3px;
 }
 
-.dp-prev:before,
-.dp-next:before {
+.dp-cal-nav:before {
 	content: '';
 	border: 2px solid;
 	width: 6px;
@@ -179,21 +176,38 @@
 .dp-prev:before {
 	border-right: 0;
 	border-bottom: 0;
-	}
+}
 
 .dp-next:before {
 	border-left: 0;
 	border-top: 0;
 	margin-left: 0;
-	margin-right: 4px;
+	margin-right: -20px;
 }
 
-.dp-cal-month,
-.dp-cal-year {
+.dp-cal-dropdown:after {
+	content: '';
+	border: 2px solid;
+	border-right: 0;
+	border-bottom: 0;
+	width: 6px;
+	height: 6px;
+	position: relative;
+	display: inline-block;
+	transform: rotate(-135deg);
+	transition: border-color 0.2s;
+	margin: 0;
+	margin-top: -6px;
+	right: -8px;
+	vertical-align: middle;
+}
+
+.dp-cal-dropdown {
+	position: relative;
 	display: inline-block;
 	font-size: 1.4em;
 	font-weight: var( --dp-bold);
-	padding: 8px 8px;
+	padding: 8px 22px 8px 8px;
 }
 
 .dp-cal-footer {
@@ -287,6 +301,7 @@
 
 .dp-month {
 	font-size: 1.4em;
+	padding: 0;
 }
 
 .dp-year {

--- a/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
@@ -10,7 +10,9 @@
 .dp {
 	position: relative;
 	background: #FFF;
-	box-shadow: 2px 2px 16px rgba(0, 0, 0, 0.25);
+	border: 1px solid rgba(0, 0, 0, 0.1);
+	box-shadow: 0 4px 10px 0 rgba(0, 0, 0, 0.1);
+
 	line-height: 1.4;
 	border-radius: 4px;
 	max-height: 400px;

--- a/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.css
@@ -184,7 +184,7 @@
 	border-left: 0;
 	border-top: 0;
 	margin-left: 0;
-	margin-right: -23px;
+	margin-right: -28px;
 }
 
 .dp-cal-dropdown:after {

--- a/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/date-picker.ts
@@ -1,0 +1,41 @@
+/**
+ * @file The root date picker file, defines public exports for the library.
+ */
+
+import { DatePickerOptions } from './date-picker-options';
+import { IDatePickerOptions } from './interfaces';
+import Emitter from './lib/emitter';
+import Mode from './mode/index';
+
+/**
+ * DatePicker constructs a new date picker for the specified input
+ *
+ * @param {HTMLElement | string} input The input or CSS selector associated with the datepicker
+ * @param {IDatePickerOptions}   opts  The options for initializing the date picker
+ * @returns {DatePicker}
+ */
+export function DatePicker(
+	input: HTMLInputElement | string,
+	opts: Partial< IDatePickerOptions >
+) {
+	const emitter = Emitter();
+	const options = DatePickerOptions( opts );
+	const mode = Mode( input, emit, options );
+	var me = {
+		get state() {
+			return mode.state;
+		},
+		on: emitter.on,
+		off: emitter.off,
+		setState: mode.setState,
+		open: mode.open,
+		close: mode.close,
+		destroy: mode.destroy,
+	};
+
+	function emit( evt: string ) {
+		emitter.emit( evt, me );
+	}
+
+	return me;
+}

--- a/projects/packages/forms/src/contact-form/libs/date-picker/interfaces.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/interfaces.ts
@@ -1,0 +1,84 @@
+export interface IDatePickerOptions {
+	lang: ILanguage;
+	mode: 'dp-below';
+	highlightedDate: Date | undefined | null;
+	format: ( dt: Date, dateFormat: string ) => string;
+	dateFormat: string;
+	parse: ( candidate: Date | string, dateFormat: string ) => Date;
+	dateClass: ( dt: Date ) => string;
+	inRange: ( dt: Date, dp?: IDatePicker ) => boolean;
+	appendTo: HTMLElement;
+	alignment: 'left' | 'right';
+	min: Date;
+	max: Date;
+	shouldFocusOnBlur?: boolean;
+	shouldFocusOnRender?: boolean;
+	dayOffset?: number;
+}
+
+export interface IDateRangePickerOptions extends IDatePickerOptions {
+	startOpts: IDatePickerOptions;
+	endOpts: IDatePickerOptions;
+}
+
+export interface IDatePicker {
+	el: HTMLElement | undefined;
+	opts: IDatePickerOptions;
+	shouldFocusOnBlur: boolean;
+	shouldFocusOnRender: boolean;
+	state: IState;
+	adjustPosition: () => void;
+	containerHTML: string;
+	attachToDom: () => void;
+	updateInput: ( selectedDate: Date ) => void;
+	computeSelectedDate: () => Date;
+	currentView: () => IPicker;
+	open: () => void;
+	isVisible: () => boolean;
+	hasFocus: () => boolean;
+	shouldHide: () => boolean;
+	close: ( becauseOfBlur?: boolean ) => void;
+	destroy: () => void;
+	render: () => void;
+	setState: ( state: unknown ) => void;
+}
+
+export interface IState {
+	selectedDate: Date;
+	view: 'day' | 'month' | 'year';
+	highlightedDate?: Date;
+}
+
+export interface IDateRangePickerState {
+	start: Date | undefined;
+	end: Date | undefined;
+}
+
+export type IAlignment = 'left' | 'right';
+
+export interface ILanguage {
+	days: string[];
+	months: string[];
+	today: string;
+	clear: string;
+	close: string;
+	ariaLabel: {
+		dayPicker: string;
+		monthPicker: string;
+		yearPicker: string;
+		monthPickerButton: string;
+		yearPickerButton: string;
+		dayButton: string;
+		todayButton: string;
+		clearButton: string;
+		closeButton: string;
+	};
+}
+
+export interface IPicker {
+	onKeyDown: ( evt: KeyboardEvent, dp: IDatePicker ) => void;
+	onClick: {
+		[ key: string ]: ( e: Event | KeyboardEvent, dp: IDatePicker ) => void;
+	};
+	render: ( dp: IDatePicker ) => string;
+}

--- a/projects/packages/forms/src/contact-form/libs/date-picker/interfaces.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/interfaces.ts
@@ -14,6 +14,7 @@ export interface IDatePickerOptions {
 	shouldFocusOnBlur?: boolean;
 	shouldFocusOnRender?: boolean;
 	dayOffset?: number;
+	hasFooter?: boolean;
 }
 
 export interface IDateRangePickerOptions extends IDatePickerOptions {

--- a/projects/packages/forms/src/contact-form/libs/date-picker/lib/date.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/lib/date.ts
@@ -13,6 +13,18 @@ export function now() {
 	return dt;
 }
 
+export function Jan1st() {
+	var dt = new Date( now().getFullYear(), 0, 1 ); // Jan 1st of the current year.
+	dt.setHours( 0, 0, 0, 0 );
+	return dt;
+}
+
+export function Dec31st() {
+	var dt = new Date( now().getFullYear(), 11, 31 ); // Dec 31st of the current year.
+	dt.setHours( 0, 0, 0, 0 );
+	return dt;
+}
+
 /**
  * dateEq compares two dates
  *

--- a/projects/packages/forms/src/contact-form/libs/date-picker/lib/date.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/lib/date.ts
@@ -1,0 +1,144 @@
+/**
+ * @file A generic set of mutation-free date functions.
+ */
+
+/**
+ * now returns the current date without any time values
+ *
+ * @returns {Date}
+ */
+export function now() {
+	var dt = new Date();
+	dt.setHours( 0, 0, 0, 0 );
+	return dt;
+}
+
+/**
+ * dateEq compares two dates
+ *
+ * @param {Date} date1 the first date
+ * @param {Date} date2 the second date
+ * @returns {boolean}
+ */
+export function datesEq( date1?: Date, date2?: Date ) {
+	return ( date1 && date1.toDateString() ) === ( date2 && date2.toDateString() );
+}
+
+/**
+ * shiftDay shifts the specified date by n days
+ *
+ * @param {Date | undefined} dt
+ * @param {number}           n
+ * @returns {Date}
+ */
+export function shiftDay( dt: Date | undefined, n: number ) {
+	dt = dt ? new Date( dt ) : now();
+	dt.setDate( dt.getDate() + n );
+	return dt;
+}
+
+/**
+ * shiftMonth shifts the specified date by a specified number of months
+ *
+ * @param {Date | undefined} dt
+ * @param {number}           n
+ * @param {boolean}          wrap optional, if true, does not change year
+ *                                value, defaults to false
+ * @returns {Date}
+ */
+export function shiftMonth( dt: Date | undefined, n: number, wrap = false ) {
+	dt = dt ? new Date( dt ) : now();
+
+	var dayOfMonth = dt.getDate();
+	var month = dt.getMonth() + n;
+
+	dt.setDate( 1 );
+	dt.setMonth( wrap ? ( 12 + month ) % 12 : month );
+	dt.setDate( dayOfMonth );
+
+	// If dayOfMonth = 31, but the target month only has 30 or 29 or whatever...
+	// head back to the max of the target month
+	if ( dt.getDate() < dayOfMonth ) {
+		dt.setDate( 0 );
+	}
+
+	return dt;
+}
+
+/**
+ * shiftYear shifts the specified date by n years
+ *
+ * @param {Date| undefined} dt
+ * @param {number}          n
+ * @returns {Date}
+ */
+export function shiftYear( dt: Date | undefined, n: number ) {
+	dt = dt ? new Date( dt ) : now();
+	dt.setFullYear( dt.getFullYear() + n );
+	return dt;
+}
+
+/**
+ * setYear changes the specified date to the specified year
+ *
+ * @param {Date| undefined} dt
+ * @param {number}          year
+ */
+export function setYear( dt: Date | undefined, year: number ) {
+	dt = dt ? new Date( dt ) : now();
+	dt.setFullYear( year );
+	return dt;
+}
+
+/**
+ * setMonth changes the specified date to the specified month
+ *
+ * @param {Date| undefined} dt
+ * @param {number}          month
+ */
+export function setMonth( dt: Date | undefined, month: number ) {
+	dt = dt ? new Date( dt ) : now();
+	return shiftMonth( dt, month - dt.getMonth() );
+}
+
+/**
+ * dateOrParse creates a function which, given a date or string, returns a date
+ *
+ * @param {function} parse the function used to parse strings
+ * @returns {function}
+ */
+export function dateOrParse( parse: ( candidate: Date | string, dateFormat: string ) => Date ) {
+	return function ( dt: Date | string, dateFormat: string ) {
+		return dropTime( typeof dt === 'string' ? parse( dt, dateFormat ) : dt );
+	};
+}
+
+/**
+ * constrainDate returns dt or min/max depending on whether dt is out of bounds (inclusive)
+ *
+ * @export
+ * @param {Date} dt
+ * @param {Date} min
+ * @param {Date} max
+ * @returns {Date}
+ */
+export function constrainDate( dt: Date, min: Date, max: Date ) {
+	if ( dt < min ) {
+		return min;
+	}
+	if ( dt > max ) {
+		return max;
+	}
+	return dt;
+}
+/**
+ * Removes the time from a date.
+ *
+ * @param {Date} dt
+ * @returns {Date}
+ */
+function dropTime( dt: Date | string ) {
+	dt = new Date( dt );
+	dt.setHours( 0, 0, 0, 0 );
+	return dt;
+}

--- a/projects/packages/forms/src/contact-form/libs/date-picker/lib/dom.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/lib/dom.ts
@@ -1,0 +1,32 @@
+/**
+ * @file Helper functions for dealing with dom elements.
+ */
+
+export const Key = {
+	left: 'ArrowLeft',
+	up: 'ArrowUp',
+	right: 'ArrowRight',
+	down: 'ArrowDown',
+	enter: 'Enter',
+	esc: 'Escape',
+	tab: 'Tab',
+	space: 'Space',
+};
+
+/**
+ * on attaches an event handler to the specified element, and returns an
+ * off function which can be used to remove the handler.
+ *
+ * @param {string}      evt     the name of the event to handle
+ * @param {HTMLElement} el      the element to attach to
+ * @param {function}    handler the event handler
+ *
+ * @returns {function} the off function
+ */
+export function on( evt: string, el: HTMLElement, handler: EventListenerOrEventListenerObject ) {
+	el.addEventListener( evt, handler, true );
+
+	return (): void => {
+		el.removeEventListener( evt, handler, true );
+	};
+}

--- a/projects/packages/forms/src/contact-form/libs/date-picker/lib/emitter.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/lib/emitter.ts
@@ -1,0 +1,61 @@
+/**
+ * @file Defines simple event emitter behavior.
+ */
+
+type TEmitterFn = ( name: string, arg: unknown ) => void;
+type TEmitterFns = { [ key: string ]: TEmitterFn };
+
+interface IHandlers {
+	[ key: string ]: Array< TEmitterFn >;
+}
+
+/**
+ * Emitter constructs a new emitter object which has on/off methods.
+ *
+ * @returns {EventEmitter}
+ */
+export default function Emitter() {
+	var handlers: IHandlers = {};
+
+	function onOne( name: string, handler: TEmitterFn ) {
+		( handlers[ name ] = handlers[ name ] || [] ).push( handler );
+	}
+
+	function onMany( fns: TEmitterFns ) {
+		for ( const name in fns ) {
+			onOne( name, fns[ name ] );
+		}
+	}
+
+	return {
+		on: function ( name: string | TEmitterFns, handler?: TEmitterFn ) {
+			if ( handler ) {
+				onOne( name as string, handler );
+			} else {
+				onMany( name as TEmitterFns );
+			}
+
+			return this;
+		},
+
+		emit: function ( name: string, arg?: unknown ) {
+			( handlers[ name ] || [] ).forEach( function ( handler ) {
+				handler( name, arg );
+			} );
+		},
+
+		off: function ( name?: string, handler?: TEmitterFn ) {
+			if ( ! name ) {
+				handlers = {};
+			} else if ( ! handler ) {
+				handlers[ name ] = [];
+			} else {
+				handlers[ name ] = ( handlers[ name ] || [] ).filter( function ( h ) {
+					return h !== handler;
+				} );
+			}
+
+			return this;
+		},
+	};
+}

--- a/projects/packages/forms/src/contact-form/libs/date-picker/lib/fns.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/lib/fns.ts
@@ -1,0 +1,41 @@
+/**
+ * @file Utility functions for function manipulation.
+ */
+
+/**
+ * bufferFn buffers calls to fn so they only happen every ms milliseconds
+ *
+ * @param {number}   ms number of milliseconds
+ * @param {function} fn the function to be buffered
+ * @returns {function}
+ */
+export function bufferFn( ms: number, fn: ( ...args: unknown[] ) => unknown ) {
+	let timeout: ReturnType< typeof setTimeout > | undefined;
+	return function () {
+		clearTimeout( timeout );
+		timeout = setTimeout( fn, ms );
+	};
+}
+
+/**
+ * noop is a function which does nothing at all.
+ */
+export function noop() {}
+
+/**
+ * copy properties from object o2 to object o1.
+ *
+ * @params {Object} o1
+ * @params {Object} o2
+ * @returns {Object}
+ */
+export function cp( ...args: Record< object, unknown >[] ) {
+	const o1 = args[ 0 ];
+	for ( let i = 1; i < args.length; ++i ) {
+		const o2 = args[ i ] || {};
+		for ( const key in o2 ) {
+			o1[ key ] = o2[ key ];
+		}
+	}
+	return o1;
+}

--- a/projects/packages/forms/src/contact-form/libs/date-picker/mode/base-mode.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/mode/base-mode.ts
@@ -1,0 +1,349 @@
+/**
+ * @file Defines the base date picker behavior, overridden by various modes.
+ */
+import { IDatePickerOptions, IDatePicker, IState } from '../interfaces';
+import { constrainDate } from '../lib/date';
+import { on, Key } from '../lib/dom';
+import { bufferFn, noop } from '../lib/fns';
+import dayPicker from '../views/day-picker';
+import monthPicker from '../views/month-picker';
+import yearPicker from '../views/year-picker';
+
+const views = {
+	day: dayPicker,
+	year: yearPicker,
+	month: monthPicker,
+};
+
+( function () {
+	if ( typeof window.CustomEvent === 'function' ) return false;
+
+	function CustomEvent(
+		event: string,
+		params: { bubbles?: boolean; cancelable?: boolean; detail?: unknown }
+	) {
+		params = params || { bubbles: false, cancelable: false, detail: null };
+		var evt = document.createEvent( 'CustomEvent' );
+		evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
+		return evt;
+	}
+
+	( window as unknown ).CustomEvent = CustomEvent;
+} )();
+
+export default function BaseMode(
+	input: HTMLInputElement,
+	emit: ( event: string, detail?: unknown ) => void,
+	opts: IDatePickerOptions
+): IDatePicker {
+	let detatchInputEvents: () => void; // A function that detaches all events from the input
+	let closing = false; // A hack to prevent calendar from re-opening when closing.
+	let selectedDate: Date; // The currently selected date
+	const dp = {
+		// The root DOM element for the date picker, initialized on first open.
+		el: undefined as HTMLElement | undefined,
+		opts: opts,
+		shouldFocusOnBlur: true,
+		shouldFocusOnRender: true,
+		state: initialState(),
+		adjustPosition: noop,
+		containerHTML: '<div class="dp"></div>',
+
+		attachToDom: function () {
+			opts.appendTo.appendChild( dp.el as Node );
+		},
+
+		updateInput: function ( selectedDateToUpdate: Date ) {
+			const e = new CustomEvent( 'change', { bubbles: true } );
+			input.value = selectedDateToUpdate
+				? opts.format( selectedDateToUpdate, opts.dateFormat )
+				: '';
+			input.dispatchEvent( e );
+		},
+
+		computeSelectedDate: function () {
+			return opts.parse( input.value, opts.dateFormat );
+		},
+
+		currentView: function () {
+			return views[ dp.state.view ];
+		},
+
+		open: function () {
+			if ( closing ) {
+				return;
+			}
+
+			if ( ! dp.el ) {
+				dp.el = createContainerElement( opts, dp.containerHTML );
+				attachContainerEvents( dp );
+			}
+
+			selectedDate = constrainDate( dp.computeSelectedDate(), opts.min, opts.max );
+			dp.state.highlightedDate = selectedDate || opts.highlightedDate;
+			dp.state.view = 'day';
+
+			dp.attachToDom();
+			dp.render();
+
+			emit( 'open' );
+		},
+
+		isVisible: function () {
+			return !! dp.el && !! dp.el.parentNode;
+		},
+
+		hasFocus: function () {
+			const focused = document.activeElement;
+			return dp.el && dp.el.contains( focused ) && focused!.className.indexOf( 'dp-focuser' ) < 0;
+		},
+
+		shouldHide: function () {
+			return dp.isVisible();
+		},
+
+		close: function ( becauseOfBlur ) {
+			const el = dp.el;
+
+			if ( ! dp.isVisible() ) {
+				return;
+			}
+
+			if ( el ) {
+				const parent = el.parentNode;
+				parent && parent.removeChild( el );
+			}
+
+			closing = true;
+
+			if ( becauseOfBlur && dp.shouldFocusOnBlur ) {
+				focusInput( input );
+			}
+
+			// When we close, the input often gains refocus, which
+			// can then launch the date picker again, so we buffer
+			// a bit and don't show the date picker within N ms of closing
+			setTimeout( function () {
+				closing = false;
+			}, 100 );
+
+			emit( 'close' );
+		},
+
+		destroy: function () {
+			dp.close();
+			detatchInputEvents();
+		},
+
+		render: function () {
+			if ( ! dp.el ) {
+				return;
+			}
+
+			const hadFocus = dp.hasFocus();
+			const html = dp.currentView().render( dp );
+
+			if ( html ) {
+				( dp.el.firstChild! as HTMLElement ).innerHTML = html;
+			}
+
+			dp.adjustPosition();
+
+			if ( hadFocus || dp.shouldFocusOnRender ) {
+				focusCurrent( dp );
+			}
+		},
+
+		// Conceptually similar to setState in React, updates
+		// the view state and re-renders.
+		setState: function ( state: IState ) {
+			for ( const key in state ) {
+				( dp.state as IState )[ key ] = ( state as Partial< IState > )[ key ]!;
+			}
+
+			emit( 'statechange' );
+			dp.render();
+		},
+	} as IDatePicker;
+
+	detatchInputEvents = attachInputEvents( input, dp );
+
+	// Builds the initial view state
+	// selectedDate is a special case and causes changes to highlightedDate
+	// highlightedDate is set on open, so remains undefined initially
+	// view is the current view (day, month, year)
+	function initialState(): IState {
+		return {
+			get selectedDate() {
+				return selectedDate;
+			},
+			set selectedDate( dt: Date ) {
+				if ( dt && ! opts.inRange( dt ) ) {
+					return;
+				}
+
+				if ( dt ) {
+					selectedDate = new Date( dt );
+					dp.state.highlightedDate = selectedDate;
+				} else {
+					selectedDate = dt;
+				}
+
+				dp.updateInput( selectedDate );
+				emit( 'select' );
+				dp.close();
+			},
+			view: 'day',
+		};
+	}
+
+	return dp;
+}
+
+function createContainerElement( opts: IDatePickerOptions, containerHTML: string ) {
+	const el = document.createElement( 'div' );
+
+	el.className = opts.mode;
+	el.innerHTML = containerHTML;
+
+	return el;
+}
+
+function attachInputEvents( input: HTMLElement, dp: IDatePicker ) {
+	input.ariaLive = 'polite';
+	input.ariaLabel = dp.opts.lang.ariaLabel.dayPicker;
+	const bufferShow = bufferFn( 5, function () {
+		if ( dp.shouldHide() ) {
+			dp.close();
+		} else {
+			dp.open();
+		}
+	} );
+
+	const off = [
+		on(
+			'blur',
+			input,
+			bufferFn( 5, function () {
+				if ( ! dp.hasFocus() ) {
+					dp.close( true );
+				}
+			} )
+		),
+
+		on( 'mousedown', input, function () {
+			if ( input === document.activeElement ) {
+				bufferShow();
+			}
+		} ),
+
+		on( 'keydown', input, function ( e ) {
+			if ( ! e || ! e.target ) {
+				return;
+			}
+
+			const ke = e as KeyboardEvent;
+
+			if ( ke.code === Key.down ) {
+				e.preventDefault();
+				dp.open();
+				focusCurrent( dp );
+				return;
+			}
+
+			if ( ke.code === Key.esc ) {
+				dp.close( true );
+			}
+		} ),
+		on( 'focus', input, bufferShow ),
+
+		on( 'input', input, function ( e ) {
+			if ( ! e || ! e.target ) {
+				return;
+			}
+
+			const target = e.target as HTMLInputElement;
+			const date = dp.opts.parse( target.value, dp.opts.dateFormat );
+			isNaN( date.valueOf() ) ||
+				dp.setState( {
+					highlightedDate: date,
+				} );
+		} ),
+	];
+
+	// Unregister all events that were registered above.
+	return function () {
+		off.forEach( function ( f ) {
+			f();
+		} );
+	};
+}
+
+function focusCurrent( dp: IDatePicker ) {
+	const current = dp.el!.querySelector( '.dp-current' ) as HTMLElement;
+	return current && current.focus();
+}
+
+function attachContainerEvents( dp: IDatePicker ) {
+	const el = dp.el as HTMLElement;
+	const calEl = el.querySelector( '.dp' ) as HTMLElement;
+
+	// Hack to get iOS to show active CSS states
+	el!.ontouchstart = noop;
+
+	function onClick( e: unknown ) {
+		e?.target?.className.split( ' ' ).forEach( function ( evt: string ) {
+			const handler = dp.currentView().onClick[ evt ];
+			handler && handler( e, dp );
+		} );
+	}
+
+	// The calender fires a blur event *every* time we redraw
+	// this means we need to buffer the blur event to see if
+	// it still has no focus after redrawing, and only then
+	// do we return focus to the input. A possible other approach
+	// would be to set context.redrawing = true on redraw and
+	// set it to false in the blur event.
+	on(
+		'blur',
+		calEl,
+		bufferFn( 5, function () {
+			if ( ! dp.hasFocus() ) {
+				dp.close( true );
+			}
+		} )
+	);
+
+	on( 'keydown', el, function ( e ) {
+		const ke = e as KeyboardEvent;
+		if ( ke.code === Key.enter ) {
+			onClick( ke );
+		} else {
+			dp.currentView().onKeyDown( ke, dp );
+		}
+	} );
+
+	// If the user clicks in non-focusable space, but
+	// still within the date picker, we don't want to
+	// hide, so we need to hack some things...
+	on( 'mousedown', calEl, function ( e ) {
+		//e.target.focus && e.target.focus(); // IE hack
+		if ( document.activeElement !== e.target ) {
+			e.preventDefault();
+			focusCurrent( dp );
+		}
+	} );
+
+	on( 'click', el, onClick );
+}
+
+function focusInput( input: HTMLInputElement ) {
+	// When the modal closes, we need to focus the original input so the
+	// user can continue tabbing from where they left off.
+	input.focus();
+
+	// iOS zonks out if we don't blur the input, so...
+	if ( /iPad|iPhone|iPod/.test( navigator.userAgent ) && ! window.MSStream ) {
+		input.blur();
+	}
+}

--- a/projects/packages/forms/src/contact-form/libs/date-picker/mode/base-mode.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/mode/base-mode.ts
@@ -31,6 +31,18 @@ const views = {
 	( window as unknown ).CustomEvent = CustomEvent;
 } )();
 
+function isMobileDevice() {
+	return /iPhone|iPad|iPod|Android/i.test( navigator.userAgent );
+}
+
+function setReadonly( input: HTMLInputElement ) {
+	if ( isMobileDevice() ) {
+		input.readOnly = true;
+	} else {
+		input.readOnly = false;
+	}
+}
+
 export default function BaseMode(
 	input: HTMLInputElement,
 	emit: ( event: string, detail?: unknown ) => void,
@@ -86,6 +98,8 @@ export default function BaseMode(
 			dp.attachToDom();
 			dp.render();
 
+			setReadonly( input );
+
 			emit( 'open' );
 		},
 
@@ -119,6 +133,7 @@ export default function BaseMode(
 			if ( becauseOfBlur && dp.shouldFocusOnBlur ) {
 				focusInput( input );
 			}
+			input.readOnly = false;
 
 			// When we close, the input often gains refocus, which
 			// can then launch the date picker again, so we buffer

--- a/projects/packages/forms/src/contact-form/libs/date-picker/mode/dropdown-mode.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/mode/dropdown-mode.ts
@@ -1,0 +1,82 @@
+/**
+ * @file Defines the dropdown date picker behavior.
+ */
+
+import { IDatePickerOptions, IAlignment, IDatePicker } from '../interfaces';
+import BaseMode from './base-mode';
+
+export default function DropdownMode(
+	input: HTMLInputElement,
+	emit: ( event: string, detail?: unknown ) => void,
+	opts: IDatePickerOptions
+) {
+	const dp = BaseMode( input, emit, opts );
+
+	dp.shouldFocusOnBlur = false;
+
+	Object.defineProperty( dp, 'shouldFocusOnRender', {
+		get: function () {
+			return input !== document.activeElement;
+		},
+	} );
+
+	dp.adjustPosition = function () {
+		autoPosition( input, dp, opts.alignment );
+	};
+
+	return dp;
+}
+
+function autoPosition( input: HTMLInputElement, dp: IDatePicker, alignment: IAlignment ) {
+	const cal = dp?.el as HTMLElement;
+	if ( ! cal ) {
+		return;
+	}
+	const inputPos = input.getBoundingClientRect();
+	const win = window;
+
+	adjustCalY( dp, inputPos, win );
+	adjustCalX( dp, inputPos, win, alignment );
+
+	cal.style.visibility = '';
+}
+
+function adjustCalX( dp: IDatePicker, inputPos: DOMRect, win: Window, alignment: IAlignment ) {
+	const cal = dp?.el as HTMLElement;
+	if ( ! cal ) {
+		return;
+	}
+	const scrollLeft = win.scrollX;
+	const inputLeft = inputPos.left + scrollLeft;
+	const maxRight = win.innerWidth + scrollLeft;
+	const offsetWidth = cal.offsetWidth;
+	const calRight = inputLeft + offsetWidth;
+	const shiftedLeft = maxRight - offsetWidth;
+	const left = calRight > maxRight && shiftedLeft > 0 ? shiftedLeft : inputLeft;
+
+	if ( alignment === 'right' ) {
+		cal.style.left = left + ( inputPos.width - offsetWidth ) + 'px';
+	} else {
+		cal.style.left = left + 'px';
+	}
+}
+
+function adjustCalY( dp: IDatePicker, inputPos: DOMRect, win: Window ) {
+	const cal = dp?.el as HTMLElement;
+	if ( ! cal ) {
+		return;
+	}
+	const scrollTop = win.scrollY;
+	const inputTop = scrollTop + inputPos.top;
+	const calHeight = cal.offsetHeight;
+	const belowTop = inputTop + inputPos.height + 8;
+	const aboveTop = inputTop - calHeight - 8;
+	const isAbove = aboveTop > 0 && belowTop + calHeight > scrollTop + win.innerHeight;
+	const top = isAbove ? aboveTop : belowTop;
+
+	if ( cal.classList ) {
+		cal.classList.toggle( 'dp-is-above', isAbove );
+		cal.classList.toggle( 'dp-is-below', ! isAbove );
+	}
+	cal.style.top = top + 'px';
+}

--- a/projects/packages/forms/src/contact-form/libs/date-picker/mode/index.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/mode/index.ts
@@ -1,0 +1,19 @@
+/**
+ * @file Defines the various date picker modes (modal, dropdown, permanent)
+ */
+
+import { IDatePickerOptions } from '../interfaces';
+import DropdownMode from './dropdown-mode';
+
+export default function Mode(
+	input: HTMLInputElement | string,
+	emit: ( event: string, detail?: unknown ) => void,
+	opts: IDatePickerOptions
+) {
+	const el = input instanceof HTMLElement ? input : document.querySelector( input );
+
+	if ( ! el ) {
+		throw new Error( `The provided input '${ input }' could not be found.` );
+	}
+	return DropdownMode( el as HTMLInputElement, emit, opts );
+}

--- a/projects/packages/forms/src/contact-form/libs/date-picker/views/day-picker.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/views/day-picker.ts
@@ -74,7 +74,7 @@ function render( dp: IDatePicker ) {
 			let className = 'dp-day';
 			className += isNotInMonth ? ' dp-edge-day' : '';
 			className += datesEq( date, highlightedDate ) ? ' dp-current' : '';
-			className += datesEq( date, selectedDate ) ? ' dp-selected' : '';
+			className += datesEq( date, selectedDate ) ? ' dp-selected dp-focusable' : '';
 			className += isDisabled ? ' dp-day-disabled' : '';
 			className += isToday ? ' dp-day-today' : '';
 			className += ' ' + opts.dateClass( date );

--- a/projects/packages/forms/src/contact-form/libs/date-picker/views/day-picker.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/views/day-picker.ts
@@ -46,16 +46,16 @@ function render( dp: IDatePicker ) {
 		'<button tabindex="-1" type="button" aria-label="' +
 		lang.months[ hilightedMonth ] +
 		lang.ariaLabel.monthPickerButton +
-		'" class="dp-focusable dp-cal-month">' +
+		'" class="dp-focusable dp-cal-month dp-cal-dropdown">' +
 		lang.months[ hilightedMonth ] +
 		'</button>' +
 		'<button tabindex="-1" type="button" aria-label="' +
 		highlightedDate!.getFullYear() +
-		'Year Picker. Use the space key to enter the year picker." class="dp-focusable dp-cal-year">' +
+		'Year Picker. Use the space key to enter the year picker." class="dp-focusable dp-cal-year dp-cal-dropdown">' +
 		highlightedDate!.getFullYear() +
 		'</button>' +
-		'<button tabindex="-1" type="button" class="dp-focusable dp-prev">Previous Month</button>' +
-		'<button tabindex="-1" type="button" class="dp-focusable dp-next">Next Month</button>' +
+		'<button tabindex="-1" type="button" class="dp-focusable dp-prev dp-cal-nav">Previous Month</button>' +
+		'<button tabindex="-1" type="button" class="dp-focusable dp-next dp-cal-nav">Next Month</button>' +
 		'</header>' +
 		'<div class="dp-days">' +
 		dayNames

--- a/projects/packages/forms/src/contact-form/libs/date-picker/views/day-picker.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/views/day-picker.ts
@@ -1,0 +1,272 @@
+/**
+ * @file Manages the calendar / day-picker view.
+ */
+
+import { IDatePicker, IPicker } from '../interfaces';
+import { now, datesEq, shiftMonth, shiftDay } from '../lib/date';
+import { Key } from '../lib/dom';
+
+export default {
+	onKeyDown: keyDown,
+	onClick: {
+		'dp-day': selectDay,
+		'dp-next': gotoNextMonth,
+		'dp-prev': gotoPrevMonth,
+		'dp-today': selectToday,
+		'dp-clear': clear,
+		'dp-close': close,
+		'dp-cal-month': showMonthPicker,
+		'dp-cal-year': showYearPicker,
+	},
+	render: render,
+} as IPicker;
+
+/**
+ * view renders the calendar (day picker) as an HTML string.
+ *
+ * @param {DatePickerContext} context the date picker being rendered
+ * @returns {string}
+ */
+function render( dp: IDatePicker ) {
+	const opts = dp.opts;
+	const lang = opts.lang;
+	const state = dp.state;
+	const dayNames = lang.days;
+	const dayOffset = opts.dayOffset || 0;
+	const selectedDate = state.selectedDate;
+	const highlightedDate = state.highlightedDate;
+	const hilightedMonth = highlightedDate!.getMonth();
+	const today = now().getTime();
+
+	return (
+		'<div tabindex="0" class="dp-cal" aria-label="' +
+		lang.ariaLabel.dayPicker +
+		'">' +
+		'<header class="dp-cal-header">' +
+		'<button tabindex="-1" type="button" aria-label="' +
+		lang.months[ hilightedMonth ] +
+		lang.ariaLabel.monthPickerButton +
+		'" class="dp-focusable dp-cal-month">' +
+		lang.months[ hilightedMonth ] +
+		'</button>' +
+		'<button tabindex="-1" type="button" aria-label="' +
+		highlightedDate!.getFullYear() +
+		'Year Picker. Use the space key to enter the year picker." class="dp-focusable dp-cal-year">' +
+		highlightedDate!.getFullYear() +
+		'</button>' +
+		'<button tabindex="-1" type="button" class="dp-focusable dp-prev">Previous Month</button>' +
+		'<button tabindex="-1" type="button" class="dp-focusable dp-next">Next Month</button>' +
+		'</header>' +
+		'<div class="dp-days">' +
+		dayNames
+			.map( function ( name: string, i: number ) {
+				return (
+					'<span class="dp-col-header">' +
+					dayNames[ ( i + dayOffset ) % dayNames.length ] +
+					'</span>'
+				);
+			} )
+			.join( '' ) +
+		mapDays( highlightedDate!, dayOffset, function ( date ) {
+			const isNotInMonth = date.getMonth() !== hilightedMonth;
+			const isDisabled = ! opts.inRange( date );
+			const isToday = date.getTime() === today;
+			let className = 'dp-day';
+			className += isNotInMonth ? ' dp-edge-day' : '';
+			className += datesEq( date, highlightedDate ) ? ' dp-current' : '';
+			className += datesEq( date, selectedDate ) ? ' dp-selected' : '';
+			className += isDisabled ? ' dp-day-disabled' : '';
+			className += isToday ? ' dp-day-today' : '';
+			className += ' ' + opts.dateClass( date );
+
+			return (
+				'<button tabindex="-1" type="button" aria-role="button" aria-label="' +
+				date.toDateString() +
+				lang.ariaLabel.dayButton +
+				'" class="' +
+				className +
+				'" data-date="' +
+				date.getTime() +
+				'">' +
+				date.getDate() +
+				'</button>'
+			);
+		} ) +
+		'</div>' +
+		'<footer class="dp-cal-footer">' +
+		'<button tabindex="-1" type="button" class="dp-focusable dp-today" aria-label="' +
+		lang.ariaLabel.todayButton +
+		'">' +
+		lang.today +
+		'</button>' +
+		'<button tabindex="-1" type="button" class="dp-focusable dp-clear" aria-label="' +
+		lang.ariaLabel.clearButton +
+		'">' +
+		lang.clear +
+		'</button>' +
+		'<button tabindex="-1" type="button" class="dp-focusable dp-close" aria-label="' +
+		lang.ariaLabel.closeButton +
+		'">' +
+		lang.close +
+		'</button>' +
+		'</footer>' +
+		'</div>'
+	);
+}
+
+/**
+ * keyDown handles the key down event for the day-picker
+ *
+ * @param {Event}             e
+ * @param {DatePickerContext} dp
+ */
+function keyDown( ke: KeyboardEvent, dp: IDatePicker ) {
+	const key = ke.code;
+	let shiftBy = 0;
+	switch ( key ) {
+		case Key.left:
+			shiftBy = -1;
+			break;
+		case Key.right:
+			shiftBy = 1;
+			break;
+		case Key.up:
+			shiftBy = -7;
+			break;
+		case Key.down:
+			shiftBy = 7;
+			break;
+	}
+
+	if ( key === Key.esc ) {
+		dp.close();
+	} else if ( shiftBy ) {
+		ke.preventDefault();
+		if ( ke.shiftKey ) {
+			// shift month
+			if ( shiftBy > 0 ) {
+				dp.setState( {
+					highlightedDate: shiftMonth( dp?.state?.highlightedDate, 1 ),
+				} );
+			} else {
+				dp.setState( {
+					highlightedDate: shiftMonth( dp?.state?.highlightedDate, -1 ),
+				} );
+			}
+		} else {
+			dp.setState( {
+				highlightedDate: shiftDay( dp?.state?.highlightedDate, shiftBy ),
+			} );
+		}
+	} else if ( key === Key.tab ) {
+		moveFocusToNextButton( ke, dp );
+	}
+}
+/**
+ * Allows the user to move focus between buttons with the tab.
+ *
+ * @param {Event}             e
+ * @param {DatePickerContext} dp
+ */
+function moveFocusToNextButton( ke: KeyboardEvent, dp: IDatePicker ) {
+	ke.preventDefault();
+	const buttons = dp.el?.querySelectorAll( '.dp-focusable' ) || [];
+
+	const activeElement = document.activeElement;
+	const focusedIndex = activeElement ? Array.from( buttons ).indexOf( activeElement ) : -1;
+	if ( focusedIndex !== -1 ) {
+		let nextIndex = ke.shiftKey ? focusedIndex - 1 : focusedIndex + 1;
+		// Loop around if at the start or end
+		if ( nextIndex >= buttons.length ) nextIndex = 0;
+		if ( nextIndex < 0 ) nextIndex = buttons.length - 1;
+
+		( buttons[ nextIndex ] as HTMLElement ).focus();
+	} else if ( buttons.length ) {
+		( buttons[ 0 ] as HTMLElement ).focus();
+	}
+}
+
+function selectToday( e: Event, dp: IDatePicker ) {
+	dp.setState( {
+		selectedDate: now(),
+	} );
+}
+
+function clear( e: Event, dp: IDatePicker ) {
+	dp.setState( {
+		selectedDate: null,
+	} );
+}
+
+function close( e: Event, dp: IDatePicker ) {
+	dp.close();
+}
+
+function showMonthPicker( e: Event, dp: IDatePicker ) {
+	dp.setState( {
+		view: 'month',
+	} );
+}
+
+function showYearPicker( e: Event, dp: IDatePicker ) {
+	dp.setState( {
+		view: 'year',
+	} );
+}
+
+function focusSelector( dp: IDatePicker, selector: string ) {
+	const el = dp.el?.querySelector( selector );
+	if ( el ) {
+		( el as HTMLElement ).focus();
+	}
+}
+
+function gotoNextMonth( e: Event, dp: IDatePicker ) {
+	const highlightedDate = dp?.state?.highlightedDate;
+	dp.setState( {
+		highlightedDate: shiftMonth( highlightedDate, 1 ),
+	} );
+	focusSelector( dp, '.dp-next' );
+}
+
+function gotoPrevMonth( e: Event, dp: IDatePicker ) {
+	const highlightedDate = dp?.state?.highlightedDate;
+	dp.setState( {
+		highlightedDate: shiftMonth( highlightedDate, -1 ),
+	} );
+	focusSelector( dp, '.dp-prev' );
+}
+
+function selectDay( e: KeyboardEvent, dp: IDatePicker ) {
+	if ( ! e.target ) {
+		return;
+	}
+	const eventTarget = e.target as HTMLElement;
+
+	dp.setState( {
+		selectedDate: new Date( parseInt( eventTarget.getAttribute( 'data-date' ) as string ) ),
+	} );
+}
+
+function mapDays( currentDate: Date, dayOffset: number, fn: ( iter: Date ) => string ) {
+	let result = '';
+	const iter = new Date( currentDate );
+	iter.setDate( 1 );
+	iter.setDate( 1 - iter.getDay() + dayOffset );
+
+	// If we are showing monday as the 1st of the week,
+	// and the monday is the 2nd of the month, the sunday won't
+	// show, so we need to shift backwards
+	if ( dayOffset && iter.getDate() === dayOffset + 1 ) {
+		iter.setDate( dayOffset - 6 );
+	}
+
+	// We are going to have 6 weeks always displayed to keep a consistent
+	// calendar size
+	for ( let day = 0; day < 6 * 7; ++day ) {
+		result += fn( iter );
+		iter.setDate( iter.getDate() + 1 );
+	}
+
+	return result;
+}

--- a/projects/packages/forms/src/contact-form/libs/date-picker/views/day-picker.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/views/day-picker.ts
@@ -93,6 +93,13 @@ function render( dp: IDatePicker ) {
 			);
 		} ) +
 		'</div>' +
+		( opts.hasFooter ? renderFooter( lang ) : '' ) +
+		'</div>'
+	);
+}
+
+function renderFooter( lang ) {
+	return (
 		'<footer class="dp-cal-footer">' +
 		'<button tabindex="-1" type="button" class="dp-focusable dp-today" aria-label="' +
 		lang.ariaLabel.todayButton +
@@ -109,8 +116,7 @@ function render( dp: IDatePicker ) {
 		'">' +
 		lang.close +
 		'</button>' +
-		'</footer>' +
-		'</div>'
+		'</footer>'
 	);
 }
 

--- a/projects/packages/forms/src/contact-form/libs/date-picker/views/day-picker.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/views/day-picker.ts
@@ -145,7 +145,7 @@ function keyDown( ke: KeyboardEvent, dp: IDatePicker ) {
 	}
 
 	if ( key === Key.esc ) {
-		dp.close();
+		dp.close( true );
 	} else if ( shiftBy ) {
 		ke.preventDefault();
 		if ( ke.shiftKey ) {

--- a/projects/packages/forms/src/contact-form/libs/date-picker/views/day-picker.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/views/day-picker.ts
@@ -263,13 +263,13 @@ function mapDays( currentDate: Date, dayOffset: number, fn: ( iter: Date ) => st
 	// If we are showing monday as the 1st of the week,
 	// and the monday is the 2nd of the month, the sunday won't
 	// show, so we need to shift backwards
-	if ( dayOffset && iter.getDate() === dayOffset + 1 ) {
+	if ( iter.getDate() === dayOffset + 1 ) {
 		iter.setDate( dayOffset - 6 );
 	}
 
 	// We are going to have 6 weeks always displayed to keep a consistent
 	// calendar size
-	for ( let day = 0; day < 5 * 7; ++day ) {
+	for ( let day = 0; day < 6 * 7; ++day ) {
 		result += fn( iter );
 		iter.setDate( iter.getDate() + 1 );
 	}

--- a/projects/packages/forms/src/contact-form/libs/date-picker/views/day-picker.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/views/day-picker.ts
@@ -269,7 +269,7 @@ function mapDays( currentDate: Date, dayOffset: number, fn: ( iter: Date ) => st
 
 	// We are going to have 6 weeks always displayed to keep a consistent
 	// calendar size
-	for ( let day = 0; day < 6 * 7; ++day ) {
+	for ( let day = 0; day < 5 * 7; ++day ) {
 		result += fn( iter );
 		iter.setDate( iter.getDate() + 1 );
 	}

--- a/projects/packages/forms/src/contact-form/libs/date-picker/views/month-picker.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/views/month-picker.ts
@@ -1,0 +1,98 @@
+/**
+ * @file Manages the month-picker view.
+ */
+import { IDatePicker } from '../interfaces';
+import { shiftMonth, setMonth, now } from '../lib/date';
+import { Key } from '../lib/dom';
+
+export default {
+	onKeyDown: keyDown,
+	onClick: {
+		'dp-month': onChooseMonth,
+	},
+	render: render,
+};
+
+function onChooseMonth( e: Event, dp: IDatePicker ) {
+	dp.setState( {
+		highlightedDate: setMonth(
+			dp?.state?.highlightedDate,
+			parseInt( ( e.target as HTMLElement ).getAttribute( 'data-month' ) as string )
+		),
+		view: 'day',
+	} );
+}
+
+/**
+ * render renders the month picker as an HTML string
+ *
+ * @param {DatePickerContext} dp the date picker context
+ * @returns {string}
+ */
+function render( dp: IDatePicker ) {
+	const opts = dp.opts;
+	const lang = opts.lang;
+	const months = lang.months;
+	const currentDate = dp?.state?.highlightedDate || now();
+	const currentMonth = currentDate.getMonth();
+
+	return (
+		'<div class="dp-months" aria-label="' +
+		lang.ariaLabel.monthPicker +
+		'">' +
+		months
+			.map( function ( month: string, i: number ) {
+				let className = 'dp-month';
+				className += currentMonth === i ? ' dp-current' : '';
+
+				return (
+					'<button tabindex="-1" type="button" class="' +
+					className +
+					'" data-month="' +
+					i +
+					'">' +
+					month +
+					'</button>'
+				);
+			} )
+			.join( '' ) +
+		'</div>'
+	);
+}
+
+/**
+ * keyDown handles keydown events that occur in the month picker
+ *
+ * @param {Event}             e
+ * @param {DatePickerContext} dp
+ */
+function keyDown( e: KeyboardEvent, dp: IDatePicker ) {
+	const key = e.code;
+	let shiftBy = 0;
+
+	switch ( key ) {
+		case Key.left:
+			shiftBy = -1;
+			break;
+		case Key.right:
+			shiftBy = 1;
+			break;
+		case Key.up:
+			shiftBy = -3;
+			break;
+		case Key.down:
+			shiftBy = 3;
+			break;
+	}
+
+	if ( key === Key.esc ) {
+		dp.setState( {
+			view: 'day',
+		} );
+	} else if ( shiftBy ) {
+		e.preventDefault();
+		dp.setState( {
+			highlightedDate: shiftMonth( dp.state.highlightedDate, shiftBy, true ),
+		} );
+	}
+}

--- a/projects/packages/forms/src/contact-form/libs/date-picker/views/year-picker.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/views/year-picker.ts
@@ -35,7 +35,7 @@ function render( dp: IDatePicker ) {
 
 	return (
 		'<div class="dp-years" aria-label="' +
-		dp.opts.lang.ariaLabel.monthPicker +
+		dp.opts.lang.ariaLabel.yearPicker +
 		'">' +
 		mapYears( dp, function ( year: number ) {
 			let className = 'dp-year';

--- a/projects/packages/forms/src/contact-form/libs/date-picker/views/year-picker.ts
+++ b/projects/packages/forms/src/contact-form/libs/date-picker/views/year-picker.ts
@@ -1,0 +1,109 @@
+/**
+ * @file Manages the year-picker view.
+ */
+import { IDatePicker } from '../interfaces';
+import { setYear, shiftYear, constrainDate, now } from '../lib/date';
+import { Key } from '../lib/dom';
+
+export default {
+	render: render,
+	onKeyDown: keyDown,
+	onClick: {
+		'dp-year': onChooseYear,
+	},
+};
+
+function getselectedDate( dp: IDatePicker ) {
+	const date = dp?.state?.selectedDate || now();
+	return date.getFullYear();
+}
+
+function getHighlightedDate( dp: IDatePicker ) {
+	const date = dp?.state?.highlightedDate || now();
+	return date.getFullYear();
+}
+
+/**
+ * view renders the year picker as an HTML string.
+ *
+ * @param {DatePickerContext} dp the date picker context
+ * @returns {string}
+ */
+function render( dp: IDatePicker ) {
+	const currentYear = getHighlightedDate( dp );
+	const selectedYear = getselectedDate( dp );
+
+	return (
+		'<div class="dp-years" aria-label="' +
+		dp.opts.lang.ariaLabel.monthPicker +
+		'">' +
+		mapYears( dp, function ( year: number ) {
+			let className = 'dp-year';
+			className += year === currentYear ? ' dp-current' : '';
+			className += year === selectedYear ? ' dp-selected' : '';
+
+			return (
+				'<button tabindex="-1" type="button" class="' +
+				className +
+				'" data-year="' +
+				year +
+				'">' +
+				year +
+				'</button>'
+			);
+		} ) +
+		'</div>'
+	);
+}
+
+function onChooseYear( e: Event, dp: IDatePicker ) {
+	dp.setState( {
+		highlightedDate: setYear(
+			dp.state.highlightedDate,
+			parseInt( ( e.target as HTMLElement ).getAttribute( 'data-year' ) as string )
+		),
+		view: 'day',
+	} );
+}
+
+function keyDown( ke: KeyboardEvent, dp: IDatePicker ) {
+	const key = ke.code;
+	const opts = dp.opts;
+	let shiftBy = 0;
+
+	switch ( key ) {
+		case Key.left:
+		case Key.up:
+			shiftBy = 1;
+			break;
+		case Key.right:
+		case Key.down:
+			shiftBy = -1;
+			break;
+	}
+	if ( key === Key.esc ) {
+		dp.setState( {
+			view: 'day',
+		} );
+	} else if ( shiftBy ) {
+		ke.preventDefault();
+		if ( ke.shiftKey ) {
+			shiftBy = shiftBy * 10;
+		}
+		const shiftedYear = shiftYear( dp.state.highlightedDate, shiftBy );
+		dp.setState( {
+			highlightedDate: constrainDate( shiftedYear, opts.min, opts.max ),
+		} );
+	}
+}
+
+function mapYears( dp: IDatePicker, fn: ( iter: number ) => string ) {
+	let result = '';
+	const max = dp.opts.max.getFullYear();
+
+	for ( let i = max; i >= dp.opts.min.getFullYear(); --i ) {
+		result += fn( i );
+	}
+
+	return result;
+}

--- a/projects/plugins/jetpack/changelog/update-date-picker-input-try-2
+++ b/projects/plugins/jetpack/changelog/update-date-picker-input-try-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Forms: update the datepicker to be more accessible and not use jquery


### PR DESCRIPTION
⚠️ - This Pr Needs more testing.

Fixes https://github.com/Automattic/jetpack/issues/41081


![Screenshot 2025-03-13 at 5 06 17 PM](https://github.com/user-attachments/assets/1dbcc6d5-846f-431f-9875-cdc2e0fb2f1e)


## Proposed changes:
* This Pr does 2 things. 
* 1. Adds a new date picker library that is based on the work https://chrisdavies.github.io/tiny-date-picker/ 
* 2. the library was updated to be more accessible and remove any not used features. 
* Removes the current use of the jQuery datepicker usage. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Load this PR. 
* Add a form with 3 date pickers. Each should have a different date format. 
* Load the PR in the front-end and play around with the date pickers. 
* You should be able to select the dates and submit the form as expected. 
* You should be able to use the keyboard to select a date. 
* You should be able to Use VoiceOver on a mac to select a date with your eyes closed. 



