### PR TITLE
Forms: add accessible name field to advanced settings

### DIFF
--- a/projects/packages/forms/changelog/update-forms-accessible-name
+++ b/projects/packages/forms/changelog/update-forms-accessible-name
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: add accessible name field to advanced settings

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -257,7 +257,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 						__nextHasNoMarginBottom={ true }
 						__next40pxDefaultSize={ true }
 					/>
-					<ExternalLink href="https://developer.mozilla.org/en-US/docs/Glossary/Accessible_name">
+					<ExternalLink href="https://developer.mozilla.org/docs/Glossary/Accessible_name">
 						{ __( 'Read more.', 'jetpack-forms' ) }
 					</ExternalLink>
 				</InspectorAdvancedControls>

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -5,6 +5,7 @@ import {
 	useModuleStatus,
 } from '@automattic/jetpack-shared-extension-utils';
 import {
+	InspectorAdvancedControls,
 	InspectorControls,
 	URLInput,
 	useBlockProps,
@@ -12,11 +13,11 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
+	ExternalLink,
 	PanelBody,
 	SelectControl,
 	TextareaControl,
 	TextControl,
-	Notice,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
@@ -75,15 +76,17 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		customThankyouRedirect,
 		jetpackCRM,
 		salesforceData,
+		formTitle,
 	} = attributes;
 	const instanceId = useInstanceId( JetpackContactFormEdit );
-	const { canUserInstallPlugins, hasInnerBlocks, postAuthorEmail } = useSelect(
+	const { postTitle, canUserInstallPlugins, hasInnerBlocks, postAuthorEmail } = useSelect(
 		select => {
 			const { getBlocks } = select( blockEditorStore );
 			const { getEditedPostAttribute } = select( editorStore );
 			const { getUser, canUser } = select( coreStore );
 			const innerBlocks = getBlocks( clientId );
 
+			const title = getEditedPostAttribute( 'title' );
 			const authorId = getEditedPostAttribute( 'author' );
 			const authorEmail = authorId && getUser( authorId )?.email;
 			const submitButton = innerBlocks.find( block => block.name === 'jetpack/button' );
@@ -93,6 +96,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 			}
 
 			return {
+				postTitle: title,
 				canUserInstallPlugins: canUser( 'create', 'plugins' ),
 				hasInnerBlocks: innerBlocks.length > 0,
 				postAuthorEmail: authorEmail,
@@ -100,6 +104,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		},
 		[ clientId ]
 	);
+
 	const wrapperRef = useRef();
 	const innerRef = useRef();
 	const blockProps = useBlockProps( { ref: wrapperRef } );
@@ -151,16 +156,6 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		elt = (
 			<>
 				<InspectorControls>
-					{ ! attributes.formTitle && (
-						<PanelBody>
-							<Notice status="warning" isDismissible={ false }>
-								{ __(
-									'Add a heading inside the form or before it to help everybody identify it.',
-									'jetpack-forms'
-								) }
-							</Notice>{ ' ' }
-						</PanelBody>
-					) }
 					<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
 						<JetpackManageResponsesSettings setAttributes={ setAttributes } />
 					</PanelBody>
@@ -249,6 +244,23 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 						</>
 					) }
 				</InspectorControls>
+				<InspectorAdvancedControls>
+					<TextControl
+						label={ __( 'Accessible name', 'jetpack-forms' ) }
+						value={ formTitle }
+						placeholder={ postTitle }
+						onChange={ value => setAttributes( { formTitle: value } ) }
+						help={ __(
+							'Add an accessible name to help people using assistive technology identify the form. Defaults to page or post title.',
+							'jetpack-forms'
+						) }
+						__nextHasNoMarginBottom={ true }
+						__next40pxDefaultSize={ true }
+					/>
+					<ExternalLink href="https://developer.mozilla.org/en-US/docs/Glossary/Accessible_name">
+						{ __( 'Read more.', 'jetpack-forms' ) }
+					</ExternalLink>
+				</InspectorAdvancedControls>
 				<div { ...innerBlocksProps } />
 			</>
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Adds new field for controlling the "accessible name" attribute of the block, and removes sticky notice from block settings.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Before there was always visible, very noticeable alert on top of the form sidebar:

<img width="1547" alt="Screenshot 2025-02-27 at 12 48 11" src="https://github.com/user-attachments/assets/7f0f72f3-2096-489a-88ac-2795a8dc6642" />

The accessible name was added in https://github.com/Automattic/jetpack/pull/34667

Notice isn't ideal because it's so visible, there's no way to hide it, and it doesn't go away even when the page _has_ a title, or the form has a heading block in it. [Previously there was a mechanism](https://github.com/Automattic/jetpack/commit/959a1ef54ae56ebb3aa07aa9eea625076bd95ff5#diff-c8a4f65de918a2bd4e3cf11e2352c5c7f755469bd1d710f032f8c0a8e0f21360R1) to pick name from blocks but it was [removed since then](https://github.com/Automattic/jetpack/pull/36485) due to technical issues.

Instead of getting smart and detecting when forms has a name, I just removed the permanent notice and added a new field under "Advanced" panel:

<img width="1437" alt="Screenshot 2025-02-27 at 13 11 16" src="https://github.com/user-attachments/assets/3d39623e-f886-4176-8528-63b347c995d8" />

The input has current page name as placeholder to indicate that the accessible name defaults to page name:

https://github.com/Automattic/jetpack/blob/db54749e91cf323f6578b0d752457eaada510740/projects/packages/forms/src/contact-form/class-contact-form.php#L373-L374

<img width="587" alt="Screenshot 2025-02-27 at 13 15 48" src="https://github.com/user-attachments/assets/cd311241-b5c1-471e-89b0-ab7814289845" />

Customizing the attribute, you get custom name:

<img width="582" alt="Screenshot 2025-02-27 at 13 16 23" src="https://github.com/user-attachments/assets/104db8c8-4777-4f6a-920f-bedaf62bf086" />

I also added some copy + link to educate people what this field does. 

From accessibility perspective, form now always have a name, and customer can customize it if needed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add Forms block, save it
* In the frontend, Form's aria-label is same as page name
* Customize the value from Advanced settings
* In the frontend aria-label is now your custom input 
