### PR TITLE
Chart Library: add and adjust WPCOM and Jetpack chart themes

### DIFF
--- a/projects/js-packages/charts/changelog/update-chart-library-adjust-theme-colours
+++ b/projects/js-packages/charts/changelog/update-chart-library-adjust-theme-colours
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Charts: adds wpcom theme, adjusts jetpack theme colours

--- a/projects/js-packages/charts/index.ts
+++ b/projects/js-packages/charts/index.ts
@@ -10,7 +10,7 @@ export { Legend } from './src/components/legend';
 
 // Providers
 export { ThemeProvider } from './src/providers/theme';
-export { defaultTheme, jetpackTheme, wooTheme } from './src/providers/theme/themes';
+export { defaultTheme, jetpackTheme, wooTheme, wpcomTheme } from './src/providers/theme/themes';
 
 // Hooks
 export { default as useChartMouseHandler } from './src/hooks/use-chart-mouse-handler';

--- a/projects/js-packages/charts/src/components/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/donut.stories.tsx
@@ -1,6 +1,6 @@
 import { Group } from '@visx/group';
 import { Text } from '@visx/text';
-import { ThemeProvider, jetpackTheme, wooTheme, WPCOMTheme } from '../../../providers/theme';
+import { ThemeProvider, jetpackTheme, wooTheme, wpcomTheme } from '../../../providers/theme';
 import { PieChart } from '../../pie-chart';
 import type { Meta, StoryObj } from '@storybook/react';
 
@@ -86,7 +86,7 @@ const meta = {
 				default: undefined,
 				jetpack: jetpackTheme,
 				woo: wooTheme,
-				wpcom: WPCOMTheme,
+				wpcom: wpcomTheme,
 			},
 			defaultValue: undefined,
 		},

--- a/projects/js-packages/charts/src/components/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/donut.stories.tsx
@@ -1,6 +1,6 @@
 import { Group } from '@visx/group';
 import { Text } from '@visx/text';
-import { ThemeProvider, jetpackTheme, wooTheme } from '../../../providers/theme';
+import { ThemeProvider, jetpackTheme, wooTheme, WPCOMTheme } from '../../../providers/theme';
 import { PieChart } from '../../pie-chart';
 import type { Meta, StoryObj } from '@storybook/react';
 
@@ -86,6 +86,7 @@ const meta = {
 				default: undefined,
 				jetpack: jetpackTheme,
 				woo: wooTheme,
+				wpcom: WPCOMTheme,
 			},
 			defaultValue: undefined,
 		},

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
@@ -1,6 +1,6 @@
 import { Group } from '@visx/group';
 import { Text } from '@visx/text';
-import { ThemeProvider, jetpackTheme, wooTheme } from '../../../providers/theme';
+import { ThemeProvider, jetpackTheme, wooTheme, WPCOMTheme } from '../../../providers/theme';
 import { PieChart } from '../index';
 import type { Meta, StoryObj } from '@storybook/react';
 
@@ -104,6 +104,7 @@ const meta = {
 				default: undefined,
 				jetpack: jetpackTheme,
 				woo: wooTheme,
+				wpcom: WPCOMTheme,
 			},
 			defaultValue: undefined,
 		},

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
@@ -1,6 +1,6 @@
 import { Group } from '@visx/group';
 import { Text } from '@visx/text';
-import { ThemeProvider, jetpackTheme, wooTheme, WPCOMTheme } from '../../../providers/theme';
+import { ThemeProvider, jetpackTheme, wooTheme, wpcomTheme } from '../../../providers/theme';
 import { PieChart } from '../index';
 import type { Meta, StoryObj } from '@storybook/react';
 
@@ -104,7 +104,7 @@ const meta = {
 				default: undefined,
 				jetpack: jetpackTheme,
 				woo: wooTheme,
-				wpcom: WPCOMTheme,
+				wpcom: wpcomTheme,
 			},
 			defaultValue: undefined,
 		},

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -10,7 +10,7 @@ export { Legend } from './components/legend';
 
 // Themes
 export { ThemeProvider } from './providers/theme';
-export { defaultTheme, jetpackTheme, wooTheme } from './providers/theme/themes';
+export { defaultTheme, jetpackTheme, wooTheme, wpcomTheme } from './providers/theme/themes';
 
 // Hooks
 export { default as useChartMouseHandler } from './hooks/use-chart-mouse-handler';

