### PR TITLE
Add label "Reader" to top nav on Atomic sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-reader-masterbar-text
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-reader-masterbar-text
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Add Reader text to the masterbar icon to match Calypso

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -220,10 +220,8 @@ function wpcom_add_reader_menu( $wp_admin_bar ) {
 	$wp_admin_bar->add_menu(
 		array(
 			'id'     => 'reader',
-			'title'  => '<span class="ab-icon" title="' . __( 'Read the blogs and topics you follow', 'jetpack-mu-wpcom' ) . '" aria-hidden="true"></span><span class="screen-reader-text">' .
-						/* translators: Hidden accessibility text. */
-						__( 'Reader', 'jetpack-mu-wpcom' ) .
-						'</span>',
+			'title'  => '<span class="ab-icon" title="' . __( 'Read the blogs and topics you follow', 'jetpack-mu-wpcom' ) . '" aria-hidden="true"></span>' .
+						__( 'Reader', 'jetpack-mu-wpcom' ),
 			'href'   => maybe_add_origin_site_id_to_url( 'https://wordpress.com/reader' ),
 			'meta'   => array(
 				'class' => 'wp-admin-bar-reader',

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -221,7 +221,7 @@ function wpcom_add_reader_menu( $wp_admin_bar ) {
 		array(
 			'id'     => 'reader',
 			'title'  => '<span class="ab-icon" title="' . __( 'Read the blogs and topics you follow', 'jetpack-mu-wpcom' ) . '" aria-hidden="true"></span>' .
-						__( 'Reader', 'jetpack-mu-wpcom' ),
+						'<span class="ab-label">' . __( 'Reader', 'jetpack-mu-wpcom' ) . '</span>',
 			'href'   => maybe_add_origin_site_id_to_url( 'https://wordpress.com/reader' ),
 			'meta'   => array(
 				'class' => 'wp-admin-bar-reader',

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -142,7 +142,7 @@
 			.ab-icon {
 				display: flex;
 				align-items: center;
-				padding: 0 8px;
+				padding: 0 6px;
 				margin: 0;
 				height: 100%;
 
@@ -157,6 +157,10 @@
 					mask-position: center;
 					mask-repeat: no-repeat;
 				}
+			}
+
+			.ab-label {
+				padding-right: 8px;
 			}
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -197,6 +197,10 @@
 			#wp-admin-bar-reader {
 				display: block;
 
+				.ab-label {
+					display: none;
+				}
+
 				.ab-item {
 					display: flex;
 					justify-content: center;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/loop/issues/518

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds Reader text to Reader icon in the masterbar for Atomic sites.
* Adjusts spacing to match Calypso on desktop

Before | After
--|--
<img width="1316" alt="Screenshot 2025-02-26 at 11 19 10 AM" src="https://github.com/user-attachments/assets/ca72c5fc-3a28-4bf2-9d08-25d6f775abdb" />  | <img width="1065" alt="Screenshot 2025-02-26 at 12 20 01 PM" src="https://github.com/user-attachments/assets/6bc1485a-6a1c-4b4c-93f5-e777510a0004" />




### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test on WPCOM
* Create a new WordPress.com site with a Business plan (but DO NOT take it Atomic).
* Add your new site to your host file so it points to your sandbox. (example.wordpress.com)
* Update wpcom on your sandbox with the command in the [comment](https://github.com/Automattic/jetpack/pull/42071#issuecomment-2685707673) below.
* Go to https://example.wordpress.com/wp-admin/edit.php and compare the masterbar to https://wordpress.com/home/example.wordpress.com. They should look pixel-perfect on the desktop. On mobile view, they are also similar but the spacing is a little different on all the icons (not addressed in this PR).

Test on Atomic
* Take your site Atomic by going to https://wordpress.com/hosting-features/example.wordpress.com and click "Activate now"
* When it is done "activating" go to https://example.wpcomstaging.com/wp-admin/
* You'll notice the "Reader" text is missing. That's because this PR has not yet been applied to your Atomic site.
* Apply this PR to your atomic site using [the Jetpack Beta plugin](https://jetpack.com/download-jetpack-beta/). Once the plugin is active, go to /wp-admin/admin.php?page=jetpack-beta, select "WordPress.com Features", and activate this `update/reader-masterbar-text` branch.
* Almost there, now you need to update the wp-config.php file on your Atomic site via SSH.
* Go to https://wordpress.com/sites/settings/sftp-ssh/example.wpcomstaging.com and enable SSH.
* SSH into your Atomic site and add `define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true );` to the top of your /htdocs/wp-config.php file and save it.
* Go back to https://example.wpcomstaging.com/wp-admin/ You should see the "Reader" text.

