### PR TITLE
Newsletter: Fix post placement not loading on certain themes

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-placement
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-placement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Newsletter: Fixed post placement not displaying on certain block themes

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
@@ -118,6 +118,13 @@ class Jetpack_Subscription_Site {
 	 * @return bool
 	 */
 	protected function is_single_post_context( $context ) {
+		/**
+		 * Some themes are not returning a WP_Block_Template. In that case, we need to check with is_singular function.
+		 */
+		if ( is_array( $context ) ) {
+			return is_singular( 'post' );
+		}
+
 		return $context instanceof WP_Block_Template && $context->slug === 'single';
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Although the core issue has been fixed in https://github.com/Automattic/jetpack/pull/39188, that PR introduced a regression where for some themes (like wp-dos) the Newsletter section wasn't displayed at all.

This PR fixes this regression.

Related to https://github.com/Automattic/jetpack/issues/38733

On certain block themes, the post placement at the bottom of the page was not displaying the newsletter section. This PR fixes this problem 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixed post placement not working on certain block themes

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install wp-dos theme
* Enable the post placement option in `Settings > Newsletter > Add the Subscribe Block at the end of each post.`
* Go to a frontend post and notice that the newsletter section is displayed

