### PR TITLE
Jetpack button: prevent button from stretching vertically

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-button-height
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-button-height
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack button: prevent vertical stretch

--- a/projects/plugins/jetpack/extensions/blocks/button/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/button/view.scss
@@ -8,6 +8,7 @@
 	@include align-block;
 	max-width: 100%;
 	width: fit-content;
+	height: fit-content; // Since .wp-block-button__link has a 100% height, this prevents the button from matching its container's height.
 	margin: 0;
 
 	&.is-style-outline > .wp-block-button__link {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/40851

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
A user reported an issue with the height of the Jetpack button in a Mailchimp block. The button would stretch vertically. We could link the root of the issue to [this Gutenberg update](https://github.com/WordPress/gutenberg/pull/64770), which applied a `height: 100%` rule to the button `.wp-block-button__link` element. To counterbalance that, we're explicitly marking the height of `.wp-block-button` as `fit-content`.

| Before | After |
| - | - |
|<img width="300" alt="Screenshot 2025-02-13 at 11 33 12 AM" src="https://github.com/user-attachments/assets/55ace1a9-8a8c-448a-b980-dfae68e367c7" />|<img width="300" alt="Screenshot 2025-02-13 at 11 32 57 AM" src="https://github.com/user-attachments/assets/89727876-283f-4fd6-916c-b31ecefe971a" />|


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

No one who tried to troubleshoot this issue could reproduce the bug locally or in a new environment (see the issue comment thread). To verify that this fix works, we can manually edit the CSS on the user site.

- Visit https://berkhistory.org/sign-up-for-email/
- Open the dev tool and inspect the Mailchimp submit button (see capture above)
- On the `.wp-block-button__link` element, comment out the `height: unset` rules that were manually added as a fix
<img width="175" alt="Screenshot 2025-02-13 at 11 32 40 AM" src="https://github.com/user-attachments/assets/7ccb5cd2-13fc-4bef-a618-922c8f16a870" />


- The button should stretch vertically (see capture above)
- On `.wp-block-button`, apply the rule `height: fit-content`. The button should no longer stretch.

