### PR TITLE
Account Protection: Fix Brute force protection account recovery conflict

### DIFF
--- a/projects/packages/account-protection/src/class-password-detection.php
+++ b/projects/packages/account-protection/src/class-password-detection.php
@@ -49,8 +49,13 @@ class Password_Detection {
 			return $user;
 		}
 
+		// Skip if we're validating a Brute force protection recovery token
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['validate_jetpack_protect_recovery'] ) ) {
+			return $user;
+		}
+
 		if ( $this->validation_service->is_weak_password( $password ) ) {
-			// TODO: Every time the user logs in we generate a new token based transient. This might not be ideal.
 			$transient = $this->generate_and_store_transient_data( $user->ID );
 
 			$email_sent = $this->email_service->api_send_auth_email( $user, $transient['auth_code'] );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
When the Brute force module reaches a point where a user is blocked and locked out, the recovery process hooks into the same `wp_authenticate_user` flow that Account Protection currently does for validation the users password. When validation fails a `WP_Error` object is returned and the BFP method then picks it up and attempts to run `check_valid_blocked_user` which doesn't currently expect that value and immediately errors out.

Note that a separate [issue](https://github.com/Automattic/jetpack-scan-team/issues/1708) has been defined separate from this project to address the bug.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Skip our validation process when we detect the Brute force recovery param in the URL string, immediately passing back the current $user object for Brute force to continue the recovery validation and redirection process.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://github.com/Automattic/jetpack-scan-team/issues/1709

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch running JT with Protect, Account Protection and Brute Force Protection enabled
* Login in incorrectly enough times to have BFP block your access, along the way ensure the BFP module is functioning correctly without conflict
* Once locked out, follow the recovery process BFP provides when attempting to login
* Remove the new `validate_jetpack_protect_recovery` check
* Follow the recovery email link and ensure that when you provide your current password that you are blocked from logging in with a `The recovery token is not valid for this user.` error
* Log out the error and verify that it is in fact from the Password Detection flow: `Password validation failed.`
* Reapply the check, and attempt to log in once again
* Ensure that validation passes (as long as the token remains valid) and that you are appropriately logged in
* Ensure no regressions in BFP or Account Protection Password Detection functionality are introduced

