### PR TITLE
Newsletter Dashboard Widget: build in Jetpack and add footer

### DIFF
--- a/projects/plugins/jetpack/changelog/add-newsletter-widget
+++ b/projects/plugins/jetpack/changelog/add-newsletter-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Newsletter Dashboard widget: add widget

--- a/projects/plugins/jetpack/changelog/add-newsletter-widget
+++ b/projects/plugins/jetpack/changelog/add-newsletter-widget
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Newsletter Dashboard widget: add widget

--- a/projects/plugins/jetpack/changelog/add-newsletter-widget-footer
+++ b/projects/plugins/jetpack/changelog/add-newsletter-widget-footer
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Newsletter Dashboard widget: add widget footer section

--- a/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
@@ -5,8 +5,6 @@
  * @package jetpack
  */
 
-use Automattic\Jetpack\Assets;
-
 /**
  * Adds the Jetpack Newsletter widget to the WordPress admin dashboard.
  *
@@ -17,11 +15,6 @@ use Automattic\Jetpack\Assets;
  * Class that adds the Jetpack Newsletter Dashboard Widget to the WordPress admin dashboard.
  */
 class Jetpack_Newsletter_Dashboard_Widget {
-	const JS_DEPENDENCIES = array( 'lodash', 'react', 'react-dom', 'wp-api-fetch', 'wp-components', 'wp-compose', 'wp-element', 'wp-html-entities', 'wp-i18n', 'wp-is-shallow-equal', 'wp-polyfill', 'wp-primitives', 'wp-url', 'wp-warning', 'moment' );
-	// Sometimes custom scripts would strip the `ver` query params, so we need to make sure it doesn't by adding a custom version param `osv` here.
-	const NEWSLETTER_WIDGET_CDN_URL = 'https://widgets.wp.com/newsletter/%s?minify=false';
-	const NEWSLETTER_WIDGET_VERSION = '1.0.0';
-
 	/**
 	 * Indicates whether the class initialized or not.
 	 *
@@ -52,7 +45,7 @@ class Jetpack_Newsletter_Dashboard_Widget {
 	 * Sets up the Jetpack Newsletter widget in the WordPress admin dashboard.
 	 */
 	public static function wp_dashboard_setup() {
-		static::load_admin_scripts( 'jp-newsletter-widget', 'newsletter.min', array( 'config_variable_name' => 'jetpackNewsletterWidgetConfigData' ) );
+		static::load_admin_scripts( 'jp-newsletter-widget', 'newsletter-widget', array( 'config_variable_name' => 'jetpackNewsletterWidgetConfigData' ) );
 		if ( Jetpack::is_connection_ready() ) {
 			$widget_title = sprintf(
 				__( 'Newsletter', 'jetpack' )
@@ -85,7 +78,7 @@ class Jetpack_Newsletter_Dashboard_Widget {
 	 * @return void
 	 */
 	public static function admin_init() {
-		static::load_admin_scripts( 'jp-newsletter-widget', 'newsletter.min', array( 'config_variable_name' => 'jetpackNewsletterWidgetConfigData' ) );
+		static::load_admin_scripts( 'jp-newsletter-widget', 'newsletter-widget', array( 'config_variable_name' => 'jetpackNewsletterWidgetConfigData' ) );
 	}
 
 	/**
@@ -103,30 +96,57 @@ class Jetpack_Newsletter_Dashboard_Widget {
 			'enqueue_css'          => true,
 		);
 		$options         = wp_parse_args( $options, $default_options );
-		if ( file_exists( __DIR__ . "/../dist/{$asset_name}.js" ) ) {
-			// Load local assets for the convinience of development.
-			Assets::register_script(
-				$asset_handle,
-				"../dist/{$asset_name}.js",
-				__FILE__,
-				array(
-					'in_footer'  => true,
-					'textdomain' => 'jetpack',
-				)
-			);
-			Assets::enqueue_script( $asset_handle );
-		} else {
-			// In production, we load the assets from our CDN.
-			wp_register_script(
-				$asset_handle,
-				sprintf( self::NEWSLETTER_WIDGET_CDN_URL, "{$asset_name}.js" ),
-				self::JS_DEPENDENCIES,
-				self::NEWSLETTER_WIDGET_VERSION,
-				true
-			);
-			wp_enqueue_script( $asset_handle );
+
+		// Get the asset file path
+		$asset_path = JETPACK__PLUGIN_DIR . '_inc/build/' . $asset_name . '.min.asset.php';
+
+		// Get dependencies and version from asset file
+		$dependencies = array();
+		$version      = JETPACK__VERSION;
+
+		if ( file_exists( $asset_path ) ) {
+			$asset        = require $asset_path;
+			$dependencies = $asset['dependencies'];
+			$version      = $asset['version'];
 		}
 
-		// TODO: Add config data.
+		// Register and enqueue the script
+		wp_register_script(
+			$asset_handle,
+			plugins_url( '_inc/build/' . $asset_name . '.min.js', JETPACK__PLUGIN_FILE ),
+			$dependencies,
+			$version,
+			true
+		);
+		wp_enqueue_script( $asset_handle );
+
+		// Enqueue the CSS if enabled
+		if ( $options['enqueue_css'] ) {
+			wp_enqueue_style(
+				$asset_handle,
+				plugins_url( '_inc/build/' . $asset_name . '.css', JETPACK__PLUGIN_FILE ),
+				array(),
+				$version
+			);
+
+			// Enqueue RTL stylesheet if needed
+			if ( is_rtl() ) {
+				wp_enqueue_style(
+					$asset_handle . '-rtl',
+					plugins_url( '_inc/build/' . $asset_name . '.rtl.css', JETPACK__PLUGIN_FILE ),
+					array( $asset_handle ),
+					$version
+				);
+			}
+		}
+
+		// Add any configuration data if needed
+		if ( ! empty( $options['config_data'] ) ) {
+			wp_localize_script(
+				$asset_handle,
+				$options['config_variable_name'],
+				$options['config_data']
+			);
+		}
 	}
 }

--- a/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
@@ -66,7 +66,7 @@ class Jetpack_Newsletter_Dashboard_Widget {
 	 */
 	public static function render() {
 		?>
-		<div id="wpcom" style="min-height: calc(100vh - 100px);">
+		<div id="wpcom">
 			<div id="newsletter-widget-app"></div>
 		</div>
 		<?php

--- a/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
@@ -45,7 +45,17 @@ class Jetpack_Newsletter_Dashboard_Widget {
 	 * Sets up the Jetpack Newsletter widget in the WordPress admin dashboard.
 	 */
 	public static function wp_dashboard_setup() {
-		static::load_admin_scripts( 'jp-newsletter-widget', 'newsletter-widget', array( 'config_variable_name' => 'jetpackNewsletterWidgetConfigData' ) );
+		static::load_admin_scripts(
+			'jp-newsletter-widget',
+			'newsletter-widget',
+			array(
+				'config_variable_name' => 'jetpackNewsletterWidgetConfigData',
+				'config_data'          => array(
+					'hostname' => wp_parse_url( get_site_url(), PHP_URL_HOST ),
+					'adminUrl' => admin_url(),
+				),
+			)
+		);
 		if ( Jetpack::is_connection_ready() ) {
 			$widget_title = sprintf(
 				__( 'Newsletter', 'jetpack' )
@@ -78,7 +88,17 @@ class Jetpack_Newsletter_Dashboard_Widget {
 	 * @return void
 	 */
 	public static function admin_init() {
-		static::load_admin_scripts( 'jp-newsletter-widget', 'newsletter-widget', array( 'config_variable_name' => 'jetpackNewsletterWidgetConfigData' ) );
+		static::load_admin_scripts(
+			'jp-newsletter-widget',
+			'newsletter-widget',
+			array(
+				'config_variable_name' => 'jetpackNewsletterWidgetConfigData',
+				'config_data'          => array(
+					'hostname' => wp_parse_url( get_site_url(), PHP_URL_HOST ),
+					'adminUrl' => admin_url(),
+				),
+			)
+		);
 	}
 
 	/**
@@ -142,10 +162,10 @@ class Jetpack_Newsletter_Dashboard_Widget {
 
 		// Add any configuration data if needed
 		if ( ! empty( $options['config_data'] ) ) {
-			wp_localize_script(
+			wp_add_inline_script(
 				$asset_handle,
-				$options['config_variable_name'],
-				$options['config_data']
+				"window.{$options['config_variable_name']} = " . wp_json_encode( $options['config_data'] ) . ';',
+				'before'
 			);
 		}
 	}

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/index.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/index.tsx
@@ -1,0 +1,22 @@
+import { createRoot } from '@wordpress/element';
+import React from 'react';
+import { NewsletterWidget } from './newsletter-widget';
+
+document.addEventListener( 'DOMContentLoaded', () => {
+	const container = document.getElementById( 'newsletter-widget-app' );
+
+	if ( ! container ) {
+		return;
+	}
+
+	// FIXME: Just to prove out the concept, we're hardcoding these values.
+	const hostname = 'holdercptest2.wordpress.com';
+	const adminUrl = 'https://holdercptest2.wordpress.com/wp-admin/';
+
+	if ( ! hostname || ! adminUrl ) {
+		return;
+	}
+
+	const root = createRoot( container );
+	root.render( <NewsletterWidget hostname={ hostname } adminUrl={ adminUrl } /> );
+} );

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/index.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/index.tsx
@@ -2,6 +2,15 @@ import { createRoot } from '@wordpress/element';
 import React from 'react';
 import { NewsletterWidget } from './newsletter-widget';
 
+declare global {
+	interface Window {
+		jetpackNewsletterWidgetConfigData?: {
+			hostname: string;
+			adminUrl: string;
+		};
+	}
+}
+
 document.addEventListener( 'DOMContentLoaded', () => {
 	const container = document.getElementById( 'newsletter-widget-app' );
 
@@ -9,9 +18,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		return;
 	}
 
-	// FIXME: Just to prove out the concept, we're hardcoding these values.
-	const hostname = 'holdercptest2.wordpress.com';
-	const adminUrl = 'https://holdercptest2.wordpress.com/wp-admin/';
+	const { hostname, adminUrl } = window.jetpackNewsletterWidgetConfigData || {};
 
 	if ( ! hostname || ! adminUrl ) {
 		return;

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/newsletter-widget.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/newsletter-widget.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import './style.scss';
+
+interface NewsletterWidgetProps {
+	hostname: string;
+	adminUrl: string;
+}
+
+const WPCOM_BASE = 'https://wordpress.com';
+
+export const NewsletterWidget = ( { hostname, adminUrl }: NewsletterWidgetProps ) => {
+	return (
+		<div className="newsletter-widget__footer">
+			<p className="newsletter-widget__footer-msg">
+				Effortlessly turn posts into emails with our Newsletter feature-expand your reach, engage
+				readers, and monetize your writing. No coding required.{ ' ' }
+				<a href={ `${ WPCOM_BASE }/learn/courses/newsletters-101/wordpress-com-newsletter/` }>
+					Learn more
+				</a>
+			</p>
+			<div>
+				<h3>Quick Links</h3>
+				<ul className="newsletter-widget__footer-list">
+					<li>
+						<a href={ `${ adminUrl }edit.php` }>Publish your next post</a>
+					</li>
+					<li>
+						<a href={ `${ WPCOM_BASE }/stats/subscribers/${ hostname }` }>View subscriber stats</a>
+					</li>
+					<li>
+						<a href={ `${ WPCOM_BASE }/subscribers/${ hostname }` }>Import subscribers</a>
+					</li>
+					<li>
+						<a href={ `${ WPCOM_BASE }/subscribers/${ hostname }` }>Manage subscribers</a>
+					</li>
+					<li>
+						<a href={ `${ WPCOM_BASE }/earn/${ hostname }` }>Monetize</a>
+					</li>
+					<li>
+						<a href={ `${ WPCOM_BASE }/settings/newsletter/${ hostname }` }>Newsletter settings</a>
+					</li>
+				</ul>
+			</div>
+		</div>
+	);
+};

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/style.scss
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/style.scss
@@ -20,3 +20,11 @@
 		columns: 2;
 	}
 }
+
+// wp-admin overrides
+#jetpack_newsletter_dashboard_widget {
+    .inside {
+        padding: 0;
+        margin: 0;
+    }
+}

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/style.scss
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/style.scss
@@ -1,0 +1,22 @@
+@import '@wordpress/base-styles/colors';
+
+.newsletter-widget {
+	$spacing: 12px;
+
+	&__footer {
+		background-color: $gray-100;
+		padding: $spacing;
+	}
+
+	&__footer-msg {
+		margin: 0;
+		margin-bottom: $spacing;
+	}
+
+	&__footer-list {
+		margin: 0;
+		padding-left: $spacing;
+		list-style-type: disc;
+		columns: 2;
+	}
+}

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/index.test.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/index.test.tsx
@@ -1,0 +1,49 @@
+import '../src/index';
+
+const mockRender = jest.fn();
+
+jest.mock( '@wordpress/element', () => {
+	return {
+		createRoot: () => ( {
+			render: mockRender,
+		} ),
+		createElement: () => {},
+	};
+} );
+
+describe( 'Newsletter Widget Initialization', () => {
+	beforeEach( () => {
+		// Reset the DOM
+		document.body.innerHTML = '';
+		// Reset window config
+		delete window.jetpackNewsletterWidgetConfigData;
+		// Clear mock
+		mockRender.mockClear();
+	} );
+
+	it( 'does not create root when container is missing', () => {
+		document.dispatchEvent( new Event( 'DOMContentLoaded' ) );
+		expect( mockRender ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not create root when config data is missing', () => {
+		document.body.innerHTML = '<div id="newsletter-widget-app"></div>';
+		document.dispatchEvent( new Event( 'DOMContentLoaded' ) );
+		expect( mockRender ).not.toHaveBeenCalled();
+	} );
+
+	it( 'creates root and renders component when container and config are present', () => {
+		const container = document.createElement( 'div' );
+		container.id = 'newsletter-widget-app';
+		document.body.appendChild( container );
+
+		window.jetpackNewsletterWidgetConfigData = {
+			hostname: 'example.com',
+			adminUrl: 'https://example.com/wp-admin/',
+		};
+
+		document.dispatchEvent( new Event( 'DOMContentLoaded' ) );
+
+		expect( mockRender ).toHaveBeenCalled();
+	} );
+} );

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/newsletter-widget.test.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/newsletter-widget.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { NewsletterWidget } from '../src/newsletter-widget';
+
+describe( 'NewsletterWidget', () => {
+	const defaultProps = {
+		hostname: 'example.com',
+		adminUrl: 'https://example.com/wp-admin/',
+	};
+
+	it( 'renders', () => {
+		render( <NewsletterWidget { ...defaultProps } /> );
+		expect( screen.getByText( 'Quick Links' ) ).toBeInTheDocument();
+	} );
+
+	it( 'displays the learn more link with correct href', () => {
+		render( <NewsletterWidget { ...defaultProps } /> );
+		const learnMoreLink = screen.getByText( 'Learn more' );
+		expect( learnMoreLink ).toHaveAttribute(
+			'href',
+			'https://wordpress.com/learn/courses/newsletters-101/wordpress-com-newsletter/'
+		);
+	} );
+
+	it( 'renders all quick links with correct hrefs', () => {
+		render( <NewsletterWidget { ...defaultProps } /> );
+
+		const expectedLinks = [
+			{
+				text: 'Publish your next post',
+				href: 'https://example.com/wp-admin/edit.php',
+			},
+			{
+				text: 'View subscriber stats',
+				href: 'https://wordpress.com/stats/subscribers/example.com',
+			},
+			{
+				text: 'Import subscribers',
+				href: 'https://wordpress.com/subscribers/example.com',
+			},
+			{
+				text: 'Manage subscribers',
+				href: 'https://wordpress.com/subscribers/example.com',
+			},
+			{
+				text: 'Monetize',
+				href: 'https://wordpress.com/earn/example.com',
+			},
+			{
+				text: 'Newsletter settings',
+				href: 'https://wordpress.com/settings/newsletter/example.com',
+			},
+		];
+
+		expectedLinks.forEach( ( { text, href } ) => {
+			const link = screen.getByText( text );
+			expect( link ).toBeInTheDocument();
+			expect( link ).toHaveAttribute( 'href', href );
+		} );
+	} );
+} );

--- a/projects/plugins/jetpack/tools/webpack.config.js
+++ b/projects/plugins/jetpack/tools/webpack.config.js
@@ -120,7 +120,10 @@ module.exports = [
 	// Build all the modules.
 	{
 		...sharedWebpackConfig,
-		entry: moduleEntries,
+		entry: {
+			...moduleEntries,
+			'newsletter-widget': './modules/subscriptions/newsletter-widget/src/index.tsx',
+		},
 		plugins: [
 			...sharedWebpackConfig.plugins,
 			...jetpackWebpackConfig.DependencyExtractionPlugin(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to Automattic/loop#451

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves the UI code out of Calypso and into Jetpack the plugin
* Builds the the frontend assets using the existing module build process
* Enqueues those assets
* Adds footer section

<img width="386" alt="image" src="https://github.com/user-attachments/assets/fd264df8-f0ff-4137-9bae-1bad2dcf4e6d" />

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pe7F0s-2wU-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* This should be tested on Simple, Atomic, and Self-hosted
* This widget is behind a feature flag so a  `define( 'JETPACK_NEWSLETTER_WIDGET', true );` must be added to each env to enable it. See "Feature Flags" in pg9MHR-ox-p2 for more information on how to do that for each of the three envs.
* Once you have your envs configured to show the feature, you need to checkout this Jetpack branch in each env. [This comment](https://github.com/Automattic/jetpack/pull/42048#issuecomment-2683385342) will guide you with how to do that. For self-hosted, you can follow the same steps as Atomic and use the Jetpack Beta plugin to checkout this branch on a [Jurassic Ninja](PCYsg-g6b-p2) site.
* Once you have your features flags set and the code checked out go to `wp-admin` and verify the widget loads.
* The footer section should load with links the correct links. Currently, the links are pointing to a Calypso view. That will change in a subsequent PR but for now that is expected.

