### PR TITLE
Likes new layout: remove feature flag and extra styles for avatars popup

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-likes-improvement-feature-flags
+++ b/projects/plugins/jetpack/changelog/remove-likes-improvement-feature-flags
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Remove feature flag for new like widget layout and code for old layout avatars popup.

--- a/projects/plugins/jetpack/extensions/blocks/like/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/edit.js
@@ -45,7 +45,7 @@ function LikeEdit( { attributes, setAttributes } ) {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<div className="wpl-likebox wpl-new-layout">
+			<div className="wpl-likebox">
 				{ isSimpleSite() && showReblogButton && (
 					<div className="wpl-button reblog">
 						<a

--- a/projects/plugins/jetpack/extensions/blocks/like/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/like/editor.scss
@@ -237,37 +237,35 @@ a.comment-like-link.loading:before {
 	}
 
 	// Prevent a number of editor and theme conflicts
-	&.wpl-new-layout {
-		* {
-			cursor: default;
-		}
+	* {
+		cursor: default;
+	}
 
-		.wpl-avatars {
+	.wpl-avatars {
+		margin: 0;
+		padding-left: 0;
+		align-content: unset;
+
+		li {
 			margin: 0;
-			padding-left: 0;
-			align-content: unset;
-
-			li {
-				margin: 0;
-			}
-
-			li a:focus {
-				outline: none;
-				box-shadow: none;
-			}
-
-			li a img {
-				vertical-align: unset;
-			}
 		}
 
-		.wpl-count:focus,
-		.wpl-count a:focus,
-		.wpl-count-text:focus,
-		.wpl-count-text a:focus {
+		li a:focus {
 			outline: none;
 			box-shadow: none;
 		}
+
+		li a img {
+			vertical-align: unset;
+		}
+	}
+
+	.wpl-count:focus,
+	.wpl-count a:focus,
+	.wpl-count-text:focus,
+	.wpl-count-text a:focus {
+		outline: none;
+		box-shadow: none;
 	}
 
 	// Prevents hover state conflicts on the button element.

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -62,17 +62,6 @@ function render_block( $attr, $content, $block ) {
 		return;
 	}
 
-	/**
-	 * Enable an alternate Likes layout.
-	 *
-	 * @since 12.9
-	 *
-	 * @module likes
-	 *
-	 * @param bool $new_layout Enable the new Likes layout. False by default.
-	 */
-	$new_layout = apply_filters( 'likes_new_layout', true ) ? '&amp;n=1' : '';
-
 	add_action( 'wp_footer', __NAMESPACE__ . '\render_iframe', 25 );
 
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -97,7 +86,7 @@ function render_block( $attr, $content, $block ) {
 		$domain             = $bloginfo->domain;
 		$reblog_param       = $show_reblog_button ? '&amp;reblog=1' : '';
 		$show_avatars_param = $show_avatars ? '' : '&amp;slim=1';
-		$src                = sprintf( '//widgets.wp.com/likes/index.html?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1%7$s%8$s', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid, $new_layout, $reblog_param, $show_avatars_param );
+		$src                = sprintf( 'https://widgets.wp.com/likes/index.html?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1%7$s', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid, $reblog_param, $show_avatars_param );
 
 		// provide the mapped domain when needed
 		if ( isset( $_SERVER['HTTP_HOST'] ) && strpos( sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ), '.wordpress.com' ) === false ) {
@@ -110,7 +99,7 @@ function render_block( $attr, $content, $block ) {
 		$url_parts          = wp_parse_url( $url );
 		$domain             = $url_parts['host'];
 		$show_avatars_param = $show_avatars ? '' : '&amp;slim=1';
-		$src                = sprintf( 'https://widgets.wp.com/likes/?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1%7$s', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid, $new_layout, $show_avatars_param );
+		$src                = sprintf( 'https://widgets.wp.com/likes/index.html?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1%7$s', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid, $show_avatars_param );
 	}
 
 	$name    = sprintf( 'like-post-frame-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -86,7 +86,7 @@ function render_block( $attr, $content, $block ) {
 		$domain             = $bloginfo->domain;
 		$reblog_param       = $show_reblog_button ? '&amp;reblog=1' : '';
 		$show_avatars_param = $show_avatars ? '' : '&amp;slim=1';
-		$src                = sprintf( 'https://widgets.wp.com/likes/index.html?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1%7$s', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid, $reblog_param, $show_avatars_param );
+		$src                = sprintf( 'https://widgets.wp.com/likes/index.html?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s%7$s&amp;block=1', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid, $reblog_param, $show_avatars_param );
 
 		// provide the mapped domain when needed
 		if ( isset( $_SERVER['HTTP_HOST'] ) && strpos( sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ), '.wordpress.com' ) === false ) {
@@ -99,7 +99,7 @@ function render_block( $attr, $content, $block ) {
 		$url_parts          = wp_parse_url( $url );
 		$domain             = $url_parts['host'];
 		$show_avatars_param = $show_avatars ? '' : '&amp;slim=1';
-		$src                = sprintf( 'https://widgets.wp.com/likes/index.html?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1%7$s', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid, $show_avatars_param );
+		$src                = sprintf( 'https://widgets.wp.com/likes/index.html?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s&amp;block=1', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid, $show_avatars_param );
 	}
 
 	$name    = sprintf( 'like-post-frame-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );

--- a/projects/plugins/jetpack/extensions/blocks/like/tools/update-editor-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/tools/update-editor-styles.js
@@ -73,37 +73,35 @@ function processCSS( css ) {
 	}
 
 	// Prevent a number of editor and theme conflicts
-	&.wpl-new-layout {
-		* {
-			cursor: default;
-		}
+	* {
+		cursor: default;
+	}
 
-		.wpl-avatars {
+	.wpl-avatars {
+		margin: 0;
+		padding-left: 0;
+		align-content: unset;
+
+		li {
 			margin: 0;
-			padding-left: 0;
-			align-content: unset;
-
-			li {
-				margin: 0;
-			}
-
-			li a:focus {
-				outline: none;
-				box-shadow: none;
-			}
-
-			li a img {
-				vertical-align: unset;
-			}
 		}
 
-		.wpl-count:focus,
-		.wpl-count a:focus,
-		.wpl-count-text:focus,
-		.wpl-count-text a:focus {
+		li a:focus {
 			outline: none;
 			box-shadow: none;
 		}
+
+		li a img {
+			vertical-align: unset;
+		}
+	}
+
+	.wpl-count:focus,
+	.wpl-count a:focus,
+	.wpl-count-text:focus,
+	.wpl-count-text a:focus {
+		outline: none;
+		box-shadow: none;
 	}
 
 	// Prevents hover state conflicts on the button element.

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -426,18 +426,7 @@ class Jetpack_Likes {
 		* we need a slightly more unique id / name for the widget wrapper.
 		*/
 		$uniqid = uniqid();
-		/**
-		 * Enable an alternate Likes layout.
-		 *
-		 * @since 12.9
-		 *
-		 * @module likes
-		 *
-		 * @param bool $new_layout Enable the new Likes layout. False by default.
-		 */
-		$new_layout = apply_filters( 'likes_new_layout', true ) ? '&amp;n=1' : '';
-
-		$src      = sprintf( 'https://widgets.wp.com/likes/?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s%6$s', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid, $new_layout );
+		$src      = sprintf( 'https://widgets.wp.com/likes/?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid );
 		$name     = sprintf( 'like-post-frame-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
 		$wrapper  = sprintf( 'like-post-wrapper-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
 		$headline = sprintf(

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -425,7 +425,7 @@ class Jetpack_Likes {
 		* If the same post appears more then once on a page the page goes crazy
 		* we need a slightly more unique id / name for the widget wrapper.
 		*/
-		$uniqid = uniqid();
+		$uniqid   = uniqid();
 		$src      = sprintf( 'https://widgets.wp.com/likes/?ver=%1$s#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%4$s&amp;obj_id=%2$d-%3$d-%5$s', rawurlencode( JETPACK__VERSION ), $blog_id, $post_id, $domain, $uniqid );
 		$name     = sprintf( 'like-post-frame-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
 		$wrapper  = sprintf( 'like-post-wrapper-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
@@ -24,7 +24,7 @@ function jetpack_likes_master_iframe() {
 
 	$likes_locale = ( '' === $_locale || 'en' === $_locale ) ? '' : '&amp;lang=' . strtolower( $_locale );
 
-	$src = sprintf( 'https://widgets.wp.com/likes/master.html?ver=%1$s#ver=%1$s%2$s',	$version, $likes_locale );
+	$src = sprintf( 'https://widgets.wp.com/likes/master.html?ver=%1$s#ver=%1$s%2$s', $version, $likes_locale );
 
 	/**
 	 * Filters the Likes iframe src, if any parameters need to be overridden or tracked.

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
@@ -23,16 +23,8 @@ function jetpack_likes_master_iframe() {
 	$_locale   = isset( $gp_locale->slug ) ? $gp_locale->slug : '';
 
 	$likes_locale = ( '' === $_locale || 'en' === $_locale ) ? '' : '&amp;lang=' . strtolower( $_locale );
-	/** This filter is documented in projects/plugins/jetpack/modules/likes.php */
-	$new_layout       = apply_filters( 'likes_new_layout', true ) ? '&amp;n=1' : '';
-	$new_layout_class = $new_layout ? 'wpl-new-layout' : '';
 
-	$src = sprintf(
-		'https://widgets.wp.com/likes/master.html?ver=%1$s#ver=%1$s%2$s%3$s',
-		$version,
-		$likes_locale,
-		$new_layout
-	);
+	$src = sprintf( 'https://widgets.wp.com/likes/master.html?ver=%1$s#ver=%1$s%2$s',	$version, $likes_locale );
 
 	/**
 	 * Filters the Likes iframe src, if any parameters need to be overridden or tracked.
@@ -45,15 +37,10 @@ function jetpack_likes_master_iframe() {
 	 */
 	$src = apply_filters( 'jetpack_likes_iframe_src', $src );
 
-	if ( $new_layout ) {
-		// The span content is replaced by queuehandler when showOtherGravatars is called.
-		$likers_text = wp_kses( '<span>%d</span>', array( 'span' => array() ) );
-	} else {
-		/* translators: The value of %d is not available at the time of output */
-		$likers_text = wp_kses( __( '<span>%d</span> bloggers like this:', 'jetpack' ), array( 'span' => array() ) );
-	}
+	// The span content is replaced by queuehandler when showOtherGravatars is called.
+	$likers_text = wp_kses( '<span>%d</span>', array( 'span' => array() ) );
 	?>
 	<iframe src='<?php echo esc_url( $src ); ?>' scrolling='no' id='likes-master' name='likes-master' style='display:none;'></iframe>
-	<div id='likes-other-gravatars' class='<?php echo esc_attr( $new_layout_class ); ?>' role="dialog" aria-hidden="true" tabindex="-1"><div class="likes-text"><?php echo $likers_text; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div><ul class="wpl-avatars sd-like-gravatars"></ul></div>
+	<div id='likes-other-gravatars' role="dialog" aria-hidden="true" tabindex="-1"><div class="likes-text"><?php echo $likers_text; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div><ul class="wpl-avatars sd-like-gravatars"></ul></div>
 	<?php
 }

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -213,22 +213,14 @@ function JetpackLikesMessageListener( event ) {
 				break;
 			}
 
-			const newLayout = container.classList.contains( 'wpl-new-layout' );
-
 			const list = container.querySelector( 'ul' );
 
 			container.style.display = 'none';
 			list.innerHTML = '';
 
-			if ( newLayout ) {
-				container
-					.querySelectorAll( '.likes-text span' )
-					.forEach( item => ( item.textContent = data.totalLikesLabel ) );
-			} else {
-				container
-					.querySelectorAll( '.likes-text span' )
-					.forEach( item => ( item.textContent = data.total ) );
-			}
+			container
+				.querySelectorAll( '.likes-text span' )
+				.forEach( item => ( item.textContent = data.totalLikesLabel ) );
 
 			( data.likers || [] ).forEach( async ( liker, index ) => {
 				if ( liker.profile_URL.substr( 0, 4 ) !== 'http' ) {
@@ -239,32 +231,19 @@ function JetpackLikesMessageListener( event ) {
 				const element = document.createElement( 'li' );
 				list.append( element );
 
-				if ( newLayout ) {
-					element.innerHTML = `
-					<a href="${ encodeURI( liker.profile_URL ) }" rel="nofollow" target="_parent" class="wpl-liker">
-						<img src="${ encodeURI( liker.avatar_URL ) }"
+				const profileLink = encodeURI( liker.profile_URL );
+				const avatarLink = encodeURI( liker.avatar_URL );
+				element.innerHTML = `<a href="${ profileLink }" rel="nofollow" target="_parent" class="wpl-liker">
+						<img src="${ avatarLink }"
 							alt=""
 							style="width: 28px; height: 28px;" />
 						<span></span>
-					</a>
-				`;
-				} else {
-					element.innerHTML = `
-					<a href="${ encodeURI( liker.profile_URL ) }" rel="nofollow" target="_parent" class="wpl-liker">
-						<img src="${ encodeURI( liker.avatar_URL ) }"
-							alt=""
-							style="width: 30px; height: 30px; padding-right: 3px;" />
-					</a>
-				`;
-				}
+					</a>`;
 
 				// Add some extra attributes through native methods, to ensure strings are sanitized.
 				element.classList.add( liker.css_class );
 				element.querySelector( 'img' ).alt = data.avatarAltTitle.replace( '%s', liker.name );
-
-				if ( newLayout ) {
-					element.querySelector( 'span' ).innerText = liker.name;
-				}
+				element.querySelector( 'span' ).innerText = liker.name;
 
 				if ( index === data.likers.length - 1 ) {
 					element.addEventListener( 'keydown', e => {
@@ -294,22 +273,17 @@ function JetpackLikesMessageListener( event ) {
 				};
 
 				let containerLeft = 0;
-				if ( newLayout ) {
-					container.style.top = offset.top + data.position.top - 1 + 'px';
+				container.style.top = offset.top + data.position.top - 1 + 'px';
 
-					if ( isRtl ) {
-						const visibleAvatarsCount = data && data.likers ? Math.min( data.likers.length, 5 ) : 0;
-						// 24px is the width of the avatar + 4px is the padding between avatars
-						containerLeft = offset.left + data.position.left + 24 * visibleAvatarsCount + 4;
-						container.style.transform = 'translateX(-100%)';
-					} else {
-						containerLeft = offset.left + data.position.left;
-					}
-					container.style.left = containerLeft + 'px';
+				if ( isRtl ) {
+					const visibleAvatarsCount = data && data.likers ? Math.min( data.likers.length, 5 ) : 0;
+					// 24px is the width of the avatar + 4px is the padding between avatars
+					containerLeft = offset.left + data.position.left + 24 * visibleAvatarsCount + 4;
+					container.style.transform = 'translateX(-100%)';
 				} else {
-					container.style.left = offset.left + data.position.left - 10 + 'px';
-					container.style.top = offset.top + data.position.top - 33 + 'px';
+					containerLeft = offset.left + data.position.left;
 				}
+				container.style.left = containerLeft + 'px';
 
 				// Container width - padding
 				const initContainerWidth = data.width - 20;
@@ -320,35 +294,21 @@ function JetpackLikesMessageListener( event ) {
 					height = 204;
 				}
 
-				if ( ! newLayout ) {
-					// Avatars + padding
-					const containerWidth = rowLength * 37 + 13;
-					container.style.height = height + 'px';
-					container.style.width = containerWidth + 'px';
+				// If the popup overflows viewport width, we should show it on the next line.
+				// Push it offscreen to calculated rendered width.
+				container.style.left = '-9999px';
+				container.style.display = 'block';
 
-					const listWidth = rowLength * 37;
-					list.style.width = listWidth + 'px';
+				// If the popup exceeds the viewport width,
+				// flip the position of the popup.
+				const containerWidth = container.offsetWidth;
+				const containerRight = containerLeft + containerWidth;
+				if ( containerRight > win.innerWidth ) {
+					containerLeft = rect.right - containerWidth;
 				}
 
-				// If the popup is overflows viewport width, we should show it on the next line
-				if ( newLayout ) {
-					// Push it offscreen to calculated rendered width
-					container.style.left = '-9999px';
-					container.style.display = 'block';
-
-					// If the popup exceeds the viewport width,
-					// flip the position of the popup.
-					const containerWidth = container.offsetWidth;
-					const containerRight = containerLeft + containerWidth;
-					if ( containerRight > win.innerWidth ) {
-						containerLeft = rect.right - containerWidth;
-					}
-
-					// Set the container left
-					container.style.left = containerLeft + 'px';
-				} else {
-					container.style.display = 'block';
-				}
+				// Set the container left
+				container.style.left = containerLeft + 'px';
 				container.setAttribute( 'aria-hidden', 'false' );
 			};
 

--- a/projects/plugins/jetpack/modules/likes/style.css
+++ b/projects/plugins/jetpack/modules/likes/style.css
@@ -56,18 +56,6 @@ div.jetpack-comment-likes-widget-wrapper iframe {
 #likes-other-gravatars {
 	display: none;
 	position: absolute;
-	padding: 10px 10px 12px 10px;
-	background-color: #2e4453;
-	border-width: 0;
-	box-shadow: 0 0 10px #2e4453;
-	box-shadow: 0 0 10px rgba(46,68,83,.6);
-	min-width: 130px;
-	z-index: 1000;
-}
-
-#likes-other-gravatars.wpl-new-layout {
-	display: none;
-	position: absolute;
 	padding: 9px 12px 10px 12px;
 	background-color: #fff;
 	border: solid 1px #dcdcde;
@@ -85,12 +73,6 @@ div.jetpack-comment-likes-widget-wrapper iframe {
 }
 
 #likes-other-gravatars .likes-text {
-	color: white;
-	font-size: 12px;
-	padding-bottom: 8px;
-}
-
-#likes-other-gravatars.wpl-new-layout .likes-text {
 	color: #101517;
 	font-size: 12px;
 	font-weight: 500;
@@ -116,13 +98,6 @@ div.jetpack-comment-likes-widget-wrapper iframe {
 }
 
 #likes-other-gravatars ul.wpl-avatars li {
-	width: 32px;
-	height: 32px;
-	float: left;
-	margin: 0 5px 5px 0;
-}
-
-#likes-other-gravatars.wpl-new-layout ul.wpl-avatars li {
 	width: 196px;
 	height: 28px;
 	float: none;
@@ -132,19 +107,13 @@ div.jetpack-comment-likes-widget-wrapper iframe {
 #likes-other-gravatars ul.wpl-avatars li a {
 	margin: 0 2px 0 0;
 	border-bottom: none !important;
-	display: block;
-}
-
-#likes-other-gravatars.wpl-new-layout ul.wpl-avatars li a {
-	margin: 0 2px 0 0;
-	border-bottom: none !important;
 	display: flex;
 	align-items: center;
 	gap: 8px;
 	text-decoration: none;
 }
 
-#likes-other-gravatars.wpl-new-layout ul.wpl-avatars li a span {
+#likes-other-gravatars ul.wpl-avatars li a span {
 	font-size: 12px;
 	color: #2C3338;
 	overflow: hidden;
@@ -155,19 +124,11 @@ div.jetpack-comment-likes-widget-wrapper iframe {
 #likes-other-gravatars ul.wpl-avatars li a img {
 	background: none;
 	border: none;
-	margin: 0 !important;
-	padding: 0 !important;
-	position: static;
-	box-sizing: border-box;
-}
-
-#likes-other-gravatars.wpl-new-layout ul.wpl-avatars li a img {
-	background: none;
-	border: none;
 	border-radius: 50%;
 	margin: 0 !important;
 	padding: 1px !important;
 	position: static;
+	box-sizing: border-box;
 }
 
 div.sd-box {
@@ -213,9 +174,6 @@ div.sd-box {
 
 .post-likes-widget-placeholder .button {
 	display: none;	/* Let's not show a dummy like button, let's just make a great button experience once it's loaded */
-}
-
-.post-likes-widget-placeholder .button span {
 }
 
 .post-likes-widget-placeholder .loading,


### PR DESCRIPTION
Some time ago a new layout for the Like button was implemented and enabled for everyone, but the feature flag and conditional code was never removed. The likes will always use the new layout because the feature is actually mostly implemented as a WP.com widget, at `widgets.wp.com/likes`.

This PR is heavily inspired by #34423 (which was abandoned without a particularly good reason). Additionally it also removes `.wpl-new-layout` from the editor styles, used when displaying a Like block placeholder in the block editor.

## Testing instructions:
Install Jetpack build from this branch on your Jetpack site, e.g., using Jetpack Beta.

Go to a post that has likes and open the popup with the full list of likers. The old layout looked like this and this PR removes all code that displayed this old layout:

![scroll-bloggers](https://github.com/user-attachments/assets/1dc139b3-44fb-40d1-b028-6f20ec73d734)

Today you'll see this list popup instead:

<img width="306" alt="Screenshot 2025-02-18 at 11 30 02" src="https://github.com/user-attachments/assets/6f5a02f5-0ab4-4214-a9e8-21d3c2b15a14" />

Verify that this works as expected. It helps to know how the Like widget and the "other gravatars" popup is implemented:
- the Like widget itself -- the button, the row of five avatars, the "X likes" text: is implemented on `widgets.wp.com/likes`, it's loaded in an `iframe` and it's independent from your site's Jetpack version
- the "other gravatars" popup, on the other hand, is implemented in Jetpack, in the `likes/queuehandler.js` script. This script runs in the top-level document, not in the `likes-master` iframe. The `likes-master` iframe sends a message to the top-level window when it wants to render a popup. It sends the desired content and the position in the message.

Last thing you want to test is that the Likes widget placeholder is correctly displayed in the block editor:

<img width="621" alt="Screenshot 2025-02-18 at 11 37 08" src="https://github.com/user-attachments/assets/654c76bb-e73b-4ae1-acc0-5ca8606c646b" />

This is what the `editor.scss` diff is about, removing the "old layout" styles and leaving only the "new layout" ones.

## Does this pull request change what data or activity we track or use?

No.

