### PR TITLE
Admin interface: Fix empty setting

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-empy-admin-interface
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-empy-admin-interface
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin interface: Fix empty setting

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -29,7 +29,7 @@ function wpcomsh_wpcom_admin_interface_settings_field() {
  */
 function wpcom_admin_interface_display() {
 	remove_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option', 10 );
-	$value = get_option( 'wpcom_admin_interface' );
+	$value = get_option( 'wpcom_admin_interface', 'calypso' );
 	add_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option', 10 );
 
 	echo '<fieldset>';


### PR DESCRIPTION
## Proposed changes:

Prevents the "admin interface style" setting from being displayed as empty when no value has been explicitly set yet.

Before | After
--- | ---
<img width="662" alt="Screenshot 2025-02-25 at 10 12 13" src="https://github.com/user-attachments/assets/e08c3c54-5d86-44b0-a9f3-c5a01d66bc50" /> | <img width="650" alt="Screenshot 2025-02-25 at 10 16 52" src="https://github.com/user-attachments/assets/63cef84d-323f-4cd9-a04e-e7a3eec5e23d" />
 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your WP.com sandbox
- Sandbox a WP.com site where you have never changed the "admin interface style" setting (you can create a new WP.com site)
- Go to `/wp-admin/options-general.php`
- Make sure the "admin interface style" setting is set to "Default".

