### PR TITLE
Jetpack SEO: add assistant events

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-seo-assistant-track-events
+++ b/projects/plugins/jetpack/changelog/add-jetpack-seo-assistant-track-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO: add tracking events on significant actions

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
@@ -119,7 +119,7 @@ export default function AssistantWizard( { close } ) {
 			tracks.recordEvent( 'jetpack_seo_assistant_close', {
 				completion,
 				step: steps[ currentStep ].id,
-				steps: steps.length,
+				steps: steps.length - 1,
 				step_number: currentStep,
 				placement: isCloseButton ? 'close' : 'done',
 			} );
@@ -199,6 +199,12 @@ export default function AssistantWizard( { close } ) {
 
 	const handleStepSubmit = useCallback( async () => {
 		debug( 'step submitted' );
+		if ( steps[ currentStep ]?.type === 'completion' ) {
+			debug( 'completion step, closing wizard' );
+			handleDone();
+			return;
+		}
+
 		setIsBusy( true );
 		const stepValue = await steps[ currentStep ]?.onSubmit?.();
 		if ( ! stepValue?.trim?.() ) {
@@ -223,13 +229,8 @@ export default function AssistantWizard( { close } ) {
 			value_length: stepValue?.length || 0,
 		} );
 
-		if ( steps[ currentStep ]?.type === 'completion' ) {
-			debug( 'completion step, closing wizard' );
-			handleDone();
-		} else {
-			debug( 'step type', steps[ currentStep ]?.type );
-			handleNext();
-		}
+		debug( 'step type', steps[ currentStep ]?.type );
+		handleNext();
 	}, [ currentStep, handleDone, handleNext, steps, tracks, handleSkip ] );
 
 	const handleRetry = useCallback( async () => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
@@ -133,14 +133,15 @@ export default function AssistantWizard( { close } ) {
 		( stepNumber: number ) => {
 			if ( stepNumber < steps.length - 1 ) {
 				tracks.recordEvent( 'jetpack_seo_assistant_step_jump', {
-					step: steps[ stepNumber ]?.id,
+					step_from: steps[ currentStep ]?.id,
+					step_to: steps[ stepNumber ]?.id,
 				} );
 				setAssistantFlowAction( 'jump' );
 				setCurrentStep( stepNumber );
 				setCurrentStepData( steps[ stepNumber ] );
 			}
 		},
-		[ steps, tracks ]
+		[ steps, tracks, currentStep ]
 	);
 
 	const handleSelect = useCallback(
@@ -158,6 +159,10 @@ export default function AssistantWizard( { close } ) {
 			setIsBusy( true );
 			setAssistantFlowAction( 'backwards' );
 			debug( 'moving back to ' + ( currentStep - 1 ) );
+			tracks.recordEvent( 'jetpack_seo_assistant_step_back', {
+				step_from: steps[ currentStep ]?.id,
+				step_to: steps[ currentStep - 1 ]?.id,
+			} );
 			steps[ currentStep ].resetState?.();
 			setCurrentStep( currentStep - 1 );
 			setCurrentStepData( steps[ currentStep - 1 ] );
@@ -180,7 +185,8 @@ export default function AssistantWizard( { close } ) {
 			} ) );
 		}
 		tracks.recordEvent( 'jetpack_seo_assistant_step_skip', {
-			step: steps[ currentStep ]?.id,
+			step_from: steps[ currentStep ]?.id,
+			step_to: steps[ currentStep + 1 ]?.id,
 		} );
 		if ( steps[ currentStep ]?.type === 'completion' ) {
 			debug( 'completion step, closing wizard' );
@@ -212,7 +218,8 @@ export default function AssistantWizard( { close } ) {
 		}
 		setAssistantFlowAction( 'submit' );
 		tracks.recordEvent( 'jetpack_seo_assistant_step_submit', {
-			step: steps[ currentStep ].id,
+			step_from: steps[ currentStep ].id,
+			step_to: steps[ currentStep + 1 ].id,
 			value: stepValue,
 		} );
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
@@ -118,7 +118,7 @@ export default function AssistantWizard( { close } ) {
 
 			tracks.recordEvent( 'jetpack_seo_assistant_close', {
 				completion,
-				step_name: steps[ currentStep ].id,
+				step: steps[ currentStep ].id,
 				steps: steps.length,
 				step_number: currentStep,
 				placement: isCloseButton ? 'close' : 'done',

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
@@ -1,3 +1,4 @@
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button, Icon, Tooltip, Notice } from '@wordpress/components';
 import { useState, useEffect, useRef, useMemo, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -24,6 +25,7 @@ export default function AssistantWizard( { close } ) {
 	const keywordsInputRef = useRef( null );
 	const prevStepIdRef = useRef< string | undefined >();
 	const [ results, setResults ] = useState( {} );
+	const { tracks } = useAnalytics();
 
 	useEffect( () => {
 		scrollToBottom();
@@ -103,47 +105,42 @@ export default function AssistantWizard( { close } ) {
 	}, [ currentStep, handleNext, steps ] );
 
 	// Reset states and close the wizard
-	const handleDone = useCallback( () => {
-		close();
-		setCurrentStep( 0 );
-	}, [ close ] );
+	const handleDone = useCallback(
+		( isCloseButton = false ) => {
+			debug( isCloseButton );
+			const completion =
+				steps.reduce( ( acc, step ) => {
+					if ( step.includeInResults && results[ step.id ]?.value ) {
+						acc++;
+					}
+					return acc;
+				}, 0 ) / steps.filter( step => step.includeInResults ).length;
 
-	const handleStepSubmit = useCallback( async () => {
-		debug( 'step submitted' );
-		setIsBusy( true );
-		const stepValue = await steps[ currentStep ]?.onSubmit?.();
-		debug( 'stepValue', stepValue );
-		if ( steps[ currentStep ].includeInResults ) {
-			const newResults = {
-				[ steps[ currentStep ].id ]: {
-					value: stepValue?.trim?.(),
-					type: steps[ currentStep ].type,
-					label: steps[ currentStep ].label,
-				},
-			};
-			debug( 'newResults', newResults );
-			setResults( prev => ( { ...prev, ...newResults } ) );
-		}
-		setAssistantFlowAction( 'submit' );
-
-		if ( steps[ currentStep ]?.type === 'completion' ) {
-			debug( 'completion step, closing wizard' );
-			handleDone();
-		} else {
-			debug( 'step type', steps[ currentStep ]?.type );
-			handleNext();
-		}
-	}, [ currentStep, handleDone, handleNext, steps ] );
+			tracks.recordEvent( 'jetpack_seo_assistant_close', {
+				completion,
+				step_name: steps[ currentStep ].id,
+				steps: steps.length,
+				step_number: currentStep,
+				placement: isCloseButton ? 'close' : 'done',
+			} );
+			close();
+			setCurrentStep( 0 );
+		},
+		[ close, currentStep, steps, tracks, results ]
+	);
 
 	const jumpToStep = useCallback(
 		( stepNumber: number ) => {
 			if ( stepNumber < steps.length - 1 ) {
+				tracks.recordEvent( 'jetpack_seo_assistant_step_jump', {
+					step: steps[ stepNumber ]?.id,
+				} );
 				setAssistantFlowAction( 'jump' );
 				setCurrentStep( stepNumber );
 				setCurrentStepData( steps[ stepNumber ] );
 			}
 		},
-		[ steps ]
+		[ steps, tracks ]
 	);
 
 	const handleSelect = useCallback(
@@ -182,6 +179,9 @@ export default function AssistantWizard( { close } ) {
 				},
 			} ) );
 		}
+		tracks.recordEvent( 'jetpack_seo_assistant_step_skip', {
+			step: steps[ currentStep ]?.id,
+		} );
 		if ( steps[ currentStep ]?.type === 'completion' ) {
 			debug( 'completion step, closing wizard' );
 			handleDone();
@@ -189,14 +189,51 @@ export default function AssistantWizard( { close } ) {
 			debug( 'step type', steps[ currentStep ]?.type );
 			handleNext();
 		}
-	}, [ currentStep, steps, handleNext, results, handleDone ] );
+	}, [ currentStep, steps, handleNext, results, handleDone, tracks ] );
+
+	const handleStepSubmit = useCallback( async () => {
+		debug( 'step submitted' );
+		setIsBusy( true );
+		const stepValue = await steps[ currentStep ]?.onSubmit?.();
+		if ( ! stepValue?.trim?.() ) {
+			return handleSkip();
+		}
+		debug( 'stepValue', stepValue );
+		if ( steps[ currentStep ].includeInResults ) {
+			const newResults = {
+				[ steps[ currentStep ].id ]: {
+					value: stepValue?.trim?.(),
+					type: steps[ currentStep ].type,
+					label: steps[ currentStep ].label,
+				},
+			};
+			debug( 'newResults', newResults );
+			setResults( prev => ( { ...prev, ...newResults } ) );
+		}
+		setAssistantFlowAction( 'submit' );
+		tracks.recordEvent( 'jetpack_seo_assistant_step_submit', {
+			step: steps[ currentStep ].id,
+			value: stepValue,
+		} );
+
+		if ( steps[ currentStep ]?.type === 'completion' ) {
+			debug( 'completion step, closing wizard' );
+			handleDone();
+		} else {
+			debug( 'step type', steps[ currentStep ]?.type );
+			handleNext();
+		}
+	}, [ currentStep, handleDone, handleNext, steps, tracks, handleSkip ] );
 
 	const handleRetry = useCallback( async () => {
 		debug( 'handleRetry' );
+		tracks.recordEvent( 'jetpack_seo_assistant_step_retry', {
+			step: steps[ currentStep ]?.id,
+		} );
 		setIsBusy( true );
 		await steps[ currentStep ].onRetry?.( {} );
 		setIsBusy( false );
-	}, [ currentStep, steps ] );
+	}, [ currentStep, steps, tracks ] );
 
 	return (
 		<div className="assistant-wizard">
@@ -217,7 +254,7 @@ export default function AssistantWizard( { close } ) {
 							<Icon icon={ next } size={ 32 } />
 						</Button>
 					</Tooltip>
-					<Button variant="link" onClick={ handleDone }>
+					<Button variant="link" onClick={ () => handleDone( true ) }>
 						<Icon icon={ closeSmall } size={ 32 } />
 					</Button>
 				</div>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
@@ -220,7 +220,7 @@ export default function AssistantWizard( { close } ) {
 		tracks.recordEvent( 'jetpack_seo_assistant_step_submit', {
 			step_from: steps[ currentStep ].id,
 			step_to: steps[ currentStep + 1 ].id,
-			value: stepValue,
+			value_length: stepValue?.length || 0,
 		} );
 
 		if ( steps[ currentStep ]?.type === 'completion' ) {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/index.tsx
@@ -1,4 +1,4 @@
-import { useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
+import { useModuleStatus, useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
@@ -12,13 +12,17 @@ import SeoAssistantWizard from './seo-assistant-wizard';
 
 const debug = debugFactory( 'jetpack-ai:seo-assistant' );
 
-export default function SeoAssistant( { disabled } ) {
+export default function SeoAssistant( { disabled, placement } ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const postIsEmpty = useSelect( select => select( editorStore ).isEditedPostEmpty(), [] );
 	const { isLoadingModules, isChangingStatus, isModuleActive, changeStatus } =
 		useModuleStatus( 'seo-tools' );
+	const { tracks } = useAnalytics();
 
-	const handleOpen = useCallback( () => setIsOpen( true ), [] );
+	const handleOpen = useCallback( () => {
+		tracks.recordEvent( 'jetpack_seo_assistant_open', { placement } );
+		setIsOpen( true );
+	}, [ placement, tracks ] );
 	const handleClose = useCallback( () => setIsOpen( false ), [] );
 
 	debug( 'rendering seo-assistant entry point' );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { askQuestionSync, usePostContent } from '@automattic/jetpack-ai-client';
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import {
@@ -52,13 +53,17 @@ export const useMetaDescriptionStep = ( {
 	const [ generatedCount, setGeneratedCount ] = useState( 0 );
 	const [ hasFailed, setHasFailed ] = useState( false );
 	const [ failurePoint, setFailurePoint ] = useState< 'generate' | 'regenerate' | null >( null );
-
+	const { tracks } = useAnalytics();
 	const prevStepHasChanged = useMemo( () => keywords !== lastValue, [ keywords, lastValue ] );
 
 	const request = useCallback( async () => {
 		if ( mockRequests ) {
 			return mockMetaDescriptionRequest( keywords );
 		}
+		tracks.recordEvent( 'jetpack_seo_assistant_request', {
+			step: 'meta',
+			keywords,
+		} );
 		return askQuestionSync(
 			[
 				{
@@ -76,7 +81,7 @@ export const useMetaDescriptionStep = ( {
 				feature: 'jetpack-seo-assistant',
 			}
 		);
-	}, [ keywords, postContent, postId, mockRequests ] );
+	}, [ keywords, postContent, postId, mockRequests, tracks ] );
 
 	const handleMetaDescriptionSelect = useCallback(
 		( option: OptionMessage ) => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -55,13 +55,14 @@ export const useMetaDescriptionStep = ( {
 	const [ failurePoint, setFailurePoint ] = useState< 'generate' | 'regenerate' | null >( null );
 	const { tracks } = useAnalytics();
 	const prevStepHasChanged = useMemo( () => keywords !== lastValue, [ keywords, lastValue ] );
+	const stepId = 'meta';
 
 	const request = useCallback( async () => {
 		if ( mockRequests ) {
 			return mockMetaDescriptionRequest( keywords );
 		}
 		tracks.recordEvent( 'jetpack_seo_assistant_request', {
-			step: 'meta',
+			step: stepId,
 			keywords,
 		} );
 		return askQuestionSync(
@@ -209,7 +210,7 @@ export const useMetaDescriptionStep = ( {
 	const regenerateLabel = __( 'Regenerate', 'jetpack' );
 
 	return {
-		id: 'meta',
+		id: stepId,
 		title: __( 'Add meta description', 'jetpack' ),
 		label: __( 'Meta description', 'jetpack' ),
 		messages: messages,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -50,13 +50,14 @@ export const useTitleStep = ( {
 	const { tracks } = useAnalytics();
 
 	const prevStepHasChanged = useMemo( () => keywords !== lastValue, [ keywords, lastValue ] );
+	const stepId = 'title';
 
 	const request = useCallback( async () => {
 		if ( mockRequests ) {
 			return mockTitleRequest( keywords );
 		}
 		tracks.recordEvent( 'jetpack_seo_assistant_request', {
-			step: 'title',
+			step: stepId,
 			keywords,
 		} );
 		return askQuestionSync(
@@ -205,7 +206,7 @@ export const useTitleStep = ( {
 	const regenerateLabel = __( 'Regenerate', 'jetpack' );
 
 	return {
-		id: 'title',
+		id: stepId,
 		title: __( 'Optimise Title', 'jetpack' ),
 		label: __( 'Title', 'jetpack' ),
 		messages,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { askQuestionSync, usePostContent } from '@automattic/jetpack-ai-client';
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import {
@@ -46,6 +47,7 @@ export const useTitleStep = ( {
 	const [ generatedCount, setGeneratedCount ] = useState( 0 );
 	const [ hasFailed, setHasFailed ] = useState( false );
 	const [ failurePoint, setFailurePoint ] = useState< 'generate' | 'regenerate' | null >( null );
+	const { tracks } = useAnalytics();
 
 	const prevStepHasChanged = useMemo( () => keywords !== lastValue, [ keywords, lastValue ] );
 
@@ -53,6 +55,10 @@ export const useTitleStep = ( {
 		if ( mockRequests ) {
 			return mockTitleRequest( keywords );
 		}
+		tracks.recordEvent( 'jetpack_seo_assistant_request', {
+			step: 'title',
+			keywords,
+		} );
 		return askQuestionSync(
 			[
 				{
@@ -69,7 +75,7 @@ export const useTitleStep = ( {
 				feature: 'jetpack-seo-assistant',
 			}
 		);
-	}, [ keywords, postContent, postId, mockRequests ] );
+	}, [ keywords, postContent, postId, mockRequests, tracks ] );
 
 	const handleTitleSelect = useCallback(
 		( option: OptionMessage ) => {

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -107,7 +107,7 @@ const Seo = () => {
 								isBetaExtension( 'ai-seo-assistant' ) ? 'is-beta-extension' : ''
 							}` }
 						>
-							<SeoAssistant disabled={ false } />
+							<SeoAssistant disabled={ false } placement="jetpack-sidebar" />
 						</PanelRow>
 					) }
 					<PanelRow>


### PR DESCRIPTION
Fixes #41104 

## Proposed changes:
This PR adds events on all major actions of the assistant.

- `jetpack_seo_assistant_open`
- `jetpack_seo_assistant_step_skip`
- `jetpack_seo_assistant_step_submit`
- `jetpack_seo_assistant_step_back`
- `jetpack_seo_assistant_step_retry`
- `jetpack_seo_assistant_close`
- `jetpack_seo_assistant_request`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1738781806941479-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
Yes

## Testing instructions:

Open the SEO assistant and use it. See the events fire properly.