### PR TITLE
Newsletter Widget: Render placeholder from Calypso app behind a constant

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/.phan/config.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/config.php
@@ -25,6 +25,7 @@ return make_phan_config(
 			__DIR__ . '/../../../plugins/jetpack/3rd-party/class.jetpack-amp-support.php',  // class Jetpack_AMP_Support
 			__DIR__ . '/../../../plugins/jetpack/modules/custom-css/custom-css.php',        // class Jetpack_Custom_CSS_Enhancements
 			__DIR__ . '/../../../plugins/jetpack/class-jetpack-stats-dashboard-widget.php', // class Jetpack_Stats_Dashboard_Widget
+			__DIR__ . '/../../../plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php', // class Jetpack_Newsletter_Dashboard_Widget
 			__DIR__ . '/../../../plugins/wpcomsh/wpcomsh.php',                              // function wpcomsh_record_tracks_event
 			__DIR__ . '/../../../plugins/wpcomsh/support-session.php',
 		),

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-widget-newsletter
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-widget-newsletter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added newsletter widget to the dashboard.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -135,8 +135,9 @@ class Jetpack_Mu_Wpcom {
 	 * Load Newsletter Dashboard in Simple sites.
 	 */
 	public static function load_wpcom_newsletter_dashboard() {
-		// TODO: Add the newsletter dashboard widget feature checks.
-		require_once __DIR__ . '/features/wpcom-newsletter-widget/wpcom-newsletter-widget.php';
+		if ( defined( 'JETPACK_NEWSLETTER_WIDGET' ) && JETPACK_NEWSLETTER_WIDGET ) {
+			require_once __DIR__ . '/features/wpcom-newsletter-widget/wpcom-newsletter-widget.php';
+		}
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -136,7 +136,7 @@ class Jetpack_Mu_Wpcom {
 	 */
 	public static function load_wpcom_newsletter_dashboard() {
 		// TODO: Add the newsletter dashboard widget feature checks.
-		require_once __DIR__ . '/features/wpcom-newsletter-widget.php/wpcom-newsletter-widget.php';
+		require_once __DIR__ . '/features/wpcom-newsletter-widget/wpcom-newsletter-widget.php';
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -58,6 +58,7 @@ class Jetpack_Mu_Wpcom {
 			add_action( 'wp_loaded', array( __CLASS__, 'load_verbum_comments_admin' ) );
 			add_action( 'admin_menu', array( __CLASS__, 'load_wpcom_simple_odyssey_stats' ) );
 			add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_random_redirect' ) );
+			add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_newsletter_dashboard' ) );
 		}
 
 		// These features run only on atomic sites.
@@ -128,6 +129,14 @@ class Jetpack_Mu_Wpcom {
 		if ( class_exists( 'Automattic\Jetpack\Scheduled_Updates' ) ) {
 			Scheduled_Updates::init();
 		}
+	}
+
+	/**
+	 * Load Newsletter Dashboard in Simple sites.
+	 */
+	public static function load_wpcom_newsletter_dashboard() {
+		// TODO: Add the newsletter dashboard widget feature checks.
+		require_once __DIR__ . '/features/wpcom-newsletter-widget.php/wpcom-newsletter-widget.php';
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-newsletter-widget/wpcom-newsletter-widget.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-newsletter-widget/wpcom-newsletter-widget.php
@@ -10,6 +10,6 @@
  */
 if ( defined( 'JETPACK_PLUGIN_LOADER_PATH' ) ) {
 	// TODO: Add the newsletter dashboard widget feature checks.
-	require_once JETPACK_PLUGIN_LOADER_PATH . '/class-jetpack-newsletter-widget.php';
+	require_once JETPACK_PLUGIN_LOADER_PATH . '/class-jetpack-newsletter-dashboard-widget.php';
 	add_action( 'wp_dashboard_setup', array( new Jetpack_Newsletter_Dashboard_Widget(), 'init' ) );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-newsletter-widget/wpcom-newsletter-widget.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-newsletter-widget/wpcom-newsletter-widget.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Load the Newsletter Widget feature on WordPress.com Simple Site.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Load the newsletter stats widget in the Dashboard.
+ */
+if ( defined( 'JETPACK_PLUGIN_LOADER_PATH' ) ) {
+	// TODO: Add the newsletter dashboard widget feature checks.
+	require_once JETPACK_PLUGIN_LOADER_PATH . '/class-jetpack-newsletter-widget.php';
+	add_action( 'wp_dashboard_setup', array( new Jetpack_Newsletter_Widget(), 'init' ) );
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-newsletter-widget/wpcom-newsletter-widget.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-newsletter-widget/wpcom-newsletter-widget.php
@@ -6,10 +6,9 @@
  */
 
 /**
- * Load the newsletter stats widget in the Dashboard.
+ * Load the newsletter widget in the Dashboard.
  */
-if ( defined( 'JETPACK_PLUGIN_LOADER_PATH' ) ) {
-	// TODO: Add the newsletter dashboard widget feature checks.
+if ( defined( 'JETPACK_PLUGIN_LOADER_PATH' ) && defined( 'JETPACK_NEWSLETTER_WIDGET' ) && JETPACK_NEWSLETTER_WIDGET ) {
 	require_once JETPACK_PLUGIN_LOADER_PATH . '/class-jetpack-newsletter-dashboard-widget.php';
 	add_action( 'wp_dashboard_setup', array( new Jetpack_Newsletter_Dashboard_Widget(), 'init' ) );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-newsletter-widget/wpcom-newsletter-widget.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-newsletter-widget/wpcom-newsletter-widget.php
@@ -11,5 +11,5 @@
 if ( defined( 'JETPACK_PLUGIN_LOADER_PATH' ) ) {
 	// TODO: Add the newsletter dashboard widget feature checks.
 	require_once JETPACK_PLUGIN_LOADER_PATH . '/class-jetpack-newsletter-widget.php';
-	add_action( 'wp_dashboard_setup', array( new Jetpack_Newsletter_Widget(), 'init' ) );
+	add_action( 'wp_dashboard_setup', array( new Jetpack_Newsletter_Dashboard_Widget(), 'init' ) );
 }

--- a/projects/plugins/jetpack/changelog/add-widget-newsletter
+++ b/projects/plugins/jetpack/changelog/add-widget-newsletter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added a newsletter widget

--- a/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Jetpack Newsletter Dashboard Widget.
+ *
+ * @package jetpack
+ */
+
+use Automattic\Jetpack\Assets;
+
+/**
+ * Adds the Jetpack Newsletter widget to the WordPress admin dashboard.
+ *
+ * @package jetpack
+ */
+
+/**
+ * Class that adds the Jetpack Newsletter Dashboard Widget to the WordPress admin dashboard.
+ */
+class Jetpack_Newsletter_Dashboard_Widget {
+	const JS_DEPENDENCIES = array( 'lodash', 'react', 'react-dom', 'wp-api-fetch', 'wp-components', 'wp-compose', 'wp-element', 'wp-html-entities', 'wp-i18n', 'wp-is-shallow-equal', 'wp-polyfill', 'wp-primitives', 'wp-url', 'wp-warning', 'moment' );
+	// Sometimes custom scripts would strip the `ver` query params, so we need to make sure it doesn't by adding a custom version param `osv` here.
+	const NEWSLETTER_WIDGET_CDN_URL = 'https://widgets.wp.com/newsletter/%s?minify=false';
+	const NEWSLETTER_WIDGET_VERSION = '1.0.0';
+
+	/**
+	 * Indicates whether the class initialized or not.
+	 *
+	 * @var bool
+	 */
+	private static $initialized = false;
+
+	/**
+	 * The Widget ID.
+	 *
+	 * @var string
+	 */
+	private static $widget_id = 'jetpack_newsletter_dashboard_widget';
+
+	/**
+	 * Initialize the class by calling the setup static function.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		if ( ! self::$initialized ) {
+			self::$initialized = true;
+			self::wp_dashboard_setup();
+		}
+	}
+
+	/**
+	 * JavaScript and CSS for dashboard widget.
+	 *
+	 * @access public
+	 * @return void
+	 */
+	public static function admin_head() {
+		?>
+			<script type="text/javascript">
+				/* <![CDATA[ */
+				jQuery( function($) {
+					var dashStats = jQuery( '#dashboard_stats div.inside' );
+
+					if ( dashStats.find( '.dashboard-widget-control-form' ).length ) {
+						return;
+					}
+
+					if ( ! dashStats.length ) {
+						dashStats = jQuery( '#dashboard_stats div.dashboard-widget-content' );
+						var h = parseInt( dashStats.parent().height() ) - parseInt( dashStats.prev().height() );
+						var args = 'width=' + dashStats.width() + '&height=' + h.toString();
+					} else {
+						if ( jQuery('#dashboard_stats' ).hasClass('postbox') ) {
+							var args = 'width=' + ( dashStats.prev().width() * 2 ).toString();
+						} else {
+							var args = 'width=' + ( dashStats.width() * 2 ).toString();
+						}
+					}
+
+					dashStats
+						.not( '.dashboard-widget-control' )
+						.load( 'admin.php?page=stats&noheader&dashboard&' + args, function() {
+							jQuery( '#dashboard_stats' ).removeClass( 'is-loading' );
+							jQuery( '#stat-chart' ).css( 'width', 'auto' );
+						} );
+
+					// Widget settings toggle container.
+					var toggle = $( '.js-toggle-stats_dashboard_widget_control' );
+
+					// Move the toggle in the widget header.
+					toggle.appendTo( '#jetpack_summary_widget .handle-actions' );
+
+					// Toggle settings when clicking on it.
+					toggle.show().click( function( e ) {
+						e.preventDefault();
+						e.stopImmediatePropagation();
+						$( this ).parent().toggleClass( 'controlVisible' );
+						$( '#stats_dashboard_widget_control' ).slideToggle();
+					} );
+				} );
+				/* ]]> */
+			</script>
+		<?php
+	}
+
+	/**
+	 * Sets up the Jetpack Newsletter widget in the WordPress admin dashboard.
+	 */
+	public static function wp_dashboard_setup() {
+
+		if ( Jetpack::is_connection_ready() ) {
+			add_action( 'admin_head', array( static::class, 'admin_head' ) );
+			add_action( 'admin_init', array( static::class, 'admin_init' ) );
+
+			$widget_title = sprintf(
+				__( 'Newsletter', 'jetpack' )
+			);
+
+			wp_add_dashboard_widget(
+				self::$widget_id,
+				$widget_title,
+				array( static::class, 'render' )
+			);
+		}
+	}
+
+	/**
+	 * Render the Jetpack Newsletter widget.
+	 *
+	 * @return void
+	 */
+	public static function render() {
+		?>
+		<div id="wpcom" style="min-height: calc(100vh - 100px);">
+			<div id="newsletter-widget-app"></div>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Load the admin scripts for the Jetpack Newsletter widget.
+	 *
+	 * @return void
+	 */
+	public static function admin_init() {
+		static::load_admin_scripts( 'jp-newsletter-widget', 'app.min', array( 'config_variable_name' => 'jetpackNewsletterWidgetConfigData' ) );
+	}
+
+	/**
+	 * Load the admin scripts for the Jetpack Newsletter widget.
+	 *
+	 * @param string $asset_handle The handle of the asset.
+	 * @param string $asset_name The name of the asset.
+	 * @param array  $options The options for the asset.
+	 * @return void
+	 */
+	public static function load_admin_scripts( $asset_handle, $asset_name, $options = array() ) {
+		$default_options = array(
+			'config_data'          => array(),
+			'config_variable_name' => 'configData',
+			'enqueue_css'          => true,
+		);
+		$options         = wp_parse_args( $options, $default_options );
+		if ( file_exists( __DIR__ . "/../dist/{$asset_name}.js" ) ) {
+			// Load local assets for the convinience of development.
+			Assets::register_script(
+				$asset_handle,
+				"../dist/{$asset_name}.js",
+				__FILE__,
+				array(
+					'in_footer'  => true,
+					'textdomain' => 'jetpack',
+				)
+			);
+			Assets::enqueue_script( $asset_handle );
+		} else {
+			// In production, we load the assets from our CDN.
+			wp_register_script(
+				$asset_handle,
+				sprintf( self::NEWSLETTER_WIDGET_CDN_URL, "{$asset_name}.js" ),
+				self::JS_DEPENDENCIES,
+				self::NEWSLETTER_WIDGET_VERSION,
+				true
+			);
+			wp_enqueue_script( $asset_handle );
+		}
+
+		// TODO: Add config data.
+	}
+}

--- a/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
@@ -49,69 +49,11 @@ class Jetpack_Newsletter_Dashboard_Widget {
 	}
 
 	/**
-	 * JavaScript and CSS for dashboard widget.
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public static function admin_head() {
-		?>
-			<script type="text/javascript">
-				/* <![CDATA[ */
-				jQuery( function($) {
-					var dashStats = jQuery( '#dashboard_stats div.inside' );
-
-					if ( dashStats.find( '.dashboard-widget-control-form' ).length ) {
-						return;
-					}
-
-					if ( ! dashStats.length ) {
-						dashStats = jQuery( '#dashboard_stats div.dashboard-widget-content' );
-						var h = parseInt( dashStats.parent().height() ) - parseInt( dashStats.prev().height() );
-						var args = 'width=' + dashStats.width() + '&height=' + h.toString();
-					} else {
-						if ( jQuery('#dashboard_stats' ).hasClass('postbox') ) {
-							var args = 'width=' + ( dashStats.prev().width() * 2 ).toString();
-						} else {
-							var args = 'width=' + ( dashStats.width() * 2 ).toString();
-						}
-					}
-
-					dashStats
-						.not( '.dashboard-widget-control' )
-						.load( 'admin.php?page=stats&noheader&dashboard&' + args, function() {
-							jQuery( '#dashboard_stats' ).removeClass( 'is-loading' );
-							jQuery( '#stat-chart' ).css( 'width', 'auto' );
-						} );
-
-					// Widget settings toggle container.
-					var toggle = $( '.js-toggle-stats_dashboard_widget_control' );
-
-					// Move the toggle in the widget header.
-					toggle.appendTo( '#jetpack_summary_widget .handle-actions' );
-
-					// Toggle settings when clicking on it.
-					toggle.show().click( function( e ) {
-						e.preventDefault();
-						e.stopImmediatePropagation();
-						$( this ).parent().toggleClass( 'controlVisible' );
-						$( '#stats_dashboard_widget_control' ).slideToggle();
-					} );
-				} );
-				/* ]]> */
-			</script>
-		<?php
-	}
-
-	/**
 	 * Sets up the Jetpack Newsletter widget in the WordPress admin dashboard.
 	 */
 	public static function wp_dashboard_setup() {
-
+		static::load_admin_scripts( 'jp-newsletter-widget', 'app.min', array( 'config_variable_name' => 'jetpackNewsletterWidgetConfigData' ) );
 		if ( Jetpack::is_connection_ready() ) {
-			add_action( 'admin_head', array( static::class, 'admin_head' ) );
-			add_action( 'admin_init', array( static::class, 'admin_init' ) );
-
 			$widget_title = sprintf(
 				__( 'Newsletter', 'jetpack' )
 			);

--- a/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
@@ -52,7 +52,7 @@ class Jetpack_Newsletter_Dashboard_Widget {
 	 * Sets up the Jetpack Newsletter widget in the WordPress admin dashboard.
 	 */
 	public static function wp_dashboard_setup() {
-		static::load_admin_scripts( 'jp-newsletter-widget', 'app.min', array( 'config_variable_name' => 'jetpackNewsletterWidgetConfigData' ) );
+		static::load_admin_scripts( 'jp-newsletter-widget', 'newsletter.min', array( 'config_variable_name' => 'jetpackNewsletterWidgetConfigData' ) );
 		if ( Jetpack::is_connection_ready() ) {
 			$widget_title = sprintf(
 				__( 'Newsletter', 'jetpack' )
@@ -85,7 +85,7 @@ class Jetpack_Newsletter_Dashboard_Widget {
 	 * @return void
 	 */
 	public static function admin_init() {
-		static::load_admin_scripts( 'jp-newsletter-widget', 'app.min', array( 'config_variable_name' => 'jetpackNewsletterWidgetConfigData' ) );
+		static::load_admin_scripts( 'jp-newsletter-widget', 'newsletter.min', array( 'config_variable_name' => 'jetpackNewsletterWidgetConfigData' ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -652,8 +652,10 @@ class Jetpack {
 		require_once JETPACK__PLUGIN_DIR . 'class-jetpack-stats-dashboard-widget.php';
 		add_action( 'wp_dashboard_setup', array( new Jetpack_Stats_Dashboard_Widget(), 'init' ) );
 
-		require_once JETPACK__PLUGIN_DIR . 'class-jetpack-newsletter-dashboard-widget.php';
-		add_action( 'wp_dashboard_setup', array( new Jetpack_Newsletter_Dashboard_Widget(), 'init' ) );
+		if ( defined( 'JETPACK_NEWSLETTER_WIDGET' ) && JETPACK_NEWSLETTER_WIDGET ) {
+			require_once JETPACK__PLUGIN_DIR . 'class-jetpack-newsletter-dashboard-widget.php';
+			add_action( 'wp_dashboard_setup', array( new Jetpack_Newsletter_Dashboard_Widget(), 'init' ) );
+		}
 
 		// Returns HTTPS support status.
 		add_action( 'wp_ajax_jetpack-recheck-ssl', array( $this, 'ajax_recheck_ssl' ) );

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -652,6 +652,9 @@ class Jetpack {
 		require_once JETPACK__PLUGIN_DIR . 'class-jetpack-stats-dashboard-widget.php';
 		add_action( 'wp_dashboard_setup', array( new Jetpack_Stats_Dashboard_Widget(), 'init' ) );
 
+		require_once JETPACK__PLUGIN_DIR . 'class-jetpack-newsletter-dashboard-widget.php';
+		add_action( 'wp_dashboard_setup', array( new Jetpack_Newsletter_Dashboard_Widget(), 'init' ) );
+
 		// Returns HTTPS support status.
 		add_action( 'wp_ajax_jetpack-recheck-ssl', array( $this, 'ajax_recheck_ssl' ) );
 

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-widget-newsletter
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-widget-newsletter
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Added newsletter widger
+Added newsletter widget.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-widget-newsletter
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-widget-newsletter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added newsletter widger

--- a/projects/plugins/wpcomsh/changelog/add-widget-newsletter
+++ b/projects/plugins/wpcomsh/changelog/add-widget-newsletter
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Added newsletter widger
+Added newsletter widget.

--- a/projects/plugins/wpcomsh/changelog/add-widget-newsletter
+++ b/projects/plugins/wpcomsh/changelog/add-widget-newsletter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added newsletter widger


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR renders a placeholder for the Newsletter widget. This happens by rendering the stadnalone app built in Calypso - https://github.com/Automattic/wp-calypso/pull/99652.

This PR also adds feature checks on Jetpack, Simple and Atomic. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Load the standalone app in Jetpack/WPCOM/Atomic. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Jetpack/WOA sites. 

- Add the constant  `define( 'JETPACK_NEWSLETTER_WIDGET', true );` to your `wp-config.php` file if you're testing this on local.  
For WOA sites, this constant can be set in the wp-config file which lives in a file like this `home/150782295/htdocs/wp-config.php`, essentially in your htdocs folder. 

Similarly for JN sites, you can do this in /srv/htdocs. Your JN site's wp-admin has the ssh creds you will need to update the `wp-config.php` file to set the JETPACK_NEWSLETTER_WIDGET constant. 

- Sandbox widget.wp.com and public-api 


```
x.x.x.x public-api.wordpress.com
x.x.x.x widgets.wp.com
```
x.x.x.x is your sandbox's IP as usual. 

- Follow the instructions in https://github.com/Automattic/wp-calypso/pull/99652 to prepare the standalone app's build. 
- Go to wp-admin and ensure that you see the newsletter widget.
- Remove the constant `JETPACK_NEWSLETTER_WIDGET` or ensure that it's set to false so you we be sure that the feature check is working. 

### Simple sites

- Follow the steps in this [comment](https://github.com/Automattic/jetpack/pull/41807#issuecomment-2658459068) to prepare your sandbox. 
-  Follow the instructions in https://github.com/Automattic/wp-calypso/pull/99652 to prepare the standalone app's build.  Ignore if already done. 
- In your `0-sandbox.php`, Add the constant  `define( 'JETPACK_NEWSLETTER_WIDGET', true );` 
- Sandbox your simple site as well along with public-api.wordpress.com and widgets.wp.com
- Go to the site's wp-admin and see that the newsletter widget loads. 
- Remove the constant to ensure that the newsletter widget disappears. 

![Screenshot 2025-02-14 at 16 44 08](https://github.com/user-attachments/assets/3c4ed6a1-dfc8-4e71-811b-23246a561803)

