### PR TITLE
Jetpack AI: Add Chrome built-in AI summarization API as the model for AI excerpt

### DIFF
--- a/projects/js-packages/ai-client/changelog/add-chrome-ai-summary
+++ b/projects/js-packages/ai-client/changelog/add-chrome-ai-summary
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+AI Assistant: Add experimental functionality to test Chrome's built-in AI API with the AI excerpt

--- a/projects/js-packages/ai-client/src/chrome-ai/suggestions.ts
+++ b/projects/js-packages/ai-client/src/chrome-ai/suggestions.ts
@@ -15,6 +15,10 @@ type ChromeAISuggestionsEventSourceConstructorArgs = {
 		sourceLanguage?: string;
 		targetLanguage?: string;
 
+		// summarization
+		tone?: string;
+		wordCount?: number;
+
 		// not sure if we need these
 		functions?: Array< object >;
 		model?: AiModelTypeProp;
@@ -64,7 +68,7 @@ export default class ChromeAISuggestionsEventSource extends EventTarget {
 		}
 
 		if ( promptType === PROMPT_TYPE_SUMMARIZE ) {
-			this.summarize( content );
+			this.summarize( content, options.tone, options.wordCount );
 		}
 	}
 
@@ -83,7 +87,7 @@ export default class ChromeAISuggestionsEventSource extends EventTarget {
 			return;
 		}
 
-		if ( e.event === 'translation' ) {
+		if ( e.event === 'translation' || e.event === 'summary' ) {
 			this.dispatchEvent( new CustomEvent( 'suggestion', { detail: data.message } ) );
 		}
 
@@ -132,8 +136,58 @@ export default class ChromeAISuggestionsEventSource extends EventTarget {
 		}
 	}
 
-	// TODO
-	async summarize( text: string ) {
-		return text;
+	// Helper function to format summarizer options
+	private getSummarizerOptions( tone?: string, wordCount?: number ) {
+		let sharedContext = `The summary you write should contain approximately ${
+			wordCount ?? 50
+		} words long. Strive for precision in word count without compromising clarity and significance`;
+
+		if ( tone ) {
+			sharedContext += `\n - Write with a ${ tone } tone.\n`;
+		}
+
+		const options = {
+			sharedContext: sharedContext,
+			type: 'teaser',
+			format: 'plain-text',
+			length: 'medium',
+		};
+
+		return options;
+	}
+
+	// use the Chrome AI summarizer
+	async summarize( text: string, tone?: string, wordCount?: number ) {
+		if ( ! ( 'ai' in self ) || ! ( 'summarizer' in self.ai ) ) {
+			return;
+		}
+		const available = ( await self.ai.summarizer.capabilities() ).available;
+
+		if ( available === 'no' ) {
+			return;
+		}
+
+		const options = this.getSummarizerOptions( tone, wordCount );
+
+		const summarizer = await self.ai.summarizer.create( options );
+
+		if ( available === 'after-download' ) {
+			await summarizer.ready;
+		}
+
+		try {
+			const context = `Write with a ${ tone } tone.`;
+			const summary = await summarizer.summarize( text, { context: context } );
+			this.processEvent( {
+				id: '',
+				event: 'summary',
+				data: JSON.stringify( {
+					message: summary,
+					complete: true,
+				} ),
+			} );
+		} catch ( error ) {
+			this.processErrorEvent( error );
+		}
 	}
 }

--- a/projects/js-packages/ai-client/src/types.ts
+++ b/projects/js-packages/ai-client/src/types.ts
@@ -158,6 +158,20 @@ declare global {
 					>;
 				} >;
 			};
+			summarizer?: {
+				capabilities: () => Promise< {
+					available: 'no' | 'yes' | 'after-download';
+				} >;
+				create: ( options: {
+					sharedContext?: string;
+					type?: string;
+					format?: string;
+					length?: string;
+				} ) => Promise< {
+					ready: Promise< void >;
+					summarize: ( text: string, summarizeOptions?: { context?: string } ) => Promise< string >;
+				} >;
+			};
 		};
 	}
 }

