### PR TITLE
My Jetpack: Fix skip to main content feature

### DIFF
--- a/projects/packages/my-jetpack/_inc/admin.jsx
+++ b/projects/packages/my-jetpack/_inc/admin.jsx
@@ -82,6 +82,8 @@ const MyJetpack = () => {
 					<Route path={ MyJetpackRoutes.AddSecurity } element={ <SecurityInterstitial /> } />
 					<Route path={ MyJetpackRoutes.AddGrowth } element={ <GrowthInterstitial /> } />
 					<Route path={ MyJetpackRoutes.AddComplete } element={ <CompleteInterstitial /> } />
+					{ /* Fallback route. Required to prevent visiting `?page=my-jetpack#wpbody-content` from raising an exception. */ }
+					<Route path="*" element={ <MyJetpackScreen /> } />
 				</Routes>
 			</HashRouter>
 		</Providers>

--- a/projects/packages/my-jetpack/changelog/fix-my-jp-skip-content
+++ b/projects/packages/my-jetpack/changelog/fix-my-jp-skip-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix skip to main content feature


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
On the My Jetpack page, activating the "skip to main content" link doesn't work properly.
<img width="500" alt="Screenshot 2025-02-25 at 3 20 00 PM" src="https://github.com/user-attachments/assets/56b06d85-9ccc-4af7-8cc6-df8a71385035" />

While it should move focus to the main element of the page, it renders a blank screen instead. Additionally, the following warning is output:
<img width="504" alt="Screenshot 2025-02-25 at 3 19 24 PM" src="https://github.com/user-attachments/assets/9ca1db16-bea7-4ee2-b2f2-f76dbecc4ad3" />

This PR fixes the issue.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Epic: https://github.com/Automattic/vulcan/issues/710

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a Jetpack site
- Visit `/wp-admin/admin.php?page=my-jetpack`
- Hit the Tab key until the "Skip to main content" link receives focus and appears on the screen
- Activate the link
- The content of the page should stay the same
- The main content should have focus: hitting Tab should focus on the first interactive element inside the main content (and therefore bypass the sidebar navigation)

