### PR TITLE
Remove dependency on automattic/jetpack-mu-wpcom that was added for P…

### DIFF
--- a/projects/packages/masterbar/.phan/config.php
+++ b/projects/packages/masterbar/.phan/config.php
@@ -31,6 +31,10 @@ return make_phan_config(
 			__DIR__ . '/../../../plugins/jetpack/modules/scan/class-admin-bar-notice.php',
 			__DIR__ . '/../../../plugins/jetpack/modules/stats.php',
 			__DIR__ . '/../../../plugins/wpcomsh/private-site/private-site.php',           // function site_is_private
+
+			// Make an exception to the above for packages/jetpack-mu-wpcom. Pulling in that whole package here causes more trouble than it solves.
+			__DIR__ . '/../../../packages/jetpack-mu-wpcom/src/features/custom-css/custom-css.php', // class Jetpack_Custom_CSS_Enhancements
+			__DIR__ . '/../../../packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php', // function wpcom_is_duplicate_views_experiment_enabled
 		),
 	)
 );

--- a/projects/packages/masterbar/changelog/update-move-wpcom-themes-api
+++ b/projects/packages/masterbar/changelog/update-move-wpcom-themes-api
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Remove dependency on automattic/jetpack-mu-wpcom that was added for Phan and causes odd dependency loops. Make Phan happy in a different way for now.
+
+

--- a/projects/packages/masterbar/composer.json
+++ b/projects/packages/masterbar/composer.json
@@ -19,7 +19,6 @@
 		"brain/monkey": "^2.6.2",
 		"yoast/phpunit-polyfills": "^1.1.1",
 		"automattic/jetpack-changelogger": "@dev",
-		"automattic/jetpack-mu-wpcom": "@dev",
 		"automattic/patchwork-redefine-exit": "@dev",
 		"automattic/jetpack-test-environment": "@dev"
 	},
@@ -74,11 +73,6 @@
 		},
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"
-		},
-		"dependencies": {
-			"test-only": [
-				"packages/jetpack-mu-wpcom"
-			]
 		},
 		"mirror-repo": "Automattic/jetpack-masterbar",
 		"textdomain": "jetpack-masterbar",

--- a/projects/plugins/jetpack/changelog/update-move-wpcom-themes-api
+++ b/projects/plugins/jetpack/changelog/update-move-wpcom-themes-api
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1709,7 +1709,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/masterbar",
-				"reference": "8f51311ffdd7a5ae6b1b425acb766a767d68d142"
+				"reference": "67d8689b5d0780d1f4ead6eb2abe553a2b82708c"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -1725,7 +1725,6 @@
 			},
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
-				"automattic/jetpack-mu-wpcom": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/patchwork-redefine-exit": "@dev",
 				"brain/monkey": "^2.6.2",
@@ -1742,11 +1741,6 @@
 				},
 				"changelogger": {
 					"link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"
-				},
-				"dependencies": {
-					"test-only": [
-						"packages/jetpack-mu-wpcom"
-					]
 				},
 				"mirror-repo": "Automattic/jetpack-masterbar",
 				"textdomain": "jetpack-masterbar",

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-move-wpcom-themes-api#2
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-move-wpcom-themes-api#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -994,7 +994,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "8f51311ffdd7a5ae6b1b425acb766a767d68d142"
+                "reference": "67d8689b5d0780d1f4ead6eb2abe553a2b82708c"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1010,7 +1010,6 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
-                "automattic/jetpack-mu-wpcom": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/patchwork-redefine-exit": "@dev",
                 "brain/monkey": "^2.6.2",
@@ -1027,11 +1026,6 @@
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"
-                },
-                "dependencies": {
-                    "test-only": [
-                        "packages/jetpack-mu-wpcom"
-                    ]
                 },
                 "mirror-repo": "Automattic/jetpack-masterbar",
                 "textdomain": "jetpack-masterbar",

--- a/projects/plugins/wpcomsh/changelog/update-move-wpcom-themes-api#2
+++ b/projects/plugins/wpcomsh/changelog/update-move-wpcom-themes-api#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1131,7 +1131,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "8f51311ffdd7a5ae6b1b425acb766a767d68d142"
+                "reference": "67d8689b5d0780d1f4ead6eb2abe553a2b82708c"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1147,7 +1147,6 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
-                "automattic/jetpack-mu-wpcom": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/patchwork-redefine-exit": "@dev",
                 "brain/monkey": "^2.6.2",
@@ -1164,11 +1163,6 @@
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"
-                },
-                "dependencies": {
-                    "test-only": [
-                        "packages/jetpack-mu-wpcom"
-                    ]
                 },
                 "mirror-repo": "Automattic/jetpack-masterbar",
                 "textdomain": "jetpack-masterbar",


### PR DESCRIPTION
It was added for Phan, but causes odd dependency loops. It needs to be removed so we can bump package/jetpack-mu-plugin to 8.1 in https://github.com/Automattic/jetpack/pull/41928.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

