### PR TITLE
Docker: Remove unimplemented `select-php` command

### DIFF
--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -683,18 +683,6 @@ export function dockerDefine( yargs ) {
 					handler: argv => execDockerCmdHandler( argv ),
 				} )
 				.command( {
-					command: 'select-php <version>',
-					description:
-						'Select the version of PHP for use inside the container. See documentation for important notes!',
-					builder: yargCmd => {
-						yargCmd.positional( 'version', {
-							describe: 'The version to select, or "default".',
-							type: 'string',
-						} );
-					},
-					handler: argv => execDockerCmdHandler( argv ),
-				} )
-				.command( {
 					command: 'phpunit',
 					description: 'Run PHPUnit tests inside container',
 					builder: yargCmd =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The `select-php` command was proposed in #32929, but was refactored to `--php` in #32979. This PR removes the command.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Make sure the command is properly deleted?