### PR TITLE
Social: Move Mastodon form input direction

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-mastodon-form-input-direction
+++ b/projects/js-packages/publicize-components/changelog/update-social-mastodon-form-input-direction
@@ -1,0 +1,4 @@
+Significance: minor
+Type: security
+
+Social: Moved Mastodon input form to start

--- a/projects/js-packages/publicize-components/src/components/services/connect-form.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/connect-form.tsx
@@ -76,7 +76,7 @@ export function ConnectForm( {
 			onSubmit={ onSubmitForm }
 		>
 			{ displayInputs ? (
-				<div className={ styles[ 'fields-wrapper' ] }>
+				<div className={ clsx( styles[ 'fields-wrapper' ], styles.input ) }>
 					<CustomInputs service={ service } />
 				</div>
 			) : null }

--- a/projects/js-packages/publicize-components/src/components/services/style.module.scss
+++ b/projects/js-packages/publicize-components/src/components/services/style.module.scss
@@ -204,6 +204,10 @@
 		width: 100%;
 		gap: 1rem;
 
+		&.input {
+			justify-content: flex-start;
+		}
+
 		@include break-medium {
 			flex-direction: row;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/826

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*  Moved inputs to the start

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the connection management
* Make sure The input is on the right, and looks good on mobile

![CleanShot 2025-02-24 at 13 04 39 png](https://github.com/user-attachments/assets/d0d7aa81-d7dc-47f3-a304-ee30838adbf1)


