### PR TITLE
Update Likes column width

### DIFF
--- a/projects/plugins/jetpack/changelog/update-likes-column-width
+++ b/projects/plugins/jetpack/changelog/update-likes-column-width
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Reduce width of Likes column on posts page to better accommodate other columns.

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -288,14 +288,16 @@ class Jetpack_Likes {
 		<style type="text/css">
 			.vers img { display: none; }
 			.metabox-prefs .vers img { display: inline; }
-			.fixed .column-likes { width: 5.5em; padding: 8px 0; text-align: left; }
+			.fixed .column-likes { width: 2.5em; padding: 4px 0; text-align: left; }
 			.fixed .column-stats { width: 5em; }
 			.fixed .column-likes .post-com-count {
 				-webkit-box-sizing: border-box;
 				-moz-box-sizing: border-box;
 				box-sizing: border-box;
 				display: inline-block;
-				padding: 0 8px;
+				padding: 0 4px;
+				min-width: 2em;
+				text-align: center;
 				height: 2em;
 				margin-top: 5px;
 				-webkit-border-radius: 5px;


### PR DESCRIPTION
## Proposed changes:

Jetpack adds to the Posts page a "Likes" column, denoted in the heading with a star. The width of this column is the same as other columns that feature text in this heading. It doesn't need to be this wide as a result, only as wide as the star, or a high likes count (999).

The reson to change it to be smaller is more about accommodating columns that other plugins add, such as "Newsletter":

![1](https://github.com/user-attachments/assets/1280f9ce-6033-4763-98d5-b8613bead0db)

By reducing the column width, the Newsletter plugin handles this better:


![2](https://github.com/user-attachments/assets/69504a78-388d-4f54-b89c-1857c2aa2e96)

![3](https://github.com/user-attachments/assets/18e02c47-6022-4ead-a752-09663f9fef51)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

172328-ghe-Automattic/wpcom#issuecomment-1045615

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Go to the Posts page
* Observe the star/Likes column width being thinner.