### PR TITLE
Performance: avoid unnecessary hosting provider detection when possible.

### DIFF
--- a/projects/js-packages/script-data/changelog/update-usage-get-nameserver-dns-records
+++ b/projects/js-packages/script-data/changelog/update-usage-get-nameserver-dns-records
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Script data: remove unneeded specific host check.

--- a/projects/js-packages/script-data/src/utils.ts
+++ b/projects/js-packages/script-data/src/utils.ts
@@ -1,16 +1,3 @@
-import { AdminSiteData } from './types';
-
-/**
- * Values come from https://github.com/Automattic/jetpack/blob/128db0505a27dcdcdef5946d60f443173b2ef6cd/projects/packages/status/src/class-host.php#L240
- */
-const NON_SELF_HOSTED_TYPES: Array< AdminSiteData[ 'host' ] > = [
-	'woa',
-	'atomic',
-	'newspack',
-	'vip',
-	'wpcom',
-];
-
 /**
  * Get the script data from the window object.
  *
@@ -126,5 +113,5 @@ export function isWpcomPlatformSite() {
  * @return {boolean} Whether the site is self-hosted Jetpack site.
  */
 export function isJetpackSelfHostedSite() {
-	return ! NON_SELF_HOSTED_TYPES.includes( getSiteData()?.host );
+	return getScriptData()?.site?.host === 'unknown';
 }

