### PR TITLE
wpcomsh: bilmur: Add site timezone to tag

### DIFF
--- a/projects/plugins/wpcomsh/changelog/wpcomsh-bilmur-tz
+++ b/projects/plugins/wpcomsh/changelog/wpcomsh-bilmur-tz
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Bilmur RUM library now reports the site's timezone

--- a/projects/plugins/wpcomsh/tests/test-wpcomsh-stats-timezone-string.php
+++ b/projects/plugins/wpcomsh/tests/test-wpcomsh-stats-timezone-string.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Wpcomsh Test file.
+ *
+ * @package wpcomsh
+ */
+
+/**
+ * Class Test_WPCOMSH_Stats_Timezone_String
+ */
+// phpcs:disable Squiz.Commenting.FunctionComment.WrongStyle
+class Test_WPCOMSH_Stats_Timezone_String extends WP_UnitTestCase {
+	private $original_timezone_string;
+	private $original_gmt_offset;
+
+	public function setUp(): void {
+		parent::setUp();
+		// Backup original options
+		$this->original_timezone_string = get_option( 'timezone_string' );
+		$this->original_gmt_offset      = get_option( 'gmt_offset' );
+	}
+
+	public function tearDown(): void {
+		// Restore original options
+		update_option( 'timezone_string', $this->original_timezone_string );
+		update_option( 'gmt_offset', $this->original_gmt_offset );
+		parent::tearDown();
+	}
+
+	// Test with a named timezone (e.g., "America/New_York")
+	public function test_wpcomsh_stats_timezone_string_with_named_tz() {
+		update_option( 'timezone_string', 'America/New_York' );
+		update_option( 'gmt_offset', '' ); // Clear offset to ensure we use timezone_string
+
+		$actual_output   = wpcomsh_stats_timezone_string();
+		$expected_output = 'America/New_York';
+		$this->assertEquals( $expected_output, $actual_output );
+	}
+
+	// Test with integer hour offset (e.g., UTC+5)
+	public function test_wpcomsh_stats_timezone_string_with_integer_offset() {
+		update_option( 'timezone_string', '' );
+		update_option( 'gmt_offset', 5 ); // +5 hours
+
+		$actual_output   = wpcomsh_stats_timezone_string();
+		$expected_output = 'Etc/GMT-5'; // Note the flipped sign per the function spec
+		$this->assertEquals( $expected_output, $actual_output );
+	}
+
+	// Test with negative integer hour offset (e.g., UTC-3)
+	public function test_wpcomsh_stats_timezone_string_with_negative_integer_offset() {
+		update_option( 'timezone_string', '' );
+		update_option( 'gmt_offset', -3 ); // -3 hours
+
+		$actual_output   = wpcomsh_stats_timezone_string();
+		$expected_output = 'Etc/GMT+3'; // Note the flipped sign per the function spec
+		$this->assertEquals( $expected_output, $actual_output );
+	}
+
+	// Test with fractional hour offset (e.g., UTC+5:30)
+	public function test_wpcomsh_stats_timezone_string_with_fractional_offset() {
+		update_option( 'timezone_string', '' );
+		update_option( 'gmt_offset', 5.5 ); // +5 hours 30 minutes
+
+		$actual_output = wpcomsh_stats_timezone_string();
+		// Expecting a city timezone like "Asia/Kolkata" for +5:30
+		// Note: exact result might depend on PHP's timezone database
+		$this->assertEquals( 'Asia/Kolkata', $actual_output );
+	}
+
+	// Test with fractional offset that has no city match (fall back to integer)
+	public function test_wpcomsh_stats_timezone_string_with_unmatched_fractional_offset() {
+		update_option( 'timezone_string', '' );
+		update_option( 'gmt_offset', 5.25 ); // +5 hours 15 minutes (no common city match)
+
+		$actual_output = wpcomsh_stats_timezone_string();
+		// Should fall back to integer offset "Etc/GMT-5"
+		$this->assertEquals( 'Etc/GMT-5', $actual_output );
+	}
+
+	public function test_wpcomsh_stats_timezone_string_with_zero_offset() {
+		update_option( 'timezone_string', '' );
+		update_option( 'gmt_offset', 0 );
+
+		$actual_output   = wpcomsh_stats_timezone_string();
+		$expected_output = 'Etc/GMT-0';
+		$this->assertEquals( $expected_output, $actual_output );
+	}
+}
+// phpcs:enable Squiz.Commenting.FunctionComment.WrongStyle

