### PR TITLE
cli: `jetpack rsync`'s untracked files check should check packages too

### DIFF
--- a/tools/cli/commands/rsync.js
+++ b/tools/cli/commands/rsync.js
@@ -464,12 +464,42 @@ async function isFileExcluded( filePath ) {
  * @return {string} Files that aren't tracked.
  */
 async function getUntrackedFiles( pluginPath ) {
+	const paths = [ pluginPath ];
+
+	// Add any Composer-symlinked vendor packages. Assumes the usual directory structure.
+	const cwd = await fs.realpath( process.cwd() );
+	for ( const dir of [ 'vendor', 'jetpack_vendor' ] ) {
+		const dirents = (
+			await fs.readdir( path.join( pluginPath, dir ), { withFileTypes: true } ).catch( () => [] )
+		).filter( e => e.isDirectory() );
+		for ( const dir2 of dirents ) {
+			const dirents2 = (
+				await fs
+					.readdir( path.join( dir2.parentPath, dir2.name ), { withFileTypes: true } )
+					.catch( () => [] )
+			).filter( e => e.isSymbolicLink() );
+			for ( const link of dirents2 ) {
+				try {
+					const rp = path.relative(
+						cwd,
+						await fs.realpath( path.join( link.parentPath, link.name ) )
+					);
+					if ( ! cwd.startsWith( '..' ) ) {
+						paths.push( rp );
+					}
+				} catch {
+					// Probably a broken symlink. Ignore it.
+				}
+			}
+		}
+	}
+
 	try {
 		const { stdout } = await execa( 'git', [
 			'ls-files',
 			'--others',
 			'--exclude-standard',
-			pluginPath,
+			...paths,
 		] );
 		return stdout;
 	} catch ( e ) {

--- a/tools/cli/commands/rsync.js
+++ b/tools/cli/commands/rsync.js
@@ -484,7 +484,7 @@ async function getUntrackedFiles( pluginPath ) {
 						cwd,
 						await fs.realpath( path.join( link.parentPath, link.name ) )
 					);
-					if ( ! cwd.startsWith( '..' ) ) {
+					if ( ! rp.startsWith( '..' + path.sep ) ) {
 						paths.push( rp );
 					}
 				} catch {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PR #41442 added messaging for when `jetpack rsync` is going to ignore a file because it hasn't been `git add`ed. But that PR only checked files directly in the plugin being synced, which is not terribly useful for mu-wpcom-plugin where everything happens in packages/jetpack-mu-wpcom.

To fix this, for the check, look at any monorepo packages symlinked from `vendor/*/*` and `jetpack_vendor/*/*` too. Further recursion is not necessary, since Composer already hoists everything relevant.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1740418546116159-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create an untracked file directly in `projects/plugins/mu-wpcom-plugin/` and `jetpack rsync mu-wpcom-plugin`, to make sure that didn't break.
* Create an untracked file in `projects/packages/jetpack-mu-wpcom/` and `jetpack rsync mu-wpcom-plugin`, that should be caught too.
* Do `jetpack rsync beta`. It shouldn't trigger on the untracked files from above and also shouldn't fail on the lack of `jetpack_vendor/` existing.
* Create a broken symlink in `projects/plugins/beta/vendor/automattic/`. It should ignore it, no error messages (at least not from this code, rsync itself will probably complain).
* Create a symlink to something outside of the monorepo in `projects/plugins/beta/vendor/automattic/`. It should ignore that too, no error message from `git ls-files`.