### PR TITLE
Boost: 3.9.0 post-beta changes backport

### DIFF
--- a/projects/plugins/boost/CHANGELOG.md
+++ b/projects/plugins/boost/CHANGELOG.md
@@ -5,15 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.9.0-beta] - 2025-02-12
+## [3.9.0-beta] - 2025-02-17
 ### Added
 - Cloud CSS: Handle prioritized cloud CSS regeneration for cornerstone pages updates. [#41516]
 - Concatenate JS: Add compatibility with "Depay Payments for WooCommerce". [#41571]
 - Speed Scores: Add tracking for speed score pop-out CTA. [#41556]
 
 ### Changed
-- Concatenate JS/CSS: Update concatenated assets to be stored on the server as files. [#41056]
 - Admin Panel: Cleanup CSS styles. [#41371]
+- Concatenate JS/CSS: Update concatenated assets to be stored on the server as files. [#41056]
 - Updated package dependencies. [#41286] [#41491] [#41577] [#41659]
 
 ### Fixed

--- a/projects/plugins/boost/CHANGELOG.md
+++ b/projects/plugins/boost/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.9.0-beta] - 2025-02-17
+## [3.9.0] - 2025-02-17
 ### Added
 - Cloud CSS: Handle prioritized cloud CSS regeneration for cornerstone pages updates. [#41516]
 - Concatenate JS: Add compatibility with "Depay Payments for WooCommerce". [#41571]
@@ -597,7 +597,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First public alpha release
 
-[3.9.0-beta]: https://github.com/Automattic/jetpack-boost-production/compare/3.8.0...3.9.0-beta
+[3.9.0]: https://github.com/Automattic/jetpack-boost-production/compare/3.8.0...3.9.0
 [3.8.0]: https://github.com/Automattic/jetpack-boost-production/compare/3.7.0...3.8.0
 [3.7.0]: https://github.com/Automattic/jetpack-boost-production/compare/3.6.1...3.7.0
 [3.6.1]: https://github.com/Automattic/jetpack-boost-production/compare/3.6.0...3.6.1

--- a/projects/plugins/boost/changelog/fix-boost-version-handler
+++ b/projects/plugins/boost/changelog/fix-boost-version-handler
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix for unreleased feature
-
-

--- a/projects/plugins/boost/changelog/fix-minify-gc
+++ b/projects/plugins/boost/changelog/fix-minify-gc
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Bug fix on unreleased feature
-
-

--- a/projects/plugins/boost/changelog/update-premium-support-link
+++ b/projects/plugins/boost/changelog/update-premium-support-link
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Changed premium support link
-
-

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -3,7 +3,7 @@
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"type": "library",
 	"license": "GPL-2.0-or-later",
-	"version": "3.9.0-beta",
+	"version": "3.9.0",
 	"authors": [
 		{
 			"name": "Automattic, Inc.",
@@ -74,7 +74,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ3_9_0_beta",
+		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ3_9_0",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3c0421974f5d840c9d2d60ef2edbc249",
+    "content-hash": "f3803a7c634cbf87a4efb4d8dbbe71f7",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -9,7 +9,7 @@
  * Plugin Name:       Jetpack Boost
  * Plugin URI:        https://jetpack.com/boost
  * Description:       Boost your WordPress site's performance, from the creators of Jetpack
- * Version: 3.9.0-beta
+ * Version: 3.9.0
  * Author:            Automattic - Jetpack Site Speed team
  * Author URI:        https://jetpack.com/boost/
  * License:           GPL-2.0+
@@ -29,7 +29,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die( 0 );
 }
 
-define( 'JETPACK_BOOST_VERSION', '3.9.0-beta' );
+define( 'JETPACK_BOOST_VERSION', '3.9.0' );
 define( 'JETPACK_BOOST_SLUG', 'jetpack-boost' );
 
 if ( ! defined( 'JETPACK_BOOST_CLIENT_NAME' ) ) {

--- a/projects/plugins/boost/readme.txt
+++ b/projects/plugins/boost/readme.txt
@@ -5,7 +5,7 @@ Tags: performance, speed, web vitals, critical css, cache
 Requires at least: 6.6
 Tested up to: 6.7
 Requires PHP: 7.2
-Stable tag: 3.8.0
+Stable tag: 3.9.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/projects/plugins/boost/readme.txt
+++ b/projects/plugins/boost/readme.txt
@@ -183,15 +183,15 @@ If you run into compatibility issues, please do let us know. You can drop us a l
 2. Jetpack Boost Speed Improvement
 
 == Changelog ==
-### 3.9.0-beta - 2025-02-12
+### 3.9.0-beta - 2025-02-17
 #### Added
 - Cloud CSS: Handle prioritized cloud CSS regeneration for cornerstone pages updates.
 - Concatenate JS: Add compatibility with "Depay Payments for WooCommerce".
 - Speed Scores: Add tracking for speed score pop-out CTA.
 
 #### Changed
-- Concatenate JS/CSS: Update concatenated assets to be stored on the server as files.
 - Admin Panel: Cleanup CSS styles.
+- Concatenate JS/CSS: Update concatenated assets to be stored on the server as files.
 - Updated package dependencies.
 
 #### Fixed

--- a/projects/plugins/boost/readme.txt
+++ b/projects/plugins/boost/readme.txt
@@ -183,7 +183,7 @@ If you run into compatibility issues, please do let us know. You can drop us a l
 2. Jetpack Boost Speed Improvement
 
 == Changelog ==
-### 3.9.0-beta - 2025-02-17
+### 3.9.0 - 2025-02-17
 #### Added
 - Cloud CSS: Handle prioritized cloud CSS regeneration for cornerstone pages updates.
 - Concatenate JS: Add compatibility with "Depay Payments for WooCommerce".


### PR DESCRIPTION
## Proposed changes:

* Update stable tag to 3.9.0;
* Backport changes from beta release.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Proof read changes.