### PR TITLE
Jetpack SEO: add flow state

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-seo-navigation-state
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-seo-navigation-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO: add assisstant flow state to better handle navigation transitions and effects

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
@@ -177,8 +177,14 @@ export default function AssistantWizard( { close } ) {
 				},
 			} ) );
 		}
-		handleNext();
-	}, [ currentStep, steps, handleNext, results ] );
+		if ( steps[ currentStep ]?.type === 'completion' ) {
+			debug( 'completion step, closing wizard' );
+			handleDone();
+		} else {
+			debug( 'step type', steps[ currentStep ]?.type );
+			handleNext();
+		}
+	}, [ currentStep, steps, handleNext, results, handleDone ] );
 
 	const handleRetry = useCallback( async () => {
 		debug( 'handleRetry' );
@@ -198,7 +204,11 @@ export default function AssistantWizard( { close } ) {
 				<h2>{ currentStepData?.title }</h2>
 				<div className="assistant-wizard__header-actions">
 					<Tooltip text={ __( 'Skip', 'jetpack' ) }>
-						<Button variant="link" disabled={ isBusy } onClick={ handleSkip }>
+						<Button
+							variant="link"
+							disabled={ isBusy || currentStep >= steps.length - 1 }
+							onClick={ handleSkip }
+						>
 							<Icon icon={ next } size={ 32 } />
 						</Button>
 					</Tooltip>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
@@ -22,6 +22,7 @@ export default function AssistantWizard( { close } ) {
 		stepsEndRef.current?.scrollIntoView( { behavior: 'smooth' } );
 	};
 	const keywordsInputRef = useRef( null );
+	const prevStepIdRef = useRef< string | undefined >();
 	const [ results, setResults ] = useState( {} );
 
 	useEffect( () => {
@@ -75,14 +76,16 @@ export default function AssistantWizard( { close } ) {
 		} );
 	}, [ stepsCount, steps ] );
 
-	useEffect(
-		() => {
-			debug( 'currentStepData changed', currentStepData?.id );
+	useEffect( () => {
+		const currentId = currentStepData?.id;
+
+		if ( prevStepIdRef.current !== currentId ) {
+			debug( 'currentStepData changed', currentId );
 			handleStepStart();
-		},
-		// @ts-expect-error - including handleStepStart in the dependency array causes the effect to run twice
-		[ currentStepData ]
-	);
+		}
+
+		prevStepIdRef.current = currentId;
+	}, [ currentStepData, handleStepStart ] );
 
 	// Initialize current step data
 	useEffect( () => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
@@ -23,7 +23,6 @@ export default function AssistantWizard( { close } ) {
 	};
 	const keywordsInputRef = useRef( null );
 	const [ results, setResults ] = useState( {} );
-	const [ lastStepValue, setLastStepValue ] = useState( '' );
 
 	useEffect( () => {
 		scrollToBottom();
@@ -44,6 +43,7 @@ export default function AssistantWizard( { close } ) {
 		[ welcomeStepData, keywordsStepData, titleStepData, metaStepData, completionStepData ]
 	);
 	const [ currentStepData, setCurrentStepData ] = useState< Step >( welcomeStepData );
+	const [ assistantFlowAction, setAssistantFlowAction ] = useState( '' );
 
 	const stepsCount = steps.length;
 
@@ -52,13 +52,14 @@ export default function AssistantWizard( { close } ) {
 		if ( ! currentStepData || ! currentStepData.onStart ) {
 			return;
 		}
-		await currentStepData?.onStart( {
-			fromSkip: ! lastStepValue,
-			stepValue: lastStepValue,
-			results,
-		} );
+		if ( assistantFlowAction !== 'backwards' ) {
+			await currentStepData?.onStart( {
+				fromSkip: assistantFlowAction === 'skip',
+				results,
+			} );
+		}
 		setIsBusy( false );
-	}, [ currentStepData, lastStepValue, results ] );
+	}, [ currentStepData, assistantFlowAction, results ] );
 
 	const handleNext = useCallback( () => {
 		debug( 'handleNext, stepsCount', stepsCount );
@@ -74,17 +75,21 @@ export default function AssistantWizard( { close } ) {
 		} );
 	}, [ stepsCount, steps ] );
 
-	useEffect( () => {
-		debug( 'currentStepData changed', currentStepData?.id );
-		handleStepStart();
-	}, [ currentStepData, handleStepStart ] );
+	useEffect(
+		() => {
+			debug( 'currentStepData changed', currentStepData?.id );
+			handleStepStart();
+		},
+		// @ts-expect-error - including handleStepStart in the dependency array causes the effect to run twice
+		[ currentStepData ]
+	);
 
 	// Initialize current step data
 	useEffect( () => {
 		if ( currentStep === 0 && steps[ 0 ].autoAdvance ) {
 			debug( 'init assistant wizard' );
-			debug( 'auto advancing' );
 			setIsBusy( true );
+			setAssistantFlowAction( 'forwards' );
 			const timeout = setTimeout( handleNext, steps[ 0 ].autoAdvance );
 			return () => clearTimeout( timeout );
 		}
@@ -112,8 +117,7 @@ export default function AssistantWizard( { close } ) {
 			debug( 'newResults', newResults );
 			setResults( prev => ( { ...prev, ...newResults } ) );
 		}
-		debug( 'set last step value', stepValue );
-		setLastStepValue( stepValue?.trim?.() );
+		setAssistantFlowAction( 'submit' );
 
 		if ( steps[ currentStep ]?.type === 'completion' ) {
 			debug( 'completion step, closing wizard' );
@@ -127,6 +131,7 @@ export default function AssistantWizard( { close } ) {
 	const jumpToStep = useCallback(
 		( stepNumber: number ) => {
 			if ( stepNumber < steps.length - 1 ) {
+				setAssistantFlowAction( 'jump' );
 				setCurrentStep( stepNumber );
 				setCurrentStepData( steps[ stepNumber ] );
 			}
@@ -147,6 +152,7 @@ export default function AssistantWizard( { close } ) {
 	const handleBack = () => {
 		if ( currentStep > 1 ) {
 			setIsBusy( true );
+			setAssistantFlowAction( 'backwards' );
 			debug( 'moving back to ' + ( currentStep - 1 ) );
 			setCurrentStep( currentStep - 1 );
 			setCurrentStepData( steps[ currentStep - 1 ] );
@@ -155,6 +161,7 @@ export default function AssistantWizard( { close } ) {
 
 	const handleSkip = useCallback( async () => {
 		setIsBusy( true );
+		setAssistantFlowAction( 'skip' );
 		await steps[ currentStep ]?.onSkip?.();
 		const step = steps[ currentStep ];
 		if ( ! results[ step.id ] && step.includeInResults ) {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/style.scss
@@ -50,7 +50,7 @@
 			padding: 8px;
 			color: #1e1e1e;
 
-			&:hover {
+			&:not( [disabled] ):hover {
 				color:#3858E9;
 			}
 		}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/types.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/types.tsx
@@ -25,7 +25,7 @@ export interface Step {
 	label?: string;
 	messages: Message[];
 	type: StepType;
-	onStart?: ( options?: { fromSkip: boolean; stepValue: string; results: Results } ) => void;
+	onStart?: ( options?: { fromSkip: boolean; results: Results } ) => void;
 	onSubmit?: () => Promise< string >;
 	onSkip?: () => void;
 	value?: string;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -4,7 +4,7 @@
 import { askQuestionSync, usePostContent } from '@automattic/jetpack-ai-client';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useCallback, useState, createInterpolateElement } from '@wordpress/element';
+import { useCallback, useState, createInterpolateElement, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /*
  * Internal dependencies
@@ -36,6 +36,7 @@ export const useMetaDescriptionStep = ( {
 	mockRequests?: boolean;
 } ): Step => {
 	const [ value, setValue ] = useState< string >();
+	const [ lastValue, setLastValue ] = useState< string >( '' );
 	const [ selectedMetaDescription, setSelectedMetaDescription ] = useState< string >();
 	const [ metaDescriptionOptions, setMetaDescriptionOptions ] = useState< OptionMessage[] >( [] );
 	const { messages, setMessages, addMessage, editLastMessage, setSelectedMessage } = useMessages();
@@ -43,6 +44,8 @@ export const useMetaDescriptionStep = ( {
 	const postContent = usePostContent();
 	const postId = useSelect( select => select( editorStore ).getCurrentPostId(), [] );
 	const [ generatedCount, setGeneratedCount ] = useState( 0 );
+
+	const prevStepHasChanged = useMemo( () => keywords !== lastValue, [ keywords, lastValue ] );
 
 	const request = useCallback( async () => {
 		if ( mockRequests ) {
@@ -102,6 +105,13 @@ export const useMetaDescriptionStep = ( {
 
 	const handleMetaDescriptionGenerate = useCallback(
 		async ( { fromSkip } ) => {
+			let newMetaDescriptions = [ ...metaDescriptionOptions ];
+
+			if ( ! prevStepHasChanged && newMetaDescriptions.length > 0 ) {
+				return;
+			}
+
+			setLastValue( keywords );
 			const initialMessage = fromSkip
 				? {
 						content: createInterpolateElement(
@@ -114,10 +124,10 @@ export const useMetaDescriptionStep = ( {
 						content: __( "Now, let's optimize your meta description.", 'jetpack' ),
 						showIcon: true,
 				  };
-			let newMetaDescriptions = [ ...metaDescriptionOptions ];
+
 			setMessages( [ initialMessage ] );
 			// we only generate if options are empty
-			if ( newMetaDescriptions.length === 0 ) {
+			if ( newMetaDescriptions.length === 0 || prevStepHasChanged ) {
 				newMetaDescriptions = await getMetaDescriptions();
 			}
 			setMetaDescriptionOptions( newMetaDescriptions );
@@ -138,7 +148,15 @@ export const useMetaDescriptionStep = ( {
 				addMessage( { ...meta, type: 'option', isUser: true } )
 			);
 		},
-		[ metaDescriptionOptions, setMessages, editLastMessage, getMetaDescriptions, addMessage ]
+		[
+			metaDescriptionOptions,
+			setMessages,
+			editLastMessage,
+			getMetaDescriptions,
+			addMessage,
+			keywords,
+			prevStepHasChanged,
+		]
 	);
 
 	const handleMetaDescriptionRegenerate = useCallback( async () => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -124,6 +124,7 @@ export const useMetaDescriptionStep = ( {
 			setMessages( [ initialMessage ] );
 			// we only generate if options are empty
 			if ( newMetaDescriptions.length === 0 || prevStepHasChanged ) {
+				setSelectedMetaDescription( '' );
 				newMetaDescriptions = await getMetaDescriptions();
 			}
 			setMetaDescriptionOptions( newMetaDescriptions );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -107,10 +107,6 @@ export const useMetaDescriptionStep = ( {
 		async ( { fromSkip } ) => {
 			let newMetaDescriptions = [ ...metaDescriptionOptions ];
 
-			if ( ! prevStepHasChanged && newMetaDescriptions.length > 0 ) {
-				return;
-			}
-
 			setLastValue( keywords );
 			const initialMessage = fromSkip
 				? {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -108,6 +108,7 @@ export const useTitleStep = ( {
 
 			// we only generate if options are empty
 			if ( newTitles.length === 0 || prevStepHasChanged ) {
+				setSelectedTitle( '' );
 				newTitles = await getTitles();
 			}
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -91,10 +91,6 @@ export const useTitleStep = ( {
 		async ( { fromSkip } ) => {
 			let newTitles = [ ...titleOptions ];
 
-			if ( ! prevStepHasChanged && newTitles.length > 0 ) {
-				return value;
-			}
-
 			setLastValue( keywords );
 			const initialMessage = fromSkip
 				? {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -4,7 +4,7 @@
 import { askQuestionSync, usePostContent } from '@automattic/jetpack-ai-client';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useCallback, useState, createInterpolateElement } from '@wordpress/element';
+import { useCallback, useState, createInterpolateElement, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /*
  * Internal dependencies
@@ -34,10 +34,12 @@ export const useTitleStep = ( {
 	const [ titleOptions, setTitleOptions ] = useState< OptionMessage[] >( [] );
 	const { editPost } = useDispatch( 'core/editor' );
 	const { messages, setMessages, addMessage, editLastMessage, setSelectedMessage } = useMessages();
-	const [ prevStepValue, setPrevStepValue ] = useState();
+	const [ lastValue, setLastValue ] = useState< string >( '' );
 	const postContent = usePostContent();
 	const postId = useSelect( select => select( editorStore ).getCurrentPostId(), [] );
 	const [ generatedCount, setGeneratedCount ] = useState( 0 );
+
+	const prevStepHasChanged = useMemo( () => keywords !== lastValue, [ keywords, lastValue ] );
 
 	const request = useCallback( async () => {
 		if ( mockRequests ) {
@@ -86,14 +88,14 @@ export const useTitleStep = ( {
 	}, [ generatedCount, request ] );
 
 	const handleTitleGenerate = useCallback(
-		async ( { fromSkip, stepValue: stepKeywords } ) => {
-			const prevStepHasChanged = stepKeywords !== prevStepValue;
+		async ( { fromSkip } ) => {
+			let newTitles = [ ...titleOptions ];
 
-			if ( ! prevStepHasChanged ) {
-				return;
+			if ( ! prevStepHasChanged && newTitles.length > 0 ) {
+				return value;
 			}
 
-			setPrevStepValue( stepKeywords );
+			setLastValue( keywords );
 			const initialMessage = fromSkip
 				? {
 						content: createInterpolateElement(
@@ -107,7 +109,6 @@ export const useTitleStep = ( {
 						showIcon: true,
 				  };
 			setMessages( [ initialMessage ] );
-			let newTitles = [ ...titleOptions ];
 
 			// we only generate if options are empty
 			if ( newTitles.length === 0 || prevStepHasChanged ) {
@@ -142,8 +143,18 @@ export const useTitleStep = ( {
 				// this addes title options as message-buttons
 				newTitles.forEach( title => addMessage( { ...title, type: 'option', isUser: true } ) );
 			}
+			return value;
 		},
-		[ prevStepValue, setMessages, titleOptions, editLastMessage, getTitles, addMessage ]
+		[
+			titleOptions,
+			prevStepHasChanged,
+			keywords,
+			setMessages,
+			editLastMessage,
+			getTitles,
+			addMessage,
+			value,
+		]
 	);
 
 	const handleTitleRegenerate = useCallback( async () => {


### PR DESCRIPTION
Fixes #41685 

## Proposed changes:
This PR adds a state on the assistant to keep track of the user flow: `forwards`, `submit`, `skip`, `jump` and `backwards`. Not all are in use, we use only `skip` right now,  but it would feel odd to leave it just empty. Will likely have more use when we add tracking events.

NOTE: there's currently a useEffect with a lacking dependency. This is on purpose as the dependency is a callback function that also changes with the same dependency as the useEffect call (`currentStepData`). This happens in the wrong order, so, for example, if you skip the keywords step, its `onStart` function gets called twice as `handleStepStart` changes and that triggers the useEffect (if you've added as a dependency). I removed it but I get a TS error and I can't seem to put the `ts-expect-error` in a place where the linter would accept it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1738962141466949-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Suggestion: change `mockRequests` to true before testing at assistant-wizard.tsx, lines 33, 36

Open the assistant. Play going back and forth, either skipping or submitting steps. Get to the end, go back and do it all over again. The messages should be consistent with skipping or not, steps depending on keywords should re-trigger generation if you change the keywords and submit, but not if you skip

