### PR TITLE
Forms: fix error setting for field

### DIFF
--- a/projects/packages/forms/.phan/baseline.php
+++ b/projects/packages/forms/.phan/baseline.php
@@ -9,7 +9,7 @@
  */
 return [
     // # Issue statistics:
-    // PhanTypeMismatchArgument : 20+ occurrences
+    // PhanTypeMismatchArgument : 25+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 10+ occurrences
     // PhanTypeMismatchReturnProbablyReal : 10+ occurrences
     // PhanTypeMismatchArgumentInternal : 6 occurrences
@@ -25,14 +25,13 @@ return [
     // PhanPossiblyNullTypeMismatchProperty : 1 occurrence
     // PhanTypeArraySuspiciousNullable : 1 occurrence
     // PhanTypeMismatchReturnNullable : 1 occurrence
-    // PhanUndeclaredProperty : 1 occurrence
     // PhanUnreferencedUseNormal : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-wpcom-rest-api-v2-endpoint-forms.php' => ['PhanTypePossiblyInvalidDimOffset'],
         'src/contact-form/class-admin.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn'],
-        'src/contact-form/class-contact-form-field.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyNullTypeMismatchProperty', 'PhanTypeConversionFromArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredProperty'],
+        'src/contact-form/class-contact-form-field.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyNullTypeMismatchProperty', 'PhanTypeConversionFromArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
         'src/contact-form/class-contact-form-plugin.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginRedundantAssignment', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal'],
         'src/contact-form/class-contact-form-shortcode.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
         'src/contact-form/class-contact-form.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginRedundantAssignment', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal'],

--- a/projects/packages/forms/changelog/fix-forms-error-setter
+++ b/projects/packages/forms/changelog/fix-forms-error-setter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix error setting for field

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -181,7 +181,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @param string $message The error message to display on the form.
 	 */
 	public function add_error( $message ) {
-		$this->is_error = true;
+		$this->error = true;
 
 		if ( ! is_wp_error( $this->form->errors ) ) {
 			$this->form->errors = new \WP_Error();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes:

> PHP Deprecated:  Creation of dynamic property Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field::$is_error is deprecated in /usr/local/src/jetpack-monorepo/projects/packages/forms/src/contact-form/class-contact-form-field.php on line 184


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change `is_error` to `error`, looks like this was a typo originally:

https://github.com/Automattic/jetpack/blob/87fbda5d7f6efd373e31b760b309ba4aaa297534/projects/packages/forms/src/contact-form/class-contact-form-field.php#L40-L45

https://github.com/Automattic/jetpack/blob/87fbda5d7f6efd373e31b760b309ba4aaa297534/projects/packages/forms/src/contact-form/class-contact-form-field.php#L184

https://github.com/Automattic/jetpack/blob/87fbda5d7f6efd373e31b760b309ba4aaa297534/projects/packages/forms/src/contact-form/class-contact-form-field.php#L193-L202

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* I'm not sure yet how this boolean is used and how to replicate its usage.
* I noticed ithe warning when testing https://github.com/Automattic/jetpack/pull/40962 and changing `type="number"` field into `text` with browser console, and trying to submit string value instead of number value:
<img width="1185" alt="Screenshot 2025-02-11 at 14 23 00" src="https://github.com/user-attachments/assets/247bef91-e819-400a-b00b-f02ac2fea0fe" />

