### PR TITLE
Verbum comments editing

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/verbum_comments_editing
+++ b/projects/packages/jetpack-mu-wpcom/changelog/verbum_comments_editing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Comments admin: Now uses Verbum on comments containing block mark-up (simple sites only)

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -57,6 +57,7 @@ class Jetpack_Mu_Wpcom {
 		// These features run only on simple sites.
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			add_action( 'plugins_loaded', array( __CLASS__, 'load_verbum_comments' ) );
+			add_action( 'plugins_loaded', array( __CLASS__, 'load_verbum_moderate' ) );
 			add_action( 'wp_loaded', array( __CLASS__, 'load_verbum_comments_admin' ) );
 			add_action( 'admin_menu', array( __CLASS__, 'load_wpcom_simple_odyssey_stats' ) );
 			add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_random_redirect' ) );
@@ -501,6 +502,14 @@ class Jetpack_Mu_Wpcom {
 	public static function load_verbum_comments_admin() {
 		require_once __DIR__ . '/features/verbum-comments/assets/class-verbum-admin.php';
 		new \Automattic\Jetpack\Verbum_Admin();
+	}
+
+	/**
+	 * Load Verbum Moderate.
+	 */
+	public static function load_verbum_moderate() {
+		require_once __DIR__ . '/features/verbum-comments/assets/class-verbum-moderate.php';
+		new \Automattic\Jetpack\Verbum_Moderate();
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-asset-loader.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-asset-loader.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Verbum Asset Loader.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare( strict_types = 1 );
+
+/**
+ * Verbum_Asset_Loader is responsible for loading the Verbum Gutenberg editor.
+ */
+class Verbum_Asset_Loader {
+
+	/**
+	 * Load supporting assets for the Verbum Gutenberg editor.
+	 */
+	public static function load_editor_supporting_assets() {
+		$vbe_cache_buster = filemtime( ABSPATH . '/widgets.wp.com/verbum-block-editor/build_meta.json' );
+
+		wp_enqueue_style(
+			'verbum-gutenberg-css',
+			'https://widgets.wp.com/verbum-block-editor/block-editor.css',
+			array(),
+			$vbe_cache_buster
+		);
+
+		// phpcs:ignore Jetpack.Functions.I18n.TextDomainMismatch
+		wp_set_script_translations( 'verbum', 'default', ABSPATH . 'widgets.wp.com/verbum-block-editor/languages/' );
+	}
+
+	/**
+	 * Load the complete Verbum Gutenberg editor.
+	 */
+	public static function load_editor() {
+
+		$vbe_cache_buster = filemtime( ABSPATH . '/widgets.wp.com/verbum-block-editor/build_meta.json' );
+
+		wp_enqueue_script(
+			'verbum',
+			'https://widgets.wp.com/verbum-block-editor/block-editor.min.js',
+			array(),
+			$vbe_cache_buster,
+			true
+		);
+
+		self::load_editor_supporting_assets();
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-gutenberg-editor.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-gutenberg-editor.php
@@ -8,6 +8,7 @@
 declare( strict_types = 1 );
 
 require_once __DIR__ . '/class-verbum-block-utils.php';
+require_once __DIR__ . '/class-verbum-asset-loader.php';
 
 /**
  * Verbum_Gutenberg_Editor is responsible for loading the Gutenberg editor for comments.
@@ -62,16 +63,6 @@ class Verbum_Gutenberg_Editor {
 			return;
 		}
 
-		$vbe_cache_buster = filemtime( ABSPATH . '/widgets.wp.com/verbum-block-editor/build_meta.json' );
-
-		wp_enqueue_style(
-			'verbum-gutenberg-css',
-			'https://widgets.wp.com/verbum-block-editor/block-editor.css',
-			array(),
-			$vbe_cache_buster
-		);
-
-		// phpcs:ignore Jetpack.Functions.I18n.TextDomainMismatch
-		wp_set_script_translations( 'verbum', 'default', ABSPATH . 'widgets.wp.com/verbum-block-editor/languages/' );
+		\Verbum_Asset_Loader::load_editor_supporting_assets(); // Editor itself is loaded dynamically
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-moderate.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-moderate.php
@@ -53,6 +53,15 @@ class Verbum_Moderate {
 
 		\Verbum_Asset_Loader::load_editor();
 
+		wp_add_inline_style(
+			'verbum-gutenberg-css',
+			'
+			#content {
+				visibility: hidden;
+			}
+		'
+		);
+
 		Assets::register_script(
 			'verbum-comments-moderation',
 			'../../../build/verbum-comments/assets/comments-moderation.js',

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-moderate.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-moderate.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Moderation feature for Verbum comments.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\Jetpack;
+
+require_once __DIR__ . '/class-verbum-asset-loader.php';
+
+/**
+ * Verbum_Moderate is responsible for moderating Verbum comments in wp-admin.
+ */
+class Verbum_Moderate {
+
+	/**
+	 * Class constructor.
+	 */
+	public function __construct() {
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+	}
+
+	/**
+	 * Enqueue scripts for loading Verbum
+	 *
+	 * @param string $hook The current admin page.
+	 */
+	public function enqueue_scripts( $hook ) {
+		// Only load on comment.php admin page
+		if ( 'comment.php' !== $hook ) {
+			return;
+		}
+
+		// Check if we have a comment ID and if its content has Gutenberg blocks
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$comment_id = isset( $_GET['c'] ) ? absint( $_GET['c'] ) : 0;
+		if ( ! $comment_id ) {
+			return;
+		}
+
+		$comment = get_comment( $comment_id );
+		if ( ! $comment || ! has_blocks( $comment->comment_content ) ) {
+			return;
+		}
+
+		\Verbum_Asset_Loader::load_editor();
+
+		Assets::register_script(
+			'verbum-comments-moderation',
+			'../../../build/verbum-comments/assets/comments-moderation.js',
+			__FILE__,
+			array(
+				'strategy'  => 'defer',
+				'in_footer' => true,
+				'enqueue'   => true,
+			)
+		);
+
+		wp_add_inline_script(
+			'verbum',
+			'window.VerbumComments = ' . wp_json_encode(
+				array(
+					'embedNonce' => wp_create_nonce( 'embed_nonce' ),
+					'isRTL'      => is_rtl(),
+				)
+			),
+			'before'
+		);
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-moderate.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-moderate.php
@@ -85,11 +85,12 @@ class Verbum_Moderate {
 	private function get_block_comment_being_edited( $hook = null ) {
 		// Check if we're on the comment.php admin page
 		if ( $hook === null ) {
-			$screen = get_current_screen();
-			if ( ! $screen || 'comment' !== $screen->id ) {
-				return false;
-			}
-		} elseif ( 'comment.php' !== $hook ) {
+			$screen          = get_current_screen();
+			$editing_comment = $screen && 'comment' === $screen->id;
+		} else {
+			$editing_comment = 'comment.php' === $hook;
+		}
+		if ( ! $editing_comment ) {
 			return false;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-moderate.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-moderate.php
@@ -80,7 +80,7 @@ class Verbum_Moderate {
 	 * Get the block-based comment being edited if on the comment edit screen.
 	 *
 	 * @param string|null $hook The current admin page hook.
-	 * @return WP_Comment|false The comment object if we're editing a block-based comment, false otherwise.
+	 * @return \WP_Comment|false The comment object if we're editing a block-based comment, false otherwise.
 	 */
 	private function get_block_comment_being_edited( $hook = null ) {
 		// Check if we're on the comment.php admin page

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-moderate.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-moderate.php
@@ -21,6 +21,23 @@ class Verbum_Moderate {
 	 */
 	public function __construct() {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_filter( 'wp_editor_settings', array( $this, 'disable_rich_editing' ) );
+	}
+
+	/**
+	 * Disable rich editing for comments with Gutenberg blocks.
+	 *
+	 * @param array $settings The editor settings.
+	 * @return array The modified editor settings.
+	 */
+	public function disable_rich_editing( $settings ) {
+		$comment = $this->get_block_comment_being_edited();
+		if ( $comment ) {
+			$settings['tinymce']   = false;
+			$settings['quicktags'] = false;
+		}
+
+		return $settings;
 	}
 
 	/**
@@ -29,20 +46,8 @@ class Verbum_Moderate {
 	 * @param string $hook The current admin page.
 	 */
 	public function enqueue_scripts( $hook ) {
-		// Only load on comment.php admin page
-		if ( 'comment.php' !== $hook ) {
-			return;
-		}
-
-		// Check if we have a comment ID and if its content has Gutenberg blocks
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$comment_id = isset( $_GET['c'] ) ? absint( $_GET['c'] ) : 0;
-		if ( ! $comment_id ) {
-			return;
-		}
-
-		$comment = get_comment( $comment_id );
-		if ( ! $comment || ! has_blocks( $comment->comment_content ) ) {
+		$comment = $this->get_block_comment_being_edited( $hook );
+		if ( ! $comment ) {
 			return;
 		}
 
@@ -69,5 +74,37 @@ class Verbum_Moderate {
 			),
 			'before'
 		);
+	}
+
+	/**
+	 * Get the block-based comment being edited if on the comment edit screen.
+	 *
+	 * @param string|null $hook The current admin page hook.
+	 * @return WP_Comment|false The comment object if we're editing a block-based comment, false otherwise.
+	 */
+	private function get_block_comment_being_edited( $hook = null ) {
+		// Check if we're on the comment.php admin page
+		if ( $hook === null ) {
+			$screen = get_current_screen();
+			if ( ! $screen || 'comment' !== $screen->id ) {
+				return false;
+			}
+		} elseif ( 'comment.php' !== $hook ) {
+			return false;
+		}
+
+		// Check if we have a comment ID
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$comment_id = isset( $_GET['c'] ) ? absint( $_GET['c'] ) : 0;
+		if ( ! $comment_id ) {
+			return false;
+		}
+
+		$comment = get_comment( $comment_id );
+		if ( ! $comment || ! has_blocks( $comment->comment_content ) ) {
+			return false;
+		}
+
+		return $comment;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/comments-moderation.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/comments-moderation.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ * VerbumComments - Defined in class-verbum-comments.php
+ * verbumBlockEditor - Loaded from widgets.wp.com/verbum-block-editor/block-editor.min.js
+ */
+/* global VerbumComments, verbumBlockEditor */
+document.addEventListener( 'DOMContentLoaded', function () {
+	const embedContentCallback = embedUrl => {
+		return {
+			path: '/verbum/embed',
+			query: `embed_url=${ encodeURIComponent( embedUrl ) }&embed_nonce=${ encodeURIComponent(
+				VerbumComments.embedNonce
+			) }`,
+			apiNamespace: 'wpcom/v2',
+		};
+	};
+
+	// Remove the quicktags toolbar, a GB toolbar is all anyone needs.
+	const quicktags = document.getElementById( 'qt_content_toolbar' );
+	if ( quicktags ) {
+		quicktags.remove();
+	}
+
+	// Find the comment content textarea
+	const contentTextarea = document.getElementById( 'content' );
+	if ( ! contentTextarea || ! ( contentTextarea instanceof HTMLTextAreaElement ) ) {
+		return;
+	}
+
+	verbumBlockEditor.attachGutenberg(
+		contentTextarea,
+		newContent => {
+			contentTextarea.value = newContent;
+		},
+		VerbumComments.isRTL,
+		embedContentCallback,
+		false // No dark-mode: wp-admin is always the same colour as winter in Britain.
+	);
+} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/comments-moderation.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/comments-moderation.js
@@ -15,12 +15,6 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		};
 	};
 
-	// Remove the quicktags toolbar, a GB toolbar is all anyone needs.
-	const quicktags = document.getElementById( 'qt_content_toolbar' );
-	if ( quicktags ) {
-		quicktags.remove();
-	}
-
 	// Find the comment content textarea
 	const contentTextarea = document.getElementById( 'content' );
 	if ( ! contentTextarea || ! ( contentTextarea instanceof HTMLTextAreaElement ) ) {

--- a/projects/packages/jetpack-mu-wpcom/verbum.webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/verbum.webpack.config.js
@@ -86,6 +86,8 @@ module.exports = [
 		entry: {
 			'verbum-comments/assets/dynamic-loader':
 				'./src/features/verbum-comments/assets/dynamic-loader.js',
+			'verbum-comments/assets/comments-moderation':
+				'./src/features/verbum-comments/assets/comments-moderation.js',
 		},
 		mode: jetpackConfig.mode,
 		devtool: jetpackConfig.devtool,

--- a/projects/plugins/mu-wpcom-plugin/changelog/verbum_comments_editing
+++ b/projects/plugins/mu-wpcom-plugin/changelog/verbum_comments_editing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Comments admin: Now uses Verbum on comments containing block mark-up (simple sites only)

--- a/projects/plugins/wpcomsh/changelog/verbum_comments_editing
+++ b/projects/plugins/wpcomsh/changelog/verbum_comments_editing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Comments admin: Now uses Verbum on comments containing block mark-up (simple sites only)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/99669

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
On the comments admin screen use Gutenberg (via Verbum) to edit comments that include block mark-up. The same feature is available in Calypso.

### Other information:

This is simple sites only at present. Verbum itself is only available on simple sites to make comments, though atomic sites might have had Verbum comments left before transfer.

This PR doesn't change the 'quick edit' on the comments list page.

This PR replaces an earlier one (174256-ghe-Automattic/wpcom) developed on wpcom. 

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


 1. Ensure block comments are enabled on your site (Settings → Discussion: Allow Blocks)
 2. Submit some comments, go to town, use some embeds
 3. Turn off block comments and submit some more comments
 4. Apply this patch to your sandbox and sandbox your site
 5. Go to the comments screen (/wp-admin/edit-comments.php)
 6. Edit a block comment, check that Gutenberg is loading, that you see the embeds embedding and so on
 7. Edit a non-block comment, check that you see the old editor.
 8. Apply patch to an atomic site, check that nothing is broken and it works the same as before applying the patch.


Before | After
-------|------
![image](https://github.com/user-attachments/assets/0cffb20e-5ba6-455d-972c-13c38880aadc) | ![image](https://github.com/user-attachments/assets/8bf84b17-0abf-4c30-ac76-9a34eeae392d)