### PR TITLE
MU WPCOM: Make email and password available on the profile.php on the default view

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/feat-user-profile-email-pwd-default-view
+++ b/projects/packages/jetpack-mu-wpcom/changelog/feat-user-profile-email-pwd-default-view
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+MU WPCOM: Make email and password available on the profile.php on the default view

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php
@@ -57,11 +57,11 @@ function wpcom_profile_settings_add_links_to_wpcom() {
 			),
 			'email'         => array(
 				'link' => esc_url( 'https://wordpress.com/me/account' ),
-				'text' => $is_wpcom_atomic ? __( 'Or manage on WP.com ↗', 'jetpack-mu-wpcom' ) : __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
+				'text' => $is_wpcom_atomic ? __( 'Or manage your WP.com account email ↗', 'jetpack-mu-wpcom' ) : __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
 			),
 			'password'      => array(
 				'link' => esc_url( 'https://wordpress.com/me/security' ),
-				'text' => $is_wpcom_atomic ? __( 'Or manage on WP.com ↗', 'jetpack-mu-wpcom' ) : __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
+				'text' => $is_wpcom_atomic ? __( 'Or manage your WP.com account password ↗', 'jetpack-mu-wpcom' ) : __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
 			),
 			'isWpcomAtomic' => $is_wpcom_atomic,
 		)

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php
@@ -33,37 +33,37 @@ function wpcom_profile_settings_add_links_to_wpcom() {
 		true
 	);
 
