### PR TITLE
Boost: Fix concatenate garbage collection for subdir installs

### DIFF
--- a/projects/plugins/boost/app/lib/minify/File_Paths.php
+++ b/projects/plugins/boost/app/lib/minify/File_Paths.php
@@ -34,6 +34,11 @@ final class File_Paths extends Cacheable {
 		);
 	}
 
+	/**
+	 * Get an array of file paths that belong to the same hash.
+	 *
+	 * @return array Array of file paths relative to the webroot.
+	 */
 	public function get_paths() {
 		return $this->paths;
 	}

--- a/projects/plugins/boost/changelog/fix-minify-gc
+++ b/projects/plugins/boost/changelog/fix-minify-gc
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Bug fix on unreleased feature
+
+


### PR DESCRIPTION
Fixes #41795

## Proposed changes:
* Instead of looking for files relative to `ABSPATH`, look relative to the webroot to correctly resolve the file paths.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
Testing this can be tricky and a bit hands on.
* Install WordPress on a subdirectory, e.g. https://example.com/wp/.
* Enable Concatenate JS/CSS features and visit the homepage and some other pages to generate some static files.
* Make sure those files are generated by looking into `wp-content/boost-cache/static`.
* Manually execute the garbage collection cron job.
  * Install WP Crontrol.
  * Go to **Tools > Cron Events**.
  * Run the `jetpack_boost_minify_cron_cache_cleanup` event.
* Previously, because of the bug it would have deleted all the static cache files. So make sure the files aren't deleted this time.
* Repeat the same steps to test on a non-subdirectory installation.