### PR TITLE
Add a non-business Instant Search version

### DIFF
--- a/projects/plugins/wpcomsh/changelog/No business instant search version
+++ b/projects/plugins/wpcomsh/changelog/No business instant search version
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a temporary version of Instant Search which excludes business/commerce sites for performance reasons. As soon as the index rebuild is done and we have jetpack-search-30 ready, we can remove this Instant Search version.

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -380,6 +380,7 @@ class WPCOM_Features {
 	public const INSTALL_THEMES                    = 'install-themes';
 	public const INSTALL_WOO_ONBOARDING_PLUGINS    = 'install-woo-onboarding-plugins';
 	public const INSTANT_SEARCH                    = 'instant-search';
+	public const INSTANT_SEARCH_29                 = 'instant-search_29'; // TEMP AND TO BE DELETED AFTER REBUILDING the jetpack-search index
 	public const JETPACK_DASHBOARD                 = 'jetpack-dashboard';
 	public const LEGACY_CONTACT                    = 'legacy-contact';
 	public const LIST_INSTALLED_PLUGINS            = 'list-installed-plugins';
@@ -776,6 +777,13 @@ class WPCOM_Features {
 			self::WPCOM_BUSINESS_PLANS,
 			self::WPCOM_ECOMMERCE_PLANS,
 			self::WPCOM_ECOMMERCE_TRIAL_PLANS,
+			self::WPCOM_SEARCH,
+			self::WPCOM_SEARCH_MONTHLY,
+			self::WP_P2_PLUS_MONTHLY,
+			self::JETPACK_SEARCH_PLANS,
+			self::JETPACK_COMPLETE_PLANS,
+		),
+		self::INSTANT_SEARCH_29                 => array(
 			self::WPCOM_SEARCH,
 			self::WPCOM_SEARCH_MONTHLY,
 			self::WP_P2_PLUS_MONTHLY,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
Just following Automattor's instructions saying It looks like you're modifying files shared with wpcomsh. Please make sure to update these files as well: https://github.com/Automattic/jetpack/tree/trunk/projects/plugins/wpcomsh/wpcom-features. So adding these changes here as well. The change is the addition of a new Instant Search version without Business/Commerce sites.
