### PR TITLE
Jetpack SEO: remove code from the first attempt of the trigger

### DIFF
--- a/projects/plugins/jetpack/changelog/cleanup-jetpack-seo-assistant-first-code
+++ b/projects/plugins/jetpack/changelog/cleanup-jetpack-seo-assistant-first-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO: remove code from the first attempt of the trigger, placed on AI panel of the Jetpack sidebar

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -26,12 +26,10 @@ import debugFactory from 'debug';
  */
 import useAiProductPage from '../../../../blocks/ai-assistant/hooks/use-ai-product-page';
 import { getFeatureAvailability } from '../../../../blocks/ai-assistant/lib/utils/get-feature-availability';
-// import { isBetaExtension } from '../../../../editor';
 import JetpackPluginSidebar from '../../../../shared/jetpack-plugin-sidebar';
 import { Breve, registerBreveHighlights, Highlight } from '../breve';
 import { getBreveAvailability, canWriteBriefBeEnabled } from '../breve/utils/get-availability';
 import Feedback from '../feedback';
-// import SeoAssistant from '../seo-assistant';
 import TitleOptimization from '../title-optimization';
 import UsagePanel from '../usage-panel';
 import {
@@ -79,15 +77,6 @@ const JetpackAndSettingsContent = ( {
 	const { checkoutUrl } = useAICheckout();
 	const { productPageUrl } = useAiProductPage();
 	const isBreveAvailable = getBreveAvailability();
-	// const isViewable = useSelect( select => {
-	// 	const postTypeName = select( editorStore ).getCurrentPostType();
-	// 	const postTypeObject = ( select( coreStore ) as unknown as CoreSelect ).getPostType(
-	// 		postTypeName
-	// 	);
-
-	// 	return postTypeObject?.viewable;
-	// }, [] );
-
 	const isPostEmpty = useSelect( select => select( editorStore ).isEditedPostEmpty(), [] );
 
 	const currentTitleOptimizationSectionLabel = __( 'Optimize Publishing', 'jetpack' );
@@ -105,19 +94,6 @@ const JetpackAndSettingsContent = ( {
 					</BaseControl>
 				</PanelRow>
 			) }
-
-			{ /* { isSeoAssistantEnabled && isViewable && (
-				<PanelRow
-					className={ `jetpack-ai-sidebar__feature-section ${
-						isBetaExtension( 'ai-seo-assistant' ) ? 'is-beta-extension' : ''
-					}` }
-				>
-					<BaseControl __nextHasNoMarginBottom={ true }>
-						<BaseControl.VisualLabel>{ __( 'SEO', 'jetpack' ) }</BaseControl.VisualLabel>
-						<SeoAssistant disabled={ false } />
-					</BaseControl>
-				</PanelRow>
-			) } */ }
 
 			{ isPostEmpty && (
 				<PanelRow className="jetpack-ai-sidebar__warning-content">


### PR DESCRIPTION


## Proposed changes:
This is a janitorial PR. It removes the commented out code from the first attempt for the trigger (AI panel on Jetpack sidebar)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
The code was commented out, nothing has changed.
Visit the editor. See the Jetpack sidebar and see there are no additional buttons on the AI panel.