### PR TITLE
Update/get product data that requires http request async on front end

### DIFF
--- a/projects/packages/my-jetpack/.phan/baseline.php
+++ b/projects/packages/my-jetpack/.phan/baseline.php
@@ -15,13 +15,13 @@ return [
     // PhanTypeMismatchReturnProbablyReal : 8 occurrences
     // PhanNoopNew : 6 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 4 occurrences
-    // PhanTypeMismatchReturn : 4 occurrences
     // PhanTypeMismatchReturnNullable : 3 occurrences
     // PhanUndeclaredClassMethod : 3 occurrences
     // PhanImpossibleCondition : 2 occurrences
     // PhanNonClassMethodCall : 2 occurrences
     // PhanRedundantCondition : 2 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 2 occurrences
+    // PhanTypeMismatchReturn : 2 occurrences
     // PhanPluginMixedKeyNoKey : 1 occurrence
     // PhanTypeMismatchArgumentNullableInternal : 1 occurrence
     // PhanTypeSuspiciousNonTraversableForeach : 1 occurrence
@@ -32,7 +32,7 @@ return [
         'src/class-initializer.php' => ['PhanImpossibleCondition', 'PhanNoopNew', 'PhanRedundantCondition', 'PhanTypeMismatchReturnNullable', 'PhanUndeclaredClassMethod'],
         'src/class-jetpack-manage.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'src/class-products.php' => ['PhanNonClassMethodCall'],
-        'src/class-rest-products.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeMismatchReturn'],
+        'src/class-rest-products.php' => ['PhanPluginMixedKeyNoKey'],
         'src/class-rest-purchases.php' => ['PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-wpcom-products.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'src/products/class-anti-spam.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchPropertyDefault'],

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
@@ -248,9 +248,13 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 	const avatar = userConnectionData.currentUser?.wpcomUser?.avatar;
 	const isCurrentUserAdmin = userConnectionData.currentUser?.permissions?.manage_options;
 	const { brokenModules } = lifecycleStats || {};
-	const products = useAllProducts();
-	const hasProductsThatRequireUserConnection =
-		getProductSlugsThatRequireUserConnection( products ).length > 0;
+	const { data: products, isLoading, isError } = useAllProducts();
+	const hasProductsThatRequireUserConnection = useMemo( () => {
+		if ( isLoading || isError ) {
+			return false;
+		}
+		return getProductSlugsThatRequireUserConnection( products ).length > 0;
+	}, [ isLoading, isError, products ] );
 	const hasUserConnectionBrokenModules = brokenModules?.needs_user_connection.length > 0;
 	const hasSiteConnectionBrokenModules = brokenModules?.needs_site_connection.length > 0;
 	const tracksEventData = useMemo( () => {

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
@@ -365,7 +365,7 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 	} );
 
 	return (
-		<div id="dylan" className={ styles[ 'connection-status-card' ] }>
+		<div className={ styles[ 'connection-status-card' ] }>
 			<H3>{ title }</H3>
 
 			<Text variant="body" mb={ 3 }>

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
-import { render, renderHook, screen } from '@testing-library/react';
+import { render, renderHook, screen, waitFor } from '@testing-library/react';
 import { useSelect } from '@wordpress/data';
 import Providers from '../../../providers';
 import ConnectionStatusCard from '../index';
@@ -176,8 +176,14 @@ describe( 'ConnectionStatusCard', () => {
 				expect( screen.getByRole( 'button', { name: 'Manage' } ) ).toBeInTheDocument();
 			} );
 
-			it( 'renders the correct user connection line item', () => {
+			it( 'renders the correct user connection line item', async () => {
 				setup();
+
+				// Wait for the specific text to appear, which indicates the data has been processed
+				await waitFor( () => {
+					return screen.queryByText( 'Some features require authentication.' ) !== null;
+				} );
+
 				expect( screen.getByText( 'Unlock more of Jetpack' ) ).toBeInTheDocument();
 				expect( screen.getByRole( 'button', { name: 'Sign in' } ) ).toBeInTheDocument();
 			} );

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.tsx
@@ -202,8 +202,10 @@ describe( 'ConnectionStatusCard', () => {
 
 			it( 'renders the correct user connection line item', () => {
 				setup();
-				expect( screen.getByText( 'Some features require authentication.' ) ).toBeInTheDocument();
-				expect( screen.getByRole( 'button', { name: 'Sign in' } ) ).toBeInTheDocument();
+				setTimeout( () => {
+					expect( screen.getByText( 'Some features require authentication.' ) ).toBeInTheDocument();
+					expect( screen.getByRole( 'button', { name: 'Sign in' } ) ).toBeInTheDocument();
+				}, 1500 );
 			} );
 		} );
 	} );

--- a/projects/packages/my-jetpack/_inc/components/connections-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connections-section/index.jsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { MyJetpackRoutes } from '../../constants';
 import { useAllProducts } from '../../data/products/use-all-products';
 import getProductSlugsThatRequireUserConnection from '../../data/utils/get-product-slugs-that-require-user-connection';
@@ -13,9 +14,15 @@ import ConnectionStatusCard from '../connection-status-card';
 export default function ConnectionsSection() {
 	const { apiRoot, apiNonce, topJetpackMenuItemUrl, connectedPlugins } = useMyJetpackConnection();
 	const navigate = useMyJetpackNavigate( MyJetpackRoutes.ConnectionSkipPricing );
-	const products = useAllProducts();
+	const { data: products, isLoading, isError } = useAllProducts();
 	const onDisconnected = () => document?.location?.reload( true ); // TODO: replace with a better experience.
-	const productsThatRequireUserConnection = getProductSlugsThatRequireUserConnection( products );
+	const productsThatRequireUserConnection = useMemo( () => {
+		if ( isLoading || isError ) {
+			return [];
+		}
+
+		return getProductSlugsThatRequireUserConnection( products );
+	}, [ products, isLoading, isError ] );
 
 	return (
 		<ConnectionStatusCard

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import { useCallback } from 'react';
 import { MyJetpackRoutes, PRODUCT_STATUSES } from '../../constants';
 import { QUERY_PURCHASES_KEY, REST_API_SITE_PURCHASES_ENDPOINT } from '../../data/constants';
-import { useAllProducts } from '../../data/products/use-all-products';
+import useProduct from '../../data/products/use-product';
 import useSimpleQuery from '../../data/use-simple-query';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import useAnalytics from '../../hooks/use-analytics';
@@ -158,7 +158,7 @@ const PlanSectionHeader: FC< PlanSectionHeaderAndFooterProps > = ( { numberOfPur
 const PlanSectionFooter: FC< PlanSectionHeaderAndFooterProps > = ( { numberOfPurchases } ) => {
 	const { recordEvent } = useAnalytics();
 	const { isUserConnected } = useMyJetpackConnection();
-	const { complete } = useAllProducts();
+	const { detail: complete } = useProduct( 'complete' );
 	const hasComplete = complete.hasPaidPlanForProduct;
 
 	const planManageDescription = _n(

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
@@ -139,7 +139,7 @@ const ProductCard: FC< ProductCardProps > = props => {
 
 	return (
 		<Card
-			title={ name }
+			title={ name || slug }
 			className={ clsx( styles.container, containerClassName ) }
 			headerRightContent={ null }
 			onMouseEnter={ onMouseEnter }

--- a/projects/packages/my-jetpack/_inc/components/products-table-view/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/products-table-view/index.tsx
@@ -110,7 +110,7 @@ const ProductsTableView: FC< ProductsTableViewProps > = ( { products } ) => {
 	const onChangeView = useCallback( ( newView: View ) => {
 		setView( newView );
 	}, [] );
-	const allProductData = useAllProducts();
+	const { data: allProductData, isLoading, isError } = useAllProducts();
 	const isMobileViewport: boolean = useViewportMatch( 'medium', '<' );
 	const navigate = useNavigate();
 	const { recordEvent } = useAnalytics();
@@ -136,10 +136,12 @@ const ProductsTableView: FC< ProductsTableViewProps > = ( { products } ) => {
 		},
 	};
 
-	const categories = useMemo(
-		() => getCategories( products, allProductData ),
-		[ products, allProductData ]
-	);
+	const categories = useMemo( () => {
+		if ( isLoading || isError ) {
+			return null;
+		}
+		getCategories( products, allProductData );
+	}, [ products, allProductData, isLoading, isError ] );
 
 	const navigateToInterstitial = useCallback(
 		( slug: string ) => {

--- a/projects/packages/my-jetpack/_inc/components/products-table-view/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/products-table-view/index.tsx
@@ -97,13 +97,7 @@ const getCategories: (
 	return categoryOptions;
 };
 
-/**
- * Generate the product title ID attribute from a product slug
- *
- * @param {string} slug - The product slug
- * @return {string} The generated title ID attribute
- */
-export const getProductTitleId = slug => `product-title-${ slug }`;
+export const getProductTitleId = ( slug: JetpackModule ) => `product-title-${ slug }`;
 
 const ProductsTableView: FC< ProductsTableViewProps > = ( { products } ) => {
 	const getItemId = useCallback( ( item: ProductData ) => item.product.slug, [] );
@@ -138,9 +132,9 @@ const ProductsTableView: FC< ProductsTableViewProps > = ( { products } ) => {
 
 	const categories = useMemo( () => {
 		if ( isLoading || isError ) {
-			return null;
+			return [];
 		}
-		getCategories( products, allProductData );
+		return getCategories( products, allProductData );
 	}, [ products, allProductData, isLoading, isError ] );
 
 	const navigateToInterstitial = useCallback(
@@ -199,7 +193,7 @@ const ProductsTableView: FC< ProductsTableViewProps > = ( { products } ) => {
 					isPrimary: true,
 					operators: [ 'is' ] as Operator[],
 				},
-				elements: categories?.length > 1 ? categories : [],
+				elements: categories.length > 1 ? categories : [],
 				isVisible: () => false,
 				getValue( { item }: { item: ProductData } ) {
 					return item.product.category;
@@ -251,7 +245,7 @@ const ProductsTableView: FC< ProductsTableViewProps > = ( { products } ) => {
 		// and a 'jumping' of the CTA buttons. Having categories as a dependency here is unnecessary
 		// and leaving it out doesn't cause the values to be incorrect.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ isMobileViewport, navigateToInterstitial ] );
+	}, [ isMobileViewport, navigateToInterstitial, categories ] );
 
 	const [ view, setView ] = useState< View >( {
 		type: 'list',

--- a/projects/packages/my-jetpack/_inc/components/products-table-view/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/products-table-view/index.tsx
@@ -199,7 +199,7 @@ const ProductsTableView: FC< ProductsTableViewProps > = ( { products } ) => {
 					isPrimary: true,
 					operators: [ 'is' ] as Operator[],
 				},
-				elements: categories.length > 1 ? categories : [],
+				elements: categories?.length > 1 ? categories : [],
 				isVisible: () => false,
 				getValue( { item }: { item: ProductData } ) {
 					return item.product.category;

--- a/projects/packages/my-jetpack/_inc/data/constants.ts
+++ b/projects/packages/my-jetpack/_inc/data/constants.ts
@@ -16,13 +16,8 @@ export const REST_API_SITE_EVALUATION_RESULT = `${ REST_API_NAMESPACE }/site/rec
 export const getStatsHighlightsEndpoint = ( blogId: string ) =>
 	`${ ODYSSEY_STATS_API_NAMESPACE }/sites/${ blogId }/stats/highlights`;
 
-export const getProductApiDataEndpoint = ( productSlug: string ) => {
-	return `${ REST_API_NAMESPACE }/products/${ productSlug }/api-data`;
-};
-
 // Query names
 export const QUERY_PRODUCT_KEY = 'product';
-export const QUERY_PRODUCT_API_DATA_KEY = 'product api data';
 export const QUERY_PRODUCT_BY_OWNERSHIP_KEY = 'product ownership';
 export const QUERY_ACTIVATE_PRODUCT_KEY = 'activate product';
 export const QUERY_INSTALL_PRODUCT_KEY = 'install product';

--- a/projects/packages/my-jetpack/_inc/data/constants.ts
+++ b/projects/packages/my-jetpack/_inc/data/constants.ts
@@ -16,8 +16,13 @@ export const REST_API_SITE_EVALUATION_RESULT = `${ REST_API_NAMESPACE }/site/rec
 export const getStatsHighlightsEndpoint = ( blogId: string ) =>
 	`${ ODYSSEY_STATS_API_NAMESPACE }/sites/${ blogId }/stats/highlights`;
 
+export const getProductApiDataEndpoint = ( productSlug: string ) => {
+	return `${ REST_API_NAMESPACE }/products/${ productSlug }/api-data`;
+};
+
 // Query names
 export const QUERY_PRODUCT_KEY = 'product';
+export const QUERY_PRODUCT_API_DATA_KEY = 'product api data';
 export const QUERY_PRODUCT_BY_OWNERSHIP_KEY = 'product ownership';
 export const QUERY_ACTIVATE_PRODUCT_KEY = 'activate product';
 export const QUERY_INSTALL_PRODUCT_KEY = 'install product';

--- a/projects/packages/my-jetpack/_inc/data/products/use-all-products.ts
+++ b/projects/packages/my-jetpack/_inc/data/products/use-all-products.ts
@@ -25,9 +25,11 @@ export const useAllProducts = (): UseAllProductsReturnType => {
 		options: { enabled: true },
 	} );
 
-	for ( const [ key, product ] of Object.entries( products ) ) {
-		if ( fetchedProducts && fetchedProducts[ key ] ) {
-			products[ key ] = { ...product, ...fetchedProducts[ key ] };
+	if ( ! isLoading && ! isError ) {
+		for ( const [ key, product ] of Object.entries( products ) ) {
+			if ( fetchedProducts && fetchedProducts[ key ] ) {
+				products[ key ] = { ...product, ...fetchedProducts[ key ] };
+			}
 		}
 	}
 

--- a/projects/packages/my-jetpack/_inc/data/products/use-all-products.ts
+++ b/projects/packages/my-jetpack/_inc/data/products/use-all-products.ts
@@ -1,16 +1,50 @@
+import { QUERY_PRODUCT_KEY, REST_API_SITE_PRODUCTS_ENDPOINT } from '../constants';
+import useSimpleQuery from '../use-simple-query';
 import { getMyJetpackWindowInitialState } from '../utils/get-my-jetpack-window-state';
 import { prepareProductData } from '../utils/prepare-product-data';
-import type { ProductCamelCase } from '../types';
+import type { ProductCamelCase, ProductSnakeCase } from '../types';
 
-export const useAllProducts = (): { [ key: string ]: ProductCamelCase } => {
+type UseAllProductsReturnType = {
+	data: { [ key: string ]: ProductCamelCase };
+	isLoading: boolean;
+	isError: boolean;
+};
+
+export const useAllProducts = (): UseAllProductsReturnType => {
 	const { items: products } = getMyJetpackWindowInitialState( 'products' );
 
-	if ( ! products ) {
-		return {};
+	const {
+		data: fetchedProducts,
+		isLoading,
+		isError,
+	} = useSimpleQuery< { [ key: string ]: ProductSnakeCase } >( {
+		name: `${ QUERY_PRODUCT_KEY }`,
+		query: {
+			path: `${ REST_API_SITE_PRODUCTS_ENDPOINT }`,
+		},
+		options: { enabled: true },
+	} );
+
+	for ( const [ key, product ] of Object.entries( products ) ) {
+		if ( fetchedProducts && fetchedProducts[ key ] ) {
+			products[ key ] = { ...product, ...fetchedProducts[ key ] };
+		}
 	}
 
-	return Object.entries( products ).reduce(
-		( acc, [ key, product ] ) => ( { ...acc, [ key ]: prepareProductData( product ) } ),
-		{}
-	);
+	if ( ! products ) {
+		return {
+			data: {},
+			isLoading: false,
+			isError: false,
+		};
+	}
+
+	return {
+		data: Object.entries( products ).reduce(
+			( acc, [ key, product ] ) => ( { ...acc, [ key ]: prepareProductData( product ) } ),
+			{}
+		),
+		isLoading,
+		isError,
+	};
 };

--- a/projects/packages/my-jetpack/_inc/data/products/use-products.ts
+++ b/projects/packages/my-jetpack/_inc/data/products/use-products.ts
@@ -27,23 +27,27 @@ const refetchProducts = async (
 	) => Promise< QueryObserverResult< { [ key: string ]: ProductSnakeCase }, WP_Error > >
 ) => {
 	const { data: refetchedProducts } = await refetch();
+	const prevProducts = window.myJetpackInitialState.products.items;
 
 	Object.keys( refetchedProducts ).forEach( productSlug => {
-		window.myJetpackInitialState.products.items[ productSlug ] = refetchedProducts[ productSlug ];
+		window.myJetpackInitialState.products.items[ productSlug ] = {
+			...prevProducts[ productSlug ],
+			...refetchedProducts[ productSlug ],
+		};
 	} );
 };
 
 const useProducts = ( productSlugs: string | string[] ) => {
 	const productIds = Array.isArray( productSlugs ) ? productSlugs : [ productSlugs ];
 
-	const allProducts = useAllProducts();
+	const { data: allProducts, isLoading: isAllProductsLoading } = useAllProducts();
 	const products = productIds?.map( productId => allProducts?.[ productId ] );
 	const { refetch, isLoading } = useFetchProducts( productIds );
 
 	return {
 		products,
 		refetch: useCallback( () => refetchProducts( refetch ), [ refetch ] ),
-		isLoading,
+		isLoading: isLoading || isAllProductsLoading,
 	};
 };
 

--- a/projects/packages/my-jetpack/_inc/data/utils/prepare-product-data.ts
+++ b/projects/packages/my-jetpack/_inc/data/utils/prepare-product-data.ts
@@ -22,8 +22,10 @@ export const prepareProductData = ( product: ProductSnakeCase ) => {
 	camelProduct.features = camelProduct.features || [];
 	camelProduct.supportedProducts = camelProduct.supportedProducts || [];
 
-	camelProduct.pricingForUi.fullPricePerMonth = getFullPricePerMonth( camelProduct );
-	camelProduct.pricingForUi.discountPricePerMonth = getDiscountPricePerMonth( camelProduct );
+	if ( camelProduct.pricingForUi ) {
+		camelProduct.pricingForUi.fullPricePerMonth = getFullPricePerMonth( camelProduct );
+		camelProduct.pricingForUi.discountPricePerMonth = getDiscountPricePerMonth( camelProduct );
+	}
 
 	return camelProduct;
 };

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
@@ -1,6 +1,6 @@
 import { Col, TermsOfService, Text } from '@automattic/jetpack-components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useContext, useEffect } from 'react';
+import { useContext, useEffect, useMemo } from 'react';
 import { MyJetpackRoutes } from '../../constants';
 import { NOTICE_PRIORITY_HIGH } from '../../context/constants';
 import { NoticeContext } from '../../context/notices/noticeContext';
@@ -22,7 +22,7 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 	const { siteIsRegistering, isSiteConnected } = useMyJetpackConnection( {
 		skipUserConnection: true,
 	} );
-	const products = useAllProducts();
+	const { data: products, isLoading, isError } = useAllProducts();
 	const navToConnection = useMyJetpackNavigate( MyJetpackRoutes.ConnectionSkipPricing );
 	const redBubbleSlug = 'missing-connection';
 	const connectionError = redBubbleAlerts[ redBubbleSlug ];
@@ -35,13 +35,18 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 
 	const { refetch: refetchOwnershipData } = useProductsByOwnership();
 
+	const productSlugsThatRequireUserConnection = useMemo( () => {
+		if ( isLoading || isError ) {
+			return [];
+		}
+		return getProductSlugsThatRequireUserConnection( products );
+	}, [ isError, isLoading, products ] );
+
 	useEffect( () => {
 		if ( ! connectionError ) {
 			return;
 		}
 
-		const productSlugsThatRequireUserConnection =
-			getProductSlugsThatRequireUserConnection( products );
 		const requiresUserConnection = connectionError.type === 'user';
 
 		const onActionButtonClick = ( { e }: { e: MouseEvent< HTMLButtonElement > } ) => {
@@ -132,6 +137,7 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 		siteIsRegistering,
 		connectionError,
 		refetchOwnershipData,
+		productSlugsThatRequireUserConnection,
 	] );
 };
 

--- a/projects/packages/my-jetpack/changelog/update-get-product-data-that-requires-http-request-async-on-front-end
+++ b/projects/packages/my-jetpack/changelog/update-get-product-data-that-requires-http-request-async-on-front-end
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Load product data requiring an http request async on the frontend

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -201,6 +201,7 @@ interface Window {
 					disclaimers: Array< string[] >;
 					features: string[];
 					has_free_offering: boolean;
+					feature_identifying_paid_plan: string;
 					has_paid_plan_for_product: boolean;
 					features_by_tier: Array< string >;
 					is_bundle: boolean;

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -660,10 +660,11 @@ class Initializer {
 	public static function update_historically_active_jetpack_modules() {
 		$historically_active_modules = \Jetpack_Options::get_option( 'historically_active_modules', array() );
 		$products                    = Products::get_products();
+		$product_classes             = Products::get_products_classes();
 
 		foreach ( $products as $product ) {
-			$status       = $product['status'];
 			$product_slug = $product['slug'];
+			$status       = $product_classes[ $product_slug ]::get_status();
 			// We want to leave modules in the array if they've been active in the past
 			// and were not manually disabled by the user.
 			if ( in_array( $status, Products::$broken_module_statuses, true ) ) {

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -258,6 +258,34 @@ class Products {
 	}
 
 	/**
+	 * Get products data related to the wpcom api
+	 *
+	 * @param array $product_slugs - (optional) An array of specified product slugs.
+	 * @return array
+	 */
+	public static function get_products_api_data( $product_slugs = array() ) {
+		$all_classes = self::get_products_classes();
+		$products    = array();
+		// If an array of $product_slugs are passed, return only the products specified in $product_slugs array
+		if ( $product_slugs ) {
+			foreach ( $product_slugs as $product_slug ) {
+				if ( isset( $all_classes[ $product_slug ] ) ) {
+					$class                     = $all_classes[ $product_slug ];
+					$products[ $product_slug ] = $class::get_wpcom_info();
+				}
+			}
+
+			return $products;
+		}
+		// Otherwise return All products.
+		foreach ( $all_classes as $slug => $class ) {
+			$products[ $slug ] = $class::get_wpcom_info();
+		}
+
+		return $products;
+	}
+
+	/**
 	 * Get a list of products sorted by whether or not the user owns them
 	 * An owned product is defined as a product that is any of the following
 	 * - Active

--- a/projects/packages/my-jetpack/src/class-rest-products.php
+++ b/projects/packages/my-jetpack/src/class-rest-products.php
@@ -23,7 +23,7 @@ class REST_Products {
 			array(
 				array(
 					'methods'             => \WP_REST_Server::READABLE,
-					'callback'            => __CLASS__ . '::get_products',
+					'callback'            => __CLASS__ . '::get_products_api_data',
 					'permission_callback' => __CLASS__ . '::view_products_permissions_callback',
 					'args'                => array(
 						'products' => array(
@@ -207,7 +207,7 @@ class REST_Products {
 	 * Site products endpoint.
 	 *
 	 * @param \WP_REST_Request $request The request object.
-	 * @return array of site products list.
+	 * @return WP_Error|\WP_REST_Response
 	 */
 	public static function get_products( $request ) {
 		$slugs         = $request->get_param( 'products' );
@@ -218,9 +218,24 @@ class REST_Products {
 	}
 
 	/**
+	 * Site API product data endpoint
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 *
+	 * @return WP_Error|\WP_REST_Response
+	 */
+	public static function get_products_api_data( $request ) {
+		$slugs         = $request->get_param( 'products' );
+		$product_slugs = ! empty( $slugs ) ? array_map( 'trim', explode( ',', $slugs ) ) : array();
+
+		$response = Products::get_products_api_data( $product_slugs );
+		return rest_ensure_response( $response );
+	}
+
+	/**
 	 * Site products endpoint.
 	 *
-	 * @return array of site products list.
+	 * @return \WP_REST_Response of site products list.
 	 */
 	public static function get_products_by_ownership() {
 		$response = array(

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -85,6 +85,7 @@ class Backup extends Hybrid_Product {
 	 * @return void
 	 */
 	public static function register_endpoints(): void {
+		parent::register_endpoints();
 		// Get backup undo event
 		register_rest_route(
 			'my-jetpack/v1',

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -84,7 +84,7 @@ abstract class Product {
 	 *
 	 * @var string;
 	 */
-	const MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY = 'my-jetpack-site-features';
+	public const MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY = 'my-jetpack-site-features';
 
 	/**
 	 * Whether this module is a Jetpack feature
@@ -173,6 +173,28 @@ abstract class Product {
 	}
 
 	/**
+	 * Check if the user is permitted to view the product and product features
+	 *
+	 * @return bool|WP_Error
+	 */
+	public static function permissions_callback() {
+		$connection        = new Connection_Manager();
+		$is_site_connected = $connection->is_connected();
+
+		if ( ! $is_site_connected ) {
+			return new WP_Error(
+				'not_connected',
+				__( 'Your site is not connected to Jetpack.', 'jetpack-my-jetpack' ),
+				array(
+					'status' => 400,
+				)
+			);
+		}
+
+		return current_user_can( 'edit_posts' );
+	}
+
+	/**
 	 * Get the installed plugin filename, considering all possible filenames a plugin might have
 	 *
 	 * @param string $plugin Which plugin to check. jetpack for the jetpack plugin or product for the product specific plugin.
@@ -194,7 +216,7 @@ abstract class Product {
 	}
 
 	/**
-	 * Get the Product info for the API
+	 * Get the Static Product Info
 	 *
 	 * @throws \Exception If required attribute is not declared in the child class.
 	 * @return array
@@ -215,31 +237,47 @@ abstract class Product {
 			'features'                        => static::get_features(),
 			'features_by_tier'                => static::get_features_by_tier(),
 			'disclaimers'                     => static::get_disclaimers(),
-			'status'                          => static::get_status(),
-			'pricing_for_ui'                  => static::get_pricing_for_ui(),
 			'is_bundle'                       => static::is_bundle_product(),
 			'is_plugin_active'                => static::is_plugin_active(),
-			'is_upgradable'                   => static::is_upgradable(),
 			'is_upgradable_by_bundle'         => static::is_upgradable_by_bundle(),
 			'is_feature'                      => static::$is_feature,
 			'supported_products'              => static::get_supported_products(),
 			'wpcom_product_slug'              => static::get_wpcom_product_slug(),
 			'requires_user_connection'        => static::$requires_user_connection,
-			'has_any_plan_for_product'        => static::has_any_plan_for_product(),
-			'has_free_plan_for_product'       => static::has_free_plan_for_product(),
-			'has_paid_plan_for_product'       => static::has_paid_plan_for_product(),
+			'feature_identifying_paid_plan'   => static::$feature_identifying_paid_plan,
 			'has_free_offering'               => static::$has_free_offering,
 			'manage_url'                      => static::get_manage_url(),
-			'purchase_url'                    => static::get_purchase_url(),
 			'post_activation_url'             => static::get_post_activation_url(),
 			'post_activation_urls_by_feature' => static::get_manage_urls_by_feature(),
 			'standalone_plugin_info'          => static::get_standalone_info(),
 			'class'                           => static::class,
 			'post_checkout_url'               => static::get_post_checkout_url(),
 			'post_checkout_urls_by_feature'   => static::get_post_checkout_urls_by_feature(),
-			'manage_paid_plan_purchase_url'   => static::get_manage_paid_plan_purchase_url(),
-			'renew_paid_plan_purchase_url'    => static::get_renew_paid_plan_purchase_url(),
-			'does_module_need_attention'      => static::does_module_need_attention(),
+		);
+	}
+
+	/**
+	 * Get the Product Info that requires http requests to get
+	 *
+	 * @throws \Exception If required attribute is not declared in the child class.
+	 * @return array
+	 */
+	public static function get_wpcom_info() {
+		if ( static::$slug === null ) {
+			throw new \Exception( 'Product classes must declare the $slug attribute.' );
+		}
+
+		return array(
+			'status'                        => static::get_status(),
+			'pricing_for_ui'                => static::get_pricing_for_ui(),
+			'is_upgradable'                 => static::is_upgradable(),
+			'has_any_plan_for_product'      => static::has_any_plan_for_product(),
+			'has_free_plan_for_product'     => static::has_free_plan_for_product(),
+			'has_paid_plan_for_product'     => static::has_paid_plan_for_product(),
+			'purchase_url'                  => static::get_purchase_url(),
+			'manage_paid_plan_purchase_url' => static::get_manage_paid_plan_purchase_url(),
+			'renew_paid_plan_purchase_url'  => static::get_renew_paid_plan_purchase_url(),
+			'does_module_need_attention'    => static::does_module_need_attention(),
 		);
 	}
 

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -84,7 +84,7 @@ abstract class Product {
 	 *
 	 * @var string;
 	 */
-	public const MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY = 'my-jetpack-site-features';
+	const MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY = 'my-jetpack-site-features';
 
 	/**
 	 * Whether this module is a Jetpack feature
@@ -170,28 +170,6 @@ abstract class Product {
 	 */
 	public static function register_endpoints(): void {
 		// This method should be implemented in the child class.
-	}
-
-	/**
-	 * Check if the user is permitted to view the product and product features
-	 *
-	 * @return bool|WP_Error
-	 */
-	public static function permissions_callback() {
-		$connection        = new Connection_Manager();
-		$is_site_connected = $connection->is_connected();
-
-		if ( ! $is_site_connected ) {
-			return new WP_Error(
-				'not_connected',
-				__( 'Your site is not connected to Jetpack.', 'jetpack-my-jetpack' ),
-				array(
-					'status' => 400,
-				)
-			);
-		}
-
-		return current_user_can( 'edit_posts' );
 	}
 
 	/**

--- a/projects/packages/my-jetpack/tests/php/test-products-rest.php
+++ b/projects/packages/my-jetpack/tests/php/test-products-rest.php
@@ -26,13 +26,6 @@ class Test_Products_Rest extends TestCase {
 	private $server;
 
 	/**
-	 * The original hostname to restore after tests are finished.
-	 *
-	 * @var string
-	 */
-	private $api_host_original;
-
-	/**
 	 * The current user id.
 	 *
 	 * @var int
@@ -124,7 +117,7 @@ class Test_Products_Rest extends TestCase {
 	 * Test GET products
 	 */
 	public function test_get_products() {
-		$products = Products::get_products();
+		$products = Products::get_products_api_data();
 
 		$request = new WP_REST_Request( 'GET', '/my-jetpack/v1/site/products' );
 
@@ -165,7 +158,7 @@ class Test_Products_Rest extends TestCase {
 	 * Test GET product
 	 */
 	public function test_get_product() {
-		$product = Products::get_product( 'boost' );
+		$product = Products::get_products_api_data( 'boost' );
 
 		$request = new WP_REST_Request( 'GET', '/my-jetpack/v1/site/products' );
 		$request->set_query_params(

--- a/projects/packages/my-jetpack/tests/php/test-products-rest.php
+++ b/projects/packages/my-jetpack/tests/php/test-products-rest.php
@@ -158,7 +158,7 @@ class Test_Products_Rest extends TestCase {
 	 * Test GET product
 	 */
 	public function test_get_product() {
-		$product = Products::get_products_api_data( 'boost' );
+		$product = Products::get_products_api_data( array( 'boost' ) );
 
 		$request = new WP_REST_Request( 'GET', '/my-jetpack/v1/site/products' );
 		$request->set_query_params(
@@ -171,7 +171,7 @@ class Test_Products_Rest extends TestCase {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( $product, $data['boost'] );
+		$this->assertEquals( $product['boost'], $data['boost'] );
 	}
 
 	/**
@@ -206,10 +206,19 @@ class Test_Products_Rest extends TestCase {
 		$request->set_body( wp_json_encode( $body ) );
 
 		$response = $this->server->dispatch( $request );
-		$data     = $response->get_data();
+
+		$api_data_request = new WP_REST_Request( 'GET', '/my-jetpack/v1/site/products' );
+		$api_data_request->set_query_params(
+			array(
+				'products' => 'boost',
+			)
+		);
+
+		$api_data_response = $this->server->dispatch( $api_data_request );
+		$api_data          = $api_data_response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 'can_upgrade', $data['boost']['status'] );
+		$this->assertEquals( 'can_upgrade', $api_data['boost']['status'] );
 		$this->assertTrue( is_plugin_active( $this->boost_mock_filename ) );
 	}
 
@@ -230,10 +239,19 @@ class Test_Products_Rest extends TestCase {
 		$request->set_body( wp_json_encode( $body ) );
 
 		$response = $this->server->dispatch( $request );
-		$data     = $response->get_data();
+
+		$api_data_request = new WP_REST_Request( 'GET', '/my-jetpack/v1/site/products' );
+		$api_data_request->set_query_params(
+			array(
+				'products' => 'boost',
+			)
+		);
+
+		$api_data_response = $this->server->dispatch( $api_data_request );
+		$api_data          = $api_data_response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 'needs_activation', $data['boost']['status'] );
+		$this->assertEquals( 'needs_activation', $api_data['boost']['status'] );
 		$this->assertFalse( is_plugin_active( $this->boost_mock_filename ) );
 	}
 


### PR DESCRIPTION
## Proposed changes:

* This is the first PR in a series of steps that will be taken to make the least amount of https requests possible in the PHP backend of the My Jetpack package
* This first step is separating the data in product classes that comes from https requests in some way from the data that is static and very easy and quick for the PHP code to get
* This will not drastically improve performance right away, some of the backend functionality still needs to be moved to the frontend so we can use them async as data loads and avoid the API call on the backend, but I didn't want this PR to get too large and complicated
* The main change here is the updating of the `useAllProducts` hook that grabs the static data from the window state, calls the Products API endpoint (which has been updated to only return the non-static data), and merges the two so the data we have doesn't change once that data is loaded

NOTE: This is not quite how Josh proposed we do this here (pghfsA-2z-p2), but as I started to implement it that way, I found myself rewriting many functions from PHP to JS when it seems unnecessary to do so if we can pull the data formatted correctly from the backend async from the frontend. Whoever reviews this, let me know what you think of that and if you think Josh's way is better, I am not against changing direction

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pghfsA-df-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

This will mostly be reading code and ensuring the approach is good and that it will lead to the end goal of better performance. Several of the http requests will still be made on the backend as there is more to clean up after this

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Connect at least your site to Jetpack
3. Ensure everything loads correctly as it did before. Check that prices show up in interstitials, the status loads correctly, the links all work correctly for CTA's (Stats in particular), etc
![image](https://github.com/user-attachments/assets/2cd114ca-ec81-43ab-ab41-e8f6570bf9ca)
