### PR TITLE
Components: use window.CONNECTION_INITIAL_STATE instead of external relative import path

### DIFF
--- a/projects/js-packages/components/changelog/fix-external-connection-import
+++ b/projects/js-packages/components/changelog/fix-external-connection-import
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Footer Component: remove relative external import

--- a/projects/js-packages/components/components/jetpack-footer/index.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.tsx
@@ -46,10 +46,8 @@ const JetpackFooter: React.FC< JetpackFooterProps > = ( {
 	const [ isMd ] = useBreakpointMatch( 'md', '<=' );
 	const [ isLg ] = useBreakpointMatch( 'lg', '>' );
 
-	const {
-		connectedPlugins,
-		connectionStatus: { isActive },
-	} = window?.JP_CONNECTION_INITIAL_STATE || {};
+	const { connectedPlugins, connectionStatus: { isActive } = { isActive: false } } =
+		window?.JP_CONNECTION_INITIAL_STATE || {};
 
 	const siteAdminUrl = getSiteAdminUrl();
 	const areAdminLinksEnabled =

--- a/projects/js-packages/components/components/jetpack-footer/index.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.tsx
@@ -1,9 +1,7 @@
-import { useSelect } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
 import { Icon, external } from '@wordpress/icons';
 import clsx from 'clsx';
 import React from 'react';
-import { STORE_ID as CONNECTION_STORE_ID } from '../../../../js-packages/connection/state/store.jsx';
 import { getRedirectUrl } from '../../index.js';
 import getSiteAdminUrl from '../../tools/get-site-admin-url/index.js';
 import AutomatticBylineLogo from '../automattic-byline-logo/index.js';
@@ -48,17 +46,11 @@ const JetpackFooter: React.FC< JetpackFooterProps > = ( {
 	const [ isMd ] = useBreakpointMatch( 'md', '<=' );
 	const [ isLg ] = useBreakpointMatch( 'lg', '>' );
 
-	const { isActive, connectedPlugins } = useSelect( select => {
-		const connectionStatus = select( CONNECTION_STORE_ID ) as {
-			getConnectedPlugins: () => { slug: string }[];
-			getConnectionStatus: () => { isActive: boolean };
-		};
+	const {
+		connectedPlugins,
+		connectionStatus: { isActive },
+	} = window?.JP_CONNECTION_INITIAL_STATE || {};
 
-		return {
-			connectedPlugins: connectionStatus?.getConnectedPlugins(),
-			...connectionStatus.getConnectionStatus(),
-		};
-	}, [] );
 	const siteAdminUrl = getSiteAdminUrl();
 	const areAdminLinksEnabled =
 		siteAdminUrl &&

--- a/tools/js-tools/types/global.d.ts
+++ b/tools/js-tools/types/global.d.ts
@@ -69,7 +69,7 @@ interface Window {
 			};
 			connectionOwner: null;
 		};
-		connectedPlugins: object[];
+		connectedPlugins: Record< string, unknown >[];
 		wpVersion: string;
 		siteSuffix: string;
 		connectionErrors: Array;

--- a/tools/js-tools/types/global.d.ts
+++ b/tools/js-tools/types/global.d.ts
@@ -69,7 +69,7 @@ interface Window {
 			};
 			connectionOwner: null;
 		};
-		connectedPlugins: object;
+		connectedPlugins: object[];
 		wpVersion: string;
 		siteSuffix: string;
 		connectionErrors: Array;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/41936

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Instead of using a relative import to reach outside of the components package's project directory, use the globally available `CONNECTION_INITIAL_STATE` object to determine when to render Jetpack-specific links in the footer component.
* Fix the type definition for `window.CONNECTION_INITIAL_STATE.connectedPlugins`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack/issues/41936

https://github.com/Automattic/jetpack/pull/41524#discussion_r1943115689

https://github.com/Automattic/jetpack/pull/41536#issuecomment-2658422546

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test a standalone plugin on a site without Jetpack installed. Ensure the footer links (about, privacy) open external URLs.
* Test on a site with Jetpack installed. Ensure the footer links (about, privacy) open the Jetpack pages in wp-admin.

