### PR TITLE
Boost: Use redirectUrl for premium support

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/layout/settings-page/support/support.tsx
+++ b/projects/plugins/boost/app/assets/src/js/layout/settings-page/support/support.tsx
@@ -1,12 +1,12 @@
 import { __ } from '@wordpress/i18n';
-import { Button } from '@automattic/jetpack-components';
+import { Button, getRedirectUrl } from '@automattic/jetpack-components';
 import styles from './support.module.scss';
 import { recordBoostEvent } from '$lib/utils/analytics';
 
 const Support = () => {
 	const openPaidSupport = () => {
 		recordBoostEvent( 'support_contact_us_clicked', {} );
-		const supportUrl = 'https://jetpackme.wordpress.com/contact-support/';
+		const supportUrl = getRedirectUrl( 'jetpack-boost-premium-support' );
 		window.open( supportUrl, '_blank' );
 	};
 

--- a/projects/plugins/boost/changelog/update-premium-support-link
+++ b/projects/plugins/boost/changelog/update-premium-support-link
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Changed premium support link
+
+


### PR DESCRIPTION
## Proposed changes:
* Update the support URL to use a jetpack-redirect

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pc9hqz-3mj-p2#comment-2370

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Upgrade Boost.
* Make sure the support link skips AI conversation.

<img width="856" alt="image" src="https://github.com/user-attachments/assets/5b8cdb5e-ce90-4122-8166-25042715d42e" />
