### PR TITLE
Social | Fix PHP warnings on WPCOM

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-php-warnings-on-connect-url
+++ b/projects/packages/publicize/changelog/fix-social-php-warnings-on-connect-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social | Fix PHP warnings on WPCOM

--- a/projects/packages/publicize/src/class-services.php
+++ b/projects/packages/publicize/src/class-services.php
@@ -72,26 +72,27 @@ class Services {
 			if ( $ignore_cache || false === $services ) {
 				$services = self::fetch_and_cache_services();
 			}
+			// This is here for backwards compatibility
+			// TODO Remove this array_map() call after April 2025 release of Jetpack.
+			return array_map(
+				function ( $service ) {
+					global $publicize;
+
+					return array_merge(
+						$service,
+						array(
+							'ID'                  => $service['id'],
+							'connect_URL'         => $publicize->connect_url( $service['id'], 'connect' ),
+							'external_users_only' => $service['supports']['additional_users_only'],
+							'multiple_external_user_ID_support' => $service['supports']['additional_users'],
+						)
+					);
+				},
+				$services
+			);
 		}
 
-		// This is here for backwards compatibility
-		// TODO Remove this array_map() call after April 2025 release of Jetpack.
-		return array_map(
-			function ( $service ) {
-				global $publicize;
-
-				return array_merge(
-					$service,
-					array(
-						'ID'                  => $service['id'],
-						'connect_URL'         => $publicize->connect_url( $service['ID'], 'connect' ),
-						'external_users_only' => $service['supports']['additional_users_only'],
-						'multiple_external_user_ID_support' => $service['supports']['additional_users'],
-					)
-				);
-			},
-			$services
-		);
+		return $services;
 	}
 
 	/**


### PR DESCRIPTION
#42095 resulted in some PHP warnings on WPCOM. We needed that change only for Jetpack sites and also it was `$service['id']` instead of `$service['ID']`.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix PHP warnings on WPCOM by using `$service['id']` instead of `$service['ID']`.
* Move the backwards compatibility check only for Jetpack sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the PR on your sandbox
* Goto editor
* Confirm that there are no PHP warnings
* Connect a Social account
* Confirm that it works fine.
* Follow the instructions from #42095

