### PR TITLE
Fix non rendered fields still validating and displaying response submission

### DIFF
--- a/projects/packages/forms/changelog/fix-non-rendered-fields-still-validating
+++ b/projects/packages/forms/changelog/fix-non-rendered-fields-still-validating
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Ensure fields that skip rendering (like empty options fields) do not trigger validation or show value in form submission response.

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -205,13 +205,14 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * Validates the form input
 	 */
 	public function validate() {
+		$field_type = $this->maybe_override_type();
+
 		// If it's not required, there's nothing to validate
-		if ( ! $this->get_attribute( 'required' ) ) {
+		if ( ! $this->get_attribute( 'required' ) || ! $this->is_field_renderable( $field_type ) ) {
 			return;
 		}
 
 		$field_id    = $this->get_attribute( 'id' );
-		$field_type  = $this->maybe_override_type();
 		$field_label = $this->get_attribute( 'label' );
 
 		if ( isset( $_POST[ $field_id ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- no site changes.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1161,6 +1161,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// For all fields, grab label and value
 		foreach ( $field_ids['all'] as $field_id ) {
 			$field = $this->fields[ $field_id ];
+
+			if ( ! $field->is_field_renderable( $field->get_attribute( 'type' ) ) ) {
+				continue;
+			}
+
 			$label = $i . '_' . $field->get_attribute( 'label' );
 			$value = $field->value;
 
@@ -1172,6 +1177,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// Extra fields have their prefix starting from count( $all_values ) + 1
 		foreach ( $field_ids['extra'] as $field_id ) {
 			$field = $this->fields[ $field_id ];
+
+			if ( ! $field->is_field_renderable( $field->get_attribute( 'type' ) ) ) {
+				continue;
+			}
+
 			$label = $i . '_' . $field->get_attribute( 'label' );
 			$value = $field->value;
 

--- a/projects/plugins/jetpack/changelog/fix-non-rendered-fields-still-validating
+++ b/projects/plugins/jetpack/changelog/fix-non-rendered-fields-still-validating
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Ensure fields that skip rendering (like empty options fields) do not trigger validation or show value in form submission response.


### PR DESCRIPTION
Fixes #41969

## Proposed changes:
Ensures that empty non-rendered fields don't trigger PHP validation or display their values after the form submission.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Create a new page.
2. Add the Form block, select any of the predefined options (e.g. contact form).
3. Add a new block into the form: Single Choice (Radio), Multiple Choice (Checkbox), or Dropdown Field.
4. Select the parent of the block that was just inserted (if needed) and mark it as required. Do not add any options to choose from.
5. Save the page.
6. On the live page, note that this block isn't visible, as there are no options to choose from.
7. Fill out the form and submit.

In trunk: The form redirects to a 404 page
In this PR: The form is submitted correctly. The block added in step 3 doesn't display in the submission results.
