### PR TITLE
Social: Update the admin page for use by Editors and Authors

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-admin-for-non-admins
+++ b/projects/js-packages/publicize-components/changelog/update-social-admin-for-non-admins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Social: Updated the admin page for use by Editors and Authors

--- a/projects/js-packages/publicize-components/src/components/admin-page/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/admin-page/index.tsx
@@ -28,7 +28,6 @@ import SocialImageGeneratorToggle from './toggles/social-image-generator-toggle'
 import SocialModuleToggle from './toggles/social-module-toggle';
 import SocialNotesToggle from './toggles/social-notes-toggle';
 import UtmToggle from './toggles/utm-toggle';
-import { version } from 'react';
 
 export const SocialAdminPage = () => {
 	const isSimple = isSimpleSite();

--- a/projects/js-packages/publicize-components/src/components/admin-page/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/admin-page/index.tsx
@@ -11,7 +11,7 @@ import {
 	isJetpackSelfHostedSite,
 	isSimpleSite,
 	siteHasFeature,
-	canUser,
+	currentUserCan,
 } from '@automattic/jetpack-script-data';
 import { useSelect } from '@wordpress/data';
 import { useState, useCallback } from '@wordpress/element';
@@ -59,7 +59,7 @@ export const SocialAdminPage = () => {
 		? `Jetpack Social ${ social.version }`
 		: `Jetpack ${ jetpack.version }`;
 
-	const canManageOptions = canUser( 'manage_options' );
+	const canManageOptions = currentUserCan( 'manage_options' );
 
 	if ( showConnectionCard ) {
 		return (

--- a/projects/js-packages/publicize-components/src/components/admin-page/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/admin-page/index.tsx
@@ -11,6 +11,7 @@ import {
 	isJetpackSelfHostedSite,
 	isSimpleSite,
 	siteHasFeature,
+	canUser,
 } from '@automattic/jetpack-script-data';
 import { useSelect } from '@wordpress/data';
 import { useState, useCallback } from '@wordpress/element';
@@ -27,6 +28,7 @@ import SocialImageGeneratorToggle from './toggles/social-image-generator-toggle'
 import SocialModuleToggle from './toggles/social-module-toggle';
 import SocialNotesToggle from './toggles/social-notes-toggle';
 import UtmToggle from './toggles/utm-toggle';
+import { version } from 'react';
 
 export const SocialAdminPage = () => {
 	const isSimple = isSimpleSite();
@@ -56,6 +58,8 @@ export const SocialAdminPage = () => {
 	const moduleName = social.version
 		? `Jetpack Social ${ social.version }`
 		: `Jetpack ${ jetpack.version }`;
+
+	const canManageOptions = canUser( 'manage_options' );
 
 	if ( showConnectionCard ) {
 		return (
@@ -92,15 +96,19 @@ export const SocialAdminPage = () => {
 					</AdminSectionHero>
 					<AdminSection>
 						<SocialModuleToggle />
-						{ isModuleEnabled && <UtmToggle /> }
-						{
-							// Only show the Social Notes toggle if Social plugin is active
-							social.version && isModuleEnabled && (
-								<SocialNotesToggle disabled={ isUpdatingJetpackSettings } />
-							)
-						}
-						{ isModuleEnabled && siteHasFeature( features.IMAGE_GENERATOR ) && (
-							<SocialImageGeneratorToggle disabled={ isUpdatingJetpackSettings } />
+						{ canManageOptions && (
+							<>
+								{ isModuleEnabled && <UtmToggle /> }
+								{
+									// Only show the Social Notes toggle if Social plugin is active
+									social.version && isModuleEnabled && (
+										<SocialNotesToggle disabled={ isUpdatingJetpackSettings } />
+									)
+								}
+								{ isModuleEnabled && siteHasFeature( features.IMAGE_GENERATOR ) && (
+									<SocialImageGeneratorToggle disabled={ isUpdatingJetpackSettings } />
+								) }
+							</>
 						) }
 					</AdminSection>
 					<AdminSectionHero>

--- a/projects/js-packages/publicize-components/src/components/admin-page/test/index.test.jsx
+++ b/projects/js-packages/publicize-components/src/components/admin-page/test/index.test.jsx
@@ -23,6 +23,11 @@ describe( 'load the app', () => {
 					},
 				},
 			},
+			user: {
+				current_user: {
+					capabilities: {},
+				},
+			},
 		};
 	} );
 

--- a/projects/js-packages/publicize-components/src/components/admin-page/toggles/social-module-toggle/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/admin-page/toggles/social-module-toggle/index.tsx
@@ -81,9 +81,10 @@ const SocialModuleToggle: React.FC = () => {
 		) : null;
 	};
 
+	const hideToggle = is_wpcom || ! currentUserCan( 'manage_modules' );
 	return (
 		<ToggleSection
-			hideToggle={ is_wpcom || ! currentUserCan( 'manage_modules' ) }
+			hideToggle={ hideToggle }
 			title={ __(
 				'Automatically share your posts to social networks',
 				'jetpack-publicize-components'
@@ -93,7 +94,7 @@ const SocialModuleToggle: React.FC = () => {
 			onChange={ toggleModule }
 		>
 			<Text className={ styles.text }>
-				{ ! is_wpcom
+				{ ! hideToggle
 					? _x(
 							'When enabled, you’ll be able to connect your social media accounts and send a post’s featured image and content to the selected channels with a single click when the post is published.',
 							'Description of the feature that the toggle enables',

--- a/projects/js-packages/publicize-components/src/components/admin-page/toggles/social-module-toggle/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/admin-page/toggles/social-module-toggle/index.tsx
@@ -5,7 +5,7 @@ import {
 	getRedirectUrl,
 	useBreakpointMatch,
 } from '@automattic/jetpack-components';
-import { getScriptData, isWpcomPlatformSite } from '@automattic/jetpack-script-data';
+import { getScriptData, isWpcomPlatformSite, canUser } from '@automattic/jetpack-script-data';
 import { ExternalLink } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
@@ -79,7 +79,7 @@ const SocialModuleToggle: React.FC = () => {
 
 	return (
 		<ToggleSection
-			hideToggle={ is_wpcom }
+			hideToggle={ is_wpcom || ! canUser( 'manage_modules' ) }
 			title={ __(
 				'Automatically share your posts to social networks',
 				'jetpack-publicize-components'

--- a/projects/js-packages/publicize-components/src/components/admin-page/toggles/social-module-toggle/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/admin-page/toggles/social-module-toggle/index.tsx
@@ -5,7 +5,11 @@ import {
 	getRedirectUrl,
 	useBreakpointMatch,
 } from '@automattic/jetpack-components';
-import { getScriptData, isWpcomPlatformSite, canUser } from '@automattic/jetpack-script-data';
+import {
+	getScriptData,
+	isWpcomPlatformSite,
+	currentUserCan,
+} from '@automattic/jetpack-script-data';
 import { ExternalLink } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
@@ -79,7 +83,7 @@ const SocialModuleToggle: React.FC = () => {
 
 	return (
 		<ToggleSection
-			hideToggle={ is_wpcom || ! canUser( 'manage_modules' ) }
+			hideToggle={ is_wpcom || ! currentUserCan( 'manage_modules' ) }
 			title={ __(
 				'Automatically share your posts to social networks',
 				'jetpack-publicize-components'

--- a/projects/js-packages/script-data/changelog/update-social-admin-for-non-admins
+++ b/projects/js-packages/script-data/changelog/update-social-admin-for-non-admins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+User data: Added permissions to the current user object

--- a/projects/js-packages/script-data/src/types.ts
+++ b/projects/js-packages/script-data/src/types.ts
@@ -33,6 +33,10 @@ export interface SiteData extends PublicSiteData, Partial< AdminSiteData > {}
 export interface CurrentUserData {
 	id: number;
 	display_name: string;
+	permissions: {
+		manage_options: boolean;
+		manage_modules: boolean;
+	};
 	wpcom?: {
 		ID: number;
 		login: string;

--- a/projects/js-packages/script-data/src/types.ts
+++ b/projects/js-packages/script-data/src/types.ts
@@ -30,10 +30,15 @@ export interface AdminSiteData {
 
 export interface SiteData extends PublicSiteData, Partial< AdminSiteData > {}
 
+export interface UserCapabilities {
+	manage_options: boolean;
+	manage_modules: boolean;
+}
+
 export interface CurrentUserData {
 	id: number;
 	display_name: string;
-	capabilities: Record< 'manage_options' | 'manage_modules', boolean >;
+	capabilities: UserCapabilities;
 	wpcom?: {
 		ID: number;
 		login: string;

--- a/projects/js-packages/script-data/src/types.ts
+++ b/projects/js-packages/script-data/src/types.ts
@@ -33,10 +33,7 @@ export interface SiteData extends PublicSiteData, Partial< AdminSiteData > {}
 export interface CurrentUserData {
 	id: number;
 	display_name: string;
-	permissions: {
-		manage_options: boolean;
-		manage_modules: boolean;
-	};
+	permissions: Record< 'manage_options' | 'manage_modules', boolean >;
 	wpcom?: {
 		ID: number;
 		login: string;

--- a/projects/js-packages/script-data/src/types.ts
+++ b/projects/js-packages/script-data/src/types.ts
@@ -33,7 +33,7 @@ export interface SiteData extends PublicSiteData, Partial< AdminSiteData > {}
 export interface CurrentUserData {
 	id: number;
 	display_name: string;
-	permissions: Record< 'manage_options' | 'manage_modules', boolean >;
+	capabilities: Record< 'manage_options' | 'manage_modules', boolean >;
 	wpcom?: {
 		ID: number;
 		login: string;

--- a/projects/js-packages/script-data/src/utils.ts
+++ b/projects/js-packages/script-data/src/utils.ts
@@ -1,3 +1,5 @@
+import { CurrentUserData } from './types';
+
 /**
  * Get the script data from the window object.
  *
@@ -114,4 +116,14 @@ export function isWpcomPlatformSite() {
  */
 export function isJetpackSelfHostedSite() {
 	return getScriptData()?.site?.host === 'unknown';
+}
+
+/**
+ * Check if the current user has a particular permission.
+ *
+ * @param permission - The feature to check.
+ * @return Whether the current user has that permission.
+ */
+export function canUser( permission: keyof CurrentUserData[ 'permissions' ] ): boolean {
+	return getScriptData().user.current_user.permissions[ permission ];
 }

--- a/projects/js-packages/script-data/src/utils.ts
+++ b/projects/js-packages/script-data/src/utils.ts
@@ -119,11 +119,11 @@ export function isJetpackSelfHostedSite() {
 }
 
 /**
- * Check if the current user has a particular permission.
+ * Check if the current user has a particular capability.
  *
- * @param permission - The feature to check.
- * @return Whether the current user has that permission.
+ * @param capability - The capability to check.
+ * @return Whether the current user has that capability.
  */
-export function canUser( permission: keyof CurrentUserData[ 'permissions' ] ): boolean {
-	return getScriptData().user.current_user.permissions[ permission ];
+export function currentUserCan( capability: keyof CurrentUserData[ 'capabilities' ] ): boolean {
+	return getScriptData().user.current_user.capabilities[ capability ];
 }

--- a/projects/packages/assets/changelog/update-social-admin-for-non-admins
+++ b/projects/packages/assets/changelog/update-social-admin-for-non-admins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+User data: Added permissions to the current user object

--- a/projects/packages/assets/src/class-script-data.php
+++ b/projects/packages/assets/src/class-script-data.php
@@ -215,6 +215,10 @@ class Script_Data {
 		return array(
 			'display_name' => $current_user->display_name,
 			'id'           => $current_user->ID,
+			'permissions'  => array(
+				'manage_options' => current_user_can( 'manage_options' ),
+				'manage_modules' => current_user_can( 'jetpack_manage_modules' ),
+			),
 		);
 	}
 }

--- a/projects/packages/assets/src/class-script-data.php
+++ b/projects/packages/assets/src/class-script-data.php
@@ -215,7 +215,7 @@ class Script_Data {
 		return array(
 			'display_name' => $current_user->display_name,
 			'id'           => $current_user->ID,
-			'permissions'  => array(
+			'capabilities' => array(
 				'manage_options' => current_user_can( 'manage_options' ),
 				'manage_modules' => current_user_can( 'jetpack_manage_modules' ),
 			),

--- a/projects/packages/publicize/changelog/update-social-admin-for-non-admins
+++ b/projects/packages/publicize/changelog/update-social-admin-for-non-admins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Social: Updated the admin page for use by Editors and Authors

--- a/projects/packages/publicize/src/class-social-admin-page.php
+++ b/projects/packages/publicize/src/class-social-admin-page.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Publicize;
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Publicize\Publicize_Utils as Utils;
 
 /**
  * The class to handle the Social Admin Page.
@@ -54,10 +55,16 @@ class Social_Admin_Page {
 		// Remove the old Social menu item, if it exists.
 		Admin_Menu::remove_menu( 'jetpack-social' );
 
+		// If this isn't an admin (or someone with the capability to change the module status )
+		// and Publicize is inactive, then don't render the admin page.
+		if ( ! current_user_can( 'manage_options' ) && ! Utils::is_publicize_active() ) {
+			return;
+		}
+
 		$page_suffix = Admin_Menu::add_menu(
 			__( 'Jetpack Social', 'jetpack-publicize-pkg' ),
 			_x( 'Social', 'The Jetpack Social product name, without the Jetpack prefix', 'jetpack-publicize-pkg' ),
-			'manage_options',
+			'publish_posts',
 			'jetpack-social',
 			array( $this, 'render' ),
 			4

--- a/projects/packages/sync/changelog/update-social-admin-for-non-admins
+++ b/projects/packages/sync/changelog/update-social-admin-for-non-admins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Modules: Moved the custom capibilities from the Jetpack plugin

--- a/projects/packages/sync/src/class-main.php
+++ b/projects/packages/sync/src/class-main.php
@@ -40,6 +40,30 @@ class Main {
 
 		// Set up package version hook.
 		add_filter( 'jetpack_package_versions', __NAMESPACE__ . '\Package_Version::send_package_version_to_tracker' );
+
+		// Add the custom capabilities for managing modules
+		add_filter( 'map_meta_cap', array( __CLASS__, 'module_custom_caps' ), 10, 2 );
+	}
+
+	/**
+	 * Sets the Module custom capabilities.
+	 *
+	 * @param  string[] $caps Array of the user's capabilities.
+	 * @param  string   $cap  Capability name.
+	 * @return string[] The user's capabilities, adjusted as necessary.
+	 */
+	public static function module_custom_caps( $caps, $cap ) {
+		switch ( $cap ) {
+			case 'jetpack_manage_modules':
+			case 'jetpack_activate_modules':
+			case 'jetpack_deactivate_modules':
+				$caps = array( 'manage_options' );
+				break;
+			case 'jetpack_configure_modules':
+				$caps = array( 'manage_options' );
+				break;
+		}
+		return $caps;
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
@@ -61,6 +61,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 				isOfflineMode = this.props.isOfflineMode;
 
 			const showUpgradeLink =
+				userCanManageModules &&
 				! isAtomicSite &&
 				activeFeatures &&
 				activeFeatures.length > 0 &&
@@ -68,7 +69,8 @@ export const Publicize = withModuleSettingsFormHelpers(
 				! hasPaidFeatures &&
 				isLinked;
 
-			const shouldShowChildElements = isActive && ! this.props.isSavingAnyOption( 'publicize' );
+			const shouldShowChildElements =
+				isActive && userCanManageModules && ! this.props.isSavingAnyOption( 'publicize' );
 
 			// We need to strip off the trailing slash for the pricing modal to open correctly.
 			const redirectUrl = encodeURIComponent( siteAdminUrl.replace( /\/$/, '' ) );
@@ -104,71 +106,69 @@ export const Publicize = withModuleSettingsFormHelpers(
 					feature={ FEATURE_JETPACK_SOCIAL }
 					isDisabled={ isOfflineMode || ! isLinked }
 				>
-					{ userCanManageModules && (
-						<SettingsGroup
-							hasChild
-							disableInOfflineMode
-							disableInSiteConnectionMode
-							module={ { module: 'publicize' } }
-							support={ {
-								text: __(
-									'Allows you to automatically share your newest content on social media sites, including Facebook and LinkedIn.',
-									'jetpack'
-								),
-								link: getRedirectUrl( 'jetpack-support-publicize' ),
-							} }
-						>
+					<SettingsGroup
+						hasChild
+						disableInOfflineMode
+						disableInSiteConnectionMode
+						module={ { module: 'publicize' } }
+						support={ {
+							text: __(
+								'Allows you to automatically share your newest content on social media sites, including Facebook and LinkedIn.',
+								'jetpack'
+							),
+							link: getRedirectUrl( 'jetpack-support-publicize' ),
+						} }
+					>
+						<p>
+							{ __(
+								'Enable Jetpack Social and connect your social accounts to automatically share your content with your followers with a single click. When you publish a post, you will be able to share it on all connected accounts.',
+								'jetpack'
+							) }
+						</p>
+						{ showUpgradeLink ? (
 							<p>
-								{ __(
-									'Enable Jetpack Social and connect your social accounts to automatically share your content with your followers with a single click. When you publish a post, you will be able to share it on all connected accounts.',
-									'jetpack'
+								{ createInterpolateElement(
+									__(
+										'<moreInfo>Upgrade to a Jetpack Social plan</moreInfo> to get advanced sharing options.',
+										'jetpack'
+									),
+									{
+										moreInfo: (
+											<a
+												href={ getRedirectUrl( 'jetpack-plugin-admin-page-sharings-screen', {
+													site: siteRawUrl,
+													query: 'redirect_to=' + redirectUrl,
+												} ) }
+											/>
+										),
+									}
 								) }
 							</p>
-							{ showUpgradeLink ? (
-								<p>
-									{ createInterpolateElement(
-										__(
-											'<moreInfo>Upgrade to a Jetpack Social plan</moreInfo> to get advanced sharing options.',
-											'jetpack'
-										),
-										{
-											moreInfo: (
-												<a
-													href={ getRedirectUrl( 'jetpack-plugin-admin-page-sharings-screen', {
-														site: siteRawUrl,
-														query: 'redirect_to=' + redirectUrl,
-													} ) }
-												/>
-											),
-										}
-									) }
-								</p>
-							) : null }
-							<ModuleToggle
-								slug="publicize"
-								disabled={ isOfflineMode || ! isLinked }
-								activated={ isActive }
-								toggling={ this.props.isSavingAnyOption( 'publicize' ) }
-								toggleModule={ this.props.toggleModuleNow }
-							>
-								<span className="jp-form-toggle-explanation">
-									{ __( 'Automatically share your posts to social networks', 'jetpack' ) }
-								</span>
-							</ModuleToggle>
-							{ shouldShowChildElements && hasSocialImageGenerator && (
-								<SocialImageGeneratorSection />
-							) }
-							{ shouldShowChildElements && <UtmToggleSection /> }
-							{ isActive &&
-							isLinked &&
-							useAdminUiV1 &&
-							! this.props.isSavingAnyOption( 'publicize' ) ? (
-								<FormFieldset className="jp-settings__connection-management">
-									<ConnectionManagement />
-								</FormFieldset>
-							) : null }
-						</SettingsGroup>
-					) }
+						) : null }
+						<ModuleToggle
+							slug="publicize"
+							disabled={ isOfflineMode || ! isLinked || ! userCanManageModules }
+							activated={ isActive }
+							toggling={ this.props.isSavingAnyOption( 'publicize' ) }
+							toggleModule={ this.props.toggleModuleNow }
+						>
+							<span className="jp-form-toggle-explanation">
+								{ __( 'Automatically share your posts to social networks', 'jetpack' ) }
+							</span>
+						</ModuleToggle>
+						{ shouldShowChildElements && hasSocialImageGenerator && (
+							<SocialImageGeneratorSection />
+						) }
+						{ shouldShowChildElements && <UtmToggleSection /> }
+						{ isActive &&
+						isLinked &&
+						useAdminUiV1 &&
+						! this.props.isSavingAnyOption( 'publicize' ) ? (
+							<FormFieldset className="jp-settings__connection-management">
+								<ConnectionManagement />
+							</FormFieldset>
+						) : null }
+					</SettingsGroup>
 					{ isActive && ! useAdminUiV1 && configCard() }
 				</SettingsCard>
 			);

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -4,6 +4,7 @@ use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets\Logo;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Publicize\Publicize_Script_Data;
 use Automattic\Jetpack\Status;
 
 require_once __DIR__ . '/class.jetpack-admin-page.php';
@@ -169,7 +170,11 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			 */
 			if (
 				! Jetpack::is_module_active( 'post-by-email' )
-				&& ! Jetpack::is_module_active( 'publicize' )
+					&& (
+						Publicize_Script_Data::has_feature_flag( 'admin-page' ) ||
+						! Jetpack::is_module_active( 'publicize' ) ||
+						! current_user_can( 'publish_posts' )
+					)
 			) {
 				return false;
 			}

--- a/projects/plugins/jetpack/changelog/update-social-admin-for-non-admins
+++ b/projects/plugins/jetpack/changelog/update-social-admin-for-non-admins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Social: Updated the admin page to be used by Editors and Authors

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -1024,14 +1024,6 @@ class Jetpack {
 	 */
 	public function jetpack_custom_caps( $caps, $cap ) {
 		switch ( $cap ) {
-			case 'jetpack_manage_modules':
-			case 'jetpack_activate_modules':
-			case 'jetpack_deactivate_modules':
-				$caps = array( 'manage_options' );
-				break;
-			case 'jetpack_configure_modules':
-				$caps = array( 'manage_options' );
-				break;
 			case 'jetpack_manage_autoupdates':
 				$caps = array(
 					'manage_options',

--- a/projects/plugins/social/changelog/update-social-admin-for-non-admins
+++ b/projects/plugins/social/changelog/update-social-admin-for-non-admins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Social: Updated the admin page for use by Editors and Authors


### PR DESCRIPTION
Fixes #38335

## Proposed changes:

This updates the Social admin page, so that it is rendered for Editors and Authors, so they can manage their connections outside of the editor.

Additionally, it updates the Jetpack settings logic, which used to enable the same functionality. The settings would still be displayed if someone could `publish_posts`, but it seems we must have broken this logic at some point, so the settings screen would be blank without the `manage_options` capability. With the new social admin page this is not needed anymore, but the logic checks the feature is enabled, just in case we need to swap back at some point.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:

* Connect two accounts to a site, one being an admin account and another being an author or editor.
* On the admin account, check that you can still manage connections, change settings and the overall module state on the social admin page.
* Using the author/editor account, check that you can see the social admin page and manage connections
* Have the admin disable the Publicize module
* Check that the Social admin page is not rendered for the author/editor
* Swap from the Jetpack to Scoial plugin and ensure that it behaves in the same way

Author Account view with this change

![CleanShot 2025-02-17 at 22 29 46@2x](https://github.com/user-attachments/assets/f62acb51-2957-4a55-ade8-510ae1e1f0c1)

Without this change the admin page isn't available to non-admins.

