### PR TITLE
My Jetpack: Improve accessibility of product card actions

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/action-button/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/action-button/index.tsx
@@ -12,7 +12,6 @@ import useAnalytics from '../../hooks/use-analytics';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 import useOutsideAlerter from '../../hooks/use-outside-alerter';
-import { getProductCardTitleId } from '../product-card';
 import styles from './style.module.scss';
 import type { SecondaryButtonProps } from './secondary-button';
 import type { AdditionalAction } from './types';
@@ -28,6 +27,7 @@ type ActionButtonProps = {
 	setIsActionLoading?: ( value: SetStateAction< boolean > ) => void;
 	className?: string;
 	tracksIdentifier?: `${ string }_${ string }`;
+	labelSuffixId?: string;
 };
 
 const ActionButton: FC< ActionButtonProps > = ( {
@@ -38,6 +38,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 	setIsActionLoading,
 	className,
 	tracksIdentifier,
+	labelSuffixId,
 } ) => {
 	const { userIsAdmin, lifecycleStats } = getMyJetpackWindowInitialState();
 	const { ownedProducts } = lifecycleStats;
@@ -74,7 +75,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 	const admin = !! userIsAdmin;
 	const troubleshootBackupsUrl =
 		'https://jetpack.com/support/backup/troubleshooting-jetpack-backup/';
-	const labelledBy = `${ getActionButtonId( slug ) } ${ getProductCardTitleId( slug ) }`;
+	const labelledBy = `${ getActionButtonId( slug ) } ${ labelSuffixId || '' }`.trim();
 
 	const buttonState = useMemo< Partial< SecondaryButtonProps > >( () => {
 		return {

--- a/projects/packages/my-jetpack/_inc/components/action-button/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/action-button/index.tsx
@@ -12,10 +12,13 @@ import useAnalytics from '../../hooks/use-analytics';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 import useOutsideAlerter from '../../hooks/use-outside-alerter';
+import { getProductCardTitleId } from '../product-card';
 import styles from './style.module.scss';
 import type { SecondaryButtonProps } from './secondary-button';
 import type { AdditionalAction } from './types';
 import type { FC, ComponentProps, MouseEvent, SetStateAction } from 'react';
+
+const getActionButtonId = ( productSlug: string ) => `action-button-label-${ productSlug }`;
 
 type ActionButtonProps = {
 	slug: JetpackModule;
@@ -71,6 +74,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 	const admin = !! userIsAdmin;
 	const troubleshootBackupsUrl =
 		'https://jetpack.com/support/backup/troubleshooting-jetpack-backup/';
+	const labelledBy = `${ getActionButtonId( slug ) } ${ getProductCardTitleId( slug ) }`;
 
 	const buttonState = useMemo< Partial< SecondaryButtonProps > >( () => {
 		return {
@@ -148,6 +152,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					variant: 'primary',
 					label: buttonText,
 					onClick: learnMoreHandler,
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.ABSENT ] ?? {} ),
 				};
 			}
@@ -158,6 +163,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					variant: 'primary',
 					label: buttonText,
 					onClick: installStandaloneHandler,
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.ABSENT_WITH_PLAN ] ?? {} ),
 				};
 			}
@@ -169,6 +175,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					variant: 'primary',
 					label: __( 'Learn more', 'jetpack-my-jetpack' ),
 					onClick: addHandler,
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.NEEDS_FIRST_SITE_CONNECTION ] ?? {} ),
 				};
 			case PRODUCT_STATUSES.NEEDS_PLAN: {
@@ -182,6 +189,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					variant: 'primary',
 					label: buttonText,
 					onClick: addHandler,
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.NEEDS_PLAN ] ?? {} ),
 				};
 			}
@@ -192,6 +200,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					variant: 'primary',
 					label: __( 'Upgrade', 'jetpack-my-jetpack' ),
 					onClick: addHandler,
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.CAN_UPGRADE ] ?? {} ),
 				};
 			}
@@ -205,6 +214,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					variant: 'secondary',
 					label: buttonText,
 					onClick: manageHandler,
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.ACTIVE ] ?? {} ),
 				};
 			}
@@ -214,6 +224,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					variant: 'primary',
 					label: __( 'Connect', 'jetpack-my-jetpack' ),
 					onClick: fixSiteConnectionHandler,
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.SITE_CONNECTION_ERROR ] ?? {} ),
 				};
 			case PRODUCT_STATUSES.USER_CONNECTION_ERROR:
@@ -222,6 +233,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					variant: 'primary',
 					label: __( 'Connect', 'jetpack-my-jetpack' ),
 					onClick: fixUserConnectionHandler,
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.USER_CONNECTION_ERROR ] ?? {} ),
 				};
 			case PRODUCT_STATUSES.INACTIVE:
