### PR TITLE
Account Protection: Protect: Add optimistic update revert

### DIFF
--- a/projects/plugins/protect/src/js/data/account-protection/use-toggle-account-protection-module-mutation.ts
+++ b/projects/plugins/protect/src/js/data/account-protection/use-toggle-account-protection-module-mutation.ts
@@ -16,7 +16,7 @@ export default function useToggleAccountProtectionMutation(): UseMutationResult 
 
 	return useMutation( {
 		mutationFn: API.toggleAccountProtection,
-		onMutate: async () => {
+		onMutate: () => {
 			showSavingNotice();
 
 			// Get the current cached data
@@ -37,7 +37,15 @@ export default function useToggleAccountProtectionMutation(): UseMutationResult 
 		onSuccess: () => {
 			showSuccessNotice( __( 'Changes saved.', 'jetpack-protect' ) );
 		},
-		onError: () => {
+		onError: ( error, variables, context ) => {
+			// If the request failed, revert the optimistic update.
+			if ( context?.previousData ) {
+				queryClient.setQueryData< AccountProtectionStatus >(
+					[ QUERY_ACCOUNT_PROTECTION_KEY ],
+					context.previousData
+				);
+			}
+
 			showErrorNotice( __( 'An error occurred.', 'jetpack-protect' ) );
 		},
 		onSettled: () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Minor enhancements I thought of while reviewing https://github.com/Automattic/jetpack/pull/41875

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Revert optimistic update when request fails.
* Removes `async` from sync function.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack/pull/41875

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test the account protection toggle in Jetpack Protect.
  * Manually throw an error in the API response to test the data revert.

