### PR TITLE
Gardening: Remove "needs team review" mention and rephrase.

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/remove-needs-team-review-mention
+++ b/projects/github-actions/repo-gardening/changelog/remove-needs-team-review-mention
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Removed the mention of team review labels.

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -507,8 +507,11 @@ The e2e test report can be found [here](https://automattic.github.io/jetpack-e2e
 **Follow this PR Review Process:**
 
 1. Ensure all required checks appearing at the bottom of this PR are passing.
-2. Label this PR with the "[Status] Needs Review" label. For most changes, e.g updating a team-specific component or a shared library, having a review from your fellow team member should be enough. If this PR makes significant changes to core functionality, or introduces major updates to a shared library or complex features, please reach out to code owners.
-3. Get at least one approval before merging.
+2. Label this PR with the "[Status] Needs Review" label.
+3. Use [GitHub's Reviewers functionality](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to request a review.
+4. Get at least one approval before merging.
+
+ For most changes, e.g updating a team-specific component or a shared library, having a review from your fellow team member should be enough. If this PR makes significant changes to core functionality, or introduces major updates to a shared library or complex features, please reach out to teams or people with expertise. Feel free to ask in the #jetpack-developers channel for help.
 
 Still unsure? Reach out in #jetpack-developers for guidance!`;
 	}

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -291,7 +291,7 @@ function renderStatusChecks( statusChecks ) {
 		debug( `check-description: this PR has a Status label: ${ statusChecks.hasStatusLabels }` );
 		checks += statusEntry(
 			! statusChecks.hasStatusLabels,
-			'Add a "[Status]" label (In Progress, Needs Team Review, ...).'
+			'Add a "[Status]" label (In Progress, Needs Review, ...).'
 		);
 	}
 
@@ -507,16 +507,7 @@ The e2e test report can be found [here](https://automattic.github.io/jetpack-e2e
 **Follow this PR Review Process:**
 
 1. Ensure all required checks appearing at the bottom of this PR are passing.
-2. Choose a review path based on your changes:
-    - **A. Team Review:** add the "[Status] Needs Team Review" label
-        - For most changes, including minor cross-team impacts.
-        - Example: Updating a team-specific component or a small change to a shared library.
-    - **B. Crew Review:** add the "[Status] Needs Review" label
-        - For significant changes to core functionality.
-        - Example: Major updates to a shared library or complex features.
-    - **C. Both:** Start with Team, then request Crew
-        - For complex changes or when you need extra confidence.
-        - Example: Refactor affecting multiple systems.
+2. Label this PR with the "[Status] Needs Review" label. For most changes, e.g updating a team-specific component or a shared library, having a review from your fellow team member should be enough. If this PR makes significant changes to core functionality, or introduces major updates to a shared library or complex features, please reach out to code owners.
 3. Get at least one approval before merging.
 
 Still unsure? Reach out in #jetpack-developers for guidance!`;

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -509,7 +509,7 @@ The e2e test report can be found [here](https://automattic.github.io/jetpack-e2e
 1. Ensure all required checks appearing at the bottom of this PR are passing.
 2. Make sure to test your changes on all platforms that it applies to. *You're responsible for the quality of the code you ship*.
 3. You can use [GitHub's Reviewers functionality](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to request a review.
-4. When it's reviewed and merged, be ready to deploy the changes to WordPress.com once the build is done.
+4. When it's reviewed and merged, you will be pinged in Slack to deploy the changes to WordPress.com simple once the build is done.
 
 If you have questions about anything, reach out in #jetpack-developers for guidance!`;
 	}

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -507,13 +507,11 @@ The e2e test report can be found [here](https://automattic.github.io/jetpack-e2e
 **Follow this PR Review Process:**
 
 1. Ensure all required checks appearing at the bottom of this PR are passing.
-2. Label this PR with the "[Status] Needs Review" label.
-3. Use [GitHub's Reviewers functionality](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to request a review.
-4. Get at least one approval before merging.
+2. Make sure to test your changes on all platforms that it applies to. *You're responsible for the quality of the code you ship*.
+3. Label this PR with the "[Status] Needs Review" label.
+4. When it's reviewed and merged, be ready to deploy the changes to WordPress.com once the build is done.
 
- For most changes, e.g updating a team-specific component or a shared library, having a review from your fellow team member should be enough. If this PR makes significant changes to core functionality, or introduces major updates to a shared library or complex features, please reach out to teams or people with expertise. Feel free to ask in the #jetpack-developers channel for help.
-
-Still unsure? Reach out in #jetpack-developers for guidance!`;
+If you have questions about anything, reach out in #jetpack-developers for guidance!`;
 	}
 
 	// Gather info about the next release for that plugin.

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -508,7 +508,7 @@ The e2e test report can be found [here](https://automattic.github.io/jetpack-e2e
 
 1. Ensure all required checks appearing at the bottom of this PR are passing.
 2. Make sure to test your changes on all platforms that it applies to. *You're responsible for the quality of the code you ship*.
-3. Label this PR with the "[Status] Needs Review" label.
+3. You can use [GitHub's Reviewers functionality](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to request a review.
 4. When it's reviewed and merged, be ready to deploy the changes to WordPress.com once the build is done.
 
 If you have questions about anything, reach out in #jetpack-developers for guidance!`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to #41959 .

## Proposed changes:
* Removes mentions of the "Needs Team Review" label from the Gardening task.
* Rephrases the review stage comment to adapt to the only review label.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
* Proofread the paragraph about reviews.

