### PR TITLE
Social | Fix Social Post UI and Twitter not supported notice

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-service-id-for-old-jetpack
+++ b/projects/packages/publicize/changelog/fix-social-service-id-for-old-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social | Fix Social post UI not showing connections

--- a/projects/packages/publicize/src/class-services.php
+++ b/projects/packages/publicize/src/class-services.php
@@ -15,7 +15,7 @@ use WP_REST_Request;
  */
 class Services {
 
-	const SERVICES_TRANSIENT = 'jetpack_social_services_list_v1';
+	const SERVICES_TRANSIENT = 'jetpack_social_services_list_v2';
 
 	/**
 	 * Get the available publicize services. Meant to be called directly only on WPCOM.
@@ -74,7 +74,24 @@ class Services {
 			}
 		}
 
-		return $services;
+		// This is here for backwards compatibility
+		// TODO Remove this array_map() call after April 2025 release of Jetpack.
+		return array_map(
+			function ( $service ) {
+				global $publicize;
+
+				return array_merge(
+					$service,
+					array(
+						'ID'                  => $service['id'],
+						'connect_URL'         => $publicize->connect_url( $service['ID'], 'connect' ),
+						'external_users_only' => $service['supports']['additional_users_only'],
+						'multiple_external_user_ID_support' => $service['supports']['additional_users'],
+					)
+				);
+			},
+			$services
+		);
 	}
 
 	/**


### PR DESCRIPTION
When using Social bleeding edge with old Jetpack <= 14.3, there is a notice saying Twitter is not supported anymore and also the Social post UI doesn't show the connections

The cause of the issue is the updated schema for services list in #42019 which changed `ID` to `id` which is used by old code to identify a service.

<details>
<summary>Click to expand to see the screenshots</summary>

![CleanShot 2025-02-26 at 14 18 00@2x](https://github.com/user-attachments/assets/1e5e0bd9-2218-4b99-a7df-83e22574b4b1)

Swapping to the Jetpack RC fixes the issue, but can we do anything to prevent it with 14.3?

Similarly, this branch on Social and any previous version of Jetpack breaks the Social Post UI 

![CleanShot 2025-02-26 at 14 43 40@2x](https://github.com/user-attachments/assets/c727104f-d2e6-4862-b861-2da2b9578d4a)
</details>

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR restores the `ID` field for services endpoint for now

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox
* Point the public API and your site to your sandbox
* Launch a JN site with Beta Tester active
* Using Beta Tester, activate Jetpack 14.3 and Social on this branch
* Goto Social admin page and add a Social connection
* Goto editor
* Open Jetpack sidebar
* Confirm that you don't see the Twitter not supported notice
* Click on "Preview social posts"
* Confirm that the connections show up fine