### PR TITLE
Connection: fetch current user ID in user provisioning

### DIFF
--- a/projects/packages/connection/changelog/update-remote-provision-permission-check-2
+++ b/projects/packages/connection/changelog/update-remote-provision-permission-check-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove excessive check in fetching current user ID in user provisioning.

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -352,7 +352,7 @@ class REST_Connector {
 	public function remote_provision( WP_REST_Request $request ) {
 		$request_data = $request->get_params();
 
-		if ( did_action( 'application_password_did_authenticate' ) && current_user_can( 'jetpack_connect_user' ) ) {
+		if ( current_user_can( 'jetpack_connect_user' ) ) {
 			$request_data['local_user'] = get_current_user_id();
 		}
 


### PR DESCRIPTION
## Proposed changes:
Remove excessive check in fetching current user ID in user provisioning.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
PT: pf5801-1dm-p2
Justification: pf5801-1q1-p2#comment-787

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Same as 169029-ghe-Automattic/wpcom
