### PR TITLE
Social | Deprecate jetpack/v4 connection endpoints

### DIFF
--- a/projects/packages/publicize/changelog/update-social-deprecate-jetpack-v4-connection-endpoints
+++ b/projects/packages/publicize/changelog/update-social-deprecate-jetpack-v4-connection-endpoints
@@ -1,0 +1,4 @@
+Significance: patch
+Type: deprecated
+
+Deprecated jetpack/v4 connection endpoints

--- a/projects/packages/publicize/src/class-connections.php
+++ b/projects/packages/publicize/src/class-connections.php
@@ -189,7 +189,7 @@ class Connections {
 	public static function fetch_site_connections() {
 		$proxy = new Proxy_Requests( 'publicize/connections' );
 
-		$request = new WP_REST_Request( 'GET', '/wpcom/v2/publicize/connections' );
+		$request = new WP_REST_Request( 'GET' );
 
 		return $proxy->proxy_request_to_wpcom_as_blog( $request );
 	}

--- a/projects/packages/publicize/src/class-publicize-utils.php
+++ b/projects/packages/publicize/src/class-publicize-utils.php
@@ -148,11 +148,7 @@ class Publicize_Utils {
 
 		$messages[] = esc_html__( 'Please update all the Jetpack plugins to the latest version.', 'jetpack-publicize-pkg' );
 
-		_doing_it_wrong(
-			esc_html( $function_name ),
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We have done it above.
-			implode( ' ', $messages ),
-			'$$next-version$$'
-		);
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We have done it above.
+		_doing_it_wrong( esc_html( $function_name ), implode( ' ', $messages ), 'package-$$next-version$$' );
 	}
 }

