### PR TITLE
Use remote translations

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-update-relative-path-for-jetpack-mu-wpcom
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-update-relative-path-for-jetpack-mu-wpcom
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-i18n: fix missing script translations

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -120,6 +120,39 @@ class Jetpack_Mu_Wpcom {
 	}
 
 	/**
+	 * Modify the JavaScript translation JSON file URL for Atomic sites.
+	 *
+	 * WordPress translation JSON files include an MD5 hash, which must remain unchanged.
+	 * - Simple Sites: Use default WordPress locale loading.
+	 * - Atomic Sites: Load from `https://widgets.wp.com/languages/mu-plugins/`.
+	 *
+	 * @param string|false $file Default JSON translation file URL (or false if none found).
+	 * @param string       $handle The script handle.
+	 * @param string       $domain The translation text domain.
+	 * @return string|false The modified JSON translation file URL for Atomic sites.
+	 */
+	public static function fix_script_translation_path( $file, $handle, $domain ) {
+		if ( 'jetpack-mu-wpcom' !== $domain ) {
+			return $file; // Keep default translation path for other domains.
+		}
+
+		$filename = wp_basename( $file ); // Example: jetpack-mu-wpcom-fr_FR-<MD5>.json
+
+		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+			// Atomic Sites: Ensure JSON translations load from `widgets.wp.com`
+			return "https://widgets.wp.com/languages/mu-plugins/{$filename}";
+		} else {
+			// Simple Sites: Ensure translations load from `languages/mu-plugins/`
+			$language_dir = defined( 'WP_LANG_DIR' ) ? WP_LANG_DIR : WP_CONTENT_DIR . '/languages';
+
+			if ( file_exists( "{$language_dir}/mu-plugins/$filename" ) ) {
+				return "{$language_dir}/mu-plugins/$filename";
+			}
+		}
+		return $file;
+	}
+
+	/**
 	 * Load features that don't need any special loading considerations.
 	 */
 	public static function load_features() {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -52,6 +52,12 @@ class Jetpack_Mu_Wpcom {
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_rest_api_endpoints' ) );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_block_theme_previews' ) );
 
+		// Load PHP translations (.mo/) for Simple or Atomic sites
+		add_action( 'plugins_loaded', array( __CLASS__, 'load_php_translations' ) );
+
+		// Modify JavaScript translations (.json) for Simple or Atomic sites
+		add_filter( 'load_script_translation_file', array( __CLASS__, 'fix_script_translation_path' ), 10, 3 );
+
 		// These features run only on simple sites.
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			add_action( 'plugins_loaded', array( __CLASS__, 'load_verbum_comments' ) );
@@ -87,6 +93,30 @@ class Jetpack_Mu_Wpcom {
 		 * @since 0.1.2
 		 */
 		do_action( 'jetpack_mu_wpcom_initialized' );
+	}
+
+	/**
+	 * Load PHP translations (.mo/.po) based on the site type.
+	 * - Simple Sites: Load from local filesystem.
+	 * - Atomic Sites: Load from a remote URL.
+	 */
+	public static function load_php_translations() {
+		$domain = 'jetpack-mu-wpcom';
+		$locale = determine_locale(); // Get the current language (e.g., 'fr_FR')
+
+		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+			// Atomic Sites: Load from a remote URL (Handled remotely - No local file)
+			$remote_mo_url = "https://widgets.wp.com/languages/mu-plugins/{$domain}-{$locale}.mo";
+			load_textdomain( $domain, $remote_mo_url );
+		} else {
+			// Simple Sites: Load from local filesystem
+			$language_dir = defined( 'WP_LANG_DIR' ) ? WP_LANG_DIR : WP_CONTENT_DIR . '/languages';
+			$mo_file      = "{$language_dir}/mu-plugins/{$domain}-{$locale}.mo";
+
+			if ( file_exists( $mo_file ) ) {
+				load_textdomain( $domain, $mo_file );
+			}
+		}
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -122,7 +122,6 @@ class Jetpack_Mu_Wpcom {
 	/**
 	 * Modify the JavaScript translation JSON file URL for Atomic sites.
 	 *
-	 * WordPress translation JSON files include an MD5 hash, which must remain unchanged.
 	 * - Simple Sites: Use default WordPress locale loading.
 	 * - Atomic Sites: Load from `https://widgets.wp.com/languages/mu-plugins/`.
 	 *

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -52,10 +52,7 @@ class Jetpack_Mu_Wpcom {
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_rest_api_endpoints' ) );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_block_theme_previews' ) );
 
-		// Load PHP translations (.mo/) for Simple or Atomic sites
-		add_action( 'plugins_loaded', array( __CLASS__, 'load_php_translations' ) );
-
-		// Modify JavaScript translations (.json) for Simple or Atomic sites
+		// Load JavaScript translations (.json) for Simple sites.
 		add_filter( 'load_script_translation_file', array( __CLASS__, 'fix_script_translation_path' ), 10, 3 );
 
 		// These features run only on simple sites.
@@ -96,34 +93,7 @@ class Jetpack_Mu_Wpcom {
 	}
 
 	/**
-	 * Load PHP translations (.mo/.po) based on the site type.
-	 * - Simple Sites: Load from local filesystem.
-	 * - Atomic Sites: Load from a remote URL.
-	 */
-	public static function load_php_translations() {
-		$domain = 'jetpack-mu-wpcom';
-		$locale = determine_locale(); // Get the current language (e.g., 'fr_FR')
-
-		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
-			// Atomic Sites: Load from a remote URL (Handled remotely - No local file)
-			$remote_mo_url = "https://widgets.wp.com/languages/mu-plugins/{$domain}-{$locale}.mo";
-			load_textdomain( $domain, $remote_mo_url );
-		} else {
-			// Simple Sites: Load from local filesystem
-			$language_dir = defined( 'WP_LANG_DIR' ) ? WP_LANG_DIR : WP_CONTENT_DIR . '/languages';
-			$mo_file      = "{$language_dir}/mu-plugins/{$domain}-{$locale}.mo";
-
-			if ( file_exists( $mo_file ) ) {
-				load_textdomain( $domain, $mo_file );
-			}
-		}
-	}
-
-	/**
-	 * Modify the JavaScript translation JSON file URL for Atomic sites.
-	 *
-	 * - Simple Sites: Use default WordPress locale loading.
-	 * - Atomic Sites: Load from `https://widgets.wp.com/languages/mu-plugins/`.
+	 * Fix the script translation path for Jetpack MU plugin
 	 *
 	 * @param string|false $file Default JSON translation file URL (or false if none found).
 	 * @param string       $handle The script handle.
@@ -132,22 +102,15 @@ class Jetpack_Mu_Wpcom {
 	 */
 	public static function fix_script_translation_path( $file, $handle, $domain ) {
 		if ( 'jetpack-mu-wpcom' !== $domain ) {
-			return $file; // Keep default translation path for other domains.
+			return $file;
 		}
 
-		$filename = wp_basename( $file ); // Example: jetpack-mu-wpcom-fr_FR-<MD5>.json
-
-		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
-			// Atomic Sites: Ensure JSON translations load from `widgets.wp.com`
-			return "https://widgets.wp.com/languages/mu-plugins/{$filename}";
-		} else {
-			// Simple Sites: Ensure translations load from `languages/mu-plugins/`
-			$language_dir = defined( 'WP_LANG_DIR' ) ? WP_LANG_DIR : WP_CONTENT_DIR . '/languages';
-
-			if ( file_exists( "{$language_dir}/mu-plugins/$filename" ) ) {
-				return "{$language_dir}/mu-plugins/$filename";
-			}
+		// Simple sites use `/languages/mu-plugins/`
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$custom_file = WP_CONTENT_DIR . '/languages/mu-plugins/' . basename( $file );
+			return file_exists( $custom_file ) ? $custom_file : $file;
 		}
