### PR TITLE
Social | Update classic editor connections schema

### DIFF
--- a/projects/packages/publicize/changelog/update-social-classic-editor-schema-in-publicize
+++ b/projects/packages/publicize/changelog/update-social-classic-editor-schema-in-publicize
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Update connection data for classic editor

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -885,19 +885,19 @@ abstract class Publicize_Base {
 			$post_id = null;
 		}
 
-		// TODO Get these services->connections from the cache populated from the REST API.
-		$services = $this->get_services( 'connected' );
 		$all_done = $this->post_is_done_sharing( $post_id );
 
 		// We don't allow Publicizing to the same external id twice, to prevent spam.
 		$service_id_done = (array) get_post_meta( $post_id, $this->POST_SERVICE_DONE, true );
 
-		foreach ( $services as $service_name => $connections ) {
+		$connections = Connections::get_all_for_user();
+
+		if ( ! empty( $connections ) ) {
+
 			foreach ( $connections as $connection ) {
-				$connection_meta = $this->get_connection_meta( $connection );
-				$connection_data = $connection_meta['connection_data'];
-				$unique_id       = $this->get_connection_unique_id( $connection );
-				$connection_id   = $this->get_connection_id( $connection );
+				$service_name  = $connection['service_name'];
+				$unique_id     = $connection['id'];
+				$connection_id = $connection['connection_id'];
 				// Was this connection (OR, old-format service) already Publicized to?
 				$done = ! empty( $post ) && (
 					// Flags based on token_id.
@@ -916,10 +916,10 @@ abstract class Publicize_Base {
 				 * @param bool true Should the post be publicized to a given service? Default to true.
 				 * @param int $post_id Post ID.
 				 * @param string $service_name Service name.
-				 * @param array $connection_data Array of information about all Publicize details for the site.
+				 * @param array $connection The connection data.
 				 */
 				/* phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores */
-				if ( ! apply_filters( 'wpas_submit_post?', true, $post_id, $service_name, $connection_data ) ) {
+				if ( ! apply_filters( 'wpas_submit_post?', true, $post_id, $service_name, $connection ) ) {
 					continue;
 				}
 
@@ -943,9 +943,7 @@ abstract class Publicize_Base {
 					)
 					||
 					(
-						is_array( $connection )
-						&&
-						isset( $connection_meta['external_id'] ) && ! empty( $service_id_done[ $service_name ][ $connection_meta['external_id'] ] )
+						isset( $connection['external_id'] ) && ! empty( $service_id_done[ $service_name ][ $connection['external_id'] ] )
 					)
 				);
 
@@ -971,7 +969,7 @@ abstract class Publicize_Base {
 				 * If this is a global connection and this user doesn't have enough permissions to modify
 				 * those connections, don't let them change it.
 				 */
-				if ( ! $done && $this->is_global_connection( $connection_meta ) && ! current_user_can( $this->GLOBAL_CAP ) ) {
+				if ( ! $done && $connection['shared'] && ! current_user_can( $this->GLOBAL_CAP ) ) {
 					$toggleable = false;
 
 					/**
@@ -993,28 +991,16 @@ abstract class Publicize_Base {
 					$enabled = true;
 				}
 
-				$connection_list[] = array(
-					// REST Meta fields.
-					'connection_id'   => $connection_id,
-					'display_name'    => $this->get_display_name( $service_name, $connection ),
-					'enabled'         => $enabled,
-					'external_handle' => $this->get_external_handle( $service_name, $connection ),
-					'external_id'     => $connection_meta['external_id'] ?? '',
-					'profile_link'    => (string) $this->get_profile_link( $service_name, $connection ),
-					'profile_picture' => (string) $this->get_profile_picture( $connection ),
-					'service_label'   => static::get_service_label( $service_name ),
-					'service_name'    => $service_name,
-					'shared'          => ! $connection_data['user_id'],
-					'status'          => null,
-
-					// Deprecated fields.
-					'id'              => $connection_id,
-					'unique_id'       => $unique_id,
-					'username'        => $this->get_username( $service_name, $connection ),
-					'done'            => $done,
-					'toggleable'      => $toggleable,
-					'global'          => 0 == $connection_data['user_id'], // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual,WordPress.PHP.StrictComparisons.LooseComparison -- Other types can be used at times.
-					'user_id'         => (int) $connection_data['user_id'],
+				$connection_list[] = array_merge(
+					$connection,
+					array(
+						'enabled'    => $enabled,
+						// Deprecated fields.
+						'id'         => $connection_id,
+						'unique_id'  => $unique_id,
+						'done'       => $done,
+						'toggleable' => $toggleable,
+					)
 				);
 			}
 		}
@@ -1303,13 +1289,9 @@ abstract class Publicize_Base {
 		// - API/XML-RPC Test Posts
 		if (
 			(
-				defined( 'XMLRPC_REQUEST' )
-			&&
-				XMLRPC_REQUEST
+			( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST )
 			||
-				defined( 'APP_REQUEST' )
-			&&
-				APP_REQUEST
+			( defined( 'APP_REQUEST' ) && constant( 'APP_REQUEST' ) )
 			)
 		&&
 			str_starts_with( $post->post_title, 'Temporary Post Used For Theme Detection' )


### PR DESCRIPTION


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update `Publicize::get_filtered_connection_data()` to use `Connections::get_all_for_user()` instead of `$publicize->get_services()`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install and activate the [Classic Editor](https://wordpress.org/plugins/classic-editor/) plugin on your site
* Add some Social connections to the site
* Create a post using classic editor
* Confirm that the connections  are loaded fine
* Publish a post sharing only to some of the connections, leaving some unchecked
* Confirm that the post gets shared only to the selected connections
* Edit the same post again
* Confirm that all the connections are now unchecked by default
* Enable a connection and reshare the post
* Confirm that the post is reshared to the selected connections and not to the other connections

