### PR TITLE
Scheduled Updates: Fix flaky test (hopefully)

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-tests-flaky_scheduled_updates
+++ b/projects/packages/scheduled-updates/changelog/fix-tests-flaky_scheduled_updates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tests: Rework logic to increase stability in edge cases.

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -756,6 +756,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	 * @covers ::delete_item
 	 */
 	public function test_updating_autoupdate_plugins_on_delete() {
+		wp_set_current_user( $this->admin_id );
 		$auto_update = array( 'hello-dolly/hello-dolly.php' );
 		$plugins_1   = array( 'custom-plugin/custom-plugin.php' );
 		$plugins_2   = array(
@@ -778,9 +779,9 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 2, self::get_sync_counter() );
 
 		$request = new WP_REST_Request( 'DELETE', '/wpcom/v2/update-schedules/' . $schedule_id );
-		wp_set_current_user( $this->admin_id );
-		rest_do_request( $request );
+		$result  = rest_do_request( $request );
 
+		$this->assertTrue( $result->get_data() );
 		$this->assertSame( $expected_result, get_option( 'auto_update_plugins' ) );
 		$this->assertSame( 3, self::get_sync_counter() );
 		$this->assertSame( 2, self::$scheduled_counter );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This might fix a flaky test in the `scheduled-updates` package and shouldn't break things more.

About weekly we end up with a test failure in this package:
```
[packages/scheduled-updates] There was 1 failure:
[packages/scheduled-updates] 
[packages/scheduled-updates] 1) WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test::test_updating_autoupdate_plugins_on_delete
[packages/scheduled-updates] Failed asserting that 4 is identical to 3.
[packages/scheduled-updates] 
[packages/scheduled-updates] /home/runner/work/jetpack/jetpack/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php:785
```

It's difficult to reproduce, but may be related to the user not being set at the beginning of the test. h/t to @zaerl for this proposed fix.

More context: p1739571713253699-slack-C034JEXD1RD

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Do tests still pass?