### PR TITLE
MU WPCOM: Launchpad: show in wp-admin dashboard post-launch

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-post-launch
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-post-launch
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Add launchpad post-launch

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
@@ -68,7 +68,6 @@ function load_wpcom_dashboard_widgets() {
 	$checklist_slug    = get_option( 'site_intent' );
 
 	if (
-		get_option( 'launch-status', 'launched' ) !== 'launched' &&
 		! empty( wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug, $launchpad_context ) ) &&
 		! wpcom_launchpad_is_task_list_dismissed( $checklist_slug )
 	) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
@@ -26,7 +26,8 @@ function load_wpcom_dashboard_widgets() {
 		'wpcom'
 	);
 
-	$tasks = array();
+	$tasks        = array();
+	$launchpad_id = null;
 
 	if ( ! is_wp_error( $layout_response ) ) {
 		$layout = json_decode( $layout_response['body'], true );
@@ -42,12 +43,19 @@ function load_wpcom_dashboard_widgets() {
 						}
 					}
 					break;
+				} elseif ( strpos( $item, 'home-launchpad-' ) === 0 ) {
+					$launchpad_id = $item;
 				}
 			}
 		}
 	}
 
-	enqueue_wpcom_dashboard_widgets( array( 'tasks' => $tasks ) );
+	enqueue_wpcom_dashboard_widgets(
+		array(
+			'tasks'       => $tasks,
+			'launchpadId' => $launchpad_id,
+		)
+	);
 
 	$wpcom_dashboard_widgets = array(
 		array(
@@ -64,13 +72,7 @@ function load_wpcom_dashboard_widgets() {
 		),
 	);
 
-	$launchpad_context = 'customer-home';
-	$checklist_slug    = get_option( 'site_intent' );
-
-	if (
-		! empty( wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug, $launchpad_context ) ) &&
-		! wpcom_launchpad_is_task_list_dismissed( $checklist_slug )
-	) {
+	if ( ! empty( $launchpad_id ) ) {
 		$wpcom_dashboard_widgets[] = array(
 			'id'       => 'wpcom_launchpad_widget',
 			'name'     => __( 'Site Setup', 'jetpack-mu-wpcom' ),
@@ -127,6 +129,7 @@ function enqueue_wpcom_dashboard_widgets( $args = array() ) {
 			'sitePlan'        => $current_plan,
 			'hasCustomDomain' => wpcom_site_has_feature( 'custom-domain' ),
 			'tasks'           => $args['tasks'],
+			'launchpadId'     => $args['launchpadId'],
 		)
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-launchpad-widget/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-launchpad-widget/index.js
@@ -39,7 +39,7 @@ export default ( { siteDomain, siteIntent } ) => {
 			<div ref={ useSetHrefBase() }>
 				<Launchpad
 					siteSlug={ siteDomain }
-					checklistSlug={ siteIntent }
+					checklistSlug={ 'intent-' + siteIntent }
 					launchpadContext="customer-home"
 					onSiteLaunched={ () => {
 						const url = new URL( window.location.href );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-launchpad-widget/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-launchpad-widget/index.js
@@ -6,6 +6,17 @@ import './style.scss';
 
 const queryClient = new QueryClient();
 
+const LAUNCHPAD_ENTREPRENEUR_SITE_SETUP = 'home-launchpad-entrepreneur-site-setup';
+const LAUNCHPAD_INTENT_BUILD = 'home-launchpad-intent-build';
+const LAUNCHPAD_INTENT_HOSTING = 'home-launchpad-intent-hosting';
+const LAUNCHPAD_INTENT_WRITE = 'home-launchpad-intent-write';
+const LAUNCHPAD_INTENT_FREE_NEWSLETTER = 'home-launchpad-intent-free-newsletter';
+const LAUNCHPAD_INTENT_PAID_NEWSLETTER = 'home-launchpad-intent-paid-newsletter';
+const LAUNCHPAD_INTENT_NEWSLETTER_GOAL = 'home-launchpad-intent-newsletter-goal';
+const LAUNCHPAD_PRE_LAUNCH = 'home-launchpad-pre-launch';
+const LAUNCHPAD_LEGACY_SITE_SETUP = 'home-launchpad-legacy-site-setup';
+const LAUNCHPAD_POST_MIGRATION = 'home-launchpad-post-migration';
+
 /**
  * Set the href base of all relative links to the wordpress.com.
  *
@@ -33,13 +44,25 @@ function useSetHrefBase() {
 	}, [] );
 }
 
-export default ( { siteDomain, siteIntent } ) => {
+export default ( { siteDomain, siteIntent, launchpadId } ) => {
+	const checklistSlugMap = {
+		[ LAUNCHPAD_ENTREPRENEUR_SITE_SETUP ]: 'entrepreneur-site-setup',
+		[ LAUNCHPAD_INTENT_BUILD ]: 'intent-build',
+		[ LAUNCHPAD_INTENT_HOSTING ]: 'host-site',
+		[ LAUNCHPAD_INTENT_WRITE ]: 'intent-write',
+		[ LAUNCHPAD_INTENT_FREE_NEWSLETTER ]: 'intent-free-newsletter',
+		[ LAUNCHPAD_INTENT_PAID_NEWSLETTER ]: 'intent-paid-newsletter',
+		[ LAUNCHPAD_INTENT_NEWSLETTER_GOAL ]: 'intent-newsletter-goal',
+		[ LAUNCHPAD_PRE_LAUNCH ]: siteIntent,
+		[ LAUNCHPAD_LEGACY_SITE_SETUP ]: 'legacy-site-setup',
+		[ LAUNCHPAD_POST_MIGRATION ]: 'post-migration',
+	};
 	return (
 		<QueryClientProvider client={ queryClient }>
 			<div ref={ useSetHrefBase() }>
 				<Launchpad
 					siteSlug={ siteDomain }
-					checklistSlug={ 'intent-' + siteIntent }
+					checklistSlug={ checklistSlugMap[ launchpadId ] }
 					launchpadContext="customer-home"
 					onSiteLaunched={ () => {
 						const url = new URL( window.location.href );

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-launchpad-post-launch
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-launchpad-post-launch
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Add launchpad post-launch

--- a/projects/plugins/wpcomsh/changelog/fix-launchpad-post-launch
+++ b/projects/plugins/wpcomsh/changelog/fix-launchpad-post-launch
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Add launchpad post-launch


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In My Home, the launchpad stays around even after launch. The wp-admin Dashboard version should behave the same.

|My Home|Dashboard|
|-|-|
|<img width="1464" alt="image" src="https://github.com/user-attachments/assets/37e1eb96-ab34-4590-ac01-8a6bd6f08fe1" />|<img width="1464" alt="image" src="https://github.com/user-attachments/assets/37284b9e-161e-4094-9a07-9e61787629d4" />|

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the launch status check.
* Pass the checklist slug correctly. We have to use a map because all the post-launch slugs are hardcoded in wp-calypso. See all the files in this folder: https://github.com/Automattic/wp-calypso/blob/3fc7d62ad8f6fb9ceca70718d5df49915604e9e4/client/my-sites/customer-home/cards/launchpad/entrepreneur-site-setup.tsx#L3

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Launch a site without completing all tasks and check that the launchpad widget is still present.

