### PR TITLE
Jetpack SEO: enabled by default, still BETA

### DIFF
--- a/projects/plugins/jetpack/changelog/change-jetpack-seo-default-filter-value
+++ b/projects/plugins/jetpack/changelog/change-jetpack-seo-default-filter-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO: turn default filter value to true so to enable the SEO assistant by default. It remains as BETA though

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -114,7 +114,7 @@ add_action(
 	'jetpack_register_gutenberg_extensions',
 	function () {
 		if ( apply_filters( 'jetpack_ai_enabled', true ) &&
-			apply_filters( 'ai_seo_assistant_enabled', false )
+			apply_filters( 'ai_seo_assistant_enabled', true )
 		) {
 			\Jetpack_Gutenberg::set_extension_available( 'ai-seo-assistant' );
 		}


### PR DESCRIPTION
Fixes #41766 

## Proposed changes:
This PR turns default filter value to true so to enable the SEO assistant by default. Internal testing coming up, but still in BETA

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pe4Cmx-32o-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Spin a Jurassic Ninja, no filter needed now so just going to Jetpack Constants and using BETA as default blocks should suffice to get the SEO assistant available on the editor.