### PR TITLE
tests: Replace `ts-jest-resolver`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5269,9 +5269,6 @@ importers:
       svelte-eslint-parser:
         specifier: 0.39.2
         version: 0.39.2(svelte@4.2.19)
-      ts-jest-resolver:
-        specifier: 2.0.1
-        version: 2.0.1
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -14717,9 +14714,6 @@ packages:
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
-
-  ts-jest-resolver@2.0.1:
-    resolution: {integrity: sha512-FolE73BqVZCs8/RbLKxC67iaAtKpBWx7PeLKFW2zJQlOf9j851I7JRxSDenri2NFvVH3QP7v3S8q1AmL24Zb9Q==}
 
   ts-jest@29.2.5:
     resolution: {integrity: sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==}
@@ -29372,10 +29366,6 @@ snapshots:
       typescript: 5.0.4
 
   ts-dedent@2.2.0: {}
-
-  ts-jest-resolver@2.0.1:
-    dependencies:
-      jest-resolve: 29.7.0
 
   ts-jest@29.2.5(jest@29.7.0)(typescript@5.0.4):
     dependencies:

--- a/tools/js-tools/jest/jest-resolver.js
+++ b/tools/js-tools/jest/jest-resolver.js
@@ -1,5 +1,3 @@
-const tsJestResolver = require( 'ts-jest-resolver' );
-
 // Some packages assume that a "browser" environment is esm or otherwise break in node.
 // List them here and the resolver will adjust the conditions to resolve them as "node" instead.
 // cf. https://github.com/microsoft/accessibility-insights-web/pull/5421#issuecomment-1109168149
@@ -7,6 +5,28 @@ const badBrowserPackages = new Set( [
 	// https://github.com/LeaVerou/parsel/issues/79
 	'parsel-js',
 ] );
+
+// TypeScript looks for various different extensions on imports. We need to reproduce this here.
+// Based on code from https://github.com/VitorLuizC/ts-jest-resolver/blob/98fdae29c6622ae67f2e10ecc03af7f79d16d24d/src/index.ts
+// (which doesn't seem to handle tsc's --jsx option)
+const resolutions = [
+	{
+		matcher: /\.js$/i,
+		extensions: [ '.ts', '.tsx', '.js', '.jsx' ],
+	},
+	{
+		matcher: /\.jsx$/i,
+		extensions: [ '.tsx', '.ts', '.jsx', '.js' ],
+	},
+	{
+		matcher: /\.cjs$/i,
+		extensions: [ '.cts', '.cjs' ],
+	},
+	{
+		matcher: /\.mjs$/i,
+		extensions: [ '.mts', '.mjs' ],
+	},
+];
 
 module.exports = ( path, options ) => {
 	const basedir = options.basedir;
@@ -22,9 +42,32 @@ module.exports = ( path, options ) => {
 		conditions.add( 'node' );
 	}
 
-	return tsJestResolver( path, {
+	// Try mapping extensions.
+	// Based on code from https://github.com/VitorLuizC/ts-jest-resolver/blob/98fdae29c6622ae67f2e10ecc03af7f79d16d24d/src/index.ts
+	const resolver = options.defaultResolver;
+	const resolution = resolutions.find( ( { matcher } ) => matcher.test( path ) );
+	const opts = {
 		...options,
 		basedir,
 		conditions,
-	} );
+	};
+
+	if ( resolution ) {
+		let ex;
+		for ( const extension of resolution.extensions ) {
+			const trypath = path.replace( resolution.matcher, extension );
+			try {
+				return resolver( trypath, opts );
+			} catch ( e ) {
+				if ( trypath === path ) {
+					ex = e;
+				}
+			}
+		}
+		if ( ex ) {
+			throw ex;
+		}
+	}
+
+	return resolver( path, opts );
 };

--- a/tools/js-tools/package.json
+++ b/tools/js-tools/package.json
@@ -59,7 +59,6 @@
 		"sort-package-json": "1.50.0",
 		"svelte": "4.2.19",
 		"svelte-eslint-parser": "0.39.2",
-		"ts-jest-resolver": "2.0.1",
 		"typescript": "5.0.4",
 		"typescript-eslint": "8.17.0",
 		"yaml": "2.2.2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
It turns out that `ts-jest-resolver` doesn't handle jsx files, even though TypeScript itself does. Since the module is so simple, let's just import the relevant code and add jsx.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/41524#discussion_r1947150808

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* Try #41524 with this added.
