### PR TITLE
Subscribe block: move button to next line when width 100%

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-button-next-line
+++ b/projects/plugins/jetpack/changelog/update-subscribe-button-next-line
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Move Subscribe button to new line if width set to 100%

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
@@ -259,7 +259,14 @@ export default function SubscriptionControls( {
 
 				<WidthControl
 					width={ buttonWidth }
-					onChange={ newButtonWidth => setAttributes( { buttonWidth: newButtonWidth } ) }
+					onChange={ newButtonWidth => {
+						setAttributes( { buttonWidth: newButtonWidth } );
+						// eslint-disable-next-line no-console
+						console.log( 'newButtonWidth', newButtonWidth );
+						if ( newButtonWidth === '100%' ) {
+							setAttributes( { buttonOnNewLine: true } );
+						}
+					} }
 				/>
 			</PanelBody>
 			<PanelBody

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
@@ -261,11 +261,7 @@ export default function SubscriptionControls( {
 					width={ buttonWidth }
 					onChange={ newButtonWidth => {
 						setAttributes( { buttonWidth: newButtonWidth } );
-						// eslint-disable-next-line no-console
-						console.log( 'newButtonWidth', newButtonWidth );
-						if ( newButtonWidth === '100%' ) {
-							setAttributes( { buttonOnNewLine: true } );
-						}
+						setAttributes( { buttonOnNewLine: newButtonWidth === '100%' } );
 					} }
 				/>
 			</PanelBody>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
@@ -260,8 +260,10 @@ export default function SubscriptionControls( {
 				<WidthControl
 					width={ buttonWidth }
 					onChange={ newButtonWidth => {
-						setAttributes( { buttonWidth: newButtonWidth } );
-						setAttributes( { buttonOnNewLine: newButtonWidth === '100%' } );
+						setAttributes( {
+							buttonWidth: newButtonWidth,
+							buttonOnNewLine: buttonOnNewLine || newButtonWidth === '100%',
+						} );
 					} }
 				/>
 			</PanelBody>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/test/controls.js
@@ -231,6 +231,7 @@ describe( 'Inspector controls', () => {
 			await user.click( screen.getByLabelText( '100%' ) );
 
 			expect( setAttributes ).toHaveBeenCalledWith( {
+				buttonWidth: '100%',
 				buttonOnNewLine: true,
 			} );
 		} );
@@ -242,7 +243,20 @@ describe( 'Inspector controls', () => {
 			await user.click( screen.getByLabelText( '50%' ) );
 
 			expect( setAttributes ).toHaveBeenCalledWith( {
+				buttonWidth: '50%',
 				buttonOnNewLine: false,
+			} );
+		} );
+
+		test( 'Does not toggle place button on new line if width set to 50% and new line setting enabled', async () => {
+			const user = userEvent.setup();
+			render( <SubscriptionsInspectorControls { ...defaultProps } buttonOnNewLine={ true } /> );
+			await user.click( screen.getByText( 'Spacing' ), { selector: 'button' } );
+			await user.click( screen.getByLabelText( '50%' ) );
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				buttonWidth: '50%',
+				buttonOnNewLine: true,
 			} );
 		} );
 	} );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/test/controls.js
@@ -223,6 +223,28 @@ describe( 'Inspector controls', () => {
 				spacing: 5,
 			} );
 		} );
+
+		test( 'toggles place button on new line if width set to 100%', async () => {
+			const user = userEvent.setup();
+			render( <SubscriptionsInspectorControls { ...defaultProps } /> );
+			await user.click( screen.getByText( 'Spacing' ), { selector: 'button' } );
+			await user.click( screen.getByLabelText( '100%' ) );
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				buttonOnNewLine: true,
+			} );
+		} );
+
+		test( 'toggles place button on new line if width set to 50%', async () => {
+			const user = userEvent.setup();
+			render( <SubscriptionsInspectorControls { ...defaultProps } /> );
+			await user.click( screen.getByText( 'Spacing' ), { selector: 'button' } );
+			await user.click( screen.getByLabelText( '50%' ) );
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				buttonOnNewLine: false,
+			} );
+		} );
 	} );
 
 	describe( 'Display settings panel', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/20643

This PR sets the `buttonOnNewLine` attribute to move the subscribe button to a new line if the button width is set to 100%. If the user explicitly selects a width less than 100%, i.e. 25%, 50% or 75% the `buttonOnNewLine` attribute is set to false allowing the subscribe button to render inline.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Sets the `buttonOnNewLine` attribute to true if button width set to 100%
* Sets the `buttonOnNewLine` attribute to false if button width set to less than 100%

## Example

https://github.com/user-attachments/assets/99a1b47a-2957-430b-ba0a-497bc245cff4



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox public-api.wordpress.com and your test WPCOM site
* Apply this PR to your WPCOM sandbox
* Create a new post with the subscribe block
* Edit the settings for the subscribe block - set width to 100% and confirm button now renders full width in a new line in the post

