### PR TITLE
VideoPress: Fix video overflow area in float containers and flex position in row blocks

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-block-float-align
+++ b/projects/packages/videopress/changelog/fix-videopress-block-float-align
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix flex position for videos inside row blocks.

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -203,8 +203,10 @@ class Initializer {
 		// Inline style
 		$style     = '';
 		$max_width = isset( $block_attributes['maxWidth'] ) ? $block_attributes['maxWidth'] : null;
+
 		if ( $max_width && $max_width !== '100%' ) {
-			$style = sprintf( 'max-width: %s; margin: auto;', $max_width );
+			$style    = sprintf( 'max-width: %s;', $max_width );
+			$classes .= ' wp-block-jetpack-videopress--has-max-width';
 		}
 
 		/*

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
@@ -57,7 +57,7 @@ export default function Player( {
 	const mainWrapperRef = useRef< HTMLDivElement >();
 	const videoWrapperRef = useRef< HTMLDivElement >();
 
-	const { maxWidth, caption, videoRatio } = attributes;
+	const { maxWidth, caption, videoRatio, align } = attributes;
 
 	/*
 	 * Temporary height is used to set the height of the video
@@ -228,6 +228,18 @@ export default function Player( {
 			: 0;
 	}
 
+	let style: Record< string, string > = { marginRight: 'auto' };
+
+	if ( align === 'center' ) {
+		style = { ...style, marginLeft: 'auto' };
+	}
+
+	const innerContainerStyle = `
+		body {
+			line-height: 0;
+		}
+	`;
+
 	return (
 		<figure ref={ mainWrapperRef } className="jetpack-videopress-player">
 			<ResizableBox
@@ -239,7 +251,7 @@ export default function Player( {
 				} }
 				maxWidth="100%"
 				size={ { width: maxWidth, height: 'auto' } }
-				style={ { marginRight: 'auto' } }
+				style={ style }
 				onResizeStop={ onBlockResize }
 				onResizeStart={ () => setVideoPlayerTemporaryHeightState( 'auto' ) }
 			>
@@ -251,7 +263,13 @@ export default function Player( {
 					style={ wrapperElementStyle }
 				>
 					<>
-						{ ! isRequestingEmbedPreview && <SandBox html={ html } scripts={ sandboxScripts } /> }
+						{ ! isRequestingEmbedPreview && (
+							<SandBox
+								html={ html }
+								scripts={ sandboxScripts }
+								styles={ [ innerContainerStyle ] }
+							/>
+						) }
 
 						{ ! isVideoPlayerLoaded && (
 							<div className="jetpack-videopress-player__loading">

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/test/index.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/test/index.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import { VideoBlockAttributes } from '../../../types';
+import Player from '../index';
+
+const baseAttributes: VideoBlockAttributes = {
+	videoRatio: 100,
+	autoplay: true,
+	align: 'center',
+	posterData: {
+		type: 'media-library',
+		id: 1,
+		url: 'https://videopress.com/wp-content/uploads/2024/10/placeholder-video-1.mp4',
+	},
+};
+
+const previewMock = {
+	html: '',
+	width: 0,
+	height: 0,
+	thumbnail_height: 0,
+	thumbnail_width: 0,
+	version: '',
+	title: '',
+	type: '',
+	provider_name: '',
+	provider_url: '',
+};
+
+describe( 'Player', () => {
+	it( 'should render', () => {
+		render(
+			<Player
+				showCaption={ true }
+				isSelected={ false }
+				attributes={ baseAttributes }
+				setAttributes={ () => {} }
+				preview={ previewMock }
+				isRequestingEmbedPreview={ false }
+				html=""
+			/>
+		);
+
+		expect( screen.getByRole( 'figure' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
@@ -3,6 +3,11 @@
 .wp-block-jetpack-videopress {
 	position: relative;
 
+	&.jetpack-videopress-player.alignright ~ &.jetpack-videopress-player,
+	&.jetpack-videopress-player.alignleft ~ &.jetpack-videopress-player {
+		clear: both;
+	}
+
 	figcaption {
 		margin-bottom: 1em;
     	margin-top: 0.5em;

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
@@ -28,4 +28,12 @@
 			opacity: 0;
 		}
 	}
+
+	&.wp-block-jetpack-videopress--has-max-width {
+		margin: auto;
+	}
+}
+
+.is-layout-flex .wp-block-jetpack-videopress.wp-block-jetpack-videopress--has-max-width {
+	margin: 0;
 }

--- a/projects/packages/videopress/tests/php/test-class-initializer.php
+++ b/projects/packages/videopress/tests/php/test-class-initializer.php
@@ -60,4 +60,51 @@ class Test_Uploader extends BaseTestCase {
 		$cache_returned = VideoPress_Initializer::video_enqueue_bridge_when_oembed_present( $cache_value, 'https://www.some-site.com', null, null );
 		$this->assertEquals( $cache_value, $cache_returned );
 	}
+
+	/** Tests the render_videopress_video_block function, when max width is set */
+	public function test_render_videopress_video_block_with_max_width() {
+		$attributes = array(
+			'controls'            => true,
+			'loop'                => false,
+			'muted'               => true,
+			'playsinline'         => true,
+			'poster'              => 'http://localhost/wp-content/uploads/2023/03/cHJpdmF0ZS9sci9pbWFnZJMvd2Vic2l0ZS8yMDIyLTA1L25zMTEwODYtaW1hZ2Uta3d2eWRqaGYuanBn.jpg',
+			'preload'             => 'none',
+			'seekbarColor'        => '#ff6900',
+			'seekbarPlayedColor'  => '#00d084',
+			'seekbarLoadingColor' => '#fcb900',
+			'useAverageColor'     => false,
+			'maxWidth'            => '300px',
+		);
+
+		$content = 'some content';
+		$block   = array( 'context' => array() );
+
+		$rendered_block = VideoPress_Initializer::render_videopress_video_block( $attributes, $content, $block );
+
+		$this->assertStringContainsString( 'wp-block-jetpack-videopress--has-max-width', $rendered_block );
+	}
+
+	/** Tests the render_videopress_video_block function, when max width is not set */
+	public function test_render_videopress_video_block_without_max_width() {
+		$attributes = array(
+			'controls'            => true,
+			'loop'                => false,
+			'muted'               => true,
+			'playsinline'         => true,
+			'poster'              => 'http://localhost/wp-content/uploads/2023/03/cHJpdmF0ZS9sci9pbWFnZJMvd2Vic2l0ZS8yMDIyLTA1L25zMTEwODYtaW1hZ2Uta3d2eWRqaGYuanBn.jpg',
+			'preload'             => 'none',
+			'seekbarColor'        => '#ff6900',
+			'seekbarPlayedColor'  => '#00d084',
+			'seekbarLoadingColor' => '#fcb900',
+			'useAverageColor'     => false,
+		);
+
+		$block   = array( 'context' => array() );
+		$content = 'some content';
+
+		$rendered_block = VideoPress_Initializer::render_videopress_video_block( $attributes, $content, $block );
+
+		$this->assertStringNotContainsString( 'wp-block-jetpack-videopress--has-max-width', $rendered_block );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/41517
Fixes https://github.com/Automattic/videopress/issues/1207

## Proposed changes:

* Fix wrong flex position for videos inside row blocks.
* Block editor: Fix center-aligned video and remove line-height.
* Fix video area overflow for multiple float videos in the same page.
  * Example, using a floated video and a regular video after, the regular video clicking area was covering the first video, making it not clickable. See the screenshots:

<img width="300" alt="Screenshot Editor" src="https://github.com/user-attachments/assets/51855aff-00d6-481b-9a6d-6027e6bee8a5" />
<img width="300" alt="Screenshot Post" src="https://github.com/user-attachments/assets/8520717c-6f13-40ce-88d8-37cd4cd23e90" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

This PR is a follow-up from https://github.com/Automattic/jetpack/issues/41517, fixing additional styling issues.
 
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your testing env.
* Use a site with VideoPress enabled.
* Create a post with a VideoPress block, using the center align option.
* The block should be centered on both the editor and the post itself.
* On another post, add a VideoPress block inside a Row block, using different flex positions.
* The video and the content should be correctly positioned on both the editor and the post.
* On another post, add a center-aligned VideoPress block, and below that add a regular VideoPress block.
* Both blocks should be rendered correctly, and the click area of the send block shouldn't overflow to the first block, meaning both blocks are clickable.
* Perform tests with multiple block combinations and make sure it works as expected. 
* If you see any issues, please check if this is an existing issue or a regression. 
