### PR TITLE
Forms: Add tracking for Jetpack CRM

### DIFF
--- a/projects/packages/forms/changelog/add-forms-tracking-jetpack-crm
+++ b/projects/packages/forms/changelog/add-forms-tracking-jetpack-crm
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Track Jetpack CRM interactions.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-crm-integration/jetpack-crm-integration-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-crm-integration/jetpack-crm-integration-settings.js
@@ -1,6 +1,8 @@
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
 import { Spinner, BaseControl } from '@wordpress/components';
 import { useState, useEffect, useCallback } from '@wordpress/element';
+import { installAndActivatePlugin, activatePlugin } from '../../util/plugin-management';
 import CRMPluginState from './jetpack-crm-integration-settings-plugin-state';
 
 const fetchCRMData = ( setHasCRMDataError, setCRMData, setIsFetchingCRMData ) => {
@@ -23,9 +25,17 @@ const CRMPluginData = ( { jetpackCRM, setAttributes } ) => {
 	const [ hasCRMDataError, setHasCRMDataError ] = useState( false );
 	const [ crmData, setCRMData ] = useState();
 	const [ isInstalling, setIsInstalling ] = useState( false );
+	const { tracks } = useAnalytics();
 
 	const onCRMPluginClick = useCallback(
 		( func, arg ) => {
+			// Track the event before starting installation/activation
+			if ( func === installAndActivatePlugin ) {
+				tracks.recordEvent( 'jetpack_forms_crm_install_click' );
+			} else if ( func === activatePlugin ) {
+				tracks.recordEvent( 'jetpack_forms_crm_activate_click' );
+			}
+
 			setIsInstalling( true );
 			func( arg )
 				.catch( () => {
@@ -37,7 +47,7 @@ const CRMPluginData = ( { jetpackCRM, setAttributes } ) => {
 					fetchCRMData( setHasCRMDataError, setCRMData, setIsFetchingCRMData );
 				} );
 		},
-		[ setIsInstalling, setHasCRMDataError, setIsFetchingCRMData ]
+		[ setIsInstalling, setHasCRMDataError, setIsFetchingCRMData, tracks ]
 	);
 
 	useEffect( () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #2254

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Adds Tracks events when users click to install or activate Jetpack CRM from the contact form block sidebar. I copied the patter we use for tracking Stripe clicks in the payment button blocks ([see here](https://github.com/Automattic/jetpack/blob/125c2430835f477bc255dae45246e6f8277f81d7/projects/plugins/jetpack/extensions/shared/components/stripe-nudge/index.jsx#L21)).

<img width="1507" alt="jetpack-forms-crm-button" src="https://github.com/user-attachments/assets/66766db0-c129-4f4c-a1ed-ae316340787f" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Preparation: 
- Tracks Vigilante: You will need to ensure you can see Tracks events as they are fired. The best way is to install Tracks Vigilante here: https://github.com/Automattic/tracks-chrome-extension Once installed, you'll be able to see tracks events in the Chrome toolbar.
- Jetpack CRM Plugin. Deactivate and delete Jetpack CRM if you have it installed as a separate plugin

Test: 
- Go to a page or post and insert a form block.
- Clear all current tracks events from Tracks Vigilante to make it easier to see new events.
- Go to the contact form block sidebar and click the button to install Jetpack CRM. 
- Confirm that the `jetpack_forms_crm_install_click` Tracks event is fired.
- Go to your site's plugin page and deactivate Jetpack CRM but leave it installed.
- Return to your post with your contact form, refresh the page if needed, go to the contact form block sidebar, and click the button the activate Jetpack CRM.
- Confirm that the `jetpack_forms_crm_activate_click` Tracks event is fired.