### PR TITLE
Account Protection: Add Settings Class

### DIFF
--- a/projects/packages/account-protection/src/class-settings.php
+++ b/projects/packages/account-protection/src/class-settings.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Class used to manage settings related to Account Protection.
+ *
+ * @package automattic/jetpack-account-protection
+ */
+
+namespace Automattic\Jetpack\Account_Protection;
+
+/**
+ * Account Protection Settings
+ */
+class Settings {
+	/**
+	 * Get account protection settings.
+	 *
+	 * @return array
+	 */
+	public function get() {
+		$settings = array(
+			'isEnabled'   => ( new Account_Protection() )->is_enabled(),
+			'isSupported' => ( new Account_Protection() )->is_supported_environment(),
+		);
+
+		return $settings;
+	}
+}

--- a/projects/packages/account-protection/src/class-settings.php
+++ b/projects/packages/account-protection/src/class-settings.php
@@ -7,10 +7,28 @@
 
 namespace Automattic\Jetpack\Account_Protection;
 
+use Automattic\Jetpack\Modules;
+
 /**
  * Account Protection Settings
  */
 class Settings {
+	/**
+	 * Modules instance.
+	 *
+	 * @var Modules|null
+	 */
+	private $modules;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Modules|null $modules Modules instance.
+	 */
+	public function __construct( ?Modules $modules = null ) {
+		$this->modules = $modules ?? new Modules();
+	}
+
 	/**
 	 * Get account protection settings.
 	 *
@@ -18,8 +36,8 @@ class Settings {
 	 */
 	public function get() {
 		$settings = array(
-			'isEnabled'   => ( new Account_Protection() )->is_enabled(),
-			'isSupported' => ( new Account_Protection() )->is_supported_environment(),
+			'isEnabled'   => ( new Account_Protection( $this->modules ) )->is_enabled(),
+			'isSupported' => ( new Account_Protection( $this->modules ) )->is_supported_environment(),
 		);
 
 		return $settings;

--- a/projects/packages/account-protection/src/class-settings.php
+++ b/projects/packages/account-protection/src/class-settings.php
@@ -35,11 +35,11 @@ class Settings {
 	 * @return array
 	 */
 	public function get() {
-		$settings = array(
-			'isEnabled'   => ( new Account_Protection( $this->modules ) )->is_enabled(),
-			'isSupported' => ( new Account_Protection( $this->modules ) )->is_supported_environment(),
-		);
+		$account_protection = new Account_Protection( $this->modules );
 
-		return $settings;
+		return array(
+			'isEnabled'   => $account_protection->is_enabled(),
+			'isSupported' => $account_protection->is_supported_environment(),
+		);
 	}
 }

--- a/projects/packages/account-protection/tests/php/test-settings.php
+++ b/projects/packages/account-protection/tests/php/test-settings.php
@@ -1,0 +1,26 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\Account_Protection;
+
+use Automattic\Jetpack\Modules;
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for the Settings class.
+ */
+class Settings_Test extends BaseTestCase {
+	public function test_base_case() {
+		$modules_mock = $this->createMock( Modules::class );
+		$modules_mock->expects( $this->once() )
+			->method( 'is_active' )
+			->willReturn( true );
+
+		$modules_mock->expects( $this->never() )
+			->method( 'activate' );
+
+		$settings = ( new Settings( $modules_mock ) )->get();
+
+		$this->assertTrue( $settings['isSupported'] );
+		$this->assertTrue( $settings['isEnabled'] );
+	}
+}

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Automattic\Jetpack\Account_Protection\Account_Protection;
+use Automattic\Jetpack\Account_Protection\Settings as Account_Protection_Settings;
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
@@ -232,7 +233,7 @@ class Jetpack_Protect {
 			'jetpackScan'        => My_Jetpack_Products::get_product( 'scan' ),
 			'hasPlan'            => Plan::has_required_plan( true ),
 			'onboardingProgress' => Onboarding::get_current_user_progress(),
-			'accountProtection'  => ( new Account_Protection() )->is_enabled(),
+			'accountProtection'  => ( new Account_Protection_Settings() )->get(),
 			'waf'                => array(
 				'wafSupported'        => Waf_Runner::is_supported_environment(),
 				'currentIp'           => IP_Utils::get_ip(),

--- a/projects/plugins/protect/src/class-rest-controller.php
+++ b/projects/plugins/protect/src/class-rest-controller.php
@@ -10,6 +10,7 @@
 namespace Automattic\Jetpack\Protect;
 
 use Automattic\Jetpack\Account_Protection\Account_Protection;
+use Automattic\Jetpack\Account_Protection\Settings as Account_Protection_Settings;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 use Automattic\Jetpack\IP\Utils as IP_Utils;
 use Automattic\Jetpack\Protect_Status\REST_Controller as Protect_Status_REST_Controller;
@@ -403,7 +404,7 @@ class REST_Controller {
 	 * @return WP_Rest_Response
 	 */
 	public static function api_get_account_protection() {
-		return new WP_REST_Response( ( new Account_Protection() )->is_enabled() );
+		return new WP_REST_Response( ( new Account_Protection_Settings() )->get() );
 	}
 
 	/**

--- a/projects/plugins/protect/src/js/data/account-protection/use-account-protection-query.ts
+++ b/projects/plugins/protect/src/js/data/account-protection/use-account-protection-query.ts
@@ -11,6 +11,6 @@ export default function useAccountProtectionQuery(): UseQueryResult {
 	return useQuery( {
 		queryKey: [ QUERY_ACCOUNT_PROTECTION_KEY ],
 		queryFn: API.getAccountProtection,
-		initialData: !! window?.jetpackProtectInitialState?.accountProtection,
+		initialData: window?.jetpackProtectInitialState?.accountProtection,
 	} );
 }

--- a/projects/plugins/protect/src/js/data/use-connection-mutation.ts
+++ b/projects/plugins/protect/src/js/data/use-connection-mutation.ts
@@ -2,6 +2,7 @@ import { useConnection } from '@automattic/jetpack-connection';
 import { type ScanStatus } from '@automattic/jetpack-scan';
 import { useMutation, UseMutationResult, useQueryClient } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
+import API from '../api';
 import {
 	QUERY_CREDENTIALS_KEY,
 	QUERY_HAS_PLAN_KEY,
@@ -46,7 +47,10 @@ export default function useConnectSiteMutation(): UseMutationResult {
 			queryClient.invalidateQueries( { queryKey: [ QUERY_HAS_PLAN_KEY ] } );
 			queryClient.invalidateQueries( { queryKey: [ QUERY_CREDENTIALS_KEY ] } );
 
-			queryClient.ensureQueryData( { queryKey: [ QUERY_ACCOUNT_PROTECTION_KEY ] } );
+			queryClient.ensureQueryData( {
+				queryKey: [ QUERY_ACCOUNT_PROTECTION_KEY ],
+				queryFn: API.getAccountProtection,
+			} );
 			queryClient.invalidateQueries( { queryKey: [ QUERY_ACCOUNT_PROTECTION_KEY ] } );
 		},
 		onError: () => {

--- a/projects/plugins/protect/src/js/routes/settings/index.jsx
+++ b/projects/plugins/protect/src/js/routes/settings/index.jsx
@@ -18,7 +18,7 @@ import styles from './styles.module.scss';
 
 const SettingsPage = () => {
 	const { hasPlan } = usePlan();
-	const { data: accountProtectionIsEnabled } = useAccountProtectionQuery();
+	const { data: accountProtection } = useAccountProtectionQuery();
 	const toggleAccountProtectionMutation = useToggleAccountProtectionMutation();
 
 	/**
@@ -42,7 +42,7 @@ const SettingsPage = () => {
 		<div className={ styles[ 'toggle-section' ] }>
 			<div className={ styles[ 'toggle-section__control' ] }>
 				<ToggleControl
-					checked={ accountProtectionIsEnabled }
+					checked={ accountProtection.isEnabled }
 					onChange={ toggleAccountProtection }
 					disabled={ toggleAccountProtectionMutation.isPending }
 				/>
@@ -68,7 +68,7 @@ const SettingsPage = () => {
 						'jetpack-protect'
 					) }
 				</Text>
-				{ ! accountProtectionIsEnabled && (
+				{ ! accountProtection.isEnabled && (
 					<Text className={ styles[ 'toggle-section__info' ] }>
 						<Icon icon={ info } />
 						{ createInterpolateElement(

--- a/projects/plugins/protect/src/js/types/global.d.ts
+++ b/projects/plugins/protect/src/js/types/global.d.ts
@@ -29,7 +29,10 @@ declare global {
 			jetpackScan: ProductData;
 			hasPlan: boolean;
 			onboardingProgress: string[];
-			accountProtection: boolean;
+			accountProtection: {
+				isEnabled: boolean;
+				isSupported: boolean;
+			};
 			waf: WafStatus;
 		};
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Added in support of https://github.com/Automattic/jetpack-scan-team/issues/1678 and https://github.com/Automattic/jetpack-scan-team/issues/1677.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a new `Automattic\Jetpack\Account_Protection\Settings` class, responsible for managing settings related to the package.
* Updates the Protect plugin to use the new `Settings` class and the full settings object.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

peb6dq-3o9-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a new JN site, validate activating Protect and viewing/toggling the account protection setting. 
* Validate the settings object provided by the server via `window.jetpackProtectInitialState` or Tanstack Query dev tools.