### PR TITLE
Experimental: Use the block editor's layout system for forms

### DIFF
--- a/projects/packages/forms/changelog/update-form-block-to-use-block-supports-layout
+++ b/projects/packages/forms/changelog/update-form-block-to-use-block-supports-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: Use layout support for the Form block, adopting a flex layout.

--- a/projects/packages/forms/src/blocks/contact-form/block.json
+++ b/projects/packages/forms/src/blocks/contact-form/block.json
@@ -21,12 +21,6 @@
 		},
 		"align": [ "wide", "full" ],
 		"layout": {
-			"allowSwitching": false,
-			"allowJustification": true,
-			"allowVerticalAlignment": false,
-			"allowOrientation": false,
-			"allowSizingOnChildren": false,
-			"allowEditing": true,
 			"default": {
 				"type": "flex"
 			}

--- a/projects/packages/forms/src/blocks/contact-form/block.json
+++ b/projects/packages/forms/src/blocks/contact-form/block.json
@@ -19,7 +19,18 @@
 			"padding": true,
 			"margin": true
 		},
-		"align": [ "wide", "full" ]
+		"align": [ "wide", "full" ],
+		"layout": {
+			"allowSwitching": false,
+			"allowJustification": true,
+			"allowVerticalAlignment": false,
+			"allowOrientation": false,
+			"allowSizingOnChildren": false,
+			"allowEditing": true,
+			"default": {
+				"type": "flex"
+			}
+		}
 	},
 	"attributes": {},
 	"editorScript": "file:./editor.js"

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -26,6 +26,14 @@ const FieldDefaults = {
 	supports: {
 		reusable: false,
 		html: false,
+		spacing: {
+			margin: true,
+			padding: true,
+			__experimentalDefaultControls: {
+				margin: false,
+				padding: false,
+			},
+		},
 	},
 	attributes: {
 		label: {
@@ -110,6 +118,10 @@ const FieldDefaults = {
 		shareFieldAttributes: {
 			type: 'boolean',
 			default: true,
+		},
+		style: {
+			type: 'object',
+			default: { layout: { selfStretch: 'fixed', flexSize: '100%' } },
 		},
 	},
 	transforms: {
@@ -318,7 +330,6 @@ const EditCheckbox = props => {
 			isSelected={ props.isSelected }
 			defaultValue={ props.attributes.defaultValue }
 			id={ props.attributes.id }
-			width={ props.attributes.width }
 			attributes={ props.attributes }
 			insertBlocksAfter={ props.insertBlocksAfter }
 		/>
@@ -335,13 +346,12 @@ const EditConsent = ( {
 } ) => {
 	useFormWrapper( { attributes, clientId, name } );
 
-	const { id, width, consentType, implicitConsentMessage, explicitConsentMessage } = attributes;
+	const { id, consentType, implicitConsentMessage, explicitConsentMessage } = attributes;
 	return (
 		<JetpackFieldConsent
 			clientId={ clientId }
 			id={ id }
 			isSelected={ isSelected }
-			width={ width }
 			consentType={ consentType }
 			implicitConsentMessage={ implicitConsentMessage }
 			explicitConsentMessage={ explicitConsentMessage }

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -26,14 +26,7 @@ const FieldDefaults = {
 	supports: {
 		reusable: false,
 		html: false,
-		spacing: {
-			margin: true,
-			padding: true,
-			__experimentalDefaultControls: {
-				margin: false,
-				padding: false,
-			},
-		},
+		spacing: {},
 	},
 	attributes: {
 		label: {

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -28,6 +28,13 @@ class Contact_Form_Block {
 			'jetpack/contact-form',
 			array(
 				'render_callback' => array( __CLASS__, 'gutenblock_render_form' ),
+				'supports'        => array(
+					'layout' => array(
+						'default' => array(
+							'type' => 'flex',
+						),
+					),
+				),
 			)
 		);
 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -22,7 +22,6 @@ function JetpackFieldCheckbox( props ) {
 		requiredText,
 		label,
 		setAttributes,
-		width,
 		defaultValue,
 		attributes,
 		insertBlocksAfter,
@@ -81,7 +80,7 @@ function JetpackFieldCheckbox( props ) {
 							help={ __( 'You can edit the "required" label in the editor', 'jetpack-forms' ) }
 							__nextHasNoMarginBottom={ true }
 						/>
-						<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
+						<JetpackFieldWidth setAttributes={ setAttributes } attributes={ attributes } />
 
 						<ToggleControl
 							label={ __( 'Sync fields style', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-choice/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-choice/edit.js
@@ -12,7 +12,7 @@ import { useJetpackFieldStyles } from '../use-jetpack-field-styles';
 const JetpackFieldChoiceEdit = props => {
 	const { name, className, clientId, instanceId, setAttributes, isSelected, attributes, type } =
 		props;
-	const { required, requiredText, options, id, width } = attributes;
+	const { required, requiredText, options, id } = attributes;
 
 	useFormWrapper( props );
 
@@ -60,7 +60,6 @@ const JetpackFieldChoiceEdit = props => {
 				attributes={ attributes }
 				setAttributes={ setAttributes }
 				type={ type }
-				width={ width }
 				hidePlaceholder
 			/>
 		</>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
@@ -9,7 +9,6 @@ import JetpackManageResponsesSettings from './jetpack-manage-responses-settings'
 
 const JetpackFieldConsent = ( {
 	instanceId,
-	width,
 	consentType,
 	implicitConsentMessage,
 	explicitConsentMessage,
@@ -50,7 +49,7 @@ const JetpackFieldConsent = ( {
 					<JetpackManageResponsesSettings isChildBlock />
 				</PanelBody>
 				<PanelBody title={ __( 'Field Settings', 'jetpack-forms' ) }>
-					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
+					<JetpackFieldWidth setAttributes={ setAttributes } attributes={ attributes } />
 					<ToggleControl
 						label={ __( 'Sync fields style', 'jetpack-forms' ) }
 						checked={ attributes.shareFieldAttributes }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -31,7 +31,6 @@ const JetpackFieldControls = ( {
 	required,
 	setAttributes,
 	type,
-	width,
 	extraFieldSettings = [],
 } ) => {
 	const formStyle = useFormStyle( clientId );
@@ -128,7 +127,7 @@ const JetpackFieldControls = ( {
 				__next40pxDefaultSize={ true }
 			/>
 		),
-		<JetpackFieldWidth key="width" setAttributes={ setAttributes } width={ width } />,
+		<JetpackFieldWidth key="width" setAttributes={ setAttributes } attributes={ attributes } />,
 		<ToggleControl
 			key="shareFieldAttributes"
 			label={ __( 'Sync fields style', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
@@ -36,7 +36,7 @@ const DATE_FORMATS = [
 
 const JetpackDatePicker = props => {
 	const { attributes, clientId, isSelected, name, setAttributes, insertBlocksAfter } = props;
-	const { id, label, required, requiredText, width, placeholder, dateFormat } = attributes;
+	const { id, label, required, requiredText, placeholder, dateFormat } = attributes;
 
 	useFormWrapper( { attributes, clientId, name } );
 
@@ -80,7 +80,6 @@ const JetpackDatePicker = props => {
 			<JetpackFieldControls
 				id={ id }
 				required={ required }
-				width={ width }
 				setAttributes={ setAttributes }
 				placeholder={ placeholder }
 				attributes={ attributes }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dropdown.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dropdown.js
@@ -13,7 +13,7 @@ import JetpackFieldLabel from './jetpack-field-label';
 import { useJetpackFieldStyles } from './use-jetpack-field-styles';
 
 const JetpackDropdown = ( { attributes, clientId, isSelected, name, setAttributes } ) => {
-	const { id, label, options, required, requiredText, toggleLabel, width } = attributes;
+	const { id, label, options, required, requiredText, toggleLabel } = attributes;
 	const optionsWrapper = useRef( undefined );
 	const formStyle = useFormStyle( clientId );
 	const { blockStyle } = useJetpackFieldStyles( attributes );
@@ -161,7 +161,6 @@ const JetpackDropdown = ( { attributes, clientId, isSelected, name, setAttribute
 				required={ required }
 				attributes={ attributes }
 				setAttributes={ setAttributes }
-				width={ width }
 				placeholder={ toggleLabel }
 				placeholderField="toggleLabel"
 				type="dropdown"

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-textarea.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-textarea.js
@@ -20,7 +20,6 @@ const JetpackFieldTextarea = props => {
 		label,
 		setAttributes,
 		placeholder,
-		width,
 	} = props;
 
 	const formStyle = useFormStyle( clientId );
@@ -64,7 +63,6 @@ const JetpackFieldTextarea = props => {
 				id={ id }
 				required={ required }
 				setAttributes={ setAttributes }
-				width={ width }
 				placeholder={ placeholder }
 				attributes={ attributes }
 			/>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-width.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-width.js
@@ -5,9 +5,9 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-const PERCENTAGE_WIDTHS = [ 25, 50, 75, 100 ];
+const PERCENTAGE_WIDTHS = [ '25%', '50%', '75%', '100%' ];
 
-export default function JetpackFieldWidth( { setAttributes, width } ) {
+export default function JetpackFieldWidth( { setAttributes, attributes } ) {
 	return (
 		<BaseControl
 			help={ __(
@@ -22,14 +22,18 @@ export default function JetpackFieldWidth( { setAttributes, width } ) {
 				aria-label={ __( 'Width', 'jetpack-forms' ) }
 				isBlock
 				label={ __( 'Width', 'jetpack-forms' ) }
-				onChange={ value => setAttributes( { width: value } ) }
-				value={ width }
+				onChange={ value =>
+					setAttributes( {
+						style: { ...attributes.style, layout: { flexSize: value, selfStretch: 'fixed' } },
+					} )
+				}
+				value={ attributes.style.layout.flexSize ?? '100%' }
 			>
 				{ PERCENTAGE_WIDTHS.map( widthValue => {
 					return (
 						<ToggleGroupControlOption
 							key={ widthValue }
-							label={ `${ widthValue }%` }
+							label={ widthValue }
 							value={ widthValue }
 						/>
 					);

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
@@ -21,7 +21,6 @@ const JetpackField = props => {
 		label,
 		setAttributes,
 		placeholder,
-		width,
 		insertBlocksAfter,
 		type,
 	} = props;
@@ -66,7 +65,6 @@ const JetpackField = props => {
 			<JetpackFieldControls
 				id={ id }
 				required={ required }
-				width={ width }
 				setAttributes={ setAttributes }
 				placeholder={ placeholder }
 				attributes={ attributes }

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -42,20 +42,11 @@
 	}
 
 	.block-editor-block-list__layout {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: flex-start;
-		flex-direction: row;
-		gap: var(--wp--style--block-gap, 1.5rem);
-
 		.wp-block {
-			flex: 0 0 100%;
-			margin-top: 0;
-			margin-bottom: 0;
-
 			&.wp-block-jetpack-button {
 				flex-basis: auto;
 			}
+			flex-basis: 100%;
 
 			&.jetpack-field__width-25,
 			&.jetpack-field__width-50,

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -43,34 +43,9 @@
 
 	.block-editor-block-list__layout {
 		.wp-block {
+			box-sizing: border-box;
 			&.wp-block-jetpack-button {
 				flex-basis: auto;
-			}
-			flex-basis: 100%;
-
-			&.jetpack-field__width-25,
-			&.jetpack-field__width-50,
-			&.jetpack-field__width-75 {
-				box-sizing: border-box;
-			}
-
-			&.jetpack-field__width-25 {
-				flex: 1 1 calc( 25% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
-				max-width: 25%;
-
-				.jetpack-option__input.jetpack-option__input.jetpack-option__input {
-					width: 70px;
-				}
-			}
-
-			&.jetpack-field__width-50 {
-				flex: 1 1 calc( 50% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
-				max-width: 50%;
-			}
-
-			&.jetpack-field__width-75 {
-				flex: 1 1 calc( 75% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
-				max-width: 75%;
 			}
 
 			@media (max-width: #{ ($break-mobile) }) {

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -59,12 +59,8 @@ export const settings = {
 		},
 		align: [ 'wide', 'full' ],
 		layout: {
-			allowSwitching: false,
-			allowJustification: true,
-			allowVerticalAlignment: false,
-			allowOrientation: false,
 			allowSizingOnChildren: false,
-			allowEditing: true,
+			allowEditing: false,
 			default: {
 				type: 'flex',
 			},

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -59,8 +59,9 @@ export const settings = {
 		},
 		align: [ 'wide', 'full' ],
 		layout: {
-			allowSizingOnChildren: false,
-			allowEditing: false,
+			allowSwitching: true,
+			allowSizingOnChildren: true,
+			allowEditing: true,
 			default: {
 				type: 'flex',
 			},

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -58,6 +58,17 @@ export const settings = {
 			margin: true,
 		},
 		align: [ 'wide', 'full' ],
+		layout: {
+			allowSwitching: false,
+			allowJustification: true,
+			allowVerticalAlignment: false,
+			allowOrientation: false,
+			allowSizingOnChildren: false,
+			allowEditing: true,
+			default: {
+				type: 'flex',
+			},
+		},
 	},
 	attributes: defaultAttributes,
 	edit,

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -17,9 +17,11 @@
 .contact-form input::placeholder {
 	transition: opacity 0.3s ease-out;
 }
+
 .contact-form input:hover::placeholder {
 	opacity: 0.5;
 }
+
 .contact-form input:focus::placeholder {
 	opacity: 0.3;
 }
@@ -28,13 +30,11 @@
 	Using :where we will keep a lower CSS specificity,
 	allowing themes to easily override these styles
  */
-:where(
-	.contact-form input[type='text'],
+:where(.contact-form input[type='text'],
 	.contact-form input[type='email'],
 	.contact-form input[type='tel'],
 	.contact-form input[type='url'],
-	.contact-form textarea
-) {
+	.contact-form textarea) {
 	box-sizing: border-box;
 	width: 100%;
 	padding: 16px;
@@ -120,7 +120,7 @@
 
 .contact-form .is-style-outlined .grunion-checkbox-multiple-options,
 .contact-form .is-style-outlined .grunion-radio-options {
-	border: solid 1px var( --jetpack--contact-form--border-color );
+	border: solid 1px var(--jetpack--contact-form--border-color);
 }
 
 .contact-form .grunion-checkbox-multiple-options legend,
@@ -221,27 +221,19 @@
 	margin-top: 7px;
 }
 
-.wp-block-jetpack-contact-form {
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: flex-start;
-	flex-direction: row;
-	flex-grow: 1;
-	gap: var(--wp--style--block-gap, 1.5rem);
-}
-
-.wp-block-jetpack-contact-form > *:not(.wp-block-jetpack-button) {
-	flex: 0 0 100%;
+.wp-block-jetpack-contact-form>*:not(.wp-block-jetpack-button) {
+	flex-basis: 100%;
 	box-sizing: border-box;
 }
 
-:where( .wp-block-jetpack-contact-form .wp-block-separator ) {
-	max-width: var( --wp--preset--spacing--80, 100px );
+:where(.wp-block-jetpack-contact-form .wp-block-separator) {
+	max-width: var(--wp--preset--spacing--80, 100px);
 	margin-top: 0;
 	margin-bottom: 0;
 }
-:where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-wide ),
-:where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-dots ) {
+
+:where(.wp-block-jetpack-contact-form .wp-block-separator.is-style-wide),
+:where(.wp-block-jetpack-contact-form .wp-block-separator.is-style-dots) {
 	max-width: inherit;
 }
 
@@ -280,21 +272,21 @@
 }
 
 .wp-block-jetpack-contact-form .grunion-field-width-25-wrap {
-	flex: 1 1 calc( 25% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
+	flex: 1 1 calc(25% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 	max-width: 25%;
 }
 
 .wp-block-jetpack-contact-form .grunion-field-width-50-wrap {
-	flex: 1 1 calc( 50% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
+	flex: 1 1 calc(50% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 	max-width: 50%;
 }
 
 .wp-block-jetpack-contact-form .grunion-field-width-75-wrap {
-	flex: 1 1 calc( 75% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
+	flex: 1 1 calc(75% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
 	max-width: 75%;
 }
 
-@media only screen and ( max-width: 480px ) {
+@media only screen and (max-width: 480px) {
 	.wp-block-jetpack-contact-form .grunion-field-wrap {
 		flex-basis: 100%;
 		max-width: none;
@@ -305,7 +297,8 @@
 	align-self: center;
 }
 
-@media only screen and ( min-width: 600px ) {
+@media only screen and (min-width: 600px) {
+
 	.contact-form input[type='text'],
 	.contact-form input[type='email'],
 	.contact-form input[type='tel'],
@@ -330,9 +323,11 @@
 .jetpack-empty-spam-container {
 	display: inline-block;
 }
+
 .jetpack-empty-spam {
 	display: inline-block;
 }
+
 .jetpack-empty-spam-spinner {
 	display: inline-block;
 	margin-top: 7px;
@@ -352,13 +347,13 @@
 	inset-inline-end: 20px;
 	top: 50%;
 
-  content: "";
-  display: block;
+	content: "";
+	display: block;
 	width: 8px;
 	height: 8px;
 
 	border-bottom: 2px solid;
-  border-right: 2px solid;
+	border-right: 2px solid;
 
 	transform: translateY(-50%) rotate(45deg);
 	transform-origin: center center;
@@ -406,8 +401,7 @@
 }
 
 .contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options
-{
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options {
 	padding: var(--jetpack--contact-form--input-padding, 16px);
 	padding-top: calc(var(--jetpack--contact-form--input-padding-top, 16px) + 4px);
 	flex-grow: 1;
@@ -426,7 +420,7 @@
 	pointer-events: none;
 }
 
-.contact-form .contact-form__select-wrapper + .notched-label {
+.contact-form .contact-form__select-wrapper+.notched-label {
 	top: 0;
 }
 
@@ -493,33 +487,31 @@ on production builds, the attributes are being reordered, causing side-effects
 	border-bottom-left-radius: unset;
 }
 
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:focus ~ .notched-label .notched-label__notch,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:not(:placeholder-shown) ~ .notched-label .notched-label__notch,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-field.has-placeholder ~ .notched-label .notched-label__notch,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options ~ .notched-label .notched-label__notch,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options ~ .notched-label .notched-label__notch,
-.contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .notched-label__notch
-{
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:focus~.notched-label .notched-label__notch,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:not(:placeholder-shown)~.notched-label .notched-label__notch,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field.has-placeholder~.notched-label .notched-label__notch,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options~.notched-label .notched-label__notch,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options~.notched-label .notched-label__notch,
+.contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .notched-label__notch {
 	border-top-color: transparent;
 }
 
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:focus ~ .notched-label .notched-label__label,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:not(:placeholder-shown) ~ .notched-label .notched-label__label,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-field.has-placeholder ~ .notched-label .notched-label__label,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options ~ .notched-label .notched-label__label,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options ~ .notched-label .notched-label__label,
-.contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .notched-label__label
-{
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:focus~.notched-label .notched-label__label,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:not(:placeholder-shown)~.notched-label .notched-label__label,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field.has-placeholder~.notched-label .notched-label__label,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options~.notched-label .notched-label__label,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options~.notched-label .notched-label__label,
+.contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .notched-label__label {
 	top: calc(var(--jetpack--contact-form--border-size) * -1);
 	transform: translateY(-50%);
 	font-size: 0.8em;
 }
 
-.contact-form .is-style-outlined .grunion-field-wrap > input,
-.contact-form .is-style-outlined .grunion-field-wrap > textarea,
-.contact-form .is-style-outlined .grunion-field-wrap select
-{
-	border-color: transparent !important; /* Need to override styles coming from the style attribute*/
+.contact-form .is-style-outlined .grunion-field-wrap>input,
+.contact-form .is-style-outlined .grunion-field-wrap>textarea,
+.contact-form .is-style-outlined .grunion-field-wrap select {
+	border-color: transparent !important;
+	/* Need to override styles coming from the style attribute*/
 	outline: none;
 	padding-left: calc(var(--notch-width) + 4px);
 	padding-right: calc(var(--notch-width) + 4px);
@@ -546,10 +538,9 @@ on production builds, the attributes are being reordered, causing side-effects
 	outline: none;
 }
 
-.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) > input,
-.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) > textarea,
-.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) select
-{
+.contact-form .is-style-animated .grunion-field-wrap:not(.no-label)>input,
+.contact-form .is-style-animated .grunion-field-wrap:not(.no-label)>textarea,
+.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) select {
 	padding-top: 1.4em;
 	padding-left: var(--field-padding);
 	padding-right: var(--field-padding);
@@ -573,18 +564,17 @@ on production builds, the attributes are being reordered, causing side-effects
 	top: var(--jetpack--contact-form--input-padding-top, 16px);
 }
 
-.contact-form .is-style-animated .grunion-field-wrap .grunion-field:focus ~ .animated-label__label,
-.contact-form .is-style-animated .grunion-field-wrap .grunion-field:not(:placeholder-shown) ~ .animated-label__label,
-.contact-form .is-style-animated .grunion-field-wrap .grunion-field.has-placeholder ~ .animated-label__label,
-.contact-form .is-style-animated .grunion-field-wrap.grunion-field-select-wrap .animated-label__label
-{
+.contact-form .is-style-animated .grunion-field-wrap .grunion-field:focus~.animated-label__label,
+.contact-form .is-style-animated .grunion-field-wrap .grunion-field:not(:placeholder-shown)~.animated-label__label,
+.contact-form .is-style-animated .grunion-field-wrap .grunion-field.has-placeholder~.animated-label__label,
+.contact-form .is-style-animated .grunion-field-wrap.grunion-field-select-wrap .animated-label__label {
 	font-size: 0.75em;
 	transform: translateY(0);
 	top: calc(2px + var(--jetpack--contact-form--border-size));
 }
 
-.contact-form .is-style-animated .grunion-field-wrap .grunion-checkbox-multiple-options ~ .animated-label__label,
-.contact-form .is-style-animated .grunion-field-wrap .grunion-radio-options ~ .animated-label__label {
+.contact-form .is-style-animated .grunion-field-wrap .grunion-checkbox-multiple-options~.animated-label__label,
+.contact-form .is-style-animated .grunion-field-wrap .grunion-radio-options~.animated-label__label {
 	top: 0;
 	left: 0;
 	transform: translateY(0);
@@ -618,7 +608,8 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .grunion-field-wrap input.radio {
 	border-radius: 50%;
 
-	transform: translateY(15%); /* Small offset to compensate the slightly odd perceived alignment that's due to the circular shape */
+	transform: translateY(15%);
+	/* Small offset to compensate the slightly odd perceived alignment that's due to the circular shape */
 }
 
 .contact-form .grunion-field-wrap input.checkbox-multiple:checked::before {
@@ -633,7 +624,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	font-size: var(--jetpack--contact-form--font-size);
 	line-height: 1;
 
-  transform: translate(-50%, -50%);
+	transform: translate(-50%, -50%);
 }
 
 .contact-form .grunion-field-wrap input.radio:checked::before {
@@ -651,7 +642,7 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .grunion-field-wrap.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .contact-form-field,
 .contact-form .grunion-field-wrap.is-style-button-wrap .grunion-radio-label {
 	display: inline-flex;
-  align-items: center;
+	align-items: center;
 
 	padding: var(--jetpack--contact-form--button-outline--padding);
 
@@ -666,25 +657,25 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button {
 	/* visually-hidden */
 	clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
+	clip-path: inset(50%);
+	height: 1px;
+	overflow: hidden;
+	position: absolute;
+	white-space: nowrap;
+	width: 1px;
 }
 
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button:checked + .grunion-radio-label {
+.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button:checked+.grunion-radio-label {
 	display: inline-flex;
 	gap: 0.5em;
 }
 
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button:checked + .grunion-radio-label:before {
+.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button:checked+.grunion-radio-label:before {
 	content: "\2713";
 }
 
 .contact-form .grunion-field-wrap.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .contact-form-field:focus-within,
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button:focus + .grunion-radio-label {
+.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button:focus+.grunion-radio-label {
 	outline: var(--jetpack--contact-form--button-outline--border);
 	outline-offset: 2px;
 }
@@ -697,10 +688,11 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.checkbox-multiple.is-style-button:focus {
-	outline-width: 0; /* focus style defined on parent */
+	outline-width: 0;
+	/* focus style defined on parent */
 }
 
-.contact-form input.grunion-field.is-style-button + .grunion-field-text::before {
+.contact-form input.grunion-field.is-style-button+.grunion-field-text::before {
 	background: var(--jetpack--contact-form--button-outline--background-color);
 	border: var(--jetpack--contact-form--button-outline--border);
 	border-color: currentColor;
@@ -721,11 +713,11 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .contact-form input.grunion-field.is-style-button:checked,
-.contact-form input.grunion-field.is-style-button:checked + .grunion-field-text {
+.contact-form input.grunion-field.is-style-button:checked+.grunion-field-text {
 	color: var(--jetpack--contact-form--button-outline--background-color-fallback);
 }
 
-.contact-form input.grunion-field.is-style-button:checked + .grunion-field-text::before {
+.contact-form input.grunion-field.is-style-button:checked+.grunion-field-text::before {
 	background: var(--jetpack--contact-form--button-outline--text-color);
 	border-color: var(--jetpack--contact-form--button-outline--text-color);
 }
@@ -819,7 +811,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	align-items: baseline;
 }
 
-.contact-form :is([type="submit"],button:not([type="reset"])) {
+.contact-form :is([type="submit"], button:not([type="reset"])) {
 	display: inline-flex;
 	justify-content: center;
 	align-items: center;
@@ -836,11 +828,11 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .visually-hidden {
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
+	clip: rect(0 0 0 0);
+	clip-path: inset(50%);
+	height: 1px;
+	overflow: hidden;
+	position: absolute;
+	white-space: nowrap;
+	width: 1px;
 }

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -17,11 +17,9 @@
 .contact-form input::placeholder {
 	transition: opacity 0.3s ease-out;
 }
-
 .contact-form input:hover::placeholder {
 	opacity: 0.5;
 }
-
 .contact-form input:focus::placeholder {
 	opacity: 0.3;
 }
@@ -30,11 +28,13 @@
 	Using :where we will keep a lower CSS specificity,
 	allowing themes to easily override these styles
  */
-:where(.contact-form input[type='text'],
+:where(
+	.contact-form input[type='text'],
 	.contact-form input[type='email'],
 	.contact-form input[type='tel'],
 	.contact-form input[type='url'],
-	.contact-form textarea) {
+	.contact-form textarea
+) {
 	box-sizing: border-box;
 	width: 100%;
 	padding: 16px;
@@ -120,7 +120,7 @@
 
 .contact-form .is-style-outlined .grunion-checkbox-multiple-options,
 .contact-form .is-style-outlined .grunion-radio-options {
-	border: solid 1px var(--jetpack--contact-form--border-color);
+	border: solid 1px var( --jetpack--contact-form--border-color );
 }
 
 .contact-form .grunion-checkbox-multiple-options legend,
@@ -221,19 +221,27 @@
 	margin-top: 7px;
 }
 
-.wp-block-jetpack-contact-form>*:not(.wp-block-jetpack-button) {
-	flex-basis: 100%;
+.wp-block-jetpack-contact-form {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: flex-start;
+	flex-direction: row;
+	flex-grow: 1;
+	gap: var(--wp--style--block-gap, 1.5rem);
+}
+
+.wp-block-jetpack-contact-form > *:not(.wp-block-jetpack-button) {
+	flex: 0 0 100%;
 	box-sizing: border-box;
 }
 
-:where(.wp-block-jetpack-contact-form .wp-block-separator) {
-	max-width: var(--wp--preset--spacing--80, 100px);
+:where( .wp-block-jetpack-contact-form .wp-block-separator ) {
+	max-width: var( --wp--preset--spacing--80, 100px );
 	margin-top: 0;
 	margin-bottom: 0;
 }
-
-:where(.wp-block-jetpack-contact-form .wp-block-separator.is-style-wide),
-:where(.wp-block-jetpack-contact-form .wp-block-separator.is-style-dots) {
+:where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-wide ),
+:where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-dots ) {
 	max-width: inherit;
 }
 
@@ -272,21 +280,21 @@
 }
 
 .wp-block-jetpack-contact-form .grunion-field-width-25-wrap {
-	flex: 1 1 calc(25% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
+	flex: 1 1 calc( 25% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
 	max-width: 25%;
 }
 
 .wp-block-jetpack-contact-form .grunion-field-width-50-wrap {
-	flex: 1 1 calc(50% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
+	flex: 1 1 calc( 50% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
 	max-width: 50%;
 }
 
 .wp-block-jetpack-contact-form .grunion-field-width-75-wrap {
-	flex: 1 1 calc(75% - calc(var(--wp--style--block-gap, 1.5rem) * 1));
+	flex: 1 1 calc( 75% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
 	max-width: 75%;
 }
 
-@media only screen and (max-width: 480px) {
+@media only screen and ( max-width: 480px ) {
 	.wp-block-jetpack-contact-form .grunion-field-wrap {
 		flex-basis: 100%;
 		max-width: none;
@@ -297,8 +305,7 @@
 	align-self: center;
 }
 
-@media only screen and (min-width: 600px) {
-
+@media only screen and ( min-width: 600px ) {
 	.contact-form input[type='text'],
 	.contact-form input[type='email'],
 	.contact-form input[type='tel'],
@@ -323,11 +330,9 @@
 .jetpack-empty-spam-container {
 	display: inline-block;
 }
-
 .jetpack-empty-spam {
 	display: inline-block;
 }
-
 .jetpack-empty-spam-spinner {
 	display: inline-block;
 	margin-top: 7px;
@@ -347,13 +352,13 @@
 	inset-inline-end: 20px;
 	top: 50%;
 
-	content: "";
-	display: block;
+  content: "";
+  display: block;
 	width: 8px;
 	height: 8px;
 
 	border-bottom: 2px solid;
-	border-right: 2px solid;
+  border-right: 2px solid;
 
 	transform: translateY(-50%) rotate(45deg);
 	transform-origin: center center;
@@ -401,7 +406,8 @@
 }
 
 .contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options {
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options
+{
 	padding: var(--jetpack--contact-form--input-padding, 16px);
 	padding-top: calc(var(--jetpack--contact-form--input-padding-top, 16px) + 4px);
 	flex-grow: 1;
@@ -420,7 +426,7 @@
 	pointer-events: none;
 }
 
-.contact-form .contact-form__select-wrapper+.notched-label {
+.contact-form .contact-form__select-wrapper + .notched-label {
 	top: 0;
 }
 
@@ -487,31 +493,33 @@ on production builds, the attributes are being reordered, causing side-effects
 	border-bottom-left-radius: unset;
 }
 
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:focus~.notched-label .notched-label__notch,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:not(:placeholder-shown)~.notched-label .notched-label__notch,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-field.has-placeholder~.notched-label .notched-label__notch,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options~.notched-label .notched-label__notch,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options~.notched-label .notched-label__notch,
-.contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .notched-label__notch {
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:focus ~ .notched-label .notched-label__notch,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:not(:placeholder-shown) ~ .notched-label .notched-label__notch,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field.has-placeholder ~ .notched-label .notched-label__notch,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options ~ .notched-label .notched-label__notch,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options ~ .notched-label .notched-label__notch,
+.contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .notched-label__notch
+{
 	border-top-color: transparent;
 }
 
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:focus~.notched-label .notched-label__label,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:not(:placeholder-shown)~.notched-label .notched-label__label,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-field.has-placeholder~.notched-label .notched-label__label,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options~.notched-label .notched-label__label,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options~.notched-label .notched-label__label,
-.contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .notched-label__label {
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:focus ~ .notched-label .notched-label__label,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:not(:placeholder-shown) ~ .notched-label .notched-label__label,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field.has-placeholder ~ .notched-label .notched-label__label,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options ~ .notched-label .notched-label__label,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options ~ .notched-label .notched-label__label,
+.contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .notched-label__label
+{
 	top: calc(var(--jetpack--contact-form--border-size) * -1);
 	transform: translateY(-50%);
 	font-size: 0.8em;
 }
 
-.contact-form .is-style-outlined .grunion-field-wrap>input,
-.contact-form .is-style-outlined .grunion-field-wrap>textarea,
-.contact-form .is-style-outlined .grunion-field-wrap select {
-	border-color: transparent !important;
-	/* Need to override styles coming from the style attribute*/
+.contact-form .is-style-outlined .grunion-field-wrap > input,
+.contact-form .is-style-outlined .grunion-field-wrap > textarea,
+.contact-form .is-style-outlined .grunion-field-wrap select
+{
+	border-color: transparent !important; /* Need to override styles coming from the style attribute*/
 	outline: none;
 	padding-left: calc(var(--notch-width) + 4px);
 	padding-right: calc(var(--notch-width) + 4px);
@@ -538,9 +546,10 @@ on production builds, the attributes are being reordered, causing side-effects
 	outline: none;
 }
 
-.contact-form .is-style-animated .grunion-field-wrap:not(.no-label)>input,
-.contact-form .is-style-animated .grunion-field-wrap:not(.no-label)>textarea,
-.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) select {
+.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) > input,
+.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) > textarea,
+.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) select
+{
 	padding-top: 1.4em;
 	padding-left: var(--field-padding);
 	padding-right: var(--field-padding);
@@ -564,17 +573,18 @@ on production builds, the attributes are being reordered, causing side-effects
 	top: var(--jetpack--contact-form--input-padding-top, 16px);
 }
 
-.contact-form .is-style-animated .grunion-field-wrap .grunion-field:focus~.animated-label__label,
-.contact-form .is-style-animated .grunion-field-wrap .grunion-field:not(:placeholder-shown)~.animated-label__label,
-.contact-form .is-style-animated .grunion-field-wrap .grunion-field.has-placeholder~.animated-label__label,
-.contact-form .is-style-animated .grunion-field-wrap.grunion-field-select-wrap .animated-label__label {
+.contact-form .is-style-animated .grunion-field-wrap .grunion-field:focus ~ .animated-label__label,
+.contact-form .is-style-animated .grunion-field-wrap .grunion-field:not(:placeholder-shown) ~ .animated-label__label,
+.contact-form .is-style-animated .grunion-field-wrap .grunion-field.has-placeholder ~ .animated-label__label,
+.contact-form .is-style-animated .grunion-field-wrap.grunion-field-select-wrap .animated-label__label
+{
 	font-size: 0.75em;
 	transform: translateY(0);
 	top: calc(2px + var(--jetpack--contact-form--border-size));
 }
 
-.contact-form .is-style-animated .grunion-field-wrap .grunion-checkbox-multiple-options~.animated-label__label,
-.contact-form .is-style-animated .grunion-field-wrap .grunion-radio-options~.animated-label__label {
+.contact-form .is-style-animated .grunion-field-wrap .grunion-checkbox-multiple-options ~ .animated-label__label,
+.contact-form .is-style-animated .grunion-field-wrap .grunion-radio-options ~ .animated-label__label {
 	top: 0;
 	left: 0;
 	transform: translateY(0);
@@ -608,8 +618,7 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .grunion-field-wrap input.radio {
 	border-radius: 50%;
 
-	transform: translateY(15%);
-	/* Small offset to compensate the slightly odd perceived alignment that's due to the circular shape */
+	transform: translateY(15%); /* Small offset to compensate the slightly odd perceived alignment that's due to the circular shape */
 }
 
 .contact-form .grunion-field-wrap input.checkbox-multiple:checked::before {
@@ -624,7 +633,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	font-size: var(--jetpack--contact-form--font-size);
 	line-height: 1;
 
-	transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%);
 }
 
 .contact-form .grunion-field-wrap input.radio:checked::before {
@@ -642,7 +651,7 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .grunion-field-wrap.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .contact-form-field,
 .contact-form .grunion-field-wrap.is-style-button-wrap .grunion-radio-label {
 	display: inline-flex;
-	align-items: center;
+  align-items: center;
 
 	padding: var(--jetpack--contact-form--button-outline--padding);
 
@@ -657,25 +666,25 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button {
 	/* visually-hidden */
 	clip: rect(0 0 0 0);
-	clip-path: inset(50%);
-	height: 1px;
-	overflow: hidden;
-	position: absolute;
-	white-space: nowrap;
-	width: 1px;
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }
 
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button:checked+.grunion-radio-label {
+.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button:checked + .grunion-radio-label {
 	display: inline-flex;
 	gap: 0.5em;
 }
 
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button:checked+.grunion-radio-label:before {
+.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button:checked + .grunion-radio-label:before {
 	content: "\2713";
 }
 
 .contact-form .grunion-field-wrap.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .contact-form-field:focus-within,
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button:focus+.grunion-radio-label {
+.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button:focus + .grunion-radio-label {
 	outline: var(--jetpack--contact-form--button-outline--border);
 	outline-offset: 2px;
 }
@@ -688,11 +697,10 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.checkbox-multiple.is-style-button:focus {
-	outline-width: 0;
-	/* focus style defined on parent */
+	outline-width: 0; /* focus style defined on parent */
 }
 
-.contact-form input.grunion-field.is-style-button+.grunion-field-text::before {
+.contact-form input.grunion-field.is-style-button + .grunion-field-text::before {
 	background: var(--jetpack--contact-form--button-outline--background-color);
 	border: var(--jetpack--contact-form--button-outline--border);
 	border-color: currentColor;
@@ -713,11 +721,11 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .contact-form input.grunion-field.is-style-button:checked,
-.contact-form input.grunion-field.is-style-button:checked+.grunion-field-text {
+.contact-form input.grunion-field.is-style-button:checked + .grunion-field-text {
 	color: var(--jetpack--contact-form--button-outline--background-color-fallback);
 }
 
-.contact-form input.grunion-field.is-style-button:checked+.grunion-field-text::before {
+.contact-form input.grunion-field.is-style-button:checked + .grunion-field-text::before {
 	background: var(--jetpack--contact-form--button-outline--text-color);
 	border-color: var(--jetpack--contact-form--button-outline--text-color);
 }
@@ -811,7 +819,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	align-items: baseline;
 }
 
-.contact-form :is([type="submit"], button:not([type="reset"])) {
+.contact-form :is([type="submit"],button:not([type="reset"])) {
 	display: inline-flex;
 	justify-content: center;
 	align-items: center;
@@ -828,11 +836,11 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .visually-hidden {
-	clip: rect(0 0 0 0);
-	clip-path: inset(50%);
-	height: 1px;
-	overflow: hidden;
-	position: absolute;
-	white-space: nowrap;
-	width: 1px;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -221,15 +221,6 @@
 	margin-top: 7px;
 }
 
-.wp-block-jetpack-contact-form {
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: flex-start;
-	flex-direction: row;
-	flex-grow: 1;
-	gap: var(--wp--style--block-gap, 1.5rem);
-}
-
 .wp-block-jetpack-contact-form > *:not(.wp-block-jetpack-button) {
 	flex: 0 0 100%;
 	box-sizing: border-box;


### PR DESCRIPTION
See #41428

## Proposed changes:
Updates the jetpack from block to use 'layout' block supports. You can read more about this PR here on the issue - https://github.com/Automattic/jetpack/issues/41428#issuecomment-2647088059.

I've removed the existing editor flexbox CSS for forms as part of this, so they don't interfere with the layout system's styles.

When a form is inserted it's by default set to the flex 'row' layout. The width controls on field blocks now updates the layout system's `flexSize` attribute to set percentage widths.

Also interesting to try is a grid layout, especially if you enable Gutenberg's grid experiments.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Add a form block
2. Note the form block now has layout controls
3. Select a field
4. See the field block also has 'Size' controls in a style tab.