### PR TITLE
Account Protection: Fix interim-login handling

### DIFF
--- a/projects/packages/account-protection/src/class-password-detection.php
+++ b/projects/packages/account-protection/src/class-password-detection.php
@@ -241,16 +241,16 @@ class Password_Detection {
 	 * @return void
 	 */
 	public function render_content( \WP_User $user, string $token ): void {
-		defined( 'ABSPATH' ) || exit;
-
 		$error_transient_key   = Config::PASSWORD_DETECTION_TRANSIENT_PREFIX . "_error_{$user->ID}";
 		$success_transient_key = Config::PASSWORD_DETECTION_TRANSIENT_PREFIX . "_success_{$user->ID}";
 
 		$error_data   = $this->extract_and_clear_transient_data( $error_transient_key );
 		$success_data = $this->extract_and_clear_transient_data( $success_transient_key );
 
-		$interim_login_success = $success_data['code'] === 'auth_code_success' ? 'interim-login-success' : '';
-		$body_classes          = implode( ' ', array_filter( array( 'password-detection-wrapper', $interim_login_success ) ) );
+		$body_classes = 'password-detection-wrapper';
+		if ( 'auth_code_success' === $success_data['code'] ) {
+			$body_classes .= ' interim-login-success';
+		}
 
 		?>
 		<!DOCTYPE html>

--- a/projects/packages/account-protection/src/class-password-detection.php
+++ b/projects/packages/account-protection/src/class-password-detection.php
@@ -69,17 +69,10 @@ class Password_Detection {
 				);
 			}
 
-			// If the user is in the interim login context
-			// phpcs:disable WordPress.Security.NonceVerification
-			$interim_login = isset( $_REQUEST['interim-login'] ) && (int) $_REQUEST['interim-login'] === 1;
-
 			return new \WP_Error(
 				Config::PASSWORD_DETECTION_ERROR_CODE,
 				__( 'Password validation failed.', 'jetpack-account-protection' ),
-				array(
-					'token'         => $transient['token'],
-					'interim_login' => $interim_login,
-				)
+				array( 'token' => $transient['token'] )
 			);
 		}
 
@@ -117,9 +110,8 @@ class Password_Detection {
 	 */
 	public function handle_password_detection_validation_error( string $username, \WP_Error $error ): void {
 		if ( isset( $error->errors['password_detection_validation_error'] ) ) {
-			$token         = $error->get_error_data()['token'];
-			$interim_login = $error->get_error_data()['interim_login'];
-			$this->redirect_and_exit( $this->get_redirect_url( $token, $interim_login ) );
+			$token = $error->get_error_data()['token'];
+			$this->redirect_and_exit( $this->get_redirect_url( $token ) );
 		}
 	}
 
@@ -264,19 +256,13 @@ class Password_Detection {
 			}
 		}
 
-		// No nonce verification necessary - reading only
-		// phpcs:disable WordPress.Security.NonceVerification
-		$interim_login         = isset( $_GET['interim-login'] ) && (int) $_GET['interim-login'] === 1;
 		$interim_login_success = '';
