### PR TITLE
Jetpack AI: Requests that use Chrome AI should not cause front-end to show a request has been used

### DIFF
--- a/projects/js-packages/ai-client/changelog/change-jetpack-ai-chrome-fe-request-fix
+++ b/projects/js-packages/ai-client/changelog/change-jetpack-ai-chrome-fe-request-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack AI: Requests that use Chrome AI should not cause front-end to show a request has been used

--- a/projects/js-packages/ai-client/src/chrome-ai/suggestions.ts
+++ b/projects/js-packages/ai-client/src/chrome-ai/suggestions.ts
@@ -88,7 +88,9 @@ export default class ChromeAISuggestionsEventSource extends EventTarget {
 		}
 
 		if ( data.complete ) {
-			this.dispatchEvent( new CustomEvent( 'done', { detail: data.message } ) );
+			this.dispatchEvent(
+				new CustomEvent( 'done', { detail: { message: data.message, source: 'chromeAI' } } )
+			);
 		}
 	}
 

--- a/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
@@ -256,9 +256,18 @@ export default function useAiSuggestions( {
 		( event: CustomEvent ) => {
 			closeEventSource();
 
-			const fullSuggestion = removeLlamaArtifact( event?.detail );
+			let message = event?.detail;
+			let skipRequestCount = false;
+			if ( event?.detail?.message ) {
+				message = event?.detail?.message;
+				if ( event.detail.source && event.detail.source === 'chromeAI' ) {
+					skipRequestCount = true;
+				}
+			}
 
-			onDone?.( fullSuggestion );
+			const fullSuggestion = removeLlamaArtifact( message );
+
+			onDone?.( fullSuggestion, skipRequestCount );
 			setRequestingState( 'done' );
 		},
 		[ onDone ]

--- a/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
@@ -70,7 +70,7 @@ type useAiSuggestionsOptions = {
 	/*
 	 * onDone callback.
 	 */
-	onDone?: ( content: string ) => void;
+	onDone?: ( content: string, skipRequestCount?: boolean ) => void;
 
 	/*
 	 * onStop callback.

--- a/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
@@ -256,18 +256,9 @@ export default function useAiSuggestions( {
 		( event: CustomEvent ) => {
 			closeEventSource();
 
-			let message = event?.detail;
-			let skipRequestCount = false;
-			if ( event?.detail?.message ) {
-				message = event?.detail?.message;
-				if ( event.detail.source && event.detail.source === 'chromeAI' ) {
-					skipRequestCount = true;
-				}
-			}
+			const fullSuggestion = removeLlamaArtifact( event?.detail?.message ?? event?.detail );
 
-			const fullSuggestion = removeLlamaArtifact( message );
-
-			onDone?.( fullSuggestion, skipRequestCount );
+			onDone?.( fullSuggestion, event?.detail?.source === 'chromeAI' );
 			setRequestingState( 'done' );
 		},
 		[ onDone ]

--- a/projects/plugins/jetpack/changelog/change-jetpack-ai-chrome-fe-request-fix
+++ b/projects/plugins/jetpack/changelog/change-jetpack-ai-chrome-fe-request-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Requests that use Chrome AI should not cause front-end to show a request has been used

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -112,10 +112,15 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 		requestingState,
 		error,
 	} = useAIAssistant( {
-		onSuggestionDone: useCallback( () => {
-			focusOnPrompt();
-			increaseRequestsCount();
-		}, [ increaseRequestsCount ] ),
+		onSuggestionDone: useCallback(
+			skipRequestCount => {
+				focusOnPrompt();
+				if ( ! skipRequestCount ) {
+					increaseRequestsCount();
+				}
+			},
+			[ increaseRequestsCount ]
+		),
 		onUnclearPrompt: useCallback( () => {
 			focusOnBlock();
 			increaseRequestsCount();

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
@@ -214,7 +214,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 
 		// Called after the last suggestion chunk is received.
 		const onDone = useCallback(
-			( suggestion: string, skipRequestCount?: bool ) => {
+			( suggestion: string, skipRequestCount?: boolean ) => {
 				disableAutoScroll();
 				onBlockDone( suggestion );
 				if ( ! skipRequestCount ) {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
@@ -214,10 +214,12 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 
 		// Called after the last suggestion chunk is received.
 		const onDone = useCallback(
-			( suggestion: string ) => {
+			( suggestion: string, skipRequestCount?: bool ) => {
 				disableAutoScroll();
 				onBlockDone( suggestion );
-				increaseRequestsCount();
+				if ( ! skipRequestCount ) {
+					increaseRequestsCount();
+				}
 				setAction( '' );
 
 				if ( lastRequest.current?.message ) {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-assistant/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-assistant/index.js
@@ -69,7 +69,7 @@ const useAIAssistant = ( {
 		snapToBottom();
 	};
 
-	const onDone = detail => {
+	const onDone = ( detail, skipRequestCount ) => {
 		// Remove the delimiter from the suggestion.
 		const assistantResponse = detail.replaceAll( delimiter, '' );
 
@@ -96,7 +96,7 @@ const useAIAssistant = ( {
 
 		snapToBottom();
 		disableAutoScroll();
-		onSuggestionDone?.();
+		onSuggestionDone?.( skipRequestCount );
 	};
 
 	const onStop = () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #[41899](https://github.com/Automattic/jetpack/issues/41899)

## Proposed changes:
* Fixes issue where the front end was counting requests to Chrome's AI as counting against their overall request count.
* This issue only occurred on the front end, so no backend fix is needed

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

### Setup

* Set up your Jetpack such that you don't have unlimited AI requests
* If sandboxing the WPCOM api (not required) you can add this to your `0-sandbox` file to fake it:

```
add_filter( 'jetpack_ai_current_period_requests_count', function() { return 5; } );
add_filter( 'jetpack_ai_all_time_requests_count', function() { return 5; } );
add_filter( 'jetpack_ai_tier_licensed_quantity', function() { return 0; } );
```

* Verify that you see the request counter in the Jetpack AI Assistant portion of the sidebar:

![Screenshot 2025-02-19 at 5 06 59 PM](https://github.com/user-attachments/assets/85fc9b77-f79f-47d2-bb1b-acdccdce2c90)

* Make sure you have Chrome AI enabled via the testing instructions in [this PR](https://github.com/Automattic/jetpack/pull/41724)

### Recreating / Verifying The Bug

* Create a new post and add some text in English. Translate into a non-supported language (French or German). The request counter should decrease by one.
* Undo your change and translate into a language supported by Chrome AI (Spanish, Chinese, Russian). After translating the request counter should also decrease by one.

### Testing The Fix

* Now check out this branch and rebuild/reload.
* Doing the same steps above, translate some text to French or German and observe that the request counter decreases.
* Next translate to a language supported by Chrome AI. The counter should no longer decrease.
