### PR TITLE
Connection: allow cookie auth for user provisioning

### DIFF
--- a/projects/packages/connection/changelog/update-remote-provision-permission-check
+++ b/projects/packages/connection/changelog/update-remote-provision-permission-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Allow cookie auth for user provisioning.

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -414,13 +414,8 @@ class REST_Connector {
 	 * @return true|WP_Error
 	 */
 	public function remote_provision_permission_check( WP_REST_Request $request ) {
-		// We allow the app password authentication only if 'local_user' is empty for security reasons.
-		if ( empty( $request['local_user'] ) && did_action( 'application_password_did_authenticate' ) ) {
-			if ( current_user_can( 'jetpack_connect_user' ) ) {
-				return true;
-			}
-
-			return new WP_Error( 'invalid_user_permission_remote_provision', self::get_user_permissions_error_msg(), array( 'status' => rest_authorization_required_code() ) );
+		if ( empty( $request['local_user'] ) && current_user_can( 'jetpack_connect_user' ) ) {
+			return true;
 		}
 
 		return Rest_Authentication::is_signed_with_blog_token()


### PR DESCRIPTION
## Proposed changes:
Allow cookie-based authentication for the user provisioning endpoint.
Previously we only allowed blog tokens and application passwords.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
PT: pf5801-1dm-p2
Justification: pf5801-1q1-p2#comment-787

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Same as 169029-ghe-Automattic/wpcom