### PR TITLE
Boost: Improve 404 handler URL path processing

### DIFF
--- a/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
@@ -198,7 +198,7 @@ class Concatenate_CSS extends WP_Styles {
 					$file_name = jetpack_boost_page_optimize_generate_concat_path( $css, $this->dependency_path_mapping );
 
 					if ( get_site_option( 'jetpack_boost_static_minification' ) ) {
-						$href = jetpack_boost_get_minify_url( $file_name . '.min.css', $siteurl );
+						$href = jetpack_boost_get_minify_url( $file_name . '.min.css' );
 					} else {
 						$href = $siteurl . jetpack_boost_get_static_prefix() . '??' . $file_name;
 					}

--- a/projects/plugins/boost/app/lib/minify/Concatenate_JS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_JS.php
@@ -257,7 +257,7 @@ class Concatenate_JS extends WP_Scripts {
 					$file_name = jetpack_boost_page_optimize_generate_concat_path( $js_array['paths'], $this->dependency_path_mapping );
 
 					if ( get_site_option( 'jetpack_boost_static_minification' ) ) {
-						$href = jetpack_boost_get_minify_url( $file_name . '.min.js', $siteurl );
+						$href = jetpack_boost_get_minify_url( $file_name . '.min.js' );
 					} else {
 						$href = $siteurl . jetpack_boost_get_static_prefix() . '??' . $file_name;
 					}

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -303,8 +303,8 @@ function jetpack_boost_get_static_prefix() {
 	return trailingslashit( $prefix );
 }
 
-function jetpack_boost_get_minify_url( $file_name, $site_url ) {
-	return $site_url . '/wp-content/boost-cache/static/' . $file_name;
+function jetpack_boost_get_minify_url( $file_name = '' ) {
+	return content_url( '/boost-cache/static/' . $file_name );
 }
 
 /**

--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -320,12 +320,7 @@ function jetpack_boost_minify_get_file_parts( $request_uri ) {
 	}
 
 	$file_info = pathinfo( $file_path );
-	$real_path = realpath( ABSPATH . $file_info['dirname'] );
-	$cache_dir = realpath( WP_CONTENT_DIR . '/boost-cache/static' );
-
-	// Security check: Ensure requested file is strictly within the designated cache directory
-	// by comparing the resolved absolute paths.
-	if ( $real_path === false || $cache_dir === false || stripos( $real_path, $cache_dir ) !== 0 ) {
+	if ( trailingslashit( site_url( $file_info['dirname'] ) ) !== jetpack_boost_get_minify_url() ) {
 		return false;
 	}
 

--- a/projects/plugins/boost/changelog/fix-minify-static-file-dir
+++ b/projects/plugins/boost/changelog/fix-minify-static-file-dir
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix 404 handler path comparison logic to handle complex setups
+
+


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Improve how URL matching for static files are handled to cover more situations.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1739291038738559-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
* On JN, the wp-content directory is not under `ABSPATH`. So, previously static file handlers would not work in JN.
* Enable Concatenate JS/CSS on a JN site.
* Make sure concatenated files are served from `wp-content/boost-cache/static/`