### PR TITLE
Jetpack E2E: Introduce Account Protection Tests

### DIFF
--- a/projects/plugins/jetpack/changelog/add-account-protection-e2e
+++ b/projects/plugins/jetpack/changelog/add-account-protection-e2e
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+E2E Tests: added test coverage for account protection features

--- a/projects/plugins/jetpack/tests/e2e/helpers/account-protection-helper.js
+++ b/projects/plugins/jetpack/tests/e2e/helpers/account-protection-helper.js
@@ -1,0 +1,51 @@
+import { execWpCommand } from '_jetpack-e2e-commons/helpers/utils-helper.js';
+import logger from '_jetpack-e2e-commons/logger.js';
+
+const PRIVILEGED_ROLES = [ 'administrator', 'editor', 'author' ];
+const NON_PRIVILEGED_ROLES = [ 'contributor', 'subscriber' ];
+
+/**
+ * Enable automatic rules
+ * @return {Promise<void>} wp-cli 'jetpack-waf generate_rules' command output
+ */
+export async function insertTestUsers() {
+	logger.sync( 'Inserting test users' );
+
+	// Create user accounts with compromised passwords.
+	for ( const role of [ ...PRIVILEGED_ROLES, ...NON_PRIVILEGED_ROLES ] ) {
+		await execWpCommand(
+			`user create ${ role } ${ role }@example.com --role=${ role } --user_pass=password`
+		);
+	}
+
+	// Create a user with a secure password.
+	await execWpCommand(
+		`user create secure_user secure_user@example.com --role=administrator --user_pass=87h23foi2uhfljhdakdh9812df`
+	);
+}
+
+/**
+ * Get account protection token from URL
+ * @param {string} url - The URL to get the token from
+ * @return {string} account protection token
+ */
+export function getAccountProtectionTokenFromUrl( url ) {
+	const queryParams = new URLSearchParams( url.split( '?' )[ 1 ] );
+	return queryParams.get( 'token' );
+}
+
+/**
+ * Get account protection auth code from transient
+ * @param {string} token - The token to get the auth code from
+ * @return {Promise<string>} account protection auth code
+ */
+export async function getAccountProtectionAuthCodeFromTransient( token ) {
+	const transient = await execWpCommand(
+		`transient get password_detection_${ token } --format=json`
+	);
+	logger.info( `Transient: ${ transient }` );
+	console.log( `Transient: ${ transient }` );
+	const { auth_code } = JSON.parse( transient );
+
+	return auth_code;
+}

