### PR TITLE
Forms: Add tracking for plugin installs

### DIFF
--- a/projects/packages/forms/changelog/update-forms-tracking-plugin-installs
+++ b/projects/packages/forms/changelog/update-forms-tracking-plugin-installs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Added tracking for plugin installations.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-crm-integration/jetpack-crm-integration-settings-plugin-state.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-crm-integration/jetpack-crm-integration-settings-plugin-state.js
@@ -56,7 +56,7 @@ const CRMPluginIsNotInstalled = ( { installAndActivateCRMPlugin, isInstalling } 
 		<Button
 			variant="secondary"
 			onClick={ () => {
-				tracks.recordEvent( 'jetpack_forms_crm_plugin_install_click' );
+				tracks.recordEvent( 'jetpack_forms_plugin_install_crm_click' );
 				installAndActivateCRMPlugin();
 			} }
 		>
@@ -98,7 +98,7 @@ const CRMPluginIsInstalled = ( { activateCRMPlugin, isInstalling } ) => {
 				<Button
 					variant="secondary"
 					onClick={ () => {
-						tracks.recordEvent( 'jetpack_forms_crm_plugin_activate_click' );
+						tracks.recordEvent( 'jetpack_forms_plugin_activate_crm_click' );
 						activateCRMPlugin();
 					} }
 				>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-crm-integration/jetpack-crm-integration-settings-plugin-state.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-crm-integration/jetpack-crm-integration-settings-plugin-state.js
@@ -1,3 +1,4 @@
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button, Icon, ToggleControl } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -50,8 +51,15 @@ const CRMPluginIsInstalling = ( { isActivating } ) => {
 };
 
 const CRMPluginIsNotInstalled = ( { installAndActivateCRMPlugin, isInstalling } ) => {
+	const { tracks } = useAnalytics();
 	let button = (
-		<Button variant="secondary" onClick={ installAndActivateCRMPlugin }>
+		<Button
+			variant="secondary"
+			onClick={ () => {
+				tracks.recordEvent( 'jetpack_forms_crm_plugin_install_click' );
+				installAndActivateCRMPlugin();
+			} }
+		>
 			{ __( 'Install Jetpack CRM', 'jetpack-forms' ) }
 		</Button>
 	);
@@ -75,18 +83,25 @@ const CRMPluginIsNotInstalled = ( { installAndActivateCRMPlugin, isInstalling } 
 };
 
 const CRMPluginIsInstalled = ( { activateCRMPlugin, isInstalling } ) => {
+	const { tracks } = useAnalytics();
 	return (
 		<p className="jetpack-contact-form__crm_text jetpack-contact-form__integration-panel">
 			<em>
 				{ __(
-					'You already have the Jetpack CRM plugin installed, but it’s not activated.',
+					"You already have the Jetpack CRM plugin installed, but it's not activated.",
 					'jetpack-forms'
 				) }
 			</em>
 			<br />
 			{ isInstalling && <CRMPluginIsInstalling isActivating /> }
 			{ ! isInstalling && (
-				<Button variant="secondary" onClick={ activateCRMPlugin }>
+				<Button
+					variant="secondary"
+					onClick={ () => {
+						tracks.recordEvent( 'jetpack_forms_crm_plugin_activate_click' );
+						activateCRMPlugin();
+					} }
+				>
 					{ __( 'Activate the Jetpack CRM plugin', 'jetpack-forms' ) }
 				</Button>
 			) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-newsletter-integration-settings-plugin-state.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-newsletter-integration-settings-plugin-state.js
@@ -1,4 +1,4 @@
-import { getJetpackData } from '@automattic/jetpack-shared-extension-utils';
+import { getJetpackData, useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button, ExternalLink, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { get } from 'lodash';
@@ -33,6 +33,7 @@ const CreativeMailPluginIsNotInstalled = ( {
 	installAndActivateCreativeMailPlugin,
 	isInstalling,
 } ) => {
+	const { tracks } = useAnalytics();
 	return (
 		<p className="jetpack-contact-form__integration-panel">
 			<em style={ { color: 'rgba(38, 46, 57, 0.7)' } }>
@@ -43,7 +44,13 @@ const CreativeMailPluginIsNotInstalled = ( {
 				<br />
 				{ isInstalling && <CreativeMailPluginIsInstalling /> }
 				{ ! isInstalling && (
-					<Button variant="secondary" onClick={ installAndActivateCreativeMailPlugin }>
+					<Button
+						variant="secondary"
+						onClick={ () => {
+							tracks.recordEvent( 'jetpack_forms_creativemail_plugin_install_click' );
+							installAndActivateCreativeMailPlugin();
+						} }
+					>
 						{ __( 'Install Creative Mail plugin', 'jetpack-forms' ) }
 					</Button>
 				) }
@@ -53,6 +60,7 @@ const CreativeMailPluginIsNotInstalled = ( {
 };
 
 const CreativeMailPluginIsInstalled = ( { activateCreativeMailPlugin, isInstalling } ) => {
+	const { tracks } = useAnalytics();
 	return (
 		<p className="jetpack-contact-form__integration-panel">
 			<em>
@@ -64,7 +72,13 @@ const CreativeMailPluginIsInstalled = ( { activateCreativeMailPlugin, isInstalli
 			<br />
 			{ isInstalling && <CreativeMailPluginIsInstalling isActivating /> }
 			{ ! isInstalling && (
-				<Button variant="secondary" onClick={ activateCreativeMailPlugin }>
+				<Button
+					variant="secondary"
+					onClick={ () => {
+						tracks.recordEvent( 'jetpack_forms_creativemail_plugin_activate_click' );
+						activateCreativeMailPlugin();
+					} }
+				>
 					{ __( 'Activate Creative Mail Plugin', 'jetpack-forms' ) }
 				</Button>
 			) }
@@ -81,7 +95,7 @@ const CreativeMailPluginIsActive = () => {
 	return (
 		<p>
 			<em>
-				{ __( 'You’re all setup for email marketing with Creative Mail.', 'jetpack-forms' ) }
+				{ __( "You're all setup for email marketing with Creative Mail.", 'jetpack-forms' ) }
 				<br />
 				<ExternalLink href={ getCreativeMailPluginUrl() }>
 					{ __( 'Open Creative Mail settings', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-newsletter-integration-settings-plugin-state.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-newsletter-integration-settings-plugin-state.js
@@ -47,7 +47,7 @@ const CreativeMailPluginIsNotInstalled = ( {
 					<Button
 						variant="secondary"
 						onClick={ () => {
-							tracks.recordEvent( 'jetpack_forms_creativemail_plugin_install_click' );
+							tracks.recordEvent( 'jetpack_forms_plugin_install_creativemail_click' );
 							installAndActivateCreativeMailPlugin();
 						} }
 					>
@@ -75,7 +75,7 @@ const CreativeMailPluginIsInstalled = ( { activateCreativeMailPlugin, isInstalli
 				<Button
 					variant="secondary"
 					onClick={ () => {
-						tracks.recordEvent( 'jetpack_forms_creativemail_plugin_activate_click' );
+						tracks.recordEvent( 'jetpack_forms_plugin_activate_creativemail_click' );
 						activateCreativeMailPlugin();
 					} }
 				>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #2254
Replaces #41695 and #41705

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Adds Tracks events when users click to install or activate either Jetpack CRM or Creative Mail from the contact form block sidebar. I copied the pattern we use for tracking Stripe clicks in the payment button blocks ([see here](https://github.com/Automattic/jetpack/blob/125c2430835f477bc255dae45246e6f8277f81d7/projects/plugins/jetpack/extensions/shared/components/stripe-nudge/index.jsx#L21)).

In one of the other PRs @enejb [suggested](https://github.com/Automattic/jetpack/pull/41695#issuecomment-2649406636) avoiding code duplication by putting the tracking in the installAndActivatePlugin method. But (a) we'd still need to add the changes twice in that method and the activatePlugin method and (b) we need to know the source of a plugin install or activation, not just that it happened. 

My other approach also didn't do (b), which is why I've prepared this this as an alternative. 

<img width="1507" alt="jetpack-forms-crm-button" src="https://github.com/user-attachments/assets/66766db0-c129-4f4c-a1ed-ae316340787f" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Preparation: 
- Tracks Vigilante: You will need to ensure you can see Tracks events as they are fired. The best way is to install Tracks Vigilante here: https://github.com/Automattic/tracks-chrome-extension Once installed, you'll be able to see tracks events in the Chrome toolbar.
- Jetpack CRM Plugin. Deactivate and delete Jetpack CRM if you have it installed as a separate plugin.
- Creative Mail Plugin. Deactivate and delete this if you have it installed as a separate plugin.

Test: 
- Go to a page or post and insert a form block.
- Clear all current tracks events from Tracks Vigilante to make it easier to see new events.
- Go to the contact form block sidebar and click the button to install Jetpack CRM. 
- Confirm that the `jetpack_form_crm_plugin_install_click` Tracks event is fired.
- Also in the sidebar click the button to install Creative Mail. 
- Confirm that the `jetpack_forms_creativemail_plugin_install_click` Tracks event is fired.
- Go to your site's plugin page and deactivate both plugins but leave the installed.
- Return to your post with your contact form, refresh the page if needed, go to the contact form block sidebar, and click the buttons the activate Jetpack CRM and Creative Mail again.
- Confirm that the `jetpack_forms_crm_plugin_activate_click` and `jetpack_forms_creativemail_plugin_activate_click` Tracks events iare fired.