### PR TITLE
Media Library: fix the Import Media button color in some color schemes

### DIFF
--- a/projects/packages/external-media/changelog/fix-import-media-button
+++ b/projects/packages/external-media/changelog/fix-import-media-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Media Library: fix the Import Media button color in some color schemes

--- a/projects/packages/external-media/src/features/admin/external-media-import-button.js
+++ b/projects/packages/external-media/src/features/admin/external-media-import-button.js
@@ -8,7 +8,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		buttonContainer.className = 'wpcom-media-library-action-buttons';
 
 		const importButton = document.createElement( 'a' );
-		importButton.className = 'button';
+		importButton.className = 'button-secondary';
 		importButton.role = 'button';
 		importButton.innerHTML = __( 'Import Media', 'jetpack-external-media' );
 		importButton.href = window.JETPACK_EXTERNAL_MEDIA_IMPORT_BUTTON?.href;

--- a/projects/packages/external-media/src/features/admin/external-media-import-button.scss
+++ b/projects/packages/external-media/src/features/admin/external-media-import-button.scss
@@ -6,7 +6,19 @@
 	> a {
 		position: relative;
 		top: -3px;
-		margin-left: 0;
 		vertical-align: baseline;
+
+		@media screen and (max-width: 782px) {
+			& {
+				margin-left: 0 !important;
+			}
+
+			&.button-secondary {
+				font-size: 14px;
+				padding: 10px 15px;
+				margin-bottom: 0;
+				line-height: 2.15384615;
+			}
+		}
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1738909266167659/1738901262.076659-slack-CRWCHQGUB

## Proposed changes:

This PR fixes the color of Media Library -> Import Media button, in some color schemes, as follows

|Color scheme|Before|After|
|-|-|-|
|Modern|<img width="430" alt="image" src="https://github.com/user-attachments/assets/0ba1cfcf-cba1-46e4-a706-e2bc20281dec" />|<img width="430" alt="image" src="https://github.com/user-attachments/assets/0ba1cfcf-cba1-46e4-a706-e2bc20281dec" />|
|Ocean|<img width="414" alt="image" src="https://github.com/user-attachments/assets/d16d09f9-5c12-442b-b7a2-1be5f042f341" />|<img width="411" alt="image" src="https://github.com/user-attachments/assets/a19a44f4-d529-4be4-bf41-a2704620027c" />|

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Patch this PR.
2. Try various color schemes:
    - For each scheme, go to `/wp-admin/upload.php?untangling-media=true`, and verify that the `Add New Media File` and `Import Media` buttons have the same appearance.