### PR TITLE
Revert Hotfix: Fix Query Loop with excerpt outputting invalid HTML

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/revert-gb-hotfix
+++ b/projects/packages/jetpack-mu-wpcom/changelog/revert-gb-hotfix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Revert Hotfix: Fix Query Loop with excerpt outputting invalid HTML

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-hotfixes/wpcom-hotfixes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-hotfixes/wpcom-hotfixes.php
@@ -24,29 +24,3 @@ add_filter(
 	},
 	20
 );
-
-/**
- * Hotfix for a {Gutenberg 20.0.0, WP 6.7.x} bug causing the Content block to output truncated HTML.
- * See: https://github.com/WordPress/gutenberg/issues/68614
- */
-if (
-	// WordPress 6.7.x contains the buggy remove_serialized_parent_block() function.
-	version_compare( get_bloginfo( 'version' ), '6.8', '<' ) ) {
-
-	add_filter(
-		'the_content',
-		function ( $content ) {
-			if ( has_filter( 'the_content', 'remove_serialized_parent_block' ) ) {
-				// We will revert the content manipulation done in https://github.com/WordPress/gutenberg/pull/67272.
-
-				// Reverts https://github.com/WordPress/gutenberg/pull/67272/files#diff-611d9e2b5a9b00eb2fbe68d044eccb195759a422e36f525186d43d752bee3d71R65-R68
-				remove_filter( 'the_content', 'remove_serialized_parent_block', 8 );
-
-				// Reverts https://github.com/WordPress/gutenberg/pull/67272/files#diff-611d9e2b5a9b00eb2fbe68d044eccb195759a422e36f525186d43d752bee3d71R57-R63
-				return remove_serialized_parent_block( $content );
-			}
-			return $content;
-		},
-		1
-	);
-}


### PR DESCRIPTION
Reverts https://github.com/Automattic/jetpack/pull/41333

## Proposed changes:

This PR reverts wpcom-specific hotfix as mentioned in the above linked PR.

This is because the [fix](https://github.com/WordPress/gutenberg/pull/68926) is already merged to [GB 20.0.2](https://github.com/WordPress/gutenberg/compare/trunk...release/20.0).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

- Follow the same instructions as in https://github.com/Automattic/jetpack/pull/41333.
