### PR TITLE
Wpcomsh WPCloud testing: Make the unlinked refresh step optional.

### DIFF
--- a/.github/workflows/wpcloud.yml
+++ b/.github/workflows/wpcloud.yml
@@ -121,7 +121,8 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Transferring wpcomsh to the testing server"
-          ssh jpwpcomsh "wp dereferenced freshen > /dev/null 2>&1"
+          ssh jpwpcomsh "wp --skip-plugins --skip-themes dereferenced freshen > /dev/null 2>&1" || CODE=$?
+          echo "wp dereferenced freshen has exited with code $CODE"
           ssh jpwpcomsh "rm -rf /tmp/old-* > /dev/null 2>&1"
           pnpm jetpack rsync wpcomsh jpwpcomsh:~/htdocs/wp-content/mu-plugins
           scp -r projects/plugins/wpcomsh/bin jpwpcomsh:/srv/htdocs/wp-content/mu-plugins/wpcomsh


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Running `wp` commands can break because of fatal errors in the tested code, so we're making the step optional. Rsyncing over the plugin code should fix any problems, and the refresh command will be ran the next time.

## Proposed changes:
* Add return code catching to the `wp dereferenced freshen` command.
* Add `--skip-plugins --skip-themes` to the WP CLI command.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Either run the commands manually, or wait until CI runs.

