### PR TITLE
Remove `Personalize Link in Bio` launchpad task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-Personalize-Link-in-Bio-launchpad-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-Personalize-Link-in-Bio-launchpad-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Removed the `Personalize Link in Bio` launchpad task, since the link in bio related flow is now deprecated

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -301,15 +301,6 @@ function wpcom_launchpad_get_task_definitions() {
 				return admin_url( 'site-editor.php' );
 			},
 		),
-		'setup_link_in_bio'               => array(
-			'get_title'            => function () {
-				return __( 'Personalize Link in Bio', 'jetpack-mu-wpcom' );
-			},
-			'is_complete_callback' => '__return_true',
-			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/setup/link-in-bio-post-setup/linkInBioPostSetup?siteSlug=' . $data['site_slug_encoded'];
-			},
-		),
 
 		// Videopress tasks.
 		'videopress_launched'             => array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -66,7 +66,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			},
 			'task_ids'            => array(
 				'design_selected',
-				'setup_link_in_bio',
 				'plan_selected',
 				'links_added',
 				'link_in_bio_launched',
@@ -79,7 +78,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			},
 			'task_ids'            => array(
 				'design_selected',
-				'setup_link_in_bio',
 				'plan_selected',
 				'links_added',
 				'link_in_bio_launched',

--- a/projects/plugins/mu-wpcom-plugin/changelog/remove-Personalize-Link-in-Bio-launchpad-task
+++ b/projects/plugins/mu-wpcom-plugin/changelog/remove-Personalize-Link-in-Bio-launchpad-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Removed the `Personalize Link in Bio` launchpad task, since the link in bio related flow is now deprecated

--- a/projects/plugins/wpcomsh/changelog/remove-Personalize-Link-in-Bio-launchpad-task
+++ b/projects/plugins/wpcomsh/changelog/remove-Personalize-Link-in-Bio-launchpad-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Removed the `Personalize Link in Bio` launchpad task, since the link in bio related flow is now deprecated


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to [9329](https://github.com/Automattic/dotcom-forge/issues/9329)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the `Personalize Link in Bio` step from the dashboard for `link-in-bio` sites, now that that flow has been deprecated

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch on your sandbox
* Create a new site
* With that site id, run this command on your sandbox so the site has a `link-in-bio` intent: `wp --blog=SITE_ID option update site_intent link-in-bio`
* Sandbox the site
* Check that you don't see the `Personalize Link in Bio` step on the dashboard

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/9d5bd3c9-807a-4534-93eb-5071668264a4)|![image](https://github.com/user-attachments/assets/692062f4-63d5-456f-8d53-c55dcecdb59d)|
|![image](https://github.com/user-attachments/assets/0e4c9dc4-735a-4f4c-8089-77d18f70b78e)|![image](https://github.com/user-attachments/assets/952b018e-1a2d-4fe6-8277-27597054ab9f)|




