### PR TITLE
Social | Fix plugin version in admin page footer

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-admin-footer-version
+++ b/projects/js-packages/publicize-components/changelog/fix-social-admin-footer-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social | Fix plugin version in admin page footer

--- a/projects/js-packages/publicize-components/src/components/admin-page/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/admin-page/index.tsx
@@ -51,9 +51,11 @@ export const SocialAdminPage = () => {
 		};
 	}, [] );
 
-	const socialPluginVersion = getSocialScriptData().plugin_info.social.version;
+	const { social, jetpack } = getSocialScriptData().plugin_info;
 
-	const moduleName = `Jetpack Social ${ socialPluginVersion }`;
+	const moduleName = social.version
+		? `Jetpack Social ${ social.version }`
+		: `Jetpack ${ jetpack.version }`;
 
 	if ( showConnectionCard ) {
 		return (
@@ -93,7 +95,7 @@ export const SocialAdminPage = () => {
 						{ isModuleEnabled && <UtmToggle /> }
 						{
 							// Only show the Social Notes toggle if Social plugin is active
-							socialPluginVersion && isModuleEnabled && (
+							social.version && isModuleEnabled && (
 								<SocialNotesToggle disabled={ isUpdatingJetpackSettings } />
 							)
 						}


### PR DESCRIPTION
Currently
> When only Jetpack is active, the footer on the Social admin page says, `"Jetpack Social null"`
> 
> <img width="413" alt="Image" src="https://github.com/user-attachments/assets/d6bcffe3-ec3b-42b5-b339-15c8a4970a9e" />

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix the plugin version on Social admin page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate Social and deactivate Jetpack
* Goto Social admin page
* Confirm that the footer version is correct - `Jetpack Social 6.x.x`
* Activate Jetpack
* Confirm that the version is still the same
* Deactivate Social
* Confirm that the footer now says, `Jetpack 14.x`

<img width="420" alt="image" src="https://github.com/user-attachments/assets/f6b2a1ba-2a08-4f35-ad9d-a93e9b19c2d8" />


<img width="457" alt="image" src="https://github.com/user-attachments/assets/1191c168-c673-425f-bf7c-9a1ebce3e200" />


