### PR TITLE
Portfolios / Testimonials: Ensure Simple sites can use features regardless of theme

### DIFF
--- a/projects/packages/classic-theme-helper/changelog/update-portfolio-testimonial-settings-simple-sites
+++ b/projects/packages/classic-theme-helper/changelog/update-portfolio-testimonial-settings-simple-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Change only relevant for Simple sites.
+
+

--- a/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-portfolio.php
+++ b/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-portfolio.php
@@ -157,7 +157,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Jetpack_Portfolio' ) ) {
 		 */
 		public static function site_should_display_portfolios() {
 			$should_display = true;
-			if ( Blocks::is_fse_theme() ) {
+			if ( ( ! ( new Host() )->is_wpcom_platform() ) && Blocks::is_fse_theme() ) {
 				if ( ! get_option( self::OPTION_NAME, '0' ) ) {
 					$should_display = false;
 				}

--- a/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-portfolio.php
+++ b/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-portfolio.php
@@ -157,7 +157,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Jetpack_Portfolio' ) ) {
 		 */
 		public static function site_should_display_portfolios() {
 			$should_display = true;
-			if ( ( ! ( new Host() )->is_wpcom_platform() ) && Blocks::is_fse_theme() ) {
+			if ( ( ! ( new Host() )->is_wpcom_simple() ) && Blocks::is_fse_theme() ) {
 				if ( ! get_option( self::OPTION_NAME, '0' ) ) {
 					$should_display = false;
 				}

--- a/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-testimonial.php
+++ b/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-testimonial.php
@@ -155,7 +155,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Jetpack_Testimonial' ) ) {
 		 */
 		public static function site_should_display_testimonials() {
 			$should_display = true;
-			if ( ( ! ( new Host() )->is_wpcom_platform() ) && Blocks::is_fse_theme() ) {
+			if ( ( ! ( new Host() )->is_wpcom_simple() ) && Blocks::is_fse_theme() ) {
 				if ( ! get_option( self::OPTION_NAME, '0' ) ) {
 					$should_display = false;
 				}

--- a/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-testimonial.php
+++ b/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-testimonial.php
@@ -155,7 +155,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Jetpack_Testimonial' ) ) {
 		 */
 		public static function site_should_display_testimonials() {
 			$should_display = true;
-			if ( Blocks::is_fse_theme() ) {
+			if ( ( ! ( new Host() )->is_wpcom_platform() ) && Blocks::is_fse_theme() ) {
 				if ( ! get_option( self::OPTION_NAME, '0' ) ) {
 					$should_display = false;
 				}


### PR DESCRIPTION
Follow up to https://github.com/Automattic/jetpack/pull/41714

## Proposed changes:

* This PR wraps functionality added in the above PR in a WPcom check, to ensure that Simple sites retain the same functionality as before.
* The reason for this is because existing processes do at times rely on testimonials and portfolios when attempting to build specific sites for customers, regardless of theme, given Simple site constraints. See pfwV0U-ik-p2#comment-423 
* Allowing the functionality to continue to be present for Simple sites regardless of theme solves this issue for now, while discussion takes place about best next steps there.
* The issue that exists for Simple sites is not an issue for WoA or self-hosted sites (once the changes in the other PR are live there), because both have the option of using the new hook to force the custom post types to be enabled if needed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1739886885183399/1739877591.257289-slack-CB0B2G43X
pfwV0U-ik-p2#comment-423

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Self-hosted / WoA:
* Test as in https://github.com/Automattic/jetpack/pull/41714 - this PR shouldn't impact the changes implemented there

Simple:
* On a sandboxed Simple site, use the commands in the generated comment below to apply the changes.
* Test using the steps in https://github.com/Automattic/jetpack/pull/41714 - however in the scenarios where you shouldn't see CPT sections, you should be able to still see them with this PR applied.