### PR TITLE
Add wpcomsh woocommerce cli initialisation

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-wpcomsh-woocommerce-cli-initialisation
+++ b/projects/plugins/wpcomsh/changelog/add-wpcomsh-woocommerce-cli-initialisation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+WPCOM Site Helper CLI: add processing for woocommerce_helper_data

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -313,7 +313,7 @@ function wpcomsh_woa_post_process_store_woocommerce_connection_details( $args, $
 
 	$unexpected_root_keys = array_diff( array_keys( $woocommerce_connection_details_decoded ), array_keys( $valid_keys ) );
 	if ( ! empty( $unexpected_root_keys ) ) {
-		WP_CLI::warning( 'Invalid WooCommerce connection details provided. Unexpected root keys: ' . implode( ', ', $unexpected_root_keys ) );
+		WP_CLI::warning( 'Invalid WooCommerce connection details provided. Unexpected root key(s): ' . implode( ', ', $unexpected_root_keys ) );
 		return;
 	}
 

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -286,6 +286,9 @@ function wpcomsh_woa_post_process_store_woocommerce_connection_details( $args, $
 	$woocommerce_connection_details_decoded = json_decode( $woocommerce_connection_details, true );
 	if ( ! is_array( $woocommerce_connection_details_decoded ) ) {
 		WP_CLI::warning( 'Invalid WooCommerce connection details provided: ' . $woocommerce_connection_details );
+
+		WPCOMSH_Log::unsafe_direct_log( 'wp wpcomsh: Invalid WooCommerce connection details provided', array( 'woocommerce_connection_details' => $woocommerce_connection_details ) );
+
 		return;
 	}
 
@@ -307,6 +310,11 @@ function wpcomsh_woa_post_process_store_woocommerce_connection_details( $args, $
 	foreach ( $required_root_keys as $required_root_key ) {
 		if ( ! isset( $woocommerce_connection_details_decoded[ $required_root_key ] ) ) {
 			WP_CLI::warning( 'Invalid WooCommerce connection details provided. Missing ' . $required_root_key );
+
+			WPCOMSH_Log::unsafe_direct_log(
+				'wp wpcomsh: Invalid WooCommerce connection details provided. Missing ' . $required_root_key,
+				array( 'woocommerce_connection_details' => $woocommerce_connection_details_decoded )
+			);
 			return;
 		}
 	}
@@ -314,7 +322,14 @@ function wpcomsh_woa_post_process_store_woocommerce_connection_details( $args, $
 	$unexpected_root_keys = array_diff( array_keys( $woocommerce_connection_details_decoded ), array_keys( $valid_keys ) );
 	if ( ! empty( $unexpected_root_keys ) ) {
 		WP_CLI::warning( 'Unexpected WooCommerce connection details provided. Ignoring the following root key(s): ' . implode( ', ', $unexpected_root_keys ) );
-		// Keep processing the valid data, so keep processing.
+		WPCOMSH_Log::unsafe_direct_log(
+			'wp wpcomsh: Unexpected additional WooCommerce connection details',
+			array(
+				'extra_keys'                     => $unexpected_root_keys,
+				'woocommerce_connection_details' => $woocommerce_connection_details_decoded,
+			)
+		);
+		// Keep processing the valid data, so avoid returning early..
 	}
 
 	$option_data = array();
@@ -327,6 +342,10 @@ function wpcomsh_woa_post_process_store_woocommerce_connection_details( $args, $
 
 		if ( ! is_array( $woocommerce_connection_details_decoded[ $valid_key ] ) ) {
 			WP_CLI::warning( 'Invalid WooCommerce connection details provided. Missing ' . $valid_key );
+			WPCOMSH_Log::unsafe_direct_log(
+				'wp wpcomsh: Invalid WooCommerce connection details provided. Missing ' . $valid_key,
+				array( 'woocommerce_connection_details' => $woocommerce_connection_details_decoded )
+			);
 			return;
 		}
 
@@ -338,6 +357,13 @@ function wpcomsh_woa_post_process_store_woocommerce_connection_details( $args, $
 		foreach ( $required_key_fields as $required_key_field ) {
 			if ( ! isset( $woocommerce_connection_details_decoded[ $valid_key ][ $required_key_field ] ) ) {
 				WP_CLI::warning( 'Invalid WooCommerce connection details provided. Missing ' . $valid_key . ' => ' . $required_key_field );
+				WPCOMSH_Log::unsafe_direct_log(
+					'wp wpcomsh: Invalid WooCommerce connection details provided. Missing required field',
+					array(
+						'missing_path'                   => "$valid_key => $required_key_field",
+						'woocommerce_connection_details' => $woocommerce_connection_details_decoded,
+					)
+				);
 				return;
 			}
 
@@ -347,6 +373,10 @@ function wpcomsh_woa_post_process_store_woocommerce_connection_details( $args, $
 
 	if ( empty( $option_data ) ) {
 		WP_CLI::warning( 'No WooCommerce connection details to update' );
+		WPCOMSH_Log::unsafe_direct_log(
+			'wp wpcomsh: No WooCommerce connection details to update',
+			array( 'woocommerce_connection_details' => $woocommerce_connection_details_decoded )
+		);
 		return;
 	}
 

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -317,11 +317,6 @@ function wpcomsh_woa_post_process_store_woocommerce_connection_details( $args, $
 		return;
 	}
 
-	foreach ( $unexpected_root_keys as $unexpected_root_key ) {
-		WP_CLI::warning( 'Invalid WooCommerce connection details provided. Unexpected root key: ' . $unexpected_root_key );
-		return;
-	}
-
 	$option_data = array();
 
 	foreach ( $valid_keys as $valid_key => $required_key_fields ) {

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -269,3 +269,102 @@ function wpcomsh_woa_post_process_maybe_enable_wordads( $args, $assoc_args ) {
 	WP_CLI::success( 'WordAds options transferred and module activated' );
 }
 add_action( 'wpcomsh_woa_post_transfer', 'wpcomsh_woa_post_process_maybe_enable_wordads', 10, 2 );
+
+/**
+ * Checks for WooCommerce connection details, validates them, and stores them in the database.
+ *
+ * @param array $args       Positional arguments.
+ * @param array $assoc_args Named arguments.
+ */
+function wpcomsh_woa_post_process_store_woocommerce_connection_details( $args, $assoc_args ) {
+	$woocommerce_connection_details = WP_CLI\Utils\get_flag_value( $assoc_args, 'store-woocommerce-connection-details', false );
+	if ( ! $woocommerce_connection_details ) {
+		return;
+	}
+
+	// Validate that we have a valid JSON object.
+	$woocommerce_connection_details_decoded = json_decode( $woocommerce_connection_details, true );
+	if ( ! is_array( $woocommerce_connection_details_decoded ) ) {
+		WP_CLI::warning( 'Invalid WooCommerce connection details provided: ' . $woocommerce_connection_details );
+		return;
+	}
+
+	$valid_keys = array(
+		'auth'           => array(
+			'access_token',
+			'access_token_secret',
+			'site_id',
+			'user_id',
+			'updated',
+		),
+		'auth_user_data' => array(
+			'email',
+		),
+	);
+
+	$required_root_keys = array( 'auth' );
+
+	foreach ( $required_root_keys as $required_root_key ) {
+		if ( ! isset( $woocommerce_connection_details_decoded[ $required_root_key ] ) ) {
+			WP_CLI::warning( 'Invalid WooCommerce connection details provided. Missing ' . $required_root_key );
+			return;
+		}
+	}
+
+	$unexpected_root_keys = array_diff( array_keys( $woocommerce_connection_details_decoded ), array_keys( $valid_keys ) );
+	if ( ! empty( $unexpected_root_keys ) ) {
+		WP_CLI::warning( 'Invalid WooCommerce connection details provided. Unexpected root keys: ' . implode( ', ', $unexpected_root_keys ) );
+		return;
+	}
+
+	foreach ( $unexpected_root_keys as $unexpected_root_key ) {
+		WP_CLI::warning( 'Invalid WooCommerce connection details provided. Unexpected root key: ' . $unexpected_root_key );
+		return;
+	}
+
+	$option_data = array();
+
+	foreach ( $valid_keys as $valid_key => $required_key_fields ) {
+		if ( ! isset( $woocommerce_connection_details_decoded[ $valid_key ] ) ) {
+			// If the data isn't present, keep going - we validate presence for required keys above.
+			continue;
+		}
+
+		if ( ! is_array( $woocommerce_connection_details_decoded[ $valid_key ] ) ) {
+			WP_CLI::warning( 'Invalid WooCommerce connection details provided. Missing ' . $valid_key );
+			return;
+		}
+
+		if ( count( $required_key_fields ) !== count( $woocommerce_connection_details_decoded[ $valid_key ] ) ) {
+			WP_CLI::warning( 'Invalid WooCommerce connection details provided. Missing or extra fields in ' . $valid_key );
+			return;
+		}
+
+		foreach ( $required_key_fields as $required_key_field ) {
+			if ( ! isset( $woocommerce_connection_details_decoded[ $valid_key ][ $required_key_field ] ) ) {
+				WP_CLI::warning( 'Invalid WooCommerce connection details provided. Missing ' . $valid_key . ' => ' . $required_key_field );
+				return;
+			}
+
+			$option_data[ $valid_key ][ $required_key_field ] = $woocommerce_connection_details_decoded[ $valid_key ][ $required_key_field ];
+		}
+	}
+
+	if ( empty( $option_data ) ) {
+		WP_CLI::warning( 'No WooCommerce connection details to update' );
+		return;
+	}
+
+	update_option( 'woocommerce_helper_data', $option_data );
+
+	WP_CLI::success( 'WooCommerce connection details stored' );
+
+	if ( class_exists( 'WC_Helper' ) && method_exists( 'WC_Helper', 'refresh_helper_subscriptions' ) ) {
+		WC_Helper::refresh_helper_subscriptions();
+
+		WP_CLI::success( 'Cleared WooCommerce Helper cache' );
+	}
+}
+add_action( 'wpcomsh_woa_post_clone', 'wpcomsh_woa_post_process_store_woocommerce_connection_details', 10, 2 );
+add_action( 'wpcomsh_woa_post_reset', 'wpcomsh_woa_post_process_store_woocommerce_connection_details', 10, 2 );
+add_action( 'wpcomsh_woa_post_transfer', 'wpcomsh_woa_post_process_store_woocommerce_connection_details', 10, 2 );

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -313,8 +313,8 @@ function wpcomsh_woa_post_process_store_woocommerce_connection_details( $args, $
 
 	$unexpected_root_keys = array_diff( array_keys( $woocommerce_connection_details_decoded ), array_keys( $valid_keys ) );
 	if ( ! empty( $unexpected_root_keys ) ) {
-		WP_CLI::warning( 'Invalid WooCommerce connection details provided. Unexpected root key(s): ' . implode( ', ', $unexpected_root_keys ) );
-		return;
+		WP_CLI::warning( 'Unexpected WooCommerce connection details provided. Ignoring the following root key(s): ' . implode( ', ', $unexpected_root_keys ) );
+		// Keep processing the valid data, so keep processing.
 	}
 
 	$option_data = array();
@@ -331,8 +331,8 @@ function wpcomsh_woa_post_process_store_woocommerce_connection_details( $args, $
 		}
 
 		if ( count( $required_key_fields ) !== count( $woocommerce_connection_details_decoded[ $valid_key ] ) ) {
-			WP_CLI::warning( 'Invalid WooCommerce connection details provided. Missing or extra fields in ' . $valid_key );
-			return;
+			WP_CLI::warning( 'Missing or extra WooCommerce connection details provided. Mismatch in ' . $valid_key );
+			// Keep processing the valid data - we may have new fields that the code isn't ready for.
 		}
 
 		foreach ( $required_key_fields as $required_key_field ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to:
 * https://github.com/Automattic/wp-calypso/issues/97036
 * 174217-ghe-Automattic/wpcom

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR implements support for a new `--store-woocommerce-connection-details` flag in the `wp wpcomsh post-(clone|reset|transfer)` CLI commands, where the logic expects a JSON string value containing data for the `woocommerce_helper_data` option. The new logic includes the following:
  - Validate that the JSON is valid array containing an `auth` key and all required sub-fields, as well as an optional `auth_user_data` key.
  - If we have valid data, write the data into the `woocommerce_helper_data` option.
  - If `WC_Helper::refresh_helper_subscriptions()` is available, clear the cache to ensure we (re) fetch the status.

The main drivers for the new flag are as follows:
 - For Commerce plan subscriptions on WordPress.com, we establish a connection to WooCommerce.com for a number of plugins that are bundled with the plan, but the code that performs that connection doesn't run on the site itself. As a result, we want a reliable way to store that data on the site. (The connection details are stored in the `woocommerce_helper_data` option.)
 - More broadly, we want to rely on the `wp wpcomsh post-*` commands to perform site initialisation.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
   - I haven't been able to get the unit test environment running, and I can't sink more time into getting that done. This is an ideal set of code for unit testing, which is super frustrating.
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up the wpcomsh package on a running site where you have access to WP CLI. A WoA dev site will work for this.
* Test that the `wp wpcomsh post-*` commands work as expected:
  - Run `wp wpcomsh post-transfer --store-woocommerce-connection-details` - you should see a `Warning: Invalid WooCommerce connection details provided: 1` message
  - Run `wp wpcomsh post-transfer --store-woocommerce-connection-details='{"auth":{"access_token":"access_token","access_token_secret":"access_token_secret","site_id":12345,"user_id":54321,"updated":1739966129}}'`
    - You should see the following message: `Success: WooCommerce connection details stored`. If you have WooCommerce installed on the site, you should also see `Success: Cleared WooCommerce Helper cache`
    - Run `wp option get woocommerce_helper_data`. You should see the following output:
```
array (
  'auth' => 
  array (
    'access_token' => 'access_token',
    'access_token_secret' => 'access_token_secret',
    'site_id' => 12345,
    'user_id' => 54321,
    'updated' => 1739966129,
  ),
)
```

- Now run `wp option delete woocommerce_helper_data` to clean up
- Run `wp wpcomsh post-reset --store-woocommerce-connection-details='{"auth":{"access_token":"access_token","access_token_secret":"access_token_secret","site_id":12345,"user_id":54321,"updated":1739966129},"auth_user_data":{"email":"test@example.com"}}'`
    - You should see the following message: `Success: WooCommerce connection details stored`. If you have WooCommerce installed on the site, you should also see `Success: Cleared WooCommerce Helper cache`
    - Run `wp option get woocommerce_helper_data`. You should see the following output:
```
array (
  'auth' => 
  array (
    'access_token' => 'access_token',
    'access_token_secret' => 'access_token_secret',
    'site_id' => 12345,
    'user_id' => 54321,
    'updated' => 1739966129,
  ),
  'auth_user_data' => 
  array (
    'email' => 'test@example.com',
  ),
)
```
- Now run `wp option delete woocommerce_helper_data` to clean up
- Check that validation of unexpected keys works as expected by running `wp wpcomsh post-clone --store-woocommerce-connection-details='{"auth":{}, "bad":true}'`
  - You should see the following message: `Warning: Invalid WooCommerce connection details provided. Unexpected root key(s): bad`