### PR TITLE
Connection: hide connection column on simple sites

### DIFF
--- a/projects/packages/connection/changelog/fix-users-page-connection-simple
+++ b/projects/packages/connection/changelog/fix-users-page-connection-simple
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Minor change only for Simple sites.
+
+

--- a/projects/packages/connection/src/class-users-connection-admin.php
+++ b/projects/packages/connection/src/class-users-connection-admin.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Connection;
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Status\Host;
 
 /**
  * Class Users_Connection_Admin

--- a/projects/packages/connection/src/class-users-connection-admin.php
+++ b/projects/packages/connection/src/class-users-connection-admin.php
@@ -32,7 +32,7 @@ class Users_Connection_Admin {
 	 * Initialize the admin functionality if conditions are met.
 	 */
 	public function init() {
-		if ( ! is_admin() || ! current_user_can( 'manage_options' ) ) {
+		if ( ! is_admin() || ! current_user_can( 'manage_options' ) || ( defined( 'IS_WPCOM' ) || IS_WPCOM ) ) {
 			return;
 		}
 

--- a/projects/packages/connection/src/class-users-connection-admin.php
+++ b/projects/packages/connection/src/class-users-connection-admin.php
@@ -113,7 +113,7 @@ class Users_Connection_Admin {
 			'jetpack-users-connection',
 			'jetpackConnectionTooltips',
 			array(
-				'columnTooltip' => esc_html__( 'Connecting a WordPress.com account unlocks Jetpack\'s full suite of features including secure logins.', 'jetpack-connection' ),
+				'columnTooltip' => esc_html__( 'Connecting a WordPress.com account unlocks Jetpack’s full suite of features including secure logins.', 'jetpack-connection' ),
 			)
 		);
 	}

--- a/projects/packages/connection/src/class-users-connection-admin.php
+++ b/projects/packages/connection/src/class-users-connection-admin.php
@@ -32,8 +32,7 @@ class Users_Connection_Admin {
 	 * Initialize the admin functionality if conditions are met.
 	 */
 	public function init() {
-		// @phan-suppress-next-line PhanUndeclaredConstant
-		if ( ! is_admin() || ! current_user_can( 'manage_options' ) || ( defined( 'IS_WPCOM' ) || IS_WPCOM ) ) {
+		if ( ! is_admin() || ! current_user_can( 'manage_options' ) || ( new Host() )->is_wpcom_simple() ) {
 			return;
 		}
 
@@ -113,7 +112,7 @@ class Users_Connection_Admin {
 			'jetpack-users-connection',
 			'jetpackConnectionTooltips',
 			array(
-				'columnTooltip' => esc_html__( 'Connecting a WordPress.com account unlocks Jetpack’s full suite of features including secure logins.', 'jetpack-connection' ),
+				'columnTooltip' => esc_html__( 'Connecting a WordPress.com account unlocks Jetpack\'s full suite of features including secure logins.', 'jetpack-connection' ),
 			)
 		);
 	}

--- a/projects/packages/connection/src/class-users-connection-admin.php
+++ b/projects/packages/connection/src/class-users-connection-admin.php
@@ -32,6 +32,7 @@ class Users_Connection_Admin {
 	 * Initialize the admin functionality if conditions are met.
 	 */
 	public function init() {
+		// @phan-suppress-next-line PhanUndeclaredConstant
 		if ( ! is_admin() || ! current_user_can( 'manage_options' ) || ( defined( 'IS_WPCOM' ) || IS_WPCOM ) ) {
 			return;
 		}


### PR DESCRIPTION
Adds a check for simple sites and hides the connection column.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Checking for ( new Host() )->is_wpcom_simple()

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load the PR on the sandbox.
* Check a simple site with a dashboard set to Classic.
* Make sure WordPress.com Account column is not showing up in wp-admin on Users page.
