### PR TITLE
Gravatar Widget: Fix linked accounts not showing

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-gravatar-widget-accounts-not-showing
+++ b/projects/plugins/jetpack/changelog/fix-gravatar-widget-accounts-not-showing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Gravatar Widget: Fix linked accounts not showing

--- a/projects/plugins/jetpack/modules/widgets/gravatar-profile.css
+++ b/projects/plugins/jetpack/modules/widgets/gravatar-profile.css
@@ -15,12 +15,14 @@
 		.widget-grofile ul.grofile-accounts li::before {
 			content: "" !important; /* Kubrick :( */
 		}
+
+		.widget-grofile ul.grofile-accounts li a:focus {
+			outline: none;
+		}
+
 		.widget-grofile .grofile-accounts-logo {
-			background-image: url('https://secure.gravatar.com/images/grav-share-sprite.png');
-			background-repeat: no-repeat;
-			/*background-position: -16px -16px;*/
-			width: 16px; /* So we don't show the topmost logo */
-			height: 16px; /* So we don't show the topmost logo */
+			width: 24px;
+			height: 24px;
 			float: left;
 			margin-right: 8px;
 			margin-bottom: 8px;
@@ -34,13 +36,3 @@
 			width: 500px;
 			max-width: 100%;
 		}
-		@media
-only screen and (-webkit-min-device-pixel-ratio: 1.5),
-only screen and (-o-min-device-pixel-ratio: 3/2),
-only screen and (min--moz-device-pixel-ratio: 1.5),
-only screen and (min-device-pixel-ratio: 1.5) {
-		.widget-grofile .grofile-accounts-logo {
-			background-image: url('https://secure.gravatar.com/images/grav-share-sprite-2x.png');
-			background-size: 16px 784px;
-			}
-}

--- a/projects/plugins/jetpack/modules/widgets/gravatar-profile.php
+++ b/projects/plugins/jetpack/modules/widgets/gravatar-profile.php
@@ -267,7 +267,7 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 
 		<?php
 		foreach ( $accounts as $account ) :
-			if ( 'true' !== $account['verified'] ) {
+			if ( true !== $account['verified'] || true === $account['is_hidden'] ) {
 				continue;
 			}
 

--- a/projects/plugins/jetpack/modules/widgets/gravatar-profile.php
+++ b/projects/plugins/jetpack/modules/widgets/gravatar-profile.php
@@ -282,7 +282,10 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 
 			<li>
 				<a href="<?php echo esc_url( $account['url'] ); ?>" title="<?php echo esc_html( $link_title ); ?>">
-					<span class="grofile-accounts-logo grofile-accounts-<?php echo esc_attr( $account['shortname'] ); ?> accounts_<?php echo esc_attr( $account['shortname'] ); ?>"></span>
+					<span
+						class="grofile-accounts-logo grofile-accounts-<?php echo esc_attr( $account['shortname'] ); ?> accounts_<?php echo esc_attr( $account['shortname'] ); ?>"
+						style="background-image: url('<?php echo esc_attr( $account['iconUrl'] ); ?>')"
+					></span>
 				</a>
 			</li>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/87159

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* This fixes the linked Gravatar accounts not showing when the "Show Account Links" option is checked. It takes into account the "is_hidden" attribute as well which probably didn't exist in the first implementation.
* It also fixes the icon images not working.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how woul d you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install a theme that has widgets, e.g. Storefront.
* Go to WP Admin -> Appearance -> Widgets.
* Add the Gravatar Profile widget and use an email that has linked (verified) accounts.
* Make sure the accounts are displayed on the front end.

<img width="258" alt="image" src="https://github.com/user-attachments/assets/a1ced32f-be60-458f-a020-dba6e8c5ff0c" />
