### PR TITLE
Connection: improve "connection owner unlink" modal responsiveness

### DIFF
--- a/projects/js-packages/connection/changelog/fix-connection-owner-disconnect-modal-bottom
+++ b/projects/js-packages/connection/changelog/fix-connection-owner-disconnect-modal-bottom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improve connection owner unlink modal responsiveness.

--- a/projects/js-packages/connection/components/owner-disconnect-dialog/style.scss
+++ b/projects/js-packages/connection/components/owner-disconnect-dialog/style.scss
@@ -6,7 +6,7 @@
    .jp-connection__disconnect-dialog__content {
         --spacing-base: 8px;
     }
-    .jp-connection__disconnect-dialog .components-modal__content > div:not(.components-modal__header) {
+    .components-modal__content > div:not(.components-modal__header) {
         display: flex;
         flex-direction: column;
         height: 100%;


### PR DESCRIPTION
## Proposed changes:
Fix the bottom buttons panel height on tall screens.

Related to #41923

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Try to disconnect the connection owner's user account via "My Jetpack".
Check the confirmation modal on a tall screen, confirm modal body grows, but the button panel stays the same height.
<img width="1210" alt="Screenshot 2025-02-24 at 11 31 32" src="https://github.com/user-attachments/assets/f45049ea-0133-4fc0-a867-8c3ca0f6100f" />