### PR TITLE
Social | Fix PHP warnings by removing unused fields in connection post field endpoint

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
@@ -248,11 +248,6 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 					$output_connection[ $property ] = $connection[ $property ];
 				}
 			}
-			$output_connection['id']            = (string) $connection['unique_id'];
-			$output_connection['connection_id'] = (string) $connection['id'];
-
-			$output_connection['can_disconnect'] = current_user_can( 'edit_others_posts' ) || get_current_user_id() === (int) $connection['user_id'];
-			$output_connection['shared']         = $connection['global'];
 
 			$output_connections[] = $output_connection;
 		}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
@@ -5,6 +5,8 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Publicize\REST_API\Connections_Controller;
+
 /**
  * Add per-post Publicize Connection data.
  *
@@ -102,64 +104,40 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 	 * Schema for the endpoint.
 	 */
 	private function post_connection_schema() {
+		$connection_fields = Connections_Controller::get_the_item_schema();
+		$deprecated_fields = array(
+			'id'       => array(
+				'type'        => 'string',
+				'description' => __( 'Unique identifier for the Jetpack Social connection.', 'jetpack' ) . ' ' . sprintf(
+					/* translators: %s is the new field name */
+					__( 'Deprecated in favor of %s.', 'jetpack' ),
+					'connection_id'
+				),
+			),
+			'username' => array(
+				'type'        => 'string',
+				'description' => __( 'Username of the connected account.', 'jetpack' ) . ' ' . sprintf(
+					/* translators: %s is the new field name */
+					__( 'Deprecated in favor of %s.', 'jetpack' ),
+					'external_handle'
+				),
+			),
+		);
+
 		return array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'jetpack-publicize-post-connection',
 			'type'       => 'object',
-			'properties' => array(
-				'id'              => array(
-					'description' => __( 'Unique identifier for the Jetpack Social connection', 'jetpack' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-				),
-				'service_name'    => array(
-					'description' => __( 'Alphanumeric identifier for the Jetpack Social service', 'jetpack' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-				),
-				'display_name'    => array(
-					'description' => __( 'Display name of the connected account', 'jetpack' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-				),
-				'username'        => array(
-					'description' => __( 'Username of the connected account', 'jetpack' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-				),
-				'profile_picture' => array(
-					'description' => __( 'Profile picture of the connected account', 'jetpack' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-				),
-				'enabled'         => array(
-					'description' => __( 'Whether to share to this connection', 'jetpack' ),
-					'type'        => 'boolean',
-					'context'     => array( 'edit' ),
-				),
-				'done'            => array(
-					'description' => __( 'Whether Jetpack Social has already finished sharing for this post', 'jetpack' ),
-					'type'        => 'boolean',
-					'context'     => array( 'edit' ),
-					'readonly'    => true,
-				),
-				'toggleable'      => array(
-					'description' => __( 'Whether `enable` can be changed for this post/connection', 'jetpack' ),
-					'type'        => 'boolean',
-					'context'     => array( 'edit' ),
-					'readonly'    => true,
-				),
-				'external_id'     => array(
-					'description' => __( 'The external ID of the connected account', 'jetpack' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-				),
+			'properties' => array_merge(
+				$deprecated_fields,
+				$connection_fields,
+				array(
+					'enabled' => array(
+						'description' => __( 'Whether to share to this connection.', 'jetpack' ),
+						'type'        => 'boolean',
+						'context'     => array( 'edit' ),
+					),
+				)
 			),
 		);
 	}

--- a/projects/plugins/jetpack/changelog/fix-wpcom-social-php-warnings
+++ b/projects/plugins/jetpack/changelog/fix-wpcom-social-php-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Social | Fix PHP warnings on WPCOM


### PR DESCRIPTION
In #41778, we updated the `Connections_Post_Field` class in publicize package to use the updated schema but its previous version inside Jetpack plugin seems to be used on WPCOM.

We have a [task to remove that class](https://github.com/Automattic/jetpack-reach/issues/719) but let us fix the issue on hand for now.

We removed [these fields](https://github.com/Automattic/jetpack/pull/41778/files#diff-149d284806dbb9124650978b0c6acef7d3a4437a73f215cdd64c347dd780ba6b) from the connection data in that class, we need to do the same in that Jetpack one to fix the warning

```
Warning: Undefined array key "unique_id" in
/.../_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php on line 251
```

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the unused fields from `WPCOM_REST_API_V2_Post_Publicize_Connections_Field` class.
* Sync the schema from `Connections_Post_Field` class in publicize package

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On production wpcom
* Point your simple site and the public API to your sandbox
* Run `tail -f /tmp/php-errors`
* Goto block editor
* Notice the PHP error mentioned above
* Now apply the PR to your sandbox
* Goto block editor again
* Confirm that there are no PHP errors
* Open Jetpack sidebar
* Confirm that the connections load fine for both new and existing posts
* Publish a post to confirm it gets shared
* Reshare a post to confirm it works fine

