### PR TITLE
Forms: only add enctype for forms that need it

### DIFF
--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -922,7 +922,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	private function render_file_field( $id, $label, $class, $required, $required_field_text ) {
-
+		add_filter( 'jetpack_form_attributes', array( 'Automattic\Jetpack\Forms\ContactForm\Contact_Form', 'add_enctype_multipart_attribute' ) );
 		Assets::register_script(
 			'jetpack-form-file-field',
 			'../../dist/contact-form/js/file-field.js',

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -365,19 +365,54 @@ class Contact_Form extends Contact_Form_Shortcode {
 			 * @param string $contact_form_id Contact form post URL.
 			 * @param $post $GLOBALS['post'] Post global variable.
 			 * @param int $id Contact Form ID.
+			 * @param int $page Page number.
 			 */
 			$url                     = apply_filters( 'grunion_contact_form_form_action', "{$url}#contact-form-{$id}", $GLOBALS['post'], $id, $page );
 			$has_submit_button_block = str_contains( $content, 'wp-block-jetpack-button' );
 			$form_classes            = 'contact-form commentsblock';
 			$post_title              = $post->post_title ?? '';
 			$form_accessible_name    = ! empty( $attributes['formTitle'] ) ? $attributes['formTitle'] : $post_title;
-			$form_aria_label         = isset( $form_accessible_name ) && ! empty( $form_accessible_name ) ? 'aria-label="' . esc_attr( $form_accessible_name ) . '"' : '';
+			$form_aria_label         = isset( $form_accessible_name ) && ! empty( $form_accessible_name ) ? esc_attr( $form_accessible_name ) : '';
 
 			if ( $has_submit_button_block ) {
 				$form_classes .= ' wp-block-jetpack-contact-form';
 			}
 
-			$r .= "<form action='" . esc_url( $url ) . "' method='post' class='" . esc_attr( $form_classes ) . "' $form_aria_label enctype='multipart/form-data' novalidate>\n";
+			/**
+			 * Filter the contact form attributes that are applied to the form element.
+			 *
+			 * @module contact-form
+			 *
+			 * @since $$next-version&&
+			 *
+			 * @param array $attributes Contact form attributes. Array of key value pairs.
+			 * @param $post $GLOBALS['post'] Post global variable.
+			 * @param int $id Contact Form ID.
+			 * @param int $page Page number.
+			 */
+			$attributes = apply_filters(
+				'jetpack_form_attributes',
+				array(
+					'aria-label' => $form_aria_label,
+					'class'      => $form_classes,
+				),
+				$GLOBALS['post'],
+				$id,
+				$page
+			);
+
+			// Remove the form enctype attribute if it was applied.
+			remove_filter( 'jetpack_form_attributes', array( 'Automattic\Jetpack\Forms\ContactForm\Contact_Form', 'add_enctype_attribute' ) );
+
+			$form_attributes = '';
+			foreach ( $attributes  as $key => $attributes ) {
+				if ( empty( $attributes ) ) {
+					continue;
+				}
+				$form_attributes .= $key . '="' . esc_attr( $attributes ) . '" ';
+			}
+
+			$r .= "<form action='" . esc_url( $url ) . "' method='post' " . $form_attributes . " novalidate>\n";
 			$r .= $form->body;
 
 			// In new versions of the contact form block the button is an inner block
@@ -459,6 +494,17 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 * @param string $r The contact form HTML.
 		 */
 		return apply_filters( 'jetpack_contact_form_html', $r );
+	}
+
+	/**
+	 * Function that adds the enctype attribute to the form element attributes.
+	 * This is useful for addin the myultipart/form-data to the form HTML element.
+	 *
+	 * @param array $attributes - the attributes.
+	 */
+	public static function add_enctype_multipart_attribute( $attributes ) {
+		$attributes['enctype'] = 'multipart/form-data';
+		return $attributes;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -402,7 +402,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			);
 
 			// Remove the form enctype attribute if it was applied.
-			remove_filter( 'jetpack_form_attributes', array( 'Automattic\Jetpack\Forms\ContactForm\Contact_Form', 'add_enctype_attribute' ) );
+			remove_filter( 'jetpack_form_attributes', array( 'Automattic\Jetpack\Forms\ContactForm\Contact_Form', 'add_enctype_multipart_attribute' ) );
 
 			$form_attributes = '';
 			foreach ( $attributes  as $key => $attributes ) {


### PR DESCRIPTION
This PR update the form filed to only include the multipart when it is needed. 

## Proposed changes:
* Adds a new filter that lets you filter and update the form attributes except for the ones that are required URL and method.
* Add the enctype attribute by calling adding the correct filter if the file filed is being rendered.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* ON a page add a bunch of forms. 
* Notice that all the form with the file filed have the `enctype` set correctly and all the other ones do not have that value. 

