### PR TITLE
[WIP] Global Styles limited: Catch TypeErrors on WP Core edge case

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-handle-type-error-in-gs-limiting
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-handle-type-error-in-gs-limiting
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Catch TypeError for GS limited logic
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -363,6 +363,37 @@ function wpcom_global_styles_current_user_can_edit_wp_global_styles( $blog_id = 
 }
 
 /**
+ * Get the user data from wp global styles.
+ *
+ * We need this wrapper because in rare occasions WP Core triggers a TypeError in this snippet:
+ *
+ * $global_style_query = new WP_Query();
+ * $recent_posts       = $global_style_query->query( $args );
+ * if ( count( $recent_posts ) === 1 ) {
+ * $user_cpt = get_object_vars( $recent_posts[0] );
+ *
+ * In some scenarios, $recent_posts[0] is null and get_object_vars triggers a TypeError.
+ *
+ * @return array
+ */
+function wpcom_get_user_data_from_wp_global_styles() {
+	try {
+		return WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( wp_get_theme() );
+	} catch ( TypeError $error ) {
+		wp_clean_theme_json_cache();
+	}
+
+	/**
+	 * Try again after theme cache json is purged. If it's not working, fallback to an empty array.
+	 */
+	try {
+		return WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( wp_get_theme() );
+	} catch ( TypeError $error ) {
+		return array();
+	}
+}
+
+/**
  * Checks if the current blog has custom styles in use.
  *
  * @return bool Returns true if custom styles are in use.
@@ -376,7 +407,7 @@ function wpcom_global_styles_in_use() {
 		return false;
 	}
 
-	$user_cpt = WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( wp_get_theme() );
+	$user_cpt = wpcom_get_user_data_from_wp_global_styles();
 
 	$global_styles_in_use = wpcom_global_styles_in_use_by_wp_global_styles_post( $user_cpt );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In some edge case scenarios, WP Core throws an TypeError when called from the logic that determines if a site should be GS limited.

This PR adds a handling for this error and tries to clean the theme cache and, if that doesn't work, return an empty array. Since it will return an empty array, the GS limited logic will consider that the site is not using global styles. 
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Catch a TypeError caused by WP Core in an edge scenario.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* TBD

