### PR TITLE
Newsletter settings: update newsletter categories settings copy

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -1,14 +1,14 @@
 import { ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
+import React, { useCallback, useMemo } from 'react';
+import { connect } from 'react-redux';
 import { createNotice } from 'components/global-notices/state/notices/actions';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { FEATURE_NEWSLETTER_JETPACK } from 'lib/plans/constants';
-import { createInterpolateElement } from 'node_modules/@wordpress/element/build-types';
-import React, { useCallback, useMemo } from 'react';
-import { connect } from 'react-redux';
 import {
 	isUnavailableInOfflineMode,
 	requiresConnection,
@@ -142,11 +142,11 @@ function NewsletterCategories( props ) {
 				<p>
 					{ createInterpolateElement(
 						__(
-							'Newsletter categories let visitors subscribe to specific topics. When enabled, only posts in the selected categories will be emailed. By default, subscribers can choose from your selected categories, or you can pre-select categories in the <link>subscribe block</link>.',
+							'Newsletter categories let visitors subscribe to specific topics. When enabled, only posts in the selected categories will be emailed. By default, subscribers can choose from your selected categories, or you can pre-select categories in the <docsLink>subscribe block</docsLink>.',
 							'jetpack'
 						),
 						{
-							link: (
+							docsLink: (
 								<ExternalLink href="https://jetpack.com/support/jetpack-blocks/subscription-form-block/" />
 							),
 						}

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -1,12 +1,14 @@
 import { ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import React, { useCallback, useMemo } from 'react';
-import { connect } from 'react-redux';
 import { createNotice } from 'components/global-notices/state/notices/actions';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { FEATURE_NEWSLETTER_JETPACK } from 'lib/plans/constants';
+import { createInterpolateElement } from 'node_modules/@wordpress/element/build-types';
+import React, { useCallback, useMemo } from 'react';
+import { connect } from 'react-redux';
 import {
 	isUnavailableInOfflineMode,
 	requiresConnection,
@@ -138,9 +140,16 @@ function NewsletterCategories( props ) {
 				} }
 			>
 				<p>
-					{ __(
-						'Newsletter categories allow visitors to subscribe only to specific topics. When enabled, only posts published under the categories selected below will be emailed to your subscribers.',
-						'jetpack'
+					{ createInterpolateElement(
+						__(
+							'Newsletter categories let visitors subscribe to specific topics. When enabled, only posts in the selected categories will be emailed. By default, subscribers can choose from your selected categories, or you can pre-select categories in the <link>subscribe block</link>.',
+							'jetpack'
+						),
+						{
+							link: (
+								<ExternalLink href="https://jetpack.com/support/jetpack-blocks/subscription-form-block/" />
+							),
+						}
 					) }
 				</p>
 				<div className="newsletter-categories-toggle-wrapper">

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -147,7 +147,7 @@ function NewsletterCategories( props ) {
 						),
 						{
 							docsLink: (
-								<ExternalLink href="https://jetpack.com/support/jetpack-blocks/subscription-form-block/" />
+								<ExternalLink href={ getRedirectUrl( 'jetpack-support-subscribe-block' ) } />
 							),
 						}
 					) }

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -142,7 +142,7 @@ function NewsletterCategories( props ) {
 				<p>
 					{ createInterpolateElement(
 						__(
-							'Newsletter categories let visitors subscribe to specific topics. When enabled, only posts in the selected categories will be emailed. By default, subscribers can choose from your selected categories, or you can pre-select categories in the <docsLink>subscribe block</docsLink>.',
+							"Newsletter categories let you select the content that's emailed to subscribers. When enabled, only posts in the selected categories will be sent as newsletters. By default, subscribers can choose from your selected categories, or you can pre-select categories using the <docsLink>subscribe block</docsLink>.",
 							'jetpack'
 						),
 						{

--- a/projects/plugins/jetpack/changelog/update-newsletter-categories-settings-copy
+++ b/projects/plugins/jetpack/changelog/update-newsletter-categories-settings-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter settings: update copy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to Automattic/loop#487

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the copy for the Newsletter Categories settings to better explain the feature

| Before | After |
|-|-|
| <img width="1044" alt="image" src="https://github.com/user-attachments/assets/46686908-61c1-4455-b671-823c0b4596b7" /> | <img width="1044" alt="image" src="https://github.com/user-attachments/assets/700e8e6a-cc83-4cf5-8418-f766bf432103" /> |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate this branch on a Jetpack site
* Go to Jetpack -> Settings -> Newsletter -> Newsletter Categories
* Ensure the copy matches what's in Automattic/loop#487
* Ensure the link to the subscribe block docs works as expected

