### PR TITLE
[WooCommerce Analytics] Remove prefix _woocommerceanalytics for clickhouse events

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/tweak-remov-prefix-woocommerceanalytics-clickhouse
+++ b/projects/packages/woocommerce-analytics/changelog/tweak-remov-prefix-woocommerceanalytics-clickhouse
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove prefix _woocommerceanalytics in ClickHouse events

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -433,11 +433,11 @@ trait Woo_Analytics_Trait {
 			)
 		);
 
-		$js = "{'_en': '" . esc_js( $event_name ) . "'";
-
-		// ch param is needed to identify ClickHouse queries in the JS Analytics library
+		// ch param is needed to identify ClickHouse queries in the JS Analytics library. Remove prefix also for ClickHouse
 		if ( $clickhouse ) {
-			$js .= ", 'ch':'1'";
+			$js = "{'_en': '" . esc_js( str_replace( 'woocommerceanalytics_', '', $event_name ) ) . "','ch':'1'";
+		} else {
+			$js = "{'_en': '" . esc_js( $event_name ) . "'";
 		}
 
 		if ( isset( $product_details ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
MateralViews in ClickHouse are created without prefix already by Sysops, we should remove the prefix for ClickHouse events. 
Since CH is exclusively used for WooCommerce Analytics events its not a problem to do that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Perform the steps in https://github.com/Automattic/jetpack/pull/41476 and verify the events are being sent without _woocommerceanalytics prefix

