### PR TITLE
My Jetpack: improve product card acessibility

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/action-button/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/action-button/index.tsx
@@ -12,7 +12,6 @@ import useAnalytics from '../../hooks/use-analytics';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 import useOutsideAlerter from '../../hooks/use-outside-alerter';
-import { getProductCardTitleId } from '../product-card';
 import styles from './style.module.scss';
 import type { SecondaryButtonProps } from './secondary-button';
 import type { AdditionalAction } from './types';
@@ -28,6 +27,7 @@ type ActionButtonProps = {
 	setIsActionLoading?: ( value: SetStateAction< boolean > ) => void;
 	className?: string;
 	tracksIdentifier?: `${ string }_${ string }`;
+	labelSuffixId?: string;
 };
 
 const ActionButton: FC< ActionButtonProps > = ( {
@@ -38,6 +38,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 	setIsActionLoading,
 	className,
 	tracksIdentifier,
+	labelSuffixId,
 } ) => {
 	const { userIsAdmin, lifecycleStats } = getMyJetpackWindowInitialState();
 	const { ownedProducts } = lifecycleStats;
@@ -74,7 +75,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 	const admin = !! userIsAdmin;
 	const troubleshootBackupsUrl =
 		'https://jetpack.com/support/backup/troubleshooting-jetpack-backup/';
-	const labelledBy = `${ getActionButtonId( slug ) } ${ getProductCardTitleId( slug ) }`;
+	const labelledBy = `${ getActionButtonId( slug ) } ${ labelSuffixId || '' }`.trim();
 
 	const buttonState = useMemo< Partial< SecondaryButtonProps > >( () => {
 		return {

--- a/projects/packages/my-jetpack/_inc/components/action-button/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/action-button/index.tsx
@@ -12,10 +12,13 @@ import useAnalytics from '../../hooks/use-analytics';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 import useOutsideAlerter from '../../hooks/use-outside-alerter';
+import { getProductCardTitleId } from '../product-card';
 import styles from './style.module.scss';
 import type { SecondaryButtonProps } from './secondary-button';
 import type { AdditionalAction } from './types';
 import type { FC, ComponentProps, MouseEvent, SetStateAction } from 'react';
+
+const getActionButtonId = ( productSlug: string ) => `action-button-label-${ productSlug }`;
 
 type ActionButtonProps = {
 	slug: JetpackModule;
@@ -71,6 +74,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 	const admin = !! userIsAdmin;
 	const troubleshootBackupsUrl =
 		'https://jetpack.com/support/backup/troubleshooting-jetpack-backup/';
+	const labelledBy = `${ getActionButtonId( slug ) } ${ getProductCardTitleId( slug ) }`;
 
 	const buttonState = useMemo< Partial< SecondaryButtonProps > >( () => {
 		return {
@@ -148,6 +152,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					variant: 'primary',
 					label: buttonText,
 					onClick: learnMoreHandler,
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.ABSENT ] ?? {} ),
 				};
 			}
@@ -158,6 +163,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					variant: 'primary',
 					label: buttonText,
 					onClick: installStandaloneHandler,
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.ABSENT_WITH_PLAN ] ?? {} ),
 				};
 			}
@@ -169,6 +175,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					variant: 'primary',
 					label: __( 'Learn more', 'jetpack-my-jetpack' ),
 					onClick: addHandler,
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.NEEDS_FIRST_SITE_CONNECTION ] ?? {} ),
 				};
 			case PRODUCT_STATUSES.NEEDS_PLAN: {
@@ -182,6 +189,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					variant: 'primary',
 					label: buttonText,
 					onClick: addHandler,
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.NEEDS_PLAN ] ?? {} ),
 				};
 			}
@@ -192,6 +200,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					variant: 'primary',
 					label: __( 'Upgrade', 'jetpack-my-jetpack' ),
 					onClick: addHandler,
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.CAN_UPGRADE ] ?? {} ),
 				};
 			}
@@ -205,6 +214,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					variant: 'secondary',
 					label: buttonText,
 					onClick: manageHandler,
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.ACTIVE ] ?? {} ),
 				};
 			}
@@ -214,6 +224,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					variant: 'primary',
 					label: __( 'Connect', 'jetpack-my-jetpack' ),
 					onClick: fixSiteConnectionHandler,
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.SITE_CONNECTION_ERROR ] ?? {} ),
 				};
 			case PRODUCT_STATUSES.USER_CONNECTION_ERROR:
@@ -222,6 +233,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					variant: 'primary',
 					label: __( 'Connect', 'jetpack-my-jetpack' ),
 					onClick: fixUserConnectionHandler,
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.USER_CONNECTION_ERROR ] ?? {} ),
 				};
 			case PRODUCT_STATUSES.INACTIVE:
@@ -232,6 +244,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					variant: 'secondary',
 					label: __( 'Activate', 'jetpack-my-jetpack' ),
 					onClick: handleActivate,
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.INACTIVE ] ?? {} ),
 				};
 			case PRODUCT_STATUSES.EXPIRING_SOON:
