### PR TITLE
Boost: Fix where a site has a directory in the base url.

### DIFF
--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -320,7 +320,9 @@ function jetpack_boost_minify_get_file_parts( $request_uri ) {
 	}
 
 	$file_info = pathinfo( $file_path );
-	if ( trailingslashit( site_url( $file_info['dirname'] ) ) !== jetpack_boost_get_minify_url() ) {
+
+	$minify_path = $utils->parse_url( jetpack_boost_get_minify_url(), PHP_URL_PATH );
+	if ( trailingslashit( $file_info['dirname'] ) !== $minify_path ) {
 		return false;
 	}
 

--- a/projects/plugins/boost/changelog/update-boost-fix-path-checking
+++ b/projects/plugins/boost/changelog/update-boost-fix-path-checking
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Concatenation: fixes for when the site_url has a directory in it when testing the path we're going to write to.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
If a site is at /blog/ then dirname will be /blog/wp-content/boost-cache/static/ and the site_url will also have a
"/blog" in it, so the site_url version will be "/blog/blog/wp-content...".

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Don't pass dirname to site_url because it may add an extra directory. Compare paths instead.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test this on a site with a sub directory in the URL.
* Make sure that static cache files are in the right place.

