### PR TITLE
Jetpack E2E: Additional Account Protection Tests

### DIFF
--- a/projects/plugins/jetpack/tests/e2e/specs/post-connection/account-protection.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/post-connection/account-protection.test.js
@@ -1,6 +1,7 @@
 import { prerequisitesBuilder } from '_jetpack-e2e-commons/env/index.js';
 import { test, expect } from '_jetpack-e2e-commons/fixtures/base-test.js';
 import { WPLoginPage } from '_jetpack-e2e-commons/pages/wp-admin/index.js';
+import ProfilePage from '_jetpack-e2e-commons/pages/wp-admin/profile.js';
 import {
 	getAccountProtectionAuthCodeFromTransient,
 	getAccountProtectionTokenFromUrl,
@@ -143,5 +144,86 @@ test.describe.parallel( 'Compromised Password Detection', () => {
 		await loginPage.waitForElementToBeHidden( '.action-update-password' );
 
 		expect( page.url() ).toContain( '/profile.php#password' );
+	} );
+} );
+
+test.describe.parallel( 'Strong password requirements', () => {
+	test.beforeAll( async ( { browser } ) => {
+		// Set up a clean environment with account protection enabled.
+		const page = await browser.newPage( playwrightConfig.use );
+
+		await prerequisitesBuilder( page )
+			.withCleanEnv()
+			.withLoggedIn( true )
+			.withInactiveModules( [ 'protect', 'sso' ] )
+			.withActiveModules( [ 'account-protection' ] )
+			.withConnection( true )
+			.build();
+
+		await page.close();
+	} );
+
+	test( 'Enforces strong password requirements', async ( { page } ) => {
+		const profilePage = await ProfilePage.visit( page );
+
+		await profilePage.page.getByRole( 'button' ).filter( { hasText: 'set new password' } ).click();
+
+		// Validate that the Jetpack password strength meter replaces the default one.
+		await expect( profilePage.page.locator( '.strength-meter' ) ).toBeVisible();
+		await expect( profilePage.page.locator( '#pass-strength-result' ) ).toBeHidden();
+		await expect( profilePage.page.getByRole( 'checkbox', { name: 'pw_weak' } ) ).toBeHidden();
+
+		// Wait for the default password to be validated.
+		await expect( profilePage.page.locator( '#pass1' ) ).not.toBeEmpty();
+		await expect(
+			profilePage.page.locator( '.strength-meter' ).filter( { hasNotText: 'Validating' } )
+		).toBeVisible();
+
+		// Enter a weak password.
+		const passwordInput = profilePage.page.locator( '#pass1' );
+		await passwordInput.fill( 'password' );
+		await passwordInput.evaluate( input => {
+			input.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		} );
+
+		// Validate that the Jetpack password strength meter displays "Weak".
+		await expect( profilePage.page.locator( '.strength-meter' ).getByText( 'Weak' ) ).toBeVisible();
+		await expect( profilePage.page.getByText( 'Strong password' ) ).toHaveCSS(
+			'color',
+			'rgb(230, 80, 84)'
+		);
+		await expect( profilePage.page.getByText( 'Not a leaked password' ) ).toHaveCSS(
+			'color',
+			'rgb(230, 80, 84)'
+		);
+		await expect( profilePage.page.getByText( 'Between 6 and 150 characters' ) ).toHaveCSS(
+			'color',
+			'rgb(0, 135, 16)'
+		);
+		await expect( profilePage.page.getByText( "Doesn't match existing user data" ) ).toHaveCSS(
+			'color',
+			'rgb(0, 135, 16)'
+		);
+		await expect( profilePage.page.getByText( 'Not used recently' ) ).toHaveCSS(
+			'color',
+			'rgb(0, 135, 16)'
+		);
+
+		await expect( profilePage.page.getByText( 'Confirm use of weak password' ) ).toBeVisible();
+		await expect( profilePage.page.getByText( 'Update Profile', { exact: true } ) ).toBeDisabled();
+
+		// check the checkbox to disable the weak password.
+		await profilePage.page.locator( '.pw-checkbox' ).check();
+
+		await expect( profilePage.page.getByText( 'Update Profile', { exact: true } ) ).toBeEnabled();
+
+		// update the password.
+		await profilePage.page.getByText( 'Update Profile', { exact: true } ).click();
+
+		// Wait for the navigation to complete.
+		await profilePage.page.waitForURL( '/wp-admin/profile.php' );
+
+		// Validate that the password was updated.
+		await expect( profilePage.page.getByText( 'Profile updated.' ) ).toBeVisible();
 	} );
 } );

--- a/tools/e2e-commons/pages/wp-admin/profile.js
+++ b/tools/e2e-commons/pages/wp-admin/profile.js
@@ -1,0 +1,9 @@
+import { resolveSiteUrl } from '../../helpers/utils-helper.js';
+import WpPage from '../wp-page.js';
+
+export default class ProfilePage extends WpPage {
+	constructor( page ) {
+		const url = `${ resolveSiteUrl() }/wp-admin/profile.php`;
+		super( page, { expectedSelectors: [ '#profile-page' ], url } );
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Additional E2E test coverage for the account protection password strength meter on the profile page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack-scan-team/issues/1696

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See [the E2E README](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/tests/e2e/README.md) to run tests locally. You can use pnpm test:run ./specs/post-connection/account-protection.test.js with optional --headed param for a live browser preview of the tests exection, or --debug to step through tests with debug tools.
* Alternatively, you can review the logs from the automated test run on this PR.

