### PR TITLE
Subscribe Block: Fix double border on "Set up a paid plan" toolbar button

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-block-set-up-plan-toolbar-borders
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-block-set-up-plan-toolbar-borders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscribe Block: Fix double border on "Set up a paid plan" toolbar button

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -8,16 +8,21 @@ import {
 	useBlockProps,
 	__experimentalUseGradient as useGradient, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/block-editor';
-import { TextControl, Toolbar, withFallbackStyles } from '@wordpress/components';
+import {
+	TextControl,
+	withFallbackStyles,
+	ToolbarGroup,
+	ToolbarButton,
+} from '@wordpress/components';
 import { compose, usePrevious } from '@wordpress/compose';
-import { useSelect, withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
-import { _n, sprintf } from '@wordpress/i18n';
+import { _n, sprintf, _x, __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { isEqual } from 'lodash';
 import { getActiveStyleName } from '../../shared/block-styles';
 import { getValidatedAttributes } from '../../shared/get-validated-attributes';
-import GetAddPaidPlanButton, { paidPlanButtonText } from '../../shared/memberships/utils';
+import { getPaidPlanLink } from '../../shared/memberships/utils';
 import './view.scss';
 import './editor.scss';
 import { store as membershipProductsStore } from '../../store/membership-products';
@@ -69,9 +74,11 @@ export function SubscriptionEdit( props ) {
 		borderColor,
 		setBorderColor,
 		fontSize,
-		hasTierPlans,
 	} = props;
-
+	const hasTierPlans = useSelect(
+		select => !! select( 'jetpack/membership-products' )?.getNewsletterTierProducts()?.length,
+		[]
+	);
 	const blockProps = useBlockProps();
 	const validatedAttributes = getValidatedAttributes( metadata.attributes, attributes );
 	if ( ! isEqual( validatedAttributes, attributes ) ) {
@@ -269,9 +276,13 @@ export function SubscriptionEdit( props ) {
 				/>
 			</InspectorControls>
 			<BlockControls>
-				<Toolbar label={ paidPlanButtonText( hasTierPlans ) }>
-					<GetAddPaidPlanButton context={ 'toolbar' } hasTierPlans={ hasTierPlans } />
-				</Toolbar>
+				<ToolbarGroup>
+					<ToolbarButton href={ getPaidPlanLink( hasTierPlans ) } target="_blank">
+						{ hasTierPlans
+							? _x( 'Manage plans', 'unused context to distinguish translations', 'jetpack' )
+							: __( 'Set up a paid plan', 'jetpack' ) }
+					</ToolbarButton>
+				</ToolbarGroup>
 			</BlockControls>
 			<div style={ cssVars }>
 				<div className="wp-block-jetpack-subscriptions__container is-not-subscriber">
@@ -320,12 +331,6 @@ const withThemeProvider = WrappedComponent => props => (
 );
 
 export default compose( [
-	withSelect( select => {
-		const newsletterPlans = select( 'jetpack/membership-products' )?.getNewsletterTierProducts();
-		return {
-			hasTierPlans: newsletterPlans?.length !== 0,
-		};
-	} ),
 	withColors(
 		{ emailFieldBackgroundColor: 'backgroundColor' },
 		{ buttonBackgroundColor: 'backgroundColor' },

--- a/projects/plugins/jetpack/extensions/shared/memberships/utils.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/utils.js
@@ -1,6 +1,6 @@
-import { Button, ToolbarButton, Notice } from '@wordpress/components';
+import { Notice } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { _x, __ } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { accessOptions } from './constants';
 
 /**
@@ -49,27 +49,3 @@ export const MisconfigurationWarning = () => (
 		) }
 	</Notice>
 );
-
-export const paidPlanButtonText = hasTierPlans => {
-	return hasTierPlans
-		? _x( 'Manage plans', 'unused context to distinguish translations', 'jetpack' )
-		: __( 'Set up a paid plan', 'jetpack' );
-};
-
-export default function GetAddPaidPlanButton( { context = 'other', hasTierPlans } ) {
-	const addPaidPlanButtonText = paidPlanButtonText( hasTierPlans );
-
-	if ( 'toolbar' === context ) {
-		return (
-			<ToolbarButton href={ getPaidPlanLink( hasTierPlans ) } target="_blank">
-				{ addPaidPlanButtonText }
-			</ToolbarButton>
-		);
-	}
-
-	return (
-		<Button variant="primary" href={ getPaidPlanLink( hasTierPlans ) } target="_blank">
-			{ addPaidPlanButtonText }
-		</Button>
-	);
-}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes: https://github.com/Automattic/jetpack/issues/41701

>The "Set up a paid plan" button has a double border.

This PR fixes the issue by removing the extra `Toolbar` (BlockContols already render a `Toolbar`). 

Since I took a quick look at the code it seems that `GetAddPaidPlanButton` is not used anywhere else and that means the `context` prop too, so I moved the component in the `edit` file and also removed the `withSelect` in favor of `useSelect`.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Insert a `Subscribe` block and observe that the toolbar button is rendered properly without double borders.
2. Everything should work as before

Before     | After
:-------------------------:|:-------------------------:
<img width="563" alt="Screenshot 2025-02-13 at 3 06 46 PM" src="https://github.com/user-attachments/assets/e5afc2d6-6b2f-4c60-b291-fa8dcda8848f" /> |  <img width="563" alt="Screenshot 2025-02-13 at 2 59 47 PM" src="https://github.com/user-attachments/assets/b4b86fa2-edae-47bf-b7ff-4e1a6b6168ca" />


