### PR TITLE
WPcom classic style site settings url update

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-settings-menu-item
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-settings-menu-item
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated /settings/general url to /sites/settings/site for classic style users

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -131,7 +131,9 @@ function wpcom_add_hosting_menu() {
 		esc_attr__( 'Site Settings', 'jetpack-mu-wpcom' ),
 		esc_attr__( 'Site Settings', 'jetpack-mu-wpcom' ),
 		'manage_options',
-		esc_url( "https://wordpress.com/sites/settings/site/$domain" ),
+		function_exists( 'wpcom_is_duplicate_views_experiment_enabled' ) && wpcom_is_duplicate_views_experiment_enabled() ?
+			esc_url( "https://wordpress.com/sites/settings/site/$domain" ) :
+			esc_url( "https://wordpress.com/settings/general/$domain" ),
 		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -131,7 +131,7 @@ function wpcom_add_hosting_menu() {
 		esc_attr__( 'Site Settings', 'jetpack-mu-wpcom' ),
 		esc_attr__( 'Site Settings', 'jetpack-mu-wpcom' ),
 		'manage_options',
-		esc_url( "https://wordpress.com/settings/general/$domain" ),
+		esc_url( "https://wordpress.com/sites/settings/site/$domain" ),
 		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
 	);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/99391

## Proposed changes:

Updates the classic style `Hosting > Site Settings` menu item link to point to /sites/settings/site instead of /settings/general after moving this screen out of nav unification and into the site management pages.

This is required to move a redirect from /settings/general on the calypso side.

```diff
- esc_url( "https://wordpress.com/settings/general/$domain" ),
+ esc_url( "https://wordpress.com/sites/settings/site/$domain" ),
```

<img src=https://github.com/user-attachments/assets/dd362852-86a7-4e74-ada7-a81dd10837a2 width=400 />


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

```
 jetpack rsync mu-wpcom-plugin wpcom:~/public_html/wp-content/mu-plugins/jetpack-mu-wpcom-plugin/dev
```

- [ ] Sandbox a test site and public-api. 
- [ ] Enable classic style
- [ ] Confirm the site settings menu is linking directly to /sites/settings/site for RDV treatment users
- [ ] Confirm the old url is still used for RDV control
