### PR TITLE
Fix column block width when used in a form

### DIFF
--- a/projects/packages/forms/changelog/fix-columns-in-form
+++ b/projects/packages/forms/changelog/fix-columns-in-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix column block width when used in the form block.

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -26,6 +26,7 @@ const FieldDefaults = {
 	supports: {
 		reusable: false,
 		html: false,
+		spacing: {},
 	},
 	attributes: {
 		label: {

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -643,7 +643,6 @@
 }
 
 .jetpack-field-dropdown {
-	width: 100%;
 	display: inline-flex;
 	flex-direction: column;
 	font-family: var(--jetpack--contact-form--font-family);

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -48,7 +48,7 @@
 		flex-direction: row;
 		gap: var(--wp--style--block-gap, 1.5rem);
 
-		> .wp-block {
+		> * {
 			flex: 0 0 100%;
 			margin-top: 0;
 			margin-bottom: 0;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -41,14 +41,14 @@
 		}
 	}
 
-	.block-editor-block-list__layout {
+	.jetpack-contact-form.block-editor-block-list__layout {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: flex-start;
 		flex-direction: row;
 		gap: var(--wp--style--block-gap, 1.5rem);
 
-		.wp-block {
+		> .wp-block {
 			flex: 0 0 100%;
 			margin-top: 0;
 			margin-bottom: 0;

--- a/projects/plugins/jetpack/changelog/fix-columns-in-form
+++ b/projects/plugins/jetpack/changelog/fix-columns-in-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: fix column block width when used in the form block.


### PR DESCRIPTION
Fixes #41519

## Proposed changes:
As noted in the issue, when a columns/column block is used within a form, each column has 100% width within the editor

The problem is that the form block has some styles that set all inner blocks, to any depth, to a `flex-basis: 100%`.

This rule should really only apply to blocks that are a direct child of the form.

In this PR I've updated the selectors being used to ensure the styles only apply to immediate children.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Add a form with every type of inner block, including a columns block
2. Ensure the column blocks within the columns are sized correctly
3. Try changing the width of various form fields and make sure they all work correctly