### PR TITLE
Forms: Update form field support for container block layouts

### DIFF
--- a/projects/packages/forms/changelog/fix-columns-in-form
+++ b/projects/packages/forms/changelog/fix-columns-in-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix column block width when used in the form block.

--- a/projects/packages/forms/changelog/fix-columns-in-form
+++ b/projects/packages/forms/changelog/fix-columns-in-form
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: fix column block width when used in the form block.
+Forms: ensure field blocks respect the layout for blocks like Group, Grid, Row, Columns.

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -27,6 +27,7 @@ const FieldDefaults = {
 	supports: {
 		reusable: false,
 		html: false,
+		spacing: {},
 	},
 	attributes: {
 		label: {

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -30,6 +30,7 @@ const FieldDefaults = {
 		// This doesn't opt in to support for any dimensions controls,
 		// but it's required to ensure the 'Styles' tab renders in the inspector.
 		// This is probably a bug in WordPress core.
+		// See: https://github.com/WordPress/gutenberg/issues/69404.
 		dimensions: {},
 	},
 	attributes: {

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -27,7 +27,10 @@ const FieldDefaults = {
 	supports: {
 		reusable: false,
 		html: false,
-		spacing: {},
+		// This doesn't opt in to support for any dimensions controls,
+		// but it's required to ensure the 'Styles' tab renders in the inspector.
+		// This is probably a bug in WordPress core.
+		dimensions: {},
 	},
 	attributes: {
 		label: {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -5,7 +5,12 @@ import {
 	BlockControls,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { PanelBody, ToggleControl } from '@wordpress/components';
+import {
+	PanelBody,
+	ToggleControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { withSharedFieldAttributes } from '../util/with-shared-field-attributes';
@@ -69,6 +74,20 @@ function JetpackFieldCheckbox( props ) {
 						/>
 					</PanelBody>
 				</InspectorControls>
+				<InspectorControls group="dimensions">
+					<ToolsPanelItem
+						hasValue={ () => !! width }
+						label={ __( 'Width', 'jetpack-forms' ) }
+						onDeselect={ () =>
+							setAttributes( {
+								width: undefined,
+							} )
+						}
+						isShownByDefault
+					>
+						<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
+					</ToolsPanelItem>
+				</InspectorControls>
 				<InspectorControls>
 					<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
 						<JetpackManageResponsesSettings isChildBlock />
@@ -81,8 +100,6 @@ function JetpackFieldCheckbox( props ) {
 							help={ __( 'You can edit the "required" label in the editor', 'jetpack-forms' ) }
 							__nextHasNoMarginBottom={ true }
 						/>
-						<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
-
 						<ToggleControl
 							label={ __( 'Sync fields style', 'jetpack-forms' ) }
 							checked={ attributes.shareFieldAttributes }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -5,18 +5,13 @@ import {
 	BlockControls,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import {
-	PanelBody,
-	ToggleControl,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalToolsPanelItem as ToolsPanelItem,
-} from '@wordpress/components';
+import { PanelBody, ToggleControl } from '@wordpress/components';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { withSharedFieldAttributes } from '../util/with-shared-field-attributes';
 import ToolbarRequiredGroup from './block-controls/toolbar-required-group';
+import JetpackFieldDimensionControls from './jetpack-field-dimension-controls';
 import JetpackFieldLabel from './jetpack-field-label';
-import JetpackFieldWidth from './jetpack-field-width';
 import JetpackManageResponsesSettings from './jetpack-manage-responses-settings';
 import { useJetpackFieldStyles } from './use-jetpack-field-styles';
 
@@ -74,20 +69,7 @@ function JetpackFieldCheckbox( props ) {
 						/>
 					</PanelBody>
 				</InspectorControls>
-				<InspectorControls group="dimensions">
-					<ToolsPanelItem
-						hasValue={ () => !! width }
-						label={ __( 'Width', 'jetpack-forms' ) }
-						onDeselect={ () =>
-							setAttributes( {
-								width: undefined,
-							} )
-						}
-						isShownByDefault
-					>
-						<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
-					</ToolsPanelItem>
-				</InspectorControls>
+				<JetpackFieldDimensionControls setAttributes={ setAttributes } width={ width } />
 				<InspectorControls>
 					<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
 						<JetpackManageResponsesSettings isChildBlock />

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
@@ -1,17 +1,10 @@
 import { InspectorControls, PanelColorSettings, useBlockProps } from '@wordpress/block-editor';
-import {
-	BaseControl,
-	PanelBody,
-	SelectControl,
-	ToggleControl,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalToolsPanelItem as ToolsPanelItem,
-} from '@wordpress/components';
+import { BaseControl, PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 import { withSharedFieldAttributes } from '../util/with-shared-field-attributes';
+import JetpackFieldDimensionControls from './jetpack-field-dimension-controls';
 import JetpackFieldLabel from './jetpack-field-label';
-import JetpackFieldWidth from './jetpack-field-width';
 import JetpackManageResponsesSettings from './jetpack-manage-responses-settings';
 
 const JetpackFieldConsent = ( {
@@ -52,20 +45,7 @@ const JetpackFieldConsent = ( {
 				) }
 				insertBlocksAfter={ insertBlocksAfter }
 			/>
-			<InspectorControls group="dimensions">
-				<ToolsPanelItem
-					hasValue={ () => !! width }
-					label={ __( 'Width', 'jetpack-forms' ) }
-					onDeselect={ () =>
-						setAttributes( {
-							width: undefined,
-						} )
-					}
-					isShownByDefault
-				>
-					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
-				</ToolsPanelItem>
-			</InspectorControls>
+			<JetpackFieldDimensionControls setAttributes={ setAttributes } width={ width } />
 			<InspectorControls>
 				<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
 					<JetpackManageResponsesSettings isChildBlock />

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
@@ -1,5 +1,12 @@
 import { InspectorControls, PanelColorSettings, useBlockProps } from '@wordpress/block-editor';
-import { BaseControl, PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
+import {
+	BaseControl,
+	PanelBody,
+	SelectControl,
+	ToggleControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 import { withSharedFieldAttributes } from '../util/with-shared-field-attributes';
@@ -45,12 +52,25 @@ const JetpackFieldConsent = ( {
 				) }
 				insertBlocksAfter={ insertBlocksAfter }
 			/>
+			<InspectorControls group="dimensions">
+				<ToolsPanelItem
+					hasValue={ () => !! width }
+					label={ __( 'Width', 'jetpack-forms' ) }
+					onDeselect={ () =>
+						setAttributes( {
+							width: undefined,
+						} )
+					}
+					isShownByDefault
+				>
+					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
+				</ToolsPanelItem>
+			</InspectorControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
 					<JetpackManageResponsesSettings isChildBlock />
 				</PanelBody>
 				<PanelBody title={ __( 'Field Settings', 'jetpack-forms' ) }>
-					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
 					<ToggleControl
 						label={ __( 'Sync fields style', 'jetpack-forms' ) }
 						checked={ attributes.shareFieldAttributes }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -12,14 +12,12 @@ import {
 	TextControl,
 	ToggleControl,
 	RangeControl,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { isValidElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useFormStyle, FORM_STYLE, getBlockStyle } from '../util/form';
 import ToolbarRequiredGroup from './block-controls/toolbar-required-group';
-import JetpackFieldWidth from './jetpack-field-width';
+import JetpackFieldDimensionControls from './jetpack-field-dimension-controls';
 import JetpackManageResponsesSettings from './jetpack-manage-responses-settings';
 
 const JetpackFieldControls = ( {
@@ -164,20 +162,7 @@ const JetpackFieldControls = ( {
 					onClick={ () => setAttributes( { required: ! required } ) }
 				/>
 			</BlockControls>
-			<InspectorControls group="dimensions">
-				<ToolsPanelItem
-					hasValue={ () => !! width }
-					label={ __( 'Width', 'jetpack-forms' ) }
-					onDeselect={ () =>
-						setAttributes( {
-							width: undefined,
-						} )
-					}
-					isShownByDefault
-				>
-					<JetpackFieldWidth key="width" setAttributes={ setAttributes } width={ width } />
-				</ToolsPanelItem>
-			</InspectorControls>
+			<JetpackFieldDimensionControls key="width" setAttributes={ setAttributes } width={ width } />
 			<InspectorControls>
 				<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
 					<JetpackManageResponsesSettings isChildBlock />

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -12,6 +12,8 @@ import {
 	TextControl,
 	ToggleControl,
 	RangeControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { isValidElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -128,7 +130,6 @@ const JetpackFieldControls = ( {
 				__next40pxDefaultSize={ true }
 			/>
 		),
-		<JetpackFieldWidth key="width" setAttributes={ setAttributes } width={ width } />,
 		<ToggleControl
 			key="shareFieldAttributes"
 			label={ __( 'Sync fields style', 'jetpack-forms' ) }
@@ -163,7 +164,20 @@ const JetpackFieldControls = ( {
 					onClick={ () => setAttributes( { required: ! required } ) }
 				/>
 			</BlockControls>
-
+			<InspectorControls group="dimensions">
+				<ToolsPanelItem
+					hasValue={ () => !! width }
+					label={ __( 'Width', 'jetpack-forms' ) }
+					onDeselect={ () =>
+						setAttributes( {
+							width: undefined,
+						} )
+					}
+					isShownByDefault
+				>
+					<JetpackFieldWidth key="width" setAttributes={ setAttributes } width={ width } />
+				</ToolsPanelItem>
+			</InspectorControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
 					<JetpackManageResponsesSettings isChildBlock />

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dimension-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dimension-controls.js
@@ -1,15 +1,16 @@
-import { useBlockEditContext } from '@wordpress/block-editor';
+import { InspectorControls, useBlockEditContext } from '@wordpress/block-editor';
 import {
 	BaseControl,
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 const PERCENTAGE_WIDTHS = [ 25, 50, 75, 100 ];
 
-export default function JetpackFieldWidth( { setAttributes, width } ) {
+export default function JetpackFieldDimensionControls( { setAttributes, width } ) {
 	const { clientId } = useBlockEditContext();
 	const parentLayoutType = useSelect(
 		select => {
@@ -35,32 +36,45 @@ export default function JetpackFieldWidth( { setAttributes, width } ) {
 	}
 
 	return (
-		<BaseControl
-			help={ __(
-				'Adjust the width of the field to include multiple fields on a single line.',
-				'jetpack-forms'
-			) }
-			__nextHasNoMarginBottom
-		>
-			<ToggleGroupControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				aria-label={ __( 'Width', 'jetpack-forms' ) }
-				isBlock
+		<InspectorControls group="dimensions">
+			<ToolsPanelItem
+				hasValue={ () => !! width }
 				label={ __( 'Width', 'jetpack-forms' ) }
-				onChange={ value => setAttributes( { width: value } ) }
-				value={ width }
+				onDeselect={ () =>
+					setAttributes( {
+						width: undefined,
+					} )
+				}
+				isShownByDefault
 			>
-				{ PERCENTAGE_WIDTHS.map( widthValue => {
-					return (
-						<ToggleGroupControlOption
-							key={ widthValue }
-							label={ `${ widthValue }%` }
-							value={ widthValue }
-						/>
-					);
-				} ) }
-			</ToggleGroupControl>
-		</BaseControl>
+				<BaseControl
+					help={ __(
+						'Adjust the width of the field to include multiple fields on a single line.',
+						'jetpack-forms'
+					) }
+					__nextHasNoMarginBottom
+				>
+					<ToggleGroupControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						aria-label={ __( 'Width', 'jetpack-forms' ) }
+						isBlock
+						label={ __( 'Width', 'jetpack-forms' ) }
+						onChange={ value => setAttributes( { width: value } ) }
+						value={ width }
+					>
+						{ PERCENTAGE_WIDTHS.map( widthValue => {
+							return (
+								<ToggleGroupControlOption
+									key={ widthValue }
+									label={ `${ widthValue }%` }
+									value={ widthValue }
+								/>
+							);
+						} ) }
+					</ToggleGroupControl>
+				</BaseControl>
+			</ToolsPanelItem>
+		</InspectorControls>
 	);
 }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dimension-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dimension-controls.js
@@ -21,12 +21,13 @@ export default function JetpackFieldDimensionControls( { setAttributes, width } 
 		[ clientId ]
 	);
 
-	// The width attribute is not supported in flex, grid, and constrained layouts.
-	// Grid and Flex have their own sizing controls provided by WordPress core.
-	// Constrained layout is complex to implement, so unsupported.
+	// The custom width control isn't shown for flex and grid layouts,
+	// WordPress core displays its own dimension controls.
 	//
-	// Flow layout does support the width control, the CSS to support this only
-	// requires simple percentage widths.
+	// The width control is complex to implement for constrained layout,
+	// so that's also not supported.
+	//
+	// Flow layout is much simpler to support, so it is supported.
 	if (
 		parentLayoutType === 'flex' ||
 		parentLayoutType === 'grid' ||

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dimension-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dimension-controls.js
@@ -24,8 +24,9 @@ export default function JetpackFieldDimensionControls( { setAttributes, width } 
 	// The custom width control isn't shown for flex and grid layouts,
 	// WordPress core displays its own dimension controls.
 	//
-	// The width control is complex to implement for constrained layout,
-	// so that's also not supported.
+	// The width control is also incompatible with constrained layout,
+	// so it is not supported. This is due to the width of the constrained
+	// content being unknown, so the correct styles cannot be calculated.
 	//
 	// Flow layout is much simpler to support, so it is supported.
 	if (

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-width.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-width.js
@@ -1,20 +1,36 @@
+import { useBlockEditContext } from '@wordpress/block-editor';
 import {
 	BaseControl,
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 const PERCENTAGE_WIDTHS = [ 25, 50, 75, 100 ];
 
 export default function JetpackFieldWidth( { setAttributes, width } ) {
+	const { clientId } = useBlockEditContext();
+	const parentLayoutType = useSelect(
+		select => {
+			const { getBlockRootClientId, getBlockAttributes } = select( 'core/block-editor' );
+			const rootClientId = getBlockRootClientId( clientId );
+			return getBlockAttributes( rootClientId )?.layout?.type;
+		},
+		[ clientId ]
+	);
+
+	if ( parentLayoutType === 'flex' || parentLayoutType === 'grid' ) {
+		return null;
+	}
+
 	return (
 		<BaseControl
 			help={ __(
 				'Adjust the width of the field to include multiple fields on a single line.',
 				'jetpack-forms'
 			) }
-			__nextHasNoMarginBottom={ true }
+			__nextHasNoMarginBottom
 		>
 			<ToggleGroupControl
 				__next40pxDefaultSize

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-width.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-width.js
@@ -20,7 +20,17 @@ export default function JetpackFieldWidth( { setAttributes, width } ) {
 		[ clientId ]
 	);
 
-	if ( parentLayoutType === 'flex' || parentLayoutType === 'grid' ) {
+	// The width attribute is not supported in flex, grid, and constrained layouts.
+	// Grid and Flex have their own sizing controls provided by WordPress core.
+	// Constrained layout is complex to implement, so unsupported.
+	//
+	// Flow layout does support the width control, the CSS to support this only
+	// requires simple percentage widths.
+	if (
+		parentLayoutType === 'flex' ||
+		parentLayoutType === 'grid' ||
+		parentLayoutType === 'constrained'
+	) {
 		return null;
 	}
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -49,7 +49,7 @@
 		flex-direction: row;
 		gap: var(--wp--style--block-gap, 1.5rem);
 
-		.wp-block {
+		> .wp-block {
 			flex: 0 0 100%;
 			margin-top: 0;
 			margin-bottom: 0;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -621,7 +621,6 @@
 }
 
 .jetpack-field-dropdown {
-	width: 100%;
 	display: inline-flex;
 	flex-direction: column;
 	font-family: var(--jetpack--contact-form--font-family);

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -49,7 +49,7 @@
 		flex-direction: row;
 		gap: var(--wp--style--block-gap, 1.5rem);
 
-		> .wp-block {
+		> * {
 			flex: 0 0 100%;
 			margin-top: 0;
 			margin-bottom: 0;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -43,69 +43,100 @@
 
 	.jetpack-contact-form,
 	[class*="wp-block-jetpack-field-option"] {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: flex-start;
-		flex-direction: row;
-		gap: var(--wp--style--block-gap, 1.5rem);
-
-		> * {
-			flex: 0 0 100%;
-			margin-top: 0;
-			margin-bottom: 0;
-
-			&.wp-block-jetpack-button {
-				flex-basis: auto;
-				align-self: flex-end; // Ensure button is aligned with the bottom of the previous field when on a same row
-			}
-
-			&.jetpack-field__width-25,
-			&.jetpack-field__width-50,
-			&.jetpack-field__width-75 {
-				box-sizing: border-box;
-			}
-
+		&.is-layout-constrained > * {
 			&.jetpack-field__width-25 {
-				flex: 1 1 calc( 25% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
-				max-width: 25%;
-
-				.jetpack-option__input.jetpack-option__input.jetpack-option__input {
-					width: 70px;
-				}
+				max-width: calc(var(--wp--style--global--content-size) * 0.25);
 			}
 
 			&.jetpack-field__width-50 {
-				flex: 1 1 calc( 50% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
+				max-width: calc(var(--wp--style--global--content-size) * 0.5);
+			}
+
+			&.jetpack-field__width-75 {
+				max-width: calc(var(--wp--style--global--content-size) * 0.75);
+			}
+		}
+
+		&.is-layout-flow > * {
+			&.jetpack-field__width-25 {
+				max-width: 25%;
+			}
+
+			&.jetpack-field__width-50 {
 				max-width: 50%;
 			}
 
 			&.jetpack-field__width-75 {
-				flex: 1 1 calc( 75% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
 				max-width: 75%;
 			}
+		}
 
-			@media (max-width: #{ ($break-mobile) }) {
-				&[class*=jetpack-field__width-] {
-					flex-basis: 100%;
-					max-width: none;
+		// Only apply the form's own layout rules when WordPress core's layout is not set on
+		// the parent block.
+		&:not(.is-layout-constrained, .is-layout-flex, .is-layout-grid, .is-layout-flow)  {
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: flex-start;
+			flex-direction: row;
+			gap: var(--wp--style--block-gap, 1.5rem);
+
+			> * {
+				flex: 0 0 100%;
+				margin-top: 0;
+				margin-bottom: 0;
+
+				&.wp-block-jetpack-button {
+					flex-basis: auto;
+					align-self: flex-end; // Ensure button is aligned with the bottom of the previous field when on a same row
+				}
+
+				&.jetpack-field__width-25,
+				&.jetpack-field__width-50,
+				&.jetpack-field__width-75 {
+					box-sizing: border-box;
+				}
+
+				&.jetpack-field__width-25 {
+					flex: 1 1 calc( 25% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
+					max-width: 25%;
+
+					.jetpack-option__input.jetpack-option__input.jetpack-option__input {
+						width: 70px;
+					}
+				}
+
+				&.jetpack-field__width-50 {
+					flex: 1 1 calc( 50% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
+					max-width: 50%;
+				}
+
+				&.jetpack-field__width-75 {
+					flex: 1 1 calc( 75% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
+					max-width: 75%;
+				}
+
+				@media (max-width: #{ ($break-mobile) }) {
+					&[class*=jetpack-field__width-] {
+						flex-basis: 100%;
+						max-width: none;
+					}
+				}
+
+				&[data-type='jetpack/field-checkbox'],
+				&[data-type='jetpack/field-consent'] {
+					align-self: center;
+				}
+
+				&:where( .wp-block-jetpack-contact-form .wp-block-separator ){
+					max-width: var( --wp--preset--spacing--80, 100px );
+					margin-left: auto;
+					margin-right: auto;
+				}
+				&:where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-wide ),
+				&:where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-dots ) {
+					max-width: inherit;
 				}
 			}
-
-			&[data-type='jetpack/field-checkbox'],
-			&[data-type='jetpack/field-consent'] {
-				align-self: center;
-			}
-
-			&:where( .wp-block-jetpack-contact-form .wp-block-separator ){
-				max-width: var( --wp--preset--spacing--80, 100px );
-				margin-left: auto;
-				margin-right: auto;
-			}
-			&:where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-wide ),
-			&:where( .wp-block-jetpack-contact-form .wp-block-separator.is-style-dots ) {
-				max-width: inherit;
-			}
-
 		}
 	}
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -43,20 +43,30 @@
 
 	.jetpack-contact-form,
 	[class*="wp-block-jetpack-field-option"] {
+		// In a constrained layout, the blocks take up a 'content size' that's defined by the theme or user.
+		// Blocks are centered using `margin: auto;`.
+		// The percentage widths need to be multiplied by the content size and additional right margin is used to keep
+		// the blocks aligned to the left of the container.
+		// Field block currently don't support alignment, so only the default 'left' alignment is supported.
+		// TODO: consider RTL.
 		&.is-layout-constrained > * {
 			&.jetpack-field__width-25 {
 				max-width: calc(var(--wp--style--global--content-size) * 0.25);
+				margin-right: calc(50% + (var(--wp--style--global--content-size) * 0.25)) !important;
 			}
 
 			&.jetpack-field__width-50 {
 				max-width: calc(var(--wp--style--global--content-size) * 0.5);
+				margin-right: 50% !important;
 			}
 
 			&.jetpack-field__width-75 {
 				max-width: calc(var(--wp--style--global--content-size) * 0.75);
+				margin-right: calc(50% - (var(--wp--style--global--content-size) * 0.25)) !important;
 			}
 		}
 
+		// In a flow layout, the blocks take up the full size of the container, so simple percentage widths work.
 		&.is-layout-flow > * {
 			&.jetpack-field__width-25 {
 				max-width: 25%;
@@ -71,8 +81,9 @@
 			}
 		}
 
-		// Only apply the form's own layout rules when WordPress core's layout is not set on
-		// the parent block.
+		// When there's no layout set on the parent block, use the form's own layout rules.
+		// This is a flexbox 'row' layout where the fields are usually 100% width and wrap
+		// to the next line.
 		&:not(.is-layout-constrained, .is-layout-flex, .is-layout-grid, .is-layout-flow)  {
 			display: flex;
 			flex-wrap: wrap;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -43,29 +43,7 @@
 
 	.jetpack-contact-form,
 	[class*="wp-block-jetpack-field-option"] {
-		// In a constrained layout, the blocks take up a 'content size' that's defined by the theme or user.
-		// Blocks are centered using `margin: auto;`.
-		// The percentage widths need to be multiplied by the content size and additional right margin is used to keep
-		// the blocks aligned to the left of the container.
-		// Field block currently don't support alignment, so only the default 'left' alignment is supported.
-		// TODO: consider RTL.
-		&.is-layout-constrained > * {
-			&.jetpack-field__width-25 {
-				max-width: calc(var(--wp--style--global--content-size) * 0.25);
-				margin-right: calc(50% + (var(--wp--style--global--content-size) * 0.25)) !important;
-			}
-
-			&.jetpack-field__width-50 {
-				max-width: calc(var(--wp--style--global--content-size) * 0.5);
-				margin-right: 50% !important;
-			}
-
-			&.jetpack-field__width-75 {
-				max-width: calc(var(--wp--style--global--content-size) * 0.75);
-				margin-right: calc(50% - (var(--wp--style--global--content-size) * 0.25)) !important;
-			}
-		}
-
+		//  Support the width attribute in a flow layout.
 		// In a flow layout, the blocks take up the full size of the container, so simple percentage widths work.
 		&.is-layout-flow > * {
 			&.jetpack-field__width-25 {
@@ -84,6 +62,8 @@
 		// When there's no layout set on the parent block, use the form's own layout rules.
 		// This is a flexbox 'row' layout where the fields are usually 100% width and wrap
 		// to the next line.
+		// The field width can be set to 25%, 50%, or 75% of the container width, which is
+ 		// handled by flex-basis and max-width.
 		&:not(.is-layout-constrained, .is-layout-flex, .is-layout-grid, .is-layout-flow)  {
 			display: flex;
 			flex-wrap: wrap;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -71,15 +71,15 @@
 			flex-direction: row;
 			gap: var(--wp--style--block-gap, 1.5rem);
 
+			> .wp-block-jetpack-button {
+				flex-basis: auto;
+				align-self: flex-end; // Ensure button is aligned with the bottom of the previous field when on a same row
+			}
+
 			> * {
 				flex: 0 0 100%;
 				margin-top: 0;
 				margin-bottom: 0;
-
-				&.wp-block-jetpack-button {
-					flex-basis: auto;
-					align-self: flex-end; // Ensure button is aligned with the bottom of the previous field when on a same row
-				}
 
 				&.jetpack-field__width-25,
 				&.jetpack-field__width-50,

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -89,7 +89,6 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'requiredtext'           => null,
 				'options'                => array(),
 				'id'                     => null,
-				'style'                  => null,
 				'fieldbackgroundcolor'   => null,
 				'buttonbackgroundcolor'  => null,
 				'buttonborderradius'     => null,
@@ -99,6 +98,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'values'                 => null,
 				'placeholder'            => null,
 				'class'                  => null,
+				'css'                    => null,
 				'width'                  => null,
 				'consenttype'            => null,
 				'dateformat'             => null,
@@ -299,6 +299,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$field_placeholder   = $this->get_attribute( 'placeholder' );
 		$field_width         = $this->get_attribute( 'width' );
 		$class               = 'date' === $field_type ? 'jp-contact-form-date' : $this->get_attribute( 'class' );
+		$block_css           = $this->get_attribute( 'css' );
 
 		if ( is_numeric( $this->get_attribute( 'borderradius' ) ) ) {
 			$this->block_styles .= '--jetpack--contact-form--border-radius: ' . esc_attr( $this->get_attribute( 'borderradius' ) ) . 'px;';
@@ -351,6 +352,10 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		}
 		if ( is_numeric( $this->get_attribute( 'labellineheight' ) ) ) {
 			$this->label_styles .= 'line-height: ' . (int) $this->get_attribute( 'labellineheight' ) . ';';
+		}
+
+		if ( ! empty( $block_css ) ) {
+			$this->block_styles .= $block_css;
 		}
 
 		if ( ! empty( $field_width ) && ! $this->has_inset_label() ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -89,6 +89,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'requiredtext'           => null,
 				'options'                => array(),
 				'id'                     => null,
+				'style'                  => null,
 				'fieldbackgroundcolor'   => null,
 				'buttonbackgroundcolor'  => null,
 				'buttonborderradius'     => null,

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -356,7 +356,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		}
 
 		if ( ! empty( $block_css ) ) {
-			$this->block_styles .= $block_css;
+			$this->block_styles .= esc_attr( $block_css );
 		}
 
 		if ( ! empty( $field_width ) && ! $this->has_inset_label() ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -319,7 +319,7 @@ class Contact_Form_Plugin {
 	/**
 	 * Build the CSS for the child layout.
 	 * This replicates part of the `wp_render_layout_support_flag` function from WordPress core.
-	 * That function doesn't work for form fields, as they're rendered as shortcodes,
+	 * That function doesn't work for form fields due to the way they're rendered as shortcodes,
 	 * while the core function will only generate and apply classnames for layout to html.
 	 *
 	 * @param array $layout - the block's `style.layout` attribute.
@@ -388,6 +388,7 @@ class Contact_Form_Plugin {
 
 		if ( isset( $atts['style']['layout'] ) ) {
 			$atts['css'] = self::build_child_layout_css( $atts['style']['layout'] );
+			unset( $atts['style'] );
 		}
 
 		return $atts;

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -17,7 +17,6 @@ use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
 use Jetpack_Options;
 use WP_Error;
-
 /**
  * Sets up various actions, filters, post types, post statuses, shortcodes.
  */
@@ -318,6 +317,55 @@ class Contact_Form_Plugin {
 	}
 
 	/**
+	 * Build the CSS for the child layout.
+	 * This replicates part of the `wp_render_layout_support_flag` function from WordPress core.
+	 * That function doesn't work for form fields, as they're rendered as shortcodes,
+	 * while the core function will only generate and apply classnames for layout to html.
+	 *
+	 * @param array $layout - the block's `style.layout` attribute.
+	 *
+	 * @return string CSS for the child layout.
+	 */
+	private static function build_child_layout_css( $layout ) {
+		$css = '';
+
+		if ( ! $layout ) {
+			return $css;
+		}
+
+		$self_stretch = isset( $layout['selfStretch'] ) ? $layout['selfStretch'] : null;
+
+		if ( 'fixed' === $self_stretch && isset( $layout['flexSize'] ) ) {
+			$css .= 'flex-basis: ' . $layout['flexSize'] . ';';
+			$css .= 'box-sizing: border-box;';
+		} elseif ( 'fill' === $self_stretch ) {
+			$css .= 'flex-grow: 1;';
+		}
+
+		$column_start = isset( $layout['columnStart'] ) ? $layout['columnStart'] : null;
+		$column_span  = isset( $layout['columnSpan'] ) ? $layout['columnSpan'] : null;
+		if ( $column_start && $column_span ) {
+			$css .= "grid-column: $column_start / span $column_span;";
+		} elseif ( $column_start ) {
+			$css .= "grid-column: $column_start;";
+		} elseif ( $column_span ) {
+			$css .= "grid-column: span $column_span;";
+		}
+
+		$row_start = isset( $layout['rowStart'] ) ? $layout['rowStart'] : null;
+		$row_span  = isset( $layout['rowSpan'] ) ? $layout['rowSpan'] : null;
+		if ( $row_start && $row_span ) {
+			$css .= "grid-row: $row_start / span $row_span;";
+		} elseif ( $row_start ) {
+			$css .= "grid-row: $row_start;";
+		} elseif ( $row_span ) {
+			$css .= "grid-row: span $row_span;";
+		}
+
+		return $css;
+	}
+
+	/**
 	 * Turn block attribute to shortcode attributes.
 	 *
 	 * @param array  $atts - the block attributes.
@@ -327,6 +375,7 @@ class Contact_Form_Plugin {
 	 */
 	public static function block_attributes_to_shortcode_attributes( $atts, $type ) {
 		$atts['type'] = $type;
+
 		if ( isset( $atts['className'] ) ) {
 			$atts['class'] = $atts['className'];
 			unset( $atts['className'] );
@@ -335,6 +384,10 @@ class Contact_Form_Plugin {
 		if ( isset( $atts['defaultValue'] ) ) {
 			$atts['default'] = $atts['defaultValue'];
 			unset( $atts['defaultValue'] );
+		}
+
+		if ( isset( $atts['style']['layout'] ) ) {
+			$atts['css'] = self::build_child_layout_css( $atts['style']['layout'] );
 		}
 
 		return $atts;

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -17,6 +17,7 @@ use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
 use Jetpack_Options;
 use WP_Error;
+
 /**
  * Sets up various actions, filters, post types, post statuses, shortcodes.
  */

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -323,6 +323,10 @@ class Contact_Form_Plugin {
 	 * That function doesn't work for form fields due to the way they're rendered as shortcodes,
 	 * while the core function will only generate and apply classnames for layout to html.
 	 *
+	 * This function also doesn't port the `columnStart`/`rowStart` styling from the core
+	 * function, since that's only required for the experimental grid functionality in the
+	 * Gutenberg plugin.
+	 *
 	 * @param array $layout - the block's `style.layout` attribute.
 	 *
 	 * @return string CSS for the child layout.
@@ -341,26 +345,6 @@ class Contact_Form_Plugin {
 			$css .= 'box-sizing: border-box;';
 		} elseif ( 'fill' === $self_stretch ) {
 			$css .= 'flex-grow: 1;';
-		}
-
-		$column_start = isset( $layout['columnStart'] ) ? $layout['columnStart'] : null;
-		$column_span  = isset( $layout['columnSpan'] ) ? $layout['columnSpan'] : null;
-		if ( $column_start && $column_span ) {
-			$css .= "grid-column: $column_start / span $column_span;";
-		} elseif ( $column_start ) {
-			$css .= "grid-column: $column_start;";
-		} elseif ( $column_span ) {
-			$css .= "grid-column: span $column_span;";
-		}
-
-		$row_start = isset( $layout['rowStart'] ) ? $layout['rowStart'] : null;
-		$row_span  = isset( $layout['rowSpan'] ) ? $layout['rowSpan'] : null;
-		if ( $row_start && $row_span ) {
-			$css .= "grid-row: $row_start / span $row_span;";
-		} elseif ( $row_start ) {
-			$css .= "grid-row: $row_start;";
-		} elseif ( $row_span ) {
-			$css .= "grid-row: span $row_span;";
 		}
 
 		return $css;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -289,38 +289,8 @@
 }
 
 /*
- * In a constrained layout, the blocks take up a 'content size' that's defined by the theme or user.
- * Blocks are centered using `margin: auto;`.
- * The percentage widths need to be multiplied by the content size and additional right margin is used to keep
- * the blocks aligned to the left of the container.
- * Field block currently don't support alignment, so only the default 'left' alignment is supported.
- * TODO: consider RTL.
- */
- .wp-block-jetpack-contact-form .is-layout-constrained {
-	.grunion-field-width-25-wrap {
-		max-width: calc(var(--wp--style--global--content-size) * 0.25);
-		margin-right: calc(50% + (var(--wp--style--global--content-size) * 0.25)) !important;
-	}
-
-	.grunion-field-width-50-wrap {
-		max-width: calc(var(--wp--style--global--content-size) * 0.5);
-		margin-right: 50% !important;
-	}
-
-	.grunion-field-width-75-wrap {
-		max-width: calc(var(--wp--style--global--content-size) * 0.75);
-		margin-right: calc(50% - (var(--wp--style--global--content-size) * 0.25)) !important;
-	}
-
-	@media only screen and ( max-width: 480px ) {
-		.grunion-field-wrap {
-			max-width: unset;
-		}
-	}
-}
-
-/*
- * In a flow layout, the blocks take up the full size of the container, so simple percentage widths work.
+ * Support the width attribute in a flow layout.
+ * In this layout, the blocks take up the full size of the container, so simple percentage widths work.
  */
 .wp-block-jetpack-contact-form .is-layout-flow {
 	.grunion-field-width-25-wrap {
@@ -346,6 +316,9 @@
  * When there's no layout set on the parent block, use the form's own layout rules.
  * This is a flexbox 'row' layout where the fields are usually 100% width and wrap
  * to the next line.
+ *
+ * The field width can be set to 25%, 50%, or 75% of the container width, which is
+ * handled by flex-basis and max-width.
  */
 .wp-block-jetpack-contact-form  :not(.is-layout-constrained, .is-layout-flow, .is-layout-flex, .is-layout-grid) {
 	.grunion-field-width-25-wrap {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -259,11 +259,6 @@
 	padding-left: 0;
 }
 
-.wp-block-jetpack-contact-form .wp-block-jetpack-button {
-	width: fit-content;
-	align-self: flex-end;
-}
-
 .wp-block-jetpack-contact-form .wp-block-jetpack-button.aligncenter {
 	display: block;
 
@@ -321,23 +316,27 @@
  * handled by flex-basis and max-width.
  */
 .wp-block-jetpack-contact-form  :not(.is-layout-constrained, .is-layout-flow, .is-layout-flex, .is-layout-grid) {
-	.grunion-field-width-25-wrap {
+	> .grunion-field-width-25-wrap {
 		flex: 1 1 calc( 25% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
 		max-width: 25%;
 	}
 
-	.grunion-field-width-50-wrap {
+	> .grunion-field-width-50-wrap {
 		flex: 1 1 calc( 50% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
 		max-width: 50%;
 	}
 
-	.grunion-field-width-75-wrap {
+	> .grunion-field-width-75-wrap {
 		flex: 1 1 calc( 75% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
 		max-width: 75%;
 	}
 
+	> .wp-block-jetpack-button {
+		align-self: flex-end;
+	}
+
 	@media only screen and ( max-width: 480px ) {
-		.grunion-field-wrap {
+		> .grunion-field-wrap {
 			flex-basis: 100%;
 			max-width: none;
 		}

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -333,6 +333,7 @@
 
 	> .wp-block-jetpack-button {
 		align-self: flex-end;
+		flex-basis: auto;
 	}
 
 	@media only screen and ( max-width: 480px ) {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -288,25 +288,86 @@
 	position: relative;
 }
 
-.wp-block-jetpack-contact-form .grunion-field-width-25-wrap {
-	flex: 1 1 calc( 25% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
-	max-width: 25%;
+/*
+ * In a constrained layout, the blocks take up a 'content size' that's defined by the theme or user.
+ * Blocks are centered using `margin: auto;`.
+ * The percentage widths need to be multiplied by the content size and additional right margin is used to keep
+ * the blocks aligned to the left of the container.
+ * Field block currently don't support alignment, so only the default 'left' alignment is supported.
+ * TODO: consider RTL.
+ */
+ .wp-block-jetpack-contact-form .is-layout-constrained {
+	.grunion-field-width-25-wrap {
+		max-width: calc(var(--wp--style--global--content-size) * 0.25);
+		margin-right: calc(50% + (var(--wp--style--global--content-size) * 0.25)) !important;
+	}
+
+	.grunion-field-width-50-wrap {
+		max-width: calc(var(--wp--style--global--content-size) * 0.5);
+		margin-right: 50% !important;
+	}
+
+	.grunion-field-width-75-wrap {
+		max-width: calc(var(--wp--style--global--content-size) * 0.75);
+		margin-right: calc(50% - (var(--wp--style--global--content-size) * 0.25)) !important;
+	}
+
+	@media only screen and ( max-width: 480px ) {
+		.grunion-field-wrap {
+			max-width: unset;
+		}
+	}
 }
 
-.wp-block-jetpack-contact-form .grunion-field-width-50-wrap {
-	flex: 1 1 calc( 50% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
-	max-width: 50%;
+/*
+ * In a flow layout, the blocks take up the full size of the container, so simple percentage widths work.
+ */
+.wp-block-jetpack-contact-form .is-layout-flow {
+	.grunion-field-width-25-wrap {
+		max-width: 25%;
+	}
+
+	.grunion-field-width-50-wrap {
+		max-width: 50%;
+	}
+
+	.grunion-field-width-75-wrap {
+		max-width: 75%;
+	}
+
+	@media only screen and ( max-width: 480px ) {
+		.grunion-field-wrap {
+			max-width: unset;
+		}
+	}
 }
 
-.wp-block-jetpack-contact-form .grunion-field-width-75-wrap {
-	flex: 1 1 calc( 75% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
-	max-width: 75%;
-}
+/*
+ * When there's no layout set on the parent block, use the form's own layout rules.
+ * This is a flexbox 'row' layout where the fields are usually 100% width and wrap
+ * to the next line.
+ */
+.wp-block-jetpack-contact-form  :not(.is-layout-constrained, .is-layout-flow, .is-layout-flex, .is-layout-grid) {
+	.grunion-field-width-25-wrap {
+		flex: 1 1 calc( 25% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
+		max-width: 25%;
+	}
 
-@media only screen and ( max-width: 480px ) {
-	.wp-block-jetpack-contact-form .grunion-field-wrap {
-		flex-basis: 100%;
-		max-width: none;
+	.grunion-field-width-50-wrap {
+		flex: 1 1 calc( 50% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
+		max-width: 50%;
+	}
+
+	.grunion-field-width-75-wrap {
+		flex: 1 1 calc( 75% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
+		max-width: 75%;
+	}
+
+	@media only screen and ( max-width: 480px ) {
+		.grunion-field-wrap {
+			flex-basis: 100%;
+			max-width: none;
+		}
 	}
 }
 

--- a/projects/plugins/jetpack/changelog/fix-columns-in-form
+++ b/projects/plugins/jetpack/changelog/fix-columns-in-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: fix column block width when used in the form block.

--- a/projects/plugins/jetpack/changelog/fix-columns-in-form
+++ b/projects/plugins/jetpack/changelog/fix-columns-in-form
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Forms: fix column block width when used in the form block.
+Forms: ensure field blocks respect the layout for blocks like Group, Grid, Row, Columns.

--- a/projects/plugins/jetpack/extensions/blocks/button/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/button/editor.scss
@@ -11,6 +11,12 @@
 		border: solid 1px currentColor;
 		color: currentColor;
 	}
+
+
+}
+
+.is-layout-grid > .wp-block-jetpack-button {
+	height: fit-content;
 }
 
 // Support align feature for older themes

--- a/projects/plugins/jetpack/extensions/blocks/button/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/button/editor.scss
@@ -5,7 +5,6 @@
 	@include align-block;
 	max-width: 100%;
 	width: fit-content;
-	margin: 0;
 
 	&.is-style-outline > .wp-block-button__link {
 		background-color: transparent;

--- a/projects/plugins/jetpack/extensions/blocks/button/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/button/view.scss
@@ -8,7 +8,6 @@
 	@include align-block;
 	max-width: 100%;
 	width: fit-content;
-	height: fit-content; // Since .wp-block-button__link has a 100% height, this prevents the button from matching its container's height.
 	margin: 0;
 
 	&.is-style-outline > .wp-block-button__link {

--- a/projects/plugins/jetpack/extensions/blocks/button/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/button/view.scss
@@ -20,3 +20,7 @@
 		border: none;
 	}
 }
+
+.is-layout-grid > .wp-block-jetpack-button {
+	height: fit-content;
+}


### PR DESCRIPTION
Fixes #41428
Fixes #41519

Remaining issues:
- [ ] Form submission error/validation messages don't look great. I think there should be a block for the main error message so that users can style it and position it where they want (and possibly show multiple).
- [x] Button width settings don't work correctly in some (all?) layouts
- [x] Width control doesn't work properly in a constrained layout
- [x] A final check that RTL is working as expected

## Description

Makes blocks like Row, Stack, Grid, Group, Columns work within the Form block. Users can add field blocks within them and they should adopt the correct layout.

This allows for layouts that would require custom CSS before:

#### Two fields and a button in a row and a checkbox underneath. The fields are set to 'Grow', while the button doesn't:
<img width="707" alt="Screenshot 2025-02-14 at 1 07 26 pm" src="https://github.com/user-attachments/assets/98b6d619-f14d-4e4f-b11e-61c10c209c7a" />

#### Interesting grids
<img width="825" alt="Screenshot 2025-02-14 at 1 24 53 pm" src="https://github.com/user-attachments/assets/b600de03-c432-477f-acd0-15e3fa7445a3" />

And probably more

## How

This mainly works by ensuring the form's opinionated styling is completely segregated and won't apply to other block layouts, which I've achieved wrapping any css for the form's own layout in the `:not(.is-layout-flex, .is-layout-row, .is-layout-flow, .is-layout-grid)` pseudoselector.

The block editor's child layout styles also weren't being applied to form fields. This is due to the way form field blocks output a shortcode, while the layout system expects to be able to apply a classname to the html output of a block. I've added a php function that transforms the layout attributes to inline styles for the shortcodes. This can be removed if #41840 is completed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
### Standard form layout
1. Add a form with a selection of fields
2. Select one of the fields, and notice the 'Width' control has moved to the Styles tab
3. Try changing the widths and ensure it still works as in trunk (on frontend and backend)

### Group (Constrained layout)
4. Select the button block, from the toolbar select the Lock icon and deselect lock removal
5. Select all the fields and the button, and from the block settings menu, group them.
6. All the fields should take up the width of the container, except the button which remains the size of its content
7. Try changing some of the Layout settings in the group block inspector
7a. 'Content Width' should result in the width of the fields changing
7b. 'Wide Width' will have no effect as field blocks don't support wide alignment
7c. 'Justification' should work as expected

### Group (Flow layout)
8. Select the group block again and in the inspector, deselect "Inner blocks use content width", which changes the block to the 'Flow' layout
9. Select a field and observe that in the Style tab, the width control shows.
10. Change the width, it should work as expected

### Row
11. Select the group block again and transform it to a Row (there should be icons for this in the BlockCard in the inspector).
12. All the fields and button should switch to being on a single row
13. Try the different layout options the Row block has
13a. 'Allow to wrap to multiple lines' should make the blocks wrap onto multiple lines 😄 
13b. Justification options should work as expected
13c. Select a field block and in the inspector styles tab observe there are options for 'Fit', 'Grow' and 'Fixed' widths
13d. When a field is 'Grow' and alongside another field that's 'Fit' or 'Fixed', you should see the 'Grow' field take up the available space. Also try two fields set to grow alongside a button set to fit.

### Stack
14. Select the Row block again and transform it to a Stack (there should be icons for this in the BlockCard in the inspector).
15. All the fields and button should switch to being in a column aligned to the left.
16. Try the different layout options the Group block has.
16a. Justification options should work as expected (though I don't think there's a way to change the width of fields when in a stack)
16b. For 'Allow to wrap multiple lines' to be effective in a stack, you'll need a way to reduce the height of the stack block. I don't think there's a way to do this in the editor, but you can set some temporary css in the browser dev tools.
16c. Similarly, for the Align Top/Middle/Bottom/Space Between option in the stack block's toolbar you'll need to increase the stack block's height. This is possible using the Minimum Height control in the stack block's Style tab. Or if you still have browser dev tools open, hack a style onto the block temporarily. Setting a background color can also help make this easier to visualize.
16d. Just like for the Row layout, the individual field blocks have controls for setting the height of the block to 'Fit', 'Grow', 'Fixed'. I'm not sure this makes sense for field blocks, but I also don't think there's a way to remove the options

### Grid
17. If you set a Minimum Height on the stack previously, you may want to remove it now
18.  Select the Stack block again and transform it to a Grid (there should be icons for this in the BlockCard in the inspector).
19. Observe the fields are now arranged in a grid
20. The grid block itself has 'Auto' mode activated. This means the blocks in the grid flow from left to right. As you add more or change the span of the blocks, the following blocks will wrap to the next row. You can change the column count by adjusting the 'Minimum Column Width' of the columns
21. Select a field, and observe you can use drag handles to make the field span multiple columns or rows. There are also options for this
22. Select the Grid again, and switch to 'Manual' mode, observe you can now select a specific count of columns.
24. If you have the Gutenberg plugin installed, you can activate an experiment for 'Grids' which adds more functionality to the block. It makes manual mode work differently, you can also select a row count and blocks don't have to be contiguous (there can be gaps in the grid). Auto mode also gets a column count.

### Columns
25. There's no easy way to transform to a columns, easiest option is to add a columns block to the form, select the column layout, then using list view drag form fields into the columns. There are limited options, it should just work as expected!
