### PR TITLE
Docker: Allow WP-CLI to be run as root

### DIFF
--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -432,7 +432,7 @@ const buildExecCmd = argv => {
 		if ( argv.type === 'e2e' ) {
 			opts.splice( 1, 0, '-T' );
 		}
-		opts.push( 'wp', '--allow-root', '--path=/var/www/html/', ...wpArgs );
+		opts.push( 'wp', '--path=/var/www/html/', ...wpArgs );
 	} else if ( cmd === 'tail' ) {
 		opts.push( '/var/scripts/tail.sh' );
 	} else if ( cmd === 'uninstall' ) {

--- a/tools/docker/bin/fakepot.sh
+++ b/tools/docker/bin/fakepot.sh
@@ -73,7 +73,7 @@ docopy "$PLUGIN_DIR" "$TMPDIR/plugin"
 
 info "Creating POT file"
 mkdir "$TMPDIR/pot"
-php -d memory_limit=2G $(command -v wp) --allow-root --debug i18n make-pot --slug="$DOMAIN" --ignore-domain "$TMPDIR/plugin/" "$TMPDIR/pot/$DOMAIN.pot"
+php -d memory_limit=2G $(command -v wp) --debug i18n make-pot --slug="$DOMAIN" --ignore-domain "$TMPDIR/plugin/" "$TMPDIR/pot/$DOMAIN.pot"
 
 info "Making translations"
 cat <<EOF > "$TMPDIR/pot/en_piglatin.po"
@@ -187,10 +187,10 @@ EOJ
 rm "$TMPDIR/pot/$DOMAIN.pot"
 
 info "Extracting JS translations"
-wp --allow-root --debug i18n make-json "$TMPDIR/pot/"
+wp --debug i18n make-json "$TMPDIR/pot/"
 
 info "Creating MO files"
-wp --allow-root --debug i18n make-mo "$TMPDIR/pot/"
+wp --debug i18n make-mo "$TMPDIR/pot/"
 
 info "Copying translations into /var/www/html/wp-content/languages/plugins/"
 mkdir -p /var/www/html/wp-content/languages/plugins/

--- a/tools/docker/bin/install.sh
+++ b/tools/docker/bin/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if wp --allow-root core is-installed; then
+if wp core is-installed; then
 	echo
 	echo "WordPress has already been installed. Uninstall it first by running:"
 	echo
@@ -10,7 +10,7 @@ if wp --allow-root core is-installed; then
 fi
 
 # Install WP core
-wp --allow-root core install \
+wp core install \
 	--url=${WP_DOMAIN} \
 	--title="${WP_TITLE}" \
 	--admin_user=${WP_ADMIN_USER} \
@@ -19,7 +19,7 @@ wp --allow-root core install \
 	--skip-email
 
 # Discourage search engines from indexing. Can be changed via UI in Settings->Reading.
-wp --allow-root option update blog_public 0
+wp option update blog_public 0
 
 if [ "$COMPOSE_PROJECT_NAME" == "jetpack_dev" ] ; then
 	# Add editor, author, contributor, and subscriber users
@@ -29,31 +29,31 @@ if [ "$COMPOSE_PROJECT_NAME" == "jetpack_dev" ] ; then
 	for role in "${roles[@]}"; do
 		echo "Creating user: $role"
 		# Silence output to avoid extra noise in the terminal. It would only output the user ID at the quietest level.
-		wp --allow-root user create "$role" "$role"@example.com --role="$role" >> /dev/null 2>&1
+		wp user create "$role" "$role"@example.com --role="$role" >> /dev/null 2>&1
 	done
 
 	# Install Query Monitor plugin
 	# https://wordpress.org/plugins/query-monitor/
-	wp --allow-root plugin install query-monitor --activate
+	wp plugin install query-monitor --activate
 
 	# Install WP-Control
 	# https://wordpress.org/plugins/wp-crontrol/
-	wp --allow-root plugin install wp-crontrol --activate
+	wp plugin install wp-crontrol --activate
 
 	# Install Gutenberg
 	# https://wordpress.org/plugins/gutenberg/
-	wp --allow-root plugin install gutenberg --activate
+	wp plugin install gutenberg --activate
 
 	# Install User Switching
 	# https://wordpress.org/plugins/user-switching/
-	wp --allow-root plugin install user-switching --activate
+	wp plugin install user-switching --activate
 
 	# Intentionally not auto-updating Akismet since we may be wanting to test that with a specific version.
-	wp --allow-root plugin auto-updates enable query-monitor wp-crontrol gutenberg user-switching
+	wp plugin auto-updates enable query-monitor wp-crontrol gutenberg user-switching
 fi
 
 # Activate Jetpack
-wp --allow-root plugin activate jetpack
+wp plugin activate jetpack
 
 echo
 echo "WordPress installed. Open ${WP_DOMAIN}"

--- a/tools/docker/bin/multisite-convert.sh
+++ b/tools/docker/bin/multisite-convert.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if ! $(wp --allow-root core is-installed); then
+if ! $(wp core is-installed); then
 	echo
 	echo "WordPress has to be installed first. To install, run:"
 	echo
@@ -10,16 +10,16 @@ if ! $(wp --allow-root core is-installed); then
 fi
 
 # Do the conversion, requires WP installed
-wp --allow-root core multisite-convert
+wp core multisite-convert
 
 # Update domain to wp-config.php
-wp --allow-root config set DOMAIN_CURRENT_SITE "${WP_DOMAIN}" --type=constant
+wp config set DOMAIN_CURRENT_SITE "${WP_DOMAIN}" --type=constant
 
 # Use multisite htaccess template
 cp -f /var/lib/jetpack-config/htaccess-multi /var/www/html/.htaccess
 
 # Update domain to DB
-wp --allow-root db query "UPDATE wp_blogs SET domain='${WP_DOMAIN}' WHERE blog_id=1;"
+wp db query "UPDATE wp_blogs SET domain='${WP_DOMAIN}' WHERE blog_id=1;"
 
 echo
 echo "WordPress converted to a multisite. Open ${WP_DOMAIN}"

--- a/tools/docker/bin/run.sh
+++ b/tools/docker/bin/run.sh
@@ -13,7 +13,7 @@ user="${APACHE_RUN_USER:-www-data}"
 group="${APACHE_RUN_GROUP:-www-data}"
 
 # Download WordPress
-[ -f /var/www/html/xmlrpc.php ] || wp --allow-root core download
+[ -f /var/www/html/xmlrpc.php ] || wp core download
 
 # Configure WordPress
 if [ ! -f /var/www/html/wp-config.php ]; then
@@ -26,7 +26,7 @@ if [ ! -f /var/www/html/wp-config.php ]; then
 	i=1
 	while [ "$i" -le "$times" ]; do
 		sleep 3
-		wp --allow-root config create \
+		wp config create \
 			--dbhost=${MYSQL_HOST} \
 			--dbname=${MYSQL_DATABASE} \
 			--dbuser=${MYSQL_USER} \
@@ -38,27 +38,27 @@ if [ ! -f /var/www/html/wp-config.php ]; then
 	done
 
 	echo "Setting other wp-config.php constants..."
-	wp --allow-root config set WP_DEBUG true --raw --type=constant
-	wp --allow-root config set WP_DEBUG_LOG true --raw --type=constant
-	wp --allow-root config set WP_DEBUG_DISPLAY false --raw --type=constant
-	wp --allow-root config set SCRIPT_DEBUG true --raw --type=constant
+	wp config set WP_DEBUG true --raw --type=constant
+	wp config set WP_DEBUG_LOG true --raw --type=constant
+	wp config set WP_DEBUG_DISPLAY false --raw --type=constant
+	wp config set SCRIPT_DEBUG true --raw --type=constant
 
 	# Respecting Dockerfile-forwarded environment variables
 	# Allow to be reverse-proxied from https
-	wp --allow-root config set "_SERVER['HTTPS']" "isset( \$_SERVER['HTTP_X_FORWARDED_PROTO'] ) && \$_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https' ? 'on' : NULL" \
+	wp config set "_SERVER['HTTPS']" "isset( \$_SERVER['HTTP_X_FORWARDED_PROTO'] ) && \$_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https' ? 'on' : NULL" \
 		--raw \
 		--type=variable
 
 	# Allow this installation to run on http or https.
-	wp --allow-root config set DOCKER_REQUEST_URL \
+	wp config set DOCKER_REQUEST_URL \
 		"( ! empty( \$_SERVER['HTTPS'] ) ? 'https://' : 'http://' ) . ( ! empty( \$_SERVER['HTTP_HOST'] ) ? \$_SERVER['HTTP_HOST'] : 'localhost' )" \
 		--raw \
 		--type=constant
-	wp --allow-root config set WP_SITEURL "DOCKER_REQUEST_URL" --raw --type=constant
-	wp --allow-root config set WP_HOME "DOCKER_REQUEST_URL" --raw --type=constant
+	wp config set WP_SITEURL "DOCKER_REQUEST_URL" --raw --type=constant
+	wp config set WP_HOME "DOCKER_REQUEST_URL" --raw --type=constant
 
 	# Tell WP-CONFIG we're in a docker instance.
-	wp --allow-root config set JETPACK_DOCKER_ENV true --raw --type=constant
+	wp config set JETPACK_DOCKER_ENV true --raw --type=constant
 fi
 
 # Copy single site htaccess if none is present
@@ -79,7 +79,7 @@ fi
 if [ "$COMPOSE_PROJECT_NAME" == "jetpack_dev" ] ; then
 	# If we don't have the wordpress test helpers, download them
 	if [ ! -d /tmp/wordpress-develop/tests ]; then
-		CUR_WP_VERSION=$(wp --allow-root core version);
+		CUR_WP_VERSION=$(wp core version);
 		# Get latest WordPress unit-test helper files
 		svn co \
 			"https://develop.svn.wordpress.org/tags/$CUR_WP_VERSION/tests/phpunit/data" \

--- a/tools/docker/bin/uninstall.sh
+++ b/tools/docker/bin/uninstall.sh
@@ -3,12 +3,12 @@
 echo "Uninstalling WordPress..."
 echo "Emptying the WordPress DB..."
 # Empty DB
-wp --allow-root db reset --yes
+wp db reset --yes
 
 echo
 echo "Removing upload and upgrade folders..."
 # Remove "uploads" and "upgrade" folders
-rm -fr /var/www/html/wp-content/uploads /var/www/html/wp-content/upgrade
+rm -rf /var/www/html/wp-content/uploads /var/www/html/wp-content/upgrade
 
 echo
 echo "Emptying the WP debug log..."
@@ -22,14 +22,14 @@ echo "Clearing out possible multi-site related changes..."
 # just like we would have in fresh container.
 cp -f /var/lib/jetpack-config/htaccess /var/www/html/.htaccess
 {
-	wp --allow-root config delete WP_ALLOW_MULTISITE
-	wp --allow-root config delete MULTISITE
-	wp --allow-root config delete SUBDOMAIN_INSTALL
-	wp --allow-root config delete base
-	wp --allow-root config delete DOMAIN_CURRENT_SITE
-	wp --allow-root config delete PATH_CURRENT_SITE
-	wp --allow-root config delete SITE_ID_CURRENT_SITE
-	wp --allow-root config delete BLOG_ID_CURRENT_SITE
+	wp config delete WP_ALLOW_MULTISITE
+	wp config delete MULTISITE
+	wp config delete SUBDOMAIN_INSTALL
+	wp config delete base
+	wp config delete DOMAIN_CURRENT_SITE
+	wp config delete PATH_CURRENT_SITE
+	wp config delete SITE_ID_CURRENT_SITE
+	wp config delete BLOG_ID_CURRENT_SITE
 } 2>&1 | grep -v "not defined"
 
 echo

--- a/tools/docker/bin/update-core.sh
+++ b/tools/docker/bin/update-core.sh
@@ -5,10 +5,10 @@ if [[ -z "$1" ]]; then
 fi
 
 TARGET_VERSION="$1"
-INIT_CORE_VERSION=$(wp --allow-root core version)
+INIT_CORE_VERSION=$(wp core version)
 
 if [[ "$TARGET_VERSION" == 'latest' ]]; then
-	TARGET_VERSION=$(wp --allow-root core check-update --field=version|tail -n1)
+	TARGET_VERSION=$(wp core check-update --field=version|tail -n1)
 	# We're already on the latest version.
 	if [[ "$TARGET_VERSION" == Success:* ]]; then
 		TARGET_VERSION=$INIT_CORE_VERSION
@@ -30,19 +30,19 @@ if [[ "$TARGET_VERSION" != "$INIT_CORE_VERSION" ]]; then
 
 	# Clean up old option if a previous update didn't complete. Otherwise one would get this:
 	# "Error: Another update is currently in progress."
-	wp --allow-root option get core_updater.lock &>/dev/null && wp --allow-root option delete core_updater.lock
+	wp option get core_updater.lock &>/dev/null && wp option delete core_updater.lock
 
-	wp --allow-root core update --version="$TARGET_VERSION" --force
+	wp core update --version="$TARGET_VERSION" --force
 
 	# If these don't match now, it means something went wrong with the update.
-	if [[ "$TARGET_VERSION" != "$(wp --allow-root core version)" ]]; then
+	if [[ "$TARGET_VERSION" != "$(wp core version)" ]]; then
 		echo "WordPress update to $TARGET_VERSION failed!"
 		exit 1
 	fi
 
 	# Update database.
 	echo 'Updating core database.'
-	wp --allow-root core update-db
+	wp core update-db
 fi
 
 # Update core unit tests.

--- a/tools/docker/default.env
+++ b/tools/docker/default.env
@@ -45,3 +45,6 @@ SFTP_USERS=wordpress:wordpress:1001
 
 # Xdebug
 PHP_IDE_CONFIG=serverName=Test
+
+# Bypass WP-CLI `--allow-root` check since we're already running as root.
+WP_CLI_ALLOW_ROOT=1

--- a/tools/docker/default.env
+++ b/tools/docker/default.env
@@ -46,5 +46,5 @@ SFTP_USERS=wordpress:wordpress:1001
 # Xdebug
 PHP_IDE_CONFIG=serverName=Test
 
-# Bypass WP-CLI `--allow-root` check since we're already running as root.
+# Bypass WP-CLI `--allow-root` check. Reworking the container to not run as root would be a lot of work for basically no benefit.
 WP_CLI_ALLOW_ROOT=1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR sets the `WP_CLI_ALLOW_ROOT` env var so running `wp` in our Docker environment doesn't require `--allow-root` every time. It also removes that flag from Docker-specific scripts.

There are some other scripts that Docker likely runs but that might run in other contexts (e.g. CI), so I've left those alone.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. `jetpack docker sh`
2. Try any `wp` command without `--allow-root`.
3. Smile.
