### PR TITLE
Launchpad: Use site goal selection to determine which checklist is shown in launchpad

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-logic-for-goal-based-checklists
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-logic-for-goal-based-checklists
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Launchpad checklists can be based on site goals

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/goal-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/goal-launchpad-task-lists.php
@@ -56,7 +56,7 @@ function get_checklist_slug_by_goals( $goals, $enable_features_for_goals ) {
 		}
 	}
 
-	if ( contains_one( $goals, 'sell', 'sell-digital', 'sell-physical' ) ) {
+	if ( contains_any( $goals, 'sell', 'sell-digital', 'sell-physical' ) ) {
 		return 'sell';
 	}
 
@@ -94,7 +94,7 @@ function contains_all( $string_list, ...$strings_to_check ) {
  * @param string ...$strings_to_check The strings to check for.
  * @return bool
  */
-function contains_one( $string_list, ...$strings_to_check ) {
+function contains_any( $string_list, ...$strings_to_check ) {
 	foreach ( $strings_to_check as $s ) {
 		if ( in_array( $s, $string_list, true ) ) {
 			return true;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/goal-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/goal-launchpad-task-lists.php
@@ -28,11 +28,11 @@ function get_goals_default_checklist_slug() {
  * are successful for which goals.
  *
  * @param array $goals Array of goal slugs.
- * @param array $enable_features_for_goals Used by the client to signal to Jetpack which launchpad goals have been enabled (e.g. via feature flags)'.
+ * @param array $enable_checklist_for_goals Used by the client to signal to Jetpack which launchpad goals have been enabled (e.g. via feature flags)'.
  *
  * @return string
  */
-function get_checklist_slug_by_goals( $goals, $enable_features_for_goals ) {
+function get_checklist_slug_by_goals( $goals, $enable_checklist_for_goals ) {
 	if ( empty( $goals ) ) {
 		return get_goals_default_checklist_slug();
 	}
@@ -44,13 +44,13 @@ function get_checklist_slug_by_goals( $goals, $enable_features_for_goals ) {
 		return get_goals_default_checklist_slug();
 	}
 
-	if ( in_array( 'courses', $enable_features_for_goals, true ) ) {
+	if ( in_array( 'courses', $enable_checklist_for_goals, true ) ) {
 		if ( in_array( 'courses', $goals, true ) ) {
 			return 'create-course-goal';
 		}
 	}
 
-	if ( in_array( 'newsletter', $enable_features_for_goals, true ) ) {
+	if ( in_array( 'newsletter', $enable_checklist_for_goals, true ) ) {
 		if ( in_array( 'newsletter', $goals, true ) ) {
 			return 'intent-newsletter-goal';
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/goal-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/goal-launchpad-task-lists.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack\Launchpad;
  *
  * @return string
  */
-function get_default_checklist_slug() {
+function get_goals_default_checklist_slug() {
 	return 'build';
 }
 
@@ -34,14 +34,14 @@ function get_default_checklist_slug() {
  */
 function get_checklist_slug_by_goals( $goals, $enable_features_for_goals ) {
 	if ( ! is_array( $goals ) || empty( $goals ) ) {
-		return get_default_checklist_slug();
+		return get_goals_default_checklist_slug();
 	}
 
 	if ( count( $goals ) >= 3 ) {
 		// If the user chooses too many goals we're not as confident we know
 		// exactly what they think is most important. A general checklist
 		// could be best.
-		return get_default_checklist_slug();
+		return get_goals_default_checklist_slug();
 	}
 
 	if ( in_array( 'courses', $enable_features_for_goals, true ) ) {
@@ -68,7 +68,7 @@ function get_checklist_slug_by_goals( $goals, $enable_features_for_goals ) {
 		return 'write';
 	}
 
-	return get_default_checklist_slug();
+	return get_goals_default_checklist_slug();
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/goal-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/goal-launchpad-task-lists.php
@@ -33,7 +33,7 @@ function get_goals_default_checklist_slug() {
  * @return string
  */
 function get_checklist_slug_by_goals( $goals, $enable_features_for_goals ) {
-	if ( ! is_array( $goals ) || empty( $goals ) ) {
+	if ( empty( $goals ) ) {
 		return get_goals_default_checklist_slug();
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/goal-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/goal-launchpad-task-lists.php
@@ -50,17 +50,10 @@ function get_checklist_slug_by_goals( $goals, $enable_features_for_goals ) {
 		}
 	}
 
-	if ( contains_all( $enable_features_for_goals, 'write' ) ) {
-		if ( contains_only( $goals, 'write' ) ) {
-			return 'new-improved-write-v2-final';
+	if ( contains_all( $enable_features_for_goals, 'newsletter' ) ) {
+		if ( contains_all( $goals, 'newsletter' ) ) {
+			return 'intent-newsletter-goal';
 		}
-		if ( contains_all( $goals, 'write', 'newsletter' ) ) {
-			return 'hybrid-write-newsletter';
-		}
-	}
-
-	if ( contains_all( $goals, 'newsletter' ) ) {
-		return 'intent-newsletter-goal';
 	}
 
 	if ( contains_one( $goals, 'sell', 'sell-digital', 'sell-physical' ) ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/goal-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/goal-launchpad-task-lists.php
@@ -44,14 +44,14 @@ function get_checklist_slug_by_goals( $goals, $enable_features_for_goals ) {
 		return get_default_checklist_slug();
 	}
 
-	if ( contains_all( $enable_features_for_goals, 'courses' ) ) {
-		if ( contains_all( $goals, 'courses' ) ) {
+	if ( in_array( 'courses', $enable_features_for_goals, true ) ) {
+		if ( in_array( 'courses', $goals, true ) ) {
 			return 'create-course-goal';
 		}
 	}
 
-	if ( contains_all( $enable_features_for_goals, 'newsletter' ) ) {
-		if ( contains_all( $goals, 'newsletter' ) ) {
+	if ( in_array( 'newsletter', $enable_features_for_goals, true ) ) {
+		if ( in_array( 'newsletter', $goals, true ) ) {
 			return 'intent-newsletter-goal';
 		}
 	}
@@ -60,31 +60,15 @@ function get_checklist_slug_by_goals( $goals, $enable_features_for_goals ) {
 		return 'sell';
 	}
 
-	if ( contains_all( $goals, 'promote' ) ) {
+	if ( in_array( 'promote', $goals, true ) ) {
 		return 'build';
 	}
 
-	if ( contains_all( $goals, 'write' ) ) {
+	if ( in_array( 'write', $goals, true ) ) {
 		return 'write';
 	}
 
 	return get_default_checklist_slug();
-}
-
-/**
- * The string_list must contains all the provided strings (but can contain more).
- *
- * @param array  $string_list The list of strings to check.
- * @param string ...$strings_to_check The strings to check for.
- * @return bool
- */
-function contains_all( $string_list, ...$strings_to_check ) {
-	foreach ( $strings_to_check as $s ) {
-		if ( ! in_array( $s, $string_list, true ) ) {
-			return false;
-		}
-	}
-	return true;
 }
 
 /**
@@ -101,15 +85,4 @@ function contains_any( $string_list, ...$strings_to_check ) {
 		}
 	}
 	return false;
-}
-
-/**
- * The string_list must contain only the provided string. That is, string_list must have length of one.
- *
- * @param array  $string_list The list of strings to check.
- * @param string $string_to_check The string to check for.
- * @return bool
- */
-function contains_only( $string_list, $string_to_check ) {
-	return count( $string_list ) === 1 && in_array( $string_to_check, $string_list, true );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/goal-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/goal-launchpad-task-lists.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Functions pertaining to Launchpad task lists, where the tasks depend
+ * on a site's goals; as choosen by the user during onboarding.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace Automattic\Jetpack\Launchpad;
+
+/**
+ * Checklist slug to use when the user chose no goals, or the chosen goals
+ * don't have a corresponding checklist.
+ *
+ * @return string
+ */
+function get_default_checklist_slug() {
+	return 'build';
+}
+
+/**
+ * Given a set of goals, which checklist is best for the user. The checklist
+ * slugs are those returned by the wpcom_launchpad_get_task_list_definitions()
+ * function in launchpad.php.
+ *
+ * The algorithm in this function shouldn't be considered final: expect it to
+ * change over time as we receive feedback and analytics on which checklists
+ * are successful for which goals.
+ *
+ * @param array $goals Array of goal slugs.
+ * @param array $enable_features_for_goals Used by the client to signal to Jetpack which launchpad goals have been enabled (e.g. via feature flags)'.
+ *
+ * @return string
+ */
+function get_checklist_slug_by_goals( $goals, $enable_features_for_goals ) {
+	if ( ! is_array( $goals ) || empty( $goals ) ) {
+		return get_default_checklist_slug();
+	}
+
+	if ( count( $goals ) >= 3 ) {
+		// If the user chooses too many goals we're not as confident we know
+		// exactly what they think is most important. A general checklist
+		// could be best.
+		return get_default_checklist_slug();
+	}
+
+	if ( contains_all( $enable_features_for_goals, 'courses' ) ) {
+		if ( contains_all( $goals, 'courses' ) ) {
+			return 'create-course-goal';
+		}
+	}
+
+	if ( contains_all( $enable_features_for_goals, 'write' ) ) {
+		if ( contains_only( $goals, 'write' ) ) {
+			return 'new-improved-write-v2-final';
+		}
+		if ( contains_all( $goals, 'write', 'newsletter' ) ) {
+			return 'hybrid-write-newsletter';
+		}
+	}
+
+	if ( contains_all( $goals, 'newsletter' ) ) {
+		return 'intent-newsletter-goal';
+	}
+
+	if ( contains_one( $goals, 'sell', 'sell-digital', 'sell-physical' ) ) {
+		return 'sell';
+	}
+
+	if ( contains_all( $goals, 'promote' ) ) {
+		return 'build';
+	}
+
+	if ( contains_all( $goals, 'write' ) ) {
+		return 'write';
+	}
+
+	return get_default_checklist_slug();
+}
+
+/**
+ * The string_list must contains all the provided strings (but can contain more).
+ *
+ * @param array  $string_list The list of strings to check.
+ * @param string ...$strings_to_check The strings to check for.
+ * @return bool
+ */
+function contains_all( $string_list, ...$strings_to_check ) {
+	foreach ( $strings_to_check as $s ) {
+		if ( ! in_array( $s, $string_list, true ) ) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
+ * The string_list must contain any of the provided strings.
+ *
+ * @param array  $string_list The list of strings to check.
+ * @param string ...$strings_to_check The strings to check for.
+ * @return bool
+ */
+function contains_one( $string_list, ...$strings_to_check ) {
+	foreach ( $strings_to_check as $s ) {
+		if ( in_array( $s, $string_list, true ) ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * The string_list must contain only the provided string. That is, string_list must have length of one.
+ *
+ * @param array  $string_list The list of strings to check.
+ * @param string $string_to_check The string to check for.
+ * @return bool
+ */
+function contains_only( $string_list, $string_to_check ) {
+	return count( $string_list ) === 1 && in_array( $string_to_check, $string_list, true );
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -6,6 +6,8 @@
  * @since 1.1.0
  */
 
+use Automattic\Jetpack\Launchpad;
+
 /**
  * Fetches Launchpad-related data for the site.
  *
@@ -36,14 +38,27 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 					'callback'            => array( $this, 'get_data' ),
 					'permission_callback' => array( $this, 'can_access' ),
 					'args'                => array(
-						'checklist_slug'    => array(
+						'checklist_slug'            => array(
 							'description' => 'Checklist slug',
 							'type'        => 'string',
 							'enum'        => $this->get_checklist_slug_enums(),
 						),
-						'launchpad_context' => array(
+						'launchpad_context'         => array(
 							'description' => 'Screen where Launchpand instance is loaded.',
 							'type'        => 'string',
+						),
+						'use_goals'                 => array(
+							'description' => 'Should the launchpad data use site goals or intent.',
+							'type'        => 'boolean',
+							'required'    => false,
+							'default'     => false,
+						),
+						'enable_features_for_goals' => array(
+							'description' => 'Used by the client to signal to Jetpack which launchpad goals have been enabled (e.g. via feature flags)',
+							'type'        => 'array',
+							'items'       => array( 'type' => 'string' ),
+							'required'    => false,
+							'default'     => array(),
 						),
 					),
 				),
@@ -157,10 +172,23 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 		}
 
 		$checklist_slug = isset( $request['checklist_slug'] ) ? $request['checklist_slug'] : get_option( 'site_intent' );
+		$use_goals      = isset( $request['use_goals'] ) ? $request['use_goals'] : false;
 
 		$launchpad_context = isset( $request['launchpad_context'] )
 			? $request['launchpad_context']
 			: null;
+
+		if ( $use_goals ) {
+			// The user must be part of a cohort which should deterine which checklist to show soley on
+			// goal selection, not the "intent".
+			$site_goals = get_option( 'site_goals' );
+			if ( $site_goals === false || empty( $site_goals ) ) {
+				$checklist_slug = Launchpad\get_default_checklist_slug();
+			} else {
+				$enable_features_for_goals = isset( $request['enable_features_for_goals'] ) ? $request['enable_features_for_goals'] : false;
+				$checklist_slug            = Launchpad\get_checklist_slug_by_goals( $site_goals, $enable_features_for_goals );
+			}
+		}
 
 		$response = array(
 			'site_intent'        => get_option( 'site_intent' ),

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -40,22 +40,22 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 					'callback'            => array( $this, 'get_data' ),
 					'permission_callback' => array( $this, 'can_access' ),
 					'args'                => array(
-						'checklist_slug'            => array(
+						'checklist_slug'             => array(
 							'description' => 'Checklist slug',
 							'type'        => 'string',
 							'enum'        => $this->get_checklist_slug_enums(),
 						),
-						'launchpad_context'         => array(
+						'launchpad_context'          => array(
 							'description' => 'Screen where Launchpand instance is loaded.',
 							'type'        => 'string',
 						),
-						'use_goals'                 => array(
+						'use_goals'                  => array(
 							'description' => 'Should the launchpad data use site goals or intent.',
 							'type'        => 'boolean',
 							'required'    => false,
 							'default'     => false,
 						),
-						'enable_features_for_goals' => array(
+						'enable_checklist_for_goals' => array(
 							'description' => 'Used by the client to signal to Jetpack which launchpad goals have been enabled (e.g. via feature flags)',
 							'type'        => 'array',
 							'items'       => array( 'type' => 'string' ),
@@ -184,7 +184,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 			// The user must be part of a cohort which should deterine which checklist to show soley on
 			// goal selection, not the "intent".
 			$site_goals     = get_option( 'site_goals', array() );
-			$checklist_slug = Launchpad\get_checklist_slug_by_goals( $site_goals, $request['enable_features_for_goals'] );
+			$checklist_slug = Launchpad\get_checklist_slug_by_goals( $site_goals, $request['enable_checklist_for_goals'] );
 		}
 
 		$response = array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -185,7 +185,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 			// goal selection, not the "intent".
 			$site_goals = get_option( 'site_goals' );
 			if ( $site_goals === false || empty( $site_goals ) ) {
-				$checklist_slug = Launchpad\get_default_checklist_slug();
+				$checklist_slug = Launchpad\get_goals_default_checklist_slug();
 			} else {
 				$enable_features_for_goals = isset( $request['enable_features_for_goals'] ) ? $request['enable_features_for_goals'] : false;
 				$checklist_slug            = Launchpad\get_checklist_slug_by_goals( $site_goals, $enable_features_for_goals );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -183,13 +183,8 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 		if ( $use_goals ) {
 			// The user must be part of a cohort which should deterine which checklist to show soley on
 			// goal selection, not the "intent".
-			$site_goals = get_option( 'site_goals' );
-			if ( $site_goals === false || empty( $site_goals ) ) {
-				$checklist_slug = Launchpad\get_goals_default_checklist_slug();
-			} else {
-				$enable_features_for_goals = isset( $request['enable_features_for_goals'] ) ? $request['enable_features_for_goals'] : false;
-				$checklist_slug            = Launchpad\get_checklist_slug_by_goals( $site_goals, $enable_features_for_goals );
-			}
+			$site_goals     = get_option( 'site_goals', array() );
+			$checklist_slug = Launchpad\get_checklist_slug_by_goals( $site_goals, $request['enable_features_for_goals'] );
 		}
 
 		$response = array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -8,6 +8,8 @@
 
 use Automattic\Jetpack\Launchpad;
 
+require_once __DIR__ . '/../launchpad/goal-launchpad-task-lists.php';
+
 /**
  * Fetches Launchpad-related data for the site.
  *

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-test.php
@@ -432,6 +432,28 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Test extends \WorDBless\BaseTestCase 
 	}
 
 	/**
+	 * Tests calling the /wpcom/v2/launchpad endpoint with the use_goals flag explicitly set to false.
+	 *
+	 * @covers ::get_data
+	 */
+	public function test_get_tasklist_when_use_goals_is_false() {
+		wp_set_current_user( $this->admin_id );
+		update_option( 'site_goals', array( 'write' ) );
+
+		$data = array(
+			'checklist_slug'    => 'post-migration',
+			'launchpad_context' => 'customer-home',
+			'use_goals'         => 'false',
+		);
+
+		$result = $this->call_launchpad_api( Requests::GET, $data );
+
+		$this->assertEquals( 200, $result->get_status() );
+		$this->assertIsArray( $result->get_data()['checklist'] );
+		$this->assertEquals( 'Site migration', $result->get_data()['title'] );
+	}
+
+	/**
 	 * Helper function to create a new WP_REST_Request and call the Launchpad REST API.
 	 *
 	 * @param string     $method The HTTP method to use.

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-test.php
@@ -353,6 +353,85 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Test extends \WorDBless\BaseTestCase 
 	}
 
 	/**
+	 * Provide test cases for {@see test_get_tasklist_using_goals()}.
+	 *
+	 * @return array[]
+	 */
+	public function provide_get_tasklist_using_goals_test_cases() {
+		return array(
+			'Write goal gets write task list' => array(
+				array( 'write' ),
+				array( 'write' ),
+				'write',
+			),
+			'Sell goal gets sell task list'   => array(
+				array( 'promote', 'sell-physical' ),
+				array(),
+				'sell',
+			),
+			'Newsletter goal gets newsletter task list if feature is enabled' => array(
+				array( 'newsletter' ),
+				array( 'newsletter' ),
+				'intent-newsletter-goal',
+			),
+			'Newsletter goal gets default task list if feature is disabled' => array(
+				array( 'newsletter' ),
+				array(),
+				'build',
+			),
+			'Too many goals ( >= 3 ) and we just return the default tasklist' => array(
+				array( 'newsletter', 'sell-digital', 'sell-physical', 'promote', 'write' ),
+				array(),
+				'build',
+			),
+		);
+	}
+
+	/**
+	 * Tests calling the /wpcom/v2/launchpad endpoint with the use_goals flag set to true.
+	 *
+	 * @dataProvider provide_get_tasklist_using_goals_test_cases()
+	 * @param array $site_goals List of goals that the user selected during onboarding.
+	 * @param mixed $enable_features_for_goals Flags used to enable/disable a specific tasklist (usually set by a client-side feature flag or experiment).
+	 * @param mixed $expected_tasklist_slug Slug for the tasklist we expect to be returned (e.g. wpcom_launchpad_get_task_list_definitions()).
+	 * @covers ::get_data
+	 */
+	public function test_get_tasklist_using_goals( $site_goals, $enable_features_for_goals, $expected_tasklist_slug ) {
+		wp_set_current_user( $this->admin_id );
+		update_option( 'site_goals', $site_goals );
+
+		$data = array(
+			'checklist_slug'            => 'start-writing', // This should get ignored, due to the use_goals flag.
+			'launchpad_context'         => 'customer-home',
+			'use_goals'                 => true,
+			'enable_features_for_goals' => $enable_features_for_goals,
+		);
+
+		$result = $this->call_launchpad_api( Requests::GET, $data );
+
+		$this->assertEquals( 200, $result->get_status() );
+
+		$this->assertIsArray( $result->get_data()['checklist'] );
+		$actual_task_ids = array_column( $result->get_data()['checklist'], 'id' );
+
+		// This is a bit of a hack, but we're using a follow up request to get the expected task IDs,
+		// as if we had asked for a specific tasklist slug rather than using a specific goal.
+		$result = $this->call_launchpad_api(
+			Requests::GET,
+			array(
+				'checklist_slug'    => $expected_tasklist_slug,
+				'use_goals'         => false,
+				'launchpad_context' => 'customer-home',
+			)
+		);
+		$this->assertEquals( 200, $result->get_status() );
+		$this->assertIsArray( $result->get_data()['checklist'] );
+		$expected_task_ids = array_column( $result->get_data()['checklist'], 'id' );
+
+		$this->assertEquals( $expected_task_ids, $actual_task_ids );
+	}
+
+	/**
 	 * Helper function to create a new WP_REST_Request and call the Launchpad REST API.
 	 *
 	 * @param string     $method The HTTP method to use.

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-test.php
@@ -392,19 +392,19 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Test extends \WorDBless\BaseTestCase 
 	 *
 	 * @dataProvider provide_get_tasklist_using_goals_test_cases()
 	 * @param array $site_goals List of goals that the user selected during onboarding.
-	 * @param mixed $enable_features_for_goals Flags used to enable/disable a specific tasklist (usually set by a client-side feature flag or experiment).
+	 * @param mixed $enable_checklist_for_goals Flags used to enable/disable a specific tasklist (usually set by a client-side feature flag or experiment).
 	 * @param mixed $expected_tasklist_slug Slug for the tasklist we expect to be returned (e.g. wpcom_launchpad_get_task_list_definitions()).
 	 * @covers ::get_data
 	 */
-	public function test_get_tasklist_using_goals( $site_goals, $enable_features_for_goals, $expected_tasklist_slug ) {
+	public function test_get_tasklist_using_goals( $site_goals, $enable_checklist_for_goals, $expected_tasklist_slug ) {
 		wp_set_current_user( $this->admin_id );
 		update_option( 'site_goals', $site_goals );
 
 		$data = array(
-			'checklist_slug'            => 'start-writing', // This should get ignored, due to the use_goals flag.
-			'launchpad_context'         => 'customer-home',
-			'use_goals'                 => true,
-			'enable_features_for_goals' => $enable_features_for_goals,
+			'checklist_slug'             => 'start-writing', // This should get ignored, due to the use_goals flag.
+			'launchpad_context'          => 'customer-home',
+			'use_goals'                  => true,
+			'enable_checklist_for_goals' => $enable_checklist_for_goals,
 		);
 
 		$result = $this->call_launchpad_api( Requests::GET, $data );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/99960

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Add `?use_goals` param to launchpad API, which opts in to using the new goal-based logic. I think the client would set this after checking whether the user was in the cumulative cohort

Add `?enable_features_for_goals` param to launchpad API, which works in a similar way to the same option in 173946-ghe-Automattic/wpcom. Basically the client is telling the backend which feature flags are enabled.

When the client opts in with `?use_goals` then we use the same checklist slugs and definitions that we've always used. Back in pet6gk-1Xe-p2 I had thought we might dynamically generate the checklist based on the selected goals. But until we have greater clarity on how product designers want this to work, we should stick with hard coding specific goal selections to specific checklists (pet6gk-1Xe-p2#comment-1653).

Since we're going with hard coding anyway ... then how about we just stick with the hardcoded definitions in `wpcom_launchpad_get_task_list_definitions()` for now 🤷.

Currently the checklist slugs from `wpcom_launchpad_get_task_list_definitions()` map one-to-one with intents. This PR implies that we can hand craft a bunch of checklist slugs that don't correspond to any intent. If the user chooses just goals A and B then we can have a special checklist just for that. If the user chooses goal A and any two of goal B, D, and F, then we can even give that a custom checklist.

Currently `get_checklist_slug_by_goals()` re-implements a bunch of the logic from `goalsToIntent()` in Calypso.
https://github.com/Automattic/wp-calypso/blob/eb10fb401a19def56b58d2d2fd8df5182d642448/packages/data-stores/src/onboard/utils.ts#L8
Since `?use_goals` will probably be set for all cumulative users, we need to reimplement a bit of that logic so that all of the goal selections keep working as before.

The reason I think it's worth moving the logic from the client to Jetpack (i.e. why is worth deprecating `goalsToIntent()`) is because even though all the checklists are hard coded right now; IMO in a future world we probably should have dynamically generated checklists. Rather than creating a checklist for every single permutation of goals, over time as the data team is able to say which tasks give the user the most success, we probably should transition to a dynamic system for generating checklists like I first described in pet6gk-1Xe-p2.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Still a WIP, but could be tested with something like https://github.com/Automattic/wp-calypso/pull/100512
*