### PR TITLE
Account Protection: Fix Brute Force Protection recovery bypass

### DIFF
--- a/projects/packages/account-protection/src/class-password-detection.php
+++ b/projects/packages/account-protection/src/class-password-detection.php
@@ -50,7 +50,7 @@ class Password_Detection {
 		}
 
 		// Skip if we're validating a Brute force protection recovery token
-		if ( get_transient( 'jetpack_protect_recovery_key_validated' ) ) {
+		if ( get_transient( 'jetpack_protect_recovery_key_validated_' . $user->ID ) ) {
 			return $user;
 		}
 

--- a/projects/packages/account-protection/src/class-password-detection.php
+++ b/projects/packages/account-protection/src/class-password-detection.php
@@ -50,8 +50,7 @@ class Password_Detection {
 		}
 
 		// Skip if we're validating a Brute force protection recovery token
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['validate_jetpack_protect_recovery'] ) ) {
+		if ( get_transient( 'jetpack_protect_recovery_key_validated' ) ) {
 			return $user;
 		}
 

--- a/projects/packages/waf/src/brute-force-protection/class-blocked-login-page.php
+++ b/projects/packages/waf/src/brute-force-protection/class-blocked-login-page.php
@@ -273,7 +273,7 @@ class Brute_Force_Protection_Blocked_Login_Page {
 			return false;
 		}
 
-		set_transient( 'jetpack_protect_recovery_key_validated', true, 600 );
+		set_transient( 'jetpack_protect_recovery_key_validated_' . $user_id, true, 600 );
 
 		return true;
 	}

--- a/projects/packages/waf/src/brute-force-protection/class-blocked-login-page.php
+++ b/projects/packages/waf/src/brute-force-protection/class-blocked-login-page.php
@@ -273,6 +273,8 @@ class Brute_Force_Protection_Blocked_Login_Page {
 			return false;
 		}
 
+		set_transient( 'jetpack_protect_recovery_key_validated', true, 600 );
+
 		return true;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
Ensures that the process of skipping validation during Brute Force Protection account recovery doesn't leave an easy bypass.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Sets a transient during the BFP validation process
* Retrieves and validates the transient during the AP password detection process

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://github.com/Automattic/jetpack-scan-team/issues/1718

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Following the testing instruction originally proposed [here](https://github.com/Automattic/jetpack/pull/41739)
* Review the code and ensure it is a logical approach that will avoid leaving a simple bypass

