### PR TITLE
Update remaining JITM jquery ajax for api fetch

### DIFF
--- a/projects/packages/jitm/changelog/update-jitm-remaining-jquery-ajax-for-api-fetch
+++ b/projects/packages/jitm/changelog/update-jitm-remaining-jquery-ajax-for-api-fetch
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Replace more JITM jQuery Ajax calls with @wordpress/api-fetch

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -303,9 +303,9 @@ jQuery( document ).ready( function ( $ ) {
 
 			apiFetch( {
 				path: addQueryArgs( 'jetpack/v4/jitm', {
-					message_path: message_path,
-					query: query,
-					full_jp_logo_exists: full_jp_logo_exists,
+					message_path,
+					query,
+					full_jp_logo_exists,
 				} ),
 				method: 'GET',
 			} ).then( function ( messages ) {

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -1,5 +1,6 @@
 import jQuery from 'jquery';
-
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
 import '../css/jetpack-admin-jitm.scss';
 
 jQuery( document ).ready( function ( $ ) {
@@ -300,23 +301,18 @@ jQuery( document ).ready( function ( $ ) {
 
 			var full_jp_logo_exists = $( '.jetpack-logo__masthead' ).length ? true : false;
 
-			$.get( window.jitm_config.api_root + 'jetpack/v4/jitm', {
-				message_path: message_path,
-				query: query,
-				full_jp_logo_exists: full_jp_logo_exists,
-				_wpnonce: $el.data( 'nonce' ),
-			} ).then( function ( response ) {
-				if ( 'object' === typeof response && response[ '1' ] ) {
-					response = [ response[ '1' ] ];
+			apiFetch( {
+				path: addQueryArgs( 'jetpack/v4/jitm', {
+					message_path: message_path,
+					query: query,
+					full_jp_logo_exists: full_jp_logo_exists,
+				} ),
+				method: 'GET',
+			} ).then( function ( messages ) {
+				const message = messages?.[ 0 ];
+				if ( message?.content ) {
+					setJITMContent( $el, message, redirect );
 				}
-
-				// properly handle the case of an empty array or no content set
-				if ( 0 === response.length || ! response[ 0 ].content ) {
-					return;
-				}
-
-				// for now, always take the first response
-				setJITMContent( $el, response[ 0 ], redirect );
 			} );
 		} );
 	};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Builds upon https://github.com/Automattic/jetpack/pull/41745.

Related to https://github.com/Automattic/jetpack/pull/41252

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Replaces the remaining jQuery Ajax call with `apiFetch`.

We use apiFetch because in the main PR we are going to start making requests to the Public API and that needs extra authentication which is built in to apiFetch. Currently the code just calls an internal endpoint on the Jetpack site and thus all that extra auth isn't required.

Lays more groundwork for https://github.com/Automattic/jetpack/pull/41252 and reduces size of that diff.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Please use exactly the same testing instructions as https://github.com/Automattic/jetpack/pull/41745.

The aim is that you should see the following JITM on the `wp-admin/admin.php?page=jetpack-search` URL:

<img width="1126" alt="Screenshot 2025-02-24 at 14 33 58" src="https://github.com/user-attachments/assets/41d3837c-01d5-4792-b5dd-659d82c4be0b" />
