### PR TITLE
Boost: Schedule Minify Events on Plugin Update

### DIFF
--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -358,6 +358,13 @@ function jetpack_boost_minify_activation() {
 	jetpack_boost_404_setup();
 }
 
+function jetpack_boost_minify_is_enabled() {
+	$minify_css = new Module( new Minify_CSS() );
+	$minify_js  = new Module( new Minify_JS() );
+
+	return $minify_css->is_enabled() || $minify_js->is_enabled();
+}
+
 /**
  * Run during deactivation of any minify module.
  *
@@ -366,10 +373,7 @@ function jetpack_boost_minify_activation() {
  * @return void
  */
 function jetpack_boost_minify_deactivation() {
-	$minify_css = new Module( new Minify_CSS() );
-	$minify_js  = new Module( new Minify_JS() );
-
-	if ( ! $minify_css->is_enabled() && ! $minify_js->is_enabled() ) {
+	if ( ! jetpack_boost_minify_is_enabled() ) {
 		jetpack_boost_minify_clear_scheduled_events();
 	}
 }

--- a/projects/plugins/boost/app/modules/optimizations/minify/class-minify-css.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/class-minify-css.php
@@ -52,7 +52,6 @@ class Minify_CSS implements Pluggable, Changes_Page_Output, Optimization, Has_Ac
 
 	public static function activate() {
 		jetpack_boost_minify_activation();
-		jetpack_boost_404_tester();
 	}
 
 	public static function deactivate() {

--- a/projects/plugins/boost/app/modules/optimizations/minify/class-minify-js.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/class-minify-js.php
@@ -52,7 +52,6 @@ class Minify_JS implements Pluggable, Changes_Page_Output, Optimization, Has_Act
 
 	public static function activate() {
 		jetpack_boost_minify_activation();
-		jetpack_boost_404_tester();
 	}
 
 	public static function deactivate() {

--- a/projects/plugins/boost/changelog/update-boost-schedule-minify-cache-cron-on-update
+++ b/projects/plugins/boost/changelog/update-boost-schedule-minify-cache-cron-on-update
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Update code for unreleased feature
+
+

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -174,6 +174,32 @@ register_activation_hook( __FILE__, array( 'Automattic\Jetpack_Boost\Jetpack_Boo
 // Redirect to plugin page when the plugin is activated.
 add_action( 'activated_plugin', __NAMESPACE__ . '\jetpack_boost_plugin_activation' );
 
+function jetpack_boost_upgrade_handler( $upgrader_object, $hook_extra ) {
+	if ( 'plugin' !== $hook_extra['type'] ) {
+		return;
+	}
+
+	if ( 'update' !== $hook_extra['action'] ) {
+		return;
+	}
+
+	if ( empty( $hook_extra['plugins'] ) ) {
+		return;
+	}
+
+	if ( ! in_array( JETPACK_BOOST_PLUGIN_BASE, $hook_extra['plugins'], true ) ) {
+		return;
+	}
+
+	if ( ! jetpack_boost_minify_is_enabled() ) {
+		return;
+	}
+
+	jetpack_boost_minify_activation();
+}
+
+add_action( 'upgrader_process_complete', __NAMESPACE__ . '\jetpack_boost_upgrade_handler', 10, 2 );
+
 /**
  * Redirects to plugin page when the plugin is activated
  *


### PR DESCRIPTION
## Proposed changes:
Boost: Improve plugin upgrade and minify module handling
- Add upgrade handler to reactivate minify module after plugin update
- Create helper function to check if minify modules are enabled
- Remove redundant 404 tester calls in module activation methods

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install Boost version 3.8.0
* Ensure JS/CSS Minify is enabled.
* Install Crontrol plugin
* Update Boost to version 3.9.0 (or this branch). 
* Verify that the cron `jetpack_boost_404_tester_cron` is scheduled
<img width="1512" alt="Screenshot 2025-02-12 at 12 14 04" src="https://github.com/user-attachments/assets/12476c4a-55c5-4064-8766-07018c4f8f3b" />

