### PR TITLE
Add new filter to allow for ignoring of dismissed JITMs

### DIFF
--- a/projects/packages/jitm/changelog/add-filter-to-ignore-dismissed-jitms
+++ b/projects/packages/jitm/changelog/add-filter-to-ignore-dismissed-jitms
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add new filter to allow for ignoring dismissal of JITMs

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -156,7 +156,7 @@ class JITM {
 		return (
 			$current_screen
 			&& $current_screen->id
-			&& (bool) preg_match( '/jetpack|woo|shop|product/', $current_screen->id )
+			&& (bool) preg_match( '/jetpack|woo|shop|product|themes/', $current_screen->id )
 		);
 	}
 

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -156,7 +156,7 @@ class JITM {
 		return (
 			$current_screen
 			&& $current_screen->id
-			&& (bool) preg_match( '/jetpack|woo|shop|product|themes/', $current_screen->id )
+			&& (bool) preg_match( '/jetpack|woo|shop|product/', $current_screen->id )
 		);
 	}
 

--- a/projects/packages/jitm/src/class-post-connection-jitm.php
+++ b/projects/packages/jitm/src/class-post-connection-jitm.php
@@ -351,8 +351,17 @@ class Post_Connection_JITM extends JITM {
 
 			$dismissed_feature = isset( $hidden_jitms[ $envelope->feature_class ] ) && is_array( $hidden_jitms[ $envelope->feature_class ] ) ? $hidden_jitms[ $envelope->feature_class ] : null;
 
+			/**
+			 * Allow ignoring JITM dismissals. Typically used for development purposes.
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param bool $ignore_dismissible Whether to ignore JITM dismissal state. Default false.
+			 */
+			$ignore_dismissible = apply_filters( 'jetpack_jitm_should_ignore_dismissals', false );
+
 			// If the this feature class has been dismissed and the request has not passed the ttl, skip it as it's been dismissed.
-			if ( is_array( $dismissed_feature ) && ( time() - $dismissed_feature['last_dismissal'] < $envelope->expires || $dismissed_feature['number'] >= $envelope->max_dismissal ) ) {
+			if ( ! $ignore_dismissible && is_array( $dismissed_feature ) && ( time() - $dismissed_feature['last_dismissal'] < $envelope->expires || $dismissed_feature['number'] >= $envelope->max_dismissal ) ) {
 				unset( $envelopes[ $idx ] );
 				continue;
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Sub PR of https://github.com/Automattic/jetpack/pull/41252.

Adds a new filter `jetpack_jitm_should_ignore_dismissals` which will force all JITMs to remain even if they have been dismissed.

Currently the Jetpack code (not the `JITM\Engine`) will hide JITMs if they have been dismissed. This makes testing/development quite challenging! This filter allows for bypassing this check which makes it easier to test JITMs.

❓ I'm not 100% convinced we should be adding filters purely for testing/development purposes. Another option is asking testers to update the `max_dismissals` on the `JITM\Message` instance to a known value during testing. However this is prone to human error. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a WoA testing site, transfer to the pool.
- Go to WPAdmin - upload the Jetpack Beta Plugin (get a copy from the Gitub repo)
- Go to Jetpack -> Beta Tester
- In the list of modules look for the Jetpack entry and click "Manage"
- Search for `add/filter-to-ignore-dismissed-jitms` and enable it. That will make _this_ PR active on your test site.
* Zip the file below and upload as an mu-plugin on the site. Double check it's active. This will create a  testing JITM message that is always available on every screen and is only allowed to be dismissed once before it doesn't appear again for a whole year!

<details>
<summary> `jitm-testing-mu-plugin.php` </summary>

```php
<?php
/**
 * Plugin Name: Test JITM
 * Plugin URI: 
 * Description: Adds a test Just in Time Message (JITM) to Jetpack
 * Version: 1.0
 * Author: Your Name
 * Author URI: 
 * License: GPL2
 */

// Prevent direct access to this file
if ( ! defined( 'ABSPATH' ) ) {
    exit;
}

// Disable JITM cache during development
add_filter( 'jetpack_just_in_time_msg_cache', '__return_false', 1000 );
add_filter('jetpack_jitm_should_return_jitms', '__return_true', 1000);


add_filter( 'jetpack_jitm_received_envelopes', function( $envelopes ) {
    // Create a test JITM message
    $test_jitm = (object) array(
        'content' => (object) array(
            'message' => 'This is a test JITM message',
            'icon' => '',
            'iconPath' => '',
            'list' => array(),
            'description' => 'This is a test description for the JITM',
            'classes' => '',
            'title' => '',
            'disclaimer' => array(),
        ),
        'CTA' => (object) array(
            'message' => 'Click Here',
            'hook' => '',
            'newWindow' => 1,
            'primary' => 1,
            'link' => 'https://example.com',
            'target' => '_self'
        ),
        'template' => 'default',
        'ttl' => 300,
        'id' => 'test-jitm',
        'feature_class' => 'test-feature',
        'expires' => 31536000, 
        'max_dismissal' => 1,
        'activate_module' => '',
        'module_settings_link' => '',
        'is_dismissible' => 1,
        'is_user_created_by_partner' => '',
        'message_expiration' => '',
        'tracks' => (object) array(
            'click' => (object) array(
                'name' => 'jitm-test-click',
                'props' => (object) array(
                    'cta_feature' => 'test-feature'
                )
            )
        )
    );

    // Add the test JITM to the existing envelopes
    $envelopes[] = $test_jitm;

    return $envelopes;
});
```
</details>

- Now open `wp-admin/admin.php?page=jetpack-search`. Double check you are in WPAdmin and not Calypso.
- You should see the JITM at the top of the page.
- Dismiss the JITM using the "X" on the message.
- Reload the page. See that the JITM does not show again as it has been dismissed (remember it's configured that way).
- Now upload another MU Plugin. Save the code below as `ignore-jitm-dismissals.php` and `.zip` it and upload via the Plugins Upload page. This should force any dismissed messages to display:

```php
<?php
/**
 * Plugin Name: Ignore JITM Dismissals
 * Plugin URI: 
 * Description: Forces JITMs to show even if they were previously dismissed
 * Version: 1.0
 * Author: Your Name
 * Author URI: 
 * License: GPL2
 */

// Prevent direct access to this file
if ( ! defined( 'ABSPATH' ) ) {
    exit;
}

add_filter('jetpack_jitm_should_ignore_dismissals', '__return_true', 1000);
```
- Go back to `wp-admin/admin.php?page=jetpack-search` and verify the JITM is shown even if you continue to dismiss it.
- Don't forget to 
    - remove both MU Plugins when you are done just in case you forget!
    - disable Jetpack Beta Plugin to restore the trunk branch on your site.