### PR TITLE
Surpress dns_get_record() warning for localhost

### DIFF
--- a/projects/packages/status/changelog/patch-1
+++ b/projects/packages/status/changelog/patch-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Hosting provider checks: avoid PHP warnings in local environments.

--- a/projects/packages/status/src/class-host.php
+++ b/projects/packages/status/src/class-host.php
@@ -146,7 +146,7 @@ class Host {
 			return array();
 		}
 
-		$dns_records = dns_get_record( $domain, DNS_NS ); // Fetches the DNS records of type NS (Name Server)
+		$dns_records = @dns_get_record( $domain, DNS_NS ); // Fetches the DNS records of type NS (Name Server)
 		$nameservers = array();
 		foreach ( $dns_records as $record ) {
 			if ( isset( $record['target'] ) ) {

--- a/projects/packages/status/src/class-host.php
+++ b/projects/packages/status/src/class-host.php
@@ -146,7 +146,11 @@ class Host {
 			return array();
 		}
 
-		$dns_records = @dns_get_record( $domain, DNS_NS ); // Fetches the DNS records of type NS (Name Server)
+		$dns_records = dns_get_record( $domain, DNS_NS ); // Fetches the DNS records of type NS (Name Server)
+		if ( false === $dns_records ) {
+			return array();
+		}
+
 		$nameservers = array();
 		foreach ( $dns_records as $record ) {
 			if ( isset( $record['target'] ) ) {


### PR DESCRIPTION
When on localhost the dns_get_record() call generates a PHP warning ("DNS Query failed"). Prefix call with @ to supress this warning.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Supress the "DNS Query failed" PHP warning when running Jetpack on localhost.
See: https://wordpress.org/support/topic/dns_get_record-warning-on-localhost/

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
Activate Jetpack on localhost with WP_DEBUG set to true and see if warning is generated.

## Does this pull request change what data or activity we track or use?
No,

* Go to '..'
*

