### PR TITLE
Subscribe button: fix width in editor

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-button-style
+++ b/projects/plugins/jetpack/changelog/update-subscribe-button-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix subscribe button width in editor

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -208,7 +208,7 @@ export function SubscriptionEdit( props ) {
 		...( ! buttonBackgroundColor.color && buttonGradient.gradientValue
 			? { background: buttonGradient.gradientValue }
 			: { backgroundColor: buttonBackgroundColor.color } ),
-		width: buttonWidth ?? 'auto',
+		width: buttonWidth.length > 0 ? buttonWidth : 'auto',
 	};
 
 	console.log( 'buttonStyles', buttonStyles );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -211,8 +211,6 @@ export function SubscriptionEdit( props ) {
 		width: buttonWidth.length > 0 ? buttonWidth : 'auto',
 	};
 
-	console.log( 'buttonStyles', buttonStyles );
-
 	if ( activeStyleName !== 'button' ) {
 		if ( buttonOnNewLine ) {
 			buttonStyles.marginTop = getSpacingStyleValue( spacing ) + 'px';

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -211,6 +211,8 @@ export function SubscriptionEdit( props ) {
 		width: buttonWidth ?? 'auto',
 	};
 
+	console.log( 'buttonStyles', buttonStyles );
+
 	if ( activeStyleName !== 'button' ) {
 		if ( buttonOnNewLine ) {
 			buttonStyles.marginTop = getSpacingStyleValue( spacing ) + 'px';

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -208,7 +208,7 @@ export function SubscriptionEdit( props ) {
 		...( ! buttonBackgroundColor.color && buttonGradient.gradientValue
 			? { background: buttonGradient.gradientValue }
 			: { backgroundColor: buttonBackgroundColor.color } ),
-		width: buttonWidth,
+		width: buttonWidth ?? 'auto',
 	};
 
 	if ( activeStyleName !== 'button' ) {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -208,7 +208,7 @@ export function SubscriptionEdit( props ) {
 		...( ! buttonBackgroundColor.color && buttonGradient.gradientValue
 			? { background: buttonGradient.gradientValue }
 			: { backgroundColor: buttonBackgroundColor.color } ),
-		width: buttonWidth.length > 0 ? buttonWidth : 'auto',
+		width: buttonWidth?.length ? buttonWidth : 'auto',
 	};
 
 	if ( activeStyleName !== 'button' ) {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -28,6 +28,7 @@ const DEFAULT_BORDER_WEIGHT_VALUE = 1;
 const DEFAULT_FONTSIZE_VALUE      = '16px';
 const DEFAULT_PADDING_VALUE       = 15;
 const DEFAULT_SPACING_VALUE       = 10;
+const DEFAULT_BUTTON_WIDTH        = 'auto';
 
 /**
  * Registers the block for use in Gutenberg
@@ -478,10 +479,7 @@ function get_element_styles_from_attributes( $attributes ) {
 	}
 
 	if ( has_attribute( $attributes, 'buttonWidth' ) ) {
-		$button_width = get_attribute( $attributes, 'buttonWidth' );
-		if ( empty( $button_width ) ) {
-			$button_width = 'auto';
-		}
+		$button_width                  = get_attribute( $attributes, 'buttonWidth', DEFAULT_BUTTON_WIDTH );
 		$submit_button_wrapper_styles .= sprintf( 'width: %s;', $button_width );
 		$submit_button_wrapper_styles .= 'max-width: 100%;';
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -479,8 +479,7 @@ function get_element_styles_from_attributes( $attributes ) {
 	}
 
 	if ( has_attribute( $attributes, 'buttonWidth' ) ) {
-		$button_width                  = get_attribute( $attributes, 'buttonWidth', DEFAULT_BUTTON_WIDTH );
-		$submit_button_wrapper_styles .= sprintf( 'width: %s;', $button_width );
+		$submit_button_wrapper_styles .= sprintf( 'width: %s;', get_attribute( $attributes, 'buttonWidth', DEFAULT_BUTTON_WIDTH ) );
 		$submit_button_wrapper_styles .= 'max-width: 100%;';
 
 		// Account for custom margins on inline forms.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -503,7 +503,6 @@ function get_element_styles_from_attributes( $attributes ) {
 	$submit_button_styles .= $style;
 	$email_field_styles   .= $style;
 
-	$button_spacing = get_attribute( $attributes, 'spacing', DEFAULT_SPACING_VALUE );
 	if ( ! $is_button_only_style ) {
 		$button_spacing = get_attribute( $attributes, 'spacing', DEFAULT_SPACING_VALUE );
 		if ( true === get_attribute( $attributes, 'buttonOnNewLine' ) ) {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -478,15 +478,17 @@ function get_element_styles_from_attributes( $attributes ) {
 	}
 
 	if ( has_attribute( $attributes, 'buttonWidth' ) ) {
-		$submit_button_wrapper_styles .= sprintf( 'width: %s;', get_attribute( $attributes, 'buttonWidth' ) );
+		$button_width = get_attribute( $attributes, 'buttonWidth' );
+		if ( empty( $button_width ) ) {
+			$button_width = 'auto';
+		}
+		$submit_button_wrapper_styles .= sprintf( 'width: %s;', $button_width );
 		$submit_button_wrapper_styles .= 'max-width: 100%;';
 
 		// Account for custom margins on inline forms.
 		$submit_button_styles .= true === get_attribute( $attributes, 'buttonOnNewLine' )
 			? 'width: 100%;'
 			: sprintf( 'width: calc(100%% - %dpx);', get_attribute( $attributes, 'spacing', DEFAULT_SPACING_VALUE ) );
-	} else {
-		$submit_button_wrapper_styles .= 'width: auto;';
 	}
 
 	$font_size = get_attribute( $attributes, 'customFontSize', DEFAULT_FONTSIZE_VALUE );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -485,6 +485,8 @@ function get_element_styles_from_attributes( $attributes ) {
 		$submit_button_styles .= true === get_attribute( $attributes, 'buttonOnNewLine' )
 			? 'width: 100%;'
 			: sprintf( 'width: calc(100%% - %dpx);', get_attribute( $attributes, 'spacing', DEFAULT_SPACING_VALUE ) );
+	} else {
+		$submit_button_wrapper_styles .= 'width: auto;';
 	}
 
 	$font_size = get_attribute( $attributes, 'customFontSize', DEFAULT_FONTSIZE_VALUE );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/41700

This PR improve the handling of button width attributes in both JavaScript and PHP files in the subscribe block.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
**edit.js**
Updated the button width logic:
- If buttonWidth has a length greater than 0, use buttonWidth.
- Otherwise, set the width to 'auto'.

**subscriptions.php**
Removed duplicate retrieval of button_spacing attribute.
Enhanced the button width handling:
- Retrieved buttonWidth attribute.
- If buttonWidth is empty, set it to 'auto'.
- Added max-width: 100%; to the button wrapper styles.

## Before

<img width="655" alt="Screenshot 2025-02-25 at 10 35 06" src="https://github.com/user-attachments/assets/93140e40-7cc0-4409-b01e-088b4d12b0bf" />

## After

<img width="660" alt="Screenshot 2025-02-25 at 10 34 10" src="https://github.com/user-attachments/assets/19bdaf97-6a1a-4bed-ba88-8812ccd8db19" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox public-api.wordpress.com and your test WPCOM site
* Apply this PR to your WPCOM sandbox
* Create a new post with the subscribe block
* Confirm the button width is as expected

