### PR TITLE
Forms: Process file field reponses and display the responses.

### DIFF
--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -794,7 +794,7 @@ class Admin {
 				if ( $json_data->field_type === 'file' ) {
 					return '<a href="' . esc_url( $json_data->url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $json_data->name ) . '</a> - ' . size_format( $json_data->size ) . '<br />';
 				}
-			} catch ( Exception $e ) {
+			} catch ( \Exception $e ) {
 				return nl2br( esc_html( $value ) );
 			}
 		}

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -761,7 +761,7 @@ class Admin {
 			printf(
 				'<div class="feedback_response__item-key">%s</div><div class="feedback_response__item-value">%s</div>',
 				esc_html( preg_replace( '#^\d+_#', '', $key ) ),
-				nl2br( esc_html( $value ) )
+				$this->esc_field_value( $value ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- we're escaping the value in the function
 			);
 		}
 		echo '</div>';
@@ -775,6 +775,31 @@ class Admin {
 		echo '<div class="feedback_response__item-key">' . esc_html__( 'Source', 'jetpack-forms' ) . '</div>';
 		echo '<div class="feedback_response__item-value"><a href="' . esc_url( $url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $url ) . '</a></div>';
 		echo '</div>';
+	}
+	/**
+	 * Escapes the field value for display.
+	 *
+	 * @param  string $value field value.
+	 * @return string
+	 */
+	public function esc_field_value( $value ) {
+
+		// check that the $value is a json_encoded value
+		if ( str_starts_with( $value, '{' ) ) {
+			try {
+				$json_data = json_decode( $value );
+				if ( is_string( $json_data ) ) {
+					return nl2br( esc_html( $value ) );
+				}
+				if ( $json_data->field_type === 'file' ) {
+					return '<a href="' . esc_url( $json_data->url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $json_data->name ) . '</a> - ' . size_format( $json_data->size ) . '<br />';
+				}
+			} catch ( Exception $e ) {
+				return nl2br( esc_html( $value ) );
+			}
+		}
+
+		return nl2br( esc_html( $value ) );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1026,6 +1026,93 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		return __( 'Unknown upload error.', 'jetpack-forms' );
 	}
+	/**
+	 * A function that gets called when processing form submissions and returns a list of files that were processed or errors.
+	 */
+	private function process_file_uploads() {
+
+		// Initialize an empty array for storing uploaded file paths
+		$uploaded_files = array();
+
+		// Define allowed mime types
+		$allowed_mime_types = array(
+			'pdf'  => 'application/pdf',
+			'jpeg' => 'image/jpeg',
+			'jpg'  => 'image/jpeg',
+		);
+
+		// Process file uploads first
+		foreach ( $this->fields as $id => $field ) {
+			if ( $field->get_attribute( 'type' ) !== 'file' ) {
+				continue;
+			}
+
+			$field_id = sanitize_key( $id );
+
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verification is handled by process_form_submission()
+			if ( ! isset( $_FILES[ $field_id ] ) || ! is_array( $_FILES[ $field_id ] ) ) {
+				continue;
+			}
+
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verification is handled by process_form_submission()
+			$file = array_map( 'sanitize_text_field', $_FILES[ $field_id ] );
+
+			// Basic validation
+			if ( ! empty( $file['error'] ) ) {
+				if ( UPLOAD_ERR_NO_FILE !== $file['error'] ) {
+					$field->add_error( $this->get_upload_error_message( $file['error'] ) );
+				}
+				continue;
+			}
+
+			// Validate file type
+			$file_name = sanitize_file_name( wp_unslash( $file['name'] ) );
+			$file_type = wp_check_filetype( $file_name, $allowed_mime_types );
+
+			if ( ! $file_type['type'] ) {
+				$field->add_error( __( 'Invalid file type. Only PDF and JPG files are allowed.', 'jetpack-forms' ) );
+				continue;
+			}
+
+			// Get upload directory
+			$upload_dir = wp_upload_dir();
+			if ( ! empty( $upload_dir['error'] ) ) {
+				$field->add_error( __( 'Unable to process file upload.', 'jetpack-forms' ) );
+				continue;
+			}
+
+			$jetpack_forms_dir = $upload_dir['basedir'] . '/jetpack-forms';
+
+			// Create upload directory if it doesn't exist
+			if ( ! wp_mkdir_p( $jetpack_forms_dir ) ) {
+				$field->add_error( __( 'Unable to create upload directory.', 'jetpack-forms' ) );
+				continue;
+			}
+
+			// Generate unique filename
+			$filename        = wp_unique_filename( $jetpack_forms_dir, $file_name );
+			$secret_filename = wp_hash( $filename . microtime() ) . '-' . $filename;
+			$new_file        = $jetpack_forms_dir . '/' . $secret_filename;
+
+			// Move uploaded file
+			$move_result = move_uploaded_file( $file['tmp_name'], $new_file );
+			if ( ! $move_result ) {
+				$field->add_error( __( 'Failed to upload file.', 'jetpack-forms' ) );
+				continue;
+			}
+
+			$uploaded_files[ $field_id ] = array(
+				'field_type' => $field->get_attribute( 'type' ),
+				'name'       => $file_name,
+				'path'       => $new_file,
+				'url'        => esc_url_raw( $upload_dir['baseurl'] . '/jetpack-forms/' . $secret_filename ),
+				'type'       => $file_type['type'],
+				'size'       => wp_filesize( $new_file ),
+			);
+		}
+
+		return $uploaded_files;
+	}
 
 	/**
 	 * Process the contact form's POST submission
@@ -1172,82 +1259,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$email_marketing_consent = false;
 		}
 
-		// Initialize an empty array for storing uploaded file paths
-		$uploaded_files = array();
-
-		// Define allowed mime types
-		$allowed_mime_types = array(
-			'pdf'  => 'application/pdf',
-			'jpeg' => 'image/jpeg',
-			'jpg'  => 'image/jpeg',
-		);
-
-		// Process file uploads first
-		foreach ( $this->fields as $id => $field ) {
-			if ( $field->get_attribute( 'type' ) !== 'file' ) {
-				continue;
-			}
-
-			$field_id = sanitize_key( $id );
-
-			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verification is handled by process_form_submission()
-			if ( ! isset( $_FILES[ $field_id ] ) || ! is_array( $_FILES[ $field_id ] ) ) {
-				continue;
-			}
-
-			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verification is handled by process_form_submission()
-			$file = array_map( 'sanitize_text_field', $_FILES[ $field_id ] );
-
-			// Basic validation
-			if ( ! empty( $file['error'] ) ) {
-				if ( UPLOAD_ERR_NO_FILE !== $file['error'] ) {
-					$field->add_error( $this->get_upload_error_message( $file['error'] ) );
-				}
-				continue;
-			}
-
-			// Validate file type
-			$file_name = sanitize_file_name( wp_unslash( $file['name'] ) );
-			$file_type = wp_check_filetype( $file_name, $allowed_mime_types );
-
-			if ( ! $file_type['type'] ) {
-				$field->add_error( __( 'Invalid file type. Only PDF and JPG files are allowed.', 'jetpack-forms' ) );
-				continue;
-			}
-
-			// Get upload directory
-			$upload_dir = wp_upload_dir();
-			if ( ! empty( $upload_dir['error'] ) ) {
-				$field->add_error( __( 'Unable to process file upload.', 'jetpack-forms' ) );
-				continue;
-			}
-
-			$jetpack_forms_dir = $upload_dir['basedir'] . '/jetpack-forms';
-
-			// Create upload directory if it doesn't exist
-			if ( ! wp_mkdir_p( $jetpack_forms_dir ) ) {
-				$field->add_error( __( 'Unable to create upload directory.', 'jetpack-forms' ) );
-				continue;
-			}
-
-			// Generate unique filename
-			$filename = wp_unique_filename( $jetpack_forms_dir, $file_name );
-			$new_file = $jetpack_forms_dir . '/' . $filename;
-
-			// Move uploaded file
-			$move_result = move_uploaded_file( $file['tmp_name'], $new_file );
-			if ( ! $move_result ) {
-				$field->add_error( __( 'Failed to upload file.', 'jetpack-forms' ) );
-				continue;
-			}
-
-			$uploaded_files[ $field_id ] = array(
-				'name' => $file_name,
-				'path' => $new_file,
-				'url'  => esc_url_raw( $upload_dir['baseurl'] . '/jetpack-forms/' . $filename ),
-				'type' => $file_type['type'],
-			);
-		}
+		$uploaded_files = $this->process_file_uploads();
 
 		$all_values   = array();
 		$extra_values = array();
@@ -1258,6 +1270,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$field = $this->fields[ $field_id ];
 			$label = $i . '_' . $field->get_attribute( 'label' );
 			$value = $field->value;
+
+			if ( $uploaded_files && isset( $uploaded_files[ $field_id ] ) ) {
+				$value = wp_json_encode( $uploaded_files[ $field_id ] );
+			}
 
 			$all_values[ $label ] = $value;
 			++$i; // Increment prefix counter for the next field
@@ -1276,10 +1292,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 			$extra_values[ $label ] = $value;
 			++$i; // Increment prefix counter for the next extra field
-		}
-
-		if ( ! empty( $uploaded_files ) ) {
-			$extra_values['files'] = $uploaded_files;
 		}
 
 		if ( ! empty( $_REQUEST['is_block'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- not changing the site.

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -5,7 +5,7 @@ $action-bar-height: 88px;
 .jp-forms__inbox {
 	a.back-button {
 		align-items: center;
-		color: #2C3338;
+		color: #2c3338;
 		cursor: pointer;
 		display: none;
 		font-size: 14px;
@@ -18,7 +18,7 @@ $action-bar-height: 88px;
 
 	// visual aid for focus, currently only export button
 	.button-primary.export-button:focus {
-		box-shadow: var( --jp-forms-focus-shadow );
+		box-shadow: var(--jp-forms-focus-shadow);
 	}
 
 	.components-dropdown-menu {
@@ -105,7 +105,7 @@ $action-bar-height: 88px;
 	border: 1px solid #dcdcde;
 	border-radius: 3px;
 	box-sizing: border-box;
-	color: #2C3338;
+	color: #2c3338;
 	display: inline-flex;
 	font-size: 12px;
 	font-weight: 400;
@@ -216,7 +216,7 @@ $action-bar-height: 88px;
 
 	.jp-forms__table-item {
 		max-height: 52px;
-		transition: max-height .2s;
+		transition: max-height 0.2s;
 
 		&.exit-active {
 			overflow: hidden;
@@ -249,7 +249,10 @@ $action-bar-height: 88px;
 
 	@media (min-width: 1025px) {
 		display: flex;
-		min-height: calc(100vh - calc(var(--wp-admin--admin-bar--height) + #{$tabs-height} + #{$action-bar-height} + 48px));
+		min-height: calc(
+			100vh -
+				calc(var(--wp-admin--admin-bar--height) + #{$tabs-height} + #{$action-bar-height} + 48px)
+		);
 	}
 
 	.jp-forms__table-cell {
@@ -284,9 +287,9 @@ $action-bar-height: 88px;
 			white-space: nowrap;
 			text-decoration: none;
 
-			 &:hover {
-				 text-decoration: underline;
-			 }
+			&:hover {
+				text-decoration: underline;
+			}
 		}
 	}
 
@@ -311,7 +314,7 @@ $action-bar-height: 88px;
 
 			// visual aid for focus
 			&:focus {
-				box-shadow: var( --jp-forms-focus-shadow );
+				box-shadow: var(--jp-forms-focus-shadow);
 			}
 		}
 
@@ -404,7 +407,10 @@ $action-bar-height: 88px;
 	position: relative;
 
 	@media (min-width: 1025px) {
-		height: calc(100vh - calc(var(--wp-admin--admin-bar--height) + #{$tabs-height} + #{$action-bar-height} + 48px));
+		height: calc(
+			100vh -
+				calc(var(--wp-admin--admin-bar--height) + #{$tabs-height} + #{$action-bar-height} + 48px)
+		);
 		overflow-y: auto;
 		position: sticky;
 		top: calc(var(--wp-admin--admin-bar--height) + #{$tabs-height} + #{$action-bar-height});
@@ -414,7 +420,7 @@ $action-bar-height: 88px;
 		background: linear-gradient(30deg, #eaeff5, #f2f3e3);
 		border-bottom: 1px solid #dcdcde;
 		box-sizing: border-box;
-		content: "";
+		content: '';
 		display: flex;
 		padding-top: 24px;
 	}
@@ -426,7 +432,7 @@ $action-bar-height: 88px;
 	@media (min-width: 1025px) {
 		&.enter,
 		&.enter-active {
-			animation: jp-forms__slide-in .2s ease-out forwards, jp-forms__fade-in .2s ease-in forwards;
+			animation: jp-forms__slide-in 0.2s ease-out forwards, jp-forms__fade-in 0.2s ease-in forwards;
 
 			.jp-forms__inbox.is-response-animation-reverted & {
 				animation: none;
@@ -442,7 +448,8 @@ $action-bar-height: 88px;
 			z-index: -1;
 
 			.jp-forms__inbox.is-response-animation-reverted & {
-				animation: jp-forms__slide-in .2s ease-out forwards reverse, jp-forms__fade-in .2s ease-in forwards reverse;
+				animation: jp-forms__slide-in 0.2s ease-out forwards reverse,
+					jp-forms__fade-in 0.2s ease-in forwards reverse;
 				z-index: 1;
 			}
 		}
@@ -568,7 +575,7 @@ $action-bar-height: 88px;
 }
 
 .jp-forms__inbox-response-separator {
-	border-bottom: 1px solid var( --jp-forms-border-color );
+	border-bottom: 1px solid var(--jp-forms-border-color);
 	width: 100%;
 }
 
@@ -587,6 +594,7 @@ $action-bar-height: 88px;
 
 .jp-forms__inbox-response-data-value {
 	white-space: pre-wrap;
+	display: flex;
 }
 
 // ACTIONS ROW
@@ -594,7 +602,7 @@ $action-bar-height: 88px;
 	background: white;
 	display: flex;
 	flex-direction: row;
-	gap: var( --jp-forms-spacing-base );
+	gap: var(--jp-forms-spacing-base);
 	padding: 32px 64px 16px;
 	position: sticky;
 	top: calc(var(--wp-admin--admin-bar--height) + #{$tabs-height});
@@ -605,7 +613,7 @@ $action-bar-height: 88px;
 	}
 
 	@media (max-width: 660px) {
-		padding: calc( var(--jp-forms-spacing-base ) * 2 ) 24px;
+		padding: calc(var(--jp-forms-spacing-base) * 2) 24px;
 	}
 
 	.jp-forms__inbox.is-response-view & {
@@ -623,22 +631,22 @@ $action-bar-height: 88px;
 	}
 
 	.components-button {
-		border-radius: var( --jp-forms-border-radius );
-		height: var( --jp-forms-input-wrapper-height );
+		border-radius: var(--jp-forms-border-radius);
+		height: var(--jp-forms-input-wrapper-height);
 		letter-spacing: -0.02em;
 		font-size: var(--jp-forms-font-size-regular);
 		font-weight: 400;
-		padding: var( --jp-forms-spacing-base ) calc( var( --jp-forms-spacing-base ) * 1.5 );
+		padding: var(--jp-forms-spacing-base) calc(var(--jp-forms-spacing-base) * 1.5);
 
 		&.is-secondary {
-			background: var( --jp-forms-white );
-			color: var( --jp-forms-black );
-			box-shadow: inset 0 0 0 1px var( --jp-forms-border-color );
+			background: var(--jp-forms-white);
+			color: var(--jp-forms-black);
+			box-shadow: inset 0 0 0 1px var(--jp-forms-border-color);
 
 			&.is-opened,
 			&:hover:not(:disabled) {
-				background: var(--jp-forms-color-darker-10 );
-				color: var( --jp-forms-white );
+				background: var(--jp-forms-color-darker-10);
+				color: var(--jp-forms-white);
 			}
 		}
 	}
@@ -648,8 +656,8 @@ $action-bar-height: 88px;
 	}
 
 	.button-primary.export-button {
-		background-color: var( --wp-admin-theme-color, #000 );
-		border-color: var( --wp-admin-theme-color, #000 );
+		background-color: var(--wp-admin-theme-color, #000);
+		border-color: var(--wp-admin-theme-color, #000);
 		margin-left: auto;
 
 		@media (max-width: 782px) {
@@ -657,5 +665,3 @@ $action-bar-height: 88px;
 		}
 	}
 }
-
-

--- a/projects/packages/forms/src/dashboard/inbox/util.js
+++ b/projects/packages/forms/src/dashboard/inbox/util.js
@@ -1,4 +1,6 @@
 import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
+import { Icon } from '@wordpress/components';
+import { upload } from '@wordpress/icons';
 import { isArray, isEmpty, join } from 'lodash';
 
 export const getDisplayName = response => {
@@ -37,6 +39,20 @@ export const formatFieldValue = fieldValue => {
 		return '-';
 	} else if ( isArray( fieldValue ) ) {
 		return join( fieldValue, ', ' );
+	}
+
+	if ( fieldValue.startsWith( '{' ) ) {
+		const fieldValueObj = JSON.parse( fieldValue );
+		if ( fieldValueObj.field_type === 'file' ) {
+			return (
+				<>
+					<Icon icon={ upload } />
+					<a href={ fieldValueObj.url } target="_blank" rel="noopener noreferrer">
+						{ fieldValueObj.name }
+					</a>
+				</>
+			);
+		}
 	}
 
 	return fieldValue;


### PR DESCRIPTION
This Pr adds the form field responses so that they can be view in the responses UI. 

See 
![Screenshot 2025-02-10 at 5 01 47 PM](https://github.com/user-attachments/assets/60c5ccca-8857-4669-905b-70f3ee7e0a6c)

![Screenshot 2025-02-10 at 5 01 35 PM](https://github.com/user-attachments/assets/b7ee9a02-dee1-4882-83d5-70be1b376170)


## Proposed changes:
* Refactors the processing of files in a private method. So that we can we don't make the main process_submission even bigger. 
* Stores the info about the file that was uploaded as a json so that we don't have to parse the file get info about it. 
* Updates the file name on the server so that you can't guess it. 
* 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
See #41693 

