### PR TITLE
Launchpad: Add `goals` prop to `wpcom_launchpad_mark_task_complete` event

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-goals-task-complete-tracks-event
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-goals-task-complete-tracks-event
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Add goals prop to wpcom_launchpad_mark_task_complete event


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/98623

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the `goals` prop to the `wpcom_launchpad_mark_task_complete` event

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No (we already know the goals the user selected, so no new data collected)

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply to sandbox
* Create a new simple site with some goals (remember the goals)
* Complete one of the tasks on the launchpad
* Wait in tracks view for the `wpcom_launchpad_mark_task_complete` event to appear
* Confirm the correct `goals` prop was recoreded

