### PR TITLE
wpcomsh: bilmur: Move bilmur attributes to meta tag

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-bilmur-meta-2
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-bilmur-meta-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: wpcomsh: bilmur: Move bilmur attributes to RDFa meta tag while keeping all RUM elements in footer
+
+

--- a/projects/plugins/wpcomsh/tests/WPCOMSH_RUM_Functions_Test.php
+++ b/projects/plugins/wpcomsh/tests/WPCOMSH_RUM_Functions_Test.php
@@ -9,7 +9,7 @@
  * Class Test_WPCOMSH_RUM_Functions
  */
 // phpcs:disable Squiz.Commenting.FunctionComment.WrongStyle
-class Test_WPCOMSH_RUM_Functions extends WP_UnitTestCase {
+class WPCOMSH_RUM_Functions_Test extends WP_UnitTestCase {
 	/**
 	 * Test that the script function is hooked correctly
 	 */

--- a/projects/plugins/wpcomsh/tests/test-wpcomsh-rum-functions.php
+++ b/projects/plugins/wpcomsh/tests/test-wpcomsh-rum-functions.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Wpcomsh Test file.
+ *
+ * @package wpcomsh
+ */
+
+/**
+ * Class Test_WPCOMSH_RUM_Functions
+ */
+// phpcs:disable Squiz.Commenting.FunctionComment.WrongStyle
+class Test_WPCOMSH_RUM_Functions extends WP_UnitTestCase {
+	/**
+	 * Test that the script function is hooked correctly
+	 */
+	public function test_wpcomsh_footer_rum_js_hooks() {
+		// Check if the function is hooked to wp_footer and admin_footer
+		$this->assertEquals(
+			10,
+			has_action( 'wp_footer', 'wpcomsh_footer_rum_js' ),
+			'wpcomsh_footer_rum_js is not properly hooked to wp_footer'
+		);
+
+		$this->assertEquals(
+			10,
+			has_action( 'admin_footer', 'wpcomsh_footer_rum_js' ),
+			'wpcomsh_footer_rum_js is not properly hooked to admin_footer'
+		);
+	}
+
+	/**
+	 * Test the output of wpcomsh_head_rum_meta
+	 */
+	public function test_wpcomsh_head_rum_meta_output() {
+		// Start output buffering
+		ob_start();
+		wpcomsh_footer_rum_js();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<meta id="bilmur"', $output );
+		$this->assertStringContainsString( 'property="bilmur:data"', $output );
+		$this->assertStringContainsString( 'data-provider="wordpress.com"', $output );
+		$this->assertStringContainsString( 'data-service="atomic"', $output );
+		$this->assertStringContainsString( 'bilmur.min.js', $output );
+	}
+}

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -617,12 +617,15 @@ function wpcomsh_footer_rum_js() {
 	$data_site_tz = 'data-site-tz="' . esc_attr( wpcomsh_stats_timezone_string() ) . '"';
 
 	printf(
-		'<script defer id="bilmur" %1$s data-provider="wordpress.com" data-service="%2$s" %3$s src="%4$s" %5$s></script>' . "\n", //phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		'<meta id="bilmur" property="bilmur:data" content="" %1$s data-provider="wordpress.com" data-service="%2$s" %3$s %4$s >' . "\n",
 		$rum_kv, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		esc_attr( $service ),
 		wp_kses_post( $allow_iframe ),
-		esc_url( 'https://s0.wp.com/wp-content/js/bilmur.min.js?m=' . gmdate( 'YW' ) ),
 		$data_site_tz // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	);
+	printf(
+		'<script defer src="%s"></script>' . "\n", //phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		esc_url( 'https://s0.wp.com/wp-content/js/bilmur.min.js?m=' . gmdate( 'YW' ) )
 	);
 }
 


### PR DESCRIPTION

## Proposed changes:

Fixes an issue where certain optimization plugins (particularly LiteSpeed Cache) modify script tags and inadvertently strip our RUM data attributes.

- Replaced the script tag with RUM data attributes with a meta tag using RDFa attributes
- Maintained the unique ID `bilmur`
- Added proper RDFa markup with `property="bilmur:data"` to follow standards

Since meta tags are less likely to be modified by optimization plugins, and the rum script already looks for an element with id="bilmur", this will work without further changes.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Make a WoA dev site, download Jetpack Beta, install it and switch wpcom site helper to this branch as explained in [the comment below](https://github.com/Automattic/jetpack/pull/42065#issuecomment-2685372870)
* Open the site in a browser and inspect the page source (Ctrl+U or right-click > View Source).
* Look for the `<script id="bilmur" ...>` tag in the footer.
* Look for a new `<meta id="bilmur" property="bilmur:data"` tag.
* Open the network tab and watch for the posts to boom.gif. They should still include the info like `&site_tz=America/Chicago` but it will have been sourced from the meta tag instead of the script tag.