### PR TITLE
MU WPCOM: Filter out the full-site-editing plugin from the active_plugins list if the plugin file doesn't exist (2nd try)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/feat-remove-fse-from-active-plugins
+++ b/projects/packages/jetpack-mu-wpcom/changelog/feat-remove-fse-from-active-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+MU WPCOM: Filter out the full-site-editing plugin from the active_plugins list if the plugin file doesn't exist

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -257,6 +257,7 @@ class Jetpack_Mu_Wpcom {
 
 		require_once __DIR__ . '/features/jetpack-global-styles/class-global-styles.php';
 		require_once __DIR__ . '/features/mailerlite/subscriber-popup.php';
+		require_once __DIR__ . '/features/wpcom-fse/wpcom-fse.php';
 
 		/**
 		 * Load features for the editor and the frontend pages.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-fse/wpcom-fse.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-fse/wpcom-fse.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This is a feature to remove FSE plugin since it has been sunset for a while.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Remove FSE plugin from the active_plugins list if the file doesn't exist.
+ *
+ * @param array<string> $plugins The list of the active plugins.
+ * @return array<string> The filtered active plugins.
+ */
+function remove_fse_plugin( $plugins ) {
+	$fse_plugin      = 'full-site-editing/full-site-editing-plugin.php';
+	$fse_plugin_path = WP_PLUGIN_DIR . '/' . $fse_plugin;
+
+	// Do nothing since the plugin file exists.
+	if ( file_exists( $fse_plugin_path ) && is_file( $fse_plugin_path ) ) {
+		return $plugins;
+	}
+
+	// Remove the plugin from the list of active plugins as the file doesn't exist.
+	$fse_plugin_key = array_search( $fse_plugin, $plugins, true );
+	if ( $fse_plugin_key !== false ) {
+		unset( $plugins[ $fse_plugin_key ] );
+	}
+
+	return $plugins;
+}
+add_filter( 'option_active_plugins', 'remove_fse_plugin' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-fse/wpcom-fse.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-fse/wpcom-fse.php
@@ -12,6 +12,10 @@
  * @return array<string> The filtered active plugins.
  */
 function remove_fse_plugin( $plugins ) {
+	if ( ! is_array( $plugins ) ) {
+		return $plugins;
+	}
+
 	$fse_plugin      = 'full-site-editing/full-site-editing-plugin.php';
 	$fse_plugin_path = WP_PLUGIN_DIR . '/' . $fse_plugin;
 

--- a/projects/plugins/mu-wpcom-plugin/changelog/feat-remove-fse-from-active-plugins
+++ b/projects/plugins/mu-wpcom-plugin/changelog/feat-remove-fse-from-active-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+MU WPCOM: Filter out the full-site-editing plugin from the active_plugins list if the plugin file doesn't exist

--- a/projects/plugins/wpcomsh/changelog/feat-remove-fse-from-active-plugins
+++ b/projects/plugins/wpcomsh/changelog/feat-remove-fse-from-active-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+MU WPCOM: Filter out the full-site-editing plugin from the active_plugins list if the plugin file doesn't exist


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to p1737694462032909/1737565339.870709-slack-CRWCHQGUB, 169775-ghe-Automattic/wpcom

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

**UPDATE**

This is the 2nd try and the previous one, https://github.com/Automattic/jetpack/pull/41841, has been reverted by https://github.com/Automattic/jetpack/pull/41886 because of the error below. See p1739932956773779-slack-C4N88L95W

```
Uncaught TypeError: array_search(): Argument #2 ($haystack) must be of type array, string given
```

It should be fixed by [c7e93ce](https://github.com/Automattic/jetpack/pull/41887/commits/c7e93ce08b469022307719f3bfc1a06f581f1c60). But, weirdly, I cannot reproduce this issue on my wpcom site as it gets an array instead of empty string 🫠

---

* The plugin `full-site-editing` was removed using the task API with the CLI command below. However, this caused an issue where the plugin is still listed in the `active_plugins` option. Therefore, this PR filters it out from active_plugins if the plugin file has already been removed.
  `wp --skip-plugins --skip-themes plugin delete full-site-editing`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to your atomic site
* Install [WordPress.com Editing Toolkit](https://arthurwoadevblog12345.com/wp-admin/plugin-install.php?tab=plugin-information&plugin=full-site-editing&TB_iframe=true&width=600&height=550)
* Run the following command to remove the plugin:
  `wp --skip-plugins --skip-themes plugin delete full-site-editing`
* Run the following command to check whether the `full-site-editing` plugin is still listed in the `active_plugins` option
  `wp option get active_plugins`
* Apply changes to your atomic site
* Run the above command again and the `full-site-editing` plugin should not be listed in the `active_plugins` option