+
 		return $file;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -27,8 +27,6 @@ class Jetpack_Mu_Wpcom {
 		if ( did_action( 'jetpack_mu_wpcom_initialized' ) ) {
 			return;
 		}
-		// Apply temporary fix for translation path MD5 mismatch due to vendor -> jetpack_vendor change in https://github.com/Automattic/jetpack/pull/41185
-		add_filter( 'load_script_textdomain_relative_path', array( __CLASS__, 'fix_translation_relative_path_mismatch_wpcom_jetpack' ), 20, 2 );
 
 		// Shared code for src/features.
 		require_once self::PKG_DIR . 'src/common/index.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
@@ -89,25 +87,6 @@ class Jetpack_Mu_Wpcom {
 		 * @since 0.1.2
 		 */
 		do_action( 'jetpack_mu_wpcom_initialized' );
-	}
-
-	/**
-	 * Fixes translation file path MD5 mismatches caused by vendor -> jetpack_vendor migration.
-	 *
-	 * WordPress generates the translation file's MD5 hash based on the script's relative path.
-	 * Since the path structure changed, we rewrite `jetpack_vendor/` back to `vendor/` before hashing.
-	 *
-	 * @param string|false $relative The relative script path (before MD5 hashing).
-	 * @param string       $src     The script's original source path (unused).
-	 * @return string|false Updated relative path that keeps WordPress's MD5 hash consistent.
-	 */
-	public static function fix_translation_relative_path_mismatch_wpcom_jetpack( $relative, $src ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		if ( $relative && str_contains( $relative, 'jetpack_vendor/automattic/jetpack-mu-wpcom/src/build/' ) ) {
-			// Rewrite "jetpack_vendor/" back to the original "vendor/" to maintain MD5 compatibility
-			$relative = str_replace( 'jetpack_vendor/', 'vendor/', $relative );
-		}
-
-		return $relative;
 	}
 
 	/**

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-update-relative-path-for-jetpack-mu-wpcom
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-update-relative-path-for-jetpack-mu-wpcom
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-i18n: fix missing script translations

--- a/projects/plugins/wpcomsh/changelog/fix-update-relative-path-for-jetpack-mu-wpcom
+++ b/projects/plugins/wpcomsh/changelog/fix-update-relative-path-for-jetpack-mu-wpcom
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-i18n: fix missing script translations


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/i18n-issues/issues/931

Related to https://github.com/Automattic/i18n-issues/issues/875

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Allow the `jetpack-mu-wpcom` plugin to load translations that are acccessible from widgets.wp.com domain for Atomic sites, and locally for Simple sites. This location will have up-to-date translations, rather than the outdated ones in the project's languages' folder.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox a simple site, and change the user locale to a Mag-16 locale, e.g. Spanish
* Execute 
```sh
bin/jetpack-downloader test jetpack-mu-wpcom-plugin fix/use-deployed-translations
```
* Verify that the pop-ups that appear in the UI, e.g `/wp-admin/edit.php`, remain translated
![CleanShot 2025-02-25 at 20 59 20](https://github.com/user-attachments/assets/f53da4a4-c2b1-4bd7-b242-82a1df3cc202)


#### Note 
Some UI, e.g. `/wp-admin/options-general.php`, has some untranslated elements
![CleanShot 2025-02-25 at 21 00 47](https://github.com/user-attachments/assets/19e46815-2646-4f8f-bf0a-81546109b601)

This occurs because `wp_set_script_translations` call is missing in https://github.com/Automattic/jetpack/blob/trunk/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php#L72-L93, and will be fixed in a future PR.

