### PR TITLE
AI Assistant: Add missing pre-defined prompt to tracking event

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-assistant-prompt-tracking
+++ b/projects/plugins/jetpack/changelog/add-ai-assistant-prompt-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Add missing pre-defined prompt value to the tracking event

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/components/ai-assistant-input/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/components/ai-assistant-input/index.tsx
@@ -117,10 +117,11 @@ export default function AiAssistantInput( {
 	const handleUndo = useCallback( () => {
 		tracks.recordEvent( 'jetpack_ai_assistant_undo', {
 			block_type: blockType,
+			prompt: lastAction || null,
 		} );
 
 		undo?.();
-	}, [ blockType, tracks, undo ] );
+	}, [ blockType, lastAction, tracks, undo ] );
 
 	const handleUpgrade = useCallback( () => {
 		tracks.recordEvent( 'jetpack_ai_upgrade_button', {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We're adding missing data to the tracking event to determine which predefined prompt was used when the user clicks on the undo button. In other parts of the code we're already tracking it, but it was missing for the undo button click event.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to a paragraph AI extension and click on Translate, and then click on any language.
* Check the Network developer tools, and look for the "t.gif" request.
* Check that the `prompt` parameter is included in the request GET parameters and that it has the corresponding "Translate ..." value.

