### PR TITLE
POC: Newsletter widget

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,6 +114,7 @@
 		}
 	},
 	"require": {
-		"ext-json": "*"
+		"ext-json": "*",
+		"automattic/jetpack-newsletter-widget": "^0.1.0@dev"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,6 @@
 		}
 	},
 	"require": {
-		"ext-json": "*",
-		"automattic/jetpack-newsletter-widget": "^0.1.0@dev"
+		"ext-json": "*"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,67 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4e5d0ab379d2df5496c6454eccaeff2b",
-    "packages": [],
+    "content-hash": "45b51e3b8cbad0055134ee5f274bf57f",
+    "packages": [
+        {
+            "name": "automattic/jetpack-newsletter-widget",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "projects/packages/newsletter-widget",
+                "reference": "68fa159b41bfa100b7bcac2572a9e8f4eb74a57d"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "yoast/phpunit-polyfills": "^1.1.1"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "textdomain": "jetpack-newsletter-widget",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-newsletter-widget.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "build-production": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "This package consumes the Calypso standalone app newsletter to render the Newsletter Widget in the wp-admin Dashboard. ",
+            "transport-options": {
+                "relative": true
+            }
+        }
+    ],
     "packages-dev": [
         {
             "name": "automattic/ignorefile",
@@ -3116,6 +3175,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "automattic/jetpack-codesniffer": 20,
+        "automattic/jetpack-newsletter-widget": 20,
         "automattic/jetpack-phan-plugins": 20,
         "automattic/jetpack-phpcs-filter": 20
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2927,6 +2927,8 @@ importers:
         specifier: 6.0.1
         version: 6.0.1(webpack@5.94.0)
 
+  projects/packages/newsletter-widget: {}
+
   projects/packages/plans: {}
 
   projects/packages/plugin-deactivation:

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-newsletter-widget
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-newsletter-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added newsletter widget.

--- a/projects/packages/jetpack-mu-wpcom/src/features/newspack-blocks/synced-newspack-blocks/package.json
+++ b/projects/packages/jetpack-mu-wpcom/src/features/newspack-blocks/synced-newspack-blocks/package.json
@@ -1,0 +1,66 @@
+{
+	"name": "@automattic/newspack-blocks",
+	"version": "3.5.0",
+	"author": "Automattic",
+	"devDependencies": {
+		"@rushstack/eslint-patch": "^1.10.3",
+		"@testing-library/dom": "^10.2.0",
+		"@testing-library/user-event": "^14.5.2",
+		"@types/lodash": "^4.17.5",
+		"@types/lodash.debounce": "^4.0.9",
+		"eslint": "^7.32.0",
+		"fetch-mock-jest": "^1.5.1",
+		"html-entities": "^2.5.2",
+		"identity-obj-proxy": "^3.0.0",
+		"lint-staged": "^15.2.7",
+		"newspack-scripts": "^5.5.1",
+		"postcss-scss": "^4.0.9",
+		"prettier": "npm:wp-prettier@^2.6.2-beta-1",
+		"stylelint": "^15.11.0"
+	},
+	"description": "=== Newspack Blocks === Contributors: (this should be a list of wordpress.org userid's) Donate link: https://example.com/ Tags: comments, spam Requires at least: 4.5 Tested up to: 5.1.1 Stable tag: 0.1.0 License: GPLv2 or later License URI: https://www.gnu.org/licenses/gpl-2.0.html",
+	"dependencies": {
+		"classnames": "^2.5.1",
+		"lodash": "^4.17.21",
+		"newspack-components": "^2.2.1",
+		"react": "^17.0.2",
+		"redux": "^4.2.1",
+		"redux-saga": "^1.3.0",
+		"regenerator-runtime": "^0.14.1",
+		"swiper": "11.1.4"
+	},
+	"scripts": {
+		"cm": "newspack-scripts commit",
+		"semantic-release": "newspack-scripts release --files=newspack-blocks.php",
+		"build": "newspack-scripts build",
+		"start": "npm ci && newspack-scripts watch",
+		"watch": "newspack-scripts watch",
+		"test": "newspack-scripts test",
+		"lint": "npm run lint:scss && npm run lint:js",
+		"lint:js": "eslint 'src/**/*.{js,jsx,ts,tsx}'",
+		"lint:js:staged": "eslint --ext .js,.jsx,.ts,.tsx",
+		"lint:php:staged": "./vendor/bin/phpcs --filter=GitStaged",
+		"format:js": "prettier 'src/**/*.{js,jsx,ts,tsx}' --write",
+		"lint:scss": "stylelint '**/*.scss' --customSyntax postcss-scss --config=./node_modules/newspack-scripts/config/stylelint.config.js",
+		"format:scss": "prettier --write 'src/**/*.scss'",
+		"lint:scss:staged": "stylelint --customSyntax postcss-scss --config=./node_modules/newspack-scripts/config/stylelint.config.js",
+		"i18n": "NODE_ENV=production npm run build; bash ./bin/update-translations.sh",
+		"typescript:check": "newspack-scripts typescript-check",
+		"release": "npm run build && npm run semantic-release",
+		"release:archive": "rm -rf release && mkdir -p release && rsync -r . ./release/newspack-blocks --exclude-from='./.distignore' && cd release && zip -r newspack-blocks.zip newspack-blocks",
+		"postinstall": "rm -rf node_modules/newspack-scripts/node_modules/prettier"
+	},
+	"lint-staged": {
+		"*.scss": "npm run lint:scss:staged",
+		"*.(js|jsx)": "npm run lint:js:staged",
+		"*.php": "npm run lint:php:staged"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/newspack-blocks.git"
+	},
+	"license": "GPL-3.0-or-later",
+	"bugs": {
+		"url": "https://github.com/Automattic/newspack-blocks/issues"
+	}
+}

--- a/projects/packages/newsletter-widget/.gitattributes
+++ b/projects/packages/newsletter-widget/.gitattributes
@@ -1,0 +1,17 @@
+# Files not needed to be distributed in the package.
+.gitattributes    export-ignore
+.github/          export-ignore
+package.json      export-ignore
+
+# Files to include in the mirror repo, but excluded via gitignore
+# Remember to end all directories with `/**` to properly tag every file.
+# /src/js/example.min.js  production-include
+
+# Files to exclude from the mirror repo, but included in the monorepo.
+# Remember to end all directories with `/**` to properly tag every file.
+.gitignore        production-exclude
+changelog/**      production-exclude
+phpunit.xml.dist  production-exclude
+.phpcs.dir.xml    production-exclude
+tests/**          production-exclude
+.phpcsignore      production-exclude

--- a/projects/packages/newsletter-widget/.gitignore
+++ b/projects/packages/newsletter-widget/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+node_modules/

--- a/projects/packages/newsletter-widget/.phan/baseline.php
+++ b/projects/packages/newsletter-widget/.phan/baseline.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * This is an automatically generated baseline for Phan issues.
+ *
+ * Use `jetpack phan --update-baseline` to update this file.
+ */
+return [
+    // Currently, file_suppressions and directory_suppressions are the only supported suppressions
+    'file_suppressions' => [],
+    // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
+    // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)
+];

--- a/projects/packages/newsletter-widget/.phan/config.php
+++ b/projects/packages/newsletter-widget/.phan/config.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * This configuration will be read and overlaid on top of the
+ * default configuration. Command-line arguments will be applied
+ * after this file is read.
+ *
+ * @package automattic/jetpack-newsletter-widget
+ */
+
+// Require base config.
+require __DIR__ . '/../../../../.phan/config.base.php';
+
+return make_phan_config( dirname( __DIR__ ) );

--- a/projects/packages/newsletter-widget/.phpcs.dir.xml
+++ b/projects/packages/newsletter-widget/.phpcs.dir.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="jetpack-newsletter-widget" />
+			</property>
+		</properties>
+	</rule>
+	<rule ref="Jetpack.Functions.I18n">
+		<properties>
+			<property name="text_domain" value="jetpack-newsletter-widget" />
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.Utils.I18nTextDomainFixer">
+		<properties>
+			<property name="old_text_domain" type="array" />
+			<property name="new_text_domain" value="jetpack-newsletter-widget" />
+		</properties>
+	</rule>
+
+</ruleset>

--- a/projects/packages/newsletter-widget/CHANGELOG.md
+++ b/projects/packages/newsletter-widget/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+

--- a/projects/packages/newsletter-widget/README.md
+++ b/projects/packages/newsletter-widget/README.md
@@ -1,0 +1,24 @@
+# newsletter-widget
+
+This package consumes the Calypso standalone app newsletter to render the Newsletter Widget in the wp-admin Dashboard. 
+
+## How to install newsletter-widget
+
+### Installation From Git Repo
+
+## Contribute
+
+## Get Help
+
+## Using this package in your WordPress plugin
+
+If you plan on using this package in your WordPress plugin, we would recommend that you use [Jetpack Autoloader](https://packagist.org/packages/automattic/jetpack-autoloader) as your autoloader. This will allow for maximum interoperability with other plugins that use this package as well.
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+newsletter-widget is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)
+

--- a/projects/packages/newsletter-widget/changelog/initial-version
+++ b/projects/packages/newsletter-widget/changelog/initial-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Initial version.

--- a/projects/packages/newsletter-widget/composer.json
+++ b/projects/packages/newsletter-widget/composer.json
@@ -1,0 +1,54 @@
+{
+	"name": "automattic/jetpack-newsletter-widget",
+	"description": "This package consumes the Calypso standalone app newsletter to render the Newsletter Widget in the wp-admin Dashboard. ",
+	"type": "jetpack-library",
+	"license": "GPL-2.0-or-later",
+	"require": {
+		"php": ">=7.2"
+	},
+	"require-dev": {
+		"yoast/phpunit-polyfills": "^1.1.1",
+		"automattic/jetpack-changelogger": "@dev"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"scripts": {
+		"build-development": "echo 'Add your build step to composer.json, please!'",
+		"build-production": "echo 'Add your build step to composer.json, please!'",
+		"phpunit": [
+			"./vendor/phpunit/phpunit/phpunit --colors=always"
+		],
+		"test-coverage": [
+			"php -dpcov.directory=. ./vendor/bin/phpunit --coverage-php \"$COVERAGE_DIR/php.cov\""
+		],
+		"test-php": [
+			"@composer phpunit"
+		]
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../packages/*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"extra": {
+		"branch-alias": {
+			"dev-trunk": "0.1.x-dev"
+		},
+		"textdomain": "jetpack-newsletter-widget",
+		"version-constants": {
+			"::PACKAGE_VERSION": "src/class-newsletter-widget.php"
+		}
+	},
+	"suggest": {
+		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+	}
+}

--- a/projects/packages/newsletter-widget/package.json
+++ b/projects/packages/newsletter-widget/package.json
@@ -1,0 +1,25 @@
+{
+	"private": true,
+	"name": "@automattic/jetpack-newsletter-widget",
+	"version": "0.1.0-alpha",
+	"description": "This package consumes the Calypso standalone app newsletter to render the Newsletter Widget in the wp-admin Dashboard. ",
+	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/newsletter-widget/#readme",
+	"bugs": {
+		"url": "https://github.com/Automattic/jetpack/labels/[Package] Newsletter Widget"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Automattic/jetpack.git",
+		"directory": "projects/packages/newsletter-widget"
+	},
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic",
+	"scripts": {
+		"build": "echo 'Not implemented.'",
+		"build-js": "echo 'Not implemented.'",
+		"build-production": "echo 'Not implemented.'",
+		"build-production-js": "echo 'Not implemented.'",
+		"clean": "true"
+	},
+	"devDependencies": {}
+}

--- a/projects/packages/newsletter-widget/phpunit.xml.dist
+++ b/projects/packages/newsletter-widget/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
+	<testsuites>
+		<testsuite name="main">
+			<directory prefix="test" suffix=".php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="false">
+			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
+			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<directory suffix=".php">src</directory>
+		</whitelist>
+	</filter>
+</phpunit>

--- a/projects/packages/newsletter-widget/src/class-dashboard.php
+++ b/projects/packages/newsletter-widget/src/class-dashboard.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * A class that adds a newsletter widget to wp-admin.
+ *
+ * @package automattic/jetpack-
+ */
+
+namespace Automattic\Jetpack\Newsletter_Widget;
+
+/**
+ * Responsible for adding a newsletter widget to wp-admin.
+ *
+ * @package jetpack-newsletter-widget
+ */
+class Dashboard {
+	/**
+	 * Whether the class has been initialized
+	 *
+	 * @var boolean
+	 */
+	private static $initialized = false;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		if ( ! self::$initialized ) {
+			self::$initialized = true;
+			$this->admin_init();
+		}
+	}
+
+	/**
+	 * Override render funtion
+	 */
+	public function render() {
+		?>
+		<div id="wpcom" style="min-height: calc(100vh - 100px);">
+			<div id="newsletter-widget-app"></div>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Initialize the admin resources.
+	 */
+	public function admin_init() {
+		add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_scripts' ) );
+	}
+
+	/**
+	 * Load the admin scripts.
+	 */
+	public function load_admin_scripts() {
+		( new Newsletter_Widget_Assets() )->load_admin_scripts( 'jp-newsletter-widget', 'app.min', array( 'config_variable_name' => 'jetpackNewsletterWidgetConfigData' ) );
+	}
+}

--- a/projects/packages/newsletter-widget/src/class-newsletter-widget-assets.php
+++ b/projects/packages/newsletter-widget/src/class-newsletter-widget-assets.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Newsletter Widget Assets
+ *
+ * @package automattic/jetpack-newsletter-widget
+ */
+
+namespace Automattic\Jetpack\Newsletter_Widget;
+
+use Automattic\Jetpack\Assets;
+
+/**
+ * Class Newsletter_Widget_Assets
+ *
+ * @package automattic/jetpack-newsletter-widget
+ */
+class Newsletter_Widget_Assets {
+	// This is a fixed list @see https://github.com/Automattic/wp-calypso/pull/71442/
+	const JS_DEPENDENCIES = array( 'lodash', 'react', 'react-dom', 'wp-api-fetch', 'wp-components', 'wp-compose', 'wp-element', 'wp-html-entities', 'wp-i18n', 'wp-is-shallow-equal', 'wp-polyfill', 'wp-primitives', 'wp-url', 'wp-warning', 'moment' );
+	// Sometimes custom scripts would strip the `ver` query params, so we need to make sure it doesn't by adding a custom version param `osv` here.
+	const NEWSLETTER_WIDGET_CDN_URL = 'https://widgets.wp.com/newsletter/%s?minify=false&osv=%s';
+
+	/**
+	 * We bump the asset version when the Jetpack back end is not compatible anymore.
+	 */
+	const NEWSLETTER_WIDGET_VERSION                = 'v1';
+	const NEWSLETTER_WIDGET_CACHE_BUSTER_CACHE_KEY = 'newsletter_widget_asset_cache_buster';
+
+	/**
+	 * Load the admin scripts.
+	 *
+	 * @param string $asset_handle The handle of the asset.
+	 * @param string $asset_name The name of the asset.
+	 * @param array  $options The options.
+	 */
+	public function load_admin_scripts( $asset_handle, $asset_name, $options = array() ) {
+		$default_options = array(
+			'config_data'          => ( new Newsletter_Widget_Config_Data() )->get_data(),
+			'config_variable_name' => 'configData',
+			'enqueue_css'          => true,
+		);
+		$options         = wp_parse_args( $options, $default_options );
+		if ( file_exists( __DIR__ . "/../dist/{$asset_name}.js" ) ) {
+			// Load local assets for the convinience of development.
+			Assets::register_script(
+				$asset_handle,
+				"../dist/{$asset_name}.js",
+				__FILE__,
+				array(
+					'in_footer'  => true,
+					'textdomain' => 'jetpack-newsletter-widget',
+				)
+			);
+			Assets::enqueue_script( $asset_handle );
+		} else {
+			// In production, we load the assets from our CDN.
+			wp_register_script(
+				$asset_handle,
+				sprintf( self::NEWSLETTER_WIDGET_CDN_URL, "{$asset_name}.js", self::NEWSLETTER_WIDGET_VERSION ),
+				self::JS_DEPENDENCIES,
+				self::NEWSLETTER_WIDGET_VERSION,
+				true
+			);
+			wp_enqueue_script( $asset_handle );
+		}
+
+		wp_add_inline_script(
+			$asset_handle,
+			( new Newsletter_Widget_Config_Data() )->get_js_config_data( $options['config_variable_name'], $options['config_data'] ),
+			'before'
+		);
+	}
+}

--- a/projects/packages/newsletter-widget/src/class-newsletter-widget-config-data.php
+++ b/projects/packages/newsletter-widget/src/class-newsletter-widget-config-data.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Newsletter Widget Initial State
+ *
+ * @package automattic/jetpack-newsletter-widget
+ */
+
+namespace Automattic\Jetpack\Newsletter_Widget;
+
+use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
+use Automattic\Jetpack\Status\Host;
+use Jetpack_Options;
+
+/**
+ * Class Newsletter_Widget_Config_Data
+ *
+ * @package automattic/jetpack-newsletter-widget
+ */
+class Newsletter_Widget_Config_Data {
+
+	/**
+	 * Set configData to window.configData.
+	 *
+	 * @param string $config_variable_name The config variable name.
+	 * @param array  $config_data The config data.
+	 */
+	public function get_js_config_data( $config_variable_name = 'configData', $config_data = null ) {
+		return "window.{$config_variable_name} = " . wp_json_encode(
+			$config_data === null ? $this->get_data() : $config_data
+		) . ';';
+	}
+
+	/**
+	 * Return the config for the app.
+	 */
+	public function get_data() {
+		global $wp_version;
+
+		$blog_id = Jetpack_Options::get_option( 'id' );
+		$host    = new Host();
+
+		return array(
+			'admin_page_base'                => $this->get_admin_path(),
+			'api_root'                       => esc_url_raw( rest_url() ),
+			'blog_id'                        => Jetpack_Options::get_option( 'id' ),
+			'enable_all_sections'            => false,
+			'env_id'                         => 'production',
+			'google_analytics_key'           => 'UA-10673494-15',
+			'google_maps_and_places_api_key' => '',
+			'hostname'                       => wp_parse_url( get_site_url(), PHP_URL_HOST ),
+			'i18n_default_locale_slug'       => 'en',
+			'i18n_locale_slug'               => $this->get_user_locale(),
+			'mc_analytics_enabled'           => false,
+			'meta'                           => array(),
+			'nonce'                          => wp_create_nonce( 'wp_rest' ),
+			'site_name'                      => \get_bloginfo( 'name' ),
+			'sections'                       => array(),
+			// Features are inlined @see https://github.com/Automattic/wp-calypso/pull/70122
+			'features'                       => array(
+				'is_running_in_jetpack_site' => ! $host->is_wpcom_simple(),
+			),
+			// Intended for apps that do not use redux.
+			'gmt_offset'                     => $this->get_gmt_offset(),
+			'newsletter_widget_base_url'     => admin_url( 'admin.php?page=newsletter' ),
+			'intial_state'                   => array(
+				'currentUser' => array(
+					'id'           => 1000,
+					'user'         => array(
+						'ID'       => 1000,
+						'username' => 'no-user',
+					),
+					'capabilities' => array(
+						"$blog_id" => $this->get_current_user_capabilities(),
+					),
+				),
+				'sites'       => array(
+					'items'    => array(
+						"$blog_id" => array(
+							'ID'           => $blog_id,
+							'URL'          => site_url(),
+							// Atomic and jetpack sites should return true.
+							'jetpack'      => ! $host->is_wpcom_simple(),
+							'visible'      => true,
+							'capabilities' => $this->get_current_user_capabilities(),
+							'products'     => Jetpack_Plan::get_products(),
+							'plan'         => $this->get_plan(),
+							'options'      => array(
+								'admin_url'             => admin_url(),
+								'gmt_offset'            => $this->get_gmt_offset(),
+								'is_automated_transfer' => $this->is_automated_transfer( $blog_id ),
+								'is_wpcom_atomic'       => $host->is_woa_site(),
+								'is_wpcom_simple'       => $host->is_wpcom_simple(),
+								'is_vip'                => $host->is_vip_site(),
+								'jetpack_version'       => defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '',
+								'software_version'      => $wp_version,
+							),
+						),
+					),
+					'features' => array( "$blog_id" => array( 'data' => $this->get_plan_features() ) ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Defines a filter to set whether a site is an automated_transfer site or not.
+	 *
+	 * Default is false. On Atomic, this is set to true by `wpcomsh`.
+	 *
+	 * @param int $blog_id Blog ID.
+	 *
+	 * @return bool
+	 */
+	public function is_automated_transfer( $blog_id ) {
+		/**
+		 * Filter if a site is an automated-transfer site.
+		 *
+		 * @module json-api
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param bool is_automated_transfer( $this->blog_id )
+		 * @param int  $blog_id Blog identifier.
+		 */
+		return apply_filters(
+			'jetpack_site_automated_transfer',
+			false,
+			$blog_id
+		);
+	}
+
+	/**
+	 * Get the current site GMT Offset.
+	 *
+	 * @return float The current site GMT Offset by hours.
+	 */
+	protected function get_gmt_offset() {
+		return (float) get_option( 'gmt_offset' );
+	}
+
+	/**
+	 * Page base for the Calypso admin page.
+	 */
+	protected function get_admin_path() {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if ( ! isset( $_SERVER['PHP_SELF'] ) || ! isset( $_SERVER['QUERY_STRING'] ) ) {
+			$parsed = wp_parse_url( admin_url( 'admin.php?page=newsletter' ) );
+			return $parsed['path'] . '?' . $parsed['query'];
+		}
+		// We do this because page.js requires the exactly page base to be set otherwise it will not work properly.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		return wp_unslash( $_SERVER['PHP_SELF'] ) . '?' . wp_unslash( $_SERVER['QUERY_STRING'] );
+	}
+
+	/**
+	 * Get locale acceptable by Calypso.
+	 */
+	protected function get_user_locale() {
+		/**
+		 * In WP, locales are formatted as LANGUAGE_REGION, for example `en`, `en_US`, `es_AR`,
+		 * but Calypso expects language-region, e.g. `en-us`, `en`,  `es-ar`. So we need to convert
+		 * them to lower case and replace the underscore with a dash.
+		 */
+		$locale = strtolower( get_user_locale() );
+		$locale = str_replace( '_', '-', $locale );
+
+		return $locale;
+	}
+
+	/**
+	 * Get the features of the current plan.
+	 */
+	protected function get_plan_features() {
+		$plan = Jetpack_Plan::get();
+		if ( empty( $plan['features'] ) ) {
+			return array();
+		}
+		return $plan['features'];
+	}
+
+	/**
+	 * Get the current plan.
+	 *
+	 * @return array
+	 */
+	protected function get_plan() {
+		$plan = Jetpack_Plan::get();
+		unset( $plan['features'] );
+		unset( $plan['supports'] );
+		return $plan;
+	}
+
+	/**
+	 * Get the capabilities of the current user.
+	 *
+	 * @return array An array of capabilities.
+	 */
+	protected function get_current_user_capabilities() {
+		return array(
+			'edit_pages'          => current_user_can( 'edit_pages' ),
+			'edit_posts'          => current_user_can( 'edit_posts' ),
+			'edit_others_posts'   => current_user_can( 'edit_others_posts' ),
+			'edit_others_pages'   => current_user_can( 'edit_others_pages' ),
+			'delete_posts'        => current_user_can( 'delete_posts' ),
+			'delete_others_posts' => current_user_can( 'delete_others_posts' ),
+			'edit_theme_options'  => current_user_can( 'edit_theme_options' ),
+			'edit_users'          => current_user_can( 'edit_users' ),
+			'list_users'          => current_user_can( 'list_users' ),
+			'manage_categories'   => current_user_can( 'manage_categories' ),
+			'manage_options'      => current_user_can( 'manage_options' ),
+			'moderate_comments'   => current_user_can( 'moderate_comments' ),
+			'activate_wordads'    => current_user_can( 'manage_options' ),
+			'promote_users'       => current_user_can( 'promote_users' ),
+			'publish_posts'       => current_user_can( 'publish_posts' ),
+			'upload_files'        => current_user_can( 'upload_files' ),
+			'delete_users'        => current_user_can( 'delete_users' ),
+			'remove_users'        => current_user_can( 'remove_users' ),
+			'own_site'            => current_user_can( 'manage_options' ), // Administrators are considered owners on site.
+			/**
+			 * Filter whether the Hosting section in Calypso should be available for site.
+			 *
+			 * @module json-api
+			 *
+			 * @since 8.2.0
+			 *
+			 * @param bool $view_hosting Can site access Hosting section. Default to false.
+			 */
+			'view_hosting'        => apply_filters( 'jetpack_json_api_site_can_view_hosting', false ),
+			'activate_plugins'    => current_user_can( 'activate_plugins' ),
+		);
+	}
+}

--- a/projects/packages/newsletter-widget/tests/.phpcs.dir.xml
+++ b/projects/packages/newsletter-widget/tests/.phpcs.dir.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset>
+	<rule ref="Jetpack-Tests" />
+</ruleset>

--- a/projects/packages/newsletter-widget/tests/php/bootstrap.php
+++ b/projects/packages/newsletter-widget/tests/php/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Bootstrap.
+ *
+ * @package automattic/
+ */
+
+/**
+ * Include the composer autoloader.
+ */
+require_once __DIR__ . '/../../vendor/autoload.php';

--- a/projects/plugins/jetpack/changelog/add-newsletter-widget
+++ b/projects/plugins/jetpack/changelog/add-newsletter-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added a newsletter widget.

--- a/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Adds the Jetpack Newsletter widget to the WordPress admin dashboard.
+ *
+ * @package jetpack
+ */
+
+/**
+ * Class that adds the Jetpack newsletter widget to the WordPress admin dashboard.
+ */
+class Jetpack_Newsletter_Dashboard_Widget {
+
+	/**
+	 * Indicates whether the class initialized or not.
+	 *
+	 * @var bool
+	 */
+	private static $initialized = false;
+
+	/**
+	 * The Widget ID.
+	 *
+	 * @var string
+	 */
+	private static $widget_id = 'jetpack_newsletter_dashboard_widget';
+
+	/**
+	 * Initialize the class by calling the setup static function.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		if ( ! self::$initialized ) {
+			self::$initialized = true;
+			self::wp_dashboard_setup();
+		}
+	}
+
+	/**
+	 * JavaScript and CSS for dashboard widget.
+	 *
+	 * @access public
+	 * @return void
+	 */
+	public static function admin_head() {
+		?>
+			<script type="text/javascript">
+				/* <![CDATA[ */
+				jQuery( function($) {
+					var dashStats = jQuery( '#dashboard_stats div.inside' );
+
+					if ( dashStats.find( '.dashboard-widget-control-form' ).length ) {
+						return;
+					}
+
+					if ( ! dashStats.length ) {
+						dashStats = jQuery( '#dashboard_stats div.dashboard-widget-content' );
+						var h = parseInt( dashStats.parent().height() ) - parseInt( dashStats.prev().height() );
+						var args = 'width=' + dashStats.width() + '&height=' + h.toString();
+					} else {
+						if ( jQuery('#dashboard_stats' ).hasClass('postbox') ) {
+							var args = 'width=' + ( dashStats.prev().width() * 2 ).toString();
+						} else {
+							var args = 'width=' + ( dashStats.width() * 2 ).toString();
+						}
+					}
+
+					dashStats
+						.not( '.dashboard-widget-control' )
+						.load( 'admin.php?page=stats&noheader&dashboard&' + args, function() {
+							jQuery( '#dashboard_stats' ).removeClass( 'is-loading' );
+							jQuery( '#stat-chart' ).css( 'width', 'auto' );
+						} );
+
+					// Widget settings toggle container.
+					var toggle = $( '.js-toggle-stats_dashboard_widget_control' );
+
+					// Move the toggle in the widget header.
+					toggle.appendTo( '#jetpack_summary_widget .handle-actions' );
+
+					// Toggle settings when clicking on it.
+					toggle.show().click( function( e ) {
+						e.preventDefault();
+						e.stopImmediatePropagation();
+						$( this ).parent().toggleClass( 'controlVisible' );
+						$( '#stats_dashboard_widget_control' ).slideToggle();
+					} );
+				} );
+				/* ]]> */
+			</script>
+		<?php
+	}
+
+	/**
+	 * Sets up the Jetpack Newsletter widget in the WordPress admin dashboard.
+	 */
+	public static function wp_dashboard_setup() {
+
+		// TODO: Check who can view the widget
+
+		if ( Jetpack::is_connection_ready() ) {
+			add_action( 'admin_head', array( static::class, 'admin_head' ) );
+
+			$widget_title = sprintf(
+				__( 'Newsletter', 'jetpack' )
+			);
+
+			wp_add_dashboard_widget(
+				self::$widget_id,
+				$widget_title,
+				array( static::class, 'render_widget' )
+			);
+		}
+	}
+
+	/**
+	 * Renders the widget.
+	 */
+	public static function render_widget() {
+		echo 'This is a test widget';
+	}
+}

--- a/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
@@ -1,5 +1,13 @@
 <?php
 /**
+ * Jetpack Newsletter Dashboard Widget wrapper.
+ *
+ * @package jetpack
+ */
+
+use Automattic\Jetpack\Newsletter_Widget\Dashboard;
+
+/**
  * Adds the Jetpack Newsletter widget to the WordPress admin dashboard.
  *
  * @package jetpack
@@ -96,8 +104,6 @@ class Jetpack_Newsletter_Dashboard_Widget {
 	 */
 	public static function wp_dashboard_setup() {
 
-		// TODO: Check who can view the widget
-
 		if ( Jetpack::is_connection_ready() ) {
 			add_action( 'admin_head', array( static::class, 'admin_head' ) );
 
@@ -105,18 +111,13 @@ class Jetpack_Newsletter_Dashboard_Widget {
 				__( 'Newsletter', 'jetpack' )
 			);
 
+			$widget = new Dashboard();
+
 			wp_add_dashboard_widget(
 				self::$widget_id,
 				$widget_title,
-				array( static::class, 'render_widget' )
+				array( $widget, 'render' )
 			);
 		}
-	}
-
-	/**
-	 * Renders the widget.
-	 */
-	public static function render_widget() {
-		echo 'This is a test widget';
 	}
 }

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -652,6 +652,10 @@ class Jetpack {
 		require_once JETPACK__PLUGIN_DIR . 'class-jetpack-stats-dashboard-widget.php';
 		add_action( 'wp_dashboard_setup', array( new Jetpack_Stats_Dashboard_Widget(), 'init' ) );
 
+		// Add this line to include the newsletter widget class
+		require_once JETPACK__PLUGIN_DIR . 'class-jetpack-newsletter-dashboard-widget.php';
+		add_action( 'wp_dashboard_setup', array( new Jetpack_Newsletter_Dashboard_Widget(), 'init' ) );
+
 		// Returns HTTPS support status.
 		add_action( 'wp_ajax_jetpack-recheck-ssl', array( $this, 'ajax_recheck_ssl' ) );
 

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -37,6 +37,7 @@
 		"automattic/jetpack-logo": "@dev",
 		"automattic/jetpack-masterbar": "@dev",
 		"automattic/jetpack-my-jetpack": "@dev",
+		"automattic/jetpack-newsletter-widget": "^0.1.0@dev",
 		"automattic/jetpack-plugins-installer": "@dev",
 		"automattic/jetpack-post-list": "@dev",
 		"automattic/jetpack-publicize": "@dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
 		"Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
 		"This file is @generated automatically"
 	],
-	"content-hash": "4ff7d971fbdbfab4e0db1e3b7b772645",
+	"content-hash": "0bff47323c36e86c7967824d6783107b",
 	"packages": [
 		{
 			"name": "automattic/jetpack-a8c-mc-stats",
@@ -1884,6 +1884,64 @@
 				"GPL-2.0-or-later"
 			],
 			"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
+			"transport-options": {
+				"relative": true
+			}
+		},
+		{
+			"name": "automattic/jetpack-newsletter-widget",
+			"version": "dev-trunk",
+			"dist": {
+				"type": "path",
+				"url": "../../packages/newsletter-widget",
+				"reference": "68fa159b41bfa100b7bcac2572a9e8f4eb74a57d"
+			},
+			"require": {
+				"php": ">=7.2"
+			},
+			"require-dev": {
+				"automattic/jetpack-changelogger": "@dev",
+				"yoast/phpunit-polyfills": "^1.1.1"
+			},
+			"suggest": {
+				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+			},
+			"type": "jetpack-library",
+			"extra": {
+				"branch-alias": {
+					"dev-trunk": "0.1.x-dev"
+				},
+				"textdomain": "jetpack-newsletter-widget",
+				"version-constants": {
+					"::PACKAGE_VERSION": "src/class-newsletter-widget.php"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"scripts": {
+				"build-development": [
+					"echo 'Add your build step to composer.json, please!'"
+				],
+				"build-production": [
+					"echo 'Add your build step to composer.json, please!'"
+				],
+				"phpunit": [
+					"./vendor/phpunit/phpunit/phpunit --colors=always"
+				],
+				"test-coverage": [
+					"php -dpcov.directory=. ./vendor/bin/phpunit --coverage-php \"$COVERAGE_DIR/php.cov\""
+				],
+				"test-php": [
+					"@composer phpunit"
+				]
+			},
+			"license": [
+				"GPL-2.0-or-later"
+			],
+			"description": "This package consumes the Calypso standalone app newsletter to render the Newsletter Widget in the wp-admin Dashboard. ",
 			"transport-options": {
 				"relative": true
 			}
@@ -6047,6 +6105,7 @@
 		"automattic/jetpack-logo": 20,
 		"automattic/jetpack-masterbar": 20,
 		"automattic/jetpack-my-jetpack": 20,
+		"automattic/jetpack-newsletter-widget": 20,
 		"automattic/jetpack-plugins-installer": 20,
 		"automattic/jetpack-post-list": 20,
 		"automattic/jetpack-publicize": 20,

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-newsletter-widget
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-newsletter-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added newsletter widget

--- a/projects/plugins/wpcomsh/changelog/add-newsletter-widget
+++ b/projects/plugins/wpcomsh/changelog/add-newsletter-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added newsletter widget


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We want to consume the standalone app being created in https://github.com/Automattic/wp-calypso/pull/99652 in Jetpack and in WPCOM. We are going to rely on the newsletters-widget package to achieve this. The idea is to display a widget for the newsletter in wp-admin. 

The stats-admin package displays the stats dashboard in a similar way. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

