### PR TITLE
Forms: Add Tracks when connecting Google Drive

### DIFF
--- a/projects/packages/forms/changelog/add-jetpack-forms-google-tracks
+++ b/projects/packages/forms/changelog/add-jetpack-forms-google-tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Added Tracks when connecting Google Drive.

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -1320,15 +1320,15 @@ class Admin {
 
 		if ( Contact_Form_Plugin::can_use_analytics() ) {
 			Tracking::register_tracks_functions_scripts( true );
-		}
 
-		wp_localize_script(
-			'grunion-admin',
-			'jetpack_forms_tracking',
-			array(
-				'tracksUserData' => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
-			)
-		);
+			wp_localize_script(
+				'grunion-admin',
+				'jetpack_forms_tracking',
+				array(
+					'tracksUserData' => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
+				)
+			);
+		}
 
 		wp_enqueue_style( 'grunion.css' );
 

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -1316,6 +1316,29 @@ class Admin {
 			)
 		);
 
+		// Add tracking scripts
+		wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
+
+		Assets::register_script(
+			'jptracks',
+			'../dist/tracks-ajax.js',
+			__FILE__,
+			array(
+				'dependencies' => array( 'jquery' ),
+				'enqueue'      => true,
+				'in_footer'    => true,
+			)
+		);
+
+		wp_localize_script(
+			'jptracks',
+			'jpTracksAJAX',
+			array(
+				'ajaxurl'            => admin_url( 'admin-ajax.php' ),
+				'jpTracksAJAX_nonce' => wp_create_nonce( 'jp-tracks-ajax-nonce' ),
+			)
+		);
+
 		wp_enqueue_style( 'grunion.css' );
 
 		// Only add to feedback, only to spam view.

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -288,7 +288,7 @@ class Admin {
 		} else {
 			$slug        = 'jetpack-form-responses-connect';
 			$button_html = sprintf(
-				'<a href="%1$s" id="%4$s" data-nonce-name="%5$s" class="button button-primary export-button export-gdrive jptracks" data-jptracks-name="jetpack-forms-upsell-clicked-googledrive" data-jptracks-prop="screen:form-submissions-classic" title="%2$s" rel="noopener noreferer" target="_blank">%3$s</a>',
+				'<a href="%1$s" id="%4$s" data-nonce-name="%5$s" class="button button-primary export-button export-gdrive jptracks" data-jptracks-name="jetpack_forms_upsell_googledrive_click" data-jptracks-prop="screen:form-submissions-classic" title="%2$s" rel="noopener noreferer" target="_blank">%3$s</a>',
 				esc_url( Redirect::get_url( $slug ) ),
 				esc_attr__( 'connect to Google Drive', 'jetpack-forms' ),
 				esc_html__( 'Connect Google Drive', 'jetpack-forms' ),

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -12,6 +12,8 @@ use Automattic\Jetpack\Assets\Logo;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Forms\Service\Google_Drive;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Tracking;
+use Jetpack_Tracks_Client;
 
 /**
  * Class Admin
@@ -288,7 +290,7 @@ class Admin {
 		} else {
 			$slug        = 'jetpack-form-responses-connect';
 			$button_html = sprintf(
-				'<a href="%1$s" id="%4$s" data-nonce-name="%5$s" class="button button-primary export-button export-gdrive jptracks" data-jptracks-name="jetpack_forms_upsell_googledrive_click" data-jptracks-prop="screen:form-submissions-classic" title="%2$s" rel="noopener noreferer" target="_blank">%3$s</a>',
+				'<a href="%1$s" id="%4$s" data-nonce-name="%5$s" class="button button-primary export-button export-gdrive" title="%2$s" rel="noopener noreferer" target="_blank">%3$s</a>',
 				esc_url( Redirect::get_url( $slug ) ),
 				esc_attr__( 'connect to Google Drive', 'jetpack-forms' ),
 				esc_html__( 'Connect Google Drive', 'jetpack-forms' ),
@@ -1317,25 +1319,12 @@ class Admin {
 		);
 
 		// Add tracking scripts
-		wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
-
-		Assets::register_script(
-			'jptracks',
-			'../dist/tracks-ajax.js',
-			__FILE__,
-			array(
-				'dependencies' => array( 'jquery' ),
-				'enqueue'      => true,
-				'in_footer'    => true,
-			)
-		);
-
+		Tracking::register_tracks_functions_scripts( true );
 		wp_localize_script(
-			'jptracks',
-			'jpTracksAJAX',
+			'grunion-admin',
+			'jetpack_forms_tracking',
 			array(
-				'ajaxurl'            => admin_url( 'admin-ajax.php' ),
-				'jpTracksAJAX_nonce' => wp_create_nonce( 'jp-tracks-ajax-nonce' ),
+				'tracksUserData' => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
 			)
 		);
 

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -288,7 +288,7 @@ class Admin {
 		} else {
 			$slug        = 'jetpack-form-responses-connect';
 			$button_html = sprintf(
-				'<a href="%1$s" id="%4$s" data-nonce-name="%5$s" class="button button-primary export-button export-gdrive" title="%2$s" rel="noopener noreferer" target="_blank">%3$s</a>',
+				'<a href="%1$s" id="%4$s" data-nonce-name="%5$s" class="button button-primary export-button export-gdrive jptracks" data-jptracks-name="jetpack-forms-upsell-clicked-googledrive" data-jptracks-prop="screen:form-submissions-classic" title="%2$s" rel="noopener noreferer" target="_blank">%3$s</a>',
 				esc_url( Redirect::get_url( $slug ) ),
 				esc_attr__( 'connect to Google Drive', 'jetpack-forms' ),
 				esc_html__( 'Connect Google Drive', 'jetpack-forms' ),

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -1318,8 +1318,10 @@ class Admin {
 			)
 		);
 
-		// Add tracking scripts
-		Tracking::register_tracks_functions_scripts( true );
+		if ( Contact_Form_Plugin::can_use_analytics() ) {
+			Tracking::register_tracks_functions_scripts( true );
+		}
+
 		wp_localize_script(
 			'grunion-admin',
 			'jetpack_forms_tracking',

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -8,9 +8,13 @@
 namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Forms\Service\Post_To_Url;
+use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Terms_Of_Service;
+use Automattic\Jetpack\Tracking;
 use Jetpack_Options;
 use WP_Error;
 
@@ -1947,7 +1951,7 @@ class Contact_Form_Plugin {
 				}
 			}
 
-			$tracking = new \Automattic\Jetpack\Tracking();
+			$tracking = new Tracking();
 			$tracking->record_user_event( $event_name, $event_props, $event_user );
 		}
 	}
@@ -2289,5 +2293,21 @@ class Contact_Form_Plugin {
 			return 'publish';
 		}
 		return $current_status;
+	}
+
+	/**
+	 * Returns whether we are in condition to track and use
+	 * analytics functionality like Tracks.
+	 *
+	 * @return bool Returns true if we can track analytics, else false.
+	 */
+	public static function can_use_analytics() {
+		$is_wpcom               = defined( 'IS_WPCOM' ) && IS_WPCOM;
+		$status                 = new Status();
+		$connection             = new Connection_Manager();
+		$tracking               = new Tracking( 'jetpack', $connection );
+		$should_enable_tracking = $tracking->should_enable_tracking( new Terms_Of_Service(), $status );
+
+		return $is_wpcom || $should_enable_tracking;
 	}
 }

--- a/projects/packages/forms/src/contact-form/js/grunion-admin.js
+++ b/projects/packages/forms/src/contact-form/js/grunion-admin.js
@@ -1,4 +1,4 @@
-/* global ajaxurl jetpack_empty_spam_button_parameters */
+/* global ajaxurl jetpack_empty_spam_button_parameters analytics jetpack_forms_tracking */
 jQuery( function ( $ ) {
 	if ( typeof jetpack_empty_spam_button_parameters !== 'undefined' ) {
 		// Create the "Empty Spam" button and add it above and below the list of spam feedbacks.
@@ -242,6 +242,18 @@ jQuery( function ( $ ) {
 			( window.exportParameters && window.exportParameters.waitingConnection ) ||
 				'Waiting for connection...'
 		);
+		if (
+			'undefined' !== typeof analytics &&
+			'undefined' !== typeof jetpack_forms_tracking &&
+			jetpack_forms_tracking?.tracksUserData
+		) {
+			const tracksUser = jetpack_forms_tracking.tracksUserData;
+			analytics.initialize( tracksUser.userid, tracksUser.username );
+			analytics.tracks.recordEvent( 'jetpack_forms_upsell_googledrive_click', {
+				screen: 'form-submissions-export',
+			} );
+		}
+
 		startPollingConnection( { name, value } );
 	} );
 

--- a/projects/packages/forms/src/contact-form/js/grunion-admin.js
+++ b/projects/packages/forms/src/contact-form/js/grunion-admin.js
@@ -257,7 +257,7 @@ jQuery( function ( $ ) {
 			const tracksUser = jetpack_forms_tracking.tracksUserData;
 			analytics.initialize( tracksUser.userid, tracksUser.username );
 			analytics.tracks.recordEvent( 'jetpack_forms_upsell_googledrive_click', {
-				screen: 'form-submissions-export',
+				screen: 'form-responses-classic',
 			} );
 		}
 

--- a/projects/packages/forms/src/contact-form/js/grunion-admin.js
+++ b/projects/packages/forms/src/contact-form/js/grunion-admin.js
@@ -233,15 +233,22 @@ jQuery( function ( $ ) {
 		}, 5000 );
 	}
 
-	$( document ).on( 'click', '#jetpack-form-responses-connect', function () {
+	$( document ).on( 'click', '#jetpack-form-responses-connect', function ( e ) {
 		const $this = $( this );
 		const name = $this.data( 'nonce-name' );
 		const value = $( '#' + name ).attr( 'value' );
+		const redirectUrl = $this.attr( 'href' );
+
+		// Pause redirect for tracking.
+		e.preventDefault();
+
 		$this.attr( 'disabled', 'disabled' );
 		$this.text(
 			( window.exportParameters && window.exportParameters.waitingConnection ) ||
 				'Waiting for connection...'
 		);
+
+		// Do the tracking.
 		if (
 			'undefined' !== typeof analytics &&
 			'undefined' !== typeof jetpack_forms_tracking &&
@@ -254,7 +261,9 @@ jQuery( function ( $ ) {
 			} );
 		}
 
+		// Start polling and continue redirect.
 		startPollingConnection( { name, value } );
+		window.open( redirectUrl, '_blank' );
 	} );
 
 	// Handle export to Google Drive

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -10,12 +10,12 @@ namespace Automattic\Jetpack\Forms\Dashboard;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Forms\Service\Google_Drive;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
-use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
 
 /**
@@ -85,14 +85,7 @@ class Dashboard {
 			)
 		);
 
-		// Enqueue the tracking script if appropriate.
-		$is_wpcom               = defined( 'IS_WPCOM' ) && IS_WPCOM;
-		$status                 = new Status();
-		$connection             = new Connection_Manager();
-		$tracking               = new Tracking( 'jetpack', $connection );
-		$should_enable_tracking = $tracking->should_enable_tracking( new Terms_Of_Service(), $status );
-
-		if ( $is_wpcom || $should_enable_tracking ) {
+		if ( Contact_Form_Plugin::can_use_analytics() ) {
 			Tracking::register_tracks_functions_scripts( true );
 		}
 

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -15,6 +15,8 @@ use Automattic\Jetpack\Forms\Service\Google_Drive;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
+use Automattic\Jetpack\Terms_Of_Service;
+use Automattic\Jetpack\Tracking;
 
 /**
  * Handles the Jetpack Forms dashboard.
@@ -82,6 +84,17 @@ class Dashboard {
 				'dependencies' => array( 'wp-api-fetch' ),
 			)
 		);
+
+		// Enqueue the tracking script if appropriate.
+		$is_wpcom               = defined( 'IS_WPCOM' ) && IS_WPCOM;
+		$status                 = new Status();
+		$connection             = new Connection_Manager();
+		$tracking               = new Tracking( 'jetpack', $connection );
+		$should_enable_tracking = $tracking->should_enable_tracking( new Terms_Of_Service(), $status );
+
+		if ( $is_wpcom || $should_enable_tracking ) {
+			Tracking::register_tracks_functions_scripts( true );
+		}
 
 		// Adds Connection package initial state.
 		Connection_Initial_State::render_script( self::SCRIPT_HANDLE );

--- a/projects/packages/forms/src/dashboard/inbox/export-modal/google-drive.js
+++ b/projects/packages/forms/src/dashboard/inbox/export-modal/google-drive.js
@@ -46,7 +46,9 @@ const GoogleDriveExport = ( { onExport } ) => {
 	}, [ isConnected ] );
 
 	const exportToGoogleDrive = useCallback( () => {
-		tracks.recordEvent( 'jetpack_forms_export_google_click' );
+		tracks.recordEvent( 'jetpack_forms_export_click', {
+			destination: 'google-drive',
+		} );
 		onExport( 'grunion_export_to_gdrive', 'feedback_export_nonce_gdrive' )
 			.then( response => response.json() )
 			.then( ( { data } ) => {

--- a/projects/packages/forms/src/dashboard/inbox/export-modal/google-drive.js
+++ b/projects/packages/forms/src/dashboard/inbox/export-modal/google-drive.js
@@ -55,7 +55,7 @@ const GoogleDriveExport = ( { onExport } ) => {
 
 	const handleConnectClick = useCallback( () => {
 		tracks.recordEvent( 'jetpack_forms_upsell_googledrive_click', {
-			screen: 'form-submissions-inbox',
+			screen: 'form-responses-inbox',
 		} );
 		pollForConnection();
 	}, [ tracks, pollForConnection ] );

--- a/projects/packages/forms/src/dashboard/inbox/export-modal/google-drive.js
+++ b/projects/packages/forms/src/dashboard/inbox/export-modal/google-drive.js
@@ -46,18 +46,19 @@ const GoogleDriveExport = ( { onExport } ) => {
 	}, [ isConnected ] );
 
 	const exportToGoogleDrive = useCallback( () => {
+		tracks.recordEvent( 'jetpack_forms_export_google_click' );
 		onExport( 'grunion_export_to_gdrive', 'feedback_export_nonce_gdrive' )
 			.then( response => response.json() )
 			.then( ( { data } ) => {
 				window.open( data.sheet_link, '_blank' );
 			} );
-	}, [ onExport ] );
+	}, [ tracks, onExport ] );
 
 	const handleConnectClick = useCallback( () => {
+		pollForConnection();
 		tracks.recordEvent( 'jetpack_forms_upsell_googledrive_click', {
 			screen: 'form-responses-inbox',
 		} );
-		pollForConnection();
 	}, [ tracks, pollForConnection ] );
 
 	const buttonClasses = clsx( 'button', 'export-button', 'export-gdrive', {

--- a/projects/packages/forms/src/dashboard/inbox/export-modal/google-drive.js
+++ b/projects/packages/forms/src/dashboard/inbox/export-modal/google-drive.js
@@ -54,7 +54,7 @@ const GoogleDriveExport = ( { onExport } ) => {
 	}, [ onExport ] );
 
 	const handleConnectClick = useCallback( () => {
-		tracks.recordEvent( 'jetpack_forms_upsell_clicked_googledrive', {
+		tracks.recordEvent( 'jetpack_forms_upsell_googledrive_click', {
 			screen: 'form-submissions-inbox',
 		} );
 		pollForConnection();

--- a/projects/packages/forms/src/dashboard/inbox/export-modal/google-drive.js
+++ b/projects/packages/forms/src/dashboard/inbox/export-modal/google-drive.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
@@ -13,6 +14,7 @@ import { isWpcom } from '../util';
 
 const GoogleDriveExport = ( { onExport } ) => {
 	const [ isConnected, setIsConnected ] = useState( config( 'gdriveConnection' ) );
+	const { tracks } = useAnalytics();
 
 	const pollForConnection = useCallback( () => {
 		const interval = setInterval( async () => {
@@ -50,6 +52,13 @@ const GoogleDriveExport = ( { onExport } ) => {
 				window.open( data.sheet_link, '_blank' );
 			} );
 	}, [ onExport ] );
+
+	const handleConnectClick = useCallback( () => {
+		tracks.recordEvent( 'jetpack_forms_upsell_clicked_googledrive', {
+			screen: 'form-submissions-inbox',
+		} );
+		pollForConnection();
+	}, [ tracks, pollForConnection ] );
 
 	const buttonClasses = clsx( 'button', 'export-button', 'export-gdrive', {
 		'button-primary': ! isWpcom(),
@@ -107,7 +116,7 @@ const GoogleDriveExport = ( { onExport } ) => {
 							className={ buttonClasses }
 							rel="noopener noreferrer"
 							target="_blank"
-							onClick={ pollForConnection }
+							onClick={ handleConnectClick }
 						>
 							{ __( 'Connect to Google Drive', 'jetpack-forms' ) }
 						</a>

--- a/projects/packages/forms/src/dashboard/inbox/export-modal/google-drive.js
+++ b/projects/packages/forms/src/dashboard/inbox/export-modal/google-drive.js
@@ -48,6 +48,7 @@ const GoogleDriveExport = ( { onExport } ) => {
 	const exportToGoogleDrive = useCallback( () => {
 		tracks.recordEvent( 'jetpack_forms_export_click', {
 			destination: 'google-drive',
+			screen: 'form-responses-inbox',
 		} );
 		onExport( 'grunion_export_to_gdrive', 'feedback_export_nonce_gdrive' )
 			.then( response => response.json() )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-roadmap/issues/2268

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Adds Tracks events when connecting Google Drive from Jetpack Forms. Event name is 'jetpack_forms_upsell_googledrive_click'. 

UPDATE: Based on feedback, also adds Tracks event when a user actually clicks the button to export form data to Google. This was very simple to add to this PR. Event is 'jetpack_forms_export_click'. The event has a 'destination' property which is set to 'google-drive'. We can use the same event for CSV exports (in a separate PR), with destination = csv. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
peKye1-1mV-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

You do not have to actually connect Google Drive to test, just click the button. 

* You will need to be able to check tracks events. You can use [Tracks Vigilante](https://github.com/Automattic/tracks-chrome-extension) or monitor 't.gif' in the Network tab of your browser dev tools..
* From your WordPress dashboard, go to the Feedback page on the main dashboard menu.
* _Test default view._  By default, you'll get the default post-type view. Click the export button, and then click the Connect Google Drive button. Confirm an 'jetpack_forms_upsell_googledrive_click' event is fired. The 'screen' property should be set to form-responses-classic.
* _Test Jetpack inbox._ At the top of the screen, click View and change to the 'Inbox' view. Again click the Export button and then click the Connect Google Drive button. Confirm a 'jetpack_forms_upsell_googledrive_click' event is fired. The 'screen' property should be set to form-responses-inbox.