### PR TITLE
Update approved screens for JITMs to a const

### DIFF
--- a/projects/packages/jitm/changelog/update-jitm-approved-screens-to-const
+++ b/projects/packages/jitm/changelog/update-jitm-approved-screens-to-const
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Refactor approved screens in preparation for https://github.com/Automattic/jetpack/pull/41252

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -48,7 +48,7 @@ class JITM {
 	 * @return Post_Connection_JITM|Pre_Connection_JITM JITM instance.
 	 */
 	public static function get_instance() {
-		if ( ( new Connection_Manager() )->is_connected() || defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		if ( ( new Connection_Manager() )->is_connected() ) {
 			$jitm = new Post_Connection_JITM();
 		} else {
 			$jitm = new Pre_Connection_JITM();

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -23,6 +23,18 @@ class JITM {
 	const PACKAGE_VERSION = '4.1.0';
 
 	/**
+	 * List of screen IDs where JITMs are allowed to display.
+	 *
+	 * @var string[]
+	 */
+	const APPROVED_SCREEN_IDS = array(
+		'jetpack',
+		'woo',
+		'shop',
+		'product',
+	);
+
+	/**
 	 * The configuration method that is called from the jetpack-config package.
 	 */
 	public static function configure() {
@@ -36,7 +48,7 @@ class JITM {
 	 * @return Post_Connection_JITM|Pre_Connection_JITM JITM instance.
 	 */
 	public static function get_instance() {
-		if ( ( new Connection_Manager() )->is_connected() ) {
+		if ( ( new Connection_Manager() )->is_connected() || defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			$jitm = new Post_Connection_JITM();
 		} else {
 			$jitm = new Pre_Connection_JITM();
@@ -127,6 +139,7 @@ class JITM {
 			add_action( 'admin_enqueue_scripts', array( $this, 'jitm_enqueue_files' ) );
 			add_action( 'admin_notices', array( $this, 'ajax_message' ) );
 			add_action( 'edit_form_top', array( $this, 'ajax_message' ) );
+
 		}
 	}
 
@@ -156,7 +169,10 @@ class JITM {
 		return (
 			$current_screen
 			&& $current_screen->id
-			&& (bool) preg_match( '/jetpack|woo|shop|product/', $current_screen->id )
+			&& (bool) preg_match(
+				'/' . implode( '|', self::APPROVED_SCREEN_IDS ) . '/',
+				$current_screen->id
+			)
 		);
 	}
 
@@ -226,7 +242,7 @@ class JITM {
 			return;
 		}
 
-		// Only add this to Jetpack or Woo admin pages.
+		// Only add this to specifically whitelisted pages.
 		if ( ! $this->is_a8c_admin_page() ) {
 			return;
 		}

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -242,7 +242,7 @@ class JITM {
 			return;
 		}
 
-		// Only add this to specifically whitelisted pages.
+		// Only add this to specifically allowed pages.
 		if ( ! $this->is_a8c_admin_page() ) {
 			return;
 		}

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -139,7 +139,6 @@ class JITM {
 			add_action( 'admin_enqueue_scripts', array( $this, 'jitm_enqueue_files' ) );
 			add_action( 'admin_notices', array( $this, 'ajax_message' ) );
 			add_action( 'edit_form_top', array( $this, 'ajax_message' ) );
-
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Sub PR of https://github.com/Automattic/jetpack/pull/41252/.

Prepares for that PR to land by refactoring the screens where JITMs can be shown to a const for easier maintenance.

Allows us to ship a smaller diff in https://github.com/Automattic/jetpack/pull/41252/.

Note that `themes` is ommitted from the "approved" list in this PR and will be added in https://github.com/Automattic/jetpack/pull/41252/.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

⚠️ There is no need to test this code on Simple sites as the JITM feature is not active there unless you are using Calypso. This code does not affect Calypso routes.

### Setup

* Create a WoA testing site, transfer to the pool.
- Go to WPAdmin - upload the Jetpack Beta Plugin (get a copy from the Gitub repo)
- Go to Jetpack -> Beta Tester
- In the list of modules look for the Jetpack entry and click "Manage"
- Search for the name of this PR's branch and enable it. That will make _this_ PR active on your test site.
* Create a file called `jitm-testing-mu-plugin.php`. Create a `.zip` and upload it to your site. Check it's active. This Plugin will:
    - disable caching in the Engine.
    - disable Jetpack site caching via `jetpack_options`.
    - ensure JITMs are "on"
    - create a Test JITM which will show on **all available screens**.

<details>
<summary>JITMs Testing MU Plugin</summary>

```php

<?php
/**
 * Plugin Name: Force JITM Display
 * Plugin URI: 
 * Description: Adds a test JITM with configurable settings
 * Version: 1.0
 * Author: Your Name
 * Author URI: 
 * License: GPL2
 */

// Prevent direct access to this file
if ( ! defined( 'ABSPATH' ) ) {
    exit;
}

// Configuration constants
const TEST_JITM_MAX_DISMISSALS = 1;     // Maximum number of times the test JITM can be dismissed
const TEST_JITM_EXPIRY_TIME = 1209600;  // How long before the test JITM expires (in seconds, default 14 days)

// Disable JITM cache during development
add_filter( 'jetpack_just_in_time_msg_cache', '__return_false', 1000 );

// Always return JITMs
add_filter( 'jetpack_jitm_should_return_jitms', '__return_true', 1000 );

// Filter the jetpack_options to ensure hide_jitm is always empty
add_filter( 'option_jetpack_options', function( $options ) {
    if ( is_array( $options ) ) {
        $options['hide_jitm'] = array();
    }
    return $options;
}, 1000 );

// Add our test JITM
add_filter( 'jetpack_jitm_received_envelopes', function( $envelopes ) {
    // Create a test JITM message
    $test_jitm = (object) array(
        'content' => (object) array(
            'message' => 'This is a test JITM message',
            'icon' => '',
            'iconPath' => '',
            'list' => array(),
            'description' => 'This is a test description for the JITM',
            'classes' => '',
            'title' => '',
            'disclaimer' => array(),
        ),
        'CTA' => (object) array(
            'message' => 'Click Here',
            'hook' => '',
            'newWindow' => 1,
            'primary' => 1,
            'link' => 'https://example.com',
            'target' => '_self'
        ),
        'template' => 'default',
        'ttl' => 300,
        'id' => 'test-jitm',
        'feature_class' => 'test-feature',
        'expires' => TEST_JITM_EXPIRY_TIME,
        'max_dismissal' => TEST_JITM_MAX_DISMISSALS,
        'activate_module' => '',
        'module_settings_link' => '',
        'is_dismissible' => 1,
        'is_user_created_by_partner' => '',
        'message_expiration' => '',
        'tracks' => (object) array(
            'click' => (object) array(
                'name' => 'jitm-test-click',
                'props' => (object) array(
                    'cta_feature' => 'test-feature'
                )
            )
        )
    );

    // Add the test JITM to the existing envelopes
    $envelopes[] = $test_jitm;

    return $envelopes;
}, 1000 );
```
</details>

### Testing

- Go to `wp-admin/admin.php?page=jetpack-search`.
- You should see the Test JITM. 
- Try going to another WPAdmin page which is not in the screens whitelist (e.g. `wp-admin/edit.php?post_type=feedback`). You should _not_ see JITM message.

