### PR TITLE
Newsletter: Add the row with the subscribers information. 

### DIFF
--- a/projects/plugins/jetpack/changelog/add-newsletter-widget-first-row
+++ b/projects/plugins/jetpack/changelog/add-newsletter-widget-first-row
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added newsletter widget header row behind a feature flag.

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/index.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/index.tsx
@@ -7,6 +7,8 @@ declare global {
 		jetpackNewsletterWidgetConfigData?: {
 			hostname: string;
 			adminUrl: string;
+			emailSubscribers?: number;
+			paidSubscribers?: number;
 		};
 	}
 }
@@ -18,12 +20,20 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		return;
 	}
 
-	const { hostname, adminUrl } = window.jetpackNewsletterWidgetConfigData || {};
+	const { hostname, adminUrl, emailSubscribers, paidSubscribers } =
+		window.jetpackNewsletterWidgetConfigData || {};
 
 	if ( ! hostname || ! adminUrl ) {
 		return;
 	}
 
 	const root = createRoot( container );
-	root.render( <NewsletterWidget hostname={ hostname } adminUrl={ adminUrl } /> );
+	root.render(
+		<NewsletterWidget
+			hostname={ hostname }
+			adminUrl={ adminUrl }
+			emailSubscribers={ emailSubscribers }
+			paidSubscribers={ paidSubscribers }
+		/>
+	);
 } );

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/newsletter-widget.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/newsletter-widget.tsx
@@ -1,45 +1,87 @@
-import React from 'react';
 import './style.scss';
+import { Icon } from '@wordpress/components';
+import { envelope, payment } from '@wordpress/icons';
 
 interface NewsletterWidgetProps {
 	hostname: string;
 	adminUrl: string;
+	emailSubscribers?: number;
+	paidSubscribers?: number;
 }
 
 const WPCOM_BASE = 'https://wordpress.com';
 