--- a/projects/plugins/jetpack/changelog/add-chrome-ai-summary
+++ b/projects/plugins/jetpack/changelog/add-chrome-ai-summary
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+AI Assistant: Adding support to use Chrome AI bult-in API.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -60,47 +60,49 @@ function load_assets( $attr, $content ) {
  * Retrieve the Chrome trial AI token for use with the Chrome AI feature.
  * This ultimately sets an Origin-Trial header with the token.
  */
-function add_chrome_ai_token_header() {
-	$token_transient_name = 'jetpack-ai-chrome-ai-token';
+function add_chrome_ai_token_headers() {
+	$token_transient_names = array( 'jetpack-ai-chrome-ai-translation-token', 'jetpack-ai-chrome-ai-summarization-token' );
 
-	$cached_token = get_transient( $token_transient_name );
+	foreach ( $token_transient_names as $token_transient_name ) {
+		$cached_token = get_transient( $token_transient_name );
 
-	if ( ! $cached_token ) {
-		$blog_id = \Jetpack_Options::get_option( 'id' );
+		if ( ! $cached_token ) {
+			$blog_id = \Jetpack_Options::get_option( 'id' );
 
-		// get the token from wpcom
-		$wpcom_request = Client::wpcom_json_api_request_as_user(
-			sprintf( '/sites/%d/jetpack-ai/ai-assistant-feature', $blog_id ),
-			'v2',
-			array(
-				'method'  => 'GET',
-				'headers' => array(
-					'X-Forwarded-For' => ( new Visitor() )->get_ip( true ),
+			// get the token from wpcom
+			$wpcom_request = Client::wpcom_json_api_request_as_user(
+				sprintf( '/sites/%d/jetpack-ai/ai-assistant-feature', $blog_id ),
+				'v2',
+				array(
+					'method'  => 'GET',
+					'headers' => array(
+						'X-Forwarded-For' => ( new Visitor() )->get_ip( true ),
+					),
+					'timeout' => 30,
 				),
-				'timeout' => 30,
-			),
-			null,
-			'wpcom'
-		);
+				null,
+				'wpcom'
+			);
 
-		$response_code = wp_remote_retrieve_response_code( $wpcom_request );
-		if ( 200 === $response_code ) {
-			$ai_assistant_feature_data = json_decode( wp_remote_retrieve_body( $wpcom_request ), true );
+			$response_code = wp_remote_retrieve_response_code( $wpcom_request );
+			if ( 200 === $response_code ) {
+				$ai_assistant_feature_data = json_decode( wp_remote_retrieve_body( $wpcom_request ), true );
 
-			if ( ! empty( $ai_assistant_feature_data['chrome-ai-token'] ) ) {
-				set_transient(
-					$token_transient_name,
-					$ai_assistant_feature_data['chrome-ai-token'],
-					3600 // cache for an hour, but this can probably be longer
-				);
+				if ( ! empty( $ai_assistant_feature_data['chrome-ai-token'] ) ) {
+					set_transient(
+						$token_transient_name,
+						$ai_assistant_feature_data['chrome-ai-token'],
+						3600 // cache for an hour, but this can probably be longer
+					);
 
-				$cached_token = $ai_assistant_feature_data['chrome-ai-token'];
+					$cached_token = $ai_assistant_feature_data['chrome-ai-token'];
+				}
 			}
 		}
-	}
 
-	if ( $cached_token ) {
-		header( "Origin-Trial: {$cached_token}" );
+		if ( $cached_token ) {
+			header( "Origin-Trial: {$cached_token}" );
+		}
 	}
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -184,7 +184,7 @@ add_action(
 		) {
 			\Jetpack_Gutenberg::set_extension_available( 'ai-use-chrome-ai-sometimes' );
 
-			add_chrome_ai_token_header();
+			add_chrome_ai_token_headers();
 		}
 	}
 );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -183,8 +183,7 @@ add_action(
 			apply_filters( 'ai_chrome_ai_enabled', false )
 		) {
 			\Jetpack_Gutenberg::set_extension_available( 'ai-use-chrome-ai-sometimes' );
-
-			add_chrome_ai_token_headers();
+			add_action( 'wp_head', __NAMESPACE__ . '\add_chrome_ai_token_headers' );
 		}
 	}
 );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -61,6 +61,11 @@ function load_assets( $attr, $content ) {
  * This ultimately sets an Origin-Trial header with the token.
  */
 function add_chrome_ai_token_headers() {
+	if ( ! apply_filters( 'jetpack_ai_enabled', true )
+		|| ! apply_filters( 'ai_chrome_ai_enabled', false ) ) {
+		return;
+	}
+
 	$token_transient_names = array( 'jetpack-ai-chrome-ai-translation-token', 'jetpack-ai-chrome-ai-summarization-token' );
 
 	foreach ( $token_transient_names as $token_transient_name ) {
@@ -183,7 +188,8 @@ add_action(
 			apply_filters( 'ai_chrome_ai_enabled', false )
 		) {
 			\Jetpack_Gutenberg::set_extension_available( 'ai-use-chrome-ai-sometimes' );
-			add_action( 'wp_head', __NAMESPACE__ . '\add_chrome_ai_token_headers' );
 		}
 	}
 );
+
+add_action( 'wp_head', __NAMESPACE__ . '\add_chrome_ai_token_headers' );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -101,7 +101,7 @@ function add_chrome_ai_token_headers() {
 		}
 
 		if ( $cached_token ) {
-			header( "Origin-Trial: {$cached_token}" );
+			echo '<meta http-equiv="origin-trial" content="' . esc_attr( $cached_token ) . '">';
 		}
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -61,11 +61,6 @@ function load_assets( $attr, $content ) {
  * This ultimately sets an Origin-Trial header with the token.
  */
 function add_chrome_ai_token_headers() {
-	if ( ! apply_filters( 'jetpack_ai_enabled', true )
-		|| ! apply_filters( 'ai_chrome_ai_enabled', false ) ) {
-		return;
-	}
-
 	$token_transient_names = array( 'jetpack-ai-chrome-ai-translation-token', 'jetpack-ai-chrome-ai-summarization-token' );
 
 	foreach ( $token_transient_names as $token_transient_name ) {
@@ -188,8 +183,7 @@ add_action(
 			apply_filters( 'ai_chrome_ai_enabled', false )
 		) {
 			\Jetpack_Gutenberg::set_extension_available( 'ai-use-chrome-ai-sometimes' );
+			add_chrome_ai_token_headers();
 		}
 	}
 );
-
-add_action( 'wp_head', __NAMESPACE__ . '\add_chrome_ai_token_headers' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #41213 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds support to Chrome AI Summarization API
* This is behind a feature flag and in beta (see test instructions for more)
* If the feature flag is not enabled, we use OpenAI API

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
No product discussion but the PT is here: pe4Cmx-30R-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Prerequisites:
  * You'll need to test it using Chrome version 133 or higher.
  * First you'll need a token to use the Chrome AI Summarization API. For a JN site you can use the one in this Slack thread: p1740413197432549/1739302089.335769-slack-C054LN8RNVA
  * To test that I haven't broke the Chrome's AI translation integration, get the translation token as well: p1739311387984089/1739302089.335769-slack-C054LN8RNVA
  * If you want to test elsewhere (locally, or somewhere else with Jetpack beta, perhaps) you will have to sign up for the trial and get your own token.
    * Sign up here: https://developer.chrome.com/origintrials/#/register_trial/1923599990840623105
    * Instructions are here: https://developer.chrome.com/docs/ai/summarizer-api
* Check out this branch, add the following snippet to enable beta features, the feature flag, and add your token in place of [ your trial token goes here ]:
```php
define( 'JETPACK_BLOCKS_VARIATION', 'beta' );
add_filter( 'ai_chrome_ai_enabled', '__return_true' );

$token_transient_name = 'jetpack-ai-chrome-ai-summarization-token';
if ( ! get_transient( $token_transient_name ) ) {
	set_transient(
		$token_transient_name,
		"[ your summarization trial token goes here ]",
		3600
	);
}


$token_transient_name = 'jetpack-ai-chrome-ai-translation-token';
if ( ! get_transient( $token_transient_name ) ) {
	set_transient(
		$token_transient_name,
		"[ your translation trial token goes here ]",
		3600
	);
}
```
* This snippet should also make it so you don't have to modify your sandbox to return your trial token. However for the duration of the trial we will have to ask WPCOM for the token. Currently there is no general purpose token, which is why this setup is required for testing.
* Once this is set up, you should be able to create an excerpt using Chrome's AI API.
* Open the javascript console and enable debug mode.
* Create a new post and add some text.
* Go to the Excerpt section in the post sidebar and click on generate.
* The first time you click on it, the browser needs to download the model, which can take several seconds (close to a minute for me). There are no UI progress indicators for this, so you'll just have to be patient the first time. The following requests are almost instantaneous.
* Tone, word count, and language settings won't have any effect on the result (it seems to be a limitation of the model).
* The summarization API only returns summaries in English, even if the post content is in another language.
* Disable the feature flag and observe that creating an excerpt now goes through OpenAI with a streamed response.
* Follow the instructions on https://github.com/Automattic/jetpack/pull/41724 to test the translation feature, but ignore the token setup part.