### PR TITLE
Launchpad: The `sell` intent has it's own launchpad

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-sell-launchpad-items
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-sell-launchpad-items
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added launchpad tasks for `sell` intent

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -320,6 +320,23 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'site_launched',
 			),
 		),
+		'sell'                    => array(
+			'get_title'      => function () {
+				return __( 'Site setup', 'jetpack-mu-wpcom' );
+			},
+			'is_dismissible' => true,
+			'task_ids'       => array(
+				'woocommerce_setup',
+				'sensei_setup',
+				'site_title',
+				'front_page_updated',
+				'verify_domain_email',
+				'verify_email',
+				'mobile_app_installed',
+				'post_sharing_enabled',
+				'site_launched',
+			),
+		),
 		'entrepreneur-site-setup' => array(
 			'task_ids' => array(
 				'woo_customize_store',

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-definitions-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-definitions-test.php
@@ -221,4 +221,25 @@ class Launchpad_Task_Definitions_Test extends \WorDBless\BaseTestCase {
 		$this->assertFalse( isset( $options['test_task_with_id_map'] ) );
 		$this->assertTrue( isset( $options['test_task_id_map'] ) );
 	}
+
+	/**
+	 * Test that tasks returned by {@see wpcom_launchpad_get_task_definitions()} have the correct shape.
+	 */
+	public function test_wpcom_launchpad_get_task_definitions() {
+		remove_all_filters( 'wpcom_launchpad_extended_task_definitions' );
+
+		$tasks = wpcom_launchpad_get_task_definitions();
+
+		$this->assertIsArray( $tasks );
+
+		// Look for one expected task
+		$this->assertArrayHasKey( 'design_edited', $tasks );
+
+		$task_ids = array_keys( $tasks );
+		foreach ( $task_ids as $task_id ) {
+			$this->assertIsString( $task_id );
+			$this->assertIsArray( $tasks[ $task_id ], 'Task definition for ' . $task_id . ' is not an array' );
+			$this->assertArrayHasKey( 'get_title', $tasks[ $task_id ], 'Task definition for ' . $task_id . ' is missing get_title function' );
+		}
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/99756

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Previously, `sell` sites were requesting the launchpad with
`checklist_slug=legacy-site-setup`. The full page launchpad doesn't have
this special casing code anymore.

It's cleanest if the `sell` intent has it's own launchpad rather than
continuing to special case it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a site with `/site/onboarding`
* Choose a "Sell physical goods" or "Sell services or digital goods" goal
* Once onboarding is complete go to `/home/{ slug }?flags=home/launchpad-first`
* The page now loads properly 😄 