-export const NewsletterWidget = ( { hostname, adminUrl }: NewsletterWidgetProps ) => {
+export const NewsletterWidget = ( {
+	hostname,
+	adminUrl,
+	emailSubscribers,
+	paidSubscribers,
+}: NewsletterWidgetProps ) => {
 	return (
-		<div className="newsletter-widget__footer">
-			<p className="newsletter-widget__footer-msg">
-				Effortlessly turn posts into emails with our Newsletter feature-expand your reach, engage
-				readers, and monetize your writing. No coding required.{ ' ' }
-				<a href={ `${ WPCOM_BASE }/learn/courses/newsletters-101/wordpress-com-newsletter/` }>
-					Learn more
-				</a>
-			</p>
-			<div>
-				<h3>Quick Links</h3>
-				<ul className="newsletter-widget__footer-list">
-					<li>
-						<a href={ `${ adminUrl }edit.php` }>Publish your next post</a>
-					</li>
-					<li>
-						<a href={ `${ WPCOM_BASE }/stats/subscribers/${ hostname }` }>View subscriber stats</a>
-					</li>
-					<li>
-						<a href={ `${ WPCOM_BASE }/subscribers/${ hostname }` }>Import subscribers</a>
-					</li>
-					<li>
-						<a href={ `${ WPCOM_BASE }/subscribers/${ hostname }` }>Manage subscribers</a>
-					</li>
-					<li>
-						<a href={ `${ WPCOM_BASE }/earn/${ hostname }` }>Monetize</a>
-					</li>
-					<li>
-						<a href={ `${ WPCOM_BASE }/settings/newsletter/${ hostname }` }>Newsletter settings</a>
-					</li>
-				</ul>
+		<div className="newsletter-widget">
+			<div className="newsletter-widget__header">
+				<div className="newsletter-widget__stats">
+					<span className="newsletter-widget__stat-item newsletter-widget__stat-item--left">
+						<span className="newsletter-widget__icon">
+							<Icon icon={ envelope } size={ 20 } />
+						</span>
+						<span className="newsletter-widget__stat-content">
+							<span className="newsletter-widget__stat-number">{ emailSubscribers }</span>
+							<span className="newsletter-widget__stat-label">
+								<a href={ `${ WPCOM_BASE }/stats/subscribers/${ hostname }` }>
+									email subscriptions
+								</a>
+							</span>
+						</span>
+					</span>
+					<span className="newsletter-widget__stat-item newsletter-widget__stat-item--right">
+						<span className="newsletter-widget__icon">
+							<Icon icon={ payment } size={ 20 } />
+						</span>
+						<span className="newsletter-widget__stat-content">
+							<span className="newsletter-widget__stat-number">{ paidSubscribers }</span>
+							<span className="newsletter-widget__stat-label">
+								<a href={ `${ WPCOM_BASE }/stats/subscribers/${ hostname }` }>paid subscriptions</a>
+							</span>
+						</span>
+					</span>
+				</div>
+			</div>
+			<div className="newsletter-widget__footer">
+				<p className="newsletter-widget__footer-msg">
+					Effortlessly turn posts into emails with our Newsletter feature-expand your reach, engage
+					readers, and monetize your writing. No coding required.{ ' ' }
+					<a href={ `${ WPCOM_BASE }/learn/courses/newsletters-101/wordpress-com-newsletter/` }>
+						Learn more
+					</a>
+				</p>
+				<div>
+					<h3>Quick Links</h3>
+					<ul className="newsletter-widget__footer-list">
+						<li>
+							<a href={ `${ adminUrl }edit.php` }>Publish your next post</a>
+						</li>
+						<li>
+							<a href={ `${ WPCOM_BASE }/stats/subscribers/${ hostname }` }>
+								View subscriber stats
+							</a>
+						</li>
+						<li>
+							<a href={ `${ WPCOM_BASE }/subscribers/${ hostname }` }>Import subscribers</a>
+						</li>
+						<li>
+							<a href={ `${ WPCOM_BASE }/subscribers/${ hostname }` }>Manage subscribers</a>
+						</li>
+						<li>
+							<a href={ `${ WPCOM_BASE }/earn/${ hostname }` }>Monetize</a>
+						</li>
+						<li>
+							<a href={ `${ WPCOM_BASE }/settings/newsletter/${ hostname }` }>
+								Newsletter settings
+							</a>
+						</li>
+					</ul>
+				</div>
 			</div>
 		</div>
 	);

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/style.scss
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/style.scss
@@ -33,22 +33,23 @@
 		text-decoration: none;
 	}
 
-	&__stat-item_email_subscribers {
-		margin-left: 4px;
-		
-	}
-
-	&__stat-item_paid_subscribers {
-		margin-left: 4px;
-	}
-
 	&__stats {
 		display: flex;
 		justify-content: space-between;
 		width: 100%;
 	}
 
+	&__icon {
+		display: inline-flex;
+		flex-direction: column;
+		align-items: flex-start;
+	}
+
 	&__stat-item {
+		display: flex;
+		align-items: center; 
+		gap: 4px;
+		text-decoration: none;
 		&--left {
 			margin-right: auto;
 		}
@@ -56,6 +57,10 @@
 		&--right {
 			margin-left: auto;
 		}
+	}
+
+	& a {
+		text-decoration: none;
 	}
 }
 

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/style.scss
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/style.scss
@@ -3,6 +3,10 @@
 .newsletter-widget {
 	$spacing: 12px;
 
+	&__header{
+		padding: $spacing;
+	}
+
 	&__footer {
 		background-color: $gray-100;
 		padding: $spacing;
@@ -18,6 +22,40 @@
 		padding-left: $spacing;
 		list-style-type: disc;
 		columns: 2;
+	}
+
+	&__stat-number {
+		margin-left: 4px;
+	}
+
+	&__stat-label {	
+		margin-left: 4px;
+		text-decoration: none;
+	}
+
+	&__stat-item_email_subscribers {
+		margin-left: 4px;
+		
+	}
+
+	&__stat-item_paid_subscribers {
+		margin-left: 4px;
+	}
+
+	&__stats {
+		display: flex;
+		justify-content: space-between;
+		width: 100%;
+	}
+
+	&__stat-item {
+		&--left {
+			margin-right: auto;
+		}
+
+		&--right {
+			margin-left: auto;
+		}
 	}
 }
 

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/index.test.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/index.test.tsx
@@ -3,11 +3,14 @@ import '../src/index';
 const mockRender = jest.fn();
 
 jest.mock( '@wordpress/element', () => {
+	const actualElement = jest.requireActual( '@wordpress/element' ); // Import the real module
+
 	return {
+		...actualElement, // Spread actual exports
 		createRoot: () => ( {
 			render: mockRender,
 		} ),
-		createElement: () => {},
+		memo: component => component, // Add memo to the mock
 	};
 } );
 

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/newsletter-widget.test.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/newsletter-widget.test.tsx
@@ -2,15 +2,37 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { NewsletterWidget } from '../src/newsletter-widget';
 
