### PR TITLE
renovate: Fix config

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -1,4 +1,3 @@
-const child_process = require( 'child_process' );
 const fs = require( 'fs' );
 const path = require( 'path' );
 
@@ -96,43 +95,39 @@ module.exports = {
 		},
 		...( () => {
 			const ret = {};
-			const { stdout } = child_process.spawnSync(
-				'git',
-				[ '-c', 'core.quotepath=off', 'ls-files', 'composer.json', '*/composer.json' ],
-				{
-					cwd: monorepoBase,
-					stdio: [ 'ignore', 'pipe', 'ignore' ],
-					encoding: 'utf-8',
-				}
-			);
-			for ( const filepath of stdout.split( /\n/ ) ) {
-				if ( filepath === '' ) {
-					continue;
-				}
-				const json = JSON.parse(
-					fs.readFileSync( path.resolve( monorepoBase, filepath ), 'utf8' )
-				);
-				if ( json.require?.php && json.require.php !== `>=${ versions.MIN_PHP_VERSION }` ) {
-					let req = json.require.php;
+			const dirs = [ '.' ];
 
-					// Renovate is very cautious, ">=7.4" won't match "^7.0 || ^8.0" because 9.0 could exist.
-					// Rewrite it to "~7.4.0", since if it supports 7.4 it's probably ok with 8.0 (minus perhaps some deprecation warnings).
-					const m = json.require.php.match( /^>=(\d+\.\d+)$/ );
-					if ( m ) {
-						req = `~${ m[ 1 ] }.0`;
-					}
+			while ( dirs.length > 0 ) {
+				const basedir = path.resolve( monorepoBase, dirs.shift() );
+				for ( const dirent of fs.readdirSync( basedir, { withFileTypes: true } ) ) {
+					const filepath = path.join( basedir, dirent.name );
+					if ( dirent.isDirectory() ) {
+						dirs.push( filepath );
+					} else if ( dirent.isFile() && dirent.name === 'composer.json' ) {
+						const json = JSON.parse( fs.readFileSync( filepath, 'utf8' ) );
+						if ( json.require?.php && json.require.php !== `>=${ versions.MIN_PHP_VERSION }` ) {
+							let req = json.require.php;
 
-					if ( ! ret[ req ] ) {
-						ret[ req ] = {
-							matchFileNames: [],
-							matchDatasources: [ 'packagist' ],
-							matchDepTypes: [ 'require' ],
-							constraints: {
-								php: req,
-							},
-						};
+							// Renovate is very cautious, ">=7.4" won't match "^7.0 || ^8.0" because 9.0 could exist.
+							// Rewrite it to "~7.4.0", since if it supports 7.4 it's probably ok with 8.0 (minus perhaps some deprecation warnings).
+							const m = json.require.php.match( /^>=(\d+\.\d+)(\.\d+)?$/ );
+							if ( m ) {
+								req = `~${ m[ 1 ] }${ m[ 2 ] ?? '.0' }`;
+							}
+
+							if ( ! ret[ req ] ) {
+								ret[ req ] = {
+									matchFileNames: [],
+									matchDatasources: [ 'packagist' ],
+									matchDepTypes: [ 'require' ],
+									constraints: {
+										php: req,
+									},
+								};
+							}
+							ret[ req ].matchFileNames.push( path.relative( monorepoBase, filepath ) );
+						}
 					}
-					ret[ req ].matchFileNames.push( filepath );
 				}
 			}
 			return Object.values( ret );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
It seems `git` is no longer available when parsing the config. It should be safe to just recurse everything at this point, there shouldn't have been any `pnpm install` or the like, so do that to find the composer.json files with different constraints.

Also properly handle cases like changelogger's `>=7.2.5` PHP version constraint.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge this in a fork, run renovate there, and see if the part where it prints the resolved config has the added constraints from this block (e.g. just after https://github.com/Automattic/jetpack/actions/runs/13424943789/job/37505958720#step:5:663).
  * [x] https://github.com/anomiex/jetpack/actions/runs/13425435738/job/37507386647#step:5:740
