### PR TITLE
Admin menu: do not display dashboard switcher twice

### DIFF
--- a/projects/packages/masterbar/changelog/fix-masterbar-switch-duplicate-take-two
+++ b/projects/packages/masterbar/changelog/fix-masterbar-switch-duplicate-take-two
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin menu: do not display the dashboard switcher button twice.

--- a/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
@@ -579,6 +579,11 @@ abstract class Base_Admin_Menu {
 	 * Adds a script to append the dashboard switcher to screen meta
 	 */
 	public function dashboard_switcher_scripts() {
+		static $is_script_added = false;
+		if ( $is_script_added ) {
+			return;
+		}
+
 		wp_add_inline_script(
 			'common',
 			"(function( $ ) {
@@ -587,16 +592,12 @@ abstract class Base_Admin_Menu {
 				var viewLink = $( '#view-link' );
 				var viewWrap = $( '#view-wrap' );
 
-				// Remove any existing click handlers before adding a new one
-				viewLink.off( 'click' ).on( 'click', function() {
-					console.log( 'click' );
+				viewLink.on( 'click', function() {
 					viewWrap.toggle();
 					viewLink.toggleClass( 'screen-meta-active' );
-					console.log( 'class is toggled' );
 				} );
 
-				// Use .off() before .on() to prevent duplicate handlers
-				$( document ).off( 'mouseup.viewWrapClose' ).on( 'mouseup.viewWrapClose', function( event ) {
+				$( document ).on( 'mouseup', function( event ) {
 					if ( ! viewLink.is( event.target ) && ! viewWrap.is( event.target ) && viewWrap.has( event.target ).length === 0 ) {
 						viewWrap.hide();
 						viewLink.removeClass( 'screen-meta-active' );
@@ -604,6 +605,8 @@ abstract class Base_Admin_Menu {
 				});
 			})( jQuery );"
 		);
+
+		$is_script_added = true;
 	}
 
 	/**

--- a/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
@@ -540,6 +540,11 @@ abstract class Base_Admin_Menu {
 	 * Adds a dashboard switcher to the list of screen meta links of the current page.
 	 */
 	public function add_dashboard_switcher() {
+		static $is_added = false;
+		if ( $is_added ) {
+			return;
+		}
+
 		$menu_mappings = require __DIR__ . '/menu-mappings.php';
 		$screen        = $this->get_current_screen();
 
@@ -566,6 +571,8 @@ abstract class Base_Admin_Menu {
 			</div>
 		</div>
 		<?php
+
+		$is_added = true;
 	}
 
 	/**
@@ -580,12 +587,16 @@ abstract class Base_Admin_Menu {
 				var viewLink = $( '#view-link' );
 				var viewWrap = $( '#view-wrap' );
 
-				viewLink.on( 'click', function() {
+				// Remove any existing click handlers before adding a new one
+				viewLink.off( 'click' ).on( 'click', function() {
+					console.log( 'click' );
 					viewWrap.toggle();
 					viewLink.toggleClass( 'screen-meta-active' );
+					console.log( 'class is toggled' );
 				} );
 
-				$( document ).on( 'mouseup', function( event ) {
+				// Use .off() before .on() to prevent duplicate handlers
+				$( document ).off( 'mouseup.viewWrapClose' ).on( 'mouseup.viewWrapClose', function( event ) {
 					if ( ! viewLink.is( event.target ) && ! viewWrap.is( event.target ) && viewWrap.has( event.target ).length === 0 ) {
 						viewWrap.hide();
 						viewLink.removeClass( 'screen-meta-active' );


### PR DESCRIPTION
## Proposed changes:

Let's avoid triggering the display of the dashboard switcher twice.

Take 2 of #42053

We also need to make changes to the js, because that js is added to the page twice.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Internal reference: p1740550870653249-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
No
## Testing instructions:

* On a WordPress.com site, go to wp-admin > Users
* Ensure the dashboard switcher button in the top right corner only appears once.
* Click on the button, and ensure it opens the little modal.