+// Add these mock declarations at the top of the file, before the tests
+jest.mock( '@wordpress/components', () => ( {
+	Icon: jest.fn( () => null ),
+} ) );
+
+jest.mock( '@wordpress/icons', () => ( {
+	envelope: 'envelope-icon-mock',
+	payment: 'payment-icon-mock',
+} ) );
+
 describe( 'NewsletterWidget', () => {
 	const defaultProps = {
 		hostname: 'example.com',
 		adminUrl: 'https://example.com/wp-admin/',
+		emailSubscribers: 100,
+		paidSubscribers: 50,
 	};
 
 	it( 'renders', () => {
 		render( <NewsletterWidget { ...defaultProps } /> );
 		expect( screen.getByText( 'Quick Links' ) ).toBeInTheDocument();
+		expect( screen.getByText( defaultProps.emailSubscribers ) ).toBeInTheDocument();
+
+		// Check for paid subscribers number
+		expect( screen.getByText( defaultProps.paidSubscribers ) ).toBeInTheDocument();
+
+		// Check for email subscriptions label
+		expect( screen.getByText( 'email subscriptions' ) ).toBeInTheDocument();
+
+		// Check for paid subscriptions label
+		expect( screen.getByText( 'paid subscriptions' ) ).toBeInTheDocument();
 	} );
 
 	it( 'displays the learn more link with correct href', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/loop/issues/449

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the email and paid subscriber row to the top of the widget

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/loop/issues/449

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


<img width="266" alt="Screenshot 2025-02-26 at 7 06 28 PM" src="https://github.com/user-attachments/assets/60e1a540-e208-4af3-a2e1-f3256c398ab5" />

This feature needs to be tested on Simple, Jetpack, and Atomic sites.

### Testing on Simple Sites
- Sandbox your Simple site
- In 0-sandbox.php, enable the newsletter widget by adding: `define( 'JETPACK_NEWSLETTER_WIDGET', true );`
- Sync your sandbox’s Jetpack version to this Jetpack branch by running the command mentioned in [this comment](https://github.com/Automattic/jetpack/pull/42060#issuecomment-2684907602).
- Go to wp-admin of your Simple site and confirm that the newsletter widget displays accurate email and paid subscribers information.

### Testing on Jetpack and Atomic Sites

- Enable the newsletter widget by adding `define( 'JETPACK_NEWSLETTER_WIDGET', true )` to your  your wp-config.php file. Modify the wp-config.php file at /srv/htdocs/wp-config.php. You can find the necessary SSH credentials in your JN site's wp-admin.
- Load this branch using the Jetpack Beta plugin.
After enabling the widget, verify in wp-admin that the newsletter widget correctly displays email and paid subscribers information.'



