### PR TITLE
Fix form validation with js disabled

### DIFF
--- a/projects/packages/forms/changelog/fix-form-validation-with-js-disabled
+++ b/projects/packages/forms/changelog/fix-form-validation-with-js-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix 404 error when a user submits an invalid form with JavaScript disabled.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -249,7 +249,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return string HTML for the concat form.
 	 */
 	public static function parse( $attributes, $content ) {
-		global $post, $page; // $page is used in the contact-form submission redirect
+		global $post, $page, $multipage; // $page is used in the contact-form submission redirect
 		if ( Settings::is_syncing() ) {
 			return '';
 		}
@@ -346,7 +346,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			} else {
 				// Submit form to the post permalink
 				$url = get_permalink();
-				if ( $page ) {
+				if ( $multipage && $page ) {
 					$url = add_query_arg( 'page', $page, $url );
 				}
 			}

--- a/projects/plugins/jetpack/changelog/fix-form-validation-with-js-disabled
+++ b/projects/plugins/jetpack/changelog/fix-form-validation-with-js-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix 404 error when a user submits an invalid form with JavaScript disabled.


### PR DESCRIPTION
Fixes part of #41942

## Proposed changes:
Fixes a bug where, if the user has JavaScript disabled in their browser, and tries submitting an invalid form, the user ends up on a 404 page instead of staying on the same page with form validation errors shown.

This is only a partial fix, there's still a bug mentioned in the comments on the issue, where I also mention how it seems to have been introduced - https://github.com/Automattic/jetpack/issues/41942#issuecomment-2673866798. 

The remaining bug is that the user needs to submit the invalid form twice for the validation issues to show. It's not great, the first time submitting the form will be reset. The fix is probably going to be quite considerable, or involve reverting the PR mentioned in the comment, but that would bring back another (much worse IMO) bug.

I expect this is very low priority though, most users won't have JS disabled, so I don't plan to work on it further than this.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Add a form to a post
2. Make sure the form has at least one required field
3. Save and view the post
4. Disable JS in your browser and reload the post
5. Submit the form

In trunk: The user ends up on a 404 page
In this PR: The page reloads

