### PR TITLE
Revert "Admin menu: do not display dashboard switcher twice (#42053)"

### DIFF
--- a/projects/packages/masterbar/changelog/fix-masterbar-switch-duplicate
+++ b/projects/packages/masterbar/changelog/fix-masterbar-switch-duplicate
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Admin menu: do not display the dashboard switcher button twice.

--- a/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
@@ -540,11 +540,6 @@ abstract class Base_Admin_Menu {
 	 * Adds a dashboard switcher to the list of screen meta links of the current page.
 	 */
 	public function add_dashboard_switcher() {
-		static $is_added = false;
-		if ( $is_added ) {
-			return;
-		}
-
 		$menu_mappings = require __DIR__ . '/menu-mappings.php';
 		$screen        = $this->get_current_screen();
 
@@ -571,8 +566,6 @@ abstract class Base_Admin_Menu {
 			</div>
 		</div>
 		<?php
-
-		$is_added = true;
 	}
 
 	/**


### PR DESCRIPTION
This reverts commit 69492b15f9e7c8eea36a6324c935f31c6fc0147f, from #42053.

## Proposed changes:

This needs to be reverted as the fix was not complete. It removed the duplicate button, but the button that is left can no longer be clicked.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

This is a revert, the bug should come back.

