### PR TITLE
Protect: Check plan on admin page load

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-always-check-plan-on-load
+++ b/projects/plugins/protect/changelog/fix-protect-always-check-plan-on-load
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Upgrading: prevent case where plan caching causes short delay in upgrading of scan data source after upgrading to a paid plan.

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -205,9 +205,11 @@ class Jetpack_Protect {
 	 */
 	public function initial_state() {
 		global $wp_version;
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		$refresh_status_from_wpcom = isset( $_GET['checkPlan'] );
-		$status                    = Status::get_status( $refresh_status_from_wpcom );
+
+		// Always fetch the latest plan status from WPCOM.
+		$has_plan = Plan::has_required_plan( true );
+
+		$status = Status::get_status();
 
 		$initial_state = array(
 			'apiRoot'            => esc_url_raw( rest_url() ),
@@ -216,7 +218,7 @@ class Jetpack_Protect {
 			'credentials'        => Credentials::get_credential_array(),
 			'status'             => $status,
 			'fixerStatus'        => Threats::fix_threats_status( $status->fixable_threat_ids ),
-			'scanHistory'        => Scan_History::get_scan_history( $refresh_status_from_wpcom ),
+			'scanHistory'        => Scan_History::get_scan_history(),
 			'installedPlugins'   => Plugins_Installer::get_plugins(),
 			'installedThemes'    => Sync_Functions::get_themes(),
 			'wpVersion'          => $wp_version,
@@ -224,7 +226,7 @@ class Jetpack_Protect {
 			'siteSuffix'         => ( new Jetpack_Status() )->get_site_suffix(),
 			'blogID'             => Connection_Manager::get_site_id( true ),
 			'jetpackScan'        => My_Jetpack_Products::get_product( 'scan' ),
-			'hasPlan'            => Plan::has_required_plan( true ),
+			'hasPlan'            => $has_plan,
 			'onboardingProgress' => Onboarding::get_current_user_progress(),
 			'waf'                => array(
 				'wafSupported'        => Waf_Runner::is_supported_environment(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Always refresh the latest plan status from WPCOM, and do this at the top of the `initial_state` method to ensure the following scan status requests use the correct data source.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Testing Jetpack Protect:
  * Install a vulnerable plugin
  * Activate Protect with the "start for free" option
  * Wait for the report to be generated
  * Upgrade your plan
  * Validate that the correct data source is used on first load after being redirected from the upgrade flow.

