### PR TITLE
Forms: use a `placeholder` attribute in the editor instead of `value`

### DIFF
--- a/projects/packages/forms/changelog/update-forms-placeholder-attr-in-editor
+++ b/projects/packages/forms/changelog/update-forms-placeholder-attr-in-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: use placeholder attribute in editor instead of value

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
@@ -52,7 +52,8 @@ const JetpackField = props => {
 					onChange={ e => setAttributes( { placeholder: e.target.value } ) }
 					style={ fieldStyle }
 					type={ type }
-					value={ placeholder }
+					value=""
+					placeholder={ placeholder }
 					onClick={ event => type === 'file' && event.preventDefault() }
 					onKeyDown={ event => {
 						if ( event.defaultPrevented || event.key !== 'Enter' ) {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
@@ -3,7 +3,6 @@ import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { createHigherOrderComponent, compose } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 import clsx from 'clsx';
-import { isEmpty } from 'lodash';
 import { useFormStyle } from '../util/form';
 import { withSharedFieldAttributes } from '../util/with-shared-field-attributes';
 import JetpackFieldControls from './jetpack-field-controls';
@@ -20,7 +19,7 @@ const JetpackField = props => {
 		requiredText,
 		label,
 		setAttributes,
-		placeholder,
+		placeholder = '',
 		width,
 		insertBlocksAfter,
 		type,
@@ -31,7 +30,7 @@ const JetpackField = props => {
 	const blockProps = useBlockProps( {
 		className: clsx( 'jetpack-field', {
 			'is-selected': isSelected,
-			'has-placeholder': ! isEmpty( placeholder ),
+			'has-placeholder': placeholder !== '',
 		} ),
 		style: blockStyle,
 	} );
@@ -51,8 +50,8 @@ const JetpackField = props => {
 					className="jetpack-field__input"
 					onChange={ e => setAttributes( { placeholder: e.target.value } ) }
 					style={ fieldStyle }
-					type={ type }
-					value=""
+					type={ isSelected ? 'text' : type }
+					value={ isSelected ? placeholder : '' }
 					placeholder={ placeholder }
 					onClick={ event => type === 'file' && event.preventDefault() }
 					onKeyDown={ event => {
@@ -71,7 +70,6 @@ const JetpackField = props => {
 				setAttributes={ setAttributes }
 				placeholder={ placeholder }
 				attributes={ attributes }
-				hidePlaceholder={ type === 'number' }
 			/>
 		</>
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Use a `placeholder` attribute in the editor for placeholder text instead of `value` attribute.

By using `value`, we have a couple issues.

When theme includes [styling for `::placeholder` pseudo element](https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder), we don't show it. Consider for example CSS:

```css
input::placeholder {
	font-style: italic;
}
```

**Before**

<img width="438" alt="Screenshot 2025-02-11 at 12 49 02" src="https://github.com/user-attachments/assets/29afb48d-fd83-4bc8-83ef-057091e219ab" />

**After**

<img width="420" alt="Screenshot 2025-02-11 at 12 48 46" src="https://github.com/user-attachments/assets/b7ac228d-1e32-43a1-9693-a1ec47de79fe" />

When we add [a number input](https://github.com/Automattic/jetpack/issues/40961), its `type="number"` disallows non-numeric `value`, even if `placeholder` could be numeric. We would only need to support numeric placeholders for that input. We could change that field to `type="text"` in the editor, but that would miss out browser number controls, any styling applied to number fields, and otherwise also mismatch what they see in the editor with frontend.

**Before**

<img width="1163" alt="Screenshot 2025-02-11 at 12 57 28" src="https://github.com/user-attachments/assets/4948e0b3-74dd-4882-a761-474b2b028d55" />
<img width="1135" alt="Screenshot 2025-02-11 at 12 58 01" src="https://github.com/user-attachments/assets/495e9306-e13a-4ffb-88d9-035d7b6295bd" />

**After**

<img width="1188" alt="Screenshot 2025-02-11 at 12 33 56" src="https://github.com/user-attachments/assets/668746c2-3495-41e6-b2a3-0875e88484f3" />


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use a `placeholder` attribute in the editor for placeholder text instead of `value` attribute.
* Use `value` attribute _for entering_ the placeholder value while block is focused

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add different inputs and set their placeholders; they continue working.
* Try different form styles; you can still enter placeholders in editor with "animated" style, but with "outlined" style you can't. That's pre-existing issue. You can use the sidebar input, though.
    <img width="200" alt="image" src="https://github.com/user-attachments/assets/34c88cb1-cd19-4f71-964a-a4414c6c1511" />

