### PR TITLE
Remove duplicate views: Set empty preferences to array.

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-default-empty-preferences-to-array
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-default-empty-preferences-to-array
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+ When we receive empty preferences we intitialize the value to an empty array

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -590,20 +590,37 @@ if ( defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST || defined( 'AT_PRO
 }
 
 /**
+ * Retrieves the current blog ID in a WordPress.com or Jetpack environment.
+ *
+ * This function determines the blog ID based on the hosting environment:
+ * - On WordPress.com (`IS_WPCOM` defined), it returns the current blog ID.
+ * - In a Jetpack environment, it checks the Jetpack options for the associated blog ID.
+ * - If no valid ID is found in the Jetpack options, it falls back to the default current blog ID.
+ *
+ * @return int The current blog ID.
+ */
+function wpcom_get_current_blog_id() {
+	// Check if we’re in a WordPress.com environment
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		return get_current_blog_id();
+	}
+
+	// Attempt to retrieve the blog ID from Jetpack options
+	$jetpack_options = get_option( 'jetpack_options' );
+	if ( is_array( $jetpack_options ) && isset( $jetpack_options['id'] ) ) {
+		return (int) $jetpack_options['id'];
+	}
+
+	// Default fallback to the standard blog ID
+	return get_current_blog_id();
+}
+
+/**
  * Displays a notice when a user visits the enforced WP Admin view of a removed Calypso screen for
  * the first time.
  */
 function wpcom_show_removed_calypso_screen_notice() {
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		$blog_id = get_current_blog_id();
-	} else {
-		$jetpack_options = get_option( 'jetpack_options' );
-		if ( is_array( $jetpack_options ) && isset( $jetpack_options['id'] ) ) {
-			$blog_id = (int) $jetpack_options['id'];
-		} else {
-			$blog_id = get_current_blog_id();
-		}
-	}
+	$blog_id = wpcom_get_current_blog_id();
 
 	// Do not show notice on sites created after the experiment started (2025-01-16).
 	if ( $blog_id > 240790000 ) { // 240790000 is the ID of a site created on 2025-01-16.
@@ -739,11 +756,18 @@ function wpcom_dismiss_removed_calypso_screen_notice() {
 
 			// If $preferences is not array we log the contents so that we can further debug.
 			if ( ! is_array( $preferences ) && function_exists( 'log2logstash' ) ) {
+				$blog_id = wpcom_get_current_blog_id();
 				log2logstash(
 					array(
 						'feature' => 'wpcom-dismiss-wp-admin-notice',
 						'message' => 'Retrieved a non-array value from Calypso preferences.',
-						'extra'   => wp_json_encode( $preferences ),
+						'extra'   => wp_json_encode(
+							array(
+								'preferences' => $preferences,
+								'user_id'     => get_current_user_id(),
+								'blog_id'     => $blog_id,
+							)
+						),
 					)
 				);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -746,8 +746,14 @@ function wpcom_dismiss_removed_calypso_screen_notice() {
 						'extra'   => wp_json_encode( $preferences ),
 					)
 				);
-				// Bail if we can't update the preferences array.
-				wp_die();
+
+				// The expected value when preferences aren't set is an empty string.
+				if ( $preferences !== '' ) {
+					wp_die();
+				}
+
+				// If the preferences are empty, we set them to an empty array.
+				$preferences = array();
 			}
 
 			$preferences[ 'removed-calypso-screen-dismissed-notice-' . $screen ] = true;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -756,23 +756,22 @@ function wpcom_dismiss_removed_calypso_screen_notice() {
 
 			// If $preferences is not array we log the contents so that we can further debug.
 			if ( ! is_array( $preferences ) && function_exists( 'log2logstash' ) ) {
-				$blog_id = wpcom_get_current_blog_id();
-				log2logstash(
-					array(
-						'feature' => 'wpcom-dismiss-wp-admin-notice',
-						'message' => 'Retrieved a non-array value from Calypso preferences.',
-						'extra'   => wp_json_encode(
-							array(
-								'preferences' => $preferences,
-								'user_id'     => get_current_user_id(),
-								'blog_id'     => $blog_id,
-							)
-						),
-					)
-				);
-
 				// The expected value when preferences aren't set is an empty string.
 				if ( $preferences !== '' ) {
+					$blog_id = wpcom_get_current_blog_id();
+					log2logstash(
+						array(
+							'feature' => 'wpcom-dismiss-wp-admin-notice',
+							'message' => 'Retrieved non-empty, non-array Calypso preferences.',
+							'extra'   => wp_json_encode(
+								array(
+									'preferences' => $preferences,
+									'user_id'     => get_current_user_id(),
+									'blog_id'     => $blog_id,
+								)
+							),
+						)
+					);
 					wp_die();
 				}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
After monitoring the logs for a few days we've seen that the empty preferences are being stored as an empty string.
This PR checks for empty preferences and uses an empty array so that the flow can continue without errors. We'll keep the logs in case we find other scenarios that need our attention.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set your preferences to "" to simulate empty preferences.
* Dismiss admin notices.
* Your preferences should be updated.

