### PR TITLE
Jetpack SEO change editLastMessage to accept append option

### DIFF
--- a/projects/plugins/jetpack/changelog/change-jetpack-seo-edit-messasge-append-option
+++ b/projects/plugins/jetpack/changelog/change-jetpack-seo-edit-messasge-append-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO: allow editLastMessage to append new content instead of replacing. Simplifies message flow editing

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -122,7 +122,7 @@ export const useMetaDescriptionStep = ( {
 			}
 			setMetaDescriptionOptions( newMetaDescriptions );
 			const readyMessageSuffix = createInterpolateElement(
-				__( '<br />Here are two suggestions based on your keywords:', 'jetpack' ),
+				__( "<br />Here's a suggestion:", 'jetpack' ),
 				{ br: <br /> }
 			);
 			editLastMessage( readyMessageSuffix, true );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -121,19 +121,11 @@ export const useMetaDescriptionStep = ( {
 				newMetaDescriptions = await getMetaDescriptions();
 			}
 			setMetaDescriptionOptions( newMetaDescriptions );
-			const editedFirstMessage = fromSkip
-				? createInterpolateElement(
-						__(
-							"Skipped!<br />Now, let's optimize your meta description.<br />Here's a suggestion:",
-							'jetpack'
-						),
-						{ br: <br /> }
-				  )
-				: createInterpolateElement(
-						__( "Now, let's optimize your meta description.<br />Here's a suggestion:", 'jetpack' ),
-						{ br: <br /> }
-				  );
-			editLastMessage( editedFirstMessage );
+			const readyMessageSuffix = createInterpolateElement(
+				__( '<br />Here are two suggestions based on your keywords:', 'jetpack' ),
+				{ br: <br /> }
+			);
+			editLastMessage( readyMessageSuffix, true );
 			newMetaDescriptions.forEach( meta =>
 				addMessage( { ...meta, type: 'option', isUser: true } )
 			);

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -114,27 +114,12 @@ export const useTitleStep = ( {
 				newTitles = await getTitles();
 			}
 
-			let editedMessage;
+			const readyMessageSuffix = createInterpolateElement(
+				__( '<br />Here are two suggestions based on your keywords:', 'jetpack' ),
+				{ br: <br /> }
+			);
 
-			if ( fromSkip ) {
-				editedMessage = createInterpolateElement(
-					__(
-						"Skipped!<br />Let's optimise your title first.<br />Here are two suggestions based on your keywords:",
-						'jetpack'
-					),
-					{ br: <br /> }
-				);
-			} else {
-				editedMessage = createInterpolateElement(
-					__(
-						"Let's optimise your title first.<br />Here are two suggestions based on your keywords:",
-						'jetpack'
-					),
-					{ br: <br /> }
-				);
-			}
-
-			editLastMessage( editedMessage );
+			editLastMessage( readyMessageSuffix, true );
 
 			if ( newTitles.length ) {
 				// this sets the title options for internal state

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-messages.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-messages.tsx
@@ -35,13 +35,27 @@ export const useMessages = () => {
 	};
 
 	/* Edits content of last message */
-	const editLastMessage = ( content: Message[ 'content' ] ) => {
+	const editLastMessage = ( content: Message[ 'content' ], append = false ) => {
 		setMessages( prev => {
 			const prevMessages = [ ...prev ];
 			if ( prevMessages.length > 0 ) {
+				const lastMessageContent = prevMessages[ prevMessages.length - 1 ].content;
+				let newContent = content;
+				if ( append ) {
+					if ( typeof lastMessageContent === 'string' ) {
+						newContent = lastMessageContent + content;
+					} else if ( typeof lastMessageContent === 'object' ) {
+						newContent = (
+							<>
+								{ lastMessageContent }
+								{ content }
+							</>
+						);
+					}
+				}
 				prevMessages[ prevMessages.length - 1 ] = {
 					...prevMessages[ prevMessages.length - 1 ],
-					content,
+					content: newContent,
 				};
 			}
 			return prevMessages;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-messages.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-messages.tsx
@@ -42,15 +42,15 @@ export const useMessages = () => {
 				const lastMessageContent = prevMessages[ prevMessages.length - 1 ].content;
 				let newContent = content;
 				if ( append ) {
-					if ( typeof lastMessageContent === 'string' ) {
-						newContent = lastMessageContent + content;
-					} else if ( typeof lastMessageContent === 'object' ) {
+					if ( typeof lastMessageContent === 'object' || typeof newContent === 'object' ) {
 						newContent = (
 							<>
 								{ lastMessageContent }
-								{ content }
+								{ newContent }
 							</>
 						);
+					} else {
+						newContent = `${ lastMessageContent } + ${ newContent }`;
 					}
 				}
 				prevMessages[ prevMessages.length - 1 ] = {


### PR DESCRIPTION

## Proposed changes:
This PR adds the option to use editLastMessage to just append a new part of the message, simplifying the message composition throughout different stages of the step

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
This is just code optimization and clean up. Verify the SEO assistant works as before