--- a/projects/plugins/jetpack/tests/e2e/specs/post-connection/account-protection.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/post-connection/account-protection.test.js
@@ -1,0 +1,147 @@
+import { prerequisitesBuilder } from '_jetpack-e2e-commons/env/index.js';
+import { test, expect } from '_jetpack-e2e-commons/fixtures/base-test.js';
+import { WPLoginPage } from '_jetpack-e2e-commons/pages/wp-admin/index.js';
+import {
+	getAccountProtectionAuthCodeFromTransient,
+	getAccountProtectionTokenFromUrl,
+	insertTestUsers,
+} from '../../helpers/account-protection-helper.js';
+import playwrightConfig from '../../playwright.config.mjs';
+
+const PRIVILEGED_ROLES = [ 'administrator', 'editor', 'author' ];
+const NON_PRIVILEGED_ROLES = [ 'contributor', 'subscriber' ];
+
+test.describe.parallel( 'Compromised Password Detection', () => {
+	test.beforeAll( async ( { browser } ) => {
+		// Set up a clean environment with account protection enabled.
+		const page = await browser.newPage( playwrightConfig.use );
+		await prerequisitesBuilder( page )
+			.withInactiveModules( [ 'protect', 'sso' ] )
+			.withActiveModules( [ 'account-protection' ] )
+			.withCleanEnv()
+			.withConnection( true )
+			.build();
+
+		await insertTestUsers();
+
+		await page.close();
+	} );
+
+	test( 'Detects compromised passwords', async ( { page } ) => {
+		for ( const role of PRIVILEGED_ROLES ) {
+			await test.step( `Enforces account protection 2FA for ${ role } users`, async () => {
+				const loginPage = await WPLoginPage.visit( page );
+
+				// Attempt sign in.
+				await loginPage.fill( '#user_login', role );
+				await loginPage.fill( '#user_pass', 'password' );
+				await loginPage.click( '#wp-submit' );
+
+				// Wait for the form submission.
+				await loginPage.waitForDomContentLoaded();
+				await loginPage.waitForElementToBeVisible( '.action-input' );
+
+				expect( page.url() ).toContain( 'token=' );
+
+				// Get the token and auth code.
+				const token = getAccountProtectionTokenFromUrl( page.url() );
+				const authCode = await getAccountProtectionAuthCodeFromTransient( token );
+
+				expect( authCode ).toBeTruthy();
+
+				// Submit the auth code.
+				await loginPage.fill( '.action-input', authCode );
+				await loginPage.click( '.action-verify' );
+
+				// Wait for the form submission.
+				await loginPage.waitForDomContentLoaded();
+				await loginPage.waitForElementToBeVisible( '.action-proceed' );
+
+				// Proceed to wp-admin.
+				await loginPage.click( '.action-proceed' );
+
+				// Wait for the navigation to complete.
+				await loginPage.waitForDomContentLoaded();
+				await loginPage.waitForElementToBeHidden( '.action-proceed' );
+
+				expect( page.url() ).toContain( '/wp-admin' );
+
+				// Sign out.
+				const accountBarSelector = '#wp-admin-bar-my-account';
+				const logoutOptionSelector = '#wp-admin-bar-logout';
+				await loginPage.waitForElementToBeVisible( accountBarSelector );
+				await loginPage.hover( accountBarSelector );
+				await loginPage.click( logoutOptionSelector );
+			} );
+		}
+
+		for ( const role of NON_PRIVILEGED_ROLES ) {
+			await test.step( `Bypasses account protection 2FA for ${ role } users`, async () => {
+				const loginPage = await WPLoginPage.visit( page );
+
+				// Attempt sign in.
+				await loginPage.fill( '#user_login', role );
+				await loginPage.fill( '#user_pass', 'password' );
+				await loginPage.click( '#wp-submit' );
+
+				// Wait for the form submission.
+				await loginPage.waitForDomContentLoaded();
+				await loginPage.waitForElementToBeHidden( loginPage.selectors[ 0 ] );
+
+				expect( page.url() ).toContain( '/wp-admin' );
+			} );
+		}
+
+		await test.step( `Bypasses account protection 2FA for users with secure passwords`, async () => {
+			const loginPage = await WPLoginPage.visit( page );
+
+			// Attempt sign in.
+			await loginPage.fill( '#user_login', 'secure_user' );
+			await loginPage.fill( '#user_pass', '87h23foi2uhfljhdakdh9812df' );
+			await loginPage.click( '#wp-submit' );
+
+			// Wait for the form submission.
+			await loginPage.waitForDomContentLoaded();
+			await loginPage.waitForElementToBeHidden( loginPage.selectors[ 0 ] );
+
+			// Test successful sign in.
+			expect( page.url() ).toContain( '/wp-admin' );
+		} );
+	} );
+
+	test( 'Password reset after verification', async ( { page } ) => {
+		const loginPage = await WPLoginPage.visit( page );
+
+		// Attempt sign in.
+		await loginPage.fill( '#user_login', 'administrator' );
+		await loginPage.fill( '#user_pass', 'password' );
+		await loginPage.click( '#wp-submit' );
+
+		// Wait for the form submission.
+		await loginPage.waitForDomContentLoaded();
+		await loginPage.waitForElementToBeVisible( '.action-input' );
+
+		expect( page.url() ).toContain( 'token=' );
+
+		// Get the token and auth code.
+		const token = getAccountProtectionTokenFromUrl( page.url() );
+		const authCode = await getAccountProtectionAuthCodeFromTransient( token );
+
+		// Submit the auth code.
+		await loginPage.fill( '.action-input', authCode );
+		await loginPage.click( '.action-verify' );
+
+		// Wait for the form submission.
+		await loginPage.waitForDomContentLoaded();
+		await loginPage.waitForElementToBeVisible( '.action-update-password' );
+
+		// Choose to update the password.
+		await loginPage.click( '.action-update-password' );
+
+		// Wait for the navigation to complete.
+		await loginPage.waitForDomContentLoaded();
+		await loginPage.waitForElementToBeHidden( '.action-update-password' );
+
+		expect( page.url() ).toContain( '/profile.php#password' );
+	} );
+} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds Jetpack E2E tests to cover the account protection feature, with initial test for compromised password detection.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack-scan-team/issues/1696

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See [the E2E README](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/tests/e2e/README.md) to run tests locally. You can use `pnpm test:run ./specs/post-connection/account-protection.test.js` with optional `--headed` param for a live browser preview of the tests exection, or `--debug` to step through tests with debug tools.
* Alternatively, you can review the logs from the automated test run on this PR.

