### PR TITLE
Admin bar: add subitems to the top-left WP.com icon menu

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/untangle-admin-bar-2
+++ b/projects/packages/jetpack-mu-wpcom/changelog/untangle-admin-bar-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Admin bar: make leftmost menu behave closer to Core

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -125,11 +125,14 @@ function wpcom_always_use_user_locale() {
 add_action( 'admin_bar_menu', 'wpcom_always_use_user_locale', -1 );
 
 /**
- * Replaces the WP logo as a link to /sites.
+ * Replaces the WP logo with WP.com logo.
  *
  * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
  */
-function wpcom_replace_wp_logo_with_wpcom_all_sites_menu( $wp_admin_bar ) {
+function wpcom_replace_wp_logo_with_wpcom_logo_menu( $wp_admin_bar ) {
+	$about_node      = $wp_admin_bar->get_node( 'about' );
+	$contribute_node = $wp_admin_bar->get_node( 'contribute' );
+
 	foreach ( $wp_admin_bar->get_nodes() as $node ) {
 		if ( $node->parent === 'wp-logo' || $node->parent === 'wp-logo-external' ) {
 			$wp_admin_bar->remove_node( $node->id );
@@ -149,8 +152,47 @@ function wpcom_replace_wp_logo_with_wpcom_all_sites_menu( $wp_admin_bar ) {
 			),
 		)
 	);
+
+	$wp_admin_bar->add_node(
+		array(
+			'parent' => 'wpcom-logo',
+			'id'     => 'wpcom-sites',
+			'title'  => __( 'Sites', 'jetpack-mu-wpcom' ),
+			'href'   => maybe_add_origin_site_id_to_url( 'https://wordpress.com/sites' ),
+		)
+	);
+
+	$wp_admin_bar->add_node(
+		array(
+			'parent' => 'wpcom-logo',
+			'id'     => 'wpcom-domains',
+			'title'  => __( 'Domains', 'jetpack-mu-wpcom' ),
+			'href'   => maybe_add_origin_site_id_to_url( 'https://wordpress.com/domains/manage' ),
+		)
+	);
+
+	if ( ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
+		$wp_admin_bar->add_group(
+			array(
+				'parent' => 'wpcom-logo',
+				'id'     => 'wpcom-logo-external',
+				'meta'   => array(
+					'class' => 'ab-sub-secondary',
+				),
+			)
+		);
+
+		if ( $about_node ) {
+			$about_node->parent = 'wpcom-logo-external';
+			$wp_admin_bar->add_node( (array) $about_node );
+		}
+		if ( $contribute_node ) {
+			$contribute_node->parent = 'wpcom-logo-external';
+			$wp_admin_bar->add_node( (array) $contribute_node );
+		}
+	}
 }
-add_action( 'admin_bar_menu', 'wpcom_replace_wp_logo_with_wpcom_all_sites_menu', 11 );
+add_action( 'admin_bar_menu', 'wpcom_replace_wp_logo_with_wpcom_logo_menu', 11 );
 
 /**
  * Adds the Cart menu to the WordPress admin bar.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to:

- https://github.com/Automattic/wp-calypso/issues/98079

## Proposed changes:

This PR adds the following to the top-left WordPress(.com) icon in the admin bar:

|Simple|Atomic|
|-|-|
|<img width="160" alt="image" src="https://github.com/user-attachments/assets/408f40d7-42a8-4b31-8773-0c3f8903c42d" />|<img width="161" alt="image" src="https://github.com/user-attachments/assets/37fb33d2-7950-41ac-aac9-d4a44e95f90f" />|

- Brought back the menu items on hover.
- Add `Sites` and `Domains` items pointing to the global view.
- On Atomic, Brought back Core's `About WordPress` and `Get Involved` menu.
   - On Simple sites, those links are not valid / hidden by opers.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Patch this PR
2. Verify the changes in the WP icon as described above.

