### PR TITLE
Forms: Show plugin integrations on atomic

### DIFF
--- a/projects/packages/forms/changelog/update-show-form-plugin-integrations-atomic
+++ b/projects/packages/forms/changelog/update-show-form-plugin-integrations-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Show plugin integrations on Atomic.

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -1,9 +1,5 @@
 import { ThemeProvider } from '@automattic/jetpack-components';
-import {
-	isAtomicSite,
-	isSimpleSite,
-	useModuleStatus,
-} from '@automattic/jetpack-shared-extension-utils';
+import { isSimpleSite, useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
 import {
 	InspectorControls,
 	URLInput,
@@ -233,7 +229,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 							instanceId={ instanceId }
 						/>
 					) }
-					{ ! ( isSimpleSite() || isAtomicSite() ) && (
+					{ ! isSimpleSite() && (
 						<>
 							{ canUserInstallPlugins && (
 								<PanelBody title={ __( 'CRM Connection', 'jetpack-forms' ) } initialOpen={ false }>


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Updates the contact form block so that plugin integrations panels show on Atomic. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1740577815218879-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Follow the instructions below to add the Jetpack beta tester plugin to an atomic site, and configure it to use this branch.
- Go to a page, add a contact form block. Confirm that you can see the CRM and Creative Mail plugin panels in the form block sidebar.  