### PR TITLE
Forms:  add date validation in all browsers

### DIFF
--- a/projects/packages/forms/changelog/fix-date-validation-in-all-browsers
+++ b/projects/packages/forms/changelog/fix-date-validation-in-all-browsers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: updates the way that we valdate date info by removing jquery

--- a/projects/packages/forms/src/contact-form/js/accessible-form.js
+++ b/projects/packages/forms/src/contact-form/js/accessible-form.js
@@ -7,6 +7,8 @@
  * (multiple radio buttons) or Multiple Choice fields (multiple checkboxes).
  */
 
+import { validateDate } from './validate-helper';
+
 document.addEventListener( 'DOMContentLoaded', () => {
 	initAllForms();
 } );
@@ -264,45 +266,6 @@ const isMultipleChoiceFieldValid = fieldset => {
 };
 
 /**
- * Validate the date Value based on the format of the date field.
- *
- * @param {string} value  Date value
- * @param {string} format Date format
- *
- * @returns {boolean}
- */
-export const validateDate = ( value, format ) => {
-	let year, month, day;
-
-	if ( ! value ) {
-		return false;
-	}
-	switch ( format ) {
-		case 'mm/dd/yy':
-			[ month, day, year ] = value.split( '/' ).map( Number );
-			break;
-
-		case 'dd/mm/yy':
-			[ day, month, year ] = value.split( '/' ).map( Number );
-			break;
-
-		case 'yy-mm-dd':
-			[ year, month, day ] = value.split( '-' ).map( Number );
-			break;
-
-		default:
-			return false;
-	}
-	if ( isNaN( year ) || isNaN( month ) || isNaN( day ) ) {
-		return false;
-	}
-
-	const date = new Date( year, month - 1, day );
-
-	return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
-};
-
-/**
  * Check if a Date Picker field is valid.
  * @param {HTMLInputElement} input Input element
  * @returns {boolean}
@@ -312,7 +275,6 @@ const isDateFieldValid = input => {
 	const value = input.value;
 
 	if ( value && format ) {
-		// only test if we have a value and format.
 		if ( validateDate( value, format ) ) {
 			input.setCustomValidity( '' );
 		} else {

--- a/projects/packages/forms/src/contact-form/js/accessible-form.js
+++ b/projects/packages/forms/src/contact-form/js/accessible-form.js
@@ -264,6 +264,42 @@ const isMultipleChoiceFieldValid = fieldset => {
 };
 
 /**
+ * Validate the date Value based on the format of the date field.
+ *
+ * @param {string} value  Date value
+ * @param {string} format Date format
+ *
+ * @returns {boolean}
+ */
+const validateDate = ( value, format ) => {
+	let year, month, day;
+
+	switch ( format ) {
+		case 'mm/dd/yy':
+			[ month, day, year ] = value.split( '/' ).map( Number );
+			break;
+
+		case 'dd/mm/yy':
+			[ day, month, year ] = value.split( '/' ).map( Number );
+			break;
+
+		case 'yy-mm-dd':
+			[ year, month, day ] = value.split( '-' ).map( Number );
+			break;
+
+		default:
+			return false;
+	}
+	if ( isNaN( year ) || isNaN( month ) || isNaN( day ) ) {
+		return false;
+	}
+
+	const date = new Date( year, month - 1, day );
+
+	return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
+};
+
+/**
  * Check if a Date Picker field is valid.
  * @param {HTMLInputElement} input Input element
  * @returns {boolean}
@@ -271,15 +307,12 @@ const isMultipleChoiceFieldValid = fieldset => {
 const isDateFieldValid = input => {
 	const format = input.getAttribute( 'data-format' );
 	const value = input.value;
-	const $ = window.jQuery;
 
-	if ( value && format && typeof $ !== 'undefined' ) {
-		try {
-			$.datepicker.parseDate( format, value );
+	if ( value && format ) {
+		if ( validateDate( value, format ) ) {
 			input.setCustomValidity( '' );
-		} catch {
+		} else {
 			input.setCustomValidity( L10N.invalidDate );
-
 			return false;
 		}
 	}

--- a/projects/packages/forms/src/contact-form/js/accessible-form.js
+++ b/projects/packages/forms/src/contact-form/js/accessible-form.js
@@ -271,9 +271,12 @@ const isMultipleChoiceFieldValid = fieldset => {
  *
  * @returns {boolean}
  */
