### PR TITLE
CRM: Fix client portal excessive top margin

### DIFF
--- a/projects/plugins/crm/changelog/crm-fix-3535-client-portal-excessive-top-margin
+++ b/projects/plugins/crm/changelog/crm-fix-3535-client-portal-excessive-top-margin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Client Portal: Removed top margin from quotes to ensure the top of the quote is visible.

--- a/projects/plugins/crm/modules/portal/templates/single-quote.php
+++ b/projects/plugins/crm/modules/portal/templates/single-quote.php
@@ -39,7 +39,6 @@ $show_nav = ( $portal->is_user_enabled() || !$portal->access_is_via_hash( ZBS_TY
     padding: 20px;
     border-radius: 0.28571429rem;
     border: 1px solid rgba(34,36,38,0.15);
-    margin-top: -32px;
 }
 .zerobs-proposal-body li, .zerobs-proposal-body li span{
   padding:5px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/zero-bs-crm/issues/3535

## Proposed changes:

* This PR removes top margin from quotes to ensure the top of the quote is visible.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3535

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the client portal (`/clients`)
* Preview any of the quotes

In `trunk` the top part should not be visible.
In this branch the whole quote should be visible.

