### PR TITLE
 My Jetpack: increase product card status contrast ratio

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/styles.module.scss
@@ -40,7 +40,7 @@ $myjetpack-connection-avatar-overlap: 10px;
 		}
 
 		.warning {
-			border-color: var( --jp-yellow-40 );
+			border-color: var( --jp-yellow-50 );
 		}
 	}
 
@@ -70,8 +70,8 @@ $myjetpack-connection-avatar-overlap: 10px;
 			}
 
 			&.warning {
-				color: var( --jp-yellow-40 );
-				fill: var( --jp-yellow-40 );
+				color: var( --jp-yellow-50 );
+				fill: var( --jp-yellow-50 );
 			}
 
 			&.success {

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -91,7 +91,7 @@ $status-size: 8px;
 	$statuses: (
 		"active": "--jp-green-50",
 		"inactive": "--jp-gray-50",
-		"warning": "--jp-yellow-40",
+		"warning": "--jp-yellow-50",
 		"error": "--jp-red-60"
 	);
 

--- a/projects/packages/my-jetpack/changelog/fix-my-jp-product-card-status-color
+++ b/projects/packages/my-jetpack/changelog/fix-my-jp-product-card-status-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+ Increase product card status contrast ratio


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
On the My Jetpack page, the color contrast ratio of the status element (against the white background) is 3:1, which is too low for a text that size according to the [WCAG guidelines](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html). It should be at least 4.5:1.

This PR fixes it by replacing the current color, `jp-yellow-40`, by `jp-yellow-50`. For information, [Color studio](https://color-studio.blog/) includes the contrast ratio against a white background.

| Before | After |
| - | - |
|![kevinho jurassic tube_wp-admin_admin php_page=my-jetpack](https://github.com/user-attachments/assets/720997fb-ccb5-4724-883b-8efd134caf62)|![kevinho jurassic tube_wp-admin_admin php_page=my-jetpack (1)](https://github.com/user-attachments/assets/77676159-76a4-4af6-b5eb-6a62924d4923)|



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Epic: https://github.com/Automattic/vulcan/issues/710

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test Jetpack site
- Visit  `/wp-admin/admin.php?page=my-jetpack`
- Inspect the status element of a product card in the _My Products_ section
- The color should be `jp-yellow-50`