--- a/projects/packages/my-jetpack/.phan/baseline.php
+++ b/projects/packages/my-jetpack/.phan/baseline.php
@@ -13,15 +13,15 @@ return [
     // PhanTypeMismatchPropertyDefault : 15+ occurrences
     // PhanAbstractStaticMethodCallInStatic : 8 occurrences
     // PhanTypeMismatchReturnProbablyReal : 8 occurrences
-    // PhanNoopNew : 7 occurrences
-    // PhanTypeMismatchReturn : 5 occurrences
+    // PhanNoopNew : 6 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 4 occurrences
+    // PhanTypeMismatchReturn : 4 occurrences
     // PhanTypeMismatchReturnNullable : 3 occurrences
+    // PhanUndeclaredClassMethod : 3 occurrences
     // PhanImpossibleCondition : 2 occurrences
     // PhanNonClassMethodCall : 2 occurrences
     // PhanRedundantCondition : 2 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 2 occurrences
-    // PhanUndeclaredClassMethod : 2 occurrences
     // PhanPluginMixedKeyNoKey : 1 occurrence
     // PhanTypeMismatchArgumentNullableInternal : 1 occurrence
     // PhanTypeSuspiciousNonTraversableForeach : 1 occurrence
@@ -29,7 +29,7 @@ return [
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-activitylog.php' => ['PhanTypeMismatchArgumentProbablyReal'],
-        'src/class-initializer.php' => ['PhanImpossibleCondition', 'PhanNoopNew', 'PhanRedundantCondition', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanUndeclaredClassMethod'],
+        'src/class-initializer.php' => ['PhanImpossibleCondition', 'PhanNoopNew', 'PhanRedundantCondition', 'PhanTypeMismatchReturnNullable', 'PhanUndeclaredClassMethod'],
         'src/class-jetpack-manage.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'src/class-products.php' => ['PhanNonClassMethodCall'],
         'src/class-rest-products.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeMismatchReturn'],

--- a/projects/packages/my-jetpack/changelog/update-usage-get-nameserver-dns-records
+++ b/projects/packages/my-jetpack/changelog/update-usage-get-nameserver-dns-records
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Script data: remove unused property.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -303,7 +303,6 @@ class Initializer {
 				),
 				'isStatsModuleActive'    => $modules->is_active( 'stats' ),
 				'canUserViewStats'       => current_user_can( 'manage_options' ) || current_user_can( 'view_stats' ),
-				'isUserFromKnownHost'    => self::is_user_from_known_host(),
 				'isCommercial'           => self::is_commercial_site(),
 				'sandboxedDomain'        => $sandboxed_domain,
 				'isDevVersion'           => $is_dev_version,
@@ -513,16 +512,6 @@ class Initializer {
 		}
 
 		return true;
-	}
-
-	/**
-	 * Determines whether the user has come from a host we can recognize.
-	 *
-	 * @return string
-	 */
-	public static function is_user_from_known_host() {
-		// Known (external) host is the one that has been determined and is not dotcom.
-		return ! in_array( ( new Status_Host() )->get_known_host_guess(), array( 'unknown', 'wpcom' ), true );
 	}
 
 	/**

--- a/projects/packages/publicize/changelog/update-usage-get-nameserver-dns-records
+++ b/projects/packages/publicize/changelog/update-usage-get-nameserver-dns-records
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Script data: extract less detailed host information.

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -70,7 +70,7 @@ class Publicize_Script_Data {
 		$data['site']['wpcom']['blog_id'] = Manager::get_site_id( true );
 		$data['site']['suffix']           = ( new Status() )->get_site_suffix();
 		if ( ! isset( $data['site']['host'] ) ) {
-			$data['site']['host'] = ( new Host() )->get_known_host_guess();
+			$data['site']['host'] = ( new Host() )->get_known_host_guess( false );
 		}
 
 		self::set_wpcom_user_data( $data['user']['current_user'] );

--- a/projects/packages/status/changelog/update-usage-get-nameserver-dns-records
+++ b/projects/packages/status/changelog/update-usage-get-nameserver-dns-records
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Host detection: only look for specific external hosting provider when required.

--- a/projects/packages/status/src/class-host.php
+++ b/projects/packages/status/src/class-host.php
@@ -235,9 +235,13 @@ class Host {
 	/**
 	 * Returns a guess of the hosting provider for the current site based on various checks.
 	 *
+	 * @since $$next-version$$ Added $guess parameter.
+	 *
+	 * @param bool $guess Whether to guess the hosting provider.
+	 *
 	 * @return string
 	 */
-	public function get_known_host_guess() {
+	public function get_known_host_guess( $guess = true ) {
 		$host = Cache::get( 'host_guess' );
 
 		if ( null !== $host ) {
@@ -267,9 +271,10 @@ class Host {
 				break;
 		}
 
-		// Second, let's check if we can recognize provider by nameservers:
+		// Second, let's check if we can recognize provider by nameservers.
+		// Only do this if we're asked to guess.
 		$domain = isset( $_SERVER['SERVER_NAME'] ) ? sanitize_text_field( wp_unslash( $_SERVER['SERVER_NAME'] ) ) : '';
-		if ( $provider === 'unknown' && ! empty( $domain ) ) {
+		if ( $provider === 'unknown' && ! empty( $domain ) && $guess ) {
 			$provider = $this->get_hosting_provider_by_nameserver( $domain );
 		}
 

--- a/projects/plugins/boost/app/admin/class-config.php
+++ b/projects/plugins/boost/app/admin/class-config.php
@@ -29,7 +29,7 @@ class Config {
 				'url'    => get_home_url(),
 				'domain' => ( new Status() )->get_site_suffix(),
 				'online' => ! ( new Status() )->is_offline_mode() && ! ( new Status() )->is_private_site(),
-				'host'   => ( new Host() )->get_known_host_guess(),
+				'host'   => $this->get_hosting_provider(),
 			),
 			'api'                 => array(
 				'namespace' => JETPACK_BOOST_REST_NAMESPACE,
@@ -68,5 +68,27 @@ class Config {
 		$post_types = array_filter( $post_types, 'is_post_type_viewable' );
 
 		return wp_list_pluck( $post_types, 'label', 'name' );
+	}
+
+	/**
+	 * Retrieves the hosting provider.
+	 * We're only interested in 'atomic' or 'woa' for now.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string The hosting provider.
+	 */
+	private static function get_hosting_provider() {
+		$host = new Host();
+
+		if ( $host->is_woa_site() ) {
+			return 'woa';
+		}
+
+		if ( $host->is_atomic_platform() ) {
+			return 'atomic';
+		}
+
+		return 'other';
 	}
 }

--- a/projects/plugins/boost/changelog/update-usage-get-nameserver-dns-records
+++ b/projects/plugins/boost/changelog/update-usage-get-nameserver-dns-records
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Performance: only look for specific hosting providers in admin page.


### PR DESCRIPTION
## Proposed changes:

This PR brings in a number of changes to improve performance around host detection in our plugins (plugins using My Jetpack, Boost, Social). In general, this starts from a simple premise: in many situations in our codebase, we do not need to know the specific hosting provider on a given site ; we really only want to know that the site is hosted on a specific WordPress.com platform.

- In the Boost plugin (#39155) and in the Social plugin (#41076), we're interested in knowing whether the site is an Atomic site or a WoA site.
- In My Jetpack, we had added host detection in #34864, but we never leveraged that. It can consequently be removed.

All this will also have a nice side-effect ; we will no longer see an error when installing Jetpack on a site built with Studio / Playground. See https://github.com/Automattic/dotcom-forge/issues/10427 for more info.

> [!NOTE]
> I added the " I don't care about code coverage for this PR" to this PR since I'm making changes to an existing file that has no tests so far. I would have added some, but it seems there are no tests for the whole Boost app/admin page right now.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1739556085639269/1739552940.621129-slack-C06DRMD6VPZ

## Does this pull request change what data or activity we track or use?
* No

## Testing instructions:

> [!NOTE]
> This needs to be tested on 3 different plugins, installed separately: Jetpack, Boost, and Social.

**Jetpack (My Jetpack)**

1. Install the Jetpack plugin
2. Go to Jetpack > My Jetpack
    * Everything will continue to work just like before.

**Boost**

1. Switch to this branch on 3 sites: a self-hosted site (not Jurassic Ninja), a WPCloud site (e.g. Pressable), and a WoA site
2. Go to Jetpack > Boost
    * On the WoA site, the Page Cache should appear as "active", but can't be toggled. A notice appears under the toggle.
    * On the WPCloud site, the behaviour should be just like above, but with a different notice.
    * On the self-hosted site, you should be able to toggle things on and off.

**Social**

1. Switch to this branch on 2 sites: a WoA site, and a self-hosted site.
2. Go to Jetpack > Social
    * On the WoA site, the support link at the bottom of the page should point to `https://jetpack.com/redirect/?source=wpcom-contact-support`
    * On the self-hosted site, it points to `https://jetpack.com/redirect/?source=jetpack-contact-support`

  
