### PR TITLE
Photon: don't attempt to process images with unsupported extension

### DIFF
--- a/projects/packages/image-cdn/changelog/fix-photon-related-posts-avif
+++ b/projects/packages/image-cdn/changelog/fix-photon-related-posts-avif
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Do not serve images using unsupported extensions with the cdn_url method.

--- a/projects/packages/image-cdn/src/class-image-cdn-core.php
+++ b/projects/packages/image-cdn/src/class-image-cdn-core.php
@@ -16,7 +16,6 @@ use Automattic\Jetpack\Status\Host;
  * A static class that provides core Image CDN functionality.
  */
 class Image_CDN_Core {
-
 	/**
 	 * Register hooks.
 	 */
@@ -121,6 +120,17 @@ class Image_CDN_Core {
 
 		// Unable to parse.
 		if ( ! is_array( $image_url_parts ) || empty( $image_url_parts['host'] ) || empty( $image_url_parts['path'] ) ) {
+			return $image_url;
+		}
+
+		// Ensure image extension is acceptable.
+		if (
+			! in_array(
+				strtolower( pathinfo( $image_url_parts['path'], PATHINFO_EXTENSION ) ),
+				Image_CDN::get_supported_extensions(),
+				true
+			)
+		) {
 			return $image_url;
 		}
 

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -1445,4 +1445,13 @@ final class Image_CDN {
 	private static function is_amp_endpoint() {
 		return class_exists( '\Jetpack_AMP_Support' ) && \Jetpack_AMP_Support::is_amp_request();
 	}
+
+	/**
+	 * Get the list of supported image extensions
+	 *
+	 * @return string[] Array of supported extensions
+	 */
+	public static function get_supported_extensions() {
+		return self::$extensions;
+	}
 }

--- a/projects/packages/image-cdn/tests/php/test_class.image_cdn_core.php
+++ b/projects/packages/image-cdn/tests/php/test_class.image_cdn_core.php
@@ -436,6 +436,19 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 	}
 
 	/**
+	 * Tests that Photon will only process images with supported extensions.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @dataProvider get_different_extensions
+	 *
+	 * @covers Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url
+	 */
+	public function test_photonizing_check_extensions( $image_url, $expected ) {
+		$this->assertEquals( $expected, Image_CDN_Core::cdn_url( $image_url, array( 'w' => 500 ) ) );
+	}
+
+	/**
 	 * Data provider for test_photon_banned_domains_banned
 	 */
 	public function get_photon_domains() {
@@ -471,6 +484,26 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 			'Banned Amazon domain'       => array(
 				true,
 				'http://m.media-amazon.com/images/I/41YeeCMUwTL._SL300_.jpg',
+			),
+		);
+	}
+
+	/**
+	 * Data provider for test_photonizing_check_extensions
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return array
+	 */
+	public function get_different_extensions() {
+		return array(
+			'HEIC: supported'     => array(
+				'https://example.com/image.heic',
+				'https://i0.wp.com/example.com/image.heic?w=500&ssl=1',
+			),
+			'AVIF: not supported' => array(
+				'https://example.com/image.avif',
+				'https://example.com/image.avif',
 			),
 		);
 	}

--- a/projects/plugins/jetpack/changelog/fix-photon-related-posts-avif
+++ b/projects/plugins/jetpack/changelog/fix-photon-related-posts-avif
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Related Posts: ensure images using the AVIF format are properly displayed.


### PR DESCRIPTION
Fixes #41753
See #35432

## Proposed changes:

Since Photon does not support AVIF yet, it should never attempt to serve images using that file format. Yet, we do not check for supported extensions when using `Jetpack_PostImages::fit_image_url()` (and thus `Image_CDN_Core::cdn_url()`). Let's fix that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

> [!NOTE]
> This is easier to test on a site with lots of posts, where related posts are displayed under some of your posts.

* Start by going to Media > Gallery, and upload an AVIF image to your site. You can pick that one for example: `https://jeherve.com/avif.avif`
* Go to Posts > Add New
* In that new post, add some content, and set the Featured image as the AVIF image you previously uploaded.
* Publish your post, and note its ID (in the post editor URL).
* Add the following snippet to your site to ensure that all related posts on your site return the post with the AVIF image:
```php
add_filter( 'jetpack_relatedposts_filter_hits', function ( $hits, $post_id ) {
	$hits = array(
		array( 'id' => 23335 ), // replace 23335 with your own post ID.
		array( 'id' => 23335 ), // replace 23335 with your own post
   ID.
		array( 'id' => 23335 ), // replace 23335 with your own post
37    ID.
	);
	return $hits;
}, 10, 2 );
```
* Visit a post on the frontend of your site.
    * When using this branch, the image should be displayed.
    * When using `trunk`, the image should appear broken (using the Photon domain prefix).
