### PR TITLE
docker: Mark the mounted monorepo as safe for git

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -49,6 +49,9 @@ RUN --mount=type=cache,target=/var/lib/apt/lists/,sharing=private \
 # Enable various Apache modules.
 RUN a2dismod mpm_prefork && a2enmod rewrite mpm_event proxy_fcgi http2
 
+# Inform git 2.39.4+ that the monorepo is safe to use, even though the ownership will look odd.
+RUN git config --global --add safe.directory /usr/local/src/jetpack-monorepo
+
 # Install requested version of PHP.
 COPY ./config/php.ini /var/lib/jetpack-config/php.ini
 RUN --mount=type=cache,target=/var/lib/apt/lists/,sharing=private \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Git 2.39.4 added a check that the ownership of the directory matches the user running git. With the way the monorepo is mounted into the Docker container, this gets triggered (at least for Linux hosts). Fix it by running the necessary git command during the container build.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `jetpack docker build-image` and restart your container.
* On a Linux host, running `jetpack docker -v phpunit --php 7.4` produced a lot of messages like
  ```
  The repository at "/usr/local/src/jetpack-monorepo/projects/plugins/jetpack" does not have the correct ownership and git refuses to use it:
  
  fatal: detected dubious ownership in repository at '/usr/local/src/jetpack-monorepo'
  To add an exception for this directory, call:
  
          git config --global --add safe.directory /usr/local/src/jetpack-monorepo
  ```
  This should fix it.
