### PR TITLE
Jetpack Sync: Performance optimizations for 'terms' module

### DIFF
--- a/projects/packages/sync/changelog/update-sync-terms-module
+++ b/projects/packages/sync/changelog/update-sync-terms-module
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack Sync: Performance optimizations for 'terms' module

--- a/projects/packages/sync/src/class-settings.php
+++ b/projects/packages/sync/src/class-settings.php
@@ -384,6 +384,24 @@ class Settings {
 	}
 
 	/**
+	 * Returns escaped SQL for whitelisted taxonomies.
+	 * Can be injected directly into a WHERE clause.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @return string SQL WHERE clause.
+	 */
+	public static function get_whitelisted_taxonomies_sql() {
+		global $wp_taxonomies;
+
+		$allowed_taxonomies = array_keys( $wp_taxonomies );
+		$allowed_taxonomies = array_diff( $allowed_taxonomies, static::get_setting( 'taxonomies_blacklist' ) );
+
+		return "taxonomy IN ('" . implode( "', '", array_map( 'esc_sql', $allowed_taxonomies ) ) . "')";
+	}
+
+	/**
 	 * Returns escaped SQL for blacklisted post meta.
 	 * Can be injected directly into a WHERE clause.
 	 *

--- a/projects/packages/sync/src/modules/class-terms.php
+++ b/projects/packages/sync/src/modules/class-terms.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Sync\Modules;
 
-use Automattic\Jetpack\Sync\Defaults;
 use Automattic\Jetpack\Sync\Settings;
 
 /**
@@ -65,42 +64,77 @@ class Terms extends Module {
 	/**
 	 * Allows WordPress.com servers to retrieve term-related objects via the sync API.
 	 *
-	 * @param string $object_type The type of object.
+	 * @param string $object_type The type of object. Accepts: 'term', 'term_taxonomy', 'term_relationships'.
 	 * @param int    $id          The id of the object.
 	 *
-	 * @return bool|object A WP_Term object, or a row from term_taxonomy table depending on object type.
+	 * @return false|object A term or term_taxonomy object, depending on object type.
 	 */
 	public function get_object_by_id( $object_type, $id ) {
+		$id = (int) $id;
+
+		if ( empty( $id ) ) {
+			return false;
+		}
+
+		$objects = $this->get_objects_by_id( $object_type, array( $id ) );
+
+		return $objects[ $id ] ?? false;
+	}
+
+	/**
+	 * Retrieve a set of objects by their IDs.
+	 *
+	 * @access public
+	 *
+	 * @param string $object_type Object type. Accepts: 'term', 'term_taxonomy', 'term_relationships'.
+	 * @param array  $ids         Object IDs.
+	 *
+	 * @return array Array of objects.
+	 */
+	public function get_objects_by_id( $object_type, $ids ) {
 		global $wpdb;
-		$object = false;
-		if ( 'term' === $object_type ) {
-			$object = get_term( (int) $id );
 
-			if ( is_wp_error( $object ) && $object->get_error_code() === 'invalid_taxonomy' ) {
-				// Fetch raw term.
-				$columns = implode( ', ', array_unique( array_merge( Defaults::$default_term_checksum_columns, array( 'term_group' ) ) ) );
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				$object = $wpdb->get_row( $wpdb->prepare( "SELECT $columns FROM $wpdb->terms WHERE term_id = %d", $id ) );
-			}
+		$objects = array();
+
+		if ( ! is_array( $ids ) || empty( $ids ) || empty( $object_type ) ) {
+			return $objects;
 		}
 
-		if ( 'term_taxonomy' === $object_type ) {
-			$columns = implode( ', ', array_unique( array_merge( Defaults::$default_term_taxonomy_checksum_columns, array( 'description' ) ) ) );
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			$object = $wpdb->get_row( $wpdb->prepare( "SELECT $columns FROM $wpdb->term_taxonomy WHERE term_taxonomy_id = %d", $id ) );
+		// Sanitize.
+		$ids     = array_map( 'intval', $ids );
+		$ids_str = implode( ',', $ids );
+
+		$where_sql = Settings::get_whitelisted_taxonomies_sql();
+
+		switch ( $object_type ) {
+			case 'term':
+				$query    = "SELECT * FROM $wpdb->terms t INNER JOIN $wpdb->term_taxonomy tt ON t.term_id=tt.term_id WHERE t.term_id IN ( $ids_str ) AND ";
+				$callback = 'expand_raw_terms';
+				break;
+			case 'term_taxonomy':
+				$query    = "SELECT * FROM $wpdb->term_taxonomy WHERE term_taxonomy_id IN ( $ids_str ) AND ";
+				$callback = 'expand_raw_term_taxonomies';
+				break;
+			case 'term_relationships':
+				$query    = "SELECT * FROM $wpdb->term_relationships tr INNER JOIN $wpdb->term_taxonomy tt ON tr.term_taxonomy_id=tt.term_taxonomy_id WHERE object_id IN ( $ids_str ) AND ";
+				$callback = 'expand_raw_term_relationships';
+				break;
+			default:
+				return array();
 		}
 
-		if ( 'term_relationships' === $object_type ) {
-			$columns = implode( ', ', Defaults::$default_term_relationships_checksum_columns );
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			$objects = $wpdb->get_results( $wpdb->prepare( "SELECT $columns FROM $wpdb->term_relationships WHERE object_id = %d", $id ) );
-			$object  = (object) array(
-				'object_id'     => $id,
-				'relationships' => array_map( array( $this, 'expand_terms_for_relationship' ), $objects ),
-			);
+		$query .= $where_sql;
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Already sanitized above.
+		$results = $wpdb->get_results( $query );
+
+		if ( ! is_array( $results ) ) {
+			return array();
 		}
 
-		return $object ? $object : false;
+		$objects = $this->$callback( $results );
+
+		return $objects ?? array();
 	}
 
 	/**
@@ -322,10 +356,127 @@ class Terms extends Module {
 	 *
 	 * @access public
 	 *
+	 * @deprecated since $$next-version$$
+	 *
 	 * @param object $relationship A row object from the term_relationships table.
 	 * @return object|bool A term object, or false if term taxonomy doesn't exist.
 	 */
 	public function expand_terms_for_relationship( $relationship ) {
+		_deprecated_function( __METHOD__, '$$next-version$$' );
+
 		return get_term_by( 'term_taxonomy_id', $relationship->term_taxonomy_id );
+	}
+
+	/**
+	 * Prepare raw terms and return them in a standard format.
+	 *
+	 * @param  array $terms An array of raw term objects.
+	 * @return array        An array of term objects.
+	 */
+	private function expand_raw_terms( array $terms ) {
+		$objects = array();
+		$columns = array(
+			'term_id'          => 'int',
+			'name'             => 'string',
+			'slug'             => 'string',
+			'taxonomy'         => 'string',
+			'description'      => 'string',
+			'term_group'       => 'int',
+			'term_taxonomy_id' => 'int',
+			'parent'           => 'int',
+			'count'            => 'int',
+		);
+
+		foreach ( $terms as $term ) {
+			if ( ! array_key_exists( $term->term_id, $objects ) ) {
+				$t_array = array();
+
+				foreach ( $columns as $field => $type ) {
+					$value             = $term->$field ?? '';
+					$t_array[ $field ] = 'int' === $type ? (int) $value : $value;
+				}
+				// This will allow us to know on WPCOM that the term name is the raw one, coming from the DB. Useful with backwards compatibility in mind.
+				$t_array['raw_name'] = $t_array['name'];
+
+				$objects[ $term->term_id ] = (object) $t_array;
+			}
+		}
+
+		return $objects;
+	}
+
+	/**
+	 * Prepare raw term taxonomies and return them in a standard format.
+	 *
+	 * @param  array $term_taxonomies An array of raw term_taxonomy objects.
+	 * @return array                  An array of term_taxonomy objects.
+	 */
+	private function expand_raw_term_taxonomies( array $term_taxonomies ) {
+		$objects = array();
+		$columns = array(
+			'term_id'          => 'int',
+			'taxonomy'         => 'string',
+			'description'      => 'string',
+			'term_taxonomy_id' => 'int',
+			'parent'           => 'int',
+			'count'            => 'int',
+		);
+
+		foreach ( $term_taxonomies as $tt ) {
+			if ( ! array_key_exists( $tt->term_taxonomy_id, $objects ) ) {
+				$t_array = array();
+
+				foreach ( $columns as $field => $type ) {
+					$value             = $tt->$field ?? '';
+					$t_array[ $field ] = 'int' === $type ? (int) $value : $value;
+				}
+
+				$objects[ $tt->term_taxonomy_id ] = (object) $t_array;
+			}
+		}
+
+		return $objects;
+	}
+
+	/**
+	 * Prepare raw term taxonomies and return them in a standard format.
+	 *
+	 * @param  array $term_relationships An array of raw term_taxonomy objects.
+	 * @return array                     An array of term_taxonomy objects or false.
+	 */
+	private function expand_raw_term_relationships( array $term_relationships ) {
+		$objects = array();
+		$columns = array(
+			'object_id'        => 'int',
+			'term_id'          => 'int',
+			'taxonomy'         => 'string',
+			'term_taxonomy_id' => 'int',
+			'term_order'       => 'int',
+			'parent'           => 'int',
+			'count'            => 'int',
+		);
+
+		foreach ( $term_relationships as $tt ) {
+			$object_id = (int) $tt->object_id;
+
+			$relationship = array();
+			foreach ( $columns as $field => $type ) {
+				$value                  = $tt->$field ?? '';
+				$relationship[ $field ] = 'int' === $type ? (int) $value : $value;
+			}
+
+			$relationship = (object) $relationship;
+
+			if ( ! array_key_exists( $object_id, $objects ) ) {
+				$objects[ $object_id ] = (object) array(
+					'object_id'     => $object_id,
+					'relationships' => array( $relationship ),
+				);
+			} else {
+				$objects[ $object_id ]->relationships[] = $relationship;
+			}
+		}
+
+		return $objects;
 	}
 }

--- a/projects/plugins/jetpack/changelog/update-sync-terms-module
+++ b/projects/plugins/jetpack/changelog/update-sync-terms-module
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated Sync related unit tests
+
+

--- a/tools/phpcs-excludelist.json
+++ b/tools/phpcs-excludelist.json
@@ -10,7 +10,6 @@
 	"projects/packages/sync/src/modules/class-module.php",
 	"projects/packages/sync/src/modules/class-posts.php",
 	"projects/packages/sync/src/modules/class-term-relationships.php",
-	"projects/packages/sync/src/modules/class-terms.php",
 	"projects/packages/sync/src/modules/class-users.php",
 	"projects/packages/sync/src/modules/class-woocommerce.php",
 	"projects/packages/sync/src/replicastore/class-table-checksum-usermeta.php",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

During `terms`, `term_relationships` and `term_taxonomy` Fix Checksums, it's possible to call `Automattic\Jetpack\Sync\Modules\Terms::get_objects_by_id` with a config of max 600 objects to fetch from the DB.
Up to now we used to fetch each one of them via a separate DB query.
This PR refactors `get_objects_by_id` so that we fetch those via a single query.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Modules\Setings`: Introduce `get_whitelisted_taxonomies_sql` method to facilitate DB queries. Note that we prefer this logic over `get_blacklisted_taxonomies` since it's more consistent with the corresponding checksum filter.
* `Automattic\Jetpack\Sync\Modules\Terms`: Introduce `get_objects_by_id` to fetch all terms via a single DB query
* `Automattic\Jetpack\Sync\Modules\Terms`: Refactor `get_object_by_id` to use `get_objects_by_id`.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pf5801-1mi-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Wipe your `terms` table on your WPCOM Cache site
* Trigger a Fix Checksum for `terms`
* Confirm the `terms` table on your WPCOM Cache site is populated. Note the total count and some sample terms
* Repeat the same but on trunk
* Confirm the `terms` table on your WPCOM Cache site matches the total count from before and the sample terms you noted hold the same values
* Repeat with `term_taxonomy` and `term_relationships`