### PR TITLE
Verbum: disable block editor

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/verbum-fix-block-editor
+++ b/projects/packages/jetpack-mu-wpcom/changelog/verbum-fix-block-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Comments: fix broken editor

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/comment-input-field.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/comment-input-field.tsx
@@ -4,7 +4,6 @@ import { forwardRef, type TargetedEvent } from 'preact/compat';
 import { useContext, useEffect, useState } from 'preact/hooks';
 import { translate } from '../i18n';
 import { VerbumSignals } from '../state';
-import { isFastConnection } from '../utils';
 import { EditorPlaceholder } from './editor-placeholder';
 
 type CommentInputFieldProps = {
@@ -41,9 +40,10 @@ export const CommentInputField = forwardRef(
 		const [ isGBEditorEnabled, setIsGBEditorEnabled ] = useState( false );
 
 		useEffect( () => {
-			setTimeout( () => {
-				setIsGBEditorEnabled( VerbumComments.enableBlocks && isFastConnection() );
-			} );
+			// TODO: Fix Gutenberg editor not loading for logged out users.
+			// setTimeout( () => {
+			// 	setIsGBEditorEnabled( VerbumComments.enableBlocks && isFastConnection() );
+			// } );
 		}, [] );
 
 		/**


### PR DESCRIPTION
Related to #41722 

## Proposed changes:

* This is a temporary fix to buy me some time to find the real issue. Disabling the block editor for now.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Follow the instructions to pull this PR into your sandbox.
2. Sandbox a test site
3. Go to a post and try to make a comment.
4. You should see a textarea and have no problem leaving a comment.
