### PR TITLE
Forms: Update block editor track events

### DIFF
--- a/projects/packages/forms/changelog/update-forms-referral-track-events
+++ b/projects/packages/forms/changelog/update-forms-referral-track-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Update block editor tracks events."

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-crm-integration/jetpack-crm-integration-settings-plugin-state.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-crm-integration/jetpack-crm-integration-settings-plugin-state.js
@@ -56,7 +56,10 @@ const CRMPluginIsNotInstalled = ( { installAndActivateCRMPlugin, isInstalling } 
 		<Button
 			variant="secondary"
 			onClick={ () => {
-				tracks.recordEvent( 'jetpack_forms_plugin_install_crm_click' );
+				tracks.recordEvent( 'jetpack_forms_upsell_clicked_crm', {
+					screen: 'block-editor',
+					intent: 'install-plugin',
+				} );
 				installAndActivateCRMPlugin();
 			} }
 		>
@@ -98,7 +101,10 @@ const CRMPluginIsInstalled = ( { activateCRMPlugin, isInstalling } ) => {
 				<Button
 					variant="secondary"
 					onClick={ () => {
-						tracks.recordEvent( 'jetpack_forms_plugin_activate_crm_click' );
+						tracks.recordEvent( 'jetpack_forms_upsell_clicked_crm', {
+							screen: 'block-editor',
+							intent: 'activate-plugin',
+						} );
 						activateCRMPlugin();
 					} }
 				>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-crm-integration/jetpack-crm-integration-settings-plugin-state.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-crm-integration/jetpack-crm-integration-settings-plugin-state.js
@@ -56,7 +56,7 @@ const CRMPluginIsNotInstalled = ( { installAndActivateCRMPlugin, isInstalling } 
 		<Button
 			variant="secondary"
 			onClick={ () => {
-				tracks.recordEvent( 'jetpack_forms_upsell_clicked_crm', {
+				tracks.recordEvent( 'jetpack_forms_upsell_crm_click', {
 					screen: 'block-editor',
 					intent: 'install-plugin',
 				} );
@@ -101,7 +101,7 @@ const CRMPluginIsInstalled = ( { activateCRMPlugin, isInstalling } ) => {
 				<Button
 					variant="secondary"
 					onClick={ () => {
-						tracks.recordEvent( 'jetpack_forms_upsell_clicked_crm', {
+						tracks.recordEvent( 'jetpack_forms_upsell_crm_click', {
 							screen: 'block-editor',
 							intent: 'activate-plugin',
 						} );

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-newsletter-integration-settings-plugin-state.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-newsletter-integration-settings-plugin-state.js
@@ -47,7 +47,10 @@ const CreativeMailPluginIsNotInstalled = ( {
 					<Button
 						variant="secondary"
 						onClick={ () => {
-							tracks.recordEvent( 'jetpack_forms_plugin_install_creativemail_click' );
+							tracks.recordEvent( 'jetpack_forms_upsell_clicked_creativemail', {
+								screen: 'block-editor',
+								intent: 'install-plugin',
+							} );
 							installAndActivateCreativeMailPlugin();
 						} }
 					>
@@ -75,7 +78,10 @@ const CreativeMailPluginIsInstalled = ( { activateCreativeMailPlugin, isInstalli
 				<Button
 					variant="secondary"
 					onClick={ () => {
-						tracks.recordEvent( 'jetpack_forms_plugin_activate_creativemail_click' );
+						tracks.recordEvent( 'jetpack_forms_upsell_clicked_creativemail', {
+							screen: 'block-editor',
+							intent: 'activate-plugin',
+						} );
 						activateCreativeMailPlugin();
 					} }
 				>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-newsletter-integration-settings-plugin-state.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-newsletter-integration-settings-plugin-state.js
@@ -47,7 +47,7 @@ const CreativeMailPluginIsNotInstalled = ( {
 					<Button
 						variant="secondary"
 						onClick={ () => {
-							tracks.recordEvent( 'jetpack_forms_upsell_clicked_creativemail', {
+							tracks.recordEvent( 'jetpack_forms_upsell_creativemail_click', {
 								screen: 'block-editor',
 								intent: 'install-plugin',
 							} );
@@ -78,7 +78,7 @@ const CreativeMailPluginIsInstalled = ( { activateCreativeMailPlugin, isInstalli
 				<Button
 					variant="secondary"
 					onClick={ () => {
-						tracks.recordEvent( 'jetpack_forms_upsell_clicked_creativemail', {
+						tracks.recordEvent( 'jetpack_forms_upsell_creativemail_click', {
 							screen: 'block-editor',
 							intent: 'activate-plugin',
 						} );


### PR DESCRIPTION
## Proposed changes:
We recently added Tracks events to track when users install plugins from the Jetpack Forms block. This updates the event names and properties in order to ensure consistency with other events we'll be adding in the near future. 

These events are new and had not yet been registered, so this will not affect historical data. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- You'll need a way to monitor Tracks events. Set up Tracks Vigilante if needed.
- Deactivate and delete the Jetpack CRM and Creative Mail plugins if needed.
- Insert a form block on any page or post. 
- On the block sidebar settings, click to install/activate those two plugins and confirm that the following events fire:
   - jetpack_forms_upsell_clicked_crm
   - jetpack_forms_upsell_clicked_creativemail



