### PR TITLE
Protect Status: Add a 30 second timeout argument to the scan status requests

### DIFF
--- a/projects/packages/protect-status/changelog/increase-scan-request-timeouts
+++ b/projects/packages/protect-status/changelog/increase-scan-request-timeouts
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Increased timeout configuration of request.
+
+

--- a/projects/packages/protect-status/src/class-protect-status.php
+++ b/projects/packages/protect-status/src/class-protect-status.php
@@ -111,7 +111,10 @@ class Protect_Status extends Status {
 		$response = Client::wpcom_json_api_request_as_blog(
 			self::get_api_url(),
 			'2',
-			array( 'method' => 'GET' ),
+			array(
+				'method'  => 'GET',
+				'timeout' => 30,
+			),
 			null,
 			'wpcom'
 		);

--- a/projects/packages/protect-status/src/class-scan-status.php
+++ b/projects/packages/protect-status/src/class-scan-status.php
@@ -117,7 +117,10 @@ class Scan_Status extends Status {
 		$response = Client::wpcom_json_api_request_as_blog(
 			self::get_api_url(),
 			'2',
-			array( 'method' => 'GET' ),
+			array(
+				'method'  => 'GET',
+				'timeout' => 30,
+			),
 			null,
 			'wpcom'
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Similar to https://github.com/Automattic/jetpack/pull/39766/files, adds a 30s timeout to scan requests as they can take a while when sites are severely compromised with many threats.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test the loading of threats in Jetpack Protect, with the request taking between 11-30 seconds to complete.
  * Sandbox the scan endpoint, and add a sleep(10) to simulate a long request.


