### PR TITLE
RDV: Add upload.php to the list of duplicated pages

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/rdv-media
+++ b/projects/packages/jetpack-mu-wpcom/changelog/rdv-media
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+RDV: Add upload.php to the list of duplicated pages

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/removed-calypso-screen-notice.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/removed-calypso-screen-notice.tsx
@@ -8,6 +8,7 @@ import {
 	archive,
 	category,
 	commentContent,
+	gallery,
 	pages,
 	postComments,
 	tag,
@@ -198,6 +199,20 @@ const Notice = () => {
 			)
 				? __(
 						"We've adopted WordPress' main Discussion Settings view to bring improvements to you and millions of WordPress users worldwide.",
+						'jetpack-mu-wpcom'
+				  )
+				: descriptionFallback,
+		},
+		'upload.php': {
+			icon: gallery,
+			title: hasTranslation( 'The Media Library just got an update' )
+				? __( 'The Media Library just got an update', 'jetpack-mu-wpcom' )
+				: titleFallback,
+			description: hasTranslation(
+				"We've adopted WordPress' main Media Library to bring improvements to you and millions of WordPress users worldwide."
+			)
+				? __(
+						"We've adopted WordPress' main Media Library to bring improvements to you and millions of WordPress users worldwide.",
 						'jetpack-mu-wpcom'
 				  )
 				: descriptionFallback,

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -131,6 +131,7 @@ const WPCOM_DUPLICATED_VIEW = array(
 	'options-writing.php',
 	'options-reading.php',
 	'options-discussion.php',
+	'upload.php',
 );
 
 /**


### PR DESCRIPTION

## Proposed changes:

This PR adds `upload.php` to the list of duplicated-view pages, meaning that users (under the holdout experiment) will be forced to use the classic `upload.php` instead of Calypso `/media/:siteSlug`.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

See the testing instructions from Calypso: 

- https://github.com/Automattic/wp-calypso/pull/99588
