### PR TITLE
Forms: Fix `empty form` check for select elements

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2486,6 +2486,9 @@ importers:
       '@testing-library/dom':
         specifier: 10.4.0
         version: 10.4.0
+      '@testing-library/user-event':
+        specifier: ^14.4.3
+        version: 14.6.1(@testing-library/dom@10.4.0)
       '@wordpress/api-fetch':
         specifier: 7.17.0
         version: 7.17.0

--- a/projects/packages/forms/changelog/forms-fix-empty-check-for-select-elements
+++ b/projects/packages/forms/changelog/forms-fix-empty-check-for-select-elements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix `empty form` check for select elements

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -66,6 +66,7 @@
 		"@babel/core": "7.26.0",
 		"@babel/runtime": "7.26.0",
 		"@testing-library/dom": "10.4.0",
+		"@testing-library/user-event": "^14.4.3",
 		"@wordpress/api-fetch": "7.17.0",
 		"@wordpress/babel-plugin-import-jsx-pragma": "5.17.0",
 		"@wordpress/browserslist-config": "6.17.0",

--- a/projects/packages/forms/src/contact-form/js/accessible-form.js
+++ b/projects/packages/forms/src/contact-form/js/accessible-form.js
@@ -51,6 +51,13 @@ const initAllForms = () => {
 
 function isFormEmpty( form ) {
 	const clonedForm = form.cloneNode( true );
+	// `cloneNode` API doesn't clone the selected value of the select element unless we
+	// had specifc html markup (`selected`). So, after cloning we need to update the existing
+	// select values.
+	Array.from( clonedForm.querySelectorAll( 'select' ) ).forEach( select => {
+		select.value = form.querySelector( `select[id="${ select.id }"` )?.value;
+	} );
+	// Remove hidden fields from the cloned form.
 	Array.from( clonedForm.querySelectorAll( 'input[type="hidden"]' ) ).forEach( input =>
 		input.remove()
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes: https://github.com/Automattic/jetpack/issues/41834

https://github.com/Automattic/jetpack/pull/41464 introduced a new check to prevent the submission of empty forms. The way [cloneNode](https://developer.mozilla.org/en-US/docs/Web/API/Node/cloneNode) works though is by taking into account the actual HTML `select` elements and the value is not cloned if we don't have the `selected` attribute in `options`. This PR fixes that by adding the value of cloned select elements.

From my investigation and testing only `select` elements are affected and we shouldn't encounter similar issues (for example with checkboxes, radio, etc..).


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Insert a form with just a select field
2. In front end select a value and observe that form can be submitted successfully.

