### PR TITLE
Connection: add modal for disconnecting owner account

### DIFF
--- a/projects/js-packages/api/changelog/fix-disconnect-owner-disconnect-all
+++ b/projects/js-packages/api/changelog/fix-disconnect-owner-disconnect-all
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Extended unlinkUser so a parameter for disconnecting all users can be passed.

--- a/projects/js-packages/api/index.jsx
+++ b/projects/js-packages/api/index.jsx
@@ -157,12 +157,23 @@ function JetpackRestApiClient( root, nonce ) {
 				.then( checkStatus )
 				.then( parseJsonResponse ),
 
-		unlinkUser: force =>
-			postRequest( `${ apiRoot }jetpack/v4/connection/user`, postParams, {
-				body: JSON.stringify( { linked: false, force: !! force } ),
+		unlinkUser: ( force = false, options = {} ) => {
+			const params = {
+				linked: false,
+				force: !! force,
+			};
+
+			// Add any additional options to the params
+			if ( options.disconnectAllUsers ) {
+				params[ 'disconnect-all-users' ] = true;
+			}
+
+			return postRequest( `${ apiRoot }jetpack/v4/connection/user`, postParams, {
+				body: JSON.stringify( params ),
 			} )
 				.then( checkStatus )
-				.then( parseJsonResponse ),
+				.then( parseJsonResponse );
+		},
 
 		reconnect: () =>
 			postRequest( `${ apiRoot }jetpack/v4/connection/reconnect`, postParams )

--- a/projects/js-packages/connection/changelog/fix-disconnect-owner-disconnect-all
+++ b/projects/js-packages/connection/changelog/fix-disconnect-owner-disconnect-all
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection: Disconnection connection ower will disconnect all other users first.

--- a/projects/js-packages/connection/components/owner-disconnect-dialog/index.jsx
+++ b/projects/js-packages/connection/components/owner-disconnect-dialog/index.jsx
@@ -1,0 +1,232 @@
+/**
+ * External dependencies
+ */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
+import restApi from '@automattic/jetpack-api';
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ExternalLink, Modal, Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Icon, chevronRight, external } from '@wordpress/icons';
+import clsx from 'clsx';
+import PropTypes from 'prop-types';
+import React, { useCallback, useState, useEffect } from 'react';
+import './style.scss';
+
+/**
+ * The Owner Disconnect Dialog component.
+ *
+ * @param {object}   props                - Component props.
+ * @param {boolean}  props.isOpen         - Whether the dialog is open.
+ * @param {Function} props.onClose        - Callback for when the dialog is closed.
+ * @param {string}   props.apiRoot        - API root URL.
+ * @param {string}   props.apiNonce       - API nonce.
+ * @param {Function} props.onDisconnected - Callback after successful disconnection.
+ * @param {Function} props.onUnlinked     - Callback after user is unlinked.
+ * @return {React.Component} The OwnerDisconnectDialog component.
+ */
+const OwnerDisconnectDialog = ( {
+	isOpen,
+	onClose,
+	apiRoot,
+	apiNonce,
+	onDisconnected,
+	onUnlinked,
+} ) => {
+	// Add state for disconnect status and error
+	const [ isDisconnecting, setIsDisconnecting ] = useState( false );
+	const [ disconnectError, setDisconnectError ] = useState( '' );
+
+	// Initialize the REST API
+	useEffect( () => {
+		restApi.setApiRoot( apiRoot );
+		restApi.setApiNonce( apiNonce );
+	}, [ apiRoot, apiNonce ] );
+
+	const handleStayConnected = useCallback( () => {
+		onClose();
+	}, [ onClose ] );
+
+	const handleDisconnectAnyway = useCallback( () => {
+		// Track disconnect click
+		jetpackAnalytics.tracks.recordEvent(
+			'jetpack_manage_connection_dialog_owner_disconnect_click'
+		);
+
+		setIsDisconnecting( true );
+		setDisconnectError( '' );
+
+		// Force parameter is needed for owner account
+		restApi
+			.unlinkUser( true )
+			.then( () => {
+				// Track successful disconnect
+				jetpackAnalytics.tracks.recordEvent(
+					'jetpack_manage_connection_dialog_owner_disconnect_success'
+				);
+				setIsDisconnecting( false );
+				onClose(); // Close first
+				onDisconnected && onDisconnected();
+				onUnlinked && onUnlinked();
+			} )
+			.catch( () => {
+				// Track failed disconnect
+				jetpackAnalytics.tracks.recordEvent(
+					'jetpack_manage_connection_dialog_owner_disconnect_error'
+				);
+				setDisconnectError(
+					__(
+						'There was a problem disconnecting your account. Please try again.',
+						'jetpack-connection-js'
+					)
+				);
+				setIsDisconnecting( false );
+			} );
+	}, [ onClose, onDisconnected, onUnlinked ] );
+
+	return (
+		isOpen && (
+			<Modal
+				title=""
+				contentLabel={ __( 'Disconnect Owner Account', 'jetpack-connection-js' ) }
+				aria={ {
+					labelledby: 'jp-connection__disconnect-dialog__heading',
+				} }
+				onRequestClose={ handleStayConnected }
+				className="jp-connection__disconnect-dialog"
+			>
+				<div className="jp-connection__disconnect-dialog__content">
+					<h1 id="jp-connection__disconnect-dialog__heading">
+						{ __( 'Disconnect Owner Account', 'jetpack-connection-js' ) }
+					</h1>
+					<p className="jp-connection__disconnect-dialog__large-text">
+						{ __(
+							'Disconnecting the owner account will remove the Jetpack connection for all users on this site. The site will remain connected.',
+							'jetpack-connection-js'
+						) }
+					</p>
+					<ManageConnectionActionCard
+						title={ __( 'Transfer ownership to another admin', 'jetpack-connection-js' ) }
+						link={ getRedirectUrl( 'calypso-settings-manage-connection', {
+							site: window?.myJetpackInitialState?.siteSuffix,
+						} ) }
+						isExternal={ true }
+						action="transfer"
+					/>
+					<ManageConnectionActionCard
+						title={ __( 'Check other connected accounts', 'jetpack-connection-js' ) }
+						link="users.php"
+						action="check-users"
+					/>
+				</div>
+
+				<div className="jp-connection__disconnect-dialog__actions">
+					<div className="jp-row">
+						<div className="lg-col-span-8 md-col-span-9 sm-col-span-4">
+							<p>
+								{ createInterpolateElement(
+									__(
+										'<strong>Need help?</strong> Learn more about the <connectionInfoLink>Jetpack connection</connectionInfoLink> or <supportLink>contact Jetpack support</supportLink>',
+										'jetpack-connection-js'
+									),
+									{
+										strong: <strong></strong>,
+										connectionInfoLink: (
+											<ExternalLink
+												href={ getRedirectUrl(
+													'why-the-wordpress-com-connection-is-important-for-jetpack'
+												) }
+												className="jp-connection__disconnect-dialog__link"
+											/>
+										),
+										supportLink: (
+											<ExternalLink
+												href={ getRedirectUrl( 'jetpack-support' ) }
+												className="jp-connection__disconnect-dialog__link"
+											/>
+										),
+									}
+								) }
+							</p>
+						</div>
+						<div className="jp-connection__disconnect-dialog__button-wrap lg-col-span-4 md-col-span-7 sm-col-span-4">
+							<Button
+								variant="primary"
+								onClick={ handleStayConnected }
+								className="jp-connection__disconnect-dialog__btn-dismiss"
+							>
+								{ __( 'Stay Connected', 'jetpack-connection-js' ) }
+							</Button>
+							<Button
+								variant="primary"
+								onClick={ handleDisconnectAnyway }
+								className="jp-connection__disconnect-dialog__btn-disconnect"
+								isDestructive
+								disabled={ isDisconnecting }
+							>
+								{ isDisconnecting
+									? __( 'Disconnecting…', 'jetpack-connection-js' )
+									: __( 'Disconnect', 'jetpack-connection-js' ) }
+							</Button>
+						</div>
+					</div>
+					{ disconnectError && (
+						<p className="jp-connection__disconnect-dialog__error">{ disconnectError }</p>
+					) }
+				</div>
+			</Modal>
+		)
+	);
+};
+
+OwnerDisconnectDialog.propTypes = {
+	/** Whether the dialog is open */
+	isOpen: PropTypes.bool,
+	/** Callback for when the dialog is closed */
+	onClose: PropTypes.func,
+	/** API root URL */
+	apiRoot: PropTypes.string.isRequired,
+	/** API nonce */
+	apiNonce: PropTypes.string.isRequired,
+	/** Callback after successful disconnection */
+	onDisconnected: PropTypes.func,
+	/** Callback after user is unlinked */
+	onUnlinked: PropTypes.func,
+};
+
+const ManageConnectionActionCard = ( {
+	title,
+	onClick = () => null,
+	isExternal = false,
+	link = '#',
+	action,
+	disabled = false,
+} ) => {
+	const disabledCallback = useCallback( e => e.preventDefault(), [] );
+
+	return (
+		<div
+			className={
+				'jp-connection__manage-dialog__action-card card' + ( disabled ? ' disabled' : '' )
+			}
+		>
+			<div className="jp-connection__manage-dialog__action-card__card-content">
+				<a
+					href={ link }
+					className={ clsx( 'jp-connection__manage-dialog__action-card__card-headline', action ) }
+					onClick={ ! disabled ? onClick : disabledCallback }
+					target={ isExternal ? '_blank' : '_self' }
+					rel={ 'noopener noreferrer' }
+				>
+					{ title }
+					<Icon
+						icon={ isExternal ? external : chevronRight }
+						className="jp-connection__manage-dialog__action-card__icon"
+					/>
+				</a>
+			</div>
+		</div>
+	);
+};
+
+export default OwnerDisconnectDialog;

--- a/projects/js-packages/connection/components/owner-disconnect-dialog/index.jsx
+++ b/projects/js-packages/connection/components/owner-disconnect-dialog/index.jsx
@@ -118,7 +118,7 @@ const OwnerDisconnectDialog = ( {
 						action="transfer"
 					/>
 					<ManageConnectionActionCard
-						title={ __( 'Check other connected accounts', 'jetpack-connection-js' ) }
+						title={ __( 'View other connected accounts', 'jetpack-connection-js' ) }
 						link="users.php"
 						action="check-users"
 					/>

--- a/projects/js-packages/connection/components/owner-disconnect-dialog/index.jsx
+++ b/projects/js-packages/connection/components/owner-disconnect-dialog/index.jsx
@@ -60,9 +60,9 @@ const OwnerDisconnectDialog = ( {
 		setIsDisconnecting( true );
 		setDisconnectError( '' );
 
-		// Force parameter is needed for owner account
+		// Disconnect owner with force and disconnect-all-users parameters
 		restApi
-			.unlinkUser( true )
+			.unlinkUser( true, { disconnectAllUsers: true } )
 			.then( () => {
 				// Track successful disconnect
 				jetpackAnalytics.tracks.recordEvent(

--- a/projects/js-packages/connection/components/owner-disconnect-dialog/index.jsx
+++ b/projects/js-packages/connection/components/owner-disconnect-dialog/index.jsx
@@ -37,6 +37,10 @@ const OwnerDisconnectDialog = ( {
 	const [ isDisconnecting, setIsDisconnecting ] = useState( false );
 	const [ disconnectError, setDisconnectError ] = useState( '' );
 
+	// Add these string constants
+	const disconnectingText = __( 'Disconnecting…', 'jetpack-connection-js' );
+	const disconnectText = __( 'Disconnect', 'jetpack-connection-js' );
+
 	// Initialize the REST API
 	useEffect( () => {
 		restApi.setApiRoot( apiRoot );
@@ -164,9 +168,7 @@ const OwnerDisconnectDialog = ( {
 								isDestructive
 								disabled={ isDisconnecting }
 							>
-								{ isDisconnecting
-									? __( 'Disconnecting…', 'jetpack-connection-js' )
-									: __( 'Disconnect', 'jetpack-connection-js' ) }
+								{ isDisconnecting ? disconnectingText : disconnectText }
 							</Button>
 						</div>
 					</div>

--- a/projects/js-packages/connection/components/owner-disconnect-dialog/index.jsx
+++ b/projects/js-packages/connection/components/owner-disconnect-dialog/index.jsx
@@ -68,8 +68,7 @@ const OwnerDisconnectDialog = ( {
 				jetpackAnalytics.tracks.recordEvent(
 					'jetpack_manage_connection_dialog_owner_disconnect_success'
 				);
-				setIsDisconnecting( false );
-				onClose(); // Close first
+				// Don't close modal or change state since page will reload
 				onDisconnected && onDisconnected();
 				onUnlinked && onUnlinked();
 			} )
@@ -86,7 +85,7 @@ const OwnerDisconnectDialog = ( {
 				);
 				setIsDisconnecting( false );
 			} );
-	}, [ onClose, onDisconnected, onUnlinked ] );
+	}, [ onDisconnected, onUnlinked ] );
 
 	return (
 		isOpen && (

--- a/projects/js-packages/connection/components/owner-disconnect-dialog/style.scss
+++ b/projects/js-packages/connection/components/owner-disconnect-dialog/style.scss
@@ -1,0 +1,9 @@
+.jp-connection__disconnect-dialog {
+    // Add !important to override WordPress styles
+    .components-button.jp-connection__disconnect-dialog__btn-dismiss {
+        background: var( --jp-black ) !important;
+    }
+   .jp-connection__disconnect-dialog__content {
+        --spacing-base: 8px;
+    }
+}

--- a/projects/js-packages/connection/components/owner-disconnect-dialog/style.scss
+++ b/projects/js-packages/connection/components/owner-disconnect-dialog/style.scss
@@ -6,4 +6,9 @@
    .jp-connection__disconnect-dialog__content {
         --spacing-base: 8px;
     }
+    .jp-connection__disconnect-dialog .components-modal__content > div:not(.components-modal__header) {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+      }
 }

--- a/projects/packages/connection/changelog/fix-disconnect-owner-disconnect-all
+++ b/projects/packages/connection/changelog/fix-disconnect-owner-disconnect-all
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection: Disconnection connection ower will disconnect all other users first.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -944,14 +944,30 @@ class Manager {
 	/**
 	 * Force user disconnect.
 	 *
-	 * @param int $user_id Local (external) user ID.
+	 * @param int  $user_id Local (external) user ID.
+	 * @param bool $disconnect_all_users Whether to disconnect all users before disconnecting the primary user.
 	 *
 	 * @return bool
 	 */
-	public function disconnect_user_force( $user_id ) {
+	public function disconnect_user_force( $user_id, $disconnect_all_users = false ) {
 		if ( ! (int) $user_id ) {
 			// Missing user ID.
 			return false;
+		}
+		// If we are disconnecting the primary user we need to disconnect all other users first
+		if ( $disconnect_all_users ) {
+			$all_connected_users = $this->get_connected_users();
+			foreach ( $all_connected_users as $user ) {
+				// Skip the primary user for now.
+				if ( $user->ID === $this->get_connection_owner_id() ) {
+					continue;
+				}
+				$disconnected = $this->disconnect_user( $user->ID, false, true );
+				// If we fail to disconnect any user, we should not proceed with disconnecting the primary user.
+				if ( ! $disconnected ) {
+					return false;
+				}
+			}
 		}
 
 		return $this->disconnect_user( $user_id, true, true );

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -954,23 +954,36 @@ class Manager {
 			// Missing user ID.
 			return false;
 		}
-		// If we are disconnecting the primary user we need to disconnect all other users first
-		if ( $disconnect_all_users ) {
-			$all_connected_users = $this->get_connected_users();
-			foreach ( $all_connected_users as $user ) {
-				// Skip the primary user for now.
-				if ( $user->ID === $this->get_connection_owner_id() ) {
-					continue;
-				}
-				$disconnected = $this->disconnect_user( $user->ID, false, true );
-				// If we fail to disconnect any user, we should not proceed with disconnecting the primary user.
-				if ( ! $disconnected ) {
-					return false;
-				}
-			}
+		// If we are disconnecting the primary user we may need to disconnect all other users first
+		if ( $user_id === $this->get_connection_owner_id() && $disconnect_all_users && ! $this->disconnect_all_users_except_primary() ) {
+			return false;
 		}
 
 		return $this->disconnect_user( $user_id, true, true );
+	}
+
+	/**
+	 * Disconnects all users except the primary user.
+	 *
+	 * @return bool
+	 */
+	public function disconnect_all_users_except_primary() {
+
+		$all_connected_users = $this->get_connected_users();
+
+		foreach ( $all_connected_users as $user ) {
+			// Skip the primary.
+			if ( $user->ID === $this->get_connection_owner_id() ) {
+				continue;
+			}
+			$disconnected = $this->disconnect_user( $user->ID, false, true );
+			// If we fail to disconnect any user, we should not proceed with disconnecting the primary user.
+			if ( ! $disconnected ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -1001,9 +1001,16 @@ class REST_Connector {
 			return new WP_Error( 'invalid_param', esc_html__( 'Invalid Parameter', 'jetpack-connection' ), array( 'status' => 404 ) );
 		}
 
+		// If the admin is also connection owner, we need to disconnect all users
+		$disconnect_all_users = false;
+
+		if ( ( new Manager() )->get_connection_owner_id() === get_current_user_id() ) {
+			$disconnect_all_users = true;
+		}
+
 		// Allow admins to force a disconnect by passing the "force" parameter
 		// This allows an admin to disconnect themselves
-		if ( isset( $request['force'] ) && false !== $request['force'] && current_user_can( 'manage_options' ) && ( new Manager( 'jetpack' ) )->disconnect_user_force( get_current_user_id() ) ) {
+		if ( isset( $request['force'] ) && false !== $request['force'] && current_user_can( 'manage_options' ) && ( new Manager( 'jetpack' ) )->disconnect_user_force( get_current_user_id(), $disconnect_all_users ) ) {
 			return rest_ensure_response(
 				array(
 					'code' => 'success',

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -1001,11 +1001,15 @@ class REST_Connector {
 			return new WP_Error( 'invalid_param', esc_html__( 'Invalid Parameter', 'jetpack-connection' ), array( 'status' => 404 ) );
 		}
 
-		// If the admin is also connection owner, we need to disconnect all users
+		// If the user is also connection owner, we need to disconnect all users. Since disconnecting all users is a destructive action, we need to pass a parameter to confirm the action.
 		$disconnect_all_users = false;
 
 		if ( ( new Manager() )->get_connection_owner_id() === get_current_user_id() ) {
-			$disconnect_all_users = true;
+			if ( isset( $request['disconnect-all-users'] ) && false !== $request['disconnect-all-users'] ) {
+				$disconnect_all_users = true;
+			} else {
+				return new WP_Error( 'unlink_user_failed', esc_html__( 'Unable to unlink the connection owner.', 'jetpack-connection' ), array( 'status' => 400 ) );
+			}
 		}
 
 		// Allow admins to force a disconnect by passing the "force" parameter

--- a/projects/packages/connection/tests/php/test-rest-endpoints.php
+++ b/projects/packages/connection/tests/php/test-rest-endpoints.php
@@ -714,16 +714,15 @@ class Test_REST_Endpoints extends TestCase {
 	 * Tests that the endpoint succeeds for a connected admin disconnecting themselves
 	 */
 	public function test_unlink_user_success() {
-		// Set current user to secondary admin
-		wp_set_current_user( self::$secondary_user_id );
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/connection/user' );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(
 				array(
-					'linked' => false,
-					'force'  => true,
+					'linked'               => false,
+					'force'                => true,
+					'disconnect-all-users' => true,
 				)
 			)
 		);

--- a/projects/packages/connection/tests/php/test-rest-endpoints.php
+++ b/projects/packages/connection/tests/php/test-rest-endpoints.php
@@ -714,6 +714,9 @@ class Test_REST_Endpoints extends TestCase {
 	 * Tests that the endpoint succeeds for a connected admin disconnecting themselves
 	 */
 	public function test_unlink_user_success() {
+		// Set current user to secondary admin
+		wp_set_current_user( self::$secondary_user_id );
+
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/connection/user' );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_body(

--- a/projects/packages/connection/tests/php/test_Manager_unit.php
+++ b/projects/packages/connection/tests/php/test_Manager_unit.php
@@ -905,6 +905,15 @@ class ManagerTest extends TestCase {
 			->method( 'disconnect_user' )
 			->willReturn( true );
 
+		// Mock access tokens for all users
+		$access_token = (object) array(
+			'secret'           => 'abcd1234',
+			'external_user_id' => 1,
+		);
+		$this->tokens->expects( $this->any() )
+			->method( 'get_access_token' )
+			->willReturn( $access_token );
+
 		// Run the disconnect
 		$result = $this->manager->disconnect_all_users_except_primary();
 
@@ -956,6 +965,15 @@ class ManagerTest extends TestCase {
 		// Mock unlink_user_from_wpcom to fail
 		$this->manager->method( 'unlink_user_from_wpcom' )
 			->willReturn( false );
+
+		// Mock access tokens for all users
+		$access_token = (object) array(
+			'secret'           => 'abcd1234',
+			'external_user_id' => 1,
+		);
+		$this->tokens->expects( $this->any() )
+			->method( 'get_access_token' )
+			->willReturn( $access_token );
 
 		// Run the disconnect
 		$result = $this->manager->disconnect_all_users_except_primary();

--- a/projects/packages/connection/tests/php/test_Manager_unit.php
+++ b/projects/packages/connection/tests/php/test_Manager_unit.php
@@ -849,4 +849,119 @@ class ManagerTest extends TestCase {
 			),
 		);
 	}
+
+	/**
+	 * Test disconnecting all users except the primary (owner) user.
+	 *
+	 * @covers Automattic\Jetpack\Connection\Manager::disconnect_all_users_except_primary
+	 */
+	public function test_disconnect_all_users_except_primary() {
+		// Create owner and connected users
+		$owner_id = wp_insert_user(
+			array(
+				'user_login' => 'owner',
+				'user_pass'  => 'pass',
+				'user_email' => 'owner@owner.com',
+				'role'       => 'administrator',
+			)
+		);
+
+		$editor_id = wp_insert_user(
+			array(
+				'user_login' => 'editor',
+				'user_pass'  => 'pass',
+				'user_email' => 'editor@editor.com',
+				'role'       => 'editor',
+			)
+		);
+
+		$secondary_admin_id = wp_insert_user(
+			array(
+				'user_login' => 'secondary_admin',
+				'user_pass'  => 'pass',
+				'user_email' => 'secondary_admin@secondary_admin.com',
+				'role'       => 'administrator',
+			)
+		);
+
+		// Set up tokens for all users
+		$tokens = new Tokens();
+		$tokens->update_user_token( $owner_id, sprintf( '%s.%s.%d', 'key', 'private', $owner_id ), false );
+		$tokens->update_user_token( $editor_id, sprintf( '%s.%s.%d', 'key', 'private', $editor_id ), false );
+		$tokens->update_user_token( $secondary_admin_id, sprintf( '%s.%s.%d', 'key', 'private', $secondary_admin_id ), false );
+
+		// Mock get_connection_owner_id to return the owner
+		$this->manager->method( 'get_connection_owner_id' )
+			->willReturn( $owner_id );
+
+		// Mock unlink_user_from_wpcom to succeed for non-owner users
+		$this->manager->method( 'unlink_user_from_wpcom' )
+			->willReturn( true );
+
+		// Mock disconnect_user to succeed for non-owner users
+		$this->tokens->method( 'disconnect_user' )
+			->willReturn( true );
+
+		// Run the disconnect
+		$result = $this->manager->disconnect_all_users_except_primary();
+
+		// Verify the result
+		$this->assertTrue( $result );
+
+		// Verify owner is still connected
+		$this->assertTrue( $this->manager->is_user_connected( $owner_id ) );
+
+		// Verify other users are disconnected
+		$this->assertFalse( $this->manager->is_user_connected( $editor_id ) );
+		$this->assertFalse( $this->manager->is_user_connected( $secondary_admin_id ) );
+	}
+
+	/**
+	 * Test disconnecting all users except primary when there's a failure.
+	 *
+	 * @covers Automattic\Jetpack\Connection\Manager::disconnect_all_users_except_primary
+	 */
+	public function test_disconnect_all_users_except_primary_failure() {
+		// Create owner and one other user
+		$owner_id = wp_insert_user(
+			array(
+				'user_login' => 'owner',
+				'user_pass'  => 'pass',
+				'user_email' => 'owner@owner.com',
+				'role'       => 'administrator',
+			)
+		);
+
+		$editor_id = wp_insert_user(
+			array(
+				'user_login' => 'editor',
+				'user_pass'  => 'pass',
+				'user_email' => 'editor@editor.com',
+				'role'       => 'editor',
+			)
+		);
+
+		// Set up tokens
+		$tokens = new Tokens();
+		$tokens->update_user_token( $owner_id, sprintf( '%s.%s.%d', 'key', 'private', $owner_id ), false );
+		$tokens->update_user_token( $editor_id, sprintf( '%s.%s.%d', 'key', 'private', $editor_id ), false );
+
+		// Mock get_connection_owner_id to return the owner
+		$this->manager->method( 'get_connection_owner_id' )
+			->willReturn( $owner_id );
+
+		// Mock unlink_user_from_wpcom to fail
+		$this->manager->method( 'unlink_user_from_wpcom' )
+			->willReturn( false );
+
+		// Run the disconnect
+		$result = $this->manager->disconnect_all_users_except_primary();
+
+		// Verify the result indicates failure
+		$this->assertFalse( $result );
+
+		// Verify both users are still connected
+		$this->assertTrue( $this->manager->is_user_connected( $owner_id ) );
+		$this->assertTrue( $this->manager->is_user_connected( $editor_id ) );
+	}
 }

--- a/projects/packages/connection/tests/php/test_Manager_unit.php
+++ b/projects/packages/connection/tests/php/test_Manager_unit.php
@@ -792,4 +792,61 @@ class ManagerTest extends TestCase {
 		$this->assertNotNull( $error );
 		$this->assertEquals( $error_code, $error->get_error_code() );
 	}
+
+	/**
+	 * Test disconnecting a user from WordPress.com with force parameter.
+	 *
+	 * @covers Automattic\Jetpack\Connection\Manager::disconnect_user_force
+	 * @dataProvider get_disconnect_user_force_scenarios
+	 *
+	 * @param bool $remote   Was the remote disconnection successful.
+	 * @param bool $local    Was the local disconnection successful.
+	 * @param bool $expected Expected outcome.
+	 */
+	public function test_disconnect_user_force( $remote, $local, $expected ) {
+		$owner_id = wp_insert_user(
+			array(
+				'user_login' => 'owner',
+				'user_pass'  => 'pass',
+				'user_email' => 'owner@owner.com',
+				'role'       => 'administrator',
+			)
+		);
+		( new Tokens() )->update_user_token( $owner_id, sprintf( '%s.%s.%d', 'key', 'private', $owner_id ), false );
+
+		$this->manager->method( 'unlink_user_from_wpcom' )
+			->willReturn( $remote );
+
+		$this->tokens->method( 'disconnect_user' )
+			->willReturn( $local );
+
+		$result = $this->manager->disconnect_user( $owner_id, true );
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Test data for test_disconnect_user_force
+	 *
+	 * @return array
+	 */
+	public function get_disconnect_user_force_scenarios() {
+		return array(
+			'Successful remote and local disconnection' => array(
+				true,
+				true,
+				true,
+			),
+			'Failed remote and successful local disconnection' => array(
+				false,
+				true,
+				false,
+			),
+			'Successful remote and failed local disconnection' => array(
+				true,
+				false,
+				false,
+			),
+		);
+	}
 }

--- a/projects/packages/connection/tests/php/test_Manager_unit.php
+++ b/projects/packages/connection/tests/php/test_Manager_unit.php
@@ -891,15 +891,18 @@ class ManagerTest extends TestCase {
 		$tokens->update_user_token( $secondary_admin_id, sprintf( '%s.%s.%d', 'key', 'private', $secondary_admin_id ), false );
 
 		// Mock get_connection_owner_id to return the owner
-		$this->manager->method( 'get_connection_owner_id' )
+		$this->manager->expects( $this->any() )
+			->method( 'get_connection_owner_id' )
 			->willReturn( $owner_id );
 
 		// Mock unlink_user_from_wpcom to succeed for non-owner users
-		$this->manager->method( 'unlink_user_from_wpcom' )
+		$this->manager->expects( $this->exactly( 2 ) )
+			->method( 'unlink_user_from_wpcom' )
 			->willReturn( true );
 
 		// Mock disconnect_user to succeed for non-owner users
-		$this->tokens->method( 'disconnect_user' )
+		$this->tokens->expects( $this->exactly( 2 ) )
+			->method( 'disconnect_user' )
 			->willReturn( true );
 
 		// Run the disconnect

--- a/projects/packages/connection/tests/php/test_Manager_unit.php
+++ b/projects/packages/connection/tests/php/test_Manager_unit.php
@@ -905,14 +905,19 @@ class ManagerTest extends TestCase {
 			->method( 'disconnect_user' )
 			->willReturn( true );
 
-		// Mock access tokens for all users
-		$access_token = (object) array(
+		// Mock access tokens to return different values based on user
+		$owner_token = (object) array(
 			'secret'           => 'abcd1234',
 			'external_user_id' => 1,
 		);
+
 		$this->tokens->expects( $this->any() )
 			->method( 'get_access_token' )
-			->willReturn( $access_token );
+			->willReturnCallback(
+				function ( $user_id ) use ( $owner_id, $owner_token ) {
+					return $user_id === $owner_id ? $owner_token : false;
+				}
+			);
 
 		// Run the disconnect
 		$result = $this->manager->disconnect_all_users_except_primary();

--- a/projects/plugins/automattic-for-agencies-client/changelog/fix-disconnect-owner-disconnect-all
+++ b/projects/plugins/automattic-for-agencies-client/changelog/fix-disconnect-owner-disconnect-all
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection: Disconnecting a connection owner account will disconnect all other users first.

--- a/projects/plugins/backup/changelog/fix-disconnect-owner-disconnect-all
+++ b/projects/plugins/backup/changelog/fix-disconnect-owner-disconnect-all
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection: Disconnecting a connection owner account will disconnect all other users first.

--- a/projects/plugins/boost/changelog/fix-disconnect-owner-disconnect-all
+++ b/projects/plugins/boost/changelog/fix-disconnect-owner-disconnect-all
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection: Disconnecting a connection owner account will disconnect all other users first.

--- a/projects/plugins/classic-theme-helper-plugin/changelog/fix-disconnect-owner-disconnect-all
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/fix-disconnect-owner-disconnect-all
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection: Disconnecting a connection owner account will disconnect all other users first.

--- a/projects/plugins/crm/changelog/fix-disconnect-owner-disconnect-all
+++ b/projects/plugins/crm/changelog/fix-disconnect-owner-disconnect-all
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection: Disconnecting a connection owner account will disconnect all other users first.

--- a/projects/plugins/inspect/changelog/fix-disconnect-owner-disconnect-all
+++ b/projects/plugins/inspect/changelog/fix-disconnect-owner-disconnect-all
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection: Disconnecting a connection owner account will disconnect all other users first.

--- a/projects/plugins/jetpack/changelog/fix-disconnect-owner-disconnect-all
+++ b/projects/plugins/jetpack/changelog/fix-disconnect-owner-disconnect-all
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Connection: Disconnecting a connection owner account will disconnect all other users first.

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-disconnect-owner-disconnect-all
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-disconnect-owner-disconnect-all
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection: Disconnecting a connection owner account will disconnect all other users first.

--- a/projects/plugins/protect/changelog/fix-disconnect-owner-disconnect-all
+++ b/projects/plugins/protect/changelog/fix-disconnect-owner-disconnect-all
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection: Disconnecting a connection owner account will disconnect all other users first.

--- a/projects/plugins/search/changelog/fix-disconnect-owner-disconnect-all
+++ b/projects/plugins/search/changelog/fix-disconnect-owner-disconnect-all
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection: Disconnecting a connection owner account will disconnect all other users first.

--- a/projects/plugins/social/changelog/fix-disconnect-owner-disconnect-all
+++ b/projects/plugins/social/changelog/fix-disconnect-owner-disconnect-all
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection: Disconnecting a connection owner account will disconnect all other users first.

--- a/projects/plugins/starter-plugin/changelog/fix-disconnect-owner-disconnect-all
+++ b/projects/plugins/starter-plugin/changelog/fix-disconnect-owner-disconnect-all
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection: Disconnecting a connection owner account will disconnect all other users first.

--- a/projects/plugins/videopress/changelog/fix-disconnect-owner-disconnect-all
+++ b/projects/plugins/videopress/changelog/fix-disconnect-owner-disconnect-all
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection: Disconnecting a connection owner account will disconnect all other users first.

--- a/projects/plugins/wpcomsh/changelog/fix-disconnect-owner-disconnect-all
+++ b/projects/plugins/wpcomsh/changelog/fix-disconnect-owner-disconnect-all
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection: Disconnecting a connection owner account will disconnect all other users first.


### PR DESCRIPTION
In https://github.com/Automattic/jetpack/pull/41520 we introduced the ability for connection owners to disconnect their accounts without the need to disconnect the site and reconnect it to get back to site-only state.

That change created a situation where other users could remain connected while the primary user was missing. This is particularly strange for secondary connected admins, who will see their accounts connected, but different features will require them to connect and show the account connection links.

This PR adds a new modal to the disconnect option that warns the connection owner that disconnecting their account will cause other users to be disconnected, too. 

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added a new modal for connection owners who choose the `Disconnect my user account` option in the Manage Connection dialog.
* New modal displays a warning and offers several options (Disconnecting, Stay connected, Transfer ownership, and View connected accounts)
* In the case the user confirms disconnection, the expanded version of the `disconnect_user_force()` method will run. The new code inside the method will loop through all connected user accounts and disconnect them.
* If any account fails to get disconnected, the owner will also remain connected.

### Other information:

<img width="1187" alt="Screenshot 2025-02-21 at 09 37 03" src="https://github.com/user-attachments/assets/53304aa7-fcfa-44b8-b7f5-b73093300d7e" />

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a JN site and create several users with different roles. Connect at least two.
* Try disconnecting a nonprimary account in My Jetpack; it should work the same as before. Reconnect.
* Try disconnecting the connection owner. Try all links. Make sure that confirming disconnect will disconnect all users.

