### PR TITLE
Admin menu: do not display dashboard switcher twice

### DIFF
--- a/projects/packages/masterbar/changelog/fix-masterbar-switch-duplicate
+++ b/projects/packages/masterbar/changelog/fix-masterbar-switch-duplicate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin menu: do not display the dashboard switcher button twice.

--- a/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
@@ -540,6 +540,11 @@ abstract class Base_Admin_Menu {
 	 * Adds a dashboard switcher to the list of screen meta links of the current page.
 	 */
 	public function add_dashboard_switcher() {
+		static $is_added = false;
+		if ( $is_added ) {
+			return;
+		}
+
 		$menu_mappings = require __DIR__ . '/menu-mappings.php';
 		$screen        = $this->get_current_screen();
 
@@ -566,6 +571,8 @@ abstract class Base_Admin_Menu {
 			</div>
 		</div>
 		<?php
+
+		$is_added = true;
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

Let's avoid triggering the display of the dashboard switcher twice.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See p1740550870653249-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* On a WordPress.com site, go to wp-admin > Users
* Ensure the dashboard switcher button in the top right corner only appears once.
