### PR TITLE
Update launchpad options based on experiment

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-options-based-on-experiment
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-options-based-on-experiment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Launchpad: block design button for users of the treatment_cumulative group on an experiment 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -26,13 +26,13 @@ function wpcom_launchpad_should_use_wp_admin_link() {
  * @return Task[]
  */
 function wpcom_launchpad_get_task_definitions() {
-	$experiment_name  = 'calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131';
-	$user             = wp_get_current_user();
-	$is_user_assigned = false;
+	$experiment_name                   = 'calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131';
+	$user                              = wp_get_current_user();
+	$is_user_in_goals_first_experiment = false;
 
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM && $user && function_exists( '\ExPlat\get_user_assignment' ) ) {
-		$assignment       = \ExPlat\get_user_assignment( $experiment_name, $user );
-		$is_user_assigned = 'treatment_cumulative' === $assignment;
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM && $user && $user->exists() && function_exists( '\ExPlat\get_user_assignment' ) ) {
+		$assignment                        = \ExPlat\get_user_assignment( $experiment_name, $user );
+		$is_user_in_goals_first_experiment = 'treatment_cumulative' === $assignment;
 	}
 
 	$task_definitions = array(
@@ -59,14 +59,14 @@ function wpcom_launchpad_get_task_definitions() {
 				$flow = get_option( 'site_intent' );
 				return '/setup/update-design/designSetup?siteSlug=' . $data['site_slug_encoded'] . '&flow=' . $flow;
 			},
-			'is_disabled_callback' => $is_user_assigned ? '__return_true' : '__return_false',
+			'is_disabled_callback' => $is_user_in_goals_first_experiment ? '__return_true' : '__return_false',
 		),
 		'design_selected'                 => array(
 			'get_title'            => function () {
 				return __( 'Select a design', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => '__return_true',
-			'is_disabled_callback' => $is_user_assigned ? '__return_true' : 'wpcom_launchpad_is_design_step_enabled',
+			'is_disabled_callback' => $is_user_in_goals_first_experiment ? '__return_true' : 'wpcom_launchpad_is_design_step_enabled',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/setup/update-design/designSetup?siteSlug=' . $data['site_slug_encoded'];
 			},

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -28,8 +28,12 @@ function wpcom_launchpad_should_use_wp_admin_link() {
 function wpcom_launchpad_get_task_definitions() {
 	$experiment_name  = 'calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131';
 	$user             = wp_get_current_user();
-	$assignment       = \ExPlat\get_user_assignment( $experiment_name, $user );
-	$is_user_assigned = 'treatment_cumulative' === $assignment;
+	$is_user_assigned = false;
+
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM && $user && function_exists( '\ExPlat\get_user_assignment' ) ) {
+		$assignment       = \ExPlat\get_user_assignment( $experiment_name, $user );
+		$is_user_assigned = 'treatment_cumulative' === $assignment;
+	}
 
 	$task_definitions = array(
 		// Core tasks.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -26,6 +26,11 @@ function wpcom_launchpad_should_use_wp_admin_link() {
  * @return Task[]
  */
 function wpcom_launchpad_get_task_definitions() {
+	$experiment_name  = 'calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131';
+	$user             = wp_get_current_user();
+	$assignment       = \ExPlat\get_user_assignment( $experiment_name, $user );
+	$is_user_assigned = 'treatment_cumulative' === $assignment;
+
 	$task_definitions = array(
 		// Core tasks.
 		'design_edited'                   => array(
@@ -50,13 +55,14 @@ function wpcom_launchpad_get_task_definitions() {
 				$flow = get_option( 'site_intent' );
 				return '/setup/update-design/designSetup?siteSlug=' . $data['site_slug_encoded'] . '&flow=' . $flow;
 			},
+			'is_disabled_callback' => $is_user_assigned ? '__return_true' : '__return_false',
 		),
 		'design_selected'                 => array(
 			'get_title'            => function () {
 				return __( 'Select a design', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => '__return_true',
-			'is_disabled_callback' => 'wpcom_launchpad_is_design_step_enabled',
+			'is_disabled_callback' => $is_user_assigned ? '__return_true' : 'wpcom_launchpad_is_design_step_enabled',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/setup/update-design/designSetup?siteSlug=' . $data['site_slug_encoded'];
 			},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/99561
More context about the experiment usage: pet6gk-1Yy-p2#comment-1674

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We're blocking the `Select a design` button for users who belongs to the `treatment_cumulative` group of the `calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131` experiment. That will prevent undesirable navigation to onboarding themes from users of Focused Launchpad:

![image](https://github.com/user-attachments/assets/75dfc650-bb16-4c15-ae55-76377d58ba74)



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure your user belongs to the `treatment_cumulative` group of this experiment: 22180-explat-experiment
* Apply this change to your sandbox
* Go through the /setup/onboarding flow using the wpcalypso
* Once you arrive at your /home, make sure the `Select a design` CTA is not clickable