### PR TITLE
Jetpack SEO steps copy edits

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-seo-completion-copy-edit
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-seo-completion-copy-edit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO: change copy edits on the completion step

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-completion-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-completion-step.tsx
@@ -77,7 +77,7 @@ export const useCompletionStep = (): Step => {
 				addMessage( {
 					content: createInterpolateElement(
 						__(
-							'<strong>SEO optimization complete! 🎉</strong><br/>Your blog post is now search-engine friendly.<br />Happy blogging! 😊',
+							'<strong>SEO improvements complete! 🎉</strong><br/>Your blog post is now search-engine friendly.<br />Happy blogging! 😊',
 							'jetpack'
 						),
 						{ br: <br />, strong: <strong /> }
@@ -94,7 +94,7 @@ export const useCompletionStep = (): Step => {
 
 	return {
 		id: 'completion',
-		title: __( 'Your post is SEO-ready', 'jetpack' ),
+		title: __( 'Your post is ready', 'jetpack' ),
 		label: 'completion',
 		messages,
 		type: 'completion',

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-keywords-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-keywords-step.tsx
@@ -77,7 +77,7 @@ export const useKeywordsStep = (): Step => {
 
 	return {
 		id: 'keywords',
-		title: __( 'Optimise for SEO', 'jetpack' ),
+		title: __( 'Improve SEO', 'jetpack' ),
 		label: __( 'Keywords', 'jetpack' ),
 		messages,
 		type: 'input',

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-welcome-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-welcome-step.tsx
@@ -17,7 +17,7 @@ export const useWelcomeStep = ( { stepLabels }: { stepLabels: string[] } ): Step
 		messages: [
 			{
 				content: createInterpolateElement(
-					__( "<b>Hi there! 👋 Let's optimise your blog post for SEO.</b>", 'jetpack' ),
+					__( "<b>Hi there! 👋 Let's make your blog post SEO-friendly.</b>", 'jetpack' ),
 					{ b: <b /> }
 				),
 				showIcon: true,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-welcome-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-welcome-step.tsx
@@ -11,7 +11,7 @@ export const useWelcomeStep = ( { stepLabels }: { stepLabels: string[] } ): Step
 		.join( '<br />' );
 	return {
 		id: 'welcome',
-		title: __( 'Optimise for SEO', 'jetpack' ),
+		title: __( 'Improve SEO', 'jetpack' ),
 		label: 'welcome',
 		type: 'welcome',
 		messages: [


### PR DESCRIPTION
Fixes #41797 

## Proposed changes:
Copy edits for the completion and welcome step on the SEO assistant:
- `Let's optimise your blog post for SEO` for `Let's make your blog post SEO-friendly`
- `SEO optimization complete!` for `SEO improvements complete!`
- step title from `Your post is SEO-ready` to `Your post is ready`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1739475352341509-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Open the assistant:
- Check first step title, it should read "Improve SEO"
- Check opening message, it should read "Hi there! 👋 Let's make your blog post SEO-friendly."
- Complete all steps to the end, completion step (last) should have "Your post is ready" for title and, with all steps completed, the last sentences should be "SEO improvements complete! 🎉Your blog post is now search-engine friendly"