### PR TITLE
Admin menu: use wpcom_get_custom_admin_menu_class instead of the class

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-admin-menu-class-usage
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-admin-menu-class-usage
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Use wpcom_get_custom_admin_menu_class helper instead of calling the admin menu class. This way, the quick fix that prevented the UI switcher to be registered twice is no longer needed.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -76,7 +76,13 @@ function wpcom_should_disable_calypso_links( string $screen ): bool {
 		return true;
 	}
 
-	return Admin_Menu::get_instance()->get_preferred_view( $screen ) === Admin_Menu::CLASSIC_VIEW;
+	$admin_menu = wpcom_get_custom_admin_menu_class();
+
+	if ( ! $admin_menu ) {
+		return true;
+	}
+
+	return $admin_menu::get_instance()->get_preferred_view( $screen ) === Admin_Menu::CLASSIC_VIEW;
 }
 
 /**
@@ -783,7 +789,7 @@ add_action( 'admin_enqueue_scripts', 'wpcom_show_removed_calypso_screen_notice' 
 /**
  * Gets the name of the class used to customize the admin menu when Nav Unification is enabled.
  *
- * @return false|string The class name of the customized admin menu if any, false otherwise.
+ * @return false|class-string<\Automattic\Jetpack\Masterbar\Base_Admin_Menu> The class name of the customized admin menu if any, false otherwise.
  */
 function wpcom_get_custom_admin_menu_class() {
 	if ( ! function_exists( '\Automattic\Jetpack\Masterbar\get_admin_menu_class' ) || ! function_exists( '\Automattic\Jetpack\Masterbar\should_customize_nav' ) ) {

--- a/projects/packages/masterbar/changelog/update-admin-menu-class-usage
+++ b/projects/packages/masterbar/changelog/update-admin-menu-class-usage
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Use wpcom_get_custom_admin_menu_class helper instead of calling the admin menu class. This way, the quick fix that prevented the UI switcher to be registered twice is no longer needed.
+
+

--- a/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
@@ -540,11 +540,6 @@ abstract class Base_Admin_Menu {
 	 * Adds a dashboard switcher to the list of screen meta links of the current page.
 	 */
 	public function add_dashboard_switcher() {
-		static $is_added = false;
-		if ( $is_added ) {
-			return;
-		}
-
 		$menu_mappings = require __DIR__ . '/menu-mappings.php';
 		$screen        = $this->get_current_screen();
 
@@ -571,8 +566,6 @@ abstract class Base_Admin_Menu {
 			</div>
 		</div>
 		<?php
-
-		$is_added = true;
 	}
 
 	/**

--- a/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
@@ -572,11 +572,6 @@ abstract class Base_Admin_Menu {
 	 * Adds a script to append the dashboard switcher to screen meta
 	 */
 	public function dashboard_switcher_scripts() {
-		static $is_script_added = false;
-		if ( $is_script_added ) {
-			return;
-		}
-
 		wp_add_inline_script(
 			'common',
 			"(function( $ ) {
@@ -598,8 +593,6 @@ abstract class Base_Admin_Menu {
 				});
 			})( jQuery );"
 		);
-
-		$is_script_added = true;
 	}
 
 	/**


### PR DESCRIPTION
Instead of calling the admin menu class, we now use a helper function that returns the object.

This also removes a quick fix that prevented the quick switcher from being registered twice in the UI.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* use wpcom_get_custom_admin_menu_class helper function
* Remove the quick fix that prevented registering the quick switcher twice

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to an Atomic site/Simple Site
* Switch Jetpack **and** mu-wpcom plugins to this version (see testing instructions below)
* Make sure you're in control variation of the holdout test. see for p7DVsv-m73-p2 for setting that up.
* Notice that we don't display the "View" UI twice on the edit.php page