### PR TITLE
Fix Launchpad copy typo for Adding subscribers

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-copy
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Launchpad: update copy for adding subscribers to a site

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -676,7 +676,7 @@ function wpcom_launchpad_get_task_definitions() {
 			// We do not want this mapped to the 'subscribers_added' task, since this task supports
 			// being marked as complete in situations where subscribers are not added.
 			'get_title'            => function () {
-				return __( 'Add your first subscribers', 'jetpack-mu-wpcom' );
+				return __( 'Add subscribers', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_add_first_subscribers_completed',
 			'is_visible_callback'  => '__return_true',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Task-related: https://github.com/Automattic/wp-calypso/issues/99816

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixing typo `Add your first subscribers` and updating it to `Add subscribers` as it is more used across the interfaces

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
This came from today-s Self-serve demo call

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this code to your sandbox
* Go to /setup/onboarding and create a site with a `Blog` intent
* On Launchpad, ensure you're seeing the new copy:

| Before | After |
|--------|--------|
|![image](https://github.com/user-attachments/assets/0b8c28e2-845c-44ce-9eb9-8d6b05ae8d4d) | ![image](https://github.com/user-attachments/assets/212359f7-d354-4cdb-b150-dd7d16134ac7)| 


Note that it's similar to the copy we have when clicking on that step:

![image](https://github.com/user-attachments/assets/4eeb6e2f-fe85-4769-8c20-e87b70c8d89e)