-	$is_wpcom_atomic_classic = is_woa_site() && get_option( 'wpcom_admin_interface' ) === 'wp-admin';
+	$is_wpcom_atomic = is_woa_site();
 
 	wp_localize_script(
 		'wpcom-profile-settings-link-to-wpcom',
 		'wpcomProfileSettingsLinkToWpcom',
 		array(
-			'language'             => array(
+			'language'      => array(
 				'link' => esc_url( 'https://wordpress.com/me/account' ),
 				'text' => __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
 			),
-			'name'                 => array(
+			'name'          => array(
 				'link' => esc_url( 'https://wordpress.com/me' ),
 				'text' => __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
 			),
-			'website'              => array(
+			'website'       => array(
 				'link' => esc_url( 'https://wordpress.com/me' ),
 				'text' => __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
 			),
-			'bio'                  => array(
+			'bio'           => array(
 				'link' => esc_url( 'https://wordpress.com/me' ),
 				'text' => __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
 			),
-			'email'                => array(
+			'email'         => array(
 				'link' => esc_url( 'https://wordpress.com/me/account' ),
-				'text' => __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
+				'text' => $is_wpcom_atomic ? __( 'Or manage on WP.com ↗', 'jetpack-mu-wpcom' ) : __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
 			),
-			'password'             => array(
+			'password'      => array(
 				'link' => esc_url( 'https://wordpress.com/me/security' ),
-				'text' => __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
+				'text' => $is_wpcom_atomic ? __( 'Or manage on WP.com ↗', 'jetpack-mu-wpcom' ) : __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
 			),
-			'isWpcomAtomicClassic' => $is_wpcom_atomic_classic,
+			'isWpcomAtomic' => $is_wpcom_atomic,
 		)
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
@@ -53,17 +53,6 @@ const wpcom_profile_settings_modify_name_section = () => {
 };
 
 const wpcom_profile_settings_modify_email_section = () => {
-	// Hide the email field except on Atomic Classic sites.
-	if ( ! window.wpcomProfileSettingsLinkToWpcom?.isWpcomAtomicClassic ) {
-		const field = document.getElementById( 'email' ) as HTMLInputElement;
-		if ( field ) {
-			field.classList.add( 'hidden' );
-		}
-
-		const description = document.getElementById( 'email-description' ) as HTMLInputElement;
-		description?.remove();
-	}
-
 	const section = document.querySelector( '.user-email-wrap' )?.querySelector( 'td' );
 	const settingsLink = window.wpcomProfileSettingsLinkToWpcom?.email?.link;
 	const settingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.email?.text;
@@ -116,10 +105,6 @@ const wpcom_profile_settings_modify_password_section = () => {
 
 	// We cannot set a password in wp-admin except on Atomic Classic sites.
 	const newPasswordSection = document.getElementById( 'password' )?.querySelector( 'td' );
-	if ( ! window.wpcomProfileSettingsLinkToWpcom?.isWpcomAtomicClassic && newPasswordSection ) {
-		newPasswordSection.innerHTML = '';
-	}
-
 	const settingsLink = window.wpcomProfileSettingsLinkToWpcom?.password?.link;
 	const settingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.password?.text;
 	if ( newPasswordSection && settingsLink && settingsLinkText ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
@@ -53,7 +53,7 @@ const wpcom_profile_settings_modify_name_section = () => {
 };
 
 const wpcom_profile_settings_modify_email_section = () => {
-	// Hide the email field except on Atomic Classic sites.
+	// Hide the email field except on simple sites.
 	if ( ! window.wpcomProfileSettingsLinkToWpcom?.isWpcomAtomic ) {
 		const field = document.getElementById( 'email' ) as HTMLInputElement;
 		if ( field ) {
@@ -114,7 +114,7 @@ const wpcom_profile_settings_modify_password_section = () => {
 	const userSessionSection = document.querySelector( '.user-sessions-wrap' );
 	userSessionSection?.remove();
 
-	// We cannot set a password in wp-admin except on Atomic Classic sites.
+	// We cannot set a password in wp-admin on simple sites.
 	const newPasswordSection = document.getElementById( 'password' )?.querySelector( 'td' );
 	if ( ! window.wpcomProfileSettingsLinkToWpcom?.isWpcomAtomic && newPasswordSection ) {
 		newPasswordSection.innerHTML = '';

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
@@ -53,6 +53,17 @@ const wpcom_profile_settings_modify_name_section = () => {
 };
 
 const wpcom_profile_settings_modify_email_section = () => {
+	// Hide the email field except on Atomic Classic sites.
+	if ( ! window.wpcomProfileSettingsLinkToWpcom?.isWpcomAtomic ) {
+		const field = document.getElementById( 'email' ) as HTMLInputElement;
+		if ( field ) {
+			field.classList.add( 'hidden' );
+		}
+
+		const description = document.getElementById( 'email-description' ) as HTMLInputElement;
+		description?.remove();
+	}
+
 	const section = document.querySelector( '.user-email-wrap' )?.querySelector( 'td' );
 	const settingsLink = window.wpcomProfileSettingsLinkToWpcom?.email?.link;
 	const settingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.email?.text;
@@ -105,6 +116,10 @@ const wpcom_profile_settings_modify_password_section = () => {
 
 	// We cannot set a password in wp-admin except on Atomic Classic sites.
 	const newPasswordSection = document.getElementById( 'password' )?.querySelector( 'td' );
+	if ( ! window.wpcomProfileSettingsLinkToWpcom?.isWpcomAtomic && newPasswordSection ) {
+		newPasswordSection.innerHTML = '';
+	}
+
 	const settingsLink = window.wpcomProfileSettingsLinkToWpcom?.password?.link;
 	const settingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.password?.text;
 	if ( newPasswordSection && settingsLink && settingsLinkText ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
@@ -53,7 +53,7 @@ const wpcom_profile_settings_modify_name_section = () => {
 };
 
 const wpcom_profile_settings_modify_email_section = () => {
-	// Hide the email field except on simple sites.
+	// Hide the email field on simple sites.
 	if ( ! window.wpcomProfileSettingsLinkToWpcom?.isWpcomAtomic ) {
 		const field = document.getElementById( 'email' ) as HTMLInputElement;
 		if ( field ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/types.d.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/types.d.ts
@@ -17,7 +17,7 @@ declare global {
 				link: string;
 				text: string;
 			};
-			isWpcomAtomicClassic: boolean;
+			isWpcomAtomic: boolean;
 		};
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/changelog/feat-user-profile-email-pwd-default-view
+++ b/projects/plugins/mu-wpcom-plugin/changelog/feat-user-profile-email-pwd-default-view
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+MU WPCOM: Make email and password available on the profile.php on the default view

--- a/projects/plugins/wpcomsh/changelog/feat-user-profile-email-pwd-default-view
+++ b/projects/plugins/wpcomsh/changelog/feat-user-profile-email-pwd-default-view
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+MU WPCOM: Make email and password available on the profile.php on the default view


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/dotcom-forge/issues/10508

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Make email and password available on the profile.php on the default view of the atomic site


**Atomic site with the default view**
| Before | After |
| - | - |
| <img width="387" alt="image" src="https://github.com/user-attachments/assets/94141ad4-936c-4a1b-83ff-dbbfc983d9e2" /> | ![image](https://github.com/user-attachments/assets/fbe0688b-cca9-40e3-b2b0-46be3400c68d) |
| <img width="382" alt="image" src="https://github.com/user-attachments/assets/968cff36-d1b1-416f-9c47-3d85c226d651" /> | ![image](https://github.com/user-attachments/assets/acc4ef26-8a92-4ec9-99e3-3a8b8c4ead0e) |

**Simple site**

Nothing changed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your atomic site
* Go to /wp-admin/profile.php on the default view
* Ensure the local email/password field is visible

