### PR TITLE
Social: Make Bluesky input clearer

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-bksy-input-clarity-fix
+++ b/projects/js-packages/publicize-components/changelog/fix-social-bksy-input-clarity-fix
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added more clarity on how Bsky handle is set uo

--- a/projects/js-packages/publicize-components/src/components/services/custom-inputs.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/custom-inputs.tsx
@@ -2,7 +2,7 @@ import { Alert } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement, useCallback, useId, useState } from '@wordpress/element';
-import { __, _x } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { store } from '../../social-store';
 import { SupportedService } from '../services/use-supported-services';
@@ -29,9 +29,13 @@ export function CustomInputs( { service }: CustomInputsProps ) {
 			const username = value.replace( '.bsky.social', '' );
 			if ( username.includes( '.' ) ) {
 				setHandleError(
-					__(
-						'Bluesky usernames cannot contain dots. If you are using a custom domain, enter it without .bsky.social',
-						'jetpack-publicize-components'
+					sprintf(
+						/* translators: %s is the handle suffix like .bsky.social */
+						__(
+							'Bluesky usernames cannot contain dots. If you are using a custom domain, enter it without "%s"',
+							'jetpack-publicize-components'
+						),
+						'.bsky.social'
 					)
 				);
 				return false;
@@ -116,16 +120,28 @@ export function CustomInputs( { service }: CustomInputsProps ) {
 						className={ clsx( 'description', handleError && styles[ 'error-text' ] ) }
 						id={ `${ id }-handle-description` }
 					>
-						{ handleError ||
-							createInterpolateElement(
-								__(
-									'You can find the handle in your Bluesky profile. This will be either <strong>username.bsky.social</strong> or just the domain name if you are using a custom domain.',
+						{ handleError || (
+							<>
+								{ __(
+									'You can find the handle in your Bluesky profile.',
 									'jetpack-publicize-components'
-								),
-								{
-									strong: <strong />,
-								}
-							) }
+								) }
+								&nbsp;
+								{ createInterpolateElement(
+									sprintf(
+										/* translators: %s is the bluesky handle suffix like .bsky.social */
+										__(
+											'This can either be %s or just the domain name if you are using a custom domain.',
+											'jetpack-publicize-components'
+										),
+										'<strong>username.bsky.social</strong>'
+									),
+									{
+										strong: <strong />,
+									}
+								) }
+							</>
+						) }
 					</p>
 				</div>
 				<div className={ styles[ 'fields-item' ] }>

--- a/projects/js-packages/publicize-components/src/components/services/custom-inputs.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/custom-inputs.tsx
@@ -1,8 +1,9 @@
 import { Alert } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { createInterpolateElement, useId } from '@wordpress/element';
+import { createInterpolateElement, useCallback, useId, useState } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
+import clsx from 'clsx';
 import { store } from '../../social-store';
 import { SupportedService } from '../services/use-supported-services';
 import styles from './style.module.scss';
@@ -19,8 +20,33 @@ type CustomInputsProps = {
  */
 export function CustomInputs( { service }: CustomInputsProps ) {
 	const id = useId();
+	const [ handleError, setHandleError ] = useState< string | null >( null );
 
 	const reconnectingAccount = useSelect( select => select( store ).getReconnectingAccount(), [] );
+
+	const validateBskyHandle = useCallback( ( value: string ) => {
+		if ( value.endsWith( '.bsky.social' ) ) {
+			const username = value.replace( '.bsky.social', '' );
+			if ( username.includes( '.' ) ) {
+				setHandleError(
+					__(
+						'Bluesky usernames cannot contain dots. If you are using a custom domain, enter it without .bsky.social',
+						'jetpack-publicize-components'
+					)
+				);
+				return false;
+			}
+		}
+		setHandleError( null );
+		return true;
+	}, [] );
+
+	const handleBskyHandleChange = useCallback(
+		( event: React.ChangeEvent< HTMLInputElement > ) => {
+			validateBskyHandle( event.target.value );
+		},
+		[ validateBskyHandle ]
+	);
 
 	if ( 'mastodon' === service.ID ) {
 		return (
@@ -83,12 +109,23 @@ export function CustomInputs( { service }: CustomInputsProps ) {
 						aria-label={ __( 'Bluesky handle', 'jetpack-publicize-components' ) }
 						aria-describedby={ `${ id }-handle-description` }
 						placeholder={ 'username.bsky.social' }
+						onChange={ handleBskyHandleChange }
+						className={ handleError ? styles.error : undefined }
 					/>
-					<p className="description" id={ `${ id }-handle-description` }>
-						{ __(
-							'You can find the handle in your Bluesky profile.',
-							'jetpack-publicize-components'
-						) }
+					<p
+						className={ clsx( 'description', handleError && styles[ 'error-text' ] ) }
+						id={ `${ id }-handle-description` }
+					>
+						{ handleError ||
+							createInterpolateElement(
+								__(
+									'You can find the handle in your Bluesky profile. This will be either <strong>username.bsky.social</strong> or just the domain name if you are using a custom domain.',
+									'jetpack-publicize-components'
+								),
+								{
+									strong: <strong />,
+								}
+							) }
 					</p>
 				</div>
 				<div className={ styles[ 'fields-item' ] }>

--- a/projects/js-packages/publicize-components/src/components/services/style.module.scss
+++ b/projects/js-packages/publicize-components/src/components/services/style.module.scss
@@ -241,10 +241,20 @@
 			padding: 0 8px;
 			font-size: 14px;
 		}
+
+		&.error {
+			border-color: var(--jp-red);
+			box-shadow: 0 0 0 1px var(--jp-red);
+		}
 	}
 }
 
 .mark-shared-wrap {
 	display: flex;
 	gap: 0.5rem;
+}
+
+.error-text.error-text {
+	color: var(--jp-red);
+	font-style: italic;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/768

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We utilized the fact that the Bsky username on the `.bsky.social` domain cannot contain dots
* Show an error if this is the case like the main site does
* Make description more descriptive

![image](https://github.com/user-attachments/assets/9b503328-3cbd-463e-a5f7-9b0dc9dd79a3)

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the connection management
* Fiddle wiht the Bsky input


https://github.com/user-attachments/assets/a5a6ff92-5e53-480d-a9aa-dcc1770e5cdc