--- a/projects/packages/publicize/src/class-publicize-utils.php
+++ b/projects/packages/publicize/src/class-publicize-utils.php
@@ -125,10 +125,11 @@ class Publicize_Utils {
 	 * Log a warning that a deprecated endpoint was called.
 	 *
 	 * @param string $function_name        The function name.
+	 * @param string $version              The version in which the endpoint was deprecated.
 	 * @param string $deprecated_endpoint  The deprecated endpoint.
 	 * @param string $alternative_endpoint The alternative endpoint.
 	 */
-	public static function endpoint_deprecated_warning( $function_name, $deprecated_endpoint, $alternative_endpoint = '' ) {
+	public static function endpoint_deprecated_warning( $function_name, $version, $deprecated_endpoint, $alternative_endpoint = '' ) {
 
 		$messages = array(
 			sprintf(
@@ -149,6 +150,6 @@ class Publicize_Utils {
 		$messages[] = esc_html__( 'Please update all the Jetpack plugins to the latest version.', 'jetpack-publicize-pkg' );
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We have done it above.
-		_doing_it_wrong( esc_html( $function_name ), implode( ' ', $messages ), 'package-$$next-version$$' );
+		_doing_it_wrong( esc_html( $function_name ), implode( ' ', $messages ), $version );
 	}
 }

--- a/projects/packages/publicize/src/class-publicize-utils.php
+++ b/projects/packages/publicize/src/class-publicize-utils.php
@@ -120,4 +120,39 @@ class Publicize_Utils {
 	public static function should_use_jetpack_module_endpoint() {
 		return class_exists( 'Jetpack' ) && defined( 'JETPACK__VERSION' ) && ( version_compare( (string) JETPACK__VERSION, '14.3', '>=' ) );
 	}
+
+	/**
+	 * Log a warning that a deprecated endpoint was called.
+	 *
+	 * @param string $function_name        The function name.
+	 * @param string $deprecated_endpoint  The deprecated endpoint.
+	 * @param string $alternative_endpoint The alternative endpoint.
+	 */
+	public static function endpoint_deprecated_warning( $function_name, $deprecated_endpoint, $alternative_endpoint = '' ) {
+
+		$messages = array(
+			sprintf(
+				/* translators: %s: REST API endpoint. */
+				esc_html__( '%1$s endpoint has been deprecated.', 'jetpack-publicize-pkg' ),
+				'"' . $deprecated_endpoint . '"'
+			),
+		);
+
+		if ( ! empty( $alternative_endpoint ) ) {
+			$messages[] = sprintf(
+				/* translators: %s: alternative endpoint. */
+				esc_html__( 'Please use %s endpoint instead.', 'jetpack-publicize-pkg' ),
+				'"' . $alternative_endpoint . '"'
+			);
+		}
+
+		$messages[] = esc_html__( 'Please update all the Jetpack plugins to the latest version.', 'jetpack-publicize-pkg' );
+
+		_doing_it_wrong(
+			esc_html( $function_name ),
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We have done it above.
+			implode( ' ', $messages ),
+			'$$next-version$$'
+		);
+	}
 }

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\Publicize;
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Rest_Authentication;
+use Automattic\Jetpack\Publicize\REST_API\Proxy_Requests;
 use Jetpack_Options;
 use WP_Error;
 use WP_REST_Request;
@@ -362,12 +363,24 @@ class REST_Controller {
 	 * Gets the current Publicize connections, with the resolt of testing them, for the site.
 	 *
 	 * GET `jetpack/v4/publicize/connection-test-results`
+	 *
+	 * @deprecated $$next-version$$
 	 */
 	public function get_publicize_connection_test_results() {
-		$blog_id  = $this->get_blog_id();
-		$path     = sprintf( '/sites/%d/publicize/connection-test-results', absint( $blog_id ) );
-		$response = Client::wpcom_json_api_request_as_user( $path, '2', array(), null, 'wpcom' );
-		return rest_ensure_response( $this->make_proper_response( $response ) );
+
+		Publicize_Utils::endpoint_deprecated_warning(
+			__METHOD__,
+			'jetpack/v4/publicize/connection-test-results',
+			'wpcom/v2/publicize/connections?test_connections=1'
+		);
+
+		$proxy = new Proxy_Requests( 'publicize/connections' );
+
+		$request = new WP_REST_Request( 'GET' );
+
+		$request->set_param( 'test_connections', '1' );
+
+		return rest_ensure_response( $proxy->proxy_request_to_wpcom_as_user( $request ) );
 	}
 
 	/**
@@ -375,24 +388,101 @@ class REST_Controller {
 	 *
 	 * GET `jetpack/v4/publicize/connections`
 	 *
+	 * @deprecated $$next-version$$
+	 *
 	 * @param WP_REST_Request $request The request object, which includes the parameters.
 	 */
 	public function get_publicize_connections( $request ) {
-		$run_test_results = $request->get_param( 'test_connections' );
-		$clear_cache      = $request->get_param( 'clear_cache' );
 
-		$args = array();
+		Publicize_Utils::endpoint_deprecated_warning(
+			__METHOD__,
+			'jetpack/v4/publicize/connections',
+			'wpcom/v2/publicize/connections?test_connections=1'
+		);
 
-		if ( ! empty( $run_test_results ) ) {
-			$args['test_connections'] = true;
+		if ( $request->get_param( 'test_connections' ) ) {
+
+			$proxy = new Proxy_Requests( 'publicize/connections' );
+
+			return rest_ensure_response( $proxy->proxy_request_to_wpcom_as_user( $request ) );
 		}
 
-		if ( ! empty( $clear_cache ) ) {
-			$args['clear_cache'] = true;
-		}
+		return rest_ensure_response( Connections::get_all_for_user() );
+	}
 
-		global $publicize;
-		return rest_ensure_response( $publicize->get_all_connections_for_user( $args ) );
+	/**
+	 * Create a publicize connection
+	 *
+	 * @deprecated $$next-version$$
+	 *
+	 * @param WP_REST_Request $request The request object, which includes the parameters.
+	 * @return WP_REST_Response|WP_Error True if the request was successful, or a WP_Error otherwise.
+	 */
+	public function create_publicize_connection( $request ) {
+
+		Publicize_Utils::endpoint_deprecated_warning(
+			__METHOD__,
+			'jetpack/v4/social/connections',
+			'wpcom/v2/publicize/connections'
+		);
+
+		$proxy = new Proxy_Requests( 'publicize/connections' );
+
+		return rest_ensure_response(
+			$proxy->proxy_request_to_wpcom_as_user( $request, '', array( 'timeout' => 120 ) )
+		);
+	}
+
+	/**
+	 * Calls the WPCOM endpoint to update the publicize connection.
+	 *
+	 * POST jetpack/v4/social/connections/{connection_id}
+	 *
+	 * @deprecated $$next-version$$
+	 *
+	 * @param WP_REST_Request $request The request object, which includes the parameters.
+	 */
+	public function update_publicize_connection( $request ) {
+
+		Publicize_Utils::endpoint_deprecated_warning(
+			__METHOD__,
+			'jetpack/v4/social/connections/:connection_id',
+			'wpcom/v2/publicize/connections/:connection_id'
+		);
+
+		$proxy = new Proxy_Requests( 'publicize/connections' );
+
+		$path = $request->get_param( 'connection_id' );
+
+		return rest_ensure_response(
+			$proxy->proxy_request_to_wpcom_as_user( $request, $path, array( 'timeout' => 120 ) )
+		);
+	}
+
+	/**
+	 * Calls the WPCOM endpoint to delete the publicize connection.
+	 *
+	 * DELETE jetpack/v4/social/connections/{connection_id}
+	 *
+	 * @deprecated $$next-version$$
+	 *
+	 * @param WP_REST_Request $request The request object, which includes the parameters.
+	 */
+	public function delete_publicize_connection( $request ) {
+
+		Publicize_Utils::endpoint_deprecated_warning(
+			__METHOD__,
+			'jetpack/v4/social/connections/:connection_id',
+			'wpcom/v2/publicize/connections/:connection_id'
+		);
+
+		$proxy = new Proxy_Requests( 'publicize/connections' );
+
+		$path = $request->get_param( 'connection_id' );
+
+		return rest_ensure_response(
+			$proxy->proxy_request_to_wpcom_as_user( $request, $path, array( 'timeout' => 120 ) )
+		);
 	}
 
 	/**
@@ -519,131 +609,6 @@ class REST_Controller {
 	 */
 	protected function get_blog_id() {
 		return $this->is_wpcom ? get_current_blog_id() : Jetpack_Options::get_option( 'id' );
-	}
-
-	/**
-	 * Calls the WPCOM endpoint to update the publicize connection.
-	 *
-	 * POST jetpack/v4/social/connections/{connection_id}
-	 *
-	 * @param WP_REST_Request $request The request object, which includes the parameters.
-	 */
-	public function update_publicize_connection( $request ) {
-		$external_user_id = $request->get_param( 'external_user_ID' );
-		$shared           = $request->get_param( 'shared' );
-		$blog_id          = $this->get_blog_id();
-		$connection_id    = $request->get_param( 'connection_id' );
-
-		$path = sprintf(
-			'/sites/%d/jetpack-social-connections/%d',
-			$blog_id,
-			$connection_id
-		);
-
-		$body = array();
-
-		if ( ! empty( $external_user_id ) ) {
-			$body['external_user_ID'] = $external_user_id;
-		}
-
-		if ( $shared || ( false === $shared ) ) {
-			$body['shared'] = $shared;
-		}
-
-		$response = Client::wpcom_json_api_request_as_user(
-			$path,
-			'2',
-			array(
-				'method'  => 'POST',
-				'timeout' => 120,
-			),
-			$body,
-			'wpcom'
-		);
-
-		$response = $this->make_proper_response( $response );
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
-		global $publicize;
-		return rest_ensure_response( $publicize->get_connection_for_user( (int) $connection_id ) );
-	}
-
-	/**
-	 * Calls the WPCOM endpoint to delete the publicize connection.
-	 *
-	 * DELETE jetpack/v4/social/connections/{connection_id}
-	 *
-	 * @param WP_REST_Request $request The request object, which includes the parameters.
-	 */
-	public function delete_publicize_connection( $request ) {
-		$connection_id = $request->get_param( 'connection_id' );
-		$blog_id       = $this->get_blog_id();
-
-		$path = sprintf(
-			'/sites/%d/jetpack-social-connections/%d',
-			$blog_id,
-			$connection_id
-		);
-
-		$response = Client::wpcom_json_api_request_as_user( $path, '2', array( 'method' => 'DELETE' ), null, 'wpcom' );
-		return rest_ensure_response( $this->make_proper_response( $response ) );
-	}
-
-	/**
-	 * Create a publicize connection
-	 *
-	 * @param WP_REST_Request $request The request object, which includes the parameters.
-	 * @return WP_REST_Response|WP_Error True if the request was successful, or a WP_Error otherwise.
-	 */
-	public function create_publicize_connection( $request ) {
-		$keyring_connection_id = $request->get_param( 'keyring_connection_ID' );
-		$shared                = $request->get_param( 'shared' );
-		$external_user_id      = $request->get_param( 'external_user_ID' );
-		$blog_id               = $this->get_blog_id();
-
-		$path = sprintf(
-			'/sites/%d/jetpack-social-connections/new',
-			$blog_id
-		);
-
-		$body = array(
-			'keyring_connection_ID' => $keyring_connection_id,
-			'shared'                => $shared,
-		);
-
-		if ( ! empty( $external_user_id ) ) {
-			$body['external_user_ID'] = $external_user_id;
-		}
-
-		$response = Client::wpcom_json_api_request_as_user(
-			$path,
-			'2',
-			array(
-				'method'  => 'POST',
-				'timeout' => 120,
-			),
-			$body,
-			'wpcom'
-		);
-
-		$response = $this->make_proper_response( $response );
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
-		if ( isset( $response['ID'] ) ) {
-			global $publicize;
-			return rest_ensure_response( $publicize->get_connection_for_user( (int) $response['ID'] ) );
-		}
-
-		return new WP_Error(
-			'could_not_create_connection',
-			__( 'Something went wrong while creating a connection.', 'jetpack-publicize-pkg' )
-		);
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -370,7 +370,7 @@ class REST_Controller {
 
 		Publicize_Utils::endpoint_deprecated_warning(
 			__METHOD__,
-			'jetpack-$$next-version$$',
+			'jetpack-14.4, jetpack-social-6.2.0',
 			'jetpack/v4/publicize/connection-test-results',
 			'wpcom/v2/publicize/connections?test_connections=1'
 		);
@@ -397,7 +397,7 @@ class REST_Controller {
 
 		Publicize_Utils::endpoint_deprecated_warning(
 			__METHOD__,
-			'jetpack-$$next-version$$',
+			'jetpack-14.4, jetpack-social-6.2.0',
 			'jetpack/v4/publicize/connections',
 			'wpcom/v2/publicize/connections?test_connections=1'
 		);
@@ -424,7 +424,7 @@ class REST_Controller {
 
 		Publicize_Utils::endpoint_deprecated_warning(
 			__METHOD__,
-			'jetpack-$$next-version$$',
+			'jetpack-14.4, jetpack-social-6.2.0',
 			'jetpack/v4/social/connections',
 			'wpcom/v2/publicize/connections'
 		);
@@ -449,7 +449,7 @@ class REST_Controller {
 
 		Publicize_Utils::endpoint_deprecated_warning(
 			__METHOD__,
-			'jetpack-$$next-version$$',
+			'jetpack-14.4, jetpack-social-6.2.0',
 			'jetpack/v4/social/connections/:connection_id',
 			'wpcom/v2/publicize/connections/:connection_id'
 		);
@@ -476,7 +476,7 @@ class REST_Controller {
 
 		Publicize_Utils::endpoint_deprecated_warning(
 			__METHOD__,
-			'jetpack-$$next-version$$',
+			'jetpack-14.4, jetpack-social-6.2.0',
 			'jetpack/v4/social/connections/:connection_id',
 			'wpcom/v2/publicize/connections/:connection_id'
 		);

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -370,6 +370,7 @@ class REST_Controller {
 
 		Publicize_Utils::endpoint_deprecated_warning(
 			__METHOD__,
+			'jetpack-$$next-version$$',
 			'jetpack/v4/publicize/connection-test-results',
 			'wpcom/v2/publicize/connections?test_connections=1'
 		);
@@ -396,6 +397,7 @@ class REST_Controller {
 
 		Publicize_Utils::endpoint_deprecated_warning(
 			__METHOD__,
+			'jetpack-$$next-version$$',
 			'jetpack/v4/publicize/connections',
 			'wpcom/v2/publicize/connections?test_connections=1'
 		);
@@ -422,6 +424,7 @@ class REST_Controller {
 
 		Publicize_Utils::endpoint_deprecated_warning(
 			__METHOD__,
+			'jetpack-$$next-version$$',
 			'jetpack/v4/social/connections',
 			'wpcom/v2/publicize/connections'
 		);
@@ -446,6 +449,7 @@ class REST_Controller {
 
 		Publicize_Utils::endpoint_deprecated_warning(
 			__METHOD__,
+			'jetpack-$$next-version$$',
 			'jetpack/v4/social/connections/:connection_id',
 			'wpcom/v2/publicize/connections/:connection_id'
 		);
@@ -472,6 +476,7 @@ class REST_Controller {
 
 		Publicize_Utils::endpoint_deprecated_warning(
 			__METHOD__,
+			'jetpack-$$next-version$$',
 			'jetpack/v4/social/connections/:connection_id',
 			'wpcom/v2/publicize/connections/:connection_id'
 		);

--- a/projects/packages/publicize/src/class-services.php
+++ b/projects/packages/publicize/src/class-services.php
@@ -64,7 +64,7 @@ class Services {
 	public static function fetch_and_cache_services() {
 		$proxy = new Proxy_Requests( 'external-services' );
 
-		$request = new WP_REST_Request( 'GET', '/wpcom/v2/external-services' );
+		$request = new WP_REST_Request( 'GET' );
 
 		$request->set_param( 'type', 'publicize' );
 

--- a/projects/packages/publicize/tests/php/test-publicize-rest-controller.php
+++ b/projects/packages/publicize/tests/php/test-publicize-rest-controller.php
@@ -87,17 +87,17 @@ class Test_REST_Controller extends TestCase {
 	 * Testing the `POST /jetpack/v4/publicize/connections` endpoint without proper permissions.
 	 */
 	public function test_get_publicize_connections_without_proper_permission() {
-		$request  = new WP_REST_Request( 'GET', '/jetpack/v4/publicize/connections' );
+		$request  = new WP_REST_Request( 'GET', '/wpcom/v2/publicize/connections' );
 		$response = $this->dispatch_request_signed_with_blog_token( $request );
 		$this->assertEquals( 401, $response->get_status() );
-		$this->assertEquals( 'Sorry, you are not allowed to do that.', $response->get_data()['message'] );
+		$this->assertEquals( 'Sorry, you are not allowed to access Jetpack Social data on this site.', $response->get_data()['message'] );
 	}
 
 	/**
 	 * Testing the `POST /jetpack/v4/publicize/connections` endpoint with proper permissions.
 	 */
 	public function test_get_publicize_connections_with_proper_permission() {
-		$request = new WP_REST_Request( 'GET', '/jetpack/v4/publicize/connections' );
+		$request = new WP_REST_Request( 'GET', '/wpcom/v2/publicize/connections' );
 		wp_set_current_user( $this->admin_id );
 		$response = $this->dispatch_request_signed_with_blog_token( $request );
 		$this->assertCount( 3, $response->data );

--- a/tools/replace-next-version-tag.sh
+++ b/tools/replace-next-version-tag.sh
@@ -85,7 +85,7 @@ for FILE in $(git ls-files "projects/$SLUG/"); do
 
 	sed -i.bak -E -e 's!(@since|@deprecated( +[sS]ince)?)( +)\$\$next-version\$\$!\1\3'"$VE"'!g' "$FILE"
 	rm "$FILE.bak" # We need a backup file because macOS requires it.
-	sed -i.bak -E -e $'s!(^\t*(_deprecated_(function|constructor|file|argument|hook|class)|_doing_it_wrong)\\( .*, \'[^\']*)\\$\\$next-version\\$\\$\'!\\1'"$VE"$'\'!g' "$FILE"
+	sed -i.bak -E -e $'s!(^\t*_deprecated_(function|constructor|file|argument|hook|class)\\( .*, \'[^\']*)\\$\\$next-version\\$\\$\'!\\1'"$VE"$'\'!g' "$FILE"
 	rm "$FILE.bak" # We need a backup file because macOS requires it.
 	sed -i.bak -E -e $'s!((do_action|apply_filters)_deprecated\\( .*, \'[^\']*)\\$\\$next-version\\$\\$\'!\\1'"$VE"$'\'!g' "$FILE"
 	rm "$FILE.bak" # We need a backup file because macOS requires it.

--- a/tools/replace-next-version-tag.sh
+++ b/tools/replace-next-version-tag.sh
@@ -85,7 +85,7 @@ for FILE in $(git ls-files "projects/$SLUG/"); do
 
 	sed -i.bak -E -e 's!(@since|@deprecated( +[sS]ince)?)( +)\$\$next-version\$\$!\1\3'"$VE"'!g' "$FILE"
 	rm "$FILE.bak" # We need a backup file because macOS requires it.
-	sed -i.bak -E -e $'s!(^\t*_deprecated_(function|constructor|file|argument|hook|class)\\( .*, \'[^\']*)\\$\\$next-version\\$\\$\'!\\1'"$VE"$'\'!g' "$FILE"
+	sed -i.bak -E -e $'s!(^\t*(_deprecated_(function|constructor|file|argument|hook|class)|_doing_it_wrong)\\( .*, \'[^\']*)\\$\\$next-version\\$\\$\'!\\1'"$VE"$'\'!g' "$FILE"
 	rm "$FILE.bak" # We need a backup file because macOS requires it.
 	sed -i.bak -E -e $'s!((do_action|apply_filters)_deprecated\\( .*, \'[^\']*)\\$\\$next-version\\$\\$\'!\\1'"$VE"$'\'!g' "$FILE"
 	rm "$FILE.bak" # We need a backup file because macOS requires it.


### PR DESCRIPTION
As a part of the clean-up following the connections schema changes, we want to deprecate `jetpack/v4` connection endpoints.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Create a utility `Publicize_Utils::endpoint_deprecated_warning`
* Deprecate the `jetpack/v4` connection endpoints
* Update those endpoints to use the `wpcom/v2/publicize/connections` endpoint

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate Social plugin from this PR
* Using Beta Tester, activate Jetpack v13.x, which uses `jetpack/v4` endpoints
* Goto Jetpack settings > Sharing
* Create a connection
* Mark one as shared
* Delete a connection
* In the Network tab, confirm that they use `jetpack/v4` endpoints
* Confirm that they work fine
* Confirm the Doing it wrong header in the request response
* Run these in the browser console
```js
await wp.apiFetch({
    path: 'jetpack/v4/publicize/connections'
})
```
```js
await wp.apiFetch({
    path: 'jetpack/v4/publicize/connection-test-results'
})
```

* Confirm that the first one works fine with status field being `null`
* Confirm that the second one has status `ok` or `broken` as per the connection health
* Confirm the doing it wrong header for both

<img width="1235" alt="Screenshot 2025-02-20 at 5 37 42 PM" src="https://github.com/user-attachments/assets/7348a8b0-ffc4-4ae8-8212-5119bdce5233" />
<img width="859" alt="Screenshot 2025-02-20 at 5 40 32 PM" src="https://github.com/user-attachments/assets/16e2785d-1763-49c6-abad-ad0cc3250618" />
