### PR TITLE
Boost: Refactor plugin update handling for minify events

### DIFF
--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -119,6 +119,8 @@ class Jetpack_Boost {
 		// Initiate jetpack sync.
 		$this->init_sync();
 
+		add_action( 'admin_init', array( $this, 'handle_version_change' ) );
+
 		add_action( 'init', array( $this, 'init_textdomain' ) );
 
 		add_action( 'jetpack_boost_critical_css_environment_changed', array( $this, 'handle_environment_change' ), 10, 2 );
@@ -145,6 +147,20 @@ class Jetpack_Boost {
 	private function register_deactivation_hook() {
 		$plugin_file = trailingslashit( dirname( __DIR__ ) ) . 'jetpack-boost.php';
 		register_deactivation_hook( $plugin_file, array( $this, 'deactivate' ) );
+	}
+
+	public function handle_version_change() {
+		$version = get_option( 'jetpack_boost_version' );
+
+		if ( $version === JETPACK_BOOST_VERSION ) {
+			return;
+		}
+
+		update_option( 'jetpack_boost_version', JETPACK_BOOST_VERSION );
+
+		if ( jetpack_boost_minify_is_enabled() ) {
+			jetpack_boost_minify_activation();
+		}
 	}
 
 	/**

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -159,6 +159,8 @@ class Jetpack_Boost {
 		update_option( 'jetpack_boost_version', JETPACK_BOOST_VERSION );
 
 		if ( jetpack_boost_minify_is_enabled() ) {
+			// We need to clear Minify scheduled events to ensure the latest scheduled jobs are only scheduled irrespective of scheduled arguments.
+			jetpack_boost_minify_clear_scheduled_events();
 			jetpack_boost_minify_activation();
 		}
 	}

--- a/projects/plugins/boost/changelog/fix-boost-version-handler
+++ b/projects/plugins/boost/changelog/fix-boost-version-handler
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix for unreleased feature
+
+

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -174,32 +174,6 @@ register_activation_hook( __FILE__, array( 'Automattic\Jetpack_Boost\Jetpack_Boo
 // Redirect to plugin page when the plugin is activated.
 add_action( 'activated_plugin', __NAMESPACE__ . '\jetpack_boost_plugin_activation' );
 
-function jetpack_boost_upgrade_handler( $upgrader_object, $hook_extra ) {
-	if ( 'plugin' !== $hook_extra['type'] ) {
-		return;
-	}
-
-	if ( 'update' !== $hook_extra['action'] ) {
-		return;
-	}
-
-	if ( empty( $hook_extra['plugins'] ) ) {
-		return;
-	}
-
-	if ( ! in_array( JETPACK_BOOST_PLUGIN_BASE, $hook_extra['plugins'], true ) ) {
-		return;
-	}
-
-	if ( ! jetpack_boost_minify_is_enabled() ) {
-		return;
-	}
-
-	jetpack_boost_minify_activation();
-}
-
-add_action( 'upgrader_process_complete', __NAMESPACE__ . '\jetpack_boost_upgrade_handler', 10, 2 );
-
 /**
  * Redirects to plugin page when the plugin is activated
  *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates how Boost handles update compatibility

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Have Boost 3.8.0 installed 
* Install WP Crontrol plugin
* Enable Minify JS and Minify CSS
* Verify that the cron `jetpack_boost_minify_cron_cache_cleanup` is run with the argument `[ "" ]` as seen below.
![Screenshot 2025-02-13 at 09 25 00](https://github.com/user-attachments/assets/0f7f2c73-b2fe-4e88-bd74-52fb15a7bef8)
* Upgrade to Boost 3.9.0
* Verify that the cron `jetpack_boost_minify_cron_cache_cleanup` and `jetpack_boost_404_tester_cron` are present and are scheduled, and no `jetpack_boost_minify_cron_cache_cleanup` cron is present with the argument `[ "" ]`
![Screenshot 2025-02-13 at 09 26 50](https://github.com/user-attachments/assets/dd5b88df-9922-441f-ab8a-31ee67491f8c)

