### PR TITLE
Jetpack AI: fix excerpt panel styles

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-excerpt-panel-styles
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-excerpt-panel-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: fix some styles and deprecation props

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/index.tsx
@@ -128,7 +128,7 @@ export function AiExcerptControl( {
 				) }
 				showTooltip={ false }
 				disabled={ disabled }
-				__nextHasNoMarginBottom={ true }
+				__next40pxDefaultSize
 			/>
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/style.scss
@@ -1,15 +1,20 @@
 .jetpack-ai-generate-excerpt-control {
 	.jetpack-ai-generate-excerpt-control__header {
-		margin-top: 8px;
+		margin-top: 12px;
 
 		.components-base-control__field {
 			display: flex;
 			justify-content: space-between;
 			align-items: center;
+			margin-bottom: 8px;
+
+			.components-base-control__label {
+				margin-bottom: 0;
+			}
 		}
 	}
 
 	.ai-assistant__tone-dropdown {
-		margin-bottom: 12px;
+		margin-bottom: 24px;
 	}
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -321,7 +321,6 @@ export const PluginDocumentSettingPanelAiExcerpt = () => {
 	};
 
 	return (
-		// @ts-expect-error - TS1003: TypeScript is unhappy with it returning ReactNode rather than ReactElement.
 		<PostTypeSupportCheck supportKeys="excerpt">
 			<SettingPanel
 				className={ isBetaExtension( 'ai-content-lens' ) ? 'is-beta-extension inset-shadow' : '' }

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -321,6 +321,7 @@ export const PluginDocumentSettingPanelAiExcerpt = () => {
 	};
 
 	return (
+		// @ts-expect-error - TS1003: TypeScript is unhappy with it returning ReactNode rather than ReactElement.
 		<PostTypeSupportCheck supportKeys="excerpt">
 			<SettingPanel
 				className={ isBetaExtension( 'ai-content-lens' ) ? 'is-beta-extension inset-shadow' : '' }

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/style.scss
@@ -16,7 +16,7 @@
 	justify-content: end;
 	margin-bottom: 10px;
 	gap: 12px;
-	justify-content:space-around;
+	justify-content:space-between;
 }
 
 // Upgrade banner


### PR DESCRIPTION
Current spacing on the Excerpt panel:
<img width="291" alt="image" src="https://github.com/user-attachments/assets/eab7f13e-e41a-4983-ba78-4254a20eb83c" />


## Proposed changes:
This PR addresses some wee issues on the styles and adds deprecation props on the components. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Create a new post, look for the excerpt panel on the Post sidebar. It should have better spacing than on the above screenshot:

<img width="285" alt="image" src="https://github.com/user-attachments/assets/05882c29-75f7-453e-9e24-1a91e1a1ca6c" />