-		if ( $interim_login && $success_code === 'auth_code_success' ) {
+		if ( $success_code === 'auth_code_success' ) {
 			$interim_login_success = 'interim-login-success';
 		}
 
 		$body_classes = array( 'password-detection-wrapper', $interim_login_success );
 		$body_classes = implode( ' ', $body_classes );
-
-		$content_classes = array( 'password-detection-content', $interim_login ? 'interim-login' : '' );
-		$content_classes = implode( ' ', $content_classes );
 
 		defined( 'ABSPATH' ) || exit;
 		?>
@@ -289,7 +275,7 @@ class Password_Detection {
 				<?php wp_head(); ?>
 			</head>
 			<body class="<?php echo esc_attr( $body_classes ); ?>">
-				<div class="<?php echo esc_attr( $content_classes ); ?>">
+				<div class="password-detection-content">
 					<?php require plugin_dir_path( __FILE__ ) . '/assets/jetpack-logo.svg'; ?>
 					<p class="password-detection-title"><?php echo $success_code === 'auth_code_success' ? esc_html__( 'Take action to stay secure', 'jetpack-account-protection' ) : esc_html__( 'Verify your identity', 'jetpack-account-protection' ); ?></p>
 					<?php if ( $error_message ) : ?>
@@ -432,18 +418,11 @@ class Password_Detection {
 	 * Get redirect URL.
 	 *
 	 * @param string $token The token.
-	 * @param bool   $interim_login Whether the login is an interim login.
 	 *
 	 * @return string The redirect URL.
 	 */
-	private function get_redirect_url( string $token, bool $interim_login = false ): string {
-		$url = home_url( '/wp-login.php?action=password-detection&token=' . $token );
-
-		if ( $interim_login ) {
-			$url = add_query_arg( 'interim-login', 1, $url );
-		}
-
-		return $url;
+	private function get_redirect_url( string $token ): string {
+		return home_url( '/wp-login.php?action=password-detection&token=' . $token );
 	}
 
 	/**

--- a/projects/packages/account-protection/src/class-password-detection.php
+++ b/projects/packages/account-protection/src/class-password-detection.php
@@ -217,6 +217,22 @@ class Password_Detection {
 	}
 
 	/**
+	 * Extract transient data safely and delete the transient.
+	 *
+	 * @param string $transient_key The transient key.
+	 * @return array An array containing 'message' and 'code'.
+	 */
+	private function extract_and_clear_transient_data( string $transient_key ): array {
+		$data = get_transient( $transient_key );
+		delete_transient( $transient_key );
+
+		return array(
+			'message' => isset( $data['message'] ) ? $data['message'] : null,
+			'code'    => isset( $data['code'] ) ? $data['code'] : null,
+		);
+	}
+
+	/**
 	 * Render content for password detection page.
 	 *
 	 * @param \WP_User $user The user.
@@ -225,46 +241,17 @@ class Password_Detection {
 	 * @return void
 	 */
 	public function render_content( \WP_User $user, string $token ): void {
+		defined( 'ABSPATH' ) || exit;
+
 		$error_transient_key   = Config::PASSWORD_DETECTION_TRANSIENT_PREFIX . "_error_{$user->ID}";
 		$success_transient_key = Config::PASSWORD_DETECTION_TRANSIENT_PREFIX . "_success_{$user->ID}";
 
-		$error_data   = get_transient( $error_transient_key );
-		$success_data = get_transient( $success_transient_key );
+		$error_data   = $this->extract_and_clear_transient_data( $error_transient_key );
+		$success_data = $this->extract_and_clear_transient_data( $success_transient_key );
 
-		delete_transient( $error_transient_key );
-		delete_transient( $success_transient_key );
+		$interim_login_success = $success_data['code'] === 'auth_code_success' ? 'interim-login-success' : '';
+		$body_classes          = implode( ' ', array_filter( array( 'password-detection-wrapper', $interim_login_success ) ) );
 
-		$error_message = null;
-		$error_code    = null;
-		if ( is_array( $error_data ) ) {
-			if ( isset( $error_data['message'] ) ) {
-				$error_message = $error_data['message'];
-			}
-			if ( isset( $error_data['code'] ) ) {
-				$error_code = $error_data['code'];
-			}
-		}
-
-		$success_message = null;
-		$success_code    = null;
-		if ( is_array( $success_data ) ) {
-			if ( isset( $success_data['message'] ) ) {
-				$success_message = $success_data['message'];
-			}
-			if ( isset( $success_data['code'] ) ) {
-				$success_code = $success_data['code'];
-			}
-		}
-
-		$interim_login_success = '';
-		if ( $success_code === 'auth_code_success' ) {
-			$interim_login_success = 'interim-login-success';
-		}
-
-		$body_classes = array( 'password-detection-wrapper', $interim_login_success );
-		$body_classes = implode( ' ', $body_classes );
-
-		defined( 'ABSPATH' ) || exit;
 		?>
 		<!DOCTYPE html>
 		<html>
@@ -277,18 +264,18 @@ class Password_Detection {
 			<body class="<?php echo esc_attr( $body_classes ); ?>">
 				<div class="password-detection-content">
 					<?php require plugin_dir_path( __FILE__ ) . '/assets/jetpack-logo.svg'; ?>
-					<p class="password-detection-title"><?php echo $success_code === 'auth_code_success' ? esc_html__( 'Take action to stay secure', 'jetpack-account-protection' ) : esc_html__( 'Verify your identity', 'jetpack-account-protection' ); ?></p>
-					<?php if ( $error_message ) : ?>
+					<p class="password-detection-title"><?php echo $success_data['code'] === 'auth_code_success' ? esc_html__( 'Take action to stay secure', 'jetpack-account-protection' ) : esc_html__( 'Verify your identity', 'jetpack-account-protection' ); ?></p>
+					<?php if ( $error_data['message'] ) : ?>
 						<div class="error notice">
-							<p class="notice-message"><?php echo esc_html( $error_message ); ?></p>
+							<p class="notice-message"><?php echo esc_html( $error_data['message'] ); ?></p>
 						</div>
 					<?php endif; ?>
-					<?php if ( $success_message ) : ?>
+					<?php if ( $success_data['message'] ) : ?>
 						<div class="success notice">
-							<p class="notice-message"><?php echo esc_html( $success_message ); ?></p>
+							<p class="notice-message"><?php echo esc_html( $success_data['message'] ); ?></p>
 						</div>
 					<?php endif; ?>
-					<?php if ( $success_code === 'auth_code_success' ) : ?>
+					<?php if ( $success_data['code'] === 'auth_code_success' ) : ?>
 						<p><?php esc_html_e( "You're all set! You can now access your account.", 'jetpack-account-protection' ); ?></p>
 						<p><?php esc_html_e( 'Please keep in mind that your current password was found in a public leak, which means your account might be at risk. It is highly recommended that you update your password.', 'jetpack-account-protection' ); ?></p>
 						<div class="actions">
@@ -338,7 +325,7 @@ class Password_Detection {
 								<button class="action action-verify" type="submit" name="verify"><?php esc_html_e( 'Verify', 'jetpack-account-protection' ); ?></button>
 							</form>
 						</div>
-						<?php if ( $error_code !== 'email_resend_limit_error' ) : ?>
+						<?php if ( $error_data['code'] !== 'email_resend_limit_error' ) : ?>
 							<p class="email-status">
 								<span><?php esc_html_e( "Didn't get the code?", 'jetpack-account-protection' ); ?> </span>
 								<a class="resend-email-link" href="<?php echo esc_url( $this->get_redirect_url( $token ) . '&resend_email=1&_wpnonce=' . wp_create_nonce( 'resend_email_nonce' ) ); ?>">

--- a/projects/packages/account-protection/src/class-password-detection.php
+++ b/projects/packages/account-protection/src/class-password-detection.php
@@ -227,8 +227,8 @@ class Password_Detection {
 		delete_transient( $transient_key );
 
 		return array(
-			'message' => isset( $data['message'] ) ? $data['message'] : null,
-			'code'    => isset( $data['code'] ) ? $data['code'] : null,
+			'message' => $data['message'] ?? null,
+			'code'    => $data['code'] ?? null,
 		);
 	}
 

--- a/projects/packages/account-protection/src/class-password-detection.php
+++ b/projects/packages/account-protection/src/class-password-detection.php
@@ -69,10 +69,17 @@ class Password_Detection {
 				);
 			}
 
+			// If the user is in the interim login context
+			// phpcs:disable WordPress.Security.NonceVerification
+			$interim_login = isset( $_REQUEST['interim-login'] ) && (int) $_REQUEST['interim-login'] === 1;
+
 			return new \WP_Error(
 				Config::PASSWORD_DETECTION_ERROR_CODE,
 				__( 'Password validation failed.', 'jetpack-account-protection' ),
-				array( 'token' => $transient['token'] )
+				array(
+					'token'         => $transient['token'],
+					'interim_login' => $interim_login,
+				)
 			);
 		}
 
@@ -110,8 +117,9 @@ class Password_Detection {
 	 */
 	public function handle_password_detection_validation_error( string $username, \WP_Error $error ): void {
 		if ( isset( $error->errors['password_detection_validation_error'] ) ) {
-			$token = $error->get_error_data()['token'];
-			$this->redirect_and_exit( $this->get_redirect_url( $token ) );
+			$token         = $error->get_error_data()['token'];
+			$interim_login = $error->get_error_data()['interim_login'];
+			$this->redirect_and_exit( $this->get_redirect_url( $token, $interim_login ) );
 		}
 	}
 
@@ -256,6 +264,20 @@ class Password_Detection {
 			}
 		}
 
+		// No nonce verification necessary - reading only
+		// phpcs:disable WordPress.Security.NonceVerification
+		$interim_login         = isset( $_GET['interim-login'] ) && (int) $_GET['interim-login'] === 1;
+		$interim_login_success = '';
+		if ( $interim_login && $success_code === 'auth_code_success' ) {
+			$interim_login_success = 'interim-login-success';
+		}
+
+		$body_classes = array( 'password-detection-wrapper', $interim_login_success );
+		$body_classes = implode( ' ', $body_classes );
+
+		$content_classes = array( 'password-detection-content', $interim_login ? 'interim-login' : '' );
+		$content_classes = implode( ' ', $content_classes );
+
 		defined( 'ABSPATH' ) || exit;
 		?>
 		<!DOCTYPE html>
@@ -266,8 +288,8 @@ class Password_Detection {
 				<title><?php esc_html_e( 'Jetpack - Secure Your Account', 'jetpack-account-protection' ); ?></title>
 				<?php wp_head(); ?>
 			</head>
-			<body class="password-detection-wrapper">
-				<div class="password-detection">
+			<body class="<?php echo esc_attr( $body_classes ); ?>">
+				<div class="<?php echo esc_attr( $content_classes ); ?>">
 					<?php require plugin_dir_path( __FILE__ ) . '/assets/jetpack-logo.svg'; ?>
 					<p class="password-detection-title"><?php echo $success_code === 'auth_code_success' ? esc_html__( 'Take action to stay secure', 'jetpack-account-protection' ) : esc_html__( 'Verify your identity', 'jetpack-account-protection' ); ?></p>
 					<?php if ( $error_message ) : ?>
@@ -410,11 +432,18 @@ class Password_Detection {
 	 * Get redirect URL.
 	 *
 	 * @param string $token The token.
+	 * @param bool   $interim_login Whether the login is an interim login.
 	 *
 	 * @return string The redirect URL.
 	 */
-	private function get_redirect_url( string $token ): string {
-		return home_url( '/wp-login.php?action=password-detection&token=' . $token );
+	private function get_redirect_url( string $token, bool $interim_login = false ): string {
+		$url = home_url( '/wp-login.php?action=password-detection&token=' . $token );
+
+		if ( $interim_login ) {
+			$url = add_query_arg( 'interim-login', 1, $url );
+		}
+
+		return $url;
 	}
 
 	/**
@@ -439,6 +468,7 @@ class Password_Detection {
 			// TODO: Ensure all transient are also removed on module and/or plugin deactivation
 			delete_transient( Config::PASSWORD_DETECTION_TRANSIENT_PREFIX . "_{$token}" );
 			wp_set_auth_cookie( $user->ID, true );
+			wp_set_current_user( $user->ID );
 		} else {
 			$this->set_transient_error(
 				$user->ID,

--- a/projects/packages/account-protection/src/css/password-detection.css
+++ b/projects/packages/account-protection/src/css/password-detection.css
@@ -1,7 +1,7 @@
 .password-detection-wrapper {
     background-color: #f0f0f1;
     min-width: 0;
-    margin: auto 30px;
+    margin: 30px;
     color: #3c434a;
     font-family: -apple-system, "system-ui", "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
     font-size: 13px;
@@ -11,16 +11,12 @@
 .password-detection-content {
     background: #fff;
     max-width: 420px;
-    margin: 124px auto;
+    margin: auto;
     padding: 26px 24px;
     font-weight: 400;
     overflow: hidden;
     border: 1px solid #c3c4c7;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
-}
-
-.interim-login {
-    margin: 0 auto;
 }
 
 .password-detection-title {

--- a/projects/packages/account-protection/src/css/password-detection.css
+++ b/projects/packages/account-protection/src/css/password-detection.css
@@ -8,7 +8,7 @@
     line-height: 1.4;
 }
 
-.password-detection {
+.password-detection-content {
     background: #fff;
     max-width: 420px;
     margin: 124px auto;
@@ -17,6 +17,10 @@
     overflow: hidden;
     border: 1px solid #c3c4c7;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+}
+
+.interim-login {
+    margin: 0 auto;
 }
 
 .password-detection-title {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
When the login is presented in the popup form after a session expires, the password detection flow overwrites the core flow and redirect within the modal rather than closing it.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure the modal gets closed after a successful authentication code is submitted and the user is logged in
* Remove top margin when in this context

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://github.com/Automattic/jetpack-scan-team/issues/1717

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch in JT and enable Protect with a user with a known compromised password
* Login on one browser and proceed through the detection flow, ensuring its continue to function and display as per usual
* Login on a second browser and reset your password
* Return the first browser and you should be prompted shortly to re-authenticate
* Notice that the password detection screen now fits appropriately in the modal window
* Test other various actions (resend, auth code failure) and ensure they continue to work
* Enter the correct auth code and on authentication success, ensure that the modal is closed and you are returned to your session

## Screenshots
![Screen Capture on 2025-02-20 at 09-49-24](https://github.com/user-attachments/assets/c1a5a7c1-1799-4d5f-a600-5f73dd27e669)