--- a/projects/js-packages/charts/src/providers/theme/index.ts
+++ b/projects/js-packages/charts/src/providers/theme/index.ts
@@ -1,2 +1,2 @@
 export { ThemeProvider, useChartTheme } from './theme-provider';
-export { defaultTheme, jetpackTheme, wooTheme } from './themes';
+export { defaultTheme, jetpackTheme, wooTheme, wpcomTheme } from './themes';

--- a/projects/js-packages/charts/src/providers/theme/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/providers/theme/stories/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { ThemeProvider, jetpackTheme, wooTheme, wpcomTheme } from '../';
+import { ThemeProvider, jetpackTheme, wooTheme, wpcomTheme as wpcomThemeConfig } from '../';
 import { LineChart, BarChart, PieSemiCircleChart } from '../../../.';
 import barSampleData from '../../../components/bar-chart/stories/sample-data';
 
@@ -94,9 +94,9 @@ export const JetpackTheme: Story = {
 	),
 };
 
-export const wpcomTheme: Story = {
+export const WPcomTheme: Story = {
 	render: () => (
-		<ThemeProvider theme={ wpcomTheme }>
+		<ThemeProvider theme={ wpcomThemeConfig }>
 			<GridComponent>
 				<LineChart data={ lineSampleData } width={ 400 } height={ 300 } />
 				<BarChart data={ sampleData } width={ 400 } height={ 300 } />

--- a/projects/js-packages/charts/src/providers/theme/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/providers/theme/stories/index.stories.tsx
@@ -94,7 +94,7 @@ export const JetpackTheme: Story = {
 	),
 };
 
-export const WPCOMTheme: Story = {
+export const wpcomTheme: Story = {
 	render: () => (
 		<ThemeProvider theme={ wpcomTheme }>
 			<GridComponent>
@@ -113,31 +113,6 @@ export const WooTheme: Story = {
 				<LineChart data={ lineSampleData } width={ 400 } height={ 300 } />
 				<BarChart data={ sampleData } width={ 400 } height={ 300 } />
 				<PieSemiCircleChart data={ pieData } width={ 400 } label="Pie Chart" note="Woo Theme" />
-			</GridComponent>
-		</ThemeProvider>
-	),
-};
-
-export const CustomColorTheme: Story = {
-	render: () => (
-		<ThemeProvider
-			theme={ {
-				colors: [ '#073B3A', '#0B6E4F', '#08A045', '#6BBF59', '#DDB771' ],
-				gridStyles: {
-					stroke: '#ffe3e3',
-					strokeWidth: 2,
-				},
-			} }
-		>
-			<GridComponent>
-				<LineChart data={ lineSampleData } width={ 400 } height={ 300 } />
-				<BarChart data={ sampleData } width={ 400 } height={ 300 } />
-				<PieSemiCircleChart
-					data={ pieData }
-					width={ 400 }
-					label="Pie Chart"
-					note="Custom Color Theme"
-				/>
 			</GridComponent>
 		</ThemeProvider>
 	),

--- a/projects/js-packages/charts/src/providers/theme/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/providers/theme/stories/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { ThemeProvider, jetpackTheme, wooTheme, wpcomTheme as wpcomThemeConfig } from '../';
+import { ThemeProvider, jetpackTheme, wooTheme, wpcomTheme } from '../';
 import { LineChart, BarChart, PieSemiCircleChart } from '../../../.';
 import barSampleData from '../../../components/bar-chart/stories/sample-data';
 
@@ -96,7 +96,7 @@ export const JetpackTheme: Story = {
 
 export const WPcomTheme: Story = {
 	render: () => (
-		<ThemeProvider theme={ wpcomThemeConfig }>
+		<ThemeProvider theme={ wpcomTheme }>
 			<GridComponent>
 				<LineChart data={ lineSampleData } width={ 400 } height={ 300 } />
 				<BarChart data={ sampleData } width={ 400 } height={ 300 } />

--- a/projects/js-packages/charts/src/providers/theme/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/providers/theme/stories/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { ThemeProvider, jetpackTheme, wooTheme } from '../.';
+import { ThemeProvider, jetpackTheme, wooTheme, wpcomTheme } from '../';
 import { LineChart, BarChart, PieSemiCircleChart } from '../../../.';
 import barSampleData from '../../../components/bar-chart/stories/sample-data';
 
@@ -89,6 +89,18 @@ export const JetpackTheme: Story = {
 				<LineChart data={ lineSampleData } width={ 400 } height={ 300 } />
 				<BarChart data={ sampleData } width={ 400 } height={ 300 } />
 				<PieSemiCircleChart data={ pieData } width={ 400 } label="Pie Chart" note="Jetpack Theme" />
+			</GridComponent>
+		</ThemeProvider>
+	),
+};
+
+export const WPCOMTheme: Story = {
+	render: () => (
+		<ThemeProvider theme={ wpcomTheme }>
+			<GridComponent>
+				<LineChart data={ lineSampleData } width={ 400 } height={ 300 } />
+				<BarChart data={ sampleData } width={ 400 } height={ 300 } />
+				<PieSemiCircleChart data={ pieData } width={ 400 } label="Pie Chart" note="WPCOM Theme" />
 			</GridComponent>
 		</ThemeProvider>
 	),

--- a/projects/js-packages/charts/src/providers/theme/themes.ts
+++ b/projects/js-packages/charts/src/providers/theme/themes.ts
@@ -22,17 +22,22 @@ const defaultTheme: ChartTheme = {
  * Jetpack theme configuration
  */
 const jetpackTheme: ChartTheme = {
-	backgroundColor: '#FFFFFF', // chart background color
-	labelBackgroundColor: '#FFFFFF', // label background color
-	colors: [ '#98C8DF', '#006DAB', '#A6DC80', '#1F9828', '#FF8C8F' ],
+	backgroundColor: '#FFFFFF',
+	labelBackgroundColor: '#FFFFFF',
+	colors: [
+		'#069e08', // --jp-green-primary (--jp-green-40)
+		'#2fb41f', // --jp-green-secondary (--jp-green-30)
+		'#64ca43', // --jp-green-20
+		'#9dd977', // --jp-green-10
+	],
 	gridStyles: {
 		stroke: '#DCDCDE',
 		strokeWidth: 1,
 	},
 	tickLength: 4,
-	gridColor: '',
-	gridColorDark: '',
-	xTickLineStyles: { stroke: 'black' },
+	gridColor: '#DCDCDE',
+	gridColorDark: '#1e1e1e',
+	xTickLineStyles: { stroke: '#1e1e1e' },
 	xAxisLineStyles: { stroke: '#DCDCDE', strokeWidth: 1 },
 };
 
@@ -54,4 +59,32 @@ const wooTheme: ChartTheme = {
 	xAxisLineStyles: { stroke: '#DCDCDE', strokeWidth: 1 },
 };
 
-export { defaultTheme, jetpackTheme, wooTheme };
+/**
+ * WPCOM theme configuration using official Calypso colors
+ */
+const wpcomTheme: ChartTheme = {
+	backgroundColor: '#FFFFFF',
+	labelBackgroundColor: '#FFFFFF',
+	colors: [
+		'#2271b1', // --studio-wordpress-blue-60
+		'#72aee6', // --studio-wordpress-blue-30
+		'#135e96', // --studio-wordpress-blue-70
+		'#c3c4c7', // --studio-wordpress-blue-10
+	],
+	gridStyles: {
+		stroke: '#1e1e1e', // --studio-gray-100
+		strokeWidth: 1,
+	},
+	tickLength: 4,
+	gridColor: '#c3c4c7', // --studio-wordpress-blue-10
+	gridColorDark: '#1e1e1e', // --studio-gray-100
+	xTickLineStyles: {
+		stroke: '#1e1e1e', // --studio-gray-100
+	},
+	xAxisLineStyles: {
+		stroke: '#c3c4c7', // --studio-wordpress-blue-10
+		strokeWidth: 1,
+	},
+};
+
+export { defaultTheme, jetpackTheme, wooTheme, wpcomTheme };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds wpcom theme with wordpress blue
* adjusts jetpack theme to use jetpack green

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

In your Jetpack local env, navigate to the Storybook development environment:

```
pnpm i
cd projects/js-packages/storybook
pnpm run storybook:dev
```

Find `JS Packages/Charts/Themes/` in the sidebar then check out the Jetpack and WPCOM themes. 

![image](https://github.com/user-attachments/assets/9b062a2a-be3f-4a56-a1d0-a67a9ba00580)

