### PR TITLE
Docker: Make WP unit test versions match installed WP version

### DIFF
--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -439,13 +439,8 @@ const buildExecCmd = argv => {
 		opts.push( '/var/scripts/uninstall.sh' );
 	} else if ( cmd === 'multisite-convert' ) {
 		opts.push( '/var/scripts/multisite-convert.sh' );
-	} else if ( cmd === 'update-core-unit-tests' ) {
-		opts.push(
-			'svn',
-			'up',
-			'/tmp/wordpress-develop/tests/phpunit/data/',
-			'/tmp/wordpress-develop/tests/phpunit/includes'
-		);
+	} else if ( cmd === 'update-core' ) {
+		opts.push( '/var/scripts/update-core.sh', argv.version );
 	} else if ( cmd === 'run-extras' ) {
 		opts.push( '/var/scripts/run-extras.sh' );
 	} else if ( cmd === 'link-plugin' ) {
@@ -767,9 +762,14 @@ export function dockerDefine( yargs ) {
 					handler: argv => execDockerCmdHandler( argv ),
 				} )
 				.command( {
-					command: 'update-core-unit-tests',
-					description: 'Pulls latest Core unit tests files from SVN',
-					builder: yargExec => defaultOpts( yargExec ),
+					command: 'update-core [version]',
+					description: 'Installs core files',
+					builder: yargExec =>
+						defaultOpts( yargExec ).positional( 'version', {
+							type: 'string',
+							description: 'Specify the version to install',
+							default: 'latest',
+						} ),
 					handler: argv => execDockerCmdHandler( argv ),
 				} )
 				.command( {

--- a/tools/docker/bin/run.sh
+++ b/tools/docker/bin/run.sh
@@ -79,14 +79,15 @@ fi
 if [ "$COMPOSE_PROJECT_NAME" == "jetpack_dev" ] ; then
 	# If we don't have the wordpress test helpers, download them
 	if [ ! -d /tmp/wordpress-develop/tests ]; then
+		CUR_WP_VERSION=$(wp --allow-root core version);
 		# Get latest WordPress unit-test helper files
 		svn co \
-			https://develop.svn.wordpress.org/trunk/tests/phpunit/data \
+			"https://develop.svn.wordpress.org/tags/$CUR_WP_VERSION/tests/phpunit/data" \
 			/tmp/wordpress-develop/tests/phpunit/data \
 			--trust-server-cert \
 			--non-interactive
 		svn co \
-			https://develop.svn.wordpress.org/trunk/tests/phpunit/includes \
+			"https://develop.svn.wordpress.org/tags/$CUR_WP_VERSION/tests/phpunit/includes" \
 			/tmp/wordpress-develop/tests/phpunit/includes \
 			--trust-server-cert \
 			--non-interactive

--- a/tools/docker/bin/update-core.sh
+++ b/tools/docker/bin/update-core.sh
@@ -32,7 +32,7 @@ if [[ "$TARGET_VERSION" != "$INIT_CORE_VERSION" ]]; then
 	# "Error: Another update is currently in progress."
 	wp --allow-root option get core_updater.lock &>/dev/null && wp --allow-root option delete core_updater.lock
 
-	wp --allow-root core update --version="$TARGET_VERSION"
+	wp --allow-root core update --version="$TARGET_VERSION" --force
 
 	# If these don't match now, it means something went wrong with the update.
 	if [[ "$TARGET_VERSION" != "$(wp --allow-root core version)" ]]; then

--- a/tools/docker/bin/update-core.sh
+++ b/tools/docker/bin/update-core.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+if [[ -z "$1" ]]; then
+	echo 'Usage: update-core.sh [<version>]'
+	exit 1
+fi
+
+TARGET_VERSION="$1"
+INIT_CORE_VERSION=$(wp --allow-root core version)
+
+if [[ "$TARGET_VERSION" == 'latest' ]]; then
+	TARGET_VERSION=$(wp --allow-root core check-update --field=version|tail -n1)
+	# We're already on the latest version.
+	if [[ "$TARGET_VERSION" == Success:* ]]; then
+		TARGET_VERSION=$INIT_CORE_VERSION
+	fi
+fi
+
+# WordPress versioning has no minor 0 version.
+if [[ "$TARGET_VERSION" =~ ^([0-9]+)\.([0-9]+)\.0$ ]]; then
+	TARGET_VERSION="${TARGET_VERSION%.0}"
+fi
+
+echo "Current version: $INIT_CORE_VERSION"
+echo "Target version: $TARGET_VERSION"
+
+# We could force-install, but for now just abort if we're already at our target.
+if [[ "$TARGET_VERSION" != "$INIT_CORE_VERSION" ]]; then
+	echo "Updating WordPress core to $TARGET_VERSION..."
+	echo "Please be patient; this may take some time."
+
+	# Clean up old option if a previous update didn't complete. Otherwise one would get this:
+	# "Error: Another update is currently in progress."
+	wp --allow-root option get core_updater.lock &>/dev/null && wp --allow-root option delete core_updater.lock
+
+	wp --allow-root core update --version="$TARGET_VERSION"
+
+	# If these don't match now, it means something went wrong with the update.
+	if [[ "$TARGET_VERSION" != "$(wp --allow-root core version)" ]]; then
+		echo "WordPress update to $TARGET_VERSION failed!"
+		exit 1
+	fi
+
+	# Update database.
+	echo 'Updating core database.'
+	wp --allow-root core update-db
+fi
+
+# Update core unit tests.
+echo 'Updating core unit tests...'
+svn -q switch "https://develop.svn.wordpress.org/tags/$TARGET_VERSION/tests/phpunit/data" /tmp/wordpress-develop/tests/phpunit/data && svn -q switch "https://develop.svn.wordpress.org/tags/$TARGET_VERSION/tests/phpunit/includes" /tmp/wordpress-develop/tests/phpunit/includes || {
+	echo 'Failed to update WordPress unit tests!'
+}
+
+echo "Successfully updated WordPress from $INIT_CORE_VERSION to $TARGET_VERSION."

--- a/tools/docker/mu-plugins/.gitignore
+++ b/tools/docker/mu-plugins/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !debug.php
 !avoid-plugin-deletion.php
+!bypass_circular_refs_during_core_update.php
 !fix-monorepo-plugin_url.php
 !jetpack-debug-helper-loader.php
 !/jetpack-debug-helper

--- a/tools/docker/mu-plugins/bypass_circular_refs_during_core_update.php
+++ b/tools/docker/mu-plugins/bypass_circular_refs_during_core_update.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Plugin Name: Bypass Circular Refs During Core Update
+ * Description: Some of our packages have circular refs for testing purposes, which makes the core upgrader choke. This removes the problematic call to `_upgrade_422_remove_genericons()`.
+ * Version: 1.0
+ * Author: Automattic
+ * Author URI: https://automattic.com/
+ * Text Domain: jetpack
+ *
+ * @package automattic/jetpack
+ */
+
+/**
+ * Remove problematic call to `_upgrade_422_remove_genericons()` from `wp-admin/includes/update-core.php`. That call
+ * recursively searches all directories for genericons files, which results in a circular reference loop for some
+ * of our projects.
+ *
+ * @param boolean $will_invalidate Whether to invalidate the file.
+ * @param string $filepath
+ *
+ * @return true
+ */
+function jetpack_bypass_circular_refs_during_core_update( $will_invalidate, $filepath ) {
+	if ( $filepath === ABSPATH . 'wp-admin/includes/update-core.php' ) {
+		$file_contents = file_get_contents( $filepath );
+		$file_contents = str_replace( '_upgrade_422_remove_genericons();', '// _upgrade_422_remove_genericons();', $file_contents );
+		file_put_contents( $filepath, $file_contents );
+	}
+	return true;
+}
+add_filter( 'wp_opcache_invalidate_file', 'jetpack_bypass_circular_refs_during_core_update', 10, 2 );

--- a/tools/docker/mu-plugins/bypass_circular_refs_during_core_update.php
+++ b/tools/docker/mu-plugins/bypass_circular_refs_during_core_update.php
@@ -15,8 +15,11 @@
  * recursively searches all directories for genericons files, which results in a circular reference loop for some
  * of our projects.
  *
+ * Unfortunately there's no direct filter in the upgrade routine, but it happens to call `wp_opcache_invalidate()` just
+ * before requiring the file, which has a filter we're able to hijack.
+ *
  * @param boolean $will_invalidate Whether to invalidate the file.
- * @param string $filepath
+ * @param string  $filepath Path to file to invalidate.
  *
  * @return true
  */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In a fresh `jetpack docker` instance, running PHPUnit tests were failing because the version of core unit tests (trunk latest) was trying to load a file that didn't exist in the version of WordPress (6.7.2).

With this PR they should be in sync on init. In particular:

* A new `jetpack docker update-core` command was added. This runs a script that updates both WP core and WP unit tests to the same version.
* The `jetpack docker update-core-unit-tests` command was removed.
* The unit tests checkout version now matches the WP core version initially installed.

See also: p1739803957236829-slack-C05Q5HSS013

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. `jetpack docker clean`
2. `jetpack docker build-image`
3. `jetpack docker up -d`
4. `jetpack docker install`
5. `jetpack docker phpunit`

In `trunk`, the last command will fail. With this branch, the last command will run PHPUnit correctly.

As for the other stuff, try some commands to upgrade and downgrade:
* `jetpack docker update-core` <-- updates to latest
* `jetpack docker update-core 6.6.0`
* `jetpack docker update-core latest`

This should successfully update both WordPress and core unit tests to the same version.