### PR TITLE
Verbum: add error log

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/verbum-add-error-logging
+++ b/projects/packages/jetpack-mu-wpcom/changelog/verbum-add-error-logging
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Just adding an error log for bug tracing
+
+


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/99436

## Proposed changes:

* Add error log to Verbum nonce failure for more data on the issue.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Nah

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* We are not able to consistently replicate this in production so I don't really have testing steps.
* I have faked an error in my branch to verify this is getting logged properly.
* Check the code for mistakes or errors.

