### PR TITLE
Social | Hide shared connection UI if the user cannot mark connections as shared

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-hide-shared-connection-ui-for-authors
+++ b/projects/js-packages/publicize-components/changelog/update-social-hide-shared-connection-ui-for-authors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Hide mark as shared UI if the user cannot share connection

--- a/projects/js-packages/publicize-components/src/components/connection-management/connection-info.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/connection-info.tsx
@@ -10,16 +10,18 @@ import { Disconnect } from './disconnect';
 import { MarkAsShared } from './mark-as-shared';
 import styles from './style.module.scss';
 
-type ConnectionInfoProps = ConnectionStatusProps;
+type ConnectionInfoProps = ConnectionStatusProps & {
+	canMarkAsShared: boolean;
+};
 
 /**
  * Connection info component
  *
  * @param {ConnectionInfoProps} props - component props
  *
- * @return {import('react').ReactNode} - React element
+ * @return React element
  */
-export function ConnectionInfo( { connection, service }: ConnectionInfoProps ) {
+export function ConnectionInfo( { connection, service, canMarkAsShared }: ConnectionInfoProps ) {
 	const [ isPanelOpen, togglePanel ] = useReducer( state => ! state, false );
 
 	return (
@@ -52,15 +54,17 @@ export function ConnectionInfo( { connection, service }: ConnectionInfoProps ) {
 			</div>
 			<Panel className={ styles[ 'connection-panel' ] }>
 				<PanelBody opened={ isPanelOpen } onToggle={ togglePanel }>
-					<div className={ styles[ 'mark-shared-wrap' ] }>
-						<MarkAsShared connection={ connection } />
-						<IconTooltip>
-							{ __(
-								'If enabled, the connection will be available to all administrators, editors, and authors.',
-								'jetpack-publicize-components'
-							) }
-						</IconTooltip>
-					</div>
+					{ canMarkAsShared && (
+						<div className={ styles[ 'mark-shared-wrap' ] }>
+							<MarkAsShared connection={ connection } />
+							<IconTooltip>
+								{ __(
+									'If enabled, the connection will be available to all administrators, editors, and authors.',
+									'jetpack-publicize-components'
+								) }
+							</IconTooltip>
+						</div>
+					) }
 					<Disconnect connection={ connection } />
 				</PanelBody>
 			</Panel>

--- a/projects/js-packages/publicize-components/src/components/connection-management/connection-info.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/connection-info.tsx
@@ -1,8 +1,10 @@
-import { Button, IconTooltip } from '@automattic/jetpack-components';
+import { Button, IconTooltip, Text } from '@automattic/jetpack-components';
 import { Panel, PanelBody } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import { useReducer } from 'react';
+import { store as socialStore } from '../../social-store';
 import ConnectionIcon from '../connection-icon';
 import { ConnectionName } from './connection-name';
 import { ConnectionStatus, ConnectionStatusProps } from './connection-status';
@@ -23,6 +25,11 @@ type ConnectionInfoProps = ConnectionStatusProps & {
  */
 export function ConnectionInfo( { connection, service, canMarkAsShared }: ConnectionInfoProps ) {
 	const [ isPanelOpen, togglePanel ] = useReducer( state => ! state, false );
+
+	const canManageConnection = useSelect(
+		select => select( socialStore ).canUserManageConnection( connection ),
+		[ connection ]
+	);
 
 	return (
 		<>
@@ -65,7 +72,16 @@ export function ConnectionInfo( { connection, service, canMarkAsShared }: Connec
 							</IconTooltip>
 						</div>
 					) }
-					<Disconnect connection={ connection } />
+					{ canManageConnection ? (
+						<Disconnect connection={ connection } />
+					) : (
+						<Text className={ styles.description }>
+							{ __(
+								'This connection is added by a site administrator.',
+								'jetpack-publicize-components'
+							) }
+						</Text>
+					) }
 				</PanelBody>
 			</Panel>
 		</>

--- a/projects/js-packages/publicize-components/src/components/connection-management/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/index.tsx
@@ -5,6 +5,7 @@ import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
+import { useUserCanShareConnection } from '../../hooks/use-user-can-share-connection';
 import { store } from '../../social-store';
 import { ThemedConnectionsModal as ManageConnectionsModal } from '../manage-connections-modal';
 import { useService } from '../services/use-service';
@@ -39,6 +40,8 @@ const ConnectionManagement = ( { className = null, disabled = false } ) => {
 
 	const { openConnectionsModal } = useDispatch( store );
 
+	const canMarkAsShared = useUserCanShareConnection();
+
 	return (
 		<div
 			className={ clsx( styles.wrapper, className ) }
@@ -60,6 +63,7 @@ const ConnectionManagement = ( { className = null, disabled = false } ) => {
 										<ConnectionInfo
 											connection={ connection }
 											service={ getService( connection.service_name ) }
+											canMarkAsShared={ canMarkAsShared }
 										/>
 									</Disabled>
 								</li>

--- a/projects/js-packages/publicize-components/src/components/connection-management/style.module.scss
+++ b/projects/js-packages/publicize-components/src/components/connection-management/style.module.scss
@@ -74,6 +74,11 @@
 	:global(.components-panel__body.is-opened) {
 		margin-top: 1rem;
 	}
+
+	.description {
+		font-size: 14px;
+		color: var(--jp-gray-50);
+	}
 }
 
 .connection-list {

--- a/projects/js-packages/publicize-components/src/components/connection-management/tests/specs/disconnect.test.js
+++ b/projects/js-packages/publicize-components/src/components/connection-management/tests/specs/disconnect.test.js
@@ -2,6 +2,10 @@ import { render, screen } from '@testing-library/react';
 import { getManagementPageObject, setup } from '../../../../utils/test-factory';
 import { Disconnect } from '../../disconnect';
 
+jest.mock( '../../../../hooks/use-user-can-share-connection', () => ( {
+	useUserCanShareConnection: jest.fn( () => true ),
+} ) );
+
 describe( 'Disconnecting a connection', () => {
 	afterEach( () => {
 		jest.clearAllMocks();

--- a/projects/js-packages/publicize-components/src/components/connection-management/tests/specs/index.test.js
+++ b/projects/js-packages/publicize-components/src/components/connection-management/tests/specs/index.test.js
@@ -2,6 +2,10 @@ import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getManagementPageObject, setup } from '../../../../utils/test-factory';
 
+jest.mock( '../../../../hooks/use-user-can-share-connection', () => ( {
+	useUserCanShareConnection: jest.fn( () => true ),
+} ) );
+
 describe( 'ConnectionManagement', () => {
 	afterEach( () => {
 		jest.clearAllMocks();

--- a/projects/js-packages/publicize-components/src/components/connection-management/tests/specs/mark-as-shared.test.js
+++ b/projects/js-packages/publicize-components/src/components/connection-management/tests/specs/mark-as-shared.test.js
@@ -2,6 +2,10 @@ import { render, screen } from '@testing-library/react';
 import { getManagementPageObject, setup } from '../../../../utils/test-factory';
 import { MarkAsShared } from '../../mark-as-shared';
 
+jest.mock( '../../../../hooks/use-user-can-share-connection', () => ( {
+	useUserCanShareConnection: jest.fn( () => true ),
+} ) );
+
 describe( 'Marking a connection as shared', () => {
 	afterEach( () => {
 		jest.clearAllMocks();

--- a/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
@@ -17,7 +17,7 @@ import styles from './style.module.scss';
 type ConfirmationFormProps = {
 	keyringResult: KeyringResult;
 	onComplete: VoidFunction;
-	isAdmin?: boolean;
+	canMarkAsShared?: boolean;
 };
 
 type AccountOption = { label: string; value: string; profile_picture?: string };
@@ -50,9 +50,13 @@ function AccountInfo( { label, profile_picture }: AccountInfoProps ) {
  *
  * @param {ConfirmationFormProps} props - Component props
  *
- * @return {import('react').ReactNode} Connection confirmation component
+ * @return Connection confirmation component
  */
-export function ConfirmationForm( { keyringResult, onComplete, isAdmin }: ConfirmationFormProps ) {
+export function ConfirmationForm( {
+	keyringResult,
+	onComplete,
+	canMarkAsShared,
+}: ConfirmationFormProps ) {
 	const supportedServices = useSupportedServices();
 	const { existingConnections, reconnectingAccount } = useSelect( select => {
 		const store = select( socialStore );
@@ -265,7 +269,7 @@ export function ConfirmationForm( { keyringResult, onComplete, isAdmin }: Confir
 							} ) }
 						</div>
 
-						{ isAdmin ? (
+						{ canMarkAsShared ? (
 							<BaseControl
 								__nextHasNoMarginBottom={ true }
 								id="mark-connection-as-shared"

--- a/projects/js-packages/publicize-components/src/components/manage-connections-modal/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/manage-connections-modal/index.tsx
@@ -5,11 +5,11 @@ import {
 	useBreakpointMatch,
 } from '@automattic/jetpack-components';
 import { ExternalLink, Modal } from '@wordpress/components';
-import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import clsx from 'clsx';
+import { useUserCanShareConnection } from '../../hooks/use-user-can-share-connection';
 import { store } from '../../social-store';
 import { ServicesList } from '../services/services-list';
 import { ConfirmationForm } from './confirmation-form';
@@ -40,7 +40,7 @@ export const ManageConnectionsModal = () => {
 		? __( 'Connection confirmation', 'jetpack-publicize-components' )
 		: _x( 'Manage Jetpack Social connections', '', 'jetpack-publicize-components' );
 
-	const isAdmin = useSelect( select => select( coreStore ).canUser( 'update', 'settings' ), [] );
+	const canMarkAsShared = useUserCanShareConnection();
 
 	return (
 		<Modal
@@ -58,7 +58,7 @@ export const ManageConnectionsModal = () => {
 							<ConfirmationForm
 								keyringResult={ keyringResult }
 								onComplete={ closeModal }
-								isAdmin={ isAdmin }
+								canMarkAsShared={ canMarkAsShared }
 							/>
 						);
 					}

--- a/projects/js-packages/publicize-components/src/components/manage-connections-modal/tests/confirmation-form.test.js
+++ b/projects/js-packages/publicize-components/src/components/manage-connections-modal/tests/confirmation-form.test.js
@@ -78,7 +78,7 @@ describe( 'ConfirmationForm', () => {
 	} );
 
 	test( 'marks connection as shared', async () => {
-		renderComponent( { isAdmin: true } );
+		renderComponent( { canMarkAsShared: true } );
 
 		await userEvent.click( screen.getByLabelText( 'Mark the connection as shared' ) );
 		await userEvent.click( screen.getByText( 'Confirm' ) );

--- a/projects/js-packages/publicize-components/src/components/manage-connections-modal/tests/index.test.js
+++ b/projects/js-packages/publicize-components/src/components/manage-connections-modal/tests/index.test.js
@@ -6,6 +6,9 @@ import { setup } from '../../../utils/test-factory';
 jest.mock( '../confirmation-form', () => ( {
 	ConfirmationForm: () => <div>Confirmation Form</div>,
 } ) );
+jest.mock( '../../../hooks/use-user-can-share-connection', () => ( {
+	useUserCanShareConnection: jest.fn( () => true ),
+} ) );
 
 describe( 'ManageConnectionsModal', () => {
 	let stubSetKeyringResult, stubGetKeyringResult;

--- a/projects/js-packages/publicize-components/src/components/services/service-connection-info.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/service-connection-info.tsx
@@ -13,13 +13,13 @@ import { SupportedService } from './use-supported-services';
 export type ServiceConnectionInfoProps = {
 	connection: Connection;
 	service: SupportedService;
-	isAdmin?: boolean;
+	canMarkAsShared: boolean;
 };
 
 export const ServiceConnectionInfo = ( {
 	connection,
 	service,
-	isAdmin,
+	canMarkAsShared,
 }: ServiceConnectionInfoProps ) => {
 	const canManageConnection = useSelect(
 		select => select( socialStore ).canUserManageConnection( connection ),
@@ -54,8 +54,7 @@ export const ServiceConnectionInfo = ( {
 						return <ConnectionStatus connection={ conn } service={ service } />;
 					}
 
-					// Only admins can mark connections as shared
-					if ( isAdmin ) {
+					if ( canMarkAsShared ) {
 						return (
 							<div className={ styles[ 'mark-shared-wrap' ] }>
 								<MarkAsShared connection={ conn } />

--- a/projects/js-packages/publicize-components/src/components/services/service-item-details.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/service-item-details.tsx
@@ -1,8 +1,8 @@
 import { useBreakpointMatch } from '@automattic/jetpack-components';
 import { Disabled } from '@wordpress/components';
-import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import clsx from 'clsx';
+import { useUserCanShareConnection } from '../../hooks/use-user-can-share-connection';
 import { store as socialStore } from '../../social-store';
 import { Connection } from '../../social-store/types';
 import { ServiceConnectionInfo } from './service-connection-info';
@@ -33,7 +33,7 @@ export function ServiceItemDetails( { service, serviceConnections }: ServicesIte
 		};
 	}, [] );
 
-	const isAdmin = useSelect( select => select( coreStore ).canUser( 'update', 'settings' ), [] );
+	const canMarkAsShared = useUserCanShareConnection();
 
 	if ( serviceConnections.length ) {
 		return (
@@ -49,7 +49,7 @@ export function ServiceItemDetails( { service, serviceConnections }: ServicesIte
 								<ServiceConnectionInfo
 									connection={ connection }
 									service={ service }
-									isAdmin={ isAdmin }
+									canMarkAsShared={ canMarkAsShared }
 								/>
 							</Disabled>
 						</li>

--- a/projects/js-packages/publicize-components/src/components/services/tests/service-connection-info.test.js
+++ b/projects/js-packages/publicize-components/src/components/services/tests/service-connection-info.test.js
@@ -14,6 +14,9 @@ jest.mock( '../../connection-management/disconnect', () => ( {
 jest.mock( '../../connection-management/mark-as-shared', () => ( {
 	MarkAsShared: () => <button>Mark as Shared</button>,
 } ) );
+jest.mock( '../../../hooks/use-user-can-share-connection', () => ( {
+	useUserCanShareConnection: jest.fn( () => true ),
+} ) );
 
 describe( 'ServiceConnectionInfo', () => {
 	const connection = {
@@ -74,7 +77,7 @@ describe( 'ServiceConnectionInfo', () => {
 	} );
 
 	test( 'displays MarkAsShared button if connection can be disconnected', () => {
-		renderComponent( {}, {}, { isAdmin: true } );
+		renderComponent( {}, {}, { canMarkAsShared: true } );
 		expect( screen.getByText( 'Mark as Shared' ) ).toBeInTheDocument();
 	} );
 

--- a/projects/js-packages/publicize-components/src/hooks/use-user-can-share-connection.ts
+++ b/projects/js-packages/publicize-components/src/hooks/use-user-can-share-connection.ts
@@ -1,0 +1,19 @@
+import { getScriptData } from '@automattic/jetpack-script-data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Whether the current user can mark a connection as shared
+ *
+ * @return Whether the current user can mark a connection as shared
+ */
+export function useUserCanShareConnection() {
+	return useSelect( select => {
+		const { getUser } = select( coreStore );
+
+		const { current_user } = getScriptData().user;
+
+		// Only the editors and above can mark a connection as shared
+		return Boolean( getUser( current_user.id )?.capabilities?.edit_others_posts );
+	}, [] );
+}


### PR DESCRIPTION
Currently, we show the UI to mark a connection as shared on the social admin page without any permissions check because the page was supposed to be accessible only to admins.
Now, in order to prepare the Social admin page for authors, we need to add a permission check for that UI, i.e. show the shared connection UI only if the user can mark a connection as shared, which means the user needs to be at least an editor.

Also, in the connections management modal, we allow only the admins to mark connections as shared, while it should be the editors as well that can mark connections as shared.

So, this PR fixes both the issues.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Create a `useUserCanShareConnection` hook to make it a single source of truth for all the UI components.
* Hide mark as shared UI on the Social admin page if user can't mark a connection as shared
* Add a little description to inform authors that a shared connection is added by admin
* Allow editors to mark connections as shared in the modal

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* As an editor, goto connections management modal in the editor
* Confirm that you can mark a connection as shared
* Login as an author to verify that you can see that connection shared by an editor
* Change `'manage_options'` capability to `'publish_posts'` here to allow authors access the admin page
https://github.com/Automattic/jetpack/blob/f24ed9abc0a7ce21b30d4f9933dc98a7659f3c09/projects/packages/publicize/src/class-social-admin-page.php#L60
* As an author, goto Social admin page
* Confirm that you don't see the UI to mark connections as shared
* Confirm that you see the shared connections with the text saying that it's added by an admin
* Confirm that you don't see the "Disconnect" button for shared connections
* Confirm that you DO see the "Disconnect" button for author's own connections


1. Panels collapsed
    <img width="645" alt="Screenshot 2025-02-14 at 11 39 07 AM" src="https://github.com/user-attachments/assets/6bb40ad0-5afb-4b60-9ca7-1d5b293633a4" />
2. Panels expanded
    <img width="659" alt="Screenshot 2025-02-14 at 11 38 53 AM" src="https://github.com/user-attachments/assets/fb532466-7c2a-469e-832a-f869054cf5f6" />
