### PR TITLE
Account Protection: Return and merge all form errors

### DIFF
--- a/projects/packages/account-protection/src/class-password-manager.php
+++ b/projects/packages/account-protection/src/class-password-manager.php
@@ -47,11 +47,12 @@ class Password_Manager {
 			return;
 		}
 
-		$error = $this->validation_service->get_first_validation_error( $user->user_pass, true, $user );
+		$core_validation_errors    = $errors->get_error_messages( 'pass' );
+		$jetpack_validation_errors = $this->validation_service->get_validation_errors( $user->user_pass, true, $user );
+		$validation_errors         = array_diff( $jetpack_validation_errors, $core_validation_errors );
 
-		if ( ! empty( $error ) ) {
-			$errors->add( 'password_error', $error );
-			return;
+		foreach ( $validation_errors as $validation_error ) {
+			$errors->add( 'pass', $validation_error, array( 'form-field' => 'pass1' ) );
 		}
 	}
 
@@ -81,10 +82,13 @@ class Password_Manager {
 
 		// phpcs:ignore WordPress.Security.NonceVerification
 		$password = sanitize_text_field( wp_unslash( $_POST['pass1'] ) );
-		$error    = $this->validation_service->get_first_validation_error( $password );
-		if ( ! empty( $error ) ) {
-			$errors->add( 'password_error', $error );
-			return;
+
+		$core_validation_errors    = $errors->get_error_messages( 'pass' );
+		$jetpack_validation_errors = $this->validation_service->get_validation_errors( $password );
+		$validation_errors         = array_diff( $jetpack_validation_errors, $core_validation_errors );
+
+		foreach ( $validation_errors as $validation_error ) {
+			$errors->add( 'pass', $validation_error, array( 'form-field' => 'pass1' ) );
 		}
 	}
 

--- a/projects/packages/account-protection/src/class-validation-service.php
+++ b/projects/packages/account-protection/src/class-validation-service.php
@@ -128,47 +128,45 @@ class Validation_Service {
 	}
 
 	/**
-	 * Return first validation error - server-side.
+	 * Return all validation errors - server-side.
 	 *
 	 * @param string         $password The password to check.
 	 * @param bool           $user_specific Whether or not to run user specific checks.
 	 * @param \stdClass|null $user The user data or null.
 	 *
-	 * @return string The first validation errors (if any).
+	 * @return array The validation errors (if any).
 	 */
-	public function get_first_validation_error( string $password, $user_specific = false, $user = null ): string {
-		// Update and create-user forms include backlash validation
-		if ( ! $user_specific ) {
-			if ( $this->contains_backslash( $password ) ) {
-				return __( '<strong>Error:</strong> The password cannot contain a backslash (\\) character.', 'jetpack-account-protection' );
-			}
+	public function get_validation_errors( string $password, $user_specific = false, $user = null ): array {
+		$errors = array();
+
+		if ( empty( $password ) ) {
+			$errors[] = __( '<strong>Error:</strong> The password cannot be a space or all spaces.', 'jetpack-account-protection' );
+		}
+
+		if ( $this->contains_backslash( $password ) ) {
+			$errors[] = __( '<strong>Error:</strong> Passwords may not contain the character "\\".', 'jetpack-account-protection' );
 		}
 
 		if ( $this->is_invalid_length( $password ) ) {
-			return __( '<strong>Error:</strong> The password must be between 6 and 150 characters.', 'jetpack-account-protection' );
+			$errors[] = __( '<strong>Error:</strong> The password must be between 6 and 150 characters.', 'jetpack-account-protection' );
 		}
 
 		if ( $this->is_weak_password( $password ) ) {
-			return __( '<strong>Error:</strong> The password was found in a public leak.', 'jetpack-account-protection' );
+			$errors[] = __( '<strong>Error:</strong> The password was found in a public leak.', 'jetpack-account-protection' );
 		}
 
 		// Skip user-specific checks during password reset
 		if ( $user_specific ) {
-			// Reset form includes empty validation
-			if ( empty( $password ) ) {
-				return __( '<strong>Error:</strong> The password cannot be a space or all spaces.', 'jetpack-account-protection' );
-			}
-
 			// Run checks on new user data
 			if ( $this->matches_user_data( $user, $password ) ) {
-				return __( '<strong>Error:</strong> The password matches new user data.', 'jetpack-account-protection' );
+				$errors[] = __( '<strong>Error:</strong> The password matches new user data.', 'jetpack-account-protection' );
 			}
 			if ( $this->is_recent_password( $user, $password ) ) {
-				return __( '<strong>Error:</strong> The password was used recently.', 'jetpack-account-protection' );
+				$errors[] = __( '<strong>Error:</strong> The password was used recently.', 'jetpack-account-protection' );
 			}
 		}
 
-		return '';
+		return $errors;
 	}
 
 	/**
@@ -302,6 +300,11 @@ class Validation_Service {
 	 * @return bool True if the password was recently used, false otherwise.
 	 */
 	public function is_recent_password( $user, string $password ): bool {
+		// Skip on user creation
+		if ( empty( $user->ID ) ) {
+			return false;
+		}
+
 		$user_data = $user instanceof \WP_User ? $user : get_userdata( $user->ID );
 		if ( $this->is_current_password( $user_data->ID, $password ) ) {
 			return true;

--- a/projects/packages/account-protection/tests/php/test-password-manager.php
+++ b/projects/packages/account-protection/tests/php/test-password-manager.php
@@ -26,8 +26,8 @@ class Password_Manager_Test extends BaseTestCase {
 
 		$validation_service_mock = $this->createMock( Validation_Service::class );
 		$validation_service_mock->expects( $this->once() )
-			->method( 'get_first_validation_error' )
-			->willReturn( '' );
+			->method( 'get_validation_errors' )
+			->willReturn( array() );
 
 		$password_manager_mock = new Password_Manager( $validation_service_mock );
 		$password_manager_mock->validate_profile_update( $errors, true, $user );
@@ -56,8 +56,8 @@ class Password_Manager_Test extends BaseTestCase {
 
 		$validation_service_mock = $this->createMock( Validation_Service::class );
 		$validation_service_mock->expects( $this->once() )
-			->method( 'get_first_validation_error' )
-			->willReturn( '' );
+			->method( 'get_validation_errors' )
+			->willReturn( array() );
 
 		$password_manager_mock = new Password_Manager( $validation_service_mock );
 		$password_manager_mock->validate_password_reset( $errors, $user );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Description
Previously, our server side validation would return only the first error of our custom conditions. Inspired by the approach taken [here](https://github.com/Automattic/jetpack/pull/41737/files#top), this PR updates that process to return all applicable validation errors for that particular form, while ensuring that none are duplicated when returning the error object to core for rendering.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch and run JT
* Enable Protect and Account Protection
* Disable JS in your browser 
* Proceed to any of the 3 profile specific forms where the new password validation applies and submit an update to the user password
* Ensure that all applicable conditions are checked and that the form submission fails with a stack of errors
* Proceed to the password reset form and perform the same tests

## Screenshots

Profile updates:
![Screen Shot on 2025-02-20 at 15-24-58](https://github.com/user-attachments/assets/30bbf5f0-ce22-4453-abdb-9c1fac2f40c2)

Password reset:
![Screen Shot on 2025-02-20 at 15-12-41](https://github.com/user-attachments/assets/c59b17ed-c221-4493-835e-fc62edf3a09b)


