### PR TITLE
Forms: fix typo on empty submission message

### DIFF
--- a/projects/packages/connection/changelog/fix-emtpy-typos
+++ b/projects/packages/connection/changelog/fix-emtpy-typos
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Minor typo: emtpy -> empty
+
+

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -691,7 +691,7 @@ class Error_Handler {
 		/**
 		 * Fires inside the admin_notices hook just before displaying the error message for a broken connection.
 		 *
-		 * If you want to disable the default message from being displayed, return an emtpy value in the jetpack_connection_error_notice_message filter.
+		 * If you want to disable the default message from being displayed, return an empty value in the jetpack_connection_error_notice_message filter.
 		 *
 		 * @since 8.9.0
 		 *

--- a/projects/packages/forms/changelog/fix-emtpy-typos
+++ b/projects/packages/forms/changelog/fix-emtpy-typos
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Minor typo: emtpy -> empty
+
+

--- a/projects/packages/forms/src/contact-form/js/accessible-form.js
+++ b/projects/packages/forms/src/contact-form/js/accessible-form.js
@@ -30,7 +30,7 @@ const L10N = {
 	/* translators: generic error message */
 	genericError: __( 'Please correct this field', 'jetpack-forms' ),
 	/* translators: error message shown when no field has been filled out */
-	emptyForm: __( 'The form you are trying to submit is emtpy.', 'jetpack-forms' ),
+	emptyForm: __( 'The form you are trying to submit is empty.', 'jetpack-forms' ),
 	errorCount: d =>
 		/* translators: message displayed when errors need to be fixed. %d is the number of errors. */
 		_n( 'You need to fix %d error.', 'You need to fix %d errors.', d, 'jetpack-forms' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

While testing blank form submissions (#41464), I noticed a typo (`emtpy` instead of `empty`). This PR fixes that text, and also updates the same typo found in a random comment elsewhere.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

