### PR TITLE
Update move product ownership data fully to frontend

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2893,6 +2893,9 @@ importers:
       '@types/jest':
         specifier: 29.5.14
         version: 29.5.14
+      '@types/node':
+        specifier: ^20.4.2
+        version: 20.17.17
       '@types/react':
         specifier: 18.3.18
         version: 18.3.18
@@ -2901,7 +2904,7 @@ importers:
         version: 7.6.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0
+        version: 29.7.0(@types/node@20.17.17)
       jest-environment-jsdom:
         specifier: 29.7.0
         version: 29.7.0

--- a/projects/packages/my-jetpack/_inc/components/action-button/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/action-button/index.tsx
@@ -7,7 +7,7 @@ import { PRODUCT_STATUSES, MyJetpackRoutes } from '../../constants';
 import useActivatePlugins from '../../data/products/use-activate-plugins';
 import useInstallPlugins from '../../data/products/use-install-plugins';
 import useProduct from '../../data/products/use-product';
-import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
+import useProductsByOwnership from '../../data/products/use-products-by-ownership';
 import useAnalytics from '../../hooks/use-analytics';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
@@ -40,8 +40,9 @@ const ActionButton: FC< ActionButtonProps > = ( {
 	tracksIdentifier,
 	labelSuffixId,
 } ) => {
-	const { lifecycleStats } = getMyJetpackWindowInitialState();
-	const { ownedProducts } = lifecycleStats;
+	const {
+		data: { ownedProducts },
+	} = useProductsByOwnership();
 
 	const [ isDropdownOpen, setIsDropdownOpen ] = useState( false );
 	const [ currentAction, setCurrentAction ] = useState< ComponentProps< typeof Button > >( {} );

--- a/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/index.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 import { useState, useEffect, useCallback, useRef } from 'react';
 import useEvaluationRecommendations from '../../data/evaluation-recommendations/use-evaluation-recommendations';
 import useAnalytics from '../../hooks/use-analytics';
+import LoadingBlock from '../loading-block';
 import { JetpackModuleToProductCard } from '../product-cards-section/all';
 import styles from './style.module.scss';
 import type { FC, RefObject } from 'react';
@@ -13,7 +14,7 @@ import type { FC, RefObject } from 'react';
 const EvaluationRecommendations: FC = () => {
 	const containerRef = useRef( null );
 	const { recordEvent } = useAnalytics();
-	const { recommendedModules, redoEvaluation, removeEvaluationResult } =
+	const { recommendedModules, redoEvaluation, removeEvaluationResult, isProductOwnershipLoading } =
 		useEvaluationRecommendations();
 	const [ isAtStart, setIsAtStart ] = useState( true );
 	const [ isAtEnd, setIsAtEnd ] = useState( false );
@@ -133,6 +134,13 @@ const EvaluationRecommendations: FC = () => {
 					{ recommendedModules.map( module => {
 						const moduleName = module.replace( 'feature_', '' );
 						const Card = JetpackModuleToProductCard[ moduleName ];
+						if ( isProductOwnershipLoading ) {
+							return (
+								<Col tagName="li" key={ module } lg={ 4 }>
+									<LoadingBlock width="100%" height="200px" />
+								</Col>
+							);
+						}
 						return (
 							Card && (
 								<Col tagName="li" key={ module } lg={ 4 }>

--- a/projects/packages/my-jetpack/_inc/components/loading-block/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/loading-block/index.tsx
@@ -1,9 +1,15 @@
+import clsx from 'clsx';
 import styles from './style.module.scss';
 import type { LoadingBlockProps } from './types';
 import type { FC } from 'react';
 
-const LoadingBlock: FC< LoadingBlockProps > = ( { height, width } ) => {
-	return <div className={ styles.skeleton } style={ { height, width } } />;
+const LoadingBlock: FC< LoadingBlockProps > = ( { height, width, spaceBelow = false } ) => {
+	return (
+		<div
+			className={ clsx( styles.skeleton, spaceBelow && styles.spaceBelow ) }
+			style={ { height, width } }
+		/>
+	);
 };
 
 export default LoadingBlock;

--- a/projects/packages/my-jetpack/_inc/components/loading-block/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/loading-block/index.tsx
@@ -1,0 +1,9 @@
+import styles from './style.module.scss';
+import type { LoadingBlockProps } from './types';
+import type { FC } from 'react';
+
+const LoadingBlock: FC< LoadingBlockProps > = ( { height, width } ) => {
+	return <div className={ styles.skeleton } style={ { height, width } } />;
+};
+
+export default LoadingBlock;

--- a/projects/packages/my-jetpack/_inc/components/loading-block/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/loading-block/style.module.scss
@@ -1,0 +1,14 @@
+.skeleton {
+    border-radius: var( --jp-border-radius-rna );
+    animation: skeleton-loading 1s linear infinite alternate;
+    color: transparent;
+}
+
+@keyframes skeleton-loading {
+    0% {
+        background-color: #F5F5F5; /* FROM Color 1 */
+    }
+    100% {
+        background-color: #E2E2E2; /* TO Color 2 */
+    }
+}

--- a/projects/packages/my-jetpack/_inc/components/loading-block/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/loading-block/style.module.scss
@@ -4,6 +4,10 @@
     color: transparent;
 }
 
+.spaceBelow {
+    margin-bottom: 1rem;
+}
+
 @keyframes skeleton-loading {
     0% {
         background-color: #F5F5F5; /* FROM Color 1 */

--- a/projects/packages/my-jetpack/_inc/components/loading-block/types.ts
+++ b/projects/packages/my-jetpack/_inc/components/loading-block/types.ts
@@ -1,0 +1,8 @@
+type DimensionUnit = 'px' | '%' | 'vw' | 'vh' | 'dvw' | 'dvh' | 'rem' | 'em';
+
+type CSSLength = `${ number }${ DimensionUnit }` | 'auto';
+
+export interface LoadingBlockProps {
+	height: CSSLength;
+	width: CSSLength;
+}

--- a/projects/packages/my-jetpack/_inc/components/loading-block/types.ts
+++ b/projects/packages/my-jetpack/_inc/components/loading-block/types.ts
@@ -5,4 +5,5 @@ type CSSLength = `${ number }${ DimensionUnit }` | 'auto';
 export interface LoadingBlockProps {
 	height: CSSLength;
 	width: CSSLength;
+	spaceBelow?: boolean;
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -205,7 +205,6 @@ export default function MyJetpackScreen() {
 			{ ! isWelcomeBannerVisible && isSectionVisible && userIsAdmin && (
 				<EvaluationRecommendations />
 			) }
-			<EvaluationRecommendations />
 
 			<ProductCardsSection />
 

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -205,6 +205,7 @@ export default function MyJetpackScreen() {
 			{ ! isWelcomeBannerVisible && isSectionVisible && userIsAdmin && (
 				<EvaluationRecommendations />
 			) }
+			<EvaluationRecommendations />
 
 			<ProductCardsSection />
 

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useCallback, useEffect, useState } from 'react';
 import { PRODUCT_STATUSES } from '../../constants';
-import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
+import useProductsByOwnership from '../../data/products/use-products-by-ownership';
 import useAnalytics from '../../hooks/use-analytics';
 import useConnectSite from '../../hooks/use-connect-site';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
@@ -66,7 +66,9 @@ const ProductCard: FC< ProductCardProps > = props => {
 
 	let { secondaryAction } = props;
 
-	const { ownedProducts } = getMyJetpackWindowInitialState( 'lifecycleStats' );
+	const {
+		data: { ownedProducts },
+	} = useProductsByOwnership();
 	const isOwned = ownedProducts?.includes( slug );
 
 	const isError =

--- a/projects/packages/my-jetpack/_inc/components/product-card/pricing-component.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/pricing-component.tsx
@@ -1,13 +1,25 @@
 import formatCurrency from '@automattic/format-currency';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
+import useProduct from '../../data/products/use-product';
+import LoadingBlock from '../loading-block';
 import styles from './style.module.scss';
 import usePricingData from './use-pricing-data';
 
 const PriceComponent = ( { slug }: { slug: string } ) => {
+	const { isLoading: isProductLoading } = useProduct( slug );
+
 	const { discountPrice, fullPrice, currencyCode, isFeature, hasFreeOffering } =
 		usePricingData( slug );
 	const isFreeFeature = isFeature && hasFreeOffering && ! fullPrice;
+
+	if ( isProductLoading ) {
+		return (
+			<div className={ styles.priceContainer }>
+				<LoadingBlock width="100%" height="20px" />
+			</div>
+		);
+	}
 	return (
 		<div className={ styles.priceContainer }>
 			{ discountPrice && (

--- a/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
@@ -39,7 +39,7 @@ const parsePricingData = ( pricingForUi: ProductCamelCase[ 'pricingForUi' ] ) =>
 		fullPricePerMonth,
 		currencyCode,
 		wpcomProductSlug,
-	} = pricingForUi;
+	} = pricingForUi || {};
 	const hasDiscount = discountPrice && discountPrice !== fullPrice;
 	const eligibleForIntroDiscount = ! introductoryOffer?.reason;
 	return {

--- a/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
@@ -12,7 +12,7 @@ import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 
 const parsePricingData = ( pricingForUi: ProductCamelCase[ 'pricingForUi' ] ) => {
 	const { tiers, wpcomFreeProductSlug, introductoryOffer } = pricingForUi || {};
-	if ( pricingForUi.tiers ) {
+	if ( tiers ) {
 		const {
 			discountPrice,
 			fullPrice,

--- a/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
@@ -48,8 +48,8 @@ const parsePricingData = ( pricingForUi: ProductCamelCase[ 'pricingForUi' ] ) =>
 		discountPrice:
 			// Only display discount if site is elgible
 			hasDiscount && eligibleForIntroDiscount ? discountPricePerMonth : null,
-		fullPrice: fullPricePerMonth,
-		currencyCode,
+		fullPrice: fullPricePerMonth ?? 0,
+		currencyCode: currencyCode ?? 'USD',
 	};
 };
 

--- a/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
@@ -89,7 +89,7 @@ const getPrimaryAction = (
 		detail.status === PRODUCT_STATUSES.ACTIVE &&
 		( detail.isUpgradableByBundle.length || detail.isUpgradable );
 	const upgradeHasPrice =
-		detail.pricingForUi.fullPrice || detail.pricingForUi.tiers?.upgraded?.fullPrice;
+		detail?.pricingForUi?.fullPrice || detail?.pricingForUi?.tiers?.upgraded?.fullPrice;
 
 	if ( detail.status === PRODUCT_STATUSES.CAN_UPGRADE || isUpgradable ) {
 		if ( upgradeHasPrice ) {

--- a/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
@@ -11,7 +11,7 @@ import useAnalytics from '../../hooks/use-analytics';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 
 const parsePricingData = ( pricingForUi: ProductCamelCase[ 'pricingForUi' ] ) => {
-	const { tiers, wpcomFreeProductSlug, introductoryOffer } = pricingForUi;
+	const { tiers, wpcomFreeProductSlug, introductoryOffer } = pricingForUi || {};
 	if ( pricingForUi.tiers ) {
 		const {
 			discountPrice,

--- a/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
@@ -27,8 +27,8 @@ const parsePricingData = ( pricingForUi: ProductCamelCase[ 'pricingForUi' ] ) =>
 			wpcomFreeProductSlug,
 			wpcomProductSlug: ! quantity ? wpcomProductSlug : `${ wpcomProductSlug }:-q-${ quantity }`,
 			discountPrice: hasDiscount && eligibleForIntroDiscount ? discountPrice / 12 : null,
-			fullPrice: fullPrice / 12,
-			currencyCode,
+			fullPrice: fullPrice ? fullPrice / 12 : 0,
+			currencyCode: currencyCode ?? 'USD',
 		};
 	}
 

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.tsx
@@ -4,6 +4,7 @@ import { useMemo, useCallback } from 'react';
 import { PRODUCT_SLUGS } from '../../data/constants';
 import useProductsByOwnership from '../../data/products/use-products-by-ownership';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
+import LoadingBlock from '../loading-block';
 import ProductsTableView from '../products-table-view';
 import StatsSection from '../stats-section';
 import AiCard from './ai-card';
@@ -21,6 +22,7 @@ import type { FC, ReactNode } from 'react';
 
 type DisplayItemsProps = {
 	slugs: JetpackModule[];
+	isLoading: boolean;
 };
 
 type DisplayItemType = Record<
@@ -32,7 +34,8 @@ type DisplayItemType = Record<
 	FC< { admin: boolean } >
 >;
 
-const DisplayItems: FC< DisplayItemsProps > = ( { slugs } ) => {
+const DisplayItems: FC< DisplayItemsProps > = ( { slugs, isLoading } ) => {
+	const mockArrayOfProducts = [ ...Array( 9 ).keys() ];
 	const { showFullJetpackStatsCard = false } = getMyJetpackWindowInitialState( 'myJetpackFlags' );
 	const { userIsAdmin = false } = getMyJetpackWindowInitialState();
 
@@ -63,11 +66,17 @@ const DisplayItems: FC< DisplayItemsProps > = ( { slugs } ) => {
 
 	return (
 		<>
-			{ slugs.includes( 'stats' ) && showFullJetpackStatsCard && (
+			{ isLoading && (
 				<Col className={ styles.fullStatsCard }>
-					<StatsSection />
+					<LoadingBlock width="100%" height="350px" />
 				</Col>
 			) }
+			{ slugs.includes( 'stats' ) && showFullJetpackStatsCard && (
+				<Col className={ styles.fullStatsCard }>
+					{ isLoading ? <LoadingBlock width="100%" height="350px" /> : <StatsSection /> }
+				</Col>
+			) }
+
 			<Container
 				className={ styles.cardlist }
 				tagName="ul"
@@ -75,15 +84,21 @@ const DisplayItems: FC< DisplayItemsProps > = ( { slugs } ) => {
 				horizontalSpacing={ 0 }
 				horizontalGap={ 3 }
 			>
-				{ filteredSlugs.map( product => {
-					const Item = items[ product ];
+				{ isLoading
+					? mockArrayOfProducts.map( ( _, index ) => (
+							<Col tagName="li" sm={ 4 } md={ 4 } lg={ 4 } key={ index }>
+								<LoadingBlock width="100%" height="200px" />
+							</Col>
+					  ) )
+					: filteredSlugs.map( product => {
+							const Item = items[ product ];
 
-					return (
-						<Col tagName="li" sm={ 4 } md={ 4 } lg={ 4 } key={ product }>
-							<Item admin={ userIsAdmin === '1' } />
-						</Col>
-					);
-				} ) }
+							return (
+								<Col tagName="li" sm={ 4 } md={ 4 } lg={ 4 } key={ product }>
+									<Item admin={ userIsAdmin === '1' } />
+								</Col>
+							);
+					  } ) }
 			</Container>
 		</>
 	);
@@ -96,6 +111,7 @@ interface ProductCardsSectionProps {
 const ProductCardsSection: FC< ProductCardsSectionProps > = ( { noticeMessage } ) => {
 	const {
 		data: { ownedProducts, unownedProducts },
+		isLoading,
 	} = useProductsByOwnership();
 
 	const { canUserViewStats, userIsAdmin } = getMyJetpackWindowInitialState();
@@ -139,7 +155,7 @@ const ProductCardsSection: FC< ProductCardsSectionProps > = ( { noticeMessage } 
 
 	return (
 		<>
-			{ filteredOwnedProducts.length > 0 && (
+			{ ( isLoading || filteredOwnedProducts.length > 0 ) && (
 				<AdminSectionHero>
 					<Container horizontalSpacing={ 6 } horizontalGap={ noticeMessage ? 3 : 6 }>
 						<Col>
@@ -147,7 +163,7 @@ const ProductCardsSection: FC< ProductCardsSectionProps > = ( { noticeMessage } 
 								<Text variant="headline-small">{ __( 'My products', 'jetpack-my-jetpack' ) }</Text>
 							</Col>
 
-							<DisplayItems slugs={ filteredOwnedProducts } />
+							<DisplayItems isLoading={ isLoading } slugs={ filteredOwnedProducts } />
 						</Col>
 					</Container>
 				</AdminSectionHero>

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.tsx
@@ -71,9 +71,9 @@ const DisplayItems: FC< DisplayItemsProps > = ( { slugs, isLoading } ) => {
 					<LoadingBlock width="100%" height="350px" />
 				</Col>
 			) }
-			{ slugs.includes( 'stats' ) && showFullJetpackStatsCard && (
+			{ ! isLoading && slugs.includes( 'stats' ) && showFullJetpackStatsCard && (
 				<Col className={ styles.fullStatsCard }>
-					{ isLoading ? <LoadingBlock width="100%" height="350px" /> : <StatsSection /> }
+					<StatsSection />
 				</Col>
 			) }
 

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -18,6 +18,7 @@ import useProduct from '../../data/products/use-product';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import useAnalytics from '../../hooks/use-analytics';
 import { useRedirectToReferrer } from '../../hooks/use-redirect-to-referrer';
+import LoadingBlock from '../loading-block';
 import ProductDetailButton from '../product-detail-button';
 import styles from './style.module.scss';
 
@@ -95,7 +96,7 @@ const ProductDetailCard = ( {
 		myJetpackCheckoutUri = '',
 	} = getMyJetpackWindowInitialState();
 
-	const { detail } = useProduct( slug );
+	const { detail, isLoading: isProductLoading } = useProduct( slug );
 
 	const {
 		name,
@@ -125,7 +126,7 @@ const ProductDetailCard = ( {
 		wpcomFreeProductSlug,
 		introductoryOffer,
 		productTerm,
-	} = pricingForUi;
+	} = pricingForUi || {};
 
 	const { recordEvent } = useAnalytics();
 
@@ -320,6 +321,8 @@ const ProductDetailCard = ( {
 						</Text>
 					) ) }
 				</ul>
+
+				{ isProductLoading && <LoadingBlock width="100%" height="70px" spaceBelow /> }
 
 				{ needsPurchase && productPrice && (
 					<>

--- a/projects/packages/my-jetpack/_inc/components/product-detail-table/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-table/index.jsx
@@ -15,6 +15,7 @@ import { useCallback, useMemo, useState, useEffect } from 'react';
 import useProduct from '../../data/products/use-product';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import { useRedirectToReferrer } from '../../hooks/use-redirect-to-referrer';
+import LoadingBlock from '../loading-block';
 
 /**
  * Product Detail Table Column component.
@@ -55,13 +56,14 @@ const ProductDetailTableColumn = ( {
 	const {
 		name,
 		featuresByTier = [],
-		pricingForUi: { tiers: tiersPricingForUi },
 		title,
 		postCheckoutUrl,
 		postCheckoutUrlsByFeature,
 		isBundle,
 		hasPaidPlanForProduct,
 	} = detail;
+
+	const tiersPricingForUi = detail?.pricingForUi?.tiers || {};
 
 	// Extract the pricing details for the provided tier.
 	const {
@@ -72,7 +74,7 @@ const ProductDetailTableColumn = ( {
 		isFree,
 		wpcomProductSlug,
 		quantity = null,
-	} = tiersPricingForUi[ tier ];
+	} = tiersPricingForUi[ tier ] || {};
 
 	useEffect( () => {
 		// If activation was successful, we will be redirecting the user
@@ -186,6 +188,8 @@ const ProductDetailTableColumn = ( {
 	return (
 		<PricingTableColumn primary={ ! isFree }>
 			<PricingTableHeader>
+				{ isFetching && <LoadingBlock width="100%" height="70px" spaceBelow /> }
+
 				{ isFree ? (
 					<ProductPrice price={ 0 } legend={ '' } currency={ 'USD' } hidePriceFraction />
 				) : (
@@ -284,7 +288,7 @@ const ProductDetailTable = ( {
 } ) => {
 	const { fileSystemWriteAccess = 'no' } = getMyJetpackWindowInitialState();
 
-	const { detail } = useProduct( slug );
+	const { detail, isLoading: isProductLoading } = useProduct( slug );
 	const {
 		description,
 		featuresByTier = [],
@@ -293,8 +297,9 @@ const ProductDetailTable = ( {
 		tiers = [],
 		hasPaidPlanForProduct,
 		title,
-		pricingForUi: { tiers: tiersPricingForUi },
 	} = detail;
+
+	const tiersPricingForUi = detail?.pricingForUi || {};
 
 	// If the plugin can not be installed automatically, the user will have to take extra steps.
 	const cantInstallPlugin = 'plugin_absent' === status && 'no' === fileSystemWriteAccess;
@@ -363,7 +368,7 @@ const ProductDetailTable = ( {
 							tier={ tier }
 							feature={ feature }
 							detail={ detail }
-							isFetching={ isFetching }
+							isFetching={ isFetching || isProductLoading }
 							isFetchingSuccess={ isFetchingSuccess }
 							onProductButtonClick={ onProductButtonClick }
 							trackProductButtonClick={ trackProductButtonClick }

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -120,7 +120,7 @@ export default function ProductInterstitial( {
 			if ( pricingForUi?.tiers?.upgraded?.wpcomProductSlug ) {
 				return pricingForUi.tiers.upgraded.wpcomProductSlug;
 			}
-			return pricingForUi.wpcomProductSlug;
+			return pricingForUi?.wpcomProductSlug;
 		},
 		[ slug, pricingForUi ]
 	);

--- a/projects/packages/my-jetpack/_inc/components/products-table-view/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/products-table-view/index.tsx
@@ -2,7 +2,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronRight } from '@wordpress/icons';
-import { useCallback, useState, useMemo } from 'react';
+import { useCallback, useState, useMemo, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAllProducts } from '../../data/products/use-all-products';
 import useAnalytics from '../../hooks/use-analytics';
@@ -108,6 +108,7 @@ const ProductsTableView: FC< ProductsTableViewProps > = ( { products } ) => {
 	const isMobileViewport: boolean = useViewportMatch( 'medium', '<' );
 	const navigate = useNavigate();
 	const { recordEvent } = useAnalytics();
+	const [ categories, setCategories ] = useState< Option[] >( [] );
 
 	const baseView: ViewList = {
 		sort: {
@@ -130,12 +131,11 @@ const ProductsTableView: FC< ProductsTableViewProps > = ( { products } ) => {
 		},
 	};
 
-	const categories = useMemo( () => {
-		if ( isLoading || isError ) {
-			return [];
+	useEffect( () => {
+		if ( ! isError && ! isLoading && ! categories.length ) {
+			setCategories( getCategories( products, allProductData ) );
 		}
-		return getCategories( products, allProductData );
-	}, [ products, allProductData, isLoading, isError ] );
+	}, [ isError, isLoading, categories, allProductData, products ] );
 
 	const navigateToInterstitial = useCallback(
 		( slug: string ) => {

--- a/projects/packages/my-jetpack/_inc/data/evaluation-recommendations/use-evaluation-recommendations.ts
+++ b/projects/packages/my-jetpack/_inc/data/evaluation-recommendations/use-evaluation-recommendations.ts
@@ -9,6 +9,7 @@ import {
 	REST_API_EVALUATE_SITE_RECOMMENDATIONS,
 	REST_API_SITE_EVALUATION_RESULT,
 } from '../constants';
+import useProductsByOwnership from '../products/use-products-by-ownership';
 import useSimpleMutation from '../use-simple-mutation';
 import { getMyJetpackWindowInitialState } from '../utils/get-my-jetpack-window-state';
 import isJetpackUserNew from '../utils/is-jetpack-user-new';
@@ -33,6 +34,9 @@ const useEvaluationRecommendations = () => {
 		getInitialRecommendedModules()
 	);
 	const [ isFirstRun, setIsFirstRun ] = useValueStore( 'isFirstRun', getInitialIsFirstRun() );
+	const {
+		data: { ownedProducts: ownedProductsData },
+	} = useProductsByOwnership();
 
 	const unownedRecommendedModules = useMemo( () => {
 		// TODO: Maybe remove this ternary condition
@@ -42,13 +46,13 @@ const useEvaluationRecommendations = () => {
 		const ownedProducts = (
 			process?.env?.NODE_ENV === 'development'
 				? [ 'anti-spam', 'extras', 'jetpack-ai' ]
-				: getMyJetpackWindowInitialState( 'lifecycleStats' )?.ownedProducts || []
+				: ownedProductsData || []
 		) as JetpackModule[];
 		// We filter out owned modules, and return the top recommendations
 		return recommendedModules
 			?.filter( module => ! ownedProducts.includes( module ) )
 			.slice( 0, NUMBER_OF_RECOMMENDATIONS_TO_SHOW );
-	}, [ recommendedModules ] );
+	}, [ recommendedModules, ownedProductsData ] );
 
 	const isEligibleForRecommendations = useMemo( () => {
 		const { dismissed } = getMyJetpackWindowInitialState( 'recommendedModules' );

--- a/projects/packages/my-jetpack/_inc/data/evaluation-recommendations/use-evaluation-recommendations.ts
+++ b/projects/packages/my-jetpack/_inc/data/evaluation-recommendations/use-evaluation-recommendations.ts
@@ -150,7 +150,7 @@ const useEvaluationRecommendations = () => {
 		saveEvaluationResult,
 		removeEvaluationResult,
 		redoEvaluation,
-		recommendedModules: unownedRecommendedModules,
+		recommendedModules: [ 'anti-spam', 'extras', 'jetpack-ai' ], //unownedRecommendedModules,
 		isSectionVisible,
 		isFirstRun,
 		isProductOwnershipLoading,

--- a/projects/packages/my-jetpack/_inc/data/evaluation-recommendations/use-evaluation-recommendations.ts
+++ b/projects/packages/my-jetpack/_inc/data/evaluation-recommendations/use-evaluation-recommendations.ts
@@ -36,6 +36,7 @@ const useEvaluationRecommendations = () => {
 	const [ isFirstRun, setIsFirstRun ] = useValueStore( 'isFirstRun', getInitialIsFirstRun() );
 	const {
 		data: { ownedProducts: ownedProductsData },
+		isLoading: isProductOwnershipLoading,
 	} = useProductsByOwnership();
 
 	const unownedRecommendedModules = useMemo( () => {
@@ -152,6 +153,7 @@ const useEvaluationRecommendations = () => {
 		recommendedModules: unownedRecommendedModules,
 		isSectionVisible,
 		isFirstRun,
+		isProductOwnershipLoading,
 	};
 };
 

--- a/projects/packages/my-jetpack/_inc/data/evaluation-recommendations/use-evaluation-recommendations.ts
+++ b/projects/packages/my-jetpack/_inc/data/evaluation-recommendations/use-evaluation-recommendations.ts
@@ -150,7 +150,7 @@ const useEvaluationRecommendations = () => {
 		saveEvaluationResult,
 		removeEvaluationResult,
 		redoEvaluation,
-		recommendedModules: [ 'anti-spam', 'extras', 'jetpack-ai' ], //unownedRecommendedModules,
+		recommendedModules: unownedRecommendedModules,
 		isSectionVisible,
 		isFirstRun,
 		isProductOwnershipLoading,

--- a/projects/packages/my-jetpack/_inc/data/products/use-products-by-ownership.ts
+++ b/projects/packages/my-jetpack/_inc/data/products/use-products-by-ownership.ts
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import { useValueStore } from '../../context/value-store/valueStoreContext';
-import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import {
 	QUERY_PRODUCT_BY_OWNERSHIP_KEY,
 	REST_API_SITE_PRODUCTS_OWNERSHIP_ENDPOINT,
@@ -23,8 +22,8 @@ const useFetchProductsByOwnership = () => {
 
 const useProductsByOwnership = () => {
 	const [ productsOwnership, setProductsOwnership ] = useValueStore( 'productsOwnership', {
-		ownedProducts: getMyJetpackWindowInitialState( 'lifecycleStats' ).ownedProducts,
-		unownedProducts: getMyJetpackWindowInitialState( 'lifecycleStats' ).unownedProducts,
+		ownedProducts: [],
+		unownedProducts: [],
 	} );
 
 	const { data, refetch, isLoading } = useFetchProductsByOwnership();

--- a/projects/packages/my-jetpack/changelog/update-move-product-ownership-data-fully-to-frontend
+++ b/projects/packages/my-jetpack/changelog/update-move-product-ownership-data-fully-to-frontend
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Move the getting of product ownership data entirely to the frontend

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -166,8 +166,6 @@ interface Window {
 			isSiteConnected: boolean;
 			isUserConnected: boolean;
 			jetpackPlugins: Array< string >;
-			ownedProducts: JetpackModule[];
-			unownedProducts: JetpackModule[];
 			modules: Array< string >;
 			purchases: Array< string >;
 		};

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -68,6 +68,7 @@
 		"@testing-library/react": "16.2.0",
 		"@testing-library/user-event": "14.6.1",
 		"@types/jest": "29.5.14",
+		"@types/node": "^20.4.2",
 		"@types/react": "18.3.18",
 		"concurrently": "7.6.0",
 		"jest": "29.7.0",

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -286,8 +286,6 @@ class Initializer {
 				'lifecycleStats'         => array(
 					'jetpackPlugins'            => self::get_installed_jetpack_plugins(),
 					'historicallyActiveModules' => \Jetpack_Options::get_option( 'historically_active_modules', array() ),
-					'ownedProducts'             => Products::get_products_by_ownership( 'owned' ),
-					'unownedProducts'           => Products::get_products_by_ownership( 'unowned' ),
 					'brokenModules'             => self::check_for_broken_modules(),
 					'isSiteConnected'           => $connection->is_connected(),
 					'isUserConnected'           => $connection->is_user_connected(),


### PR DESCRIPTION
## Proposed changes:

* The product ownership data relies on the `get_status` and `is_owned` functions, both of which get data from http calls. The `is_owned` function checks if the site has a plan for the product which includes querying purchases (which have a very small transient due to wanting to have purchases be updated as quickly as posslbe)
* This PR removes the ownership data from the initial state and adds a loading state for the product card table and the recommendations for when the ownership data is loading
* This PR also fixes an issue with the prices loading that was introduced in [this PR](https://github.com/Automattic/jetpack-marketing/issues/1166). It uses the new loading indicator component where necessary for pricing data

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: pghfsA-df-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Go to My Jetpack and ensure the loading status looks good and that the products are loaded into the correct category (owned and unowned, or `My Products` and `Discover more`)

https://github.com/user-attachments/assets/90ecf24f-9172-411d-8018-1b470a5da7da

3. Fill out the welcome survey and ensure that the recommendations load okay, refresh the page to make sure they load from scratch too

4. Go to a product table interstitial and a product card interstitial and reload the page, make sure they both load okay from scratch. Make sure the loading indicator looks good

![image](https://github.com/user-attachments/assets/37a06de6-a689-47e7-a701-840b15380df0)
![image](https://github.com/user-attachments/assets/31e7e3e8-d6ad-48ee-9e8b-5d852395557d)

