### PR TITLE
My Jetpack: move product card status before action for screen readers

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
@@ -149,6 +149,13 @@ const ProductCard: FC< ProductCardProps > = props => {
 				<RecommendationActions slug={ slug } />
 			) : (
 				<div className={ styles.actions }>
+					<Status
+						status={ status }
+						isFetching={ isLoading }
+						isInstallingStandalone={ false }
+						isOwned={ isOwned }
+						suppressNeedsAttention={ slug === 'protect' }
+					/>
 					<div className={ styles.buttons }>
 						{ secondaryAction && secondaryAction?.positionFirst && (
 							<SecondaryButton { ...secondaryAction } />
@@ -165,13 +172,6 @@ const ProductCard: FC< ProductCardProps > = props => {
 							<SecondaryButton { ...secondaryAction } />
 						) }
 					</div>
-					<Status
-						status={ status }
-						isFetching={ isLoading }
-						isInstallingStandalone={ false }
-						isOwned={ isOwned }
-						suppressNeedsAttention={ slug === 'protect' }
-					/>
 				</div>
 			) }
 		</Card>

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -20,6 +20,7 @@ $status-size: 8px;
 
 .actions {
 	display: flex;
+	flex-direction: row-reverse;
 	align-items: center;
 	justify-content: space-between;
 	width: 100%;

--- a/projects/packages/my-jetpack/changelog/fix-invert-my-jp-product-card-actions
+++ b/projects/packages/my-jetpack/changelog/fix-invert-my-jp-product-card-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Move product card status before action for screen readers


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
On the My Jetpack page, the action and status elements follow the reading direction in that order. While it's not an issue when we consider the UI, it's not ideal for screen reader users. In the example below, the reader would read _Connect_ before reading _Needs connection_. It'd be best to inform users about the status before asking them to take action.
<img width="333" alt="Screenshot 2025-02-18 at 1 05 50 PM" src="https://github.com/user-attachments/assets/a034f0fc-5658-44ee-84b6-2ff02ff8ded6" />


This PR fixes it by keeping the UI as is but swapping both elements in the DOM.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Epic: https://github.com/Automattic/vulcan/issues/710

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test Jetpack site
- Visit  `/wp-admin/admin.php?page=my-jetpack`
- If you're familiar with screen readers, ensure the status is read before the action
- Otherwise, open the dev tool and check that the status element is before the action element in the DOM
- Ensure the UI hasn't changed