--- a/projects/plugins/wpcomsh/tests/test-wpcomsh-stats-timezone-string.php
+++ b/projects/plugins/wpcomsh/tests/test-wpcomsh-stats-timezone-string.php
@@ -86,8 +86,5 @@ class Test_WPCOMSH_Stats_Timezone_String extends WP_UnitTestCase {
 		$expected_output = 'Etc/GMT-0';
 		$this->assertEquals( $expected_output, $actual_output );
 	}
-	public function test_wpcomsh_stats_timezone_broken() {
-		$this->assertEquals( 'foo', 'bar' );
-	}
 }
 // phpcs:enable Squiz.Commenting.FunctionComment.WrongStyle

--- a/projects/plugins/wpcomsh/tests/test-wpcomsh-stats-timezone-string.php
+++ b/projects/plugins/wpcomsh/tests/test-wpcomsh-stats-timezone-string.php
@@ -86,5 +86,8 @@ class Test_WPCOMSH_Stats_Timezone_String extends WP_UnitTestCase {
 		$expected_output = 'Etc/GMT-0';
 		$this->assertEquals( $expected_output, $actual_output );
 	}
+	public function test_wpcomsh_stats_timezone_broken() {
+		$this->assertEquals( 'foo', 'bar' );
+	}
 }
 // phpcs:enable Squiz.Commenting.FunctionComment.WrongStyle

--- a/projects/plugins/wpcomsh/tests/test-wpcomsh.php
+++ b/projects/plugins/wpcomsh/tests/test-wpcomsh.php
@@ -61,7 +61,7 @@ class WpcomshTest extends WP_UnitTestCase {
 	}
 	public function test_wpcomsh_stats_timezone_string() {
 		$actual_output   = wpcomsh_stats_timezone_string();
-		$expected_output = 'abc';
+		$expected_output = 'Etc/GMT-0';
 		$this->assertEquals( $expected_output, $actual_output );
 	}
 }

--- a/projects/plugins/wpcomsh/tests/test-wpcomsh.php
+++ b/projects/plugins/wpcomsh/tests/test-wpcomsh.php
@@ -59,9 +59,4 @@ class WpcomshTest extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected_output, wpcomsh_make_content_clickable( $original_content ) );
 	}
-	public function test_wpcomsh_stats_timezone_string() {
-		$actual_output   = wpcomsh_stats_timezone_string();
-		$expected_output = 'Etc/GMT-0';
-		$this->assertEquals( $expected_output, $actual_output );
-	}
 }

--- a/projects/plugins/wpcomsh/tests/test-wpcomsh.php
+++ b/projects/plugins/wpcomsh/tests/test-wpcomsh.php
@@ -59,4 +59,9 @@ class WpcomshTest extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected_output, wpcomsh_make_content_clickable( $original_content ) );
 	}
