### PR TITLE
Brute Force Protection: Do not log failed attempt logging on password validation failure

### DIFF
--- a/projects/packages/waf/changelog/update-packages-waf-bfp-no-failed-attempt-logging-on-password-validation-failure
+++ b/projects/packages/waf/changelog/update-packages-waf-bfp-no-failed-attempt-logging-on-password-validation-failure
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Ensures BFP does not log failed attempts on password validation failure

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -515,8 +515,8 @@ class Brute_Force_Protection {
 	 *
 	 * Fires custom, plugable action jpp_log_failed_attempt with the IP
 	 *
-	 * @param string    $username - the user attempting to log in.
-	 * @param \WP_Error $error - the error object.
+	 * @param string    $username - The username or email address attempting to log in.
+	 * @param \WP_Error $error    - A WP_Error object with the authentication failure details.
 	 *
 	 * @return void
 	 */

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -134,7 +134,7 @@ class Brute_Force_Protection {
 		add_filter( 'authenticate', array( $this, 'check_preauth' ), 10, 3 );
 		add_filter( 'jetpack_has_login_ability', array( $this, 'has_login_ability' ) );
 		add_action( 'wp_login', array( $this, 'log_successful_login' ), 10, 2 );
-		add_action( 'wp_login_failed', array( $this, 'log_failed_attempt' ) );
+		add_action( 'wp_login_failed', array( $this, 'log_failed_attempt' ), 10, 2 );
 		add_action( 'admin_init', array( $this, 'maybe_update_headers' ) );
 		add_action( 'admin_init', array( $this, 'maybe_display_security_warning' ) );
 
@@ -515,10 +515,17 @@ class Brute_Force_Protection {
 	 *
 	 * Fires custom, plugable action jpp_log_failed_attempt with the IP
 	 *
-	 * @param string $login_user - the user attempting to log in.
+	 * @param string    $username - the user attempting to log in.
+	 * @param \WP_Error $error - the error object.
+	 *
 	 * @return void
 	 */
-	public function log_failed_attempt( $login_user = null ) {
+	public function log_failed_attempt( string $username, \WP_Error $error ) {
+
+		// Skip if Account protection password validation error.
+		if ( isset( $error->errors['password_detection_validation_error'] ) ) {
+			return;
+		}
 
 		/**
 		 * Fires before every failed login attempt.
@@ -532,7 +539,7 @@ class Brute_Force_Protection {
 		 *     'login'             => (string) Username or email used in failed login attempt
 		 *   ]
 		 */
-		do_action( 'jpp_log_failed_attempt', array( 'login' => $login_user ) );
+		do_action( 'jpp_log_failed_attempt', array( 'login' => $username ) );
 
 		if ( isset( $_COOKIE['jpp_math_pass'] ) ) {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
Currently when password validation fails during the Account Protection login password detection flow, we throw a unique error, capture it in the `wp_login_failed` action and redirect accordingly. Just so happens BFP uses this same hook to log failed attempts and currently logs one every time password validation fails. It would take a significant number of failed validations over a short period of time to trigger a BFP block but it can be done. This PR addresses that possibility and ensures that when our particular error is thrown, we will not log that attempt as failed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://github.com/Automattic/jetpack-scan-team/issues/1720

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch in JT
* Load Protect with Account Protection and Brute Force Protection enabled
* Add an error log in `Brute_Force_Protection::log_failed_attempt()` with the new check this PR adds
* Login with a known compromised password and when redirect to the password detection page refer to your error logs to ensure that BFP returns early and bypasses logging the attempt as failed
* Ensure no regressions in BFP or Account Protection functionality are introduced


