### PR TITLE
Jetpack SEO: change AI feature request name

### DIFF
--- a/projects/plugins/jetpack/changelog/change-jetpack-seo-ai-request-feature
+++ b/projects/plugins/jetpack/changelog/change-jetpack-seo-ai-request-feature
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO: change AI feature request name, see https://github.a8c.com/Automattic/wpcom/pull/173244

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -65,7 +65,7 @@ export const useMetaDescriptionStep = ( {
 			],
 			{
 				postId,
-				feature: 'seo-meta-description',
+				feature: 'jetpack-seo-assistant',
 			}
 		);
 	}, [ keywords, postContent, postId, mockRequests ] );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -66,7 +66,7 @@ export const useTitleStep = ( {
 			],
 			{
 				postId,
-				feature: 'seo-title',
+				feature: 'jetpack-seo-assistant',
 			}
 		);
 	}, [ keywords, postContent, postId, mockRequests ] );


### PR DESCRIPTION
Fixes #41752 

## Proposed changes:
Change feature request name, see 173244-ghe-Automattic/wpcom for more details. This will use a feature that doesn't count as AI requests

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Either test against the sandbox with 173244-ghe-Automattic/wpcom applied to it or wait until that one is deployed. The requests should work fine on both cases (title, description) and checking your request count should not change after those have been triggered (check by running `wp.data.dispatch('wordpress-com/plans').fetchAiAssistantFeature()` on your console before and after the SEO assistant requests)