### PR TITLE
Connection: Display connection status on Users page independent of the SSO module

### DIFF
--- a/projects/packages/connection/changelog/add-display-connection-status-users-page
+++ b/projects/packages/connection/changelog/add-display-connection-status-users-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Connection: Display connection status on Users page independent of the SSO module.  

--- a/projects/packages/connection/src/class-plugin.php
+++ b/projects/packages/connection/src/class-plugin.php
@@ -46,10 +46,8 @@ class Plugin {
 	public function __construct( $slug ) {
 		$this->slug = $slug;
 
-		// Always initialize Users_Connection_Admin - it will handle its own conditional loading
-		if ( is_admin() ) {
-			$this->users_connection_admin = new Users_Connection_Admin();
-		}
+		// Initialize Users_Connection_Admin
+		$this->users_connection_admin = new Users_Connection_Admin();
 	}
 
 	/**

--- a/projects/packages/connection/src/class-plugin.php
+++ b/projects/packages/connection/src/class-plugin.php
@@ -38,6 +38,11 @@ class Plugin {
 	 */
 	public function __construct( $slug ) {
 		$this->slug = $slug;
+
+		// Always initialize Users_Connection_Admin - it will handle its own conditional loading
+		if ( is_admin() ) {
+			new Users_Connection_Admin();
+		}
 	}
 
 	/**

--- a/projects/packages/connection/src/class-plugin.php
+++ b/projects/packages/connection/src/class-plugin.php
@@ -32,6 +32,13 @@ class Plugin {
 	private $slug;
 
 	/**
+	 * Users Connection Admin instance.
+	 *
+	 * @var Users_Connection_Admin
+	 */
+	private $users_connection_admin;
+
+	/**
 	 * Initialize the plugin manager.
 	 *
 	 * @param string $slug Plugin slug.
@@ -41,7 +48,7 @@ class Plugin {
 
 		// Always initialize Users_Connection_Admin - it will handle its own conditional loading
 		if ( is_admin() ) {
-			new Users_Connection_Admin();
+			$this->users_connection_admin = new Users_Connection_Admin();
 		}
 	}
 

--- a/projects/packages/connection/src/class-users-connection-admin.php
+++ b/projects/packages/connection/src/class-users-connection-admin.php
@@ -76,7 +76,7 @@ class Users_Connection_Admin {
 		if ( ( new Manager() )->is_user_connected( $user_id ) ) {
 			return sprintf(
 				'<span title="%1$s" class="jetpack-connection-status">%2$s</span>',
-				esc_attr__( 'This user is connected and can log-in to this site.', 'jetpack-connection' ),
+				esc_attr__( 'This user has connected their WordPress.com account.', 'jetpack-connection' ),
 				esc_html__( 'Connected', 'jetpack-connection' )
 			);
 		}
@@ -112,7 +112,7 @@ class Users_Connection_Admin {
 			'jetpack-users-connection',
 			'jetpackConnectionTooltips',
 			array(
-				'columnTooltip' => esc_html__( 'Jetpack enables users to connect their WordPress.com accounts to log in securely and enable additional features.', 'jetpack-connection' ),
+				'columnTooltip' => esc_html__( 'Connecting a WordPress.com account unlocks Jetpack’s full suite of features including secure logins.', 'jetpack-connection' ),
 			)
 		);
 	}

--- a/projects/packages/connection/src/class-users-connection-admin.php
+++ b/projects/packages/connection/src/class-users-connection-admin.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Handles the WordPress.com account column in the users list table.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+use Automattic\Jetpack\Assets;
+
+/**
+ * Class Users_Connection_Admin
+ */
+class Users_Connection_Admin {
+	/**
+	 * The column ID used for the WordPress.com account column.
+	 *
+	 * @var string
+	 */
+	const COLUMN_ID = 'user_jetpack';
+
+	/**
+	 * Initialize the Users Connection Admin functionality.
+	 */
+	public function __construct() {
+		// Only initialize if we're in admin and current user can manage options
+		if ( ! is_admin() || ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		add_filter( 'manage_users_columns', array( $this, 'add_connection_column' ) );
+		add_filter( 'manage_users_custom_column', array( $this, 'render_connection_column' ), 9, 3 ); // Priority 9 to run before SSO
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'admin_print_styles-users.php', array( $this, 'add_connection_column_styles' ) );
+	}
+
+	/**
+	 * Add the connection column to the users list table.
+	 *
+	 * @param array $columns The current columns.
+	 * @return array Modified columns.
+	 */
+	public function add_connection_column( $columns ) {
+		$columns[ self::COLUMN_ID ] = sprintf(
+			'<span class="jetpack-connection-tooltip-icon" role="tooltip" tabindex="0" aria-label="%2$s: %1$s">
+				%1$s
+				<span class="jetpack-connection-tooltip"></span>
+			</span>',
+			esc_html__( 'WordPress.com account', 'jetpack-connection' ),
+			esc_attr__( 'Tooltip', 'jetpack-connection' )
+		);
+		return $columns;
+	}
+
+	/**
+	 * Render the connection column content.
+	 *
+	 * @param string $output      Custom column output.
+	 * @param string $column_name Column name.
+	 * @param int    $user_id     ID of the currently-listed user.
+	 * @return string
+	 */
+	public function render_connection_column( $output, $column_name, $user_id ) {
+		if ( self::COLUMN_ID !== $column_name ) {
+			return $output;
+		}
+
+		if ( ( new Manager() )->is_user_connected( $user_id ) ) {
+			return sprintf(
+				'<span title="%1$s" class="jetpack-connection-status">%2$s</span>',
+				esc_attr__( 'This user is connected and can log-in to this site.', 'jetpack-connection' ),
+				esc_html__( 'Connected', 'jetpack-connection' )
+			);
+		}
+
+		return $output;
+	}
+
+	/**
+	 * Enqueue scripts and styles.
+	 *
+	 * @param string $hook The current admin page.
+	 */
+	public function enqueue_scripts( $hook ) {
+		if ( 'users.php' !== $hook ) {
+			return;
+		}
+
+		Assets::register_script(
+			'jetpack-users-connection',
+			'js/jetpack-users-connection.js',
+			__FILE__,
+			array(
+				'strategy'  => 'defer',
+				'in_footer' => true,
+				'enqueue'   => true,
+				'version'   => Package_Version::PACKAGE_VERSION,
+			)
+		);
+
+		wp_localize_script(
+			'jetpack-users-connection',
+			'jetpackConnectionTooltips',
+			array(
+				'columnTooltip' => esc_html__( 'Jetpack enables users to connect their WordPress.com accounts to log in securely and enable additional features.', 'jetpack-connection' ),
+			)
+		);
+	}
+
+	/**
+	 * Add styles for the connection column.
+	 */
+	public function add_connection_column_styles() {
+		?>
+		<style>
+			.jetpack-connection-tooltip-icon {
+				position: relative;
+				cursor: pointer;
+			}
+			/* Add [?] icon using pseudo-element, only in column header */
+			th.manage-column .jetpack-connection-tooltip-icon::after {
+				content: '[?]';
+				color: #3c434a;
+				font-size: 1em;
+				margin-left: 4px;
+			}
+			.jetpack-connection-tooltip {
+				position: absolute;
+				background: #f6f7f7;
+				top: -85px;
+				width: 250px;
+				padding: 7px;
+				color: #3c434a;
+				font-size: .75rem;
+				line-height: 17px;
+				text-align: left;
+				margin: 0;
+				display: none;
+				border-radius: 4px;
+				font-family: sans-serif;
+				box-shadow: 5px 10px 10px rgba(0, 0, 0, 0.1);
+				left: -170px;
+			}
+			/* Show tooltip on hover and focus */
+			.jetpack-connection-tooltip-icon:hover .jetpack-connection-tooltip,
+			.jetpack-connection-tooltip-icon:focus-within .jetpack-connection-tooltip {
+				display: block;
+			}
+		</style>
+		<?php
+	}
+
+	/**
+	 * Get the column ID. Allows other classes to reference the same column.
+	 *
+	 * @return string
+	 */
+	public static function get_column_id() {
+		return self::COLUMN_ID;
+	}
+}

--- a/projects/packages/connection/src/class-users-connection-admin.php
+++ b/projects/packages/connection/src/class-users-connection-admin.php
@@ -21,10 +21,17 @@ class Users_Connection_Admin {
 	const COLUMN_ID = 'user_jetpack';
 
 	/**
-	 * Initialize the Users Connection Admin functionality.
+	 * Constructor.
 	 */
 	public function __construct() {
-		// Only initialize if we're in admin and current user can manage options
+		// Only set up hooks if we're in the admin area and user has proper permissions
+		add_action( 'init', array( $this, 'init' ) );
+	}
+
+	/**
+	 * Initialize the admin functionality if conditions are met.
+	 */
+	public function init() {
 		if ( ! is_admin() || ! current_user_can( 'manage_options' ) ) {
 			return;
 		}

--- a/projects/packages/connection/src/class-users-connection-admin.php
+++ b/projects/packages/connection/src/class-users-connection-admin.php
@@ -89,13 +89,15 @@ class Users_Connection_Admin {
 
 		Assets::register_script(
 			'jetpack-users-connection',
-			'js/jetpack-users-connection.js',
+			'../dist/jetpack-users-connection.js',
 			__FILE__,
 			array(
 				'strategy'  => 'defer',
 				'in_footer' => true,
 				'enqueue'   => true,
 				'version'   => Package_Version::PACKAGE_VERSION,
+				'deps'      => array( 'wp-i18n' ),
+
 			)
 		);
 
@@ -141,6 +143,9 @@ class Users_Connection_Admin {
 				font-family: sans-serif;
 				box-shadow: 5px 10px 10px rgba(0, 0, 0, 0.1);
 				left: -170px;
+			}
+			.column-user_jetpack {
+				width: 140px;
 			}
 			/* Show tooltip on hover and focus */
 			.jetpack-connection-tooltip-icon:hover .jetpack-connection-tooltip,

--- a/projects/packages/connection/src/js/jetpack-users-connection.js
+++ b/projects/packages/connection/src/js/jetpack-users-connection.js
@@ -1,0 +1,10 @@
+/**
+ * Handle tooltips in the WordPress.com account column.
+ */
+document.addEventListener( 'DOMContentLoaded', function () {
+	const tooltipElements = document.querySelectorAll( '.jetpack-connection-tooltip' );
+
+	tooltipElements.forEach( function ( element ) {
+		element.textContent = window.jetpackConnectionTooltips.columnTooltip;
+	} );
+} );

--- a/projects/packages/connection/src/sso/class-user-admin.php
+++ b/projects/packages/connection/src/sso/class-user-admin.php
@@ -1207,7 +1207,7 @@ class User_Admin extends Base_Admin {
 	 * Creates error notices and redirects the user to the previous page.
 	 *
 	 * @param array $query_params - query parameters added to redirection URL.
-	 * @return never
+	 * @phan-suppress PhanPluginNeverReturnMethod
 	 */
 	public function create_error_notice_and_redirect( $query_params ) {
 		$ref = wp_get_referer();

--- a/projects/packages/connection/src/sso/class-user-admin.php
+++ b/projects/packages/connection/src/sso/class-user-admin.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Connection\Package_Version;
+use Automattic\Jetpack\Connection\Users_Connection_Admin as Base_Admin;
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Tracking;
@@ -21,7 +22,7 @@ use WP_User_Query;
 /**
  * Jetpack sso user admin class.
  */
-class User_Admin {
+class User_Admin extends Base_Admin {
 	/**
 	 * Instance of WP_User_Query.
 	 *
@@ -56,7 +57,6 @@ class User_Admin {
 		add_action( 'user_new_form', array( $this, 'render_custom_email_message_form_field' ), 1 );
 		add_action( 'delete_user_form', array( $this, 'render_invitations_notices_for_deleted_users' ) );
 		add_action( 'delete_user', array( $this, 'revoke_user_invite' ) );
-		add_filter( 'manage_users_columns', array( $this, 'jetpack_user_connected_th' ) );
 		add_filter( 'manage_users_custom_column', array( $this, 'jetpack_show_connection_status' ), 10, 3 );
 		add_action( 'user_row_actions', array( $this, 'jetpack_user_table_row_actions' ), 10, 2 );
 
@@ -70,6 +70,7 @@ class User_Admin {
 		add_action( 'admin_print_styles-users.php', array( $this, 'jetpack_user_table_styles' ) );
 		add_filter( 'users_list_table_query_args', array( $this, 'set_user_query' ), 100, 1 );
 		add_action( 'admin_print_styles-user-new.php', array( $this, 'jetpack_new_users_styles' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 
 		self::$tracking = new Tracking();
 	}
@@ -106,6 +107,7 @@ class User_Admin {
 	 * Revokes WordPress.com invitation.
 	 *
 	 * @param int $user_id The user ID.
+	 * @return mixed Response from the API call or false on failure.
 	 */
 	public function revoke_user_invite( $user_id ) {
 		try {
@@ -974,39 +976,14 @@ class User_Admin {
 	}
 
 	/**
-	 * Adds a column in the user admin table to display user connection status and actions.
+	 * Deprecated method. Adds a column in the user admin table to display user connection status and actions.
 	 *
 	 * @param array $columns User list table columns.
-	 *
 	 * @return array
+	 * @deprecated $$next-version$$
 	 */
 	public function jetpack_user_connected_th( $columns ) {
-		Assets::register_script(
-			'jetpack-sso-users',
-			'../../dist/jetpack-sso-users.js',
-			__FILE__,
-			array(
-				'strategy'  => 'defer',
-				'in_footer' => true,
-				'enqueue'   => true,
-				'version'   => Package_Version::PACKAGE_VERSION,
-			)
-		);
-
-		$tooltip_string = esc_attr__( 'Jetpack SSO allows a seamless and secure experience on WordPress.com. Join millions of WordPress users who trust us to keep their accounts safe.', 'jetpack-connection' );
-
-		wp_add_inline_script(
-			'jetpack-sso-users',
-			"var Jetpack_SSOTooltip = { 'tooltipString': '{$tooltip_string}' }",
-			'before'
-		);
-
-		$columns['user_jetpack'] = sprintf(
-			'<span class="jetpack-sso-invitation-tooltip-icon jetpack-sso-status-column" role="tooltip" aria-label="%3$s: %1$s" tabindex="0">%2$s</span>',
-			$tooltip_string,
-			esc_html__( 'SSO Status', 'jetpack-connection' ),
-			esc_attr__( 'Tooltip', 'jetpack-connection' )
-		);
+		_deprecated_function( __METHOD__, 'package-$$next-version$$' );
 		return $columns;
 	}
 
@@ -1179,59 +1156,58 @@ class User_Admin {
 	 * @param string $val HTML for the column.
 	 * @param string $col User list table column.
 	 * @param int    $user_id User ID.
-	 *
-	 * @return string
+	 * @return string Modified column content.
 	 */
 	public function jetpack_show_connection_status( $val, $col, $user_id ) {
-		if ( 'user_jetpack' === $col ) {
-			if ( ( new Manager() )->is_user_connected( $user_id ) ) {
-				$connection_html = sprintf(
-					'<span title="%1$s" class="jetpack-sso-invitation">%2$s</span>',
-					esc_attr__( 'This user is connected and can log-in to this site.', 'jetpack-connection' ),
-					esc_html__( 'Connected', 'jetpack-connection' )
-				);
-				return $connection_html;
-			} else {
-				$has_pending_invite = self::has_pending_wpcom_invite( $user_id );
-				if ( $has_pending_invite ) {
-					$connection_html = sprintf(
-						'<span title="%1$s" class="jetpack-sso-invitation sso-pending-invite">%2$s</span>',
-						esc_attr__( 'This user didn&#8217;t accept the invitation to join this site yet.', 'jetpack-connection' ),
-						esc_html__( 'Pending invite', 'jetpack-connection' )
-					);
-					return $connection_html;
-				}
-				$nonce           = wp_create_nonce( 'jetpack-sso-invite-user' );
-				$connection_html = sprintf(
-				// Using formmethod and formaction because we can't nest forms and have to submit using the main form.
-					'<span tabindex="0" role="tooltip" aria-label="%4$s: %3$s" class="jetpack-sso-invitation-tooltip-icon sso-disconnected-user">
-						<a href="%1$s" class="jetpack-sso-invitation sso-disconnected-user">%2$s</a>
-						<span class="sso-disconnected-user-icon dashicons dashicons-warning">
-							<span class="jetpack-sso-invitation-tooltip jetpack-sso-td-tooltip">%3$s</span>
-						</span>
-					</span>',
-					add_query_arg(
-						array(
-							'user_id'      => $user_id,
-							'invite_nonce' => $nonce,
-							'action'       => 'jetpack_invite_user_to_wpcom',
-						),
-						admin_url( 'admin-post.php' )
-					),
-					esc_html__( 'Send invite', 'jetpack-connection' ),
-					esc_attr__( 'This user doesn&#8217;t have an SSO connection to WordPress.com. Invite them to the site to increase security and improve their experience.', 'jetpack-connection' ),
-					esc_attr__( 'Tooltip', 'jetpack-connection' )
-				);
-				return $connection_html;
-			}
+		if ( 'user_jetpack' !== $col ) {
+			return $val;
 		}
-		return $val;
+
+		// Get base connection status from parent
+		$connection_status = parent::render_connection_column( '', $col, $user_id );
+
+		// If user is not connected, check for pending invite
+		if ( ! $connection_status ) {
+			$has_pending_invite = self::has_pending_wpcom_invite( $user_id );
+			if ( $has_pending_invite ) {
+				return sprintf(
+					'<span title="%1$s" class="jetpack-sso-invitation sso-pending-invite">%2$s</span>',
+					esc_attr__( 'This user didn&#8217;t accept the invitation to join this site yet.', 'jetpack-connection' ),
+					esc_html__( 'Pending invite', 'jetpack-connection' )
+				);
+			}
+
+			// Show invite button for non-connected users
+			$nonce = wp_create_nonce( 'jetpack-sso-invite-user' );
+			return sprintf(
+				'<span tabindex="0" role="tooltip" aria-label="%4$s: %3$s" class="jetpack-sso-invitation-tooltip-icon sso-disconnected-user">
+					<a href="%1$s" class="jetpack-sso-invitation sso-disconnected-user">%2$s</a>
+					<span class="sso-disconnected-user-icon dashicons dashicons-warning">
+						<span class="jetpack-sso-invitation-tooltip jetpack-sso-td-tooltip">%3$s</span>
+					</span>
+				</span>',
+				add_query_arg(
+					array(
+						'user_id'      => $user_id,
+						'invite_nonce' => $nonce,
+						'action'       => 'jetpack_invite_user_to_wpcom',
+					),
+					admin_url( 'admin-post.php' )
+				),
+				esc_html__( 'Send invite', 'jetpack-connection' ),
+				esc_attr__( 'This user doesn&#8217;t have a Jetpack SSO connection to WordPress.com. Invite them to the site to increase security and improve their experience.', 'jetpack-connection' ),
+				esc_attr__( 'Tooltip', 'jetpack-connection' )
+			);
+		}
+
+		return $connection_status;
 	}
 
 	/**
 	 * Creates error notices and redirects the user to the previous page.
 	 *
 	 * @param array $query_params - query parameters added to redirection URL.
+	 * @return string|void The redirect URL or void on failure.
 	 */
 	public function create_error_notice_and_redirect( $query_params ) {
 		$ref = wp_get_referer();
@@ -1257,9 +1233,6 @@ class User_Admin {
 		}
 		#the-list tr:has(.sso-pending-invite) {
 			background: #E9F0F5;
-		}
-		.fixed .column-user_jetpack {
-			width: 100px;
 		}
 		.jetpack-sso-invitation {
 			background: none;
@@ -1297,9 +1270,6 @@ class User_Admin {
 			position: relative;
 			cursor: pointer;
 		}
-		.jetpack-sso-th-tooltip {
-			left: -170px;
-		}
 		.jetpack-sso-td-tooltip {
 			left: -256px;
 		}
@@ -1322,5 +1292,30 @@ class User_Admin {
 
 	</style>
 		<?php
+	}
+
+	/**
+	 * Enqueue SSO-specific scripts.
+	 *
+	 * @param string $hook The current admin page.
+	 */
+	public function enqueue_scripts( $hook ) {
+		if ( 'users.php' !== $hook ) {
+			return;
+		}
+
+		parent::enqueue_scripts( $hook );
+		// Enqueue the SSO users script.
+		Assets::register_script(
+			'jetpack-sso-users',
+			'../../dist/jetpack-sso-users.js',
+			__FILE__,
+			array(
+				'strategy'  => 'defer',
+				'in_footer' => true,
+				'enqueue'   => true,
+				'version'   => Package_Version::PACKAGE_VERSION,
+			)
+		);
 	}
 }

--- a/projects/packages/connection/src/sso/class-user-admin.php
+++ b/projects/packages/connection/src/sso/class-user-admin.php
@@ -1207,7 +1207,7 @@ class User_Admin extends Base_Admin {
 	 * Creates error notices and redirects the user to the previous page.
 	 *
 	 * @param array $query_params - query parameters added to redirection URL.
-	 * @return void
+	 * @return never
 	 */
 	public function create_error_notice_and_redirect( $query_params ) {
 		$ref = wp_get_referer();

--- a/projects/packages/connection/src/sso/class-user-admin.php
+++ b/projects/packages/connection/src/sso/class-user-admin.php
@@ -1207,7 +1207,7 @@ class User_Admin extends Base_Admin {
 	 * Creates error notices and redirects the user to the previous page.
 	 *
 	 * @param array $query_params - query parameters added to redirection URL.
-	 * @return string|void The redirect URL or void on failure.
+	 * @return void
 	 */
 	public function create_error_notice_and_redirect( $query_params ) {
 		$ref = wp_get_referer();
@@ -1219,7 +1219,8 @@ class User_Admin extends Base_Admin {
 			$query_params,
 			$ref
 		);
-		return wp_safe_redirect( $url );
+		wp_safe_redirect( $url );
+		exit;
 	}
 
 	/**

--- a/projects/packages/connection/src/sso/jetpack-sso-users.js
+++ b/projects/packages/connection/src/sso/jetpack-sso-users.js
@@ -5,7 +5,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			tooltip.innerHTML += ' [?]';
 
 			const tooltipTextbox = document.createElement( 'span' );
-			tooltipTextbox.classList.add( 'jetpack-sso-invitation-tooltip', 'jetpack-sso-th-tooltip' );
+			tooltipTextbox.classList.add( 'jetpack-sso-invitation-tooltip' );
 
 			const tooltipString = window.Jetpack_SSOTooltip.tooltipString;
 			tooltipTextbox.innerHTML += tooltipString;

--- a/projects/packages/connection/webpack.config.js
+++ b/projects/packages/connection/webpack.config.js
@@ -77,6 +77,7 @@ module.exports = [
 				},
 			},
 			'identity-crisis': './src/identity-crisis/_inc/admin.jsx',
+			'jetpack-users-connection': './src/js/jetpack-users-connection.js',
 			...ssoEntries,
 		},
 		plugins: [

--- a/projects/plugins/automattic-for-agencies-client/changelog/add-display-connection-status-users-page
+++ b/projects/plugins/automattic-for-agencies-client/changelog/add-display-connection-status-users-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Connection: Display connection status on Users page independent of the SSO module.

--- a/projects/plugins/backup/changelog/add-display-connection-status-users-page
+++ b/projects/plugins/backup/changelog/add-display-connection-status-users-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Connection: Display connection status on Users page independent of the SSO module.

--- a/projects/plugins/boost/changelog/add-display-connection-status-users-page
+++ b/projects/plugins/boost/changelog/add-display-connection-status-users-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Connection: Display connection status on Users page independent of the SSO module.

--- a/projects/plugins/inspect/changelog/add-display-connection-status-users-page
+++ b/projects/plugins/inspect/changelog/add-display-connection-status-users-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Connection: Display connection status on Users page independent of the SSO module.

--- a/projects/plugins/jetpack/changelog/add-display-connection-status-users-page
+++ b/projects/plugins/jetpack/changelog/add-display-connection-status-users-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Connection: Display connection status on Users page independent of the SSO module.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-display-connection-status-users-page
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-display-connection-status-users-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Connection: Display connection status on Users page independent of the SSO module.

--- a/projects/plugins/protect/changelog/add-display-connection-status-users-page
+++ b/projects/plugins/protect/changelog/add-display-connection-status-users-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Connection: Display connection status on Users page independent of the SSO module.

--- a/projects/plugins/search/changelog/add-display-connection-status-users-page
+++ b/projects/plugins/search/changelog/add-display-connection-status-users-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Connection: Display connection status on Users page independent of the SSO module.

--- a/projects/plugins/social/changelog/add-display-connection-status-users-page
+++ b/projects/plugins/social/changelog/add-display-connection-status-users-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Connection: Display connection status on Users page independent of the SSO module.

--- a/projects/plugins/starter-plugin/changelog/add-display-connection-status-users-page
+++ b/projects/plugins/starter-plugin/changelog/add-display-connection-status-users-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Connection: Display connection status on Users page independent of the SSO module.

--- a/projects/plugins/videopress/changelog/add-display-connection-status-users-page
+++ b/projects/plugins/videopress/changelog/add-display-connection-status-users-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Connection: Display connection status on Users page independent of the SSO module.

--- a/projects/plugins/wpcomsh/changelog/add-display-connection-status-users-page
+++ b/projects/plugins/wpcomsh/changelog/add-display-connection-status-users-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Connection: Display connection status on Users page independent of the SSO module.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR extracted the code for creating a column on the Users page from the SSO module and added it to a new class.
Currently, only connected admins on a site with an SSO module enabled can see who else has a connected account. This PR will display the connection column to all admins regardless of whether they are connected or the SSO is used.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The new class takes over creating the custom column on the Users page from SSO and adds the Connection status.
* I added the new js file that adds a column tooltip and separated it from the tooltip used for SSO features.
* The old SSO class extends the new class by adding only SSO specific options (invitation management).
* I renamed the column from `SSO Status` to `WordPress.com account` because that fits better different uses that are not just about SSO. Jetpack and SSO are mentioned in tooltip texts.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pghT6q-4N-p2


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new site and add two admins. One account should be connected, and the other should not.
* Try disabling and enabling SSO and make sure the Connection status is displayed for both admins.
* When SSO is on, the extra SSO features should be available. Try them out to make sure nothing got broken.