### PR TITLE
Fix wpcom user ID being `[object Object]`

### DIFF
--- a/projects/packages/connection/changelog/fix-userid-object-object
+++ b/projects/packages/connection/changelog/fix-userid-object-object
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Make sure wpcom_id is a string before passing it over as _ui

--- a/projects/packages/connection/src/class-tracking.php
+++ b/projects/packages/connection/src/class-tracking.php
@@ -280,24 +280,28 @@ class Tracking {
 	 */
 	public function tracks_get_identity( $user_id ) {
 
-		// Meta is set, and user is still connected.  Use WPCOM ID.
+		// Meta is set, and user is still connected. Use WPCOM ID.
 		$wpcom_id = get_user_meta( $user_id, 'jetpack_tracks_wpcom_id', true );
-		if ( $wpcom_id && $this->connection->is_user_connected( $user_id ) ) {
+		if ( $wpcom_id && is_string( $wpcom_id ) && $this->connection->is_user_connected( $user_id ) ) {
 			return array(
 				'_ut' => 'wpcom:user_id',
 				'_ui' => $wpcom_id,
 			);
 		}
 
-		// User is connected, but no meta is set yet.  Use WPCOM ID and set meta.
+		// User is connected, but no meta is set yet. Use WPCOM ID and set meta.
 		if ( $this->connection->is_user_connected( $user_id ) ) {
 			$wpcom_user_data = $this->connection->get_connected_user_data( $user_id );
-			update_user_meta( $user_id, 'jetpack_tracks_wpcom_id', $wpcom_user_data['ID'] );
+			$wpcom_id        = $wpcom_user_data['ID'] ?? null;
 
-			return array(
-				'_ut' => 'wpcom:user_id',
-				'_ui' => $wpcom_user_data['ID'],
-			);
+			if ( is_string( $wpcom_id ) ) {
+				update_user_meta( $user_id, 'jetpack_tracks_wpcom_id', $wpcom_id );
+
+				return array(
+					'_ut' => 'wpcom:user_id',
+					'_ui' => $wpcom_id,
+				);
+			}
 		}
 
 		// User isn't linked at all.  Fall back to anonymous ID.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

For some blogs, the `_ui` in tracks end up as `[object Object]`. This points to the JS code which coerce object into string. This happens only with `_ut` `wpcom:user_id`.

The user recognition happens in `tracks_get_identity` method and seems like in some edge cases `$wpcom_user_data['ID']` is not a string. I don't know Jetpack enough so I couldn't determine what are the conditions.

Why I think it's here and not other places?

The same issue occurs in WooCommerce and if Jetpack is available it uses the Jetpack's Tracking method [directly here](https://github.com/woocommerce/woocommerce/blob/59793b290ede073d285341e86e0eecc3ee3dc08c/plugins/woocommerce/includes/tracks/class-wc-tracks-client.php#L160C3-L172C4) to determine the `_ut` and `_ui`, then use it directly [with no further modifications](https://github.com/woocommerce/woocommerce/blob/59793b290ede073d285341e86e0eecc3ee3dc08c/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php#L89).

Ref: p4qSXL-8qM-p2#comment-24297

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* I suggest adding additional check if the values are strings before using them as `_ui`. If not, fallback to `anon`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*