### PR TITLE
Jetpack: remove site registration nonce (step 1)

### DIFF
--- a/projects/js-packages/api/changelog/remove-site-registration-nonce-step-1
+++ b/projects/js-packages/api/changelog/remove-site-registration-nonce-step-1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove the register_nonce from site connection.

--- a/projects/js-packages/api/index.jsx
+++ b/projects/js-packages/api/index.jsx
@@ -83,11 +83,8 @@ function JetpackRestApiClient( root, nonce ) {
 			cacheBusterCallback = callback;
 		},
 
-		registerSite: ( registrationNonce, redirectUri, from ) => {
-			const params = {
-				registration_nonce: registrationNonce,
-				no_iframe: true,
-			};
+		registerSite: ( deprecated, redirectUri, from ) => {
+			const params = {};
 
 			if ( jetpackConfigHas( 'consumer_slug' ) ) {
 				params.plugin_slug = jetpackConfigGet( 'consumer_slug' );

--- a/projects/js-packages/connection/changelog/remove-site-registration-nonce-step-1
+++ b/projects/js-packages/connection/changelog/remove-site-registration-nonce-step-1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove register_nonce from site connection.

--- a/projects/js-packages/connection/state/controls.jsx
+++ b/projects/js-packages/connection/state/controls.jsx
@@ -2,8 +2,7 @@ import restApi from '@automattic/jetpack-api';
 import { createRegistryControl } from '@wordpress/data';
 import STORE_ID from './store-id';
 
-const REGISTER_SITE = ( { registrationNonce, redirectUri, from } ) =>
-	restApi.registerSite( registrationNonce, redirectUri, from );
+const REGISTER_SITE = ( { redirectUri, from } ) => restApi.registerSite( null, redirectUri, from );
 
 const CONNECT_USER = createRegistryControl(
 	( { resolveSelect } ) =>

--- a/projects/js-packages/connection/state/test/controls.jsx
+++ b/projects/js-packages/connection/state/test/controls.jsx
@@ -24,15 +24,14 @@ describe( 'controls', () => {
 
 	describe( 'REGISTER_SITE', () => {
 		it( 'resolves with result', async () => {
-			const registrationNonce = 'REGISTRATION_NONCE';
 			const redirectUri = 'REDIRECT_URI';
 			const from = 'FROM';
 			const fakeResult = {};
 			stubRegisterSite.mockResolvedValue( fakeResult );
 
-			const result = await registerSite( { registrationNonce, redirectUri, from } );
+			const result = await registerSite( { redirectUri, from } );
 			expect( result ).toEqual( fakeResult );
-			expect( stubRegisterSite ).toHaveBeenCalledWith( registrationNonce, redirectUri, from );
+			expect( stubRegisterSite ).toHaveBeenCalledWith( redirectUri, from );
 		} );
 
 		it( 'resolves with error', async () => {

--- a/projects/js-packages/connection/state/test/controls.jsx
+++ b/projects/js-packages/connection/state/test/controls.jsx
@@ -31,7 +31,7 @@ describe( 'controls', () => {
 
 			const result = await registerSite( { redirectUri, from } );
 			expect( result ).toEqual( fakeResult );
-			expect( stubRegisterSite ).toHaveBeenCalledWith( redirectUri, from );
+			expect( stubRegisterSite ).toHaveBeenCalledWith( null, redirectUri, from );
 		} );
 
 		it( 'resolves with error', async () => {

--- a/projects/packages/connection/changelog/remove-site-registration-nonce-step-1
+++ b/projects/packages/connection/changelog/remove-site-registration-nonce-step-1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove register_nonce from site connection.

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -228,19 +228,15 @@ class REST_Connector {
 				'callback'            => array( $this, 'connection_register' ),
 				'permission_callback' => __CLASS__ . '::jetpack_register_permission_check',
 				'args'                => array(
-					'from'               => array(
+					'from'         => array(
 						'description' => __( 'Indicates where the registration action was triggered for tracking/segmentation purposes', 'jetpack-connection' ),
 						'type'        => 'string',
 					),
-					'registration_nonce' => array(
-						'description' => __( 'The registration nonce', 'jetpack-connection' ),
-						'type'        => 'string',
-					),
-					'redirect_uri'       => array(
+					'redirect_uri' => array(
 						'description' => __( 'URI of the admin page where the user should be redirected after connection flow', 'jetpack-connection' ),
 						'type'        => 'string',
 					),
-					'plugin_slug'        => array(
+					'plugin_slug'  => array(
 						'description' => __( 'Indicates from what plugin the request is coming from', 'jetpack-connection' ),
 						'type'        => 'string',
 					),
@@ -836,9 +832,10 @@ class REST_Connector {
 	}
 
 	/**
-	 * The endpoint tried to partially or fully reconnect the website to WP.com.
+	 * The endpoint tried to connect Jetpack site to WPCOM.
 	 *
 	 * @since 1.7.0
+	 * @since $$next-version$$ No longer needs `registration_nonce`.
 	 * @since-jetpack 7.7.0
 	 *
 	 * @param \WP_REST_Request $request The request sent to the WP REST API.
@@ -846,11 +843,6 @@ class REST_Connector {
 	 * @return \WP_REST_Response|WP_Error
 	 */
 	public function connection_register( $request ) {
-		// Only require nonce if cookie authentication is used.
-		if ( did_action( 'auth_cookie_valid' ) && ! wp_verify_nonce( $request->get_param( 'registration_nonce' ), 'jetpack-registration-nonce' ) ) {
-			return new WP_Error( 'invalid_nonce', __( 'Unable to verify your request.', 'jetpack-connection' ), array( 'status' => 403 ) );
-		}
-
 		if ( isset( $request['from'] ) ) {
 			$this->connection->add_register_request_param( 'from', (string) $request['from'] );
 		}


### PR DESCRIPTION
## Proposed changes:
Remove `registration_nonce` from site connection endpoint, and the JS API client that calls it.
We already have WP nonce in there, so another nonce is excessive and hinders our progress on other projects.

To prevent potential issues, this PR will only remove its usage with minimal change in JS components.
Full cleanup will happen in a follow-up PR to be merged early in the next release cycle.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
PT: pf5801-1dm-p2
Justification: pf5801-1q1-p2#comment-787

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Test connection flow in Jetpack-the-plugin, My Jetpack, and a few standalone plugins.
Check for JS errors.