### PR TITLE
Jetpack SEO CSS classes and events

### DIFF
--- a/projects/plugins/jetpack/changelog/refactor-jetpack-seo-classes-and-events
+++ b/projects/plugins/jetpack/changelog/refactor-jetpack-seo-classes-and-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO: rename css classes and events for consistency and alignment with event requirements

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
@@ -95,7 +95,7 @@ export default function AssistantWizard( { close, steps, assistantName } ) {
 					return acc;
 				}, 0 ) / steps.filter( step => step.includeInResults ).length;
 
-			tracks.recordEvent( 'assistant_wizard_chat_close', {
+			tracks.recordEvent( 'jetpack_wizard_chat_close', {
 				completion,
 				step: steps[ currentStep ].id,
 				steps: steps.length - 1,
@@ -112,7 +112,7 @@ export default function AssistantWizard( { close, steps, assistantName } ) {
 	const jumpToStep = useCallback(
 		( stepNumber: number ) => {
 			if ( stepNumber < steps.length - 1 ) {
-				tracks.recordEvent( 'assistant_wizard_chat_step_jump', {
+				tracks.recordEvent( 'jetpack_wizard_chat_jump', {
 					step_from: steps[ currentStep ]?.id,
 					step_to: steps[ stepNumber ]?.id,
 					assistant_name: assistantName,
@@ -140,7 +140,7 @@ export default function AssistantWizard( { close, steps, assistantName } ) {
 			setIsBusy( true );
 			setAssistantFlowAction( 'backwards' );
 			debug( 'moving back to ' + ( currentStep - 1 ) );
-			tracks.recordEvent( 'assistant_wizard_chat_step_back', {
+			tracks.recordEvent( 'jetpack_wizard_chat_back', {
 				step_from: steps[ currentStep ]?.id,
 				step_to: steps[ currentStep - 1 ]?.id,
 				assistant_name: assistantName,
@@ -167,7 +167,7 @@ export default function AssistantWizard( { close, steps, assistantName } ) {
 				},
 			} ) );
 		}
-		tracks.recordEvent( 'assistant_wizard_chat_step_skip', {
+		tracks.recordEvent( 'jetpack_wizard_chat_skip', {
 			step_from: steps[ currentStep ]?.id,
 			step_to: steps[ currentStep + 1 ]?.id,
 			assistant_name: assistantName,
@@ -205,7 +205,7 @@ export default function AssistantWizard( { close, steps, assistantName } ) {
 			setResults( prev => ( { ...prev, ...newResults } ) );
 		}
 		setAssistantFlowAction( 'submit' );
-		tracks.recordEvent( 'assistant_wizard_chat_step_submit', {
+		tracks.recordEvent( 'jetpack_wizard_chat_submit', {
 			step_from: steps[ currentStep ].id,
 			step_to: steps[ currentStep + 1 ].id,
 			value_length: stepValue?.length || 0,
@@ -216,7 +216,7 @@ export default function AssistantWizard( { close, steps, assistantName } ) {
 	}, [ currentStep, handleDone, handleNext, steps, tracks, handleSkip, assistantName ] );
 
 	const handleRetry = useCallback( async () => {
-		tracks.recordEvent( 'assistant_wizard_chat_step_retry', {
+		tracks.recordEvent( 'jetpack_wizard_chat_retry', {
 			step: steps[ currentStep ]?.id,
 			assistant_name: assistantName,
 		} );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/assistant-wizard.tsx
@@ -8,7 +8,7 @@ import { OptionsInput, TextInput, CompletionInput } from './wizard-input';
 import WizardStep from './wizard-step';
 import type { Step, OptionMessage } from './types';
 
-const debug = debugFactory( 'assistant-wizard-chat' );
+const debug = debugFactory( 'jetpack-wizard-chat' );
 
 export default function AssistantWizard( { close, steps, assistantName } ) {
 	const [ currentStep, setCurrentStep ] = useState( 0 );
@@ -226,15 +226,15 @@ export default function AssistantWizard( { close, steps, assistantName } ) {
 	}, [ currentStep, steps, tracks, assistantName ] );
 
 	return (
-		<div className="assistant-wizard">
-			<div className="assistant-wizard__header">
-				<div className="assistant-wizard__header-actions">
+		<div className="jetpack-wizard-chat">
+			<div className="jetpack-wizard-chat__header">
+				<div className="jetpack-wizard-chat__header-actions">
 					<Button variant="link" disabled={ isBusy } onClick={ handleBack }>
 						<Icon icon={ chevronLeft } size={ 32 } />
 					</Button>
 				</div>
 				<h2>{ currentStepData?.title }</h2>
-				<div className="assistant-wizard__header-actions">
+				<div className="jetpack-wizard-chat__header-actions">
 					<Tooltip text={ __( 'Skip', 'jetpack' ) }>
 						<Button
 							variant="link"
@@ -250,7 +250,7 @@ export default function AssistantWizard( { close, steps, assistantName } ) {
 				</div>
 			</div>
 
-			<div className="assistant-wizard__content">
+			<div className="jetpack-wizard-chat__content">
 				{ steps.map( ( step, index ) => (
 					<WizardStep
 						key={ step.id }
@@ -270,7 +270,7 @@ export default function AssistantWizard( { close, steps, assistantName } ) {
 				<div ref={ stepsEndRef } />
 			</div>
 
-			<div className="assistant-wizard__input-container">
+			<div className="jetpack-wizard-chat__input-container">
 				{ steps[ currentStep ].type === 'input' && (
 					<TextInput
 						ref={ steps[ currentStep ].inputRef }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/index.tsx
@@ -20,7 +20,10 @@ export default function SeoAssistant( { disabled, placement } ) {
 	const { tracks } = useAnalytics();
 
 	const handleOpen = useCallback( () => {
-		tracks.recordEvent( 'jetpack_seo_assistant_open', { placement } );
+		tracks.recordEvent( 'jetpack_wizard_chat_open', {
+			placement,
+			assistant_name: 'seo-assistant',
+		} );
 		setIsOpen( true );
 	}, [ placement, tracks ] );
 	const handleClose = useCallback( () => setIsOpen( false ), [] );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/seo-assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/seo-assistant-wizard.tsx
@@ -7,7 +7,7 @@ import { useMetaDescriptionStep } from './use-meta-description-step';
 import { useTitleStep } from './use-title-step';
 import { useWelcomeStep } from './use-welcome-step';
 
-const debug = debugFactory( 'jetpack-ai:seo-assistant-wizard' );
+const debug = debugFactory( 'jetpack-seo:wizard-chat' );
 
 export default function SeoAssistantWizard( { close }: { close?: () => void } ) {
 	const keywordsStepData = useKeywordsStep();

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/seo-assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/seo-assistant-wizard.tsx
@@ -1,11 +1,11 @@
 import debugFactory from 'debug';
 import './style.scss';
-import AssistantWizard from './assistant-wizard';
 import { useCompletionStep } from './use-completion-step';
 import { useKeywordsStep } from './use-keywords-step';
 import { useMetaDescriptionStep } from './use-meta-description-step';
 import { useTitleStep } from './use-title-step';
 import { useWelcomeStep } from './use-welcome-step';
+import WizardChat from './wizard-chat';
 
 const debug = debugFactory( 'jetpack-seo:wizard-chat' );
 
@@ -30,7 +30,7 @@ export default function SeoAssistantWizard( { close }: { close?: () => void } ) 
 	debug( 'render seo assistant wizard' );
 
 	return (
-		<AssistantWizard
+		<WizardChat
 			close={ close }
 			steps={ [
 				welcomeStepData,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/style.scss
@@ -1,4 +1,4 @@
-.assistant-wizard {
+.jetpack-wizard-chat {
 	position: fixed;
 	bottom: 32px;
 	left: 50%;
@@ -56,7 +56,7 @@
 			}
 		}
 
-		.assistant-wizard__header-actions {
+		.jetpack-wizard-chat__header-actions {
 			width: 98px;
 			flex-shrink: 0;
 		}
@@ -87,15 +87,15 @@
 		align-items: flex-start;
 
 		// weirdly placed here, this makes the first option have a top margin
-		& > .assistant-wizard__message.is-option {
+		& > .jetpack-wizard-chat__message.is-option {
 			margin-top: 8px;
 		}
 
-		& > .assistant-wizard__message.is-option ~ .assistant-wizard__message.is-option {
+		& > .jetpack-wizard-chat__message.is-option ~ .jetpack-wizard-chat__message.is-option {
 			margin-top: 0px;
 		}
 
-		& > .assistant-wizard__message.is-option:last-of-type {
+		& > .jetpack-wizard-chat__message.is-option:last-of-type {
 			margin-bottom: 8px;
 		}
 	}
@@ -114,7 +114,7 @@
 			margin-bottom: 8px;
 		}
 
-		.assistant-wizard__message-icon {
+		.jetpack-wizard-chat__message-icon {
 			flex-shrink: 0;
 			align-self: baseline;
 			flex-basis: 26px;
@@ -125,7 +125,7 @@
 			}
 		}
 
-		.assistant-wizard__message-text {
+		.jetpack-wizard-chat__message-text {
 			padding: 0px 12px;
 		}
 
@@ -134,11 +134,11 @@
 			align-self: flex-end;
 			min-width: 15%;
 			
-			.assistant-wizard__message-text {
+			.jetpack-wizard-chat__message-text {
 				padding: 16px 20px;
 			}
 	
-			.assistant-wizard__message-icon {
+			.jetpack-wizard-chat__message-icon {
 				display: none;
 			}
 		}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-meta-description-step.tsx
@@ -61,9 +61,10 @@ export const useMetaDescriptionStep = ( {
 		if ( mockRequests ) {
 			return mockMetaDescriptionRequest( keywords );
 		}
-		tracks.recordEvent( 'jetpack_seo_assistant_request', {
+		tracks.recordEvent( 'jetpack_wizard_chat_request', {
 			step: stepId,
-			keywords,
+			context: keywords,
+			assistant_name: 'seo-assistant',
 		} );
 		return askQuestionSync(
 			[

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -56,9 +56,10 @@ export const useTitleStep = ( {
 		if ( mockRequests ) {
 			return mockTitleRequest( keywords );
 		}
-		tracks.recordEvent( 'jetpack_seo_assistant_request', {
+		tracks.recordEvent( 'jetpack_wizard_chat_request', {
 			step: stepId,
-			keywords,
+			context: keywords,
+			assistant_name: 'seo-assistant',
 		} );
 		return askQuestionSync(
 			[

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-chat.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-chat.tsx
@@ -10,7 +10,7 @@ import type { Step, OptionMessage } from './types';
 
 const debug = debugFactory( 'jetpack-wizard-chat' );
 
-export default function AssistantWizard( { close, steps, assistantName } ) {
+export default function WizardChat( { close, steps, assistantName } ) {
 	const [ currentStep, setCurrentStep ] = useState( 0 );
 	const [ isBusy, setIsBusy ] = useState( false );
 	const stepsEndRef = useRef( null );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-input.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-input.tsx
@@ -11,10 +11,10 @@ export const OptionsInput = ( {
 	submitCtaLabel,
 } ) => {
 	return (
-		<div className="assistant-wizard__actions">
+		<div className="jetpack-wizard-chat__actions">
 			<Button
 				variant="secondary"
-				className="assistant-wizard__submit"
+				className="jetpack-wizard-chat__submit"
 				onClick={ handleRetry }
 				disabled={ loading }
 			>
@@ -23,7 +23,7 @@ export const OptionsInput = ( {
 
 			<Button
 				variant="primary"
-				className="assistant-wizard__submit"
+				className="jetpack-wizard-chat__submit"
 				onClick={ handleSubmit }
 				disabled={ disabled }
 			>
@@ -36,7 +36,7 @@ export const OptionsInput = ( {
 
 function UnforwardedKeywordsInput( { placeholder, value, setValue, handleSubmit }, ref ) {
 	return (
-		<div ref={ ref } className="assistant-wizard__input">
+		<div ref={ ref } className="jetpack-wizard-chat__input">
 			<KeyboardShortcuts shortcuts={ { enter: handleSubmit } }>
 				<TextControl
 					__next40pxDefaultSize
@@ -48,7 +48,7 @@ function UnforwardedKeywordsInput( { placeholder, value, setValue, handleSubmit 
 			</KeyboardShortcuts>
 			<Button
 				variant="primary"
-				className="assistant-wizard__submit"
+				className="jetpack-wizard-chat__submit"
 				onClick={ handleSubmit }
 				size="small"
 				disabled={ ! value }
@@ -63,8 +63,8 @@ export const TextInput = forwardRef( UnforwardedKeywordsInput );
 
 export const CompletionInput = ( { submitCtaLabel, handleSubmit } ) => {
 	return (
-		<div className="assistant-wizard__completion">
-			<Button variant="primary" className="assistant-wizard__submit" onClick={ handleSubmit }>
+		<div className="jetpack-wizard-chat__completion">
+			<Button variant="primary" className="jetpack-wizard-chat__submit" onClick={ handleSubmit }>
 				{ submitCtaLabel }
 			</Button>
 		</div>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-messages.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-messages.tsx
@@ -81,12 +81,12 @@ export const useMessages = () => {
 export const MessageBubble = ( { message, onSelect = ( m: Message ) => m } ) => {
 	return (
 		<div
-			className={ clsx( 'assistant-wizard__message', {
+			className={ clsx( 'jetpack-wizard-chat__message', {
 				'is-user': message.isUser,
 				'is-option': message.type === 'option',
 			} ) }
 		>
-			<div className="assistant-wizard__message-icon">
+			<div className="jetpack-wizard-chat__message-icon">
 				{ message.showIcon && (
 					<img src={ bigSkyIcon } alt={ __( 'SEO Assistant avatar', 'jetpack' ) } />
 				) }
@@ -94,7 +94,7 @@ export const MessageBubble = ( { message, onSelect = ( m: Message ) => m } ) => 
 
 			{ message.type === 'option' && (
 				<button
-					className={ clsx( 'assistant-wizard__option', {
+					className={ clsx( 'jetpack-wizard-chat__option', {
 						'is-selected': message.selected,
 					} ) }
 					onClick={ () => onSelect( message ) }
@@ -104,7 +104,7 @@ export const MessageBubble = ( { message, onSelect = ( m: Message ) => m } ) => 
 			) }
 
 			{ ( ! message.type || message.type === 'chat' ) && (
-				<div className="assistant-wizard__message-text">{ message.content }</div>
+				<div className="jetpack-wizard-chat__message-text">{ message.content }</div>
 			) }
 		</div>
 	);
@@ -113,7 +113,7 @@ export const MessageBubble = ( { message, onSelect = ( m: Message ) => m } ) => 
 export default function Messages( { onSelect, messages, isBusy } ) {
 	return (
 		<>
-			<div className="assistant-wizard__messages">
+			<div className="jetpack-wizard-chat__messages">
 				{ messages.map( message => (
 					<MessageBubble key={ message.id } onSelect={ onSelect } message={ message } />
 				) ) }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/wizard-step.tsx
@@ -11,7 +11,7 @@ export default function WizardStep( {
 	current,
 } ) {
 	const stepRef = useRef( null );
-	const classes = clsx( 'assistant-wizard-step', className );
+	const classes = clsx( 'jetpack-wizard-chat__step', className );
 	const stepIsBusy = isBusy && current;
 
 	return (


### PR DESCRIPTION


## Proposed changes:
Turns out we need to use `jetpack_*` prefix for our events. This PR addresses that issue.
Also for the sake of consistency
- we're naming the component WizardChat, hence rename the file appropriately
- change the CSS classes based on `jetpack-wizard-chat`
- change internal debug factories


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Verify the wizard looks fine (no CSS left behind on the renames)
Verify the events trigger with prefix `jetpack_wizard_chat_*`