+	public function test_wpcomsh_stats_timezone_string() {
+		$actual_output   = wpcomsh_stats_timezone_string();
+		$expected_output = 'abc';
+		$this->assertEquals( $expected_output, $actual_output );
+	}
 }

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -562,7 +562,7 @@ function wpcomsh_stats_timezone_string() {
 		// matching "<Area>/<City>" timezone.
 		if ( $minutes > 0 ) {
 			$offset  = $sign * ( $hours * 3600 + $minutes * 60 );
-			$city_tz = timezone_name_from_abbr( '', $offset, false );
+			$city_tz = timezone_name_from_abbr( '', $offset, 0 );
 
 			if ( ! empty( $city_tz ) ) {
 				return $city_tz;

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -541,6 +541,49 @@ function wpcom_hide_scan_threats_from_api( $response ) {
 add_filter( 'rest_post_dispatch', 'wpcom_hide_scan_threats_from_api' );
 
 /**
+ * Returns a standardized timezone string.
+ *
+ * `wp_timezone_string()` sometimes returns offsets (e.g. "-07:00"), which are
+ * a non-standard representation of a UTC offset that only works in PHP.
+ * This function returns a standardized timezone string instead, of the form
+ * "Etc/GMT+7" for integer hour offsets, or a matching "<Area>/<City>" form for
+ * fractional hour offsets (used e.g. in India).
+ */
+function wpcomsh_stats_timezone_string() {
+	$wp_tz = wp_timezone_string();
+
+	// Did we get back an offset?
+	if ( preg_match( '/^([+-])?(\d{1,2}):(\d{2})$/', $wp_tz, $matches ) ) {
+		$sign    = $matches[1] === '-' ? -1 : 1;
+		$hours   = intval( $matches[2], 10 );
+		$minutes = intval( $matches[3], 10 );
+
+		// For fractional hour offsets, use `timezone_name_from_abbr` to get a
+		// matching "<Area>/<City>" timezone.
+		if ( $minutes > 0 ) {
+			$offset  = $sign * ( $hours * 3600 + $minutes * 60 );
+			$city_tz = timezone_name_from_abbr( '', $offset, false );
+
+			if ( ! empty( $city_tz ) ) {
+				return $city_tz;
+			}
+		}
+
+		// For integer hour offsets, use "Etc/GMT(+|-)<offset>".
+		// The sign is flipped, to match how the `Etc` area is specced.
+		//
+		// This codepath is also followed if no city exists to match a
+		// fractional offset, by simply discarding the fractional part.
+		// This isn't ideal, but there's no standard way of describing
+		// these offsets, and is likely to be an extreme edge case.
+		return 'Etc/GMT' . ( $sign === -1 ? '+' : '-' ) . $hours;
+	}
+
+	// For anything that's not an offset, return the string we got from WP.
+	return $wp_tz;
+}
+
+/**
  * Collect RUM performance data
  * p9o2xV-XY-p2
  */
@@ -571,12 +614,15 @@ function wpcomsh_footer_rum_js() {
 		$rum_kv = '';
 	}
 
+	$data_site_tz = 'data-site-tz="' . esc_attr( wpcomsh_stats_timezone_string() ) . '"';
+
 	printf(
-		'<script defer id="bilmur" %1$s data-provider="wordpress.com" data-service="%2$s" %3$s src="%4$s"></script>' . "\n", //phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		'<script defer id="bilmur" %1$s data-provider="wordpress.com" data-service="%2$s" %3$s src="%4$s" %5$s></script>' . "\n", //phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		$rum_kv, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		esc_attr( $service ),
 		wp_kses_post( $allow_iframe ),
-		esc_url( 'https://s0.wp.com/wp-content/js/bilmur.min.js?m=' . gmdate( 'YW' ) )
+		esc_url( 'https://s0.wp.com/wp-content/js/bilmur.min.js?m=' . gmdate( 'YW' ) ),
+		$data_site_tz // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:

* Updates the Bilmur Real User Monitoring (RUM) library to include the site’s timezone.
* Adds a new function `wpcomsh_stats_timezone_string()` to standardize timezone output (e.g., converts `+05:30` to `Asia/Kolkata` or `Etc/GMT+5`).
* Injects the timezone as a `data-site-tz` attribute in the Bilmur `<script>` tag.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes, this PR adds the site’s timezone to the data sent to Bilmur for performance tracking. This could indirectly reveal location info (e.g., `America/New_York`), but it’s site-level, not user-level data.


## Testing instructions:
* Make a WoA dev site, download Jetpack Beta, install it and switch wpcom site helper to this branch as [explained in the comment below](https://github.com/Automattic/jetpack/pull/41964#issuecomment-2675467552)
* Open the site in a browser and inspect the page source (Ctrl+U or right-click > View Source).
* Look for the `<script id="bilmur" ...>` tag in the footer.
* Check that it includes a `data-site-tz` attribute (e.g., `data-site-tz="Etc/GMT+0"` or a city like `Asia/Kolkata`).
* Change the site’s timezone in WordPress (Settings > General > Timezone) to something else (e.g., `UTC+5:30` or `New York`), reload, and verify the `data-site-tz` updates accordingly.
