### PR TITLE
Social - Clean up | Update connections schema for publicize command Jetpack WP CLI

### DIFF
--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -156,7 +156,7 @@ return [
         'class-jetpack-xmlrpc-methods.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition'],
         'class.jetpack-admin.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeMismatchArgumentProbablyReal'],
         'class.jetpack-autoupdate.php' => ['PhanTypeMismatchArgument'],
-        'class.jetpack-cli.php' => ['PhanAccessMethodInternal', 'PhanParamTooManyCallable', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn'],
+        'class.jetpack-cli.php' => ['PhanAccessMethodInternal', 'PhanParamTooManyCallable', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn'],
         'class.jetpack-gutenberg.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeSuspiciousStringExpression'],
         'class.jetpack-heartbeat.php' => ['PhanTypeMismatchPropertyDefault'],
         'class.jetpack-modules-list-table.php' => ['PhanCommentAbstractOnInheritedMethod'],

--- a/projects/plugins/jetpack/changelog/update-social-fix-publicize-in-WP-CLI-jetpack-command
+++ b/projects/plugins/jetpack/changelog/update-social-fix-publicize-in-WP-CLI-jetpack-command
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Publicize | Fix jetpack publicize disconnect command not working

--- a/projects/plugins/jetpack/class.jetpack-cli.php
+++ b/projects/plugins/jetpack/class.jetpack-cli.php
@@ -1670,6 +1670,9 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 * [<identifier>]
 	 * : The connection ID or service to perform an action on.
 	 *
+	 * [--ignore-cache]
+	 * : Whether to ignore connections cache.
+	 *
 	 * [--format=<format>]
 	 * : Allows overriding the output of the command when listing connections.
 	 * ---
@@ -1687,6 +1690,9 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 *
 	 *     # List all publicize connections.
 	 *     $ wp jetpack publicize list
+	 *
+	 *     # List all publicize connections, ignoring the cache.
+	 *     $ wp jetpack publicize list --ignore-cache
 	 *
 	 *     # List publicize connections for a given service.
 	 *     $ wp jetpack publicize list linkedin
@@ -1746,11 +1752,14 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		switch ( $action ) {
 			case 'list':
+				$_args = array(
+					'ignore_cache' => $named_args['ignore-cache'] ?? false,
+				);
 				// For the CLI command, let's return all connections when a user isn't specified. This
 				// differs from the logic in the Publicize class.
 				$connections_to_return = is_user_logged_in()
-					? Connections::get_all_for_user()
-					: Connections::get_all();
+					? Connections::get_all_for_user( $_args )
+					: Connections::get_all( $_args );
 
 				if ( $id_is_service && ! empty( $identifier ) && ! empty( $connections_to_return ) ) {
 					$temp_connections      = $connections_to_return;

--- a/projects/plugins/jetpack/class.jetpack-cli.php
+++ b/projects/plugins/jetpack/class.jetpack-cli.php
@@ -10,6 +10,7 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Tokens;
 use Automattic\Jetpack\Identity_Crisis;
 use Automattic\Jetpack\IP\Utils as IP_Utils;
+use Automattic\Jetpack\Publicize\Connections;
 use Automattic\Jetpack\Publicize\Publicize;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Sync\Actions;
@@ -1745,49 +1746,34 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		switch ( $action ) {
 			case 'list':
-				$connections_to_return = array();
-
 				// For the CLI command, let's return all connections when a user isn't specified. This
 				// differs from the logic in the Publicize class.
-				$option_connections = is_user_logged_in()
-					? (array) $publicize->get_all_connections_for_user()
-					: (array) $publicize->get_all_connections();
-
-				foreach ( $option_connections as $service_name => $connections ) {
-					foreach ( (array) $connections as $id => $connection ) {
-						$connection['id']        = $id;
-						$connection['service']   = $service_name;
-						$connections_to_return[] = $connection;
-					}
-				}
+				$connections_to_return = is_user_logged_in()
+					? Connections::get_all_for_user()
+					: Connections::get_all();
 
 				if ( $id_is_service && ! empty( $identifier ) && ! empty( $connections_to_return ) ) {
 					$temp_connections      = $connections_to_return;
 					$connections_to_return = array();
 
 					foreach ( $temp_connections as $connection ) {
-						if ( $identifier === $connection['service'] ) {
+						if ( $identifier === $connection['service_name'] ) {
 							$connections_to_return[] = $connection;
 						}
 					}
 				}
 
 				if ( $identifier && ! $id_is_service && ! empty( $connections_to_return ) ) {
-					$connections_to_return = wp_list_filter( $connections_to_return, array( 'id' => $identifier ) );
+					$connections_to_return = wp_list_filter( $connections_to_return, array( 'connection_id' => $identifier ) );
 				}
 
 				$expected_keys = array(
-					'id',
-					'service',
-					'user_id',
-					'provider',
-					'issued',
-					'expires',
+					'connection_id',
+					'service_name',
+					'display_name',
 					'external_id',
-					'external_name',
-					'external_display',
-					'type',
-					'connection_data',
+					'wpcom_user_id',
+					'shared',
 				);
 
 				// Somehow, a test site ended up in a state where $connections_to_return looked like:
@@ -1827,21 +1813,13 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 					jetpack_cli_are_you_sure();
 
-					$connections = array();
 					$service     = $identifier;
+					$connections = is_user_logged_in()
+						? Connections::get_all_for_user()
+						: Connections::get_all();
 
-					$option_connections = is_user_logged_in()
-						? (array) $publicize->get_all_connections_for_user()
-						: (array) $publicize->get_all_connections();
-
-					if ( 'all' === $service ) {
-						foreach ( (array) $option_connections as $service_name => $service_connections ) {
-							foreach ( $service_connections as $id => $connection ) {
-								$connections[ $id ] = $connection;
-							}
-						}
-					} elseif ( ! empty( $option_connections[ $service ] ) ) {
-						$connections = $option_connections[ $service ];
+					if ( 'all' !== $service ) {
+						$connections = wp_list_filter( $connections, array( 'service_name' => $service ) );
 					}
 
 					if ( ! empty( $connections ) ) {
@@ -1852,7 +1830,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 							$count
 						);
 
-						foreach ( $connections as $id => $connection ) {
+						foreach ( $connections as $connection ) {
+							$id = $connection['connection_id'];
 							if ( false === $publicize->disconnect( false, $id ) ) {
 								WP_CLI::error(
 									sprintf(

--- a/projects/plugins/jetpack/class.jetpack-cli.php
+++ b/projects/plugins/jetpack/class.jetpack-cli.php
@@ -1858,6 +1858,9 @@ class Jetpack_CLI extends WP_CLI_Command {
 						// @phan-suppress-next-line PhanUndeclaredClassMethod - Class is missing from php-stubs/wp-cli-stubs 🤷
 						$progress->finish();
 
+						// Populate the cache with the new data.
+						Connections::get_all( array( 'ignore_cache' => true ) );
+
 						if ( 'all' === $service ) {
 							WP_CLI::success( __( 'All Jetpack Social connections were successfully disconnected.', 'jetpack' ) );
 						} else {

--- a/projects/plugins/jetpack/class.jetpack-cli.php
+++ b/projects/plugins/jetpack/class.jetpack-cli.php
@@ -1858,9 +1858,6 @@ class Jetpack_CLI extends WP_CLI_Command {
 						// @phan-suppress-next-line PhanUndeclaredClassMethod - Class is missing from php-stubs/wp-cli-stubs 🤷
 						$progress->finish();
 
-						// Populate the cache with the new data.
-						Connections::get_all( array( 'ignore_cache' => true ) );
-
 						if ( 'all' === $service ) {
 							WP_CLI::success( __( 'All Jetpack Social connections were successfully disconnected.', 'jetpack' ) );
 						} else {


### PR DESCRIPTION
Our `jetpack publicize` command uses `Publicize::get_all_connections_for_user()` which we are going to deprecate soon.

So, as a part of the clean-up following the connections schema changes, we want to replace the usage of `Publicize::get_all_connections_for_user()` with `Connections:get_all_for_user()`.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replace the usage of `Publicize::get_all_connections_for_user()` with `Connections:get_all_for_user()` in  Jetpack CLI `publicize` command
* Update the schema and fields for `publicize list` command
* Add `ignore-cache` option for the list command

While working on these changes, I found out that the disconnect command doesn't work and thus I created a corresponding WPCOM change.

I don't know if anyone uses these CLI commands but it's better to fix them.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Prerequisites
- If testing locally on a JT site, you must update this to your JT site URL in your `wp-config.php` to avoid getting the error related to Jetpack being offline.
```php
define( 'WP_SITEURL', 'http://your-site.jurassic.tube' );
```

* Apply 174196-ghe-Automattic/wpcom to your sandbox
* Point your site to your sandbox
* Run `jetpack docker wp jetpack publicize list`
* Confirm that it lists all the connections for the site
* Mark a connection or two as shared
* Run `jetpack docker wp jetpack publicize list -- --user=<AUTHOR_ID>`
* Confirm that it shows the list of shared as well as author's own connections 
* Try deleting a connection by service, connection ID etc - `jetpack docker wp jetpack publicize disconnect bluesky -- --user=testauthor`
* Confirm that it works fine

<img width="863" alt="Screenshot 2025-02-20 at 12 35 16 PM" src="https://github.com/user-attachments/assets/11e3add3-4fa6-4aa3-b729-5f3e3e517d14" />
