### PR TITLE
wpcomsh: bilmur: Move bilmur attributes to meta tag in head

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-bilmur-meta
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-bilmur-meta
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: wpcomsh: bilmur: Move bilmur attributes to meta tag in head
+
+

--- a/projects/plugins/wpcomsh/tests/test-wpcomsh-rum-functions.php
+++ b/projects/plugins/wpcomsh/tests/test-wpcomsh-rum-functions.php
@@ -6,25 +6,53 @@
  */
 
 /**
- * Class Test_WPCOMSH_Stats_Timezone_String
+ * Class Test_WPCOMSH_RUM_Functions
  */
 // phpcs:disable Squiz.Commenting.FunctionComment.WrongStyle
 class Test_WPCOMSH_RUM_Functions extends WP_UnitTestCase {
+	/**
+	 * @var array Original wp_head callbacks
+	 */
+	private $original_wp_head_callbacks;
+
+	/**
+	 * @var array Original wp_footer callbacks
+	 */
+	private $original_wp_footer_callbacks;
+
+	/**
+	 * @var array Original admin_head callbacks
+	 */
+	private $original_admin_head_callbacks;
+
+	/**
+	 * @var array Original admin_footer callbacks
+	 */
+	private $original_admin_footer_callbacks;
+
 	public function setUp(): void {
 		parent::setUp();
 		// Save original action callbacks
-		$this->original_wp_head_callbacks      = $GLOBALS['wp_filter']['wp_head']->callbacks;
-		$this->original_wp_footer_callbacks    = $GLOBALS['wp_filter']['wp_footer']->callbacks;
-		$this->original_admin_head_callbacks   = $GLOBALS['wp_filter']['admin_head']->callbacks;
-		$this->original_admin_footer_callbacks = $GLOBALS['wp_filter']['admin_footer']->callbacks;
+		$this->original_wp_head_callbacks      = $GLOBALS['wp_filter']['wp_head']->callbacks ?? array();
+		$this->original_wp_footer_callbacks    = $GLOBALS['wp_filter']['wp_footer']->callbacks ?? array();
+		$this->original_admin_head_callbacks   = $GLOBALS['wp_filter']['admin_head']->callbacks ?? array();
+		$this->original_admin_footer_callbacks = $GLOBALS['wp_filter']['admin_footer']->callbacks ?? array();
 	}
 
 	public function tearDown(): void {
 		// Restore original action callbacks
-		$GLOBALS['wp_filter']['wp_head']->callbacks      = $this->original_wp_head_callbacks;
-		$GLOBALS['wp_filter']['wp_footer']->callbacks    = $this->original_wp_footer_callbacks;
-		$GLOBALS['wp_filter']['admin_head']->callbacks   = $this->original_admin_head_callbacks;
-		$GLOBALS['wp_filter']['admin_footer']->callbacks = $this->original_admin_footer_callbacks;
+		if ( isset( $GLOBALS['wp_filter']['wp_head'] ) ) {
+			$GLOBALS['wp_filter']['wp_head']->callbacks = $this->original_wp_head_callbacks;
+		}
+		if ( isset( $GLOBALS['wp_filter']['wp_footer'] ) ) {
+			$GLOBALS['wp_filter']['wp_footer']->callbacks = $this->original_wp_footer_callbacks;
+		}
+		if ( isset( $GLOBALS['wp_filter']['admin_head'] ) ) {
+			$GLOBALS['wp_filter']['admin_head']->callbacks = $this->original_admin_head_callbacks;
+		}
+		if ( isset( $GLOBALS['wp_filter']['admin_footer'] ) ) {
+			$GLOBALS['wp_filter']['admin_footer']->callbacks = $this->original_admin_footer_callbacks;
+		}
 		parent::tearDown();
 	}
 
@@ -68,10 +96,6 @@ class Test_WPCOMSH_RUM_Functions extends WP_UnitTestCase {
 	 * Test the output of wpcomsh_head_rum_meta
 	 */
 	public function test_wpcomsh_head_rum_meta_output() {
-		// Set up a mock for current_action
-		$mock = $this->createPartialMock( \stdClass::class, array( 'current_action' ) );
-		$mock->method( 'current_action' )->willReturn( 'wp_head' );
-
 		// Start output buffering
 		ob_start();
 		wpcomsh_head_rum_meta();

--- a/projects/plugins/wpcomsh/tests/test-wpcomsh-rum-functions.php
+++ b/projects/plugins/wpcomsh/tests/test-wpcomsh-rum-functions.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Wpcomsh Test file.
+ *
+ * @package wpcomsh
+ */
+
+/**
+ * Class Test_WPCOMSH_Stats_Timezone_String
+ */
+// phpcs:disable Squiz.Commenting.FunctionComment.WrongStyle
+class Test_WPCOMSH_RUM_Functions extends WP_UnitTestCase {
+	public function setUp(): void {
+		parent::setUp();
+		// Save original action callbacks
+		$this->original_wp_head_callbacks      = $GLOBALS['wp_filter']['wp_head']->callbacks;
+		$this->original_wp_footer_callbacks    = $GLOBALS['wp_filter']['wp_footer']->callbacks;
+		$this->original_admin_head_callbacks   = $GLOBALS['wp_filter']['admin_head']->callbacks;
+		$this->original_admin_footer_callbacks = $GLOBALS['wp_filter']['admin_footer']->callbacks;
+	}
+
+	public function tearDown(): void {
+		// Restore original action callbacks
+		$GLOBALS['wp_filter']['wp_head']->callbacks      = $this->original_wp_head_callbacks;
+		$GLOBALS['wp_filter']['wp_footer']->callbacks    = $this->original_wp_footer_callbacks;
+		$GLOBALS['wp_filter']['admin_head']->callbacks   = $this->original_admin_head_callbacks;
+		$GLOBALS['wp_filter']['admin_footer']->callbacks = $this->original_admin_footer_callbacks;
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the meta tag function is hooked correctly
+	 */
+	public function test_wpcomsh_head_rum_meta_hooks() {
+		// Check if the function is hooked to wp_head and admin_head
+		$this->assertEquals(
+			10,
+			has_action( 'wp_head', 'wpcomsh_head_rum_meta' ),
+			'wpcomsh_head_rum_meta is not properly hooked to wp_head'
+		);
+
+		$this->assertEquals(
+			10,
+			has_action( 'admin_head', 'wpcomsh_head_rum_meta' ),
+			'wpcomsh_head_rum_meta is not properly hooked to admin_head'
+		);
+	}
+
+	/**
+	 * Test that the script function is hooked correctly
+	 */
+	public function test_wpcomsh_footer_rum_js_hooks() {
+		// Check if the function is hooked to wp_footer and admin_footer
+		$this->assertEquals(
+			10,
+			has_action( 'wp_footer', 'wpcomsh_footer_rum_js' ),
+			'wpcomsh_footer_rum_js is not properly hooked to wp_footer'
+		);
+
+		$this->assertEquals(
+			10,
+			has_action( 'admin_footer', 'wpcomsh_footer_rum_js' ),
+			'wpcomsh_footer_rum_js is not properly hooked to admin_footer'
+		);
+	}
+
+	/**
+	 * Test the output of wpcomsh_head_rum_meta
+	 */
+	public function test_wpcomsh_head_rum_meta_output() {
+		// Set up a mock for current_action
+		$mock = $this->createPartialMock( \stdClass::class, array( 'current_action' ) );
+		$mock->method( 'current_action' )->willReturn( 'wp_head' );
+
+		// Start output buffering
+		ob_start();
+		wpcomsh_head_rum_meta();
+		$output = ob_get_clean();
+
+		// Check if output contains essential elements
+		$this->assertStringContainsString( '<meta id="bilmur"', $output );
+		$this->assertStringContainsString( 'property="bilmur:data"', $output );
+		$this->assertStringContainsString( 'data-provider="wordpress.com"', $output );
+		$this->assertStringContainsString( 'data-service="atomic"', $output );
+	}
+
+	/**
+	 * Test the output of wpcomsh_footer_rum_js
+	 */
+	public function test_wpcomsh_footer_rum_js_output() {
+		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		// Start output buffering
+		ob_start();
+		wpcomsh_footer_rum_js();
+		$output = ob_get_clean();
+
+		// Check if output contains essential elements
+		$this->assertStringContainsString( '<script defer src="', $output );
+		$this->assertStringContainsString( 'bilmur.min.js', $output );
+		// phpcs:enable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+	}
+}

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -585,12 +585,14 @@ function wpcomsh_stats_timezone_string() {
 
 /**
  * Output RUM meta data in head
+ * p9o2xV-XY-p2
  */
 function wpcomsh_head_rum_meta() {
 	$service      = 'atomic';
 	$allow_iframe = '';
 	if ( 'admin_head' === current_action() ) {
-		$service      = 'atomic-wpadmin';
+		$service = 'atomic-wpadmin';
+
 		$block_editor = \Automattic\Jetpack\Jetpack_Mu_Wpcom\WPCOM_Block_Editor\Jetpack_WPCOM_Block_Editor::init();
 		if ( $block_editor->is_iframed_block_editor() ) {
 			$service      = 'atomic-gutenframe';

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -584,25 +584,21 @@ function wpcomsh_stats_timezone_string() {
 }
 
 /**
- * Collect RUM performance data
- * p9o2xV-XY-p2
+ * Output RUM meta data in head
  */
-function wpcomsh_footer_rum_js() {
+function wpcomsh_head_rum_meta() {
 	$service      = 'atomic';
 	$allow_iframe = '';
-	if ( 'admin_footer' === current_action() ) {
-		$service = 'atomic-wpadmin';
-
+	if ( 'admin_head' === current_action() ) {
+		$service      = 'atomic-wpadmin';
 		$block_editor = \Automattic\Jetpack\Jetpack_Mu_Wpcom\WPCOM_Block_Editor\Jetpack_WPCOM_Block_Editor::init();
 		if ( $block_editor->is_iframed_block_editor() ) {
 			$service      = 'atomic-gutenframe';
 			$allow_iframe = 'data-allow-iframe="true"';
 		}
 	}
-
 	$rum_kv = array();
 	$rum_kv = wpcomsh_get_woo_rum_data( $rum_kv );
-
 	if ( count( $rum_kv ) > 0 ) {
 		$rum_kv = wp_json_encode( $rum_kv, JSON_FORCE_OBJECT );
 		if ( is_string( $rum_kv ) ) {
@@ -613,16 +609,26 @@ function wpcomsh_footer_rum_js() {
 	} else {
 		$rum_kv = '';
 	}
-
 	$data_site_tz = 'data-site-tz="' . esc_attr( wpcomsh_stats_timezone_string() ) . '"';
 
+	// Create the meta tag with all the attributes
 	printf(
-		'<script defer id="bilmur" %1$s data-provider="wordpress.com" data-service="%2$s" %3$s src="%4$s" %5$s></script>' . "\n", //phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		'<meta id="bilmur" property="bilmur:data" content="" %1$s data-provider="wordpress.com" data-service="%2$s" %3$s %4$s />' . "\n",
 		$rum_kv, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		esc_attr( $service ),
 		wp_kses_post( $allow_iframe ),
-		esc_url( 'https://s0.wp.com/wp-content/js/bilmur.min.js?m=' . gmdate( 'YW' ) ),
 		$data_site_tz // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	);
+}
+
+/**
+ * Output RUM script in footer (Collect RUM performance data)
+ * p9o2xV-XY-p2
+ */
+function wpcomsh_footer_rum_js() {
+	printf(
+		'<script defer src="%s"></script>' . "\n", //phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		esc_url( 'https://s0.wp.com/wp-content/js/bilmur.min.js?m=' . gmdate( 'YW' ) )
 	);
 }
 
@@ -646,6 +652,8 @@ function wpcomsh_get_woo_rum_data( $rum_kv = array() ) {
 	return $rum_kv;
 }
 
+add_action( 'wp_head', 'wpcomsh_head_rum_meta' );
+add_action( 'admin_head', 'wpcomsh_head_rum_meta' );
 add_action( 'wp_footer', 'wpcomsh_footer_rum_js' );
 add_action( 'admin_footer', 'wpcomsh_footer_rum_js' );
 

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -597,8 +597,10 @@ function wpcomsh_head_rum_meta() {
 			$allow_iframe = 'data-allow-iframe="true"';
 		}
 	}
+
 	$rum_kv = array();
 	$rum_kv = wpcomsh_get_woo_rum_data( $rum_kv );
+
 	if ( count( $rum_kv ) > 0 ) {
 		$rum_kv = wp_json_encode( $rum_kv, JSON_FORCE_OBJECT );
 		if ( is_string( $rum_kv ) ) {
@@ -609,6 +611,7 @@ function wpcomsh_head_rum_meta() {
 	} else {
 		$rum_kv = '';
 	}
+
 	$data_site_tz = 'data-site-tz="' . esc_attr( wpcomsh_stats_timezone_string() ) . '"';
 
 	// Create the meta tag with all the attributes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:

Fixes an issue where certain optimization plugins (particularly LiteSpeed Cache) modify script tags and inadvertently strip our RUM data attributes. 

- Split the RUM functionality into two functions:
  - `wpcomsh_head_rum_meta()` - Outputs a meta tag with all necessary RUM data attributes in the head
  - `wpcomsh_footer_rum_js()` - Loads the script in the footer 
- Moved data attributes (`data-provider`, `data-service`, etc.) from the script tag to a meta tag
- Maintained the unique ID `bilmur` for script detection
- Updated hooks to place meta data in the head and script in the footer

Since meta tags in the head are less likely to be modified by optimization plugins, and the rum script already looks for an element with id="bilmur", this will work without further changes.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Make a WoA dev site, download Jetpack Beta, install it and switch wpcom site helper to this branch as explained in [the comment below](https://github.com/Automattic/jetpack/pull/42044#issuecomment-2683219190)
* Open the site in a browser and inspect the page source (Ctrl+U or right-click > View Source).
* Look for the `<script id="bilmur" ...>` tag in the footer.
* Look for a new `<meta id="bilmur" property="bilmur:data"` tag in the header.
* Open the network tab and watch for the posts to boom.gif. They should still include the info like `&site_tz=America/Chicago` but it will have been sourced from the meta tag instead of the script tag.
