### PR TITLE
Carousel: Enable core lightbox on single image blocks

### DIFF
--- a/projects/plugins/jetpack/changelog/update-carousel-core-lightbox-images
+++ b/projects/plugins/jetpack/changelog/update-carousel-core-lightbox-images
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Carousel: Enable core lightbox on single image blocks

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -96,9 +96,6 @@ class Jetpack_Carousel {
 			add_action( 'wp_ajax_nopriv_get_attachment_comments', array( $this, 'get_attachment_comments' ) );
 			add_action( 'wp_ajax_post_attachment_comment', array( $this, 'post_attachment_comment' ) );
 			add_action( 'wp_ajax_nopriv_post_attachment_comment', array( $this, 'post_attachment_comment' ) );
-
-			// Disable core lightbox when Carousel is enabled.
-			add_action( 'wp_theme_json_data_theme', array( $this, 'disable_core_lightbox' ) );
 		} else {
 			if ( ! $this->in_jetpack ) {
 				if ( 0 === $this->test_1or0_option( get_option( 'carousel_enable_it' ), true ) ) {
@@ -126,11 +123,10 @@ class Jetpack_Carousel {
 				add_filter( 'the_content', array( $this, 'add_data_img_tags_and_enqueue_assets' ) );
 			}
 
+			add_filter( 'render_block_data', array( $this, 'remove_core_lightbox_in_gallery' ), 10, 3 );
+
 			// `is_amp_request()` can't be called until the 'wp' filter.
 			add_action( 'wp', array( $this, 'check_amp_support' ) );
-
-			// Disable core lightbox when Carousel is enabled.
-			add_action( 'wp_theme_json_data_theme', array( $this, 'disable_core_lightbox' ) );
 		}
 
 		if ( $this->in_jetpack ) {
@@ -210,32 +206,6 @@ class Jetpack_Carousel {
 		 * @param bool false Should Carousel be enabled for single images linking to 'Media File'? Default to false.
 		 */
 		return apply_filters( 'jp_carousel_load_for_images_linked_to_file', false );
-	}
-
-	/**
-	 * Disable the "Lightbox" option offered in WordPress core
-	 * whenever Jetpack's Carousel feature is enabled.
-	 *
-	 * @since 13.3
-	 *
-	 * @param WP_Theme_JSON_Data $theme_json Class to access and update theme.json data.
-	 */
-	public function disable_core_lightbox( $theme_json ) {
-		return $theme_json->update_with(
-			array(
-				'version'  => 2,
-				'settings' => array(
-					'blocks' => array(
-						'core/image' => array(
-							'lightbox' => array(
-								'allowEditing' => false,
-								'enabled'      => false,
-							),
-						),
-					),
-				),
-			)
-		);
 	}
 
 	/**
@@ -364,6 +334,26 @@ class Jetpack_Carousel {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Remove core lightbox settings from images in a gallery, if Carousel is enabled.
+	 *
+	 * @param array         $parsed_block An associative array of the block being rendered.
+	 * @param array         $source_block An un-modified copy of `$parsed_block`, as it appeared in the source content.
+	 * @param WP_Block|null $parent_block If this is a nested block, a reference to the parent block.
+	 * @return array The modified block data.
+	 */
+	public function remove_core_lightbox_in_gallery( $parsed_block, $source_block, $parent_block ) {
+		if (
+			! empty( $parsed_block['blockName'] ) &&
+			'core/image' === $parsed_block['blockName'] &&
+			! empty( $parent_block->name ) &&
+			'core/gallery' === $parent_block->name
+		) {
+			unset( $parsed_block['attrs']['lightbox'] );
+		}
+		return $parsed_block;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #36820

## Proposed changes:

This PR removes the code to disable the core lightbox feature. As noted in [this comment thread](https://github.com/Automattic/jetpack/issues/36820#issuecomment-2424108157), the core feature is better for single image blocks, so it should not be disabled. The Jetpack carousel is still used for galleries though, so there is also code to remove the lightbox settings on image blocks in galleries (otherwise you get a double-lightbox view).

**Screenshots**

The setting is back on Image blocks.

<img width="513" alt="Screenshot 2025-02-26 at 5 45 55 PM" src="https://github.com/user-attachments/assets/9c507bff-23e2-4007-b4df-8c659240be6b" />

On the front end, the core lightbox is used, you can tell by hovering over the image and seeing the "Expand" icon button (focused here).

<img width="680" alt="Screenshot 2025-02-26 at 5 48 43 PM" src="https://github.com/user-attachments/assets/92c08c0e-2c6a-43a7-a2f5-94ddc8407f57" />

The core lightbox setting is also available on galleries, but it does nothing different when applied (in fact, as far as I can tell, none of these have any effect, it always uses the JP Carousel).

<img width="461" alt="Screenshot 2025-02-26 at 5 46 54 PM" src="https://github.com/user-attachments/assets/b78a4873-e0e5-48eb-9172-ed4322c95613" />

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Check that Carousel is enabled in Jetpack > Settings > Writing tab > Media section
2. Create or edit a post with images
3. When inserting an image block, you should see the option to link to "Enlarge on click"
4. On the front end, it should use the core lightbox
5. When inserting a gallery block, you'll also see an option to "Enlarge on click"
6. On the front end, it will still use the Jetpack Carousel

The expected behavior, for each click option:

| | Carousel enabled | Carousel disabled |
|---|---|---|
| Image: image file | image file | image file |
| Image: attachment | Jetpack Carousel | attachment page† |
| Image: enlarge | Core lightbox | Core lightbox |
| Gallery: image file | Jetpack Carousel | image file |
| Gallery: attachment | Jetpack Carousel | attachment page† |
| Gallery: enlarge | Jetpack Carousel‡ | Core lightbox |
| Gallery: none | Jetpack Carousel‡ | nothing |

† The attachment page will redirect to image file on newer installs, since attachment pages have been disabled (see https://github.com/WordPress/gutenberg/issues/56019). It is kind of strange that the attachment page == carousel, but that's the current behavior.
‡ Since there is no link, these don't have an interactive element, and so the carousel cannot be activated by keyboard. The fact that the carousel still opens on "none" has already been reported #28030.