### PR TITLE
tools: Fix php-test-env composer.lock issue

### DIFF
--- a/tools/php-test-env/composer.json
+++ b/tools/php-test-env/composer.json
@@ -4,13 +4,9 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"php": ">=7.0",
+		"php": ">=7.2",
 		"automattic/wordbless": "^0.5.0",
 		"yoast/phpunit-polyfills": "^1.1.3"
-	},
-	"require-dev": {
-		"automattic/jetpack-changelogger": "@dev",
-		"automattic/jetpack-codesniffer": "@dev"
 	},
 	"scripts": {
 		"post-install-cmd": "WorDBless\\Composer\\InstallDropin::copy",
@@ -21,9 +17,9 @@
 	"config": {
 		"sort-packages": true,
 		"allow-plugins": {
-			"dealerdirect/phpcodesniffer-composer-installer": true,
 			"roots/wordpress-core-installer": true
 		},
-		"prepend-autoloader": false
+		"prepend-autoloader": false,
+		"lock": false
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
With the way things are currently set up, changes to `tools/php-test-env/composer.json` will cause problems for existing installs because `jetpack install -r` will try to reuse the untracked `tools/php-test-env/composer.lock` from a previous install and fail because it's not up to date with the composer.json.

There are a few ways we might fix this:

1. Disable composer.lock for that dir.
2. Check in composer.lock for that dir.
3. Have the post-install-cmd do `composer update`.

I decided to go for option 1 here, since there doesn't seem to be much need to lock stuff and wait for the Renovate lockfile update job to get any updates; previous to the introduction of php-test-env, we weren't locking the deps for any of the package tests, so why change it?

I also took the opportunity to remove some unused deps from `tools/php-test-env/composer.json` and bump the php version to match the rest of the monorepo.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1739544326909059-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In a fresh clone, check out d6bc8256^ and do `pnpm install` and then `jetpack install -rv`.
* Check out trunk and do `jetpack install -rv`. Observe the failure.
* Check out this PR and do `jetpack install -rv`. Observe it works now.