### PR TITLE
Connection Client: wpcom_json_api_request_as_user: do internal request for WPCOM

### DIFF
--- a/projects/packages/connection/changelog/add-request-as-user-internal
+++ b/projects/packages/connection/changelog/add-request-as-user-internal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection Client: wpcom_json_api_request_as_user: add support for internal request

--- a/projects/packages/connection/src/class-client.php
+++ b/projects/packages/connection/src/class-client.php
@@ -412,6 +412,24 @@ class Client {
 	}
 
 	/**
+	 * Makes a remote request, or a direct request if the site is a Simple site.
+	 *
+	 * @param array             $args the arguments for the remote request.
+	 * @param array|string|null $body the request body.
+	 * @return array|WP_Error WP HTTP response on success
+	 * @phan-return _WP_Remote_Response_Array|WP_Error
+	 */
+	private static function remote_or_direct_request( $args, $body ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			add_filter( 'is_jetpack_authorized_for_site', '__return_true' );
+			require_lib( 'wpcom-api-direct' );
+			return \WPCOM_API_Direct::do_request( $args, $body );
+		}
+
+		return self::remote_request( $args, $body );
+	}
+
+	/**
 	 * Queries the WordPress.com REST API with a user token.
 	 *
 	 * @param string            $path             REST API path.
@@ -441,7 +459,7 @@ class Client {
 			$body = wp_json_encode( $body );
 		}
 
-		return self::remote_request( $args, $body );
+		return self::remote_or_direct_request( $args, $body );
 	}
 
 	/**
@@ -465,14 +483,7 @@ class Client {
 		$validated_args            = self::validate_args_for_wpcom_json_api_request( $path, $version, $args, $base_api_path );
 		$validated_args['blog_id'] = (int) \Jetpack_Options::get_option( 'id' );
 
-		// For Simple sites get the response directly without any HTTP requests.
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			add_filter( 'is_jetpack_authorized_for_site', '__return_true' );
-			require_lib( 'wpcom-api-direct' );
-			return \WPCOM_API_Direct::do_request( $validated_args, $body );
-		}
-
-		return self::remote_request( $validated_args, $body );
+		return self::remote_or_direct_request( $validated_args, $body );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-request-as-user-internal
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-request-as-user-internal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection Client: wpcom_json_api_request_as_user: add support for internal request

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
@@ -15,10 +15,7 @@ function load_wpcom_dashboard_widgets() {
 		return;
 	}
 
-	// wpcom_json_api_request_as_user does not support internal requests.
-	$request = defined( 'IS_WPCOM' ) && IS_WPCOM ? 'wpcom_json_api_request_as_blog' : 'wpcom_json_api_request_as_user';
-
-	$layout_response = Client::$request(
+	$layout_response = Client::wpcom_json_api_request_as_user(
 		'/sites/' . get_wpcom_blog_id() . '/home/layout',
 		'v2',
 		array(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related: #41150

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Do an internal request for `wpcom_json_api_request_as_user` when the site is a Simple Site.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check that the "Suggestions" widget on the wp-admin Dashboard still works, e.g. on the `ellaiseulde` test site. On other test site you should make sure that the launchpad tasks are completed.
* There's a TON of other uses of `wpcom_json_api_request_as_user`.