@@ -240,6 +253,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					href: renewPaidPlanPurchaseUrl,
 					variant: 'primary',
 					label: __( 'Renew my plan', 'jetpack-my-jetpack' ),
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.EXPIRING_SOON ] ?? {} ),
 				};
 			case PRODUCT_STATUSES.EXPIRED:
@@ -248,6 +262,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					href: managePaidPlanPurchaseUrl,
 					variant: 'primary',
 					label: __( 'Resume my plan', 'jetpack-my-jetpack' ),
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.EXPIRED ] ?? {} ),
 				};
 			case PRODUCT_STATUSES.NEEDS_ATTENTION__ERROR: {
@@ -256,6 +271,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					href: manageUrl,
 					variant: 'primary',
 					label: __( 'Troubleshoot', 'jetpack-my-jetpack' ),
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.NEEDS_ATTENTION__ERROR ] ?? {} ),
 				};
 				switch ( slug ) {
@@ -279,6 +295,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					href: manageUrl,
 					variant: 'primary',
 					label: __( 'Troubleshoot', 'jetpack-my-jetpack' ),
+					'aria-labelledby': labelledBy,
 					...( primaryActionOverride?.[ PRODUCT_STATUSES.NEEDS_ATTENTION__WARNING ] ?? {} ),
 				};
 				switch ( slug ) {
@@ -299,6 +316,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					href: purchaseUrl || `#/add-${ slug }`,
 					label: __( 'Learn more', 'jetpack-my-jetpack' ),
 					onClick: addHandler,
+					'aria-labelledby': labelledBy,
 				};
 		}
 	}, [
@@ -319,6 +337,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 		installStandaloneHandler,
 		learnMoreHandler,
 		manageHandler,
+		labelledBy,
 	] );
 
 	const allActions = useMemo(
@@ -414,7 +433,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					hasAdditionalActions ? styles[ 'has-additional-actions' ] : null
 				) }
 			>
