### PR TITLE
Add/forms tracking creative mail

### DIFF
--- a/projects/packages/forms/changelog/add-forms-tracking-creative-mail
+++ b/projects/packages/forms/changelog/add-forms-tracking-creative-mail
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Add tracking for Creative Mail clicks.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-newsletter-integration-settings-creativemail.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-newsletter-integration-settings-creativemail.js
@@ -1,7 +1,8 @@
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Spinner } from '@wordpress/components';
 import { useCallback, useState, useEffect } from '@wordpress/element';
 import { get } from 'lodash';
-import { getPlugins } from '../util/plugin-management';
+import { getPlugins, installAndActivatePlugin, activatePlugin } from '../util/plugin-management';
 import CreativeMailPluginErrorState from './jetpack-newsletter-integration-settings-error-state';
 import CreativeMailPluginState, {
 	pluginStateEnum,
@@ -11,8 +12,17 @@ const pluginPathWithoutPhp = 'creative-mail-by-constant-contact/creative-mail-pl
 const pluginPath = `${ pluginPathWithoutPhp }.php`;
 
 const useOnCreativeMailPluginPromise = ( setPluginError, setIsInstalling, setPluginState ) => {
+	const { tracks } = useAnalytics();
+
 	const onCreativeMailPluginClick = useCallback(
 		( func, arg ) => {
+			// Track the event before starting installation/activation
+			if ( func === installAndActivatePlugin ) {
+				tracks.recordEvent( 'jetpack_forms_creative_mail_install_click' );
+			} else if ( func === activatePlugin ) {
+				tracks.recordEvent( 'jetpack_forms_creative_mail_activate_click' );
+			}
+
 			setPluginError( undefined );
 			setIsInstalling( true );
 			func( arg )
@@ -24,7 +34,7 @@ const useOnCreativeMailPluginPromise = ( setPluginError, setIsInstalling, setPlu
 				} )
 				.finally( () => setIsInstalling( false ) );
 		},
-		[ setIsInstalling, setPluginError, setPluginState ]
+		[ setIsInstalling, setPluginError, setPluginState, tracks ]
 	);
 	return onCreativeMailPluginClick;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #2269
Follow up to #41695 (which does the same tracking for Jetpack CRM)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Adds Tracks events when users click to install or activate Creative Mail from the contact form block sidebar.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Preparation: 
- Tracks Vigilante: You will need to ensure you can see Tracks events as they are fired. The best way is to install Tracks Vigilante here: https://github.com/Automattic/tracks-chrome-extension Once installed, you'll be able to see tracks events in the Chrome toolbar.
- Creative Mail Plugin. Deactivate and delete Creative Mail if you have it installed as a separate plugin

Test: 
- Go to a page or post and insert a form block.
- Clear all current tracks events from Tracks Vigilante to make it easier to see new events.
- Go to the contact form block sidebar and click the button to install Creative Mail. 
- Confirm that the `jetpack_forms_creative_mail_install_click` Tracks event is fired.
- Go to your site's plugin page and deactivate Creative Mail but leave it installed.
- Return to your post with your contact form, refresh the page if needed, go to the contact form block sidebar, and click the button the activate Creative Mail
- Confirm that the `jetpack_forms_creative_mail_activate_click` Tracks event is fired.