### PR TITLE
Forms: Fix syncing of shared styles for nested fields and related undo issue

### DIFF
--- a/projects/packages/forms/changelog/fix-synced-styles-for-nested-fields
+++ b/projects/packages/forms/changelog/fix-synced-styles-for-nested-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix syncing of shared styles for nested fields

--- a/projects/packages/forms/src/blocks/contact-form/util/with-shared-field-attributes.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/with-shared-field-attributes.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { select, useDispatch, useRegistry } from '@wordpress/data';
+import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { useCallback, useEffect } from '@wordpress/element';
 import { isEmpty, first, map, pick, isNil } from 'lodash';
 
@@ -14,28 +14,25 @@ export const useSharedFieldAttributes = ( {
 	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
 	const registry = useRegistry();
 
-	// Not using `useSelect` here to get fresh sibling data within `useEffect` and `useCallback`.
+	const { getBlockParentsByBlockName, getClientIdsOfDescendants, getBlocksByClientId } =
+		useSelect( 'core/block-editor' );
+
 	const getSiblings = useCallback( () => {
-		const blockEditor = select( 'core/block-editor' );
-		const parentId = first(
-			blockEditor.getBlockParentsByBlockName( clientId, 'jetpack/contact-form' )
-		);
+		const parentId = first( getBlockParentsByBlockName( clientId, 'jetpack/contact-form' ) );
 
 		if ( ! parentId ) {
 			return [];
 		}
 
-		const formDescendants = blockEditor.getClientIdsOfDescendants( parentId );
+		const formDescendants = getClientIdsOfDescendants( parentId );
 
-		return blockEditor
-			.getBlocksByClientId( formDescendants )
-			.filter(
-				block =>
-					block?.name?.includes( 'jetpack/field' ) &&
-					block?.attributes?.shareFieldAttributes &&
-					block?.clientId !== clientId
-			);
-	}, [ clientId ] );
+		return getBlocksByClientId( formDescendants ).filter(
+			block =>
+				block?.name?.includes( 'jetpack/field' ) &&
+				block?.attributes?.shareFieldAttributes &&
+				block?.clientId !== clientId
+		);
+	}, [ clientId, getBlockParentsByBlockName, getClientIdsOfDescendants, getBlocksByClientId ] );
 
 	useEffect( () => {
 		const siblings = getSiblings();

--- a/projects/packages/forms/src/blocks/contact-form/util/with-shared-field-attributes.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/with-shared-field-attributes.js
@@ -3,7 +3,7 @@
  */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect } from '@wordpress/element';
-import { isEmpty, filter, first, map, pick, isNil } from 'lodash';
+import { isEmpty, first, map, pick, isNil } from 'lodash';
 
 export const useSharedFieldAttributes = ( {
 	attributes,
@@ -21,10 +21,18 @@ export const useSharedFieldAttributes = ( {
 				blockEditor.getBlockParentsByBlockName( clientId, 'jetpack/contact-form' )
 			);
 
-			return filter(
-				blockEditor.getBlocks( parentId ),
-				block => block.name.indexOf( 'jetpack/field' ) > -1 && block.attributes.shareFieldAttributes
-			);
+			if ( ! parentId ) {
+				return [];
+			}
+
+			const formDescendants = blockEditor.getClientIdsOfDescendants( parentId );
+
+			return blockEditor
+				.getBlocksByClientId( formDescendants )
+				.filter(
+					block =>
+						block?.name?.indexOf( 'jetpack/field' ) > -1 && block?.attributes?.shareFieldAttributes
+				);
 		},
 		[ clientId ]
 	);

--- a/projects/packages/forms/src/blocks/contact-form/util/with-shared-field-attributes.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/with-shared-field-attributes.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
+import { select, useDispatch } from '@wordpress/data';
 import { useCallback, useEffect } from '@wordpress/element';
 import { isEmpty, first, map, pick, isNil } from 'lodash';
 
@@ -13,31 +13,29 @@ export const useSharedFieldAttributes = ( {
 } ) => {
 	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
 
-	const siblings = useSelect(
-		select => {
-			const blockEditor = select( 'core/block-editor' );
+	// Not using `useSelect` here to get fresh sibling data within `useEffect` and `useCallback`.
+	const getSiblings = useCallback( () => {
+		const blockEditor = select( 'core/block-editor' );
+		const parentId = first(
+			blockEditor.getBlockParentsByBlockName( clientId, 'jetpack/contact-form' )
+		);
 
-			const parentId = first(
-				blockEditor.getBlockParentsByBlockName( clientId, 'jetpack/contact-form' )
+		if ( ! parentId ) {
+			return [];
+		}
+
+		const formDescendants = blockEditor.getClientIdsOfDescendants( parentId );
+
+		return blockEditor
+			.getBlocksByClientId( formDescendants )
+			.filter(
+				block => block?.name?.includes( 'jetpack/field' ) && block?.attributes?.shareFieldAttributes
 			);
-
-			if ( ! parentId ) {
-				return [];
-			}
-
-			const formDescendants = blockEditor.getClientIdsOfDescendants( parentId );
-
-			return blockEditor
-				.getBlocksByClientId( formDescendants )
-				.filter(
-					block =>
-						block?.name?.indexOf( 'jetpack/field' ) > -1 && block?.attributes?.shareFieldAttributes
-				);
-		},
-		[ clientId ]
-	);
+	}, [ clientId ] );
 
 	useEffect( () => {
+		const siblings = getSiblings();
+
 		if ( ! isEmpty( siblings ) && attributes.shareFieldAttributes ) {
 			const newSharedAttributes = pick( first( siblings ).attributes, sharedAttributes );
 			updateBlockAttributes( [ clientId ], newSharedAttributes );
@@ -45,10 +43,12 @@ export const useSharedFieldAttributes = ( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	return useCallback(
+	const updateAttributes = useCallback(
 		newAttributes => {
-			let blocksToUpdate;
-			let newSharedAttributes;
+			const siblings = getSiblings();
+
+			let blocksToUpdate = [];
+			let newSharedAttributes = {};
 
 			if ( attributes.shareFieldAttributes && isNil( newAttributes.shareFieldAttributes ) ) {
 				blocksToUpdate = map( siblings, block => block.clientId );
@@ -64,8 +64,10 @@ export const useSharedFieldAttributes = ( {
 
 			setAttributes( newAttributes );
 		},
-		[ attributes, clientId, setAttributes, sharedAttributes, siblings, updateBlockAttributes ]
+		[ attributes, clientId, getSiblings, setAttributes, sharedAttributes, updateBlockAttributes ]
 	);
+
+	return updateAttributes;
 };
 
 export const withSharedFieldAttributes =

--- a/projects/packages/forms/src/blocks/contact-form/util/with-shared-field-attributes.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/with-shared-field-attributes.js
@@ -11,8 +11,9 @@ export const useSharedFieldAttributes = ( {
 	setAttributes,
 	sharedAttributes,
 } ) => {
-	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
 	const registry = useRegistry();
+	const { updateBlockAttributes, __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( 'core/block-editor' );
 
 	const { getBlockParentsByBlockName, getClientIdsOfDescendants, getBlocksByClientId } =
 		useSelect( 'core/block-editor' );
@@ -39,7 +40,10 @@ export const useSharedFieldAttributes = ( {
 
 		if ( ! isEmpty( siblings ) && attributes.shareFieldAttributes ) {
 			const newSharedAttributes = pick( first( siblings ).attributes, sharedAttributes );
-			updateBlockAttributes( [ clientId ], newSharedAttributes );
+			registry.batch( () => {
+				__unstableMarkNextChangeAsNotPersistent();
+				updateBlockAttributes( [ clientId ], newSharedAttributes );
+			} );
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );

--- a/projects/packages/forms/src/blocks/contact-form/util/with-shared-field-attributes.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/with-shared-field-attributes.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { select, useDispatch } from '@wordpress/data';
+import { select, useDispatch, useRegistry } from '@wordpress/data';
 import { useCallback, useEffect } from '@wordpress/element';
 import { isEmpty, first, map, pick, isNil } from 'lodash';
 
@@ -12,6 +12,7 @@ export const useSharedFieldAttributes = ( {
 	sharedAttributes,
 } ) => {
 	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
+	const registry = useRegistry();
 
 	// Not using `useSelect` here to get fresh sibling data within `useEffect` and `useCallback`.
 	const getSiblings = useCallback( () => {
@@ -61,13 +62,23 @@ export const useSharedFieldAttributes = ( {
 				newSharedAttributes = pick( first( siblings ).attributes, sharedAttributes );
 			}
 
-			if ( ! isEmpty( blocksToUpdate ) && ! isEmpty( newSharedAttributes ) ) {
-				updateBlockAttributes( blocksToUpdate, newSharedAttributes );
-			}
+			registry.batch( () => {
+				if ( ! isEmpty( blocksToUpdate ) && ! isEmpty( newSharedAttributes ) ) {
+					updateBlockAttributes( blocksToUpdate, newSharedAttributes );
+				}
 
-			setAttributes( newAttributes );
+				setAttributes( newAttributes );
+			} );
 		},
-		[ attributes, clientId, getSiblings, setAttributes, sharedAttributes, updateBlockAttributes ]
+		[
+			attributes,
+			clientId,
+			getSiblings,
+			registry,
+			setAttributes,
+			sharedAttributes,
+			updateBlockAttributes,
+		]
 	);
 
 	return updateAttributes;

--- a/projects/packages/forms/src/blocks/contact-form/util/with-shared-field-attributes.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/with-shared-field-attributes.js
@@ -29,7 +29,10 @@ export const useSharedFieldAttributes = ( {
 		return blockEditor
 			.getBlocksByClientId( formDescendants )
 			.filter(
-				block => block?.name?.includes( 'jetpack/field' ) && block?.attributes?.shareFieldAttributes
+				block =>
+					block?.name?.includes( 'jetpack/field' ) &&
+					block?.attributes?.shareFieldAttributes &&
+					block?.clientId !== clientId
 			);
 	}, [ clientId ] );
 


### PR DESCRIPTION
Fixes #41704

## Proposed changes:

* Updates the `useSharedFieldAttributes` hook to factor in that form fields can be nested within other blocks and may not be immediate children of the primary form block.
* Fixes multiple bugs related to style syncing
    * Prevents fields from using themselves as the source for shared attributes
    * Eliminates duplicate undo stack entries that were causing undo loops
    * Fixes undo when syncing styles on block insertion e.g. dropping field from second form into the current one.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No changes.

## Testing instructions:

1. Test nested field style syncing:
    - Add a form with fields nested in a Group block (example block markup provided below)
    - Enable "sync field styles" on nested fields, if not already set
    - Modify styles on a nested field and verify all opted-in fields update
    - Modify styles on a top-level field and verify nested fields update correctly

2. Test undo functionality:
    - Make style changes to synced fields
    - Verify that undo/redo operations work smoothly without loops
    - Drop a new field into the form and verify undo still works appropriately
        - _Note: this PR doesn't aim to make form and field undos perfect just improve the situation around syncing styles_

3. Test block insertion with synced styles:
    - Ensure some form fields have shared styles set
    - Add a new field to the beginning of the form (either by drag and dropping one or inserter)
    - Verify it correctly inherits the shared styles from existing fields

```html
<!-- wp:jetpack/contact-form {"style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}}} -->
<div class="wp-block-jetpack-contact-form" style="padding-top:16px;padding-right:16px;padding-bottom:16px;padding-left:16px"><!-- wp:jetpack/field-name {"required":true,"placeholder":"Placeholder"} /-->

<!-- wp:jetpack/field-email {"required":true,"placeholder":"Placeholder"} /-->

<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"color":{"background":"#eeeeee"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group has-background" style="background-color:#eeeeee;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:jetpack/field-name {"label":"Nested Field 1","required":true,"placeholder":"Placeholder","width":50} /-->

<!-- wp:jetpack/field-email {"label":"Nested Field 2","required":true,"placeholder":"Placeholder","width":50} /--></div>
<!-- /wp:group -->

<!-- wp:jetpack/field-textarea {"label":"Message","placeholder":"Placeholder"} /-->

<!-- wp:jetpack/button {"element":"button","text":"Contact Us","lock":{"remove":true}} /--></div>
<!-- /wp:jetpack/contact-form -->
```


#### Nested Field Syncing

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/5567f58f-86a0-43c1-9987-5bf4427a8db3" /> | <video src="https://github.com/user-attachments/assets/955864e0-0478-4f9d-890e-27b1b13b26ad" /> |


#### Undo fix for general style sync

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/61dd99b1-de57-45c2-9080-725e6ae331ee" /> | <video src="https://github.com/user-attachments/assets/6774a1f8-3d27-4998-9509-892f72f3d0d7" /> |


#### Source of truth and sync on mount fixes

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/04a4458b-8aa1-4f09-a5ed-b043145e453a" /> | <video src="https://github.com/user-attachments/assets/f116277b-79cf-4648-b760-000038e90edb" /> |