### PR TITLE
RDV: Sync calypso preference for a12s

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-rdv-set-calypso-preferences-for-a12s
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-rdv-set-calypso-preferences-for-a12s
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Remove duplicate views: Sync calypso preference for a12s and force reset cache.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -454,6 +454,7 @@ function wpcom_is_duplicate_views_experiment_enabled() {
 
 	/**
 	 * We cache it for both AT and Simple because we want to give a12s to be able to switch between variations for their accounts - this can be useful during support.
+	 * Note that switching the variations can only be achieved through the escape hatch, not via ExPlat.
 	 *
 	 * If we don't cache it, the is_automattician conditions will force treatment every time.
 	 */

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -394,6 +394,37 @@ function wpcom_show_admin_interface_notice() {
 add_action( 'admin_notices', 'wpcom_show_admin_interface_notice' );
 
 /**
+ * Force a cache purge.
+ *
+ * @return void
+ */
+function wpcom_rdv_reset_cache_if_needed() {
+	if ( ! get_user_option( 'rdv_force_cache_is_deleted', get_current_user_id() ) ) {
+		update_user_option( get_current_user_id(), 'rdv_force_cache_is_deleted', true, true );
+		delete_user_option( get_current_user_id(), RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, true );
+	}
+}
+
+/**
+ * Check if the might be an a11n on Atomic sites.
+ *
+ * @return bool
+ */
+function wpcom_atomic_rdv_maybe_is_a11n() {
+	$is_proxy_atomic    = defined( 'AT_PROXIED_REQUEST' ) && AT_PROXIED_REQUEST;
+	$is_support_session = WPCOMSH_Support_Session_Detect::is_probably_support_session();
+	$admin_menu_is_a11n = isset( $_GET['admin_menu_is_a11n'] ) && function_exists( 'wpcomsh_is_admin_menu_api_request' ) && wpcomsh_is_admin_menu_api_request();
+
+	/**
+	 * This handles two contexts: Calypso and WP-Admin.
+	 *
+	 * Calypso: WPCOM admin-menu API endpoint mapper sends a "admin_menu_is_a11n" param for a12s. If the param exists, then we'll switch to treatment.
+	 * WP-Admin: We check if the user is proxied and if it's not in a support session.
+	 */
+	return $admin_menu_is_a11n || ( $is_proxy_atomic && ! $is_support_session );
+}
+
+/**
  * Option to force and cache the Remove duplicate Views experiment assigned variation.
  */
 const RDV_EXPERIMENT_FORCE_ASSIGN_OPTION = 'remove_duplicate_views_experiment_assignment_160125';
@@ -413,6 +444,12 @@ function wpcom_is_duplicate_views_experiment_enabled() {
 		return $is_enabled;
 	}
 
+	$host = new Host();
+
+	if ( $host->is_wpcom_simple() && is_automattician() || $host->is_atomic_platform() && wpcom_atomic_rdv_maybe_is_a11n() ) {
+		wpcom_rdv_reset_cache_if_needed();
+	}
+
 	$variation = get_user_option( RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, get_current_user_id() );
 
 	/**
@@ -425,31 +462,22 @@ function wpcom_is_duplicate_views_experiment_enabled() {
 		return $is_enabled;
 	}
 
-	if ( ( new Host() )->is_wpcom_simple() ) {
+	if ( $host->is_wpcom_simple() ) {
 		\ExPlat\assign_current_user( $aa_test_name );
 		$is_enabled = 'treatment' === \ExPlat\assign_current_user( $experiment_name );
 
 		if ( is_automattician() ) {
 			$is_enabled = true;
 			update_user_option( get_current_user_id(), RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, 'treatment', true );
+			wpcom_set_rdv_calypso_preference( 'treatment' );
 		}
 
 		return $is_enabled;
 	}
 
-	$is_proxy_atomic    = defined( 'AT_PROXIED_REQUEST' ) && AT_PROXIED_REQUEST;
-	$is_support_session = WPCOMSH_Support_Session_Detect::is_probably_support_session();
-	$admin_menu_is_a11n = isset( $_GET['admin_menu_is_a11n'] ) && function_exists( 'wpcomsh_is_admin_menu_api_request' ) && wpcomsh_is_admin_menu_api_request();
-
-	/**
-	 * This handles two contexts: Calypso and WP-Admin.
-	 *
-	 * Calypso: WPCOM admin-menu API endpoint mapper sends a "admin_menu_is_a11n" param for a12s. If the param exists, then we'll switch to treatment.
-	 * WP-Admin: We check if the user is proxied and if it's not in a support session.
-	 */
-
-	if ( $admin_menu_is_a11n || ( $is_proxy_atomic && ! $is_support_session ) ) {
+	if ( wpcom_atomic_rdv_maybe_is_a11n() ) {
 		update_user_option( get_current_user_id(), RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, 'treatment', true );
+		wpcom_set_rdv_calypso_preference( 'treatment' );
 		$is_enabled = true;
 
 		return true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

a12s are assigned in our client code the treatment variation - variation which is cached in an option. However, the variation was not also passed in the calypso preferences.

While this wasn't a major problem in the past, this is now causing problems because the Calypso preference is now used in other contexts.

Since the assignment variation is cached in a user option, short-circuiting the code, we also need a way to dynamically purge the cache for a12s so that the calypso preference is configured. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Sync the Calypso preference for a12s (since they are assigned treatment in our code)
* Force a caching purge for a12s

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the PR on your sandbox and an Atomic site
* Add a `die('purged')` in `wpcom_rdv_reset_cache_if_needed`, on line 403, after delete_user_option
* Add a `die('cached')` on line 460
* Go to wp-admin and notice you get `purged`
* Refresh the page twice and notice the `cache` text
* This means that the cache has been purged and cached again
* Notice that the calypso preference is in sync.
