### PR TITLE
Media Library: only load the upload via URL form in admin screens

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-upload-media-url-hook
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-upload-media-url-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Media Library: only load the upload via URL form in admin screens

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-media-url-upload.php
@@ -88,7 +88,7 @@ function wpcom_handle_media_url_upload() {
  * Load the wpcom media URL upload form.
  */
 function load_wpcom_media_url_upload_form() {
-	if ( ! current_user_can( 'upload_files' ) ) {
+	if ( ! is_admin() || ! current_user_can( 'upload_files' ) ) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes p9F6qB-hdj-p2

## Proposed changes:

This PR loads the new upload via URL form in admin screens only.

This is meant as a first mitigation of a React version conflict with certain plugins that load the media library in frontend screens.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Follow the same test instructions from:

- https://github.com/Automattic/jetpack/pull/41089