### PR TITLE
Nux: hide suggested tags on P2 sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-suggested-modal-p2
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-suggested-modal-p2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Hide suggested tags on p2

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
@@ -67,7 +67,7 @@ class WPCOM_Block_Editor_NUX {
 			'before'
 		);
 
-		$site_id    = Jetpack_Options::get_option( 'id' );
+		$site_id    = \Jetpack_Options::get_option( 'id' );
 		$is_p2_site = str_contains( get_stylesheet(), 'pub/p2' ) || function_exists( '\WPForTeams\is_wpforteams_site' ) && is_wpforteams_site( $site_id );
 
 		/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
@@ -67,12 +67,16 @@ class WPCOM_Block_Editor_NUX {
 			'before'
 		);
 
+		$site_id    = Jetpack_Options::get_option( 'id' );
+		$is_p2_site = str_contains( get_stylesheet(), 'pub/p2' ) || function_exists( '\WPForTeams\is_wpforteams_site' ) && is_wpforteams_site( $site_id );
+
 		/**
 		 * Enqueue the recommended tags modal options.
 		 */
 		$recommended_tags_modal_options = wp_json_encode(
 			array(
 				'isDismissed' => WP_REST_WPCOM_Block_Editor_Recommended_Tags_Modal_Controller::get_wpcom_recommended_tags_modal_dismissed(),
+				'isP2'        => $is_p2_site,
 			),
 			JSON_HEX_TAG | JSON_HEX_AMP
 		);

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/recommended-tags-modal/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/recommended-tags-modal/index.tsx
@@ -26,6 +26,7 @@ type CoreEditorPlaceholder = {
 };
 
 const RecommendedTagsModalInner: React.FC = () => {
+	const isP2 = window?.recommendedTagsModalOptions?.isP2 || false;
 	const isDismissedDefault = window?.recommendedTagsModalOptions?.isDismissed || false;
 	const { launchpadScreenOption } = window?.launchpadOptions || {};
 	const { isDismissed, updateIsDismissed } = useRecommendedTagsModalDismissed( isDismissedDefault );
@@ -83,7 +84,7 @@ const RecommendedTagsModalInner: React.FC = () => {
 		launchpadScreenOption,
 	] );
 
-	if ( ! isOpen || ! shouldShowSuggestedTags || isDismissedDefault ) {
+	if ( ! isOpen || ! shouldShowSuggestedTags || isDismissedDefault || isP2 ) {
 		return null;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We don't need to suggest tags on p2 sites

<img width="556" alt="Screenshot 2025-02-13 at 11 58 10" src="https://github.com/user-attachments/assets/9e2bd907-bbb4-45db-b2b7-cfb4dcf6b9f7" />


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We don't want to show suggested tags on p2 posts as this feature isn't useful on p2 sites as most of the tags are too generic or unrelated to p2 content
* This checks if the site is a P2 site. It passes this to the React app as a window variable. If the `isP2` is set in React app, the suggested tags modal will not render.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox public-api.wordpress.com and the testp2a8c . wordpress .com domains
* Go to testp2a8c P2 post editor - make sure you are sandboxed
* Run the following in terminal;
```
> wpsh
> switch_to_blog( 48514416 )
> update_option( 'wpcom_recommended_tags_modal_dismissed', false )
```
* Create a new post with more than 150 words - publish the post
* Confirm you see the suggested tags modal above
* Apply this PR to your wpcom sandbox
* Repeat the steps and confirm you don't see the suggested tags modal

