### PR TITLE
Protect Status: Fix vulnerabilities check prior to attempting map

### DIFF
--- a/projects/packages/protect-status/changelog/fix-protect-status-wp-error-vulnerabilities
+++ b/projects/packages/protect-status/changelog/fix-protect-status-wp-error-vulnerabilities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Protect Status: ensure vulnerabilities property is always an array.

--- a/projects/packages/protect-status/src/class-protect-status.php
+++ b/projects/packages/protect-status/src/class-protect-status.php
@@ -293,7 +293,7 @@ class Protect_Status extends Status {
 		$core->checked = true;
 
 		// Generate a threat from core vulnerabilities.
-		if ( ! empty( $report_data->core->vulnerabilities ) ) {
+		if ( is_array( $report_data->core->vulnerabilities ) && ! empty( $report_data->core->vulnerabilities ) ) {
 			// normalize the vulnerabilities data
 			$vulnerabilities = array_map(
 				function ( $vulnerability ) {

--- a/projects/packages/protect-status/src/class-protect-status.php
+++ b/projects/packages/protect-status/src/class-protect-status.php
@@ -226,7 +226,7 @@ class Protect_Status extends Status {
 			$extension->checked         = true;
 			$extension_threats[ $slug ] = $extension;
 
-			if ( ! empty( $checked_extension->vulnerabilities ) ) {
+			if ( is_array( $checked_extension->vulnerabilities ) && ! empty( $checked_extension->vulnerabilities ) ) {
 				// normalize the vulnerabilities data
 				$vulnerabilities = array_map(
 					function ( $vulnerability ) {

--- a/projects/packages/protect-status/tests/php/test-status.php
+++ b/projects/packages/protect-status/tests/php/test-status.php
@@ -522,6 +522,8 @@ class Test_Status extends BaseTestCase {
 
 	/**
 	 * Test graceful handling of invalid data from the API.
+	 *
+	 * @phan-suppress PhanDeprecatedProperty -- Testing backwards compatibility.
 	 */
 	public function test_invalid_extension_data() {
 		add_filter( 'pre_http_request', array( $this, 'return_broken_sample_response' ) );

--- a/projects/packages/protect-status/tests/php/test-status.php
+++ b/projects/packages/protect-status/tests/php/test-status.php
@@ -154,6 +154,20 @@ class Test_Status extends BaseTestCase {
 	}
 
 	/**
+	 * Get a sample response with broken data.
+	 *
+	 * @return object
+	 */
+	public function get_broken_sample_api_response() {
+		$response                                       = $this->get_sample_api_response();
+		$response->themes['theme-1']->vulnerabilities   = new \WP_Error( 'broken', 'Broken' );
+		$response->plugins['plugin-1']->vulnerabilities = new \WP_Error( 'broken', 'Broken' );
+		$response->core->vulnerabilities                = new \WP_Error( 'broken', 'Broken' );
+
+		return $response;
+	}
+
+	/**
 	 * Get a sample result of Protect_Status::get_status().
 	 *
 	 * @phan-suppress PhanDeprecatedProperty -- Testing backwards compatibility.
@@ -310,6 +324,21 @@ class Test_Status extends BaseTestCase {
 	public function return_sample_response() {
 		return array(
 			'body'     => wp_json_encode( $this->get_sample_api_response() ),
+			'response' => array(
+				'code'    => 200,
+				'message' => '',
+			),
+		);
+	}
+
+	/**
+	 * Return a sample wpcom status response.
+	 *
+	 * @return array
+	 */
+	public function return_broken_sample_response() {
+		return array(
+			'body'     => wp_json_encode( $this->get_broken_sample_api_response() ),
 			'response' => array(
 				'code'    => 200,
 				'message' => '',
@@ -489,5 +518,22 @@ class Test_Status extends BaseTestCase {
 		if ( is_object( $status ) && 'full' === $check_type ) {
 			$this->assertSame( time() + Protect_Status::OPTION_EXPIRES_AFTER, $timestamp );
 		}
+	}
+
+	/**
+	 * Test graceful handling of invalid data from the API.
+	 */
+	public function test_invalid_extension_data() {
+		add_filter( 'pre_http_request', array( $this, 'return_broken_sample_response' ) );
+
+		$status = Protect_Status::get_status();
+
+		$this->assertIsArray( $status->threats );
+		$this->assertEmpty( $status->threats );
+
+		$this->assertIsObject( $status->core );
+		$this->assertFalse( isset( $status->core->vulnerabilities ) );
+
+		remove_filter( 'pre_http_request', array( $this, 'return_broken_sample_response' ) );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes the check to ensure the `vulnerabilities` property is an array prior to using it with `array_map` in the Protect Status package.
* Adds a test case where `WP_Error` objects are returned for `vulnerabilities` properties instead of the expected arrays.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1739202415315389-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Proof read fix and added test case.
* Validate all tests are passing.
* Smoke test viewing a free report in Jetpack Protect.