### PR TITLE
ci: Use app token for coverage check reporting

### DIFF
--- a/.github/files/coverage-munger/post-message.sh
+++ b/.github/files/coverage-munger/post-message.sh
@@ -115,7 +115,7 @@ while true; do
 		--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${ID}/comments?per_page=100&page=$PAGE" \
 		--header "authorization: Bearer $POST_MESSAGE_TOKEN"
 	)
-	CID=$( jq -r --arg CID "$CID" '[ { id: $CID }, ( .[] | select( .user.login == "github-actions[bot]" ) | select( .body | test( "^### Code Coverage Summary" ) ) ) ] | last | .id' <<<"$J" )
+	CID=$( jq -r --arg CID "$CID" '[ { id: $CID }, ( .[] | select( .user.login == "jp-launch-control[bot]" ) | select( .body | test( "^### Code Coverage Summary" ) ) ) ] | last | .id' <<<"$J" )
 	if jq -e 'length < 100' <<<"$J" &>/dev/null; then
 		break
 	fi

--- a/.github/files/coverage-munger/post-message.sh
+++ b/.github/files/coverage-munger/post-message.sh
@@ -3,9 +3,9 @@
 ## Environment used by this script:
 #
 # Required:
-# - API_TOKEN_GITHUB: GitHub API token.
 # - GITHUB_API_URL: GitHub API URL.
 # - GITHUB_REPOSITORY: GitHub repo.
+# - POST_MESSAGE_TOKEN: GitHub API token.
 # - PR_HEAD: SHA for the PR head commit (versus GITHUB_SHA which is a merge commit)
 # - PR_ID: PR number or "trunk".
 #
@@ -51,7 +51,7 @@ if [[ -z "$STATUS" ]]; then
 	while true; do
 		J=$( curl -v -L fail \
 			--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/commits/${COMMIT}/check-runs?per_page=100&page=$PAGE" \
-			--header "authorization: Bearer $API_TOKEN_GITHUB"
+			--header "authorization: Bearer $POST_MESSAGE_TOKEN"
 		)
 		R=$( jq --argjson R "$R" '[ ( $R, .check_runs[] ) | select( .name == "Code coverage" ) ] | sort_by( .completed_at // "running" ) | last' <<<"$J" )
 		if jq -e '.check_runs | length < 100' <<<"$J" &>/dev/null; then
@@ -68,7 +68,7 @@ echo "Last run status is $STATUS"
 echo '::group::Checking labels for PR'
 LABELS=$( curl -v -L --fail \
 	--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${ID}/labels?per_page=100" \
-	--header "authorization: Bearer $API_TOKEN_GITHUB"
+	--header "authorization: Bearer $POST_MESSAGE_TOKEN"
 )
 jq . <<<"$LABELS"
 echo "::endgroup::"
