### PR TITLE
Jetpack SEO: fix message width

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-seo-assistant-message-width
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-seo-assistant-message-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO: wee CSS fix on message width

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/style.scss
@@ -106,7 +106,7 @@
 		line-height: 1.5;
 		display: flex;
 		align-items: center;
-		max-width: 255px;
+		max-width: 281px;
 
 		&:not( .is-option ) {
 			margin-top: 8px;


### PR DESCRIPTION


Fixes #41488 

## Proposed changes:
fix message width so final width of the actual text box fits 255px

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
#41488 

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Use the SEO assistant, inspect the messages to verify the text box of the message is 255px width