### PR TITLE
Connection: add modal for disconnecting owner account in dashboard

### DIFF
--- a/projects/js-packages/connection/changelog/add-disconnect-owner-dashboard
+++ b/projects/js-packages/connection/changelog/add-disconnect-owner-dashboard
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Enabled connection owner disconnection in dashboard.

--- a/projects/js-packages/connection/components/manage-connection-dialog/style.scss
+++ b/projects/js-packages/connection/components/manage-connection-dialog/style.scss
@@ -107,6 +107,11 @@
 			fill: var( --jp-red );
 		}
 
+		.check-users {
+			color: var( --jp-black );
+			fill: var( --jp-black );
+		}
+
 	}
 
 	.components-notice {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/connections.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/connections.jsx
@@ -113,7 +113,7 @@ export class DashConnections extends Component {
 	 * @returns {string}
 	 */
 	userConnection() {
-		const maybeShowLinkUnlinkBtn = this.props.isConnectionOwner ? null : (
+		const maybeShowLinkUnlinkBtn = (
 			<ConnectButton asBanner connectUser={ true } from="connection-settings" />
 		);
 

--- a/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
@@ -21,6 +21,7 @@ import {
 	isCurrentUserLinked as _isCurrentUserLinked,
 	isUnlinkingUser as _isUnlinkingUser,
 	isConnectingUser as _isConnectingUser,
+	isConnectionOwner,
 	fetchSiteConnectionStatus,
 	fetchConnectUrl,
 } from 'state/connection';
@@ -38,8 +39,9 @@ import {
 } from 'state/initial-state';
 import { getSiteBenefits } from 'state/site';
 import onKeyDownCallback from 'utils/onkeydown-callback';
-import './style.scss';
 import JetpackBenefits from '../jetpack-benefits';
+import OwnerDisconnectDialog from '../owner-disconnect-dialog';
+import './style.scss';
 
 export class ConnectButton extends React.Component {
 	static displayName = 'ConnectButton';
@@ -55,6 +57,7 @@ export class ConnectButton extends React.Component {
 		autoOpenInDisconnectRoute: PropTypes.bool,
 		rna: PropTypes.bool,
 		compact: PropTypes.bool,
+		isConnectionOwner: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -65,6 +68,7 @@ export class ConnectButton extends React.Component {
 		autoOpenInDisconnectRoute: false,
 		rna: false,
 		compact: false,
+		isConnectionOwner: false,
 	};
 
 	constructor( props ) {
@@ -72,6 +76,7 @@ export class ConnectButton extends React.Component {
 		this.state = {
 			showModal:
 				props.autoOpenInDisconnectRoute && '#/disconnect' === getFragment( window.location.href ),
+			showOwnerDisconnectDialog: false,
 		};
 	}
 
@@ -84,9 +89,17 @@ export class ConnectButton extends React.Component {
 		this.toggleVisibility();
 	};
 
+	handleUserDisconnectClick = () => {
+		if ( this.props.isConnectionOwner ) {
+			this.setState( { showOwnerDisconnectDialog: true } );
+		} else {
+			this.props.unlinkUser();
+		}
+	};
+
 	handleDisconnected = () => {
-		this.props.fetchConnectUrl();
-		this.props.fetchSiteConnectionStatus();
+		// Refresh the page or update UI state after successful disconnect
+		window.location.reload();
 	};
 
 	toggleVisibility = () => {
@@ -128,12 +141,23 @@ export class ConnectButton extends React.Component {
 						role="button"
 						tabIndex="0"
 						className="jp-jetpack-unlink__button"
-						onKeyDown={ onKeyDownCallback( this.props.unlinkUser ) }
-						onClick={ this.props.unlinkUser }
+						onKeyDown={ onKeyDownCallback( this.handleUserDisconnectClick ) }
+						onClick={ this.handleUserDisconnectClick }
 						disabled={ this.props.isUnlinking }
 					>
 						{ this.props.connectLegend || __( 'Disconnect your WordPress.com account', 'jetpack' ) }
 					</a>
+
+					{ this.props.isConnectionOwner && this.state.showOwnerDisconnectDialog && (
+						<OwnerDisconnectDialog
+							isOpen={ this.state.showOwnerDisconnectDialog }
+							onClose={ this.handleOwnerDialogClose }
+							apiRoot={ this.props.apiRoot }
+							apiNonce={ this.props.apiNonce }
+							onDisconnected={ this.handleDisconnected }
+							onUnlinked={ this.handleDisconnected }
+						/>
+					) }
 				</div>
 			);
 		}
@@ -219,6 +243,10 @@ export class ConnectButton extends React.Component {
 		);
 	};
 
+	handleOwnerDialogClose = () => {
+		this.setState( { showOwnerDisconnectDialog: false } );
+	};
+
 	render() {
 		return (
 			<div>
@@ -227,7 +255,7 @@ export class ConnectButton extends React.Component {
 					<p className="jp-banner__tos-blurb">
 						{ createInterpolateElement(
 							__(
-								'By clicking the button below, you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>sync your site‘s data</shareDetailsLink> with us.',
+								`By clicking the button below, you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>sync your site's data</shareDetailsLink> with us.`,
 								'jetpack'
 							),
 							{
@@ -242,21 +270,23 @@ export class ConnectButton extends React.Component {
 					</p>
 				) }
 				{ this.renderContent() }
-				<DisconnectDialog
-					apiNonce={ this.props.apiNonce }
-					apiRoot={ this.props.apiRoot }
-					connectedPlugins={ this.props.connectedPlugins }
-					connectedUser={ {
-						ID: this.props.userWpComId,
-						login: this.props.userWpComLogin,
-					} }
-					connectedSiteId={ this.props.connectedSiteId }
-					disconnectStepComponent={ this.renderDisconnectStepComponent() }
-					onDisconnected={ this.handleDisconnected } // On disconnect, need to update the connection status in the app state.
-					isOpen={ this.state.showModal }
-					onClose={ this.toggleVisibility }
-					context={ 'jetpack' }
-				/>
+				{ ! this.state.showOwnerDisconnectDialog && (
+					<DisconnectDialog
+						apiNonce={ this.props.apiNonce }
+						apiRoot={ this.props.apiRoot }
+						connectedPlugins={ this.props.connectedPlugins }
+						connectedUser={ {
+							ID: this.props.userWpComId,
+							login: this.props.userWpComLogin,
+						} }
+						connectedSiteId={ this.props.connectedSiteId }
+						disconnectStepComponent={ this.renderDisconnectStepComponent() }
+						onDisconnected={ this.handleDisconnected }
+						isOpen={ this.state.showModal }
+						onClose={ this.toggleVisibility }
+						context={ 'jetpack' }
+					/>
+				) }
 			</div>
 		);
 	}
@@ -283,6 +313,7 @@ export default connect(
 			userWpComLogin: getUserWpComLogin( state ),
 			userWpComId: getUserWpComId( state ),
 			connectedSiteId: getSiteId( state ),
+			isConnectionOwner: isConnectionOwner( state ),
 		};
 	},
 	dispatch => {
@@ -293,8 +324,8 @@ export default connect(
 			fetchSiteConnectionStatus: () => {
 				return dispatch( fetchSiteConnectionStatus() );
 			},
-			unlinkUser: () => {
-				return dispatch( unlinkUser() );
+			unlinkUser: ( isOwner = false ) => {
+				return dispatch( unlinkUser( isOwner ) );
 			},
 			doConnectUser: ( featureLabel, from ) => {
 				return dispatch( _connectUser( featureLabel, from ) );

--- a/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
@@ -324,8 +324,8 @@ export default connect(
 			fetchSiteConnectionStatus: () => {
 				return dispatch( fetchSiteConnectionStatus() );
 			},
-			unlinkUser: ( isOwner = false ) => {
-				return dispatch( unlinkUser( isOwner ) );
+			unlinkUser: () => {
+				return dispatch( unlinkUser() );
 			},
 			doConnectUser: ( featureLabel, from ) => {
 				return dispatch( _connectUser( featureLabel, from ) );

--- a/projects/plugins/jetpack/_inc/client/components/owner-disconnect-dialog/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/owner-disconnect-dialog/index.jsx
@@ -51,6 +51,10 @@ const OwnerDisconnectDialog = ( { isOpen, onClose, apiRoot, apiNonce, onDisconne
 	const [ isDisconnecting, setIsDisconnecting ] = useState( false );
 	const [ disconnectError, setDisconnectError ] = useState( '' );
 
+	// Define translation strings as constants
+	const disconnectingText = __( 'Disconnecting…', 'jetpack' );
+	const disconnectText = __( 'Disconnect', 'jetpack' );
+
 	useEffect( () => {
 		restApi.setApiRoot( apiRoot );
 		restApi.setApiNonce( apiNonce );
@@ -165,9 +169,7 @@ const OwnerDisconnectDialog = ( { isOpen, onClose, apiRoot, apiNonce, onDisconne
 							isDestructive
 							disabled={ isDisconnecting }
 						>
-							{ isDisconnecting
-								? __( 'Disconnecting…', 'jetpack' )
-								: __( 'Disconnect', 'jetpack' ) }
+							{ isDisconnecting ? disconnectingText : disconnectText }
 						</Button>
 					</div>
 				</div>

--- a/projects/plugins/jetpack/_inc/client/components/owner-disconnect-dialog/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/owner-disconnect-dialog/index.jsx
@@ -1,0 +1,190 @@
+/**
+ * External dependencies
+ */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
+import restApi from '@automattic/jetpack-api';
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ExternalLink, Modal, Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Icon, chevronRight, external } from '@wordpress/icons';
+import clsx from 'clsx';
+import PropTypes from 'prop-types';
+import React, { useCallback, useState, useEffect } from 'react';
+
+const ActionCard = ( {
+	title,
+	onClick = () => null,
+	isExternal = false,
+	link = '#',
+	action,
+	disabled = false,
+} ) => {
+	const disabledCallback = useCallback( e => e.preventDefault(), [] );
+
+	return (
+		<div
+			className={
+				'jp-connection__manage-dialog__action-card card' + ( disabled ? ' disabled' : '' )
+			}
+		>
+			<div className="jp-connection__manage-dialog__action-card__card-content">
+				<a
+					href={ link }
+					className={ clsx( 'jp-connection__manage-dialog__action-card__card-headline', action ) }
+					onClick={ ! disabled ? onClick : disabledCallback }
+					target={ isExternal ? '_blank' : '_self' }
+					rel={ 'noopener noreferrer' }
+				>
+					{ title }
+					<Icon
+						icon={ isExternal ? external : chevronRight }
+						className="jp-connection__manage-dialog__action-card__icon"
+					/>
+				</a>
+			</div>
+		</div>
+	);
+};
+
+const OwnerDisconnectDialog = ( { isOpen, onClose, apiRoot, apiNonce, onDisconnected } ) => {
+	const [ isDisconnecting, setIsDisconnecting ] = useState( false );
+	const [ disconnectError, setDisconnectError ] = useState( '' );
+
+	useEffect( () => {
+		restApi.setApiRoot( apiRoot );
+		restApi.setApiNonce( apiNonce );
+	}, [ apiRoot, apiNonce ] );
+
+	const handleStayConnected = useCallback( () => {
+		onClose();
+	}, [ onClose ] );
+
+	const handleDisconnectAnyway = useCallback( () => {
+		jetpackAnalytics.tracks.recordEvent(
+			'jetpack_manage_connection_dialog_owner_disconnect_click'
+		);
+
+		setIsDisconnecting( true );
+		setDisconnectError( '' );
+
+		restApi
+			.unlinkUser( true, { disconnectAllUsers: true } )
+			.then( () => {
+				jetpackAnalytics.tracks.recordEvent(
+					'jetpack_manage_connection_dialog_owner_disconnect_success'
+				);
+				onDisconnected && onDisconnected();
+			} )
+			.catch( () => {
+				jetpackAnalytics.tracks.recordEvent(
+					'jetpack_manage_connection_dialog_owner_disconnect_error'
+				);
+				setDisconnectError(
+					__( 'There was a problem disconnecting your account. Please try again.', 'jetpack' )
+				);
+				setIsDisconnecting( false );
+			} );
+	}, [ onDisconnected ] );
+
+	return (
+		<Modal
+			title=""
+			contentLabel={ __( 'Disconnect Owner Account', 'jetpack' ) }
+			aria={ { labelledby: 'jp-connection__disconnect-dialog__heading' } }
+			onRequestClose={ handleStayConnected }
+			className="jp-connection__disconnect-dialog"
+			isOpen={ isOpen }
+		>
+			{ /* Modal content */ }
+			<div className="jp-connection__disconnect-dialog__content">
+				<h1 id="jp-connection__disconnect-dialog__heading">
+					{ __( 'Disconnect Owner Account', 'jetpack' ) }
+				</h1>
+				<p className="jp-connection__disconnect-dialog__large-text">
+					{ __(
+						'Disconnecting the owner account will remove the Jetpack connection for all users on this site. The site will remain connected.',
+						'jetpack'
+					) }
+				</p>
+				<ActionCard
+					title={ __( 'Transfer ownership to another admin', 'jetpack' ) }
+					link={ getRedirectUrl( 'calypso-settings-manage-connection' ) }
+					isExternal={ true }
+					action="transfer"
+				/>
+				<ActionCard
+					title={ __( 'View other connected accounts', 'jetpack' ) }
+					link="users.php"
+					action="check-users"
+				/>
+			</div>
+
+			<div className="jp-connection__disconnect-dialog__actions">
+				{ /* Footer content */ }
+				<div className="jp-row">
+					<div className="lg-col-span-8 md-col-span-9 sm-col-span-4">
+						<p>
+							{ createInterpolateElement(
+								__(
+									'<strong>Need help?</strong> Learn more about the <connectionInfoLink>Jetpack connection</connectionInfoLink> or <supportLink>contact Jetpack support</supportLink>',
+									'jetpack'
+								),
+								{
+									strong: <strong />,
+									connectionInfoLink: (
+										<ExternalLink
+											href={ getRedirectUrl(
+												'why-the-wordpress-com-connection-is-important-for-jetpack'
+											) }
+											className="jp-connection__disconnect-dialog__link"
+										/>
+									),
+									supportLink: (
+										<ExternalLink
+											href={ getRedirectUrl( 'jetpack-support' ) }
+											className="jp-connection__disconnect-dialog__link"
+										/>
+									),
+								}
+							) }
+						</p>
+					</div>
+					<div className="jp-connection__disconnect-dialog__button-wrap lg-col-span-4 md-col-span-7 sm-col-span-4">
+						<Button
+							variant="primary"
+							onClick={ handleStayConnected }
+							className="jp-connection__disconnect-dialog__btn-dismiss"
+						>
+							{ __( 'Stay Connected', 'jetpack' ) }
+						</Button>
+						<Button
+							variant="primary"
+							onClick={ handleDisconnectAnyway }
+							className="jp-connection__disconnect-dialog__btn-disconnect"
+							isDestructive
+							disabled={ isDisconnecting }
+						>
+							{ isDisconnecting
+								? __( 'Disconnecting…', 'jetpack' )
+								: __( 'Disconnect', 'jetpack' ) }
+						</Button>
+					</div>
+				</div>
+				{ disconnectError && (
+					<p className="jp-connection__disconnect-dialog__error">{ disconnectError }</p>
+				) }
+			</div>
+		</Modal>
+	);
+};
+
+OwnerDisconnectDialog.propTypes = {
+	isOpen: PropTypes.bool,
+	onClose: PropTypes.func,
+	apiRoot: PropTypes.string.isRequired,
+	apiNonce: PropTypes.string.isRequired,
+	onDisconnected: PropTypes.func,
+};
+
+export default OwnerDisconnectDialog;

--- a/projects/plugins/jetpack/_inc/client/components/owner-disconnect-dialog/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/owner-disconnect-dialog/test/component.js
@@ -1,0 +1,87 @@
+import { jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import OwnerDisconnectDialog from '../index';
+
+// Mock the external dependencies
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	tracks: {
+		recordEvent: jest.fn(),
+	},
+} ) );
+
+jest.mock( '@automattic/jetpack-api', () => ( {
+	setApiRoot: jest.fn(),
+	setApiNonce: jest.fn(),
+	unlinkUser: jest.fn().mockResolvedValue( {} ),
+} ) );
+
+describe( 'OwnerDisconnectDialog', () => {
+	const defaultProps = {
+		isOpen: true,
+		onClose: jest.fn(),
+		apiRoot: 'https://example.com/wp-json',
+		apiNonce: 'test-nonce',
+		onDisconnected: jest.fn(),
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should render the dialog when isOpen is true', () => {
+		render( <OwnerDisconnectDialog { ...defaultProps } /> );
+
+		expect( screen.getByText( 'Disconnect Owner Account' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Transfer ownership to another admin' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'View other connected accounts' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should call onClose when "Stay Connected" is clicked', async () => {
+		const user = userEvent.setup();
+		render( <OwnerDisconnectDialog { ...defaultProps } /> );
+
+		await user.click( screen.getByText( 'Stay Connected' ) );
+		expect( defaultProps.onClose ).toHaveBeenCalled();
+	} );
+
+	it( 'should show loading state when disconnecting', async () => {
+		const user = userEvent.setup();
+		render( <OwnerDisconnectDialog { ...defaultProps } /> );
+
+		const disconnectButton = screen.getByText( 'Disconnect' );
+		await user.click( disconnectButton );
+
+		expect( screen.getByText( 'Disconnecting…' ) ).toBeInTheDocument();
+		expect( disconnectButton ).toBeDisabled();
+	} );
+
+	it( 'should call onDisconnected when disconnect is successful', async () => {
+		const mockUnlinkUser = jest.fn().mockResolvedValue( {} );
+		require( '@automattic/jetpack-api' ).unlinkUser = mockUnlinkUser;
+
+		render( <OwnerDisconnectDialog { ...defaultProps } /> );
+		const user = userEvent.setup();
+		await user.click( screen.getByText( 'Disconnect' ) );
+
+		await expect( screen.findByText( 'Disconnecting…' ) ).resolves.toBeInTheDocument();
+		expect( mockUnlinkUser ).toHaveBeenCalledWith( true, { disconnectAllUsers: true } );
+		expect( defaultProps.onDisconnected ).toHaveBeenCalled();
+	} );
+
+	it( 'should show error message when disconnect fails', async () => {
+		require( '@automattic/jetpack-api' ).unlinkUser.mockRejectedValueOnce(
+			new Error( 'Failed to disconnect' )
+		);
+
+		render( <OwnerDisconnectDialog { ...defaultProps } /> );
+		const user = userEvent.setup();
+		await user.click( screen.getByText( 'Disconnect' ) );
+
+		await expect(
+			screen.findByText( 'There was a problem disconnecting your account. Please try again.' )
+		).resolves.toBeInTheDocument();
+		expect( defaultProps.onDisconnected ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/plugins/jetpack/changelog/add-disconnect-owner-dashboard
+++ b/projects/plugins/jetpack/changelog/add-disconnect-owner-dashboard
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Enabled connection owner disconnection in dashboard.


### PR DESCRIPTION
Recreated behavior added in https://github.com/Automattic/jetpack/pull/41923 in the dashbord.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Created a new component that mirrors the behavior of the previously added OwnerDisconnectDialog.
* Updated the CSS for color link in the Owner Disconnect modal.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a JN site and create several users with different roles. Connect at least two.
* Try disconnecting a nonprimary account in dashboard; it should work the same as before. Reconnect.
* Try disconnecting the connection owner. Try all links. Make sure that confirming disconnect will disconnect all user.
* Make sure all disconnections look and behave the same as the ones in MyJetpack.
