### PR TITLE
Subscribe block: unset invalid newsletter categories from attributes

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-unset-invalid-newsletter-category-ids
+++ b/projects/plugins/jetpack/changelog/fix-unset-invalid-newsletter-category-ids
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions block: unset invalid newsletter categories from attributes

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
@@ -13,7 +13,7 @@ import {
 	TextareaControl,
 	CheckboxControl,
 } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useEffect } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import InspectorNotice from '../../shared/components/inspector-notice';
 import { WidthControl } from '../../shared/width-panel';
@@ -66,6 +66,27 @@ export default function SubscriptionControls( {
 	successMessage = DEFAULT_SUCCESS_MESSAGE,
 } ) {
 	const { isModuleActive: isPublicizeEnabled } = useModuleStatus( 'publicize' );
+
+	// Unset any selected categories that are no longer available
+	useEffect( () => {
+		if ( availableNewsletterCategories?.length > 0 && selectedNewsletterCategoryIds?.length > 0 ) {
+			const availableIds = availableNewsletterCategories.map( cat => cat.id );
+			const validSelectedIds = selectedNewsletterCategoryIds.filter( id =>
+				availableIds.includes( id )
+			);
+
+			if ( validSelectedIds.length !== selectedNewsletterCategoryIds.length ) {
+				const updates = { selectedNewsletterCategoryIds: validSelectedIds };
+
+				// If no valid categories remain selected, disable preselection
+				if ( validSelectedIds.length === 0 ) {
+					updates.preselectNewsletterCategories = false;
+				}
+
+				setAttributes( updates );
+			}
+		}
+	}, [ availableNewsletterCategories, setAttributes, selectedNewsletterCategoryIds ] );
 
 	return (
 		<>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/test/controls.js
@@ -265,7 +265,7 @@ describe( 'Inspector controls', () => {
 			} );
 		} );
 
-		describe( 'Newsletter categories', () => {
+		describe( 'Pre-select newsletter categories', () => {
 			test( 'displays newsletter category controls when enabled', async () => {
 				const user = userEvent.setup();
 				render( <SubscriptionsInspectorControls { ...defaultProps } /> );
@@ -352,6 +352,41 @@ describe( 'Inspector controls', () => {
 
 				await user.click( screen.getByText( 'Settings' ), { selector: 'button' } );
 				await user.click( screen.getByLabelText( 'Category 1' ) );
+
+				expect( setAttributes ).toHaveBeenCalledWith( {
+					selectedNewsletterCategoryIds: [],
+					preselectNewsletterCategories: false,
+				} );
+			} );
+
+			test( 'filters out invalid selected IDs', () => {
+				render(
+					<SubscriptionsInspectorControls
+						{ ...defaultProps }
+						selectedNewsletterCategoryIds={ [
+							defaultProps.availableNewsletterCategories[ 0 ].id,
+							defaultProps.availableNewsletterCategories[ 1 ].id,
+							3,
+						] }
+					/>
+				);
+
+				expect( setAttributes ).toHaveBeenCalledWith( {
+					selectedNewsletterCategoryIds: [
+						defaultProps.availableNewsletterCategories[ 0 ].id,
+						defaultProps.availableNewsletterCategories[ 1 ].id,
+					],
+				} );
+			} );
+
+			test( 'disables pre-select option if no valid categories remain selected', () => {
+				render(
+					<SubscriptionsInspectorControls
+						{ ...defaultProps }
+						selectedNewsletterCategoryIds={ [ 3 ] }
+						preselectNewsletterCategories
+					/>
+				);
 
 				expect( setAttributes ).toHaveBeenCalledWith( {
 					selectedNewsletterCategoryIds: [],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to Automattic/loop#378

Here's a video showing the issue:


https://github.com/user-attachments/assets/65a27f1d-1b9b-4ff3-b990-331dde6f7302


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When the block loads in the editor, we will now check if any selected categories present in the attributes are no longer valid, i.e. (unchecked, deleted), and if so, remove them.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pe7F0s-2tV-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In site settings, enable and add some newsletter categories
  * These are located at Settings -> Newsletters -> Newsletter Categories on simple or Jetpack -> Settings -> Newsletters -> Newsletter Categories on atomic
* Add a subscribe block to a page and in its settings, configure it to pre-select some of those categories. Select more than one
* Save that block
* Go back to site settings and either delete or uncheck some of those categories
* Go back to the block you just created in the Editor and look at its settings
  * The removed categories should no longer be present
* Save the block
* Inspect the markup of the block on the front-end
  * The `selected_newsletter_categories` hidden input should not contain any of the removed category ids

