### PR TITLE
Update design selection behavior for Focused Launchpad users

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-design-selection-on-focused-launchpad
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-design-selection-on-focused-launchpad
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Launchpad: Update select a design step allowing user to interact with it

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -54,20 +54,26 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Select a design', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
-			'get_calypso_path'     => function ( $task, $default, $data ) {
+			'is_complete_callback' => $is_user_in_goals_first_experiment ? '__return_true' : 'wpcom_launchpad_is_task_option_completed',
+			'get_calypso_path'     => function ( $task, $default, $data ) use ( $is_user_in_goals_first_experiment ) {
 				$flow = get_option( 'site_intent' );
+				if ( $is_user_in_goals_first_experiment ) {
+					return '/themes/' . $data['site_slug_encoded'];
+				}
 				return '/setup/update-design/designSetup?siteSlug=' . $data['site_slug_encoded'] . '&flow=' . $flow;
 			},
-			'is_disabled_callback' => $is_user_in_goals_first_experiment ? '__return_true' : '__return_false',
+			'is_disabled_callback' => $is_user_in_goals_first_experiment ? '__return_false' : 'wpcom_launchpad_is_design_step_enabled',
 		),
 		'design_selected'                 => array(
 			'get_title'            => function () {
 				return __( 'Select a design', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => '__return_true',
-			'is_disabled_callback' => $is_user_in_goals_first_experiment ? '__return_true' : 'wpcom_launchpad_is_design_step_enabled',
-			'get_calypso_path'     => function ( $task, $default, $data ) {
+			'is_disabled_callback' => $is_user_in_goals_first_experiment ? '__return_false' : 'wpcom_launchpad_is_design_step_enabled',
+			'get_calypso_path'     => function ( $task, $default, $data ) use ( $is_user_in_goals_first_experiment ) {
+				if ( $is_user_in_goals_first_experiment ) {
+					return '/themes/' . $data['site_slug_encoded'];
+				}
 				return '/setup/update-design/designSetup?siteSlug=' . $data['site_slug_encoded'];
 			},
 		),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/100144
More context about the experiment usage: pet6gk-1Yy-p2#comment-1674 and [here](https://github.com/Automattic/wp-calypso/issues/99561#issuecomment-2651647066)

I don't care about code coverage for this PR: We will revisit these changes as soon as the experiment ends.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We have a new behavior for `treatment_cumulative` users:

- Allow users to interact with it
- Update its path to /themtes/{siteSlug}
- Always show it as completed

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to /setup/onboarding flow with `treatment_cumulative`
* Select the `Publish a blog` goal
* Don't select any theme and complete the onboarding
* At the Focused Launchpad, you should see `Select a design` step completed, and if you click on it, it will redirect you to the theme screen.