### PR TITLE
Social - Clean up | Use new connections class for share status

### DIFF
--- a/projects/packages/publicize/changelog/update-social-use-new-connections-class-for-share-status
+++ b/projects/packages/publicize/changelog/update-social-use-new-connections-class-for-share-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Use new connections class for share status

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -769,20 +769,12 @@ class Publicize extends Publicize_Base {
 
 		if ( $done ) {
 			// The site could have multiple admins, editors and authors connected. Load shares information that only the current user has access to.
-			$connection_ids = array_map(
-				function ( $connection ) {
-					if ( isset( $connection['connection_id'] ) ) {
-						return (int) $connection['connection_id'];
-					}
-					return 0;
-				},
-				$this->get_all_connections_for_user()
-			);
+			$connection_ids = wp_list_pluck( Connections::get_all_for_user(), 'connection_id', 'connection_id' );
 
 			$shares = array_filter(
 				$shares,
 				function ( $share ) use ( $connection_ids ) {
-					return in_array( (int) $share['connection_id'], $connection_ids, true );
+					return isset( $connection_ids[ $share['connection_id'] ] );
 				}
 			);
 


### PR DESCRIPTION
As a part of the clean up following the connections schema changes, we want to replace the usage of `Publicize::get_all_connections_for_user()` with `Connections:get_all_for_user()`.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replace the usage of `Publicize::get_all_connections_for_user()` with `Connections:get_all_for_user()` in  `Publicize::get_post_share_status()`
* Replace `array_map` there with `wp_list_pluck` to clean up the logic.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* As an admin, ensure the site has 2 social connections
* Mark one connection as shared
* Login as an author
* Ensure that the author has at least 1 social connection
* As the author, publish and share a post
* Wait for the share status to finish
* Reload the page
* Confirm that the author can see the share status of both the shared connections and the ones that belong to the author
* Now, as the admin, unmark the connection as shared
* Reload the post edit page as author
* Confirm that the share status for the shared connection is no longer visible
* Now delete a connection
* Confirm that its share status is not shown either
