### PR TITLE
Boost: Make sure the 404 test uses an "ordinary looking" file.

### DIFF
--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -5,6 +5,10 @@ use Automattic\Jetpack_Boost\Lib\Minify\Config;
 use Automattic\Jetpack_Boost\Lib\Minify\File_Paths;
 use Automattic\Jetpack_Boost\Lib\Minify\Utils;
 
+if ( ! defined( 'JETPACK_BOOST_STATIC_CACHE_404_TESTER_PATH' ) ) {
+	define( 'JETPACK_BOOST_STATIC_CACHE_404_TESTER_PATH', '/wp-content/boost-cache/static/testing_404.js' );
+}
+
 function jetpack_boost_handle_minify_request( $request_uri ) {
 	// We handle the cache here, tell other caches not to.
 	if ( ! defined( 'DONOTCACHEPAGE' ) ) {
@@ -48,7 +52,7 @@ function jetpack_boost_handle_minify_request( $request_uri ) {
  * Using a crafted request, we can check if is_404() is working in wp-content/
  */
 function jetpack_boost_check_404_handler( $request_uri ) {
-	if ( ! str_contains( strtolower( $request_uri ), 'wp-content/boost-cache/static/testing_404' ) ) {
+	if ( ! str_contains( strtolower( $request_uri ), JETPACK_BOOST_STATIC_CACHE_404_TESTER_PATH ) ) {
 		return;
 	}
 
@@ -78,7 +82,7 @@ function jetpack_boost_404_tester() {
 	}
 
 	$minification_enabled = '';
-	wp_remote_get( home_url( '/wp-content/boost-cache/static/testing_404' ) );
+	wp_remote_get( home_url( JETPACK_BOOST_STATIC_CACHE_404_TESTER_PATH ) );
 	if ( file_exists( Config::get_static_cache_dir_path() . '/404' ) ) {
 		wp_delete_file( Config::get_static_cache_dir_path() . '/404' );
 		$minification_enabled = 1;

--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -50,6 +50,7 @@ function jetpack_boost_handle_minify_request( $request_uri ) {
 
 /**
  * Using a crafted request, we can check if is_404() is working in wp-content/
+ * The constant JETPACK_BOOST_STATIC_CACHE_404_TESTER_PATH is the path to the file that will be requested.
  */
 function jetpack_boost_check_404_handler( $request_uri ) {
 	if ( ! str_contains( strtolower( $request_uri ), JETPACK_BOOST_STATIC_CACHE_404_TESTER_PATH ) ) {
@@ -73,6 +74,7 @@ function jetpack_boost_check_404_handler( $request_uri ) {
  * It sends a request to a non-existent URL, that will execute the 404 handler
  * in jetpack_boost_check_404_handler().
  * Define the constant JETPACK_BOOST_DISABLE_404_TESTER to disable this.
+ * The constant JETPACK_BOOST_STATIC_CACHE_404_TESTER_PATH is the path to the file that will be requested.
  *
  * This function is called when the Minify_CSS or Minify_JS module is activated, and once per day.
  */

--- a/projects/plugins/boost/changelog/update-boost-404_tester_path
+++ b/projects/plugins/boost/changelog/update-boost-404_tester_path
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Concatenation: make the 404 test url look like a static file to detect hosts that treat those files differently
+
+

--- a/projects/plugins/boost/tests/php/lib/minify/test-functions-service.php
+++ b/projects/plugins/boost/tests/php/lib/minify/test-functions-service.php
@@ -34,12 +34,12 @@ class Test_Functions_Service extends Base_Test_Case {
 
 		Functions\expect( 'home_url' )
 			->once()
-			->with( '/wp-content/boost-cache/static/testing_404' )
-			->andReturn( 'http://example.com/wp-content/boost-cache/static/testing_404' );
+			->with( '/wp-content/boost-cache/static/testing_404.js' )
+			->andReturn( 'http://example.com/wp-content/boost-cache/static/testing_404.js' );
 
 		Functions\expect( 'wp_remote_get' )
 			->once()
-			->with( 'http://example.com/wp-content/boost-cache/static/testing_404' );
+			->with( 'http://example.com/wp-content/boost-cache/static/testing_404.js' );
 
 		Functions\expect( 'wp_delete_file' )
 			->once()
@@ -55,12 +55,12 @@ class Test_Functions_Service extends Base_Test_Case {
 	public function test_404_tester_when_404_file_does_not_exist() {
 		Functions\expect( 'home_url' )
 			->once()
-			->with( '/wp-content/boost-cache/static/testing_404' )
-			->andReturn( 'http://example.com/wp-content/boost-cache/static/testing_404' );
+			->with( '/wp-content/boost-cache/static/testing_404.js' )
+			->andReturn( 'http://example.com/wp-content/boost-cache/static/testing_404.js' );
 
 		Functions\expect( 'wp_remote_get' )
 			->once()
-			->with( 'http://example.com/wp-content/boost-cache/static/testing_404' );
+			->with( 'http://example.com/wp-content/boost-cache/static/testing_404.js' );
 
 		Functions\expect( 'update_site_option' )
 			->once()


### PR DESCRIPTION
Some hosts will optimize delivery of static files in wp-content and won't allow WordPress to show a 404 page if the file is missing.
This testing_404.js file should make testing in those environments more accurate.
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a constant JETPACK_BOOST_STATIC_CACHE_404_TESTER_PATH to define the 404 file to use for the concatenation test.
* Change the file requested to "testing_404.js".

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply patch on a host that handles static files differently.
* Toggle both concatenation modules off, and toggle one on.
* Reload the front page of the site to check if the static cache is used. 
