### PR TITLE
Wpcom: Remove page optimize link from performance settings

### DIFF
--- a/projects/plugins/jetpack/_inc/client/performance/speed-up-site.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/speed-up-site.jsx
@@ -2,7 +2,6 @@ import { ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
 import { __, sprintf } from '@wordpress/i18n';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import CompactCard from 'components/card/compact';
 import { FormFieldset } from 'components/forms';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { ModuleToggle } from 'components/module-toggle';
@@ -12,8 +11,6 @@ import analytics from 'lib/analytics';
 import { isOfflineMode } from 'state/connection';
 import { getModule, getModuleOverride } from 'state/modules';
 import { isModuleFound as _isModuleFound } from 'state/search';
-import { isAtomicSite } from '../state/initial-state';
-import { isPluginActive } from '../state/site/plugins';
 
 const SpeedUpSite = withModuleSettingsFormHelpers(
 	class extends Component {
@@ -290,17 +287,6 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 									) }
 								</FormFieldset>
 							</SettingsGroup>
-							{ this.props.isAtomicSite && this.props.isPageOptimizeActive && (
-								<CompactCard
-									className="jp-settings-card__configure-link"
-									href={ `${ this.props.siteAdminUrl }admin.php?page=page-optimize` }
-								>
-									{ __(
-										'Optimize JS and CSS for faster page load and render in the browser.',
-										'jetpack'
-									) }
-								</CompactCard>
-							) }
 						</>
 					) }
 				</SettingsCard>
@@ -315,7 +301,5 @@ export default connect( state => {
 		isModuleFound: module_name => _isModuleFound( state, module_name ),
 		isOfflineMode: isOfflineMode( state ),
 		getModuleOverride: module_name => getModuleOverride( state, module_name ),
-		isAtomicSite: isAtomicSite( state ),
-		isPageOptimizeActive: isPluginActive( state, 'page-optimize/page-optimize.php' ),
 	};
 } )( SpeedUpSite );

--- a/projects/plugins/jetpack/changelog/update-remove-page-optimize-link
+++ b/projects/plugins/jetpack/changelog/update-remove-page-optimize-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+The page-optimize plugin link shown to Atomic sites only is no longer required and has been removed.


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/10303

## Proposed changes:

* The page-optimize plugin link shown to Atomic sites only was added as a stop gap measure to preserve access to a menu item that calypso overrides. That page no longer exists and the page-optimize plugin can now place it's menu item correctly. We no longer need this Jetpack side link in it's place, this PR removes the Jetpack link to page-optimize.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A this link is only shown to atomic sites on WordPress.com 

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* https://woatest1254131.wpcomstaging.com/wp-admin/admin.php?page=jetpack#performance
* Confirm this link is no longer visible:

![Screenshot(112)](https://github.com/user-attachments/assets/c56f6112-f24f-44ac-9e4e-280fe64c7e1a)


