### PR TITLE
Newsletter Dashboard Widget: update footer links

### DIFF
--- a/projects/plugins/jetpack/changelog/update-newsletter-widget-footer-links
+++ b/projects/plugins/jetpack/changelog/update-newsletter-widget-footer-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter Dashboard Widget: update footer links behind feature flag

--- a/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
@@ -50,13 +50,9 @@ class Jetpack_Newsletter_Dashboard_Widget {
 	 */
 	public static function get_config_data() {
 		$subscriber_counts = array();
-		$config_data       = array(
-			'hostname' => wp_parse_url( get_site_url(), PHP_URL_HOST ),
-			'adminUrl' => admin_url(),
-		);
+		$config_data       = array();
 
 		if ( Jetpack::is_connection_ready() ) {
-
 			$site_id  = Jetpack_Options::get_option( 'id' );
 			$api_path = sprintf( '/sites/%d/subscribers/counts', $site_id );
 			$response = Client::wpcom_json_api_request_as_blog(

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/index.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/index.tsx
@@ -1,6 +1,5 @@
 import * as jpDataUtils from '@automattic/jetpack-script-data';
 import { createRoot } from '@wordpress/element';
-import React from 'react';
 import { NewsletterWidget } from './newsletter-widget';
 
 declare global {
@@ -22,8 +21,9 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	const { emailSubscribers, paidSubscribers } = window.jetpackNewsletterWidgetConfigData || {};
 	const { suffix: site } = jpDataUtils.getSiteData();
 	const adminUrl = jpDataUtils.getAdminUrl();
+	const isWpcomSite = jpDataUtils.isWpcomPlatformSite();
 
-	if ( ! site || ! adminUrl ) {
+	if ( ! site || ! adminUrl || isWpcomSite === undefined ) {
 		return;
 	}
 
@@ -32,6 +32,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		<NewsletterWidget
 			site={ site }
 			adminUrl={ adminUrl }
+			isWpcomSite={ isWpcomSite }
 			emailSubscribers={ emailSubscribers }
 			paidSubscribers={ paidSubscribers }
 		/>

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/index.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/index.tsx
@@ -1,3 +1,4 @@
+import * as jpDataUtils from '@automattic/jetpack-script-data';
 import { createRoot } from '@wordpress/element';
 import React from 'react';
 import { NewsletterWidget } from './newsletter-widget';
@@ -5,8 +6,6 @@ import { NewsletterWidget } from './newsletter-widget';
 declare global {
 	interface Window {
 		jetpackNewsletterWidgetConfigData?: {
-			hostname: string;
-			adminUrl: string;
 			emailSubscribers?: number;
 			paidSubscribers?: number;
 		};
@@ -20,17 +19,18 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		return;
 	}
 
-	const { hostname, adminUrl, emailSubscribers, paidSubscribers } =
-		window.jetpackNewsletterWidgetConfigData || {};
+	const { emailSubscribers, paidSubscribers } = window.jetpackNewsletterWidgetConfigData || {};
+	const { suffix: site } = jpDataUtils.getSiteData();
+	const adminUrl = jpDataUtils.getAdminUrl();
 
-	if ( ! hostname || ! adminUrl ) {
+	if ( ! site || ! adminUrl ) {
 		return;
 	}
 
 	const root = createRoot( container );
 	root.render(
 		<NewsletterWidget
-			hostname={ hostname }
+			site={ site }
 			adminUrl={ adminUrl }
 			emailSubscribers={ emailSubscribers }
 			paidSubscribers={ paidSubscribers }

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/newsletter-widget.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/newsletter-widget.tsx
@@ -4,16 +4,21 @@ import { Icon } from '@wordpress/components';
 import { envelope, payment } from '@wordpress/icons';
 
 interface NewsletterWidgetProps {
-	hostname: string;
+	site: string;
 	adminUrl: string;
 	emailSubscribers?: number;
 	paidSubscribers?: number;
 }
 
+interface NewsletterWidgetProps {
+	site: string;
+	adminUrl: string;
+}
+
 const WPCOM_BASE = 'https://wordpress.com';
 
 export const NewsletterWidget = ( {
-	hostname,
+	site,
 	adminUrl,
 	emailSubscribers,
 	paidSubscribers,
@@ -29,9 +34,7 @@ export const NewsletterWidget = ( {
 						<span className="newsletter-widget__stat-content">
 							<span className="newsletter-widget__stat-number">{ emailSubscribers }</span>
 							<span className="newsletter-widget__stat-label">
-								<a href={ `${ WPCOM_BASE }/stats/subscribers/${ hostname }` }>
-									email subscriptions
-								</a>
+								<a href={ `${ WPCOM_BASE }/stats/subscribers/${ site }` }>email subscriptions</a>
 							</span>
 						</span>
 					</span>
@@ -42,7 +45,7 @@ export const NewsletterWidget = ( {
 						<span className="newsletter-widget__stat-content">
 							<span className="newsletter-widget__stat-number">{ paidSubscribers }</span>
 							<span className="newsletter-widget__stat-label">
-								<a href={ `${ WPCOM_BASE }/stats/subscribers/${ hostname }` }>paid subscriptions</a>
+								<a href={ `${ WPCOM_BASE }/stats/subscribers/${ site }` }>paid subscriptions</a>
 							</span>
 						</span>
 					</span>
@@ -63,23 +66,19 @@ export const NewsletterWidget = ( {
 							<a href={ `${ adminUrl }edit.php` }>Publish your next post</a>
 						</li>
 						<li>
-							<a href={ `${ WPCOM_BASE }/stats/subscribers/${ hostname }` }>
-								View subscriber stats
-							</a>
+							<a href={ `${ WPCOM_BASE }/stats/subscribers/${ site }` }>View subscriber stats</a>
 						</li>
 						<li>
-							<a href={ `${ WPCOM_BASE }/subscribers/${ hostname }` }>Import subscribers</a>
+							<a href={ `${ WPCOM_BASE }/subscribers/${ site }` }>Import subscribers</a>
 						</li>
 						<li>
-							<a href={ `${ WPCOM_BASE }/subscribers/${ hostname }` }>Manage subscribers</a>
+							<a href={ `${ WPCOM_BASE }/subscribers/${ site }` }>Manage subscribers</a>
 						</li>
 						<li>
-							<a href={ `${ WPCOM_BASE }/earn/${ hostname }` }>Monetize</a>
+							<a href={ `${ WPCOM_BASE }/earn/${ site }` }>Monetize</a>
 						</li>
 						<li>
-							<a href={ `${ WPCOM_BASE }/settings/newsletter/${ hostname }` }>
-								Newsletter settings
-							</a>
+							<a href={ `${ WPCOM_BASE }/settings/newsletter/${ site }` }>Newsletter settings</a>
 						</li>
 					</ul>
 				</div>

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/newsletter-widget.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/newsletter-widget.tsx
@@ -1,3 +1,4 @@
+import { getSiteData, getAdminUrl } from '@automattic/jetpack-script-data';
 import './style.scss';
 import { Icon } from '@wordpress/components';
 import { envelope, payment } from '@wordpress/icons';

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/newsletter-widget.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/newsletter-widget.tsx
@@ -1,4 +1,4 @@
-import { getSiteData, getAdminUrl } from '@automattic/jetpack-script-data';
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import './style.scss';
 import { Icon } from '@wordpress/components';
 import { envelope, payment } from '@wordpress/icons';
@@ -6,20 +6,31 @@ import { envelope, payment } from '@wordpress/icons';
 interface NewsletterWidgetProps {
 	site: string;
 	adminUrl: string;
+	isWpcomSite: boolean;
 	emailSubscribers?: number;
 	paidSubscribers?: number;
 }
 
-interface NewsletterWidgetProps {
-	site: string;
-	adminUrl: string;
-}
-
-const WPCOM_BASE = 'https://wordpress.com';
+/**
+ * Helper function to build the Jetpack redirect source URL.
+ * @param url         - The url to redirect to. Note: it can only be to a whitelisted domain, and query params and anchors must be passed to getRedirectUrl as arguments.
+ * @param isWpcomSite - The the site on the WordPress.com platform. Simple or WoA.
+ * @return The URL that can be passed to the getRedirectUrl function.
+ * @example
+ * const site = 'example.wordpress.com';
+ * const redirectUrl = buildJPRedirectSource( `subscribers/${ site }`, true );
+ *
+ * <a href={ getRedirectUrl( redirectUrl ) }>Subscriber</a>;
+ */
+const buildJPRedirectSource = ( url: string, isWpcomSite: boolean = true ) => {
+	const host = isWpcomSite ? 'wordpress.com' : 'cloud.jetpack.com';
+	return `https://${ host }/${ url }`;
+};
 
 export const NewsletterWidget = ( {
 	site,
 	adminUrl,
+	isWpcomSite,
 	emailSubscribers,
 	paidSubscribers,
 }: NewsletterWidgetProps ) => {
@@ -34,7 +45,15 @@ export const NewsletterWidget = ( {
 						<span className="newsletter-widget__stat-content">
 							<span className="newsletter-widget__stat-number">{ emailSubscribers }</span>
 							<span className="newsletter-widget__stat-label">
-								<a href={ `${ WPCOM_BASE }/stats/subscribers/${ site }` }>email subscriptions</a>
+								<a
+									href={
+										isWpcomSite
+											? getRedirectUrl( buildJPRedirectSource( `stats/subscribers/${ site }` ) )
+											: `${ adminUrl }admin.php?page=stats#!/stats/subscribers/${ site }`
+									}
+								>
+									email subscriptions
+								</a>
 							</span>
 						</span>
 					</span>
@@ -45,7 +64,15 @@ export const NewsletterWidget = ( {
 						<span className="newsletter-widget__stat-content">
 							<span className="newsletter-widget__stat-number">{ paidSubscribers }</span>
 							<span className="newsletter-widget__stat-label">
-								<a href={ `${ WPCOM_BASE }/stats/subscribers/${ site }` }>paid subscriptions</a>
+								<a
+									href={
+										isWpcomSite
+											? getRedirectUrl( buildJPRedirectSource( `stats/subscribers/${ site }` ) )
+											: `${ adminUrl }admin.php?page=stats#!/stats/subscribers/${ site }`
+									}
+								>
+									paid subscriptions
+								</a>
 							</span>
 						</span>
 					</span>
@@ -55,7 +82,11 @@ export const NewsletterWidget = ( {
 				<p className="newsletter-widget__footer-msg">
 					Effortlessly turn posts into emails with our Newsletter feature-expand your reach, engage
 					readers, and monetize your writing. No coding required.{ ' ' }
-					<a href={ `${ WPCOM_BASE }/learn/courses/newsletters-101/wordpress-com-newsletter/` }>
+					<a
+						href={ getRedirectUrl(
+							buildJPRedirectSource( 'learn/courses/newsletters-101/wordpress-com-newsletter' )
+						) }
+					>
 						Learn more
 					</a>
 				</p>
@@ -66,19 +97,56 @@ export const NewsletterWidget = ( {
 							<a href={ `${ adminUrl }edit.php` }>Publish your next post</a>
 						</li>
 						<li>
-							<a href={ `${ WPCOM_BASE }/stats/subscribers/${ site }` }>View subscriber stats</a>
+							<a
+								href={
+									isWpcomSite
+										? getRedirectUrl( buildJPRedirectSource( `stats/subscribers/${ site }` ) )
+										: `${ adminUrl }admin.php?page=stats#!/stats/subscribers/${ site }`
+								}
+							>
+								View subscriber stats
+							</a>
 						</li>
 						<li>
-							<a href={ `${ WPCOM_BASE }/subscribers/${ site }` }>Import subscribers</a>
+							<a
+								href={ getRedirectUrl(
+									buildJPRedirectSource( `subscribers/${ site }`, isWpcomSite )
+								) }
+							>
+								Import subscribers
+							</a>
 						</li>
 						<li>
-							<a href={ `${ WPCOM_BASE }/subscribers/${ site }` }>Manage subscribers</a>
+							<a
+								href={ getRedirectUrl(
+									buildJPRedirectSource( `subscribers/${ site }`, isWpcomSite )
+								) }
+							>
+								Manage subscribers
+							</a>
 						</li>
 						<li>
-							<a href={ `${ WPCOM_BASE }/earn/${ site }` }>Monetize</a>
+							<a
+								href={ getRedirectUrl(
+									buildJPRedirectSource(
+										`${ isWpcomSite ? 'earn' : 'monetize' }/${ site }`,
+										isWpcomSite
+									)
+								) }
+							>
+								Monetize
+							</a>
 						</li>
 						<li>
-							<a href={ `${ WPCOM_BASE }/settings/newsletter/${ site }` }>Newsletter settings</a>
+							<a
+								href={
+									isWpcomSite
+										? getRedirectUrl( buildJPRedirectSource( `settings/newsletter/${ site }` ) )
+										: `${ adminUrl }admin.php?page=jetpack#newsletter`
+								}
+							>
+								Newsletter settings
+							</a>
 						</li>
 					</ul>
 				</div>

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/index.test.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { JetpackScriptData } from '@automattic/jetpack-script-data';
 import '../src/index';
 
 const mockRender = jest.fn();
@@ -14,13 +15,19 @@ jest.mock( '@wordpress/element', () => {
 	};
 } );
 
+const defaultScriptData = {
+	site: {
+		admin_url: 'https://example.com/wp-admin/',
+		suffix: 'example.com',
+	},
+} as JetpackScriptData;
+
 describe( 'Newsletter Widget Initialization', () => {
 	beforeEach( () => {
-		// Reset the DOM
 		document.body.innerHTML = '';
-		// Reset window config
-		delete window.jetpackNewsletterWidgetConfigData;
-		// Clear mock
+
+		window.JetpackScriptData = defaultScriptData;
+
 		mockRender.mockClear();
 	} );
 
@@ -30,8 +37,11 @@ describe( 'Newsletter Widget Initialization', () => {
 	} );
 
 	it( 'does not create root when config data is missing', () => {
+		window.JetpackScriptData = { site: { admin_url: '', suffix: '' } } as JetpackScriptData;
 		document.body.innerHTML = '<div id="newsletter-widget-app"></div>';
+
 		document.dispatchEvent( new Event( 'DOMContentLoaded' ) );
+
 		expect( mockRender ).not.toHaveBeenCalled();
 	} );
 
@@ -39,11 +49,6 @@ describe( 'Newsletter Widget Initialization', () => {
 		const container = document.createElement( 'div' );
 		container.id = 'newsletter-widget-app';
 		document.body.appendChild( container );
-
-		window.jetpackNewsletterWidgetConfigData = {
-			hostname: 'example.com',
-			adminUrl: 'https://example.com/wp-admin/',
-		};
 
 		document.dispatchEvent( new Event( 'DOMContentLoaded' ) );
 

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/newsletter-widget.test.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/newsletter-widget.test.tsx
@@ -1,3 +1,4 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { NewsletterWidget } from '../src/newsletter-widget';
@@ -16,6 +17,7 @@ describe( 'NewsletterWidget', () => {
 	const defaultProps = {
 		site: 'example.com',
 		adminUrl: 'https://example.com/wp-admin/',
+		isWpcomSite: true,
 		emailSubscribers: 100,
 		paidSubscribers: 50,
 	};
@@ -40,11 +42,14 @@ describe( 'NewsletterWidget', () => {
 		const learnMoreLink = screen.getByText( 'Learn more' );
 		expect( learnMoreLink ).toHaveAttribute(
 			'href',
-			'https://wordpress.com/learn/courses/newsletters-101/wordpress-com-newsletter/'
+			getRedirectUrl(
+				'https://wordpress.com/learn/courses/newsletters-101/wordpress-com-newsletter'
+			)
 		);
 	} );
 
-	it( 'renders all quick links with correct hrefs', () => {
+	it( 'renders correct quick links when hosted on WordPress.com', () => {
+		const redirectDomain = 'wordpress.com';
 		render( <NewsletterWidget { ...defaultProps } /> );
 
 		const expectedLinks = [
@@ -54,23 +59,65 @@ describe( 'NewsletterWidget', () => {
 			},
 			{
 				text: 'View subscriber stats',
-				href: 'https://wordpress.com/stats/subscribers/example.com',
+				href: getRedirectUrl(
+					`https://${ redirectDomain }/stats/subscribers/${ defaultProps.site }`
+				),
 			},
 			{
 				text: 'Import subscribers',
-				href: 'https://wordpress.com/subscribers/example.com',
+				href: getRedirectUrl( `https://${ redirectDomain }/subscribers/${ defaultProps.site }` ),
 			},
 			{
 				text: 'Manage subscribers',
-				href: 'https://wordpress.com/subscribers/example.com',
+				href: getRedirectUrl( `https://${ redirectDomain }/subscribers/${ defaultProps.site }` ),
 			},
 			{
 				text: 'Monetize',
-				href: 'https://wordpress.com/earn/example.com',
+				href: getRedirectUrl( `https://${ redirectDomain }/earn/${ defaultProps.site }` ),
 			},
 			{
 				text: 'Newsletter settings',
-				href: 'https://wordpress.com/settings/newsletter/example.com',
+				href: getRedirectUrl(
+					`https://${ redirectDomain }/settings/newsletter/${ defaultProps.site }`
+				),
+			},
+		];
+
+		expectedLinks.forEach( ( { text, href } ) => {
+			const link = screen.getByText( text );
+			expect( link ).toBeInTheDocument();
+			expect( link ).toHaveAttribute( 'href', href );
+		} );
+	} );
+
+	it( 'renders correct quick links when self-hosted', () => {
+		const redirectDomain = 'cloud.jetpack.com';
+		render( <NewsletterWidget { ...defaultProps } isWpcomSite={ false } /> );
+
+		const expectedLinks = [
+			{
+				text: 'Publish your next post',
+				href: `https://${ defaultProps.site }/wp-admin/edit.php`,
+			},
+			{
+				text: 'View subscriber stats',
+				href: `https://${ defaultProps.site }/wp-admin/admin.php?page=stats#!/stats/subscribers/${ defaultProps.site }`,
+			},
+			{
+				text: 'Import subscribers',
+				href: getRedirectUrl( `https://${ redirectDomain }/subscribers/${ defaultProps.site }` ),
+			},
+			{
+				text: 'Manage subscribers',
+				href: getRedirectUrl( `https://${ redirectDomain }/subscribers/${ defaultProps.site }` ),
+			},
+			{
+				text: 'Monetize',
+				href: getRedirectUrl( `https://${ redirectDomain }/monetize/${ defaultProps.site }` ),
+			},
+			{
+				text: 'Newsletter settings',
+				href: `https://${ defaultProps.site }/wp-admin/admin.php?page=jetpack#newsletter`,
 			},
 		];
 

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/newsletter-widget.test.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/newsletter-widget.test.tsx
@@ -14,7 +14,7 @@ jest.mock( '@wordpress/icons', () => ( {
 
 describe( 'NewsletterWidget', () => {
 	const defaultProps = {
-		hostname: 'example.com',
+		site: 'example.com',
 		adminUrl: 'https://example.com/wp-admin/',
 		emailSubscribers: 100,
 		paidSubscribers: 50,

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/tsconfig.json
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../../tsconfig.json",
+	"include": [ "src/**/*.tsx", "src/**/*.ts", "test/**/*.tsx", "test/**/*.ts" ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes Automattic/loop#451

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the links in the footer to point to the correct destination depending on if the site is on WPCOM (Simple or WoA) or not.
* WPCOM sites will link to the Calypso view and others will either link to JP Cloud or the Jetpack view.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* This should be tested on Simple, Atomic, and Self-hosted
* This widget is behind a feature flag so a  `define( 'JETPACK_NEWSLETTER_WIDGET', true );` must be added to each env to enable it. See "Feature Flags" in pg9MHR-ox-p2 for more information on how to do that for each of the three envs.
* Once you have your envs configured to show the feature, you need to checkout this Jetpack branch in each env. [This comment](https://github.com/Automattic/jetpack/pull/42048#issuecomment-2683385342) will guide you with how to do that.
* Once you have your features flags set and the code checked out go to `wp-admin` and verify the widget links navigate correctly.