-const validateDate = ( value, format ) => {
+export const validateDate = ( value, format ) => {
 	let year, month, day;
 
+	if ( ! value ) {
+		return false;
+	}
 	switch ( format ) {
 		case 'mm/dd/yy':
 			[ month, day, year ] = value.split( '/' ).map( Number );
@@ -309,6 +312,7 @@ const isDateFieldValid = input => {
 	const value = input.value;
 
 	if ( value && format ) {
+		// only test if we have a value and format.
 		if ( validateDate( value, format ) ) {
 			input.setCustomValidity( '' );
 		} else {

--- a/projects/packages/forms/src/contact-form/js/validate-helper.js
+++ b/projects/packages/forms/src/contact-form/js/validate-helper.js
@@ -1,0 +1,38 @@
+/**
+ * Validate the date Value based on the format of the date field.
+ *
+ * @param {string} value  Date value
+ * @param {string} format Date format
+ *
+ * @returns {boolean}
+ */
+export const validateDate = ( value, format ) => {
+	let year, month, day;
+
+	if ( ! value ) {
+		return false;
+	}
+	switch ( format ) {
+		case 'mm/dd/yy':
+			[ month, day, year ] = value.split( '/' ).map( Number );
+			break;
+
+		case 'dd/mm/yy':
+			[ day, month, year ] = value.split( '/' ).map( Number );
+			break;
+
+		case 'yy-mm-dd':
+			[ year, month, day ] = value.split( '-' ).map( Number );
+			break;
+
+		default:
+			return false;
+	}
+	if ( isNaN( year ) || isNaN( month ) || isNaN( day ) ) {
+		return false;
+	}
+
+	const date = new Date( year, month - 1, day );
+
+	return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
+};

--- a/projects/packages/forms/tests/js/contact-form/accessible-form.test.js
+++ b/projects/packages/forms/tests/js/contact-form/accessible-form.test.js
@@ -1,0 +1,92 @@
+// Add these mocks at the top of your test file
+import './wp-mocks';
+import { validateDate } from '../../../src/contact-form/js/accessible-form';
+
+describe( 'validateDate', () => {
+	// Test mm/dd/yy format
+	describe( 'mm/dd/yy format', () => {
+		const format = 'mm/dd/yy';
+
+		test( 'validates correct dates', () => {
+			expect( validateDate( '12/31/2023', format ) ).toBe( true );
+			expect( validateDate( '01/01/2024', format ) ).toBe( true );
+			expect( validateDate( '02/29/2024', format ) ).toBe( true ); // leap year
+		} );
+
+		test( 'invalidates incorrect dates', () => {
+			expect( validateDate( '13/01/2023', format ) ).toBe( false ); // invalid month
+			expect( validateDate( '00/01/2023', format ) ).toBe( false ); // invalid month
+			expect( validateDate( '12/32/2023', format ) ).toBe( false ); // invalid day
+			expect( validateDate( '12/00/2023', format ) ).toBe( false ); // invalid day
+			expect( validateDate( '02/29/2023', format ) ).toBe( false ); // not a leap year
+		} );
+
+		test( 'invalidates malformed inputs', () => {
+			expect( validateDate( '12-31-2023', format ) ).toBe( false ); // wrong separator
+			expect( validateDate( '12/31/', format ) ).toBe( false ); // incomplete
+			expect( validateDate( 'abc', format ) ).toBe( false ); // nonsense input
+		} );
+	} );
+
+	// Test dd/mm/yy format
+	describe( 'dd/mm/yy format', () => {
+		const format = 'dd/mm/yy';
+
+		test( 'validates correct dates', () => {
+			expect( validateDate( '31/12/2023', format ) ).toBe( true );
+			expect( validateDate( '01/01/2024', format ) ).toBe( true );
+			expect( validateDate( '29/02/2024', format ) ).toBe( true ); // leap year
+		} );
+
+		test( 'invalidates incorrect dates', () => {
+			expect( validateDate( '32/12/2023', format ) ).toBe( false ); // invalid day
+			expect( validateDate( '00/12/2023', format ) ).toBe( false ); // invalid day
+			expect( validateDate( '31/13/2023', format ) ).toBe( false ); // invalid month
+			expect( validateDate( '31/00/2023', format ) ).toBe( false ); // invalid month
+			expect( validateDate( '29/02/2023', format ) ).toBe( false ); // not a leap year
+		} );
+
+		test( 'invalidates malformed inputs', () => {
+			expect( validateDate( '31-12-2023', format ) ).toBe( false ); // wrong separator
+			expect( validateDate( '31/12/', format ) ).toBe( false ); // incomplete
+			expect( validateDate( 'abc', format ) ).toBe( false ); // nonsense input
+		} );
+	} );
+
+	// Test yy-mm-dd format
+	describe( 'yy-mm-dd format', () => {
+		const format = 'yy-mm-dd';
+
+		test( 'validates correct dates', () => {
+			expect( validateDate( '2023-12-31', format ) ).toBe( true );
+			expect( validateDate( '2024-01-01', format ) ).toBe( true );
+			expect( validateDate( '2024-02-29', format ) ).toBe( true ); // leap year
+		} );
+
+		test( 'invalidates incorrect dates', () => {
+			expect( validateDate( '2023-13-01', format ) ).toBe( false ); // invalid month
+			expect( validateDate( '2023-00-01', format ) ).toBe( false ); // invalid month
+			expect( validateDate( '2023-12-32', format ) ).toBe( false ); // invalid day
+			expect( validateDate( '2023-12-00', format ) ).toBe( false ); // invalid day
+			expect( validateDate( '2023-02-29', format ) ).toBe( false ); // not a leap year
+		} );
+
+		test( 'invalidates malformed inputs', () => {
+			expect( validateDate( '2023/12/31', format ) ).toBe( false ); // wrong separator
+			expect( validateDate( '2023-12-', format ) ).toBe( false ); // incomplete
+			expect( validateDate( 'abc', format ) ).toBe( false ); // nonsense input
+		} );
+	} );
+
+	// Test invalid format
+	test( 'returns false for invalid format', () => {
+		expect( validateDate( '12/31/2023', 'invalid-format' ) ).toBe( false );
+	} );
+
+	// Test empty/null inputs
+	test( 'handles empty/null inputs', () => {
+		expect( validateDate( '', 'mm/dd/yy' ) ).toBe( false );
+		expect( validateDate( null, 'mm/dd/yy' ) ).toBe( false );
+		expect( validateDate( undefined, 'mm/dd/yy' ) ).toBe( false );
+	} );
+} );

--- a/projects/packages/forms/tests/js/contact-form/validate-helper.test.js
+++ b/projects/packages/forms/tests/js/contact-form/validate-helper.test.js
@@ -1,6 +1,5 @@
 // Add these mocks at the top of your test file
-import './wp-mocks';
-import { validateDate } from '../../../src/contact-form/js/accessible-form';
+import { validateDate } from '../../../src/contact-form/js/validate-helper';
 
 describe( 'validateDate', () => {
 	// Test mm/dd/yy format

--- a/projects/packages/forms/tests/js/contact-form/wp-mocks.js
+++ b/projects/packages/forms/tests/js/contact-form/wp-mocks.js
@@ -1,0 +1,8 @@
+global.wp = {
+	i18n: {
+		__: jest.fn().mockImplementation( str => str ),
+		_n: jest
+			.fn()
+			.mockImplementation( ( single, plural, number ) => ( number === 1 ? single : plural ) ),
+	},
+};

--- a/projects/plugins/jetpack/changelog/fix-date-validation-in-all-browsers
+++ b/projects/plugins/jetpack/changelog/fix-date-validation-in-all-browsers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+not useful since it doesn't completly remove jquery from the front end


### PR DESCRIPTION
Fixes #7888 
This Pr adds simple date validation and test the date formats that the date input supports. 

## Proposed changes:
* Removed jquery date picker for date validation. 
* Adds a simpler date validation function. 
* Adds tests for the different supported date formats.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load this Pr. 
* Add the date picker in different date format options. 
* Test that the validation works as expected. Enter a invalid date. Try to submit the form notice that you are not able to. 
* run the tests by going to the `cd projects/packages/forms ` and running the command `pnpm test`

