### PR TITLE
Docker: Allow Jetpack PHPUnit tests to be run alongside wpcomsh

### DIFF
--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -255,6 +255,17 @@ const launchNgrok = argv => {
 	}
 };
 
+/**
+ * Builds the command options for running PHPUnit tests inside a Docker container.
+ *
+ * @param {object}        argv                      - Command line args.
+ * @param {Array}         opts                      - Options for the Docker command.
+ * @param {object}        unitTestArgs              - Unit test args.
+ * @param {string}        unitTestArgs.plugin       - The name of the plugin we're running tests against.
+ * @param {string}        [unitTestArgs.configFile] - The PHPUnit configuration file to use. Defaults to 'phpunit.xml.dist'.
+ * @param {Array<string>} [unitTestArgs.envVars]    - Environment variables to set in the Docker container.
+ * @return {Array} Modified opts array.
+ */
 const buildPhpUnitTestCmd = ( argv, opts, unitTestArgs ) => {
 	const passthruArgs = argv._.slice( 2 );
 	const configFile = unitTestArgs.configFile ?? 'phpunit.xml.dist';

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -398,6 +398,18 @@ const buildExecCmd = argv => {
 			configFile: 'tests/php.multisite.xml',
 		};
 		opts = buildPhpUnitTestCmd( argv, opts, unitTestArgs );
+	} else if ( cmd === 'phpunit-wpcomsh' ) {
+		console.warn( chalk.yellow( 'This currently only run tests for the Jetpack plugin.' ) );
+		console.warn(
+			chalk.yellow(
+				'Other projects do not require a working database, so you can run them locally or directly within jetpack docker sh'
+			)
+		);
+		const unitTestArgs = {
+			plugin: 'jetpack',
+			envVars: [ 'JETPACK_TEST_WPCOMSH=1' ],
+		};
+		opts = buildPhpUnitTestCmd( argv, opts, unitTestArgs );
 	} else if ( cmd === 'phpunit-woocommerce' ) {
 		console.warn( chalk.yellow( 'This currently only run tests for the Jetpack plugin.' ) );
 		console.warn(
@@ -723,6 +735,17 @@ export function dockerDefine( yargs ) {
 					command: 'phpunit-multisite',
 					alias: 'phpunit:multisite',
 					description: 'Run multisite Jetpack PHPUnit tests inside container',
+					builder: yargCmd =>
+						defaultOpts( yargCmd ).option( 'php', {
+							describe: 'Use the specified version of PHP.',
+							type: 'string',
+						} ),
+					handler: argv => execDockerCmdHandler( argv ),
+				} )
+				.command( {
+					command: 'phpunit-wpcomsh',
+					alias: 'phpunit:wpcomsh',
+					description: 'Run Jetpack PHPUnit tests with wpcomsh inside container',
 					builder: yargCmd =>
 						defaultOpts( yargCmd ).option( 'php', {
 							describe: 'Use the specified version of PHP.',

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -255,6 +255,27 @@ const launchNgrok = argv => {
 	}
 };
 
+const buildPhpUnitTestCmd = ( argv, opts, unitTestArgs ) => {
+	const passthruArgs = argv._.slice( 2 );
+	const configFile = unitTestArgs.configFile ?? 'phpunit.xml.dist';
+
+	opts.splice( 1, 0, '-w', '/var/www/html/wp-content/plugins/' + unitTestArgs.plugin ); // Need to add this option to `exec` before the container name.
+	if ( unitTestArgs.envVars ) {
+		for ( let i = 0; i < unitTestArgs.envVars.length; i++ ) {
+			opts.splice( 3, 0, '-e', unitTestArgs.envVars[ i ] );
+		}
+	}
+
+	opts.push(
+		...( argv.php
+			? [ '/var/scripts/phpunit-version-wrapper.sh', argv.php ]
+			: [ 'vendor/bin/phpunit' ] ),
+		'--configuration=/var/www/html/wp-content/plugins/' + unitTestArgs.plugin + '/' + configFile,
+		...passthruArgs
+	);
+	return opts;
+};
+
 /**
  * Performs the given action again and again until it does not throw an error.
  *
@@ -335,7 +356,7 @@ const defaultDockerCmdHandler = async argv => {
  * @return {Array} Array of options required for specified command
  */
 const buildExecCmd = argv => {
-	const opts = [ 'exec', 'wordpress' ];
+	let opts = [ 'exec', 'wordpress' ];
 	const cmd = argv._[ 1 ];
 
 	if ( cmd === 'exec' ) {
@@ -359,16 +380,10 @@ const buildExecCmd = argv => {
 				'Other projects do not require a working database, so you can run them locally or directly within jetpack docker sh'
 			)
 		);
-		const unitArgs = argv._.slice( 2 );
-
-		opts.splice( 1, 0, '-w', '/var/www/html/wp-content/plugins/jetpack' ); // Need to add this option to `exec` before the container name.
-		opts.push(
-			...( argv.php
-				? [ '/var/scripts/phpunit-version-wrapper.sh', argv.php ]
-				: [ 'vendor/bin/phpunit' ] ),
-			'--configuration=/var/www/html/wp-content/plugins/jetpack/phpunit.xml.dist',
-			...unitArgs
-		);
+		const unitTestArgs = {
+			plugin: 'jetpack',
+		};
+		opts = buildPhpUnitTestCmd( argv, opts, unitTestArgs );
 	} else if ( cmd === 'phpunit-multisite' ) {
 		// @todo: Make this scale.
 		console.warn( chalk.yellow( 'This currently only run tests for the Jetpack plugin.' ) );
@@ -377,16 +392,12 @@ const buildExecCmd = argv => {
 				'Other projects do not require a working database, so you can run them locally or directly within jetpack docker sh'
 			)
 		);
-		const unitArgs = argv._.slice( 2 );
 
-		opts.splice( 1, 0, '-w', '/var/www/html/wp-content/plugins/jetpack' ); // Need to add this option to `exec` before the container name.
-		opts.push(
-			...( argv.php
-				? [ '/var/scripts/phpunit-version-wrapper.sh', argv.php ]
-				: [ 'vendor/bin/phpunit' ] ),
-			'--configuration=/var/www/html/wp-content/plugins/jetpack/tests/php.multisite.xml',
-			...unitArgs
-		);
+		const unitTestArgs = {
+			plugin: 'jetpack',
+			configFile: 'tests/php.multisite.xml',
+		};
+		opts = buildPhpUnitTestCmd( argv, opts, unitTestArgs );
 	} else if ( cmd === 'phpunit-woocommerce' ) {
 		console.warn( chalk.yellow( 'This currently only run tests for the Jetpack plugin.' ) );
 		console.warn(
@@ -394,37 +405,18 @@ const buildExecCmd = argv => {
 				'Other projects do not require a working database, so you can run them locally or directly within jetpack docker sh'
 			)
 		);
-		const unitArgs = argv._.slice( 2 );
-
-		opts.splice(
-			1,
-			0,
-			'-w',
-			'/var/www/html/wp-content/plugins/jetpack',
-			'-e',
-			'JETPACK_TEST_WOOCOMMERCE=1'
-		); // Need to add this option to `exec` before the container name.
-		opts.push(
-			...( argv.php
-				? [ '/var/scripts/phpunit-version-wrapper.sh', argv.php ]
-				: [ 'vendor/bin/phpunit' ] ),
-			'--configuration=/var/www/html/wp-content/plugins/jetpack/phpunit.xml.dist',
-			'--group=woocommerce',
-			...unitArgs
-		);
+		const unitTestArgs = {
+			plugin: 'jetpack',
+			envVars: [ 'JETPACK_TEST_WOOCOMMERCE=1' ],
+		};
+		opts = buildPhpUnitTestCmd( argv, opts, unitTestArgs );
+		opts.push( '--group=woocommerce' );
 	} else if ( cmd === 'phpunit-crm' ) {
-		// @todo: Make this scale.
 		console.warn( chalk.yellow( 'This currently only run tests for the Jetpack CRM plugin.' ) );
-		const unitArgs = argv._.slice( 2 );
-
-		opts.splice( 1, 0, '-w', '/var/www/html/wp-content/plugins/crm' ); // Need to add this option to `exec` before the container name.
-		opts.push(
-			...( argv.php
-				? [ '/var/scripts/phpunit-version-wrapper.sh', argv.php ]
-				: [ 'vendor/bin/phpunit' ] ),
-			'--configuration=/var/www/html/wp-content/plugins/crm/phpunit.xml.dist',
-			...unitArgs
-		);
+		const unitTestArgs = {
+			plugin: 'crm',
+		};
+		opts = buildPhpUnitTestCmd( argv, opts, unitTestArgs );
 	} else if ( cmd === 'wp' ) {
 		const wpArgs = argv._.slice( 2 );
 		// Ugly solution to allow interactive shell work in dev context
@@ -677,7 +669,7 @@ export function dockerDefine( yargs ) {
 				} )
 				.command( {
 					command: 'db',
-					description: 'Access MySql CLI',
+					description: 'Access MySQL CLI',
 					builder: yargExec => defaultOpts( yargExec ),
 					handler: argv => execDockerCmdHandler( argv ),
 				} )
@@ -730,7 +722,7 @@ export function dockerDefine( yargs ) {
 				.command( {
 					command: 'phpunit-multisite',
 					alias: 'phpunit:multisite',
-					description: 'Run multisite PHPUnit tests inside container ',
+					description: 'Run multisite Jetpack PHPUnit tests inside container',
 					builder: yargCmd =>
 						defaultOpts( yargCmd ).option( 'php', {
 							describe: 'Use the specified version of PHP.',
@@ -741,7 +733,7 @@ export function dockerDefine( yargs ) {
 				.command( {
 					command: 'phpunit-woocommerce',
 					alias: 'phpunit:woocommerce',
-					description: 'Run PHPUnit tests with WooCommerce inside container ',
+					description: 'Run Jetpack PHPUnit tests with WooCommerce inside container',
 					builder: yargCmd =>
 						defaultOpts( yargCmd ).option( 'php', {
 							describe: 'Use the specified version of PHP.',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

To run Jetpack PHPUnit tests with wpcomsh, it expects a `JETPACK_TEST_WPCOMSH=1` env var. This does a slight reshuffle of `jetpack docker phpunit*` code and adds support for `jetpack docker phpunit-wpcomsh`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Try running `jetpack docker phpunit-wpcomsh`.

May as well try the other options too:
* `jetpack docker phpunit`
* `jetpack docker phpunit-woocommerce` <-- this doesn't work for me in `trunk` or this PR
* `jetpack docker phpunit-crm`