-				<Button { ...buttonState } { ...currentAction }>
+				<Button { ...buttonState } { ...currentAction } id={ getActionButtonId( slug ) }>
 					{ currentAction.label }
 				</Button>
 				{ hasAdditionalActions && (

--- a/projects/packages/my-jetpack/_inc/components/action-button/secondary-button.tsx
+++ b/projects/packages/my-jetpack/_inc/components/action-button/secondary-button.tsx
@@ -16,6 +16,7 @@ export type SecondaryButtonProps = {
 	disabled?: boolean;
 	isLoading?: boolean;
 	className?: string;
+	'aria-labelledby'?: string;
 };
 
 // SecondaryButton component

--- a/projects/packages/my-jetpack/_inc/components/card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/card/index.jsx
@@ -22,7 +22,8 @@ export const CardWrapper = props => {
 };
 
 const Card = props => {
-	const { title, headerRightContent, className, children, onMouseEnter, onMouseLeave } = props;
+	const { title, headerRightContent, className, children, onMouseEnter, onMouseLeave, titleId } =
+		props;
 
 	return (
 		<CardWrapper
@@ -32,7 +33,9 @@ const Card = props => {
 		>
 			<div className={ styles.title }>
 				<div className={ styles.name }>
-					<Text variant="title-medium">{ title }</Text>
+					<Text variant="title-medium" id={ titleId || null }>
+						{ title }
+					</Text>
 				</div>
 				{ headerRightContent }
 			</div>
@@ -48,6 +51,7 @@ Card.propTypes = {
 	headerRightContent: PropTypes.node,
 	onMouseEnter: PropTypes.func,
 	onMouseLeave: PropTypes.func,
+	titleId: PropTypes.string,
 };
 
 export default Card;

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/styles.module.scss
@@ -40,7 +40,7 @@ $myjetpack-connection-avatar-overlap: 10px;
 		}
 
 		.warning {
-			border-color: var( --jp-yellow-40 );
+			border-color: var( --jp-yellow-50 );
 		}
 	}
 
@@ -70,8 +70,8 @@ $myjetpack-connection-avatar-overlap: 10px;
 			}
 
 			&.warning {
-				color: var( --jp-yellow-40 );
-				fill: var( --jp-yellow-40 );
+				color: var( --jp-yellow-50 );
+				fill: var( --jp-yellow-50 );
 			}
 
 			&.success {

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
@@ -169,6 +169,7 @@ const ProductCard: FC< ProductCardProps > = props => {
 							fixSiteConnectionHandler={ fixSiteConnectionHandler }
 							setIsActionLoading={ setIsActionLoading }
 							tracksIdentifier="product_card"
+							labelSuffixId={ getProductCardTitleId( slug ) }
 						/>
 						{ secondaryAction && ! secondaryAction?.positionFirst && (
 							<SecondaryButton { ...secondaryAction } />

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
@@ -149,6 +149,13 @@ const ProductCard: FC< ProductCardProps > = props => {
 				<RecommendationActions slug={ slug } />
 			) : (
 				<div className={ styles.actions }>
+					<Status
+						status={ status }
+						isFetching={ isLoading }
+						isInstallingStandalone={ false }
+						isOwned={ isOwned }
+						suppressNeedsAttention={ slug === 'protect' }
+					/>
 					<div className={ styles.buttons }>
 						{ secondaryAction && secondaryAction?.positionFirst && (
 							<SecondaryButton { ...secondaryAction } />
@@ -165,13 +172,6 @@ const ProductCard: FC< ProductCardProps > = props => {
 							<SecondaryButton { ...secondaryAction } />
 						) }
 					</div>
-					<Status
-						status={ status }
-						isFetching={ isLoading }
-						isInstallingStandalone={ false }
-						isOwned={ isOwned }
-						suppressNeedsAttention={ slug === 'protect' }
-					/>
 				</div>
 			) }
 		</Card>

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
@@ -16,6 +16,14 @@ import styles from './style.module.scss';
 import type { AdditionalAction, SecondaryAction } from '../action-button/types';
 import type { FC, MouseEventHandler, ReactNode, MouseEvent } from 'react';
 
+/**
+ * Generate the product card title ID attribute from a product slug
+ *
+ * @param {string} slug - The product slug
+ * @return {string} The generated title ID attribute
+ */
+export const getProductCardTitleId = slug => `product-card-title-${ slug }`;
+
 export type ProductCardProps = {
 	children?: ReactNode;
 	name: string;
@@ -135,6 +143,7 @@ const ProductCard: FC< ProductCardProps > = props => {
 			headerRightContent={ null }
 			onMouseEnter={ onMouseEnter }
 			onMouseLeave={ onMouseLeave }
+			titleId={ getProductCardTitleId( slug ) }
 		>
 			{ recommendation && <PriceComponent slug={ slug } /> }
 			<Description />

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -91,7 +91,7 @@ $status-size: 8px;
 	$statuses: (
 		"active": "--jp-green-50",
 		"inactive": "--jp-gray-50",
-		"warning": "--jp-yellow-40",
+		"warning": "--jp-yellow-50",
 		"error": "--jp-red-60"
 	);
 

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -20,6 +20,7 @@ $status-size: 8px;
 
 .actions {
 	display: flex;
+	flex-direction: row-reverse;
 	align-items: center;
 	justify-content: space-between;
 	width: 100%;

--- a/projects/packages/my-jetpack/_inc/components/products-table-view/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/products-table-view/index.tsx
@@ -97,6 +97,14 @@ const getCategories: (
 	return categoryOptions;
 };
 
+/**
+ * Generate the product title ID attribute from a product slug
+ *
+ * @param {string} slug - The product slug
+ * @return {string} The generated title ID attribute
+ */
+export const getProductTitleId = slug => `product-title-${ slug }`;
+
 const ProductsTableView: FC< ProductsTableViewProps > = ( { products } ) => {
 	const getItemId = useCallback( ( item: ProductData ) => item.product.slug, [] );
 	const onChangeView = useCallback( ( newView: View ) => {
@@ -164,7 +172,7 @@ const ProductsTableView: FC< ProductsTableViewProps > = ( { products } ) => {
 				},
 				render: ( { item }: { item: ProductData } ) => {
 					const { product } = item;
-					return <div>{ product.name }</div>;
+					return <div id={ getProductTitleId( product.slug ) }>{ product.name }</div>;
 				},
 			},
 			{
@@ -231,6 +239,7 @@ const ProductsTableView: FC< ProductsTableViewProps > = ( { products } ) => {
 							className="product-list-item-cta"
 							slug={ slug }
 							tracksIdentifier="product_list_item"
+							labelSuffixId={ getProductTitleId( slug ) }
 						/>
 					);
 				},

--- a/projects/packages/my-jetpack/changelog/fix-invert-my-jp-product-card-actions
+++ b/projects/packages/my-jetpack/changelog/fix-invert-my-jp-product-card-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Move product card status before action for screen readers

--- a/projects/packages/my-jetpack/changelog/fix-my-jp-product-card-status-color
+++ b/projects/packages/my-jetpack/changelog/fix-my-jp-product-card-status-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+ Increase product card status contrast ratio

--- a/projects/packages/my-jetpack/changelog/fix-product-card-cta-a11y
+++ b/projects/packages/my-jetpack/changelog/fix-product-card-cta-a11y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improve accessibility for product card actions with ARIA labelling


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR merges the following PRs, which improve the accessibility of the product card on the My Jetpack page.
- https://github.com/Automattic/jetpack/pull/41877
- https://github.com/Automattic/jetpack/pull/41874
- https://github.com/Automattic/jetpack/pull/41856

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Epic: https://github.com/Automattic/vulcan/issues/710

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

See individual PRs.

