### PR TITLE
Update JITM JavaScript to utilise @wordpress/api-fetch

### DIFF
--- a/projects/packages/jitm/changelog/update-jitm-js-api-fetch
+++ b/projects/packages/jitm/changelog/update-jitm-js-api-fetch
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update Ajax calls to utililse @wordpress/api-fetch in preparation for https://github.com/Automattic/jetpack/pull/41252.

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -1,6 +1,4 @@
 import jQuery from 'jquery';
-import apiFetch from '@wordpress/api-fetch';
-import { addQueryArgs } from '@wordpress/url';
 
 import '../css/jetpack-admin-jitm.scss';
 
@@ -158,7 +156,7 @@ jQuery( document ).ready( function ( $ ) {
 
 				apiFetch( {
 					path: '/jetpack/v4/jitm',
-					method: 'POST', // using POST since DELETE has nginx issues
+					method: 'POST', // using DELETE without permalinks is broken in default nginx configuration
 					data: {
 						id: response.id,
 						feature_class: response.feature_class,
@@ -204,15 +202,22 @@ jQuery( document ).ready( function ( $ ) {
 				return false;
 			}
 
-			// Change the button status to disabled as the change is in progress.
-			$( '#jitm-banner__activate a' ).text( window.jitm_config.activating_module_text );
-			$( '#jitm-banner__activate a' ).attr( 'disabled', true );
-
 			// Make request to activate module.
-			apiFetch( {
-				path: `/jetpack/v4/module/${ $activate_button.data( 'module' ) }/active`,
+			$.ajax( {
+				url:
+					window.jitm_config.api_root +
+					'jetpack/v4/module/' +
+					$activate_button.data( 'module' ) +
+					'/active',
 				method: 'POST',
-			} ).then( function () {
+				beforeSend: function ( xhr ) {
+					xhr.setRequestHeader( 'X-WP-Nonce', $el.data( 'nonce' ) );
+
+					// Change the button status to disabled as the change is in progress.
+					$( '#jitm-banner__activate a' ).text( window.jitm_config.activating_module_text );
+					$( '#jitm-banner__activate a' ).attr( 'disabled', true );
+				},
+			} ).done( function () {
 				// Display the link to settings and hide the activate link
 				$( '#jitm-banner__activate a' ).text( window.jitm_config.activated_module_text );
 				$( '#jitm-banner__activate a' ).attr( 'disabled', true );
@@ -295,13 +300,11 @@ jQuery( document ).ready( function ( $ ) {
 
 			var full_jp_logo_exists = $( '.jetpack-logo__masthead' ).length ? true : false;
 
-			apiFetch( {
-				path: addQueryArgs( '/jetpack/v4/jitm', {
-					message_path: message_path,
-					query: query,
-					full_jp_logo_exists: full_jp_logo_exists,
-				} ),
-				method: 'GET',
+			$.get( window.jitm_config.api_root + 'jetpack/v4/jitm', {
+				message_path: message_path,
+				query: query,
+				full_jp_logo_exists: full_jp_logo_exists,
+				_wpnonce: $el.data( 'nonce' ),
 			} ).then( function ( response ) {
 				if ( 'object' === typeof response && response[ '1' ] ) {
 					response = [ response[ '1' ] ];

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -54,11 +54,7 @@ jQuery( document ).ready( function ( $ ) {
 								'</a>';
 						}
 
-						html +=
-							'<li>' +
-							CHECKMARK_ICON +
-							text +
-							'</li>';
+						html += '<li>' + CHECKMARK_ICON + text + '</li>';
 					}
 				}
 				html += '</div>';
@@ -73,7 +69,8 @@ jQuery( document ).ready( function ( $ ) {
 				html +=
 					'<a href="#" data-module="' +
 					envelope.activate_module +
-					'" data-settings_link="' + envelope.module_settings_link +
+					'" data-settings_link="' +
+					envelope.module_settings_link +
 					'" type="button" class="jitm-button is-compact is-primary" data-jptracks-name="nudge_click" data-jptracks-prop="jitm-' +
 					envelope.id +
 					'-activate_module" data-jitm-path="' +
@@ -82,8 +79,9 @@ jQuery( document ).ready( function ( $ ) {
 					window.jitm_config.activate_module_text +
 					'</a>';
 				html += '</div>';
-				if ( envelope.module_settings_link){
-					html += '<div class="jitm-banner__action" id="jitm-banner__settings" style="display:none;">';
+				if ( envelope.module_settings_link ) {
+					html +=
+						'<div class="jitm-banner__action" id="jitm-banner__settings" style="display:none;">';
 					html +=
 						'<a href="' +
 						envelope.module_settings_link +
@@ -128,8 +126,8 @@ jQuery( document ).ready( function ( $ ) {
 					( ajaxAction ? 'data-ajax-action="' + ajaxAction + '"' : '' ) +
 					'>' +
 					envelope.CTA.message +
-					( externalLink ? EXTERNAL_LINK_ICON : '' )
-					'</a>';
+					( externalLink ? EXTERNAL_LINK_ICON : '' );
+				( '</a>' );
 				html += '</div>';
 			}
 
@@ -158,7 +156,7 @@ jQuery( document ).ready( function ( $ ) {
 
 				$.ajax( {
 					url: window.jitm_config.api_root + 'jetpack/v4/jitm',
-					method: 'POST', // using DELETE without permalinks is broken in default nginx configuration
+					method: 'POST', // using DELETE without permalinks is broken in default nginx configuration.
 					beforeSend: function ( xhr ) {
 						xhr.setRequestHeader( 'X-WP-Nonce', window.jitm_config.nonce );
 					},
@@ -260,7 +258,6 @@ jQuery( document ).ready( function ( $ ) {
 
 		// Handle tracking for JITM CTA buttons
 		$template.find( '.jitm-button' ).on( 'click', function ( e ) {
-
 			var button = $( this );
 			var eventName = button.attr( 'data-jptracks-name' );
 			if ( undefined === eventName ) {
@@ -275,7 +272,7 @@ jQuery( document ).ready( function ( $ ) {
 			};
 
 			if ( window.jpTracksAJAX ) {
-				window.jpTracksAJAX.record_ajax_event(eventName, 'click', eventProp);
+				window.jpTracksAJAX.record_ajax_event( eventName, 'click', eventProp );
 			}
 		} );
 	};
@@ -292,7 +289,7 @@ jQuery( document ).ready( function ( $ ) {
 			hash = hash.replace( /#\//, '_' );
 
 			// We always include the hash if this is My Jetpack page
-			if ( message_path.includes( 'jetpack_page_my-jetpack' )) {
+			if ( message_path.includes( 'jetpack_page_my-jetpack' ) ) {
 				message_path = message_path.replace(
 					'jetpack_page_my-jetpack',
 					'jetpack_page_my-jetpack' + hash

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -1,4 +1,6 @@
 import jQuery from 'jquery';
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
 
 import '../css/jetpack-admin-jitm.scss';
 
@@ -154,12 +156,9 @@ jQuery( document ).ready( function ( $ ) {
 
 				$my_template.hide();
 
-				$.ajax( {
-					url: window.jitm_config.api_root + 'jetpack/v4/jitm',
-					method: 'POST', // using DELETE without permalinks is broken in default nginx configuration.
-					beforeSend: function ( xhr ) {
-						xhr.setRequestHeader( 'X-WP-Nonce', window.jitm_config.nonce );
-					},
+				apiFetch( {
+					path: '/jetpack/v4/jitm',
+					method: 'POST', // using POST since DELETE has nginx issues
 					data: {
 						id: response.id,
 						feature_class: response.feature_class,
@@ -205,22 +204,15 @@ jQuery( document ).ready( function ( $ ) {
 				return false;
 			}
 
-			// Make request to activate module.
-			$.ajax( {
-				url:
-					window.jitm_config.api_root +
-					'jetpack/v4/module/' +
-					$activate_button.data( 'module' ) +
-					'/active',
-				method: 'POST',
-				beforeSend: function ( xhr ) {
-					xhr.setRequestHeader( 'X-WP-Nonce', $el.data( 'nonce' ) );
+			// Change the button status to disabled as the change is in progress.
+			$( '#jitm-banner__activate a' ).text( window.jitm_config.activating_module_text );
+			$( '#jitm-banner__activate a' ).attr( 'disabled', true );
 
-					// Change the button status to disabled as the change is in progress.
-					$( '#jitm-banner__activate a' ).text( window.jitm_config.activating_module_text );
-					$( '#jitm-banner__activate a' ).attr( 'disabled', true );
-				},
-			} ).done( function () {
+			// Make request to activate module.
+			apiFetch( {
+				path: `/jetpack/v4/module/${ $activate_button.data( 'module' ) }/active`,
+				method: 'POST',
+			} ).then( function () {
 				// Display the link to settings and hide the activate link
 				$( '#jitm-banner__activate a' ).text( window.jitm_config.activated_module_text );
 				$( '#jitm-banner__activate a' ).attr( 'disabled', true );
@@ -303,11 +295,13 @@ jQuery( document ).ready( function ( $ ) {
 
 			var full_jp_logo_exists = $( '.jetpack-logo__masthead' ).length ? true : false;
 
-			$.get( window.jitm_config.api_root + 'jetpack/v4/jitm', {
-				message_path: message_path,
-				query: query,
-				full_jp_logo_exists: full_jp_logo_exists,
-				_wpnonce: $el.data( 'nonce' ),
+			apiFetch( {
+				path: addQueryArgs( '/jetpack/v4/jitm', {
+					message_path: message_path,
+					query: query,
+					full_jp_logo_exists: full_jp_logo_exists,
+				} ),
+				method: 'GET',
 			} ).then( function ( response ) {
 				if ( 'object' === typeof response && response[ '1' ] ) {
 					response = [ response[ '1' ] ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Sub PR of https://github.com/Automattic/jetpack/pull/41252.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Breaking out the following changes from https://github.com/Automattic/jetpack/pull/41252:

- move to `@wordpress/api-fetch`.
- formatting changes

You can verify this PR works as intended if there are no changes vs production when testing WPAdmin. Essentially we are swapping out jQuery for apiFetch in limited instances to prepare for https://github.com/Automattic/jetpack/pull/41252. 

Why are we doing this?

Because since p5j4vm-53Z-p2 apiFetch automatically handles calling the Public API vs the local site API correctly. As the new endpoint introduced in https://github.com/Automattic/jetpack/pull/41252 will run in both environments we need the JS code to automatically adapt. 

I've deliberately kept the scope limited to the `jetpack/v4/jitm` endpoint. This is to avoided unintended knock on effects which are difficult to test and increase the scope of this PR:
- jQuery REST calls to `jetpack/v4/modules` are left "as is" 
- existing _AJAX_ calls (as opposed to REST) are left using jQuery (for now).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

⚠️ There is no need to test this code on Simple sites as the JITM feature is not active there unless you are using Calypso. This code does not affect Calypso routes.

### Setup

* Create a WoA testing site, transfer to the pool.
- Go to WPAdmin - upload the Jetpack Beta Plugin (get a copy from the Gitub repo)
- Go to Jetpack -> Beta Tester
- In the list of modules look for the Jetpack entry and click "Manage"
- Search for the name of this PR's branch and enable it. That will make _this_ PR active on your test site.
* Create a file called `jitm-testing-mu-plugin.php`. Create a `.zip` and upload it to your site. Check it's active. This Plugin will:
    - disable caching in the Engine.
    - disable Jetpack site caching via `jetpack_options`.
    - ensure JITMs are "on"
    - create a Test JITM which will show on **all available screens**.

<details>
<summary>JITMs Testing MU Plugin</summary>

```php

<?php
/**
 * Plugin Name: Force JITM Display
 * Plugin URI: 
 * Description: Adds a test JITM with configurable settings
 * Version: 1.0
 * Author: Your Name
 * Author URI: 
 * License: GPL2
 */

// Prevent direct access to this file
if ( ! defined( 'ABSPATH' ) ) {
    exit;
}

// Configuration constants
const TEST_JITM_MAX_DISMISSALS = 1;     // Maximum number of times the test JITM can be dismissed
const TEST_JITM_EXPIRY_TIME = 1209600;  // How long before the test JITM expires (in seconds, default 14 days)

// Disable JITM cache during development
add_filter( 'jetpack_just_in_time_msg_cache', '__return_false', 1000 );

// Always return JITMs
add_filter( 'jetpack_jitm_should_return_jitms', '__return_true', 1000 );

// Filter the jetpack_options to ensure hide_jitm is always empty
add_filter( 'option_jetpack_options', function( $options ) {
    if ( is_array( $options ) ) {
        $options['hide_jitm'] = array();
    }
    return $options;
}, 1000 );

// Add our test JITM
add_filter( 'jetpack_jitm_received_envelopes', function( $envelopes ) {
    // Create a test JITM message
    $test_jitm = (object) array(
        'content' => (object) array(
            'message' => 'This is a test JITM message',
            'icon' => '',
            'iconPath' => '',
            'list' => array(),
            'description' => 'This is a test description for the JITM',
            'classes' => '',
            'title' => '',
            'disclaimer' => array(),
        ),
        'CTA' => (object) array(
            'message' => 'Click Here',
            'hook' => '',
            'newWindow' => 1,
            'primary' => 1,
            'link' => 'https://example.com',
            'target' => '_self'
        ),
        'template' => 'default',
        'ttl' => 300,
        'id' => 'test-jitm',
        'feature_class' => 'test-feature',
        'expires' => TEST_JITM_EXPIRY_TIME,
        'max_dismissal' => TEST_JITM_MAX_DISMISSALS,
        'activate_module' => '',
        'module_settings_link' => '',
        'is_dismissible' => 1,
        'is_user_created_by_partner' => '',
        'message_expiration' => '',
        'tracks' => (object) array(
            'click' => (object) array(
                'name' => 'jitm-test-click',
                'props' => (object) array(
                    'cta_feature' => 'test-feature'
                )
            )
        )
    );

    // Add the test JITM to the existing envelopes
    $envelopes[] = $test_jitm;

    return $envelopes;
}, 1000 );
```
</details>

### Testing

- Go to `wp-admin/admin.php?page=jetpack-search`.
- You should see the Test JITM as per Production.