### PR TITLE
Add logging for logged out access to launchpad

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/.phan/config.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/config.php
@@ -28,6 +28,7 @@ return make_phan_config(
 			__DIR__ . '/../../../plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php', // class Jetpack_Newsletter_Dashboard_Widget
 			__DIR__ . '/../../../plugins/wpcomsh/wpcomsh.php',                              // function wpcomsh_record_tracks_event
 			__DIR__ . '/../../../plugins/wpcomsh/support-session.php',
+			__DIR__ . '/../../../plugins/wpcomsh/class-wpcomsh-log.php',                    // class WPCOMSH_Log
 		),
 		'exclude_analysis_directory_list' => array(
 			'src/features/custom-css/csstidy/',

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-logging-for-logged-out-access-to-launchpad
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-logging-for-logged-out-access-to-launchpad
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Launchpad: add logging when launchpad is loaded without a user context

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1053,6 +1053,22 @@ function wpcom_launchpad_update_task_status( $new_statuses ) {
 		return array();
 	}
 
+	// Add logging for when one or more tasks are updated with no user.
+	if ( ! is_user_logged_in() ) {
+		$should_log = apply_filters( 'wpcom_launchpad_should_log_no_user', false );
+		if ( $should_log ) {
+			jetpack_wpcom_log2logstash(
+				'Launchpad checklist task updated with no user',
+				array(
+					'new_statuses' => $new_statuses,
+					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_wp_debug_backtrace_summary
+					'stack_trace'  => wp_debug_backtrace_summary(),
+				),
+				true
+			);
+		}
+	}
+
 	$task_definitions = wpcom_launchpad_get_task_definitions();
 	$reverse_id_map   = wpcom_launchpad_get_reverse_id_mappings();
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -433,20 +433,6 @@ function wpcom_launchpad_get_task_lists( $rebuild = false ) {
  * Register all tasks and task lists on init.
  */
 function wpcom_register_default_launchpad_checklists() {
-	if ( ! is_user_logged_in() ) {
-		// Add filter so we can gradually roll out the logging without triggering a flood of log data.
-		$should_log = apply_filters( 'wpcom_launchpad_should_log_no_user', false );
-
-		if ( $should_log ) {
-			jetpack_wpcom_log2logstash(
-				'Launchpad checklists registered with no user',
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_wp_debug_backtrace_summary
-				array( 'stack_trace' => wp_debug_backtrace_summary() ),
-				true
-			);
-		}
-	}
-
 	wpcom_launchpad_get_task_lists();
 	wpcom_add_active_task_listener_hooks_to_correct_action();
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -434,11 +434,16 @@ function wpcom_launchpad_get_task_lists( $rebuild = false ) {
  */
 function wpcom_register_default_launchpad_checklists() {
 	if ( ! is_user_logged_in() ) {
-		jetpack_wpcom_log2logstash(
-			'Launchpad checklists registered with no user',
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_wp_debug_backtrace_summary
-			array( 'stack_trace' => wp_debug_backtrace_summary() )
-		);
+		// Add filter so we can gradually roll out the logging without triggering a flood of log data.
+		$should_log = apply_filters( 'wpcom_launchpad_should_log_no_user', false );
+
+		if ( $should_log ) {
+			jetpack_wpcom_log2logstash(
+				'Launchpad checklists registered with no user',
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_wp_debug_backtrace_summary
+				array( 'stack_trace' => wp_debug_backtrace_summary() )
+			);
+		}
 	}
 
 	wpcom_launchpad_get_task_lists();

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -433,6 +433,14 @@ function wpcom_launchpad_get_task_lists( $rebuild = false ) {
  * Register all tasks and task lists on init.
  */
 function wpcom_register_default_launchpad_checklists() {
+	if ( ! is_user_logged_in() ) {
+		jetpack_wpcom_log2logstash(
+			'Launchpad checklists registered with no user',
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_wp_debug_backtrace_summary
+			array( 'stack_trace' => wp_debug_backtrace_summary() )
+		);
+	}
+
 	wpcom_launchpad_get_task_lists();
 	wpcom_add_active_task_listener_hooks_to_correct_action();
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -441,7 +441,8 @@ function wpcom_register_default_launchpad_checklists() {
 			jetpack_wpcom_log2logstash(
 				'Launchpad checklists registered with no user',
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_wp_debug_backtrace_summary
-				array( 'stack_trace' => wp_debug_backtrace_summary() )
+				array( 'stack_trace' => wp_debug_backtrace_summary() ),
+				true
 			);
 		}
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/utils.php
@@ -154,3 +154,32 @@ function get_wpcom_blog_id() {
 
 	return false;
 }
+
+/**
+ * Log data to logstash based on the environment we're in.
+ *
+ * @param string $message The message to log.
+ * @param array  $extra   Extra data to log.
+ */
+function jetpack_wpcom_log2logstash( $message, $extra = array() ): void {
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM && file_exists( WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php' ) ) {
+		require_once WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
+
+		log2logstash(
+			array(
+				'feature' => 'jetpack-mu-wpcom-log',
+				'message' => $message,
+				'blog_id' => get_current_blog_id(),
+				'extra'   => wp_json_encode( $extra ),
+			)
+		);
+
+		return;
+	}
+
+	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC && class_exists( 'WPCOMSH_Log' ) && method_exists( 'WPCOMSH_Log', 'log' ) ) {
+		WPCOMSH_Log::log( $message, $extra );
+
+		return;
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/utils.php
@@ -158,10 +158,11 @@ function get_wpcom_blog_id() {
 /**
  * Log data to logstash based on the environment we're in.
  *
- * @param string $message The message to log.
- * @param array  $extra   Extra data to log.
+ * @param string $message      The message to log.
+ * @param array  $extra        Extra data to log.
+ * @param bool   $force_at_log Whether to force the log to be written. This is only relevant for Atomic sites, where logging depends on a site option.
  */
-function jetpack_wpcom_log2logstash( $message, $extra = array() ): void {
+function jetpack_wpcom_log2logstash( $message, $extra = array(), $force_at_log = false ): void {
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM && file_exists( WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php' ) ) {
 		require_once WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
 
@@ -177,8 +178,12 @@ function jetpack_wpcom_log2logstash( $message, $extra = array() ): void {
 		return;
 	}
 
-	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC && class_exists( 'WPCOMSH_Log' ) && method_exists( 'WPCOMSH_Log', 'log' ) ) {
-		WPCOMSH_Log::log( $message, $extra );
+	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC && class_exists( 'WPCOMSH_Log' ) ) {
+		if ( $force_at_log && method_exists( 'WPCOMSH_Log', 'unsafe_direct_log' ) ) {
+			WPCOMSH_Log::unsafe_direct_log( $message, $extra );
+		} else {
+			do_action( 'wpcomsh_log', $message, $extra );
+		}
 
 		return;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR includes two small items:
* I've added a new `jetpack_wpcom_log2logstash()` helper function to log data depending on the environment. If we're on WordPress.com Simple, we load and invoke the `log2logstash()` function directly. If we're on WordPress.com on Atomic sites where we expect the wpcomsh plugin to be present, we call the `WPCOMSH_Log::log()` function when it is available.
* I've added a call to the function above to log a message when we end up initialising the Launchpad code without a user context. To start with, that logging is protected by the `wpcom_launchpad_should_log_no_user` filter, which defaults to not logging. That will allow us to gradually add logging across sites rather than opening us up to a flood of log messages that's hard to disable.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

