### PR TITLE
Forms: fix missing translations in Multiple choice field settings

### DIFF
--- a/projects/packages/forms/changelog/update-forms-choice-missing-translations
+++ b/projects/packages/forms/changelog/update-forms-choice-missing-translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix missing translations in choice field settings

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-choice/settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-choice/settings.js
@@ -1,6 +1,8 @@
+import { __ } from '@wordpress/i18n';
+
 export default {
 	styles: [
-		{ name: 'list', label: 'List', isDefault: true },
-		{ name: 'button', label: 'Button' },
+		{ name: 'list', label: __( 'List', 'jetpack-forms' ), isDefault: true },
+		{ name: 'button', label: __( 'Button', 'jetpack-forms' ) },
 	],
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes missing translations from Multiple choice field settings

<img width="284" alt="Screenshot 2025-02-11 at 16 12 01" src="https://github.com/user-attachments/assets/c2c1efd2-7eb7-42bf-bae7-ebd71768a946" />


Missed these in the previous scan for untranslated strings:
- https://github.com/Automattic/jetpack/pull/41671

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Multiple Choice field settings continue work just fine

