### PR TITLE
Add WP_CLI_ALLOW_ROOT env var to Dockerfile

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -10,6 +10,9 @@ ARG PNPM_VERSION
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
+# Bypass WP-CLI `--allow-root` check. Reworking the container to not run as root would be a lot of work for basically no benefit.
+ENV WP_CLI_ALLOW_ROOT=1
+
 WORKDIR /tmp
 
 # Record ARGs

--- a/tools/docker/Dockerfile.monorepo
+++ b/tools/docker/Dockerfile.monorepo
@@ -13,8 +13,7 @@ ENV LANG=en_US.UTF-8 \
     JETPACK_MONOREPO_ENV=1 \
     PNPM_HOME=/usr/local/pnpm \
     PATH="/usr/local/pnpm:${PATH}" \
-    npm_config_update_notifier=false \
-    WP_CLI_ALLOW_ROOT=1
+    npm_config_update_notifier=false
 
 WORKDIR /app
 

--- a/tools/docker/Dockerfile.monorepo
+++ b/tools/docker/Dockerfile.monorepo
@@ -13,7 +13,8 @@ ENV LANG=en_US.UTF-8 \
     JETPACK_MONOREPO_ENV=1 \
     PNPM_HOME=/usr/local/pnpm \
     PATH="/usr/local/pnpm:${PATH}" \
-    npm_config_update_notifier=false
+    npm_config_update_notifier=false \
+    WP_CLI_ALLOW_ROOT=1
 
 WORKDIR /app
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We set `WP_CLI_ALLOW_ROOT` in the `default.env` file, but directly using the container would bypass that file (e.g. in our Post Build tests). This PR adds that env var to the Dockerfile.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

After merge, verify "Post Build tests" complete as expected.