@@ -97,7 +97,7 @@ fi
 jq . <<<"$COVINFO"
 curl -v -L --fail \
 	--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/statuses/$( jq --arg V "$PR_HEAD" -nr '$V | @uri' )" \
-	--header "authorization: Bearer $API_TOKEN_GITHUB" \
+	--header "authorization: Bearer $POST_MESSAGE_TOKEN" \
 	--header 'content-type: application/json' \
 	--data "$( jq -c --arg PR "$PR_ID" '{
 		context: "Code coverage requirement",
@@ -113,7 +113,7 @@ PAGE=1
 while true; do
 	J=$( curl -v -L fail \
 		--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${ID}/comments?per_page=100&page=$PAGE" \
-		--header "authorization: Bearer $API_TOKEN_GITHUB"
+		--header "authorization: Bearer $POST_MESSAGE_TOKEN"
 	)
 	CID=$( jq -r --arg CID "$CID" '[ { id: $CID }, ( .[] | select( .user.login == "github-actions[bot]" ) | select( .body | test( "^### Code Coverage Summary" ) ) ) ] | last | .id' <<<"$J" )
 	if jq -e 'length < 100' <<<"$J" &>/dev/null; then
@@ -134,7 +134,7 @@ if jq -e '.msg != ""' <<<"$COVINFO" &>/dev/null; then
 		curl -v -L --fail \
 			-X PATCH \
 			--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/comments/${CID}" \
-			--header "authorization: Bearer $API_TOKEN_GITHUB" \
+			--header "authorization: Bearer $POST_MESSAGE_TOKEN" \
 			--header 'content-type: application/json' \
 			--data "$( jq -c '{
 				body: "### Code Coverage Summary\n\n\( .msg )\n\n\( .footer )",
@@ -145,7 +145,7 @@ if jq -e '.msg != ""' <<<"$COVINFO" &>/dev/null; then
 		curl -v -L --fail \
 			-X POST \
 			--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${ID}/comments" \
-			--header "authorization: Bearer $API_TOKEN_GITHUB" \
+			--header "authorization: Bearer $POST_MESSAGE_TOKEN" \
 			--header 'content-type: application/json' \
 			--data "$( jq -c '{
 				body: "### Code Coverage Summary\n\n\( .msg )\n\n\( .footer )",
@@ -158,6 +158,6 @@ elif [[ -n "$CID" ]]; then
 	curl -v -L --fail \
 		-X DELETE \
 		--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/comments/${CID}" \
-		--header "authorization: Bearer $API_TOKEN_GITHUB"
+		--header "authorization: Bearer $POST_MESSAGE_TOKEN"
 	echo "::endgroup::"
 fi

--- a/.github/files/coverage-munger/upload-coverage.sh
+++ b/.github/files/coverage-munger/upload-coverage.sh
@@ -3,14 +3,10 @@
 ## Environment used by this script:
 #
 # Required:
-# - API_TOKEN_GITHUB: GitHub API token.
-# - GITHUB_API_URL: GitHub API URL.
-# - GITHUB_REPOSITORY: GitHub repo.
 # - GITHUB_SHA: Commit SHA.
-# - PR_HEAD: SHA for the PR head commit (versus GITHUB_SHA which is a merge commit)
 # - PR_ID: PR number or "trunk".
 # - SECRET: Shared secret.
-# - STATUS: Status of the coverage run.
+# - For non-trunk runs, anything needed by post-message.sh
 
 set -eo pipefail
 

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -27,9 +27,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Get token
+        id: get_token
+        uses: ./.github/actions/gh-app-token
+        with:
+          app_id: ${{ secrets.JP_LAUNCH_CONTROL_ID }}
+          private_key: ${{ secrets.JP_LAUNCH_CONTROL_KEY }}
+
       - name: Post message
         env:
           PR_ID: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr }}
           PR_HEAD: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+          POST_MESSAGE_TOKEN: ${{ steps.get_token.outputs.token }}
         run: .github/files/coverage-munger/post-message.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -309,6 +309,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Get token
+        id: get_token
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/gh-app-token
+        with:
+          app_id: ${{ secrets.JP_LAUNCH_CONTROL_ID }}
+          private_key: ${{ secrets.JP_LAUNCH_CONTROL_KEY }}
+
       - name: Setup tools
         uses: ./.github/actions/tool-setup
 
@@ -324,7 +332,7 @@ jobs:
           SECRET: ${{ secrets.CODECOV_SECRET }}
           STATUS: ${{ needs.run-tests.outputs.coverage-status }}
           PR_HEAD: ${{ github.event.pull_request.head.sha }}
-          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+          POST_MESSAGE_TOKEN: ${{ steps.get_token.outputs.token }}
         run: .github/files/coverage-munger/upload-coverage.sh
 
   storybook-test:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
GitHub has announced that the Actions token will soon no longer be able to update statuses created with an Actions token from other runs.

Switch the coverage check reporting to use a token from our existing JP Launch Control app instead.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1739464645882499-slack-C05Q5HSS013
https://github.blog/changelog/2025-02-12-notice-of-upcoming-deprecations-and-breaking-changes-for-github-actions/#changes-to-check-run-status-modification

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* The coverage message and check on this PR should show up as coming from the app rather than Actions.
* Toggle the "I don't care" label. The changes for that too should show up as coming from the app rather than Actions.