### PR TITLE
Newsletter Dashboard widget: enqueue styles and add config data for footer links

### DIFF
--- a/projects/plugins/jetpack/changelog/add-newsletter-widget-footer
+++ b/projects/plugins/jetpack/changelog/add-newsletter-widget-footer
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Newsletter widget: add footer links

--- a/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
@@ -57,7 +57,8 @@ class Jetpack_Newsletter_Dashboard_Widget {
 			'newsletter',
 			array(
 				'config_data' => array(
-					'hostname' => wp_parse_url( get_site_url(), PHP_URL_HOST ),
+					'hostname'  => wp_parse_url( get_site_url(), PHP_URL_HOST ),
+					'admin_url' => admin_url(),
 				),
 			)
 		);
@@ -98,7 +99,8 @@ class Jetpack_Newsletter_Dashboard_Widget {
 			'newsletter',
 			array(
 				'config_data' => array(
-					'hostname' => wp_parse_url( get_site_url(), PHP_URL_HOST ),
+					'hostname'  => wp_parse_url( get_site_url(), PHP_URL_HOST ),
+					'admin_url' => admin_url(),
 				),
 			)
 		);

--- a/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
@@ -6,7 +6,6 @@
  */
 
 use Automattic\Jetpack\Assets;
-use Automattic\Jetpack\Status\Host;
 
 /**
  * Adds the Jetpack Newsletter widget to the WordPress admin dashboard.
@@ -53,7 +52,15 @@ class Jetpack_Newsletter_Dashboard_Widget {
 	 * Sets up the Jetpack Newsletter widget in the WordPress admin dashboard.
 	 */
 	public static function wp_dashboard_setup() {
-		static::load_admin_scripts( 'jp-newsletter-widget', 'newsletter.min', array( 'config_variable_name' => 'jetpackNewsletterWidgetConfigData' ) );
+		static::load_admin_scripts(
+			'jp-newsletter-widget',
+			'newsletter',
+			array(
+				'config_data' => array(
+					'hostname' => wp_parse_url( get_site_url(), PHP_URL_HOST ),
+				),
+			)
+		);
 		if ( Jetpack::is_connection_ready() ) {
 			$widget_title = sprintf(
 				__( 'Newsletter', 'jetpack' )
@@ -88,13 +95,10 @@ class Jetpack_Newsletter_Dashboard_Widget {
 	public static function admin_init() {
 		static::load_admin_scripts(
 			'jp-newsletter-widget',
-			'newsletter.min',
+			'newsletter',
 			array(
-				'config_variable_name' => 'jetpackNewsletterWidgetConfigData',
-				'config_data'          => array(
-					'blog_id'         => Jetpack_Options::get_option( 'id' ),
-					'hostname'        => wp_parse_url( get_site_url(), PHP_URL_HOST ),
-					'is_jetpack_site' => ! ( new Host() )->is_wpcom_simple(),
+				'config_data' => array(
+					'hostname' => wp_parse_url( get_site_url(), PHP_URL_HOST ),
 				),
 			)
 		);
@@ -112,18 +116,18 @@ class Jetpack_Newsletter_Dashboard_Widget {
 		$default_options = array(
 			'config_data'          => array(),
 			'config_variable_name' => 'configData',
-			'enqueue_css'          => true,
 		);
 		$options         = wp_parse_args( $options, $default_options );
-		if ( file_exists( __DIR__ . "/../dist/{$asset_name}.js" ) ) {
+		if ( file_exists( __DIR__ . "/../dist/{$asset_name}.min.js" ) ) {
 			// Load local assets for the convinience of development.
 			Assets::register_script(
 				$asset_handle,
-				"../dist/{$asset_name}.js",
+				"../dist/{$asset_name}.min.js",
 				__FILE__,
 				array(
 					'in_footer'  => true,
 					'textdomain' => 'jetpack',
+					'css_path'   => "../dist/{$asset_name}.css",
 				)
 			);
 			Assets::enqueue_script( $asset_handle );
@@ -131,13 +135,23 @@ class Jetpack_Newsletter_Dashboard_Widget {
 			// In production, we load the assets from our CDN.
 			wp_register_script(
 				$asset_handle,
-				sprintf( self::NEWSLETTER_WIDGET_CDN_URL, "{$asset_name}.js" ),
+				sprintf( self::NEWSLETTER_WIDGET_CDN_URL, "{$asset_name}.min.js" ),
 				self::JS_DEPENDENCIES,
 				self::NEWSLETTER_WIDGET_VERSION,
 				true
 			);
 			wp_enqueue_script( $asset_handle );
 		}
+
+		$css_url    = $asset_name . ( is_rtl() ? '.rtl' : '' ) . '.css';
+		$css_handle = $asset_handle . '-style';
+		wp_register_style(
+			$css_handle,
+			sprintf( self::NEWSLETTER_WIDGET_CDN_URL, $css_url ),
+			array(),
+			self::NEWSLETTER_WIDGET_VERSION
+		);
+		wp_enqueue_style( $css_handle );
 
 		wp_add_inline_script(
 			$asset_handle,

--- a/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Status\Host;
 
 /**
  * Adds the Jetpack Newsletter widget to the WordPress admin dashboard.
@@ -73,7 +74,7 @@ class Jetpack_Newsletter_Dashboard_Widget {
 	 */
 	public static function render() {
 		?>
-		<div id="wpcom" style="min-height: calc(100vh - 100px);">
+		<div id="wpcom">
 			<div id="newsletter-widget-app"></div>
 		</div>
 		<?php
@@ -85,7 +86,18 @@ class Jetpack_Newsletter_Dashboard_Widget {
 	 * @return void
 	 */
 	public static function admin_init() {
-		static::load_admin_scripts( 'jp-newsletter-widget', 'newsletter.min', array( 'config_variable_name' => 'jetpackNewsletterWidgetConfigData' ) );
+		static::load_admin_scripts(
+			'jp-newsletter-widget',
+			'newsletter.min',
+			array(
+				'config_variable_name' => 'jetpackNewsletterWidgetConfigData',
+				'config_data'          => array(
+					'blog_id'         => Jetpack_Options::get_option( 'id' ),
+					'hostname'        => wp_parse_url( get_site_url(), PHP_URL_HOST ),
+					'is_jetpack_site' => ! ( new Host() )->is_wpcom_simple(),
+				),
+			)
+		);
 	}
 
 	/**
@@ -127,6 +139,10 @@ class Jetpack_Newsletter_Dashboard_Widget {
 			wp_enqueue_script( $asset_handle );
 		}
 
-		// TODO: Add config data.
+		wp_add_inline_script(
+			$asset_handle,
+			"window.{$options['config_variable_name']} = " . wp_json_encode( $options['config_data'] ) . ';',
+			'before'
+		);
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to Automattic/loop#451

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Enqueues the widget styles from the Calypso app
* Adds config data needed to render the footer links

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Jetpack/WOA sites. 

- Add the constant  `define( 'JETPACK_NEWSLETTER_WIDGET', true );` to your `wp-config.php` file if you're testing this on local.  
- For WOA sites, this constant can be set in the wp-config file which lives in a file like this `~/htdocs/wp-config.php`. 
- Similarly for JN sites, you can do this same thing. Your JN site's wp-admin has the ssh creds you will need to update the `wp-config.php` file to set the JETPACK_NEWSLETTER_WIDGET constant.
- Make sure this Jetpack branch is active using the Jetpack Beta plugin
- Sandbox widget.wp.com and public-api
- Build the Calypso app from [this branch](https://github.com/Automattic/wp-calypso/pull/100040) following this guide: pg9MHR-ox-p2.
- Go to wp-admin to see the widget and the footer section
- Verify all links work as expected

### Simple sites

- Follow the steps [here](https://github.com/Automattic/jetpack/pull/41903#issuecomment-2669970331) to prepare your sandbox. 
-  Build the Calypso app if you didn't in the section above.
- In your `0-sandbox.php`, Add the constant  `define( 'JETPACK_NEWSLETTER_WIDGET', true );` 
- Sandbox your simple site, public-api.wordpress.com, and widgets.wp.com
- Go to wp-admin to see the widget and the footer section 
- Verify all links work as expected
