### PR TITLE
Jetpack SEO: add assistant box shadow

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-seo-assistant-box-shadow
+++ b/projects/plugins/jetpack/changelog/add-jetpack-seo-assistant-box-shadow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO: add box-shadow as in bigsky

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/style.scss
@@ -12,6 +12,7 @@
 	display: flex;
 	flex-direction: column;
 	padding: 24px;
+	box-shadow: 0 0 1px rgba(0,0,0,0.25), 0 3px 8px rgba(0,0,0,0.1), 0 1px 3px rgba(0,0,0,0.1), inset 0 0 1px rgba( 232, 232, 237, 0.11);
 	// countering the Jetpack sidebar ai-feature styles:
 	button {
 		width: unset;


### PR DESCRIPTION

Fixes #41532 

## Proposed changes:
Add box shadow to the SEO assistant

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
#41532 

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Open the SEO assistant, see the shadow is defined as requested on the issue