@@ -232,6 +244,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					variant: 'secondary',
 					label: __( 'Activate', 'jetpack-my-jetpack' ),
 					onClick: handleActivate,
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.INACTIVE ] ?? {} ),
 				};
 			case PRODUCT_STATUSES.EXPIRING_SOON:
@@ -240,6 +253,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					href: renewPaidPlanPurchaseUrl,
 					variant: 'primary',
 					label: __( 'Renew my plan', 'jetpack-my-jetpack' ),
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.EXPIRING_SOON ] ?? {} ),
 				};
 			case PRODUCT_STATUSES.EXPIRED:
@@ -248,6 +262,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					href: managePaidPlanPurchaseUrl,
 					variant: 'primary',
 					label: __( 'Resume my plan', 'jetpack-my-jetpack' ),
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.EXPIRED ] ?? {} ),
 				};
 			case PRODUCT_STATUSES.NEEDS_ATTENTION__ERROR: {
@@ -256,6 +271,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					href: manageUrl,
 					variant: 'primary',
 					label: __( 'Troubleshoot', 'jetpack-my-jetpack' ),
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.NEEDS_ATTENTION__ERROR ] ?? {} ),
 				};
 				switch ( slug ) {
@@ -279,6 +295,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					href: manageUrl,
 					variant: 'primary',
 					label: __( 'Troubleshoot', 'jetpack-my-jetpack' ),
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.NEEDS_ATTENTION__WARNING ] ?? {} ),
 				};
 				switch ( slug ) {
@@ -299,6 +316,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					href: purchaseUrl || `#/add-${ slug }`,
 					label: __( 'Learn more', 'jetpack-my-jetpack' ),
 					onClick: addHandler,
+					'aria-labelledby': labelledBy,
 				};
 		}
 	}, [
@@ -319,6 +337,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 		installStandaloneHandler,
 		learnMoreHandler,
 		manageHandler,
+		labelledBy,
 	] );
 
 	const allActions = useMemo(
@@ -414,7 +433,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					hasAdditionalActions ? styles[ 'has-additional-actions' ] : null
 				) }
 			>
-				<Button { ...buttonState } { ...currentAction }>
+				<Button { ...buttonState } { ...currentAction } id={ getActionButtonId( slug ) }>
 					{ currentAction.label }
 				</Button>
 				{ hasAdditionalActions && (

--- a/projects/packages/my-jetpack/_inc/components/action-button/secondary-button.tsx
+++ b/projects/packages/my-jetpack/_inc/components/action-button/secondary-button.tsx
@@ -16,6 +16,7 @@ export type SecondaryButtonProps = {
 	disabled?: boolean;
 	isLoading?: boolean;
 	className?: string;
+	'aria-labelledby'?: string;
 };
 
 // SecondaryButton component

--- a/projects/packages/my-jetpack/_inc/components/card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/card/index.jsx
@@ -22,7 +22,8 @@ export const CardWrapper = props => {
 };
 
 const Card = props => {
-	const { title, headerRightContent, className, children, onMouseEnter, onMouseLeave } = props;
+	const { title, headerRightContent, className, children, onMouseEnter, onMouseLeave, titleId } =
+		props;
 
 	return (
 		<CardWrapper
@@ -32,7 +33,9 @@ const Card = props => {
 		>
 			<div className={ styles.title }>
 				<div className={ styles.name }>
-					<Text variant="title-medium">{ title }</Text>
+					<Text variant="title-medium" id={ titleId || null }>
+						{ title }
+					</Text>
 				</div>
 				{ headerRightContent }
 			</div>
@@ -48,6 +51,7 @@ Card.propTypes = {
 	headerRightContent: PropTypes.node,
 	onMouseEnter: PropTypes.func,
 	onMouseLeave: PropTypes.func,
+	titleId: PropTypes.string,
 };
 
 export default Card;

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
@@ -169,6 +169,7 @@ const ProductCard: FC< ProductCardProps > = props => {
 							fixSiteConnectionHandler={ fixSiteConnectionHandler }
 							setIsActionLoading={ setIsActionLoading }
 							tracksIdentifier="product_card"
+							labelSuffixId={ getProductCardTitleId( slug ) }
 						/>
 						{ secondaryAction && ! secondaryAction?.positionFirst && (
 							<SecondaryButton { ...secondaryAction } />

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
@@ -16,6 +16,14 @@ import styles from './style.module.scss';
 import type { AdditionalAction, SecondaryAction } from '../action-button/types';
 import type { FC, MouseEventHandler, ReactNode, MouseEvent } from 'react';
 
+/**
+ * Generate the product card title ID attribute from a product slug
+ *
+ * @param {string} slug - The product slug
+ * @return {string} The generated title ID attribute
+ */
+export const getProductCardTitleId = slug => `product-card-title-${ slug }`;
+
 export type ProductCardProps = {
 	children?: ReactNode;
 	name: string;
@@ -135,6 +143,7 @@ const ProductCard: FC< ProductCardProps > = props => {
 			headerRightContent={ null }
 			onMouseEnter={ onMouseEnter }
 			onMouseLeave={ onMouseLeave }
+			titleId={ getProductCardTitleId( slug ) }
 		>
 			{ recommendation && <PriceComponent slug={ slug } /> }
 			<Description />

--- a/projects/packages/my-jetpack/_inc/components/products-table-view/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/products-table-view/index.tsx
@@ -97,6 +97,14 @@ const getCategories: (
 	return categoryOptions;
 };
 
+/**
+ * Generate the product title ID attribute from a product slug
+ *
+ * @param {string} slug - The product slug
+ * @return {string} The generated title ID attribute
+ */
+export const getProductTitleId = slug => `product-title-${ slug }`;
+
 const ProductsTableView: FC< ProductsTableViewProps > = ( { products } ) => {
 	const getItemId = useCallback( ( item: ProductData ) => item.product.slug, [] );
 	const onChangeView = useCallback( ( newView: View ) => {
@@ -164,7 +172,7 @@ const ProductsTableView: FC< ProductsTableViewProps > = ( { products } ) => {
 				},
 				render: ( { item }: { item: ProductData } ) => {
 					const { product } = item;
-					return <div>{ product.name }</div>;
+					return <div id={ getProductTitleId( product.slug ) }>{ product.name }</div>;
 				},
 			},
 			{
@@ -231,6 +239,7 @@ const ProductsTableView: FC< ProductsTableViewProps > = ( { products } ) => {
 							className="product-list-item-cta"
 							slug={ slug }
 							tracksIdentifier="product_list_item"
+							labelSuffixId={ getProductTitleId( slug ) }
 						/>
 					);
 				},

--- a/projects/packages/my-jetpack/changelog/fix-product-card-cta-a11y
+++ b/projects/packages/my-jetpack/changelog/fix-product-card-cta-a11y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improve accessibility for product card actions with ARIA labelling


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The call-to-actions of the product cards in My Jetpack don't mention the name of the products they're related to. In the example below, all links are labeled _Renew my plan_.
<img width="500" alt="Screenshot 2025-02-17 at 3 56 18 PM" src="https://github.com/user-attachments/assets/af744b42-45d3-4519-b1b4-d7b8cee4c818" />

This makes it harder for assistive technology users (such as screen readers or speech recognition software) to navigate or interact with the page. This PR ensures the product card call-to-actions are distinct by including the product name in their accessible name, making the page more accessible.

About the implementation:
- To determine an accessible name, it's best practice to use content that's already on the page.
- `aria-labelledby` is therefore recommended.
- Moreover `aria-label` isn’t always picked up by translation services.
- Phrasing is not ideal with all call-to-actions (e.g., _Learn more Boost_ instead of _Learn more about Boost_) but that's already an improvement. We can refine this in a further iteration.
- `aria-labelledby` accepts the id of the element whose content represents the accessible name. It also accepts a list of ids in which case the content of the elements will be concatenated.

| Before | After |
| - | - |
|<img width="400" alt="Screenshot 2025-02-17 at 3 58 02 PM" src="https://github.com/user-attachments/assets/056bb3ba-d40e-476f-8c9d-002ba88abf00" />|<img width="400" alt="Screenshot 2025-02-17 at 3 59 16 PM" src="https://github.com/user-attachments/assets/9f02b0c0-918a-4cdb-aeda-bef1d8b75bab" />|


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Epic: https://github.com/Automattic/vulcan/issues/710

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test Jetpack site
- Visit `/wp-admin/admin.php?page=my-jetpack`
- If you're familiar with screen readers, ensure all product card call-to-actions are distinct
- Otherwise, open the dev tool
- Inspect a product card call-to-action in the _My Products_ section
- In most browsers, you should be able to access an Accessibility panel
- Notice the accessible name of the selected element includes the product name
<img width="326" alt="Screenshot 2025-02-17 at 4 08 33 PM" src="https://github.com/user-attachments/assets/18983b87-472d-417f-abc5-b50cc8ac70a4" />

_In Chrome, the accessible name is the value of Name in the Computed Properties section_

- Test buttons in the _Discover More_ section as well
<img width="500" alt="Screenshot 2025-02-18 at 1 00 54 PM" src="https://github.com/user-attachments/assets/8075c4b6-7889-4031-9642-9a0908f0626f" />


