### PR TITLE
SEO Assistant: Add error handling to meta description

### DIFF
--- a/projects/plugins/jetpack/changelog/update-seo-assistant-error-metadescription
+++ b/projects/plugins/jetpack/changelog/update-seo-assistant-error-metadescription
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+SEO Assistant: Add error handling to meta description step

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
@@ -53,14 +53,15 @@ export default function AssistantWizard( { close } ) {
 		if ( ! currentStepData || ! currentStepData.onStart ) {
 			return;
 		}
-		if ( assistantFlowAction !== 'backwards' ) {
+		// If the step is backwards, we don't want to start the step again, unless it failed before and has no options
+		if ( assistantFlowAction !== 'backwards' || steps[ currentStep ]?.options?.length === 0 ) {
 			await currentStepData?.onStart( {
 				fromSkip: assistantFlowAction === 'skip',
 				results,
 			} );
 		}
 		setIsBusy( false );
-	}, [ currentStepData, assistantFlowAction, results ] );
+	}, [ currentStepData, assistantFlowAction, steps, currentStep, results ] );
 
 	const handleNext = useCallback( () => {
 		debug( 'handleNext, stepsCount', stepsCount );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -4,7 +4,13 @@
 import { askQuestionSync, usePostContent } from '@automattic/jetpack-ai-client';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useCallback, useState, createInterpolateElement, useMemo } from '@wordpress/element';
+import {
+	useCallback,
+	useState,
+	createInterpolateElement,
+	useMemo,
+	useEffect,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /*
  * Internal dependencies
@@ -44,6 +50,8 @@ export const useMetaDescriptionStep = ( {
 	const postContent = usePostContent();
 	const postId = useSelect( select => select( editorStore ).getCurrentPostId(), [] );
 	const [ generatedCount, setGeneratedCount ] = useState( 0 );
+	const [ hasFailed, setHasFailed ] = useState( false );
+	const [ failurePoint, setFailurePoint ] = useState< 'generate' | 'regenerate' | null >( null );
 
 	const prevStepHasChanged = useMemo( () => keywords !== lastValue, [ keywords, lastValue ] );
 
@@ -103,57 +111,99 @@ export const useMetaDescriptionStep = ( {
 		return selectedMetaDescription;
 	}, [ selectedMetaDescription, addMessage, editPost ] );
 
+	useEffect( () => {
+		if ( ! hasFailed ) {
+			// Reset the failure point when the request is successful
+			setFailurePoint( null );
+		}
+	}, [ hasFailed ] );
+
 	const handleMetaDescriptionGenerate = useCallback(
 		async ( { fromSkip } ) => {
 			let newMetaDescriptions = [ ...metaDescriptionOptions ];
+			const previousLastValue = lastValue;
 
 			setLastValue( keywords );
-			const initialMessage = fromSkip
-				? {
-						content: createInterpolateElement(
-							__( "Skipped!<br />Now, let's optimize your meta description.", 'jetpack' ),
-							{ br: <br /> }
-						),
-						showIcon: true,
-				  }
-				: {
-						content: __( "Now, let's optimize your meta description.", 'jetpack' ),
-						showIcon: true,
-				  };
 
-			setMessages( [ initialMessage ] );
+			if ( ! hasFailed ) {
+				const initialMessage = fromSkip
+					? {
+							content: createInterpolateElement(
+								__( "Skipped!<br />Now, let's optimize your meta description.", 'jetpack' ),
+								{ br: <br /> }
+							),
+							showIcon: true,
+					  }
+					: {
+							content: __( "Now, let's optimize your meta description.", 'jetpack' ),
+							showIcon: true,
+					  };
+
+				setMessages( [ initialMessage ] );
+			}
+
 			// we only generate if options are empty
 			if ( newMetaDescriptions.length === 0 || prevStepHasChanged ) {
-				setSelectedMetaDescription( '' );
-				newMetaDescriptions = await getMetaDescriptions();
+				try {
+					setSelectedMetaDescription( '' );
+					setHasFailed( false );
+					newMetaDescriptions = await getMetaDescriptions();
+				} catch {
+					setFailurePoint( 'generate' );
+					setHasFailed( true );
+					// reset the last value to the previous value on failure to avoid a wrong value for prevStepHasChanged
+					setLastValue( previousLastValue );
+					return;
+				}
 			}
+
 			setMetaDescriptionOptions( newMetaDescriptions );
+
 			const readyMessageSuffix = createInterpolateElement(
 				__( "<br />Here's a suggestion:", 'jetpack' ),
 				{ br: <br /> }
 			);
+
 			editLastMessage( readyMessageSuffix, true );
+
 			newMetaDescriptions.forEach( meta =>
 				addMessage( { ...meta, type: 'option', isUser: true } )
 			);
 		},
 		[
 			metaDescriptionOptions,
-			setMessages,
+			lastValue,
+			keywords,
+			hasFailed,
+			prevStepHasChanged,
 			editLastMessage,
+			setMessages,
 			getMetaDescriptions,
 			addMessage,
-			keywords,
-			prevStepHasChanged,
 		]
 	);
 
 	const handleMetaDescriptionRegenerate = useCallback( async () => {
-		const newMetaDescription = await getMetaDescriptions();
+		try {
+			setHasFailed( false );
+			const newMetaDescription = await getMetaDescriptions();
 
-		setMetaDescriptionOptions( prev => [ ...prev, ...newMetaDescription ] );
-		newMetaDescription.forEach( meta => addMessage( { ...meta, type: 'option', isUser: true } ) );
+			setMetaDescriptionOptions( prev => [ ...prev, ...newMetaDescription ] );
+			newMetaDescription.forEach( meta => addMessage( { ...meta, type: 'option', isUser: true } ) );
+		} catch {
+			setFailurePoint( 'regenerate' );
+			setHasFailed( true );
+		}
 	}, [ addMessage, getMetaDescriptions ] );
+
+	const resetState = useCallback( () => {
+		setHasFailed( false );
+		setFailurePoint( null );
+	}, [] );
+
+	// The build fails if we use i18n strings directly in a ternary operator.
+	const tryAgainLabel = __( 'Try again', 'jetpack' );
+	const regenerateLabel = __( 'Regenerate', 'jetpack' );
 
 	return {
 		id: 'meta',
@@ -165,12 +215,15 @@ export const useMetaDescriptionStep = ( {
 		onSelect: handleMetaDescriptionSelect,
 		onSubmit: handleMetaDescriptionSubmit,
 		submitCtaLabel: __( 'Insert', 'jetpack' ),
-		onRetry: handleMetaDescriptionRegenerate,
-		retryCtaLabel: __( 'Regenerate', 'jetpack' ),
+		onRetry:
+			failurePoint === 'generate' ? handleMetaDescriptionGenerate : handleMetaDescriptionRegenerate,
+		retryCtaLabel: failurePoint === 'generate' ? tryAgainLabel : regenerateLabel,
 		onStart: handleMetaDescriptionGenerate,
 		value,
 		setValue,
 		includeInResults: true,
 		hasSelection: !! selectedMetaDescription,
+		hasFailed,
+		resetState,
 	};
 };

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -44,7 +44,7 @@ export const useMetaDescriptionStep = ( {
 	const [ value, setValue ] = useState< string >();
 	const [ lastValue, setLastValue ] = useState< string >( '' );
 	const [ selectedMetaDescription, setSelectedMetaDescription ] = useState< string >();
-	const [ metaDescriptionOptions, setMetaDescriptionOptions ] = useState< OptionMessage[] >( [] );
+	const [ valueOptions, setValueOptions ] = useState< OptionMessage[] >( [] );
 	const { messages, setMessages, addMessage, editLastMessage, setSelectedMessage } = useMessages();
 	const { editPost } = useDispatch( editorStore );
 	const postContent = usePostContent();
@@ -82,9 +82,7 @@ export const useMetaDescriptionStep = ( {
 		( option: OptionMessage ) => {
 			setSelectedMetaDescription( option.content as string );
 			setSelectedMessage( option );
-			setMetaDescriptionOptions( prev =>
-				prev.map( o => ( { ...o, selected: o.id === option.id } ) )
-			);
+			setValueOptions( prev => prev.map( o => ( { ...o, selected: o.id === option.id } ) ) );
 		},
 		[ setSelectedMessage ]
 	);
@@ -120,7 +118,7 @@ export const useMetaDescriptionStep = ( {
 
 	const handleMetaDescriptionGenerate = useCallback(
 		async ( { fromSkip } ) => {
-			let newMetaDescriptions = [ ...metaDescriptionOptions ];
+			let newMetaDescriptions = [ ...valueOptions ];
 			const previousLastValue = lastValue;
 
 			setLastValue( keywords );
@@ -157,7 +155,7 @@ export const useMetaDescriptionStep = ( {
 				}
 			}
 
-			setMetaDescriptionOptions( newMetaDescriptions );
+			setValueOptions( newMetaDescriptions );
 
 			const readyMessageSuffix = createInterpolateElement(
 				__( "<br />Here's a suggestion:", 'jetpack' ),
@@ -171,7 +169,7 @@ export const useMetaDescriptionStep = ( {
 			);
 		},
 		[
-			metaDescriptionOptions,
+			valueOptions,
 			lastValue,
 			keywords,
 			hasFailed,
@@ -188,7 +186,7 @@ export const useMetaDescriptionStep = ( {
 			setHasFailed( false );
 			const newMetaDescription = await getMetaDescriptions();
 
-			setMetaDescriptionOptions( prev => [ ...prev, ...newMetaDescription ] );
+			setValueOptions( prev => [ ...prev, ...newMetaDescription ] );
 			newMetaDescription.forEach( meta => addMessage( { ...meta, type: 'option', isUser: true } ) );
 		} catch {
 			setFailurePoint( 'regenerate' );
@@ -211,7 +209,7 @@ export const useMetaDescriptionStep = ( {
 		label: __( 'Meta description', 'jetpack' ),
 		messages: messages,
 		type: 'options',
-		options: metaDescriptionOptions,
+		options: valueOptions,
 		onSelect: handleMetaDescriptionSelect,
 		onSubmit: handleMetaDescriptionSubmit,
 		submitCtaLabel: __( 'Insert', 'jetpack' ),

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -37,7 +37,7 @@ export const useTitleStep = ( {
 } ): Step => {
 	const [ value, setValue ] = useState< string >( '' );
 	const [ selectedTitle, setSelectedTitle ] = useState< string >( '' );
-	const [ titleOptions, setTitleOptions ] = useState< OptionMessage[] >( [] );
+	const [ valueOptions, setValueOptions ] = useState< OptionMessage[] >( [] );
 	const { editPost } = useDispatch( 'core/editor' );
 	const { messages, setMessages, addMessage, editLastMessage, setSelectedMessage } = useMessages();
 	const [ lastValue, setLastValue ] = useState< string >( '' );
@@ -75,7 +75,7 @@ export const useTitleStep = ( {
 		( option: OptionMessage ) => {
 			setSelectedTitle( option.content as string );
 			setSelectedMessage( option );
-			setTitleOptions( prev => prev.map( o => ( { ...o, selected: o.id === option.id } ) ) );
+			setValueOptions( prev => prev.map( o => ( { ...o, selected: o.id === option.id } ) ) );
 		},
 		[ setSelectedMessage ]
 	);
@@ -104,7 +104,7 @@ export const useTitleStep = ( {
 
 	const handleTitleGenerate = useCallback(
 		async ( { fromSkip } ) => {
-			let newTitles = [ ...titleOptions ];
+			let newTitles = [ ...valueOptions ];
 			const previousLastValue = lastValue;
 
 			setLastValue( keywords );
@@ -149,14 +149,14 @@ export const useTitleStep = ( {
 
 			if ( newTitles.length ) {
 				// this sets the title options for internal state
-				setTitleOptions( newTitles );
+				setValueOptions( newTitles );
 				// this adds title options as message-buttons
 				newTitles.forEach( title => addMessage( { ...title, type: 'option', isUser: true } ) );
 			}
 			return value;
 		},
 		[
-			titleOptions,
+			valueOptions,
 			lastValue,
 			keywords,
 			hasFailed,
@@ -174,13 +174,13 @@ export const useTitleStep = ( {
 			setHasFailed( false );
 			const newTitles = await getTitles();
 
-			setTitleOptions( [ ...titleOptions, ...newTitles ] );
+			setValueOptions( [ ...valueOptions, ...newTitles ] );
 			newTitles.forEach( title => addMessage( { ...title, type: 'option', isUser: true } ) );
 		} catch {
 			setFailurePoint( 'regenerate' );
 			setHasFailed( true );
 		}
-	}, [ getTitles, titleOptions, addMessage ] );
+	}, [ getTitles, valueOptions, addMessage ] );
 
 	const handleTitleSubmit = useCallback( async () => {
 		setValue( selectedTitle );
@@ -204,7 +204,7 @@ export const useTitleStep = ( {
 		label: __( 'Title', 'jetpack' ),
 		messages,
 		type: 'options',
-		options: titleOptions,
+		options: valueOptions,
 		onSelect: handleTitleSelect,
 		onSubmit: handleTitleSubmit,
 		submitCtaLabel: __( 'Insert', 'jetpack' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #41648 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Applies the error handling from the title step to the metadescription step
Note: It should probably be a hook or something to avoid code duplication, but I think this is premature optimization as we still have to deal with dynamic steps and things could get more complicated.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Same as https://github.com/Automattic/jetpack/pull/41649, just in the next step
