### PR TITLE
jest: Fix `roots` configs

### DIFF
--- a/projects/github-actions/test-results-to-slack/changelog/fix-jest-roots
+++ b/projects/github-actions/test-results-to-slack/changelog/fix-jest-roots
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix jest `roots` config.
+
+

--- a/projects/github-actions/test-results-to-slack/tests/jest.config.js
+++ b/projects/github-actions/test-results-to-slack/tests/jest.config.js
@@ -4,7 +4,7 @@ const coverageConfig = require( 'jetpack-js-tools/jest/config.coverage.js' );
 module.exports = {
 	...coverageConfig,
 	rootDir: path.resolve( __dirname, '..' ),
-	roots: [ '<rootDir>/tests/' ],
+	roots: [ '<rootDir>/src/', '<rootDir>/tests/' ],
 	resolver: require.resolve( 'jetpack-js-tools/jest/jest-resolver.js' ),
 	clearMocks: true,
 	resetModules: true,

--- a/projects/js-packages/eslint-changed/changelog/fix-jest-roots
+++ b/projects/js-packages/eslint-changed/changelog/fix-jest-roots
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix jest `roots` config.
+
+

--- a/projects/js-packages/eslint-changed/tests/jest.config.cjs
+++ b/projects/js-packages/eslint-changed/tests/jest.config.cjs
@@ -4,7 +4,7 @@ const coverageConfig = require( 'jetpack-js-tools/jest/config.coverage.js' );
 module.exports = {
 	...coverageConfig,
 	rootDir: path.resolve( __dirname, '..' ),
-	roots: [ '<rootDir>/tests/' ],
+	roots: [ '<rootDir>/bin/', '<rootDir>/src/', '<rootDir>/tests/' ],
 	resolver: require.resolve( 'jetpack-js-tools/jest/jest-resolver.js' ),
 	collectCoverageFrom: [
 		'<rootDir>/bin/**/*.{js,mjs,cjs,jsx,ts,tsx,mts,cts}',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Jest's `roots` config setting controls where it looks for tests _and sources_. If it's set, `collectCoverageFrom` won't collect from uncovered files outside of `roots`.

Two of our projects had incorrect values that prevented collecting coverage for some files.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
None

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* Coverage will probably complain about new uncovered files.