### PR TITLE
Connection: add 'isRegistered' flag to `connection/data` endpoint

### DIFF
--- a/projects/packages/connection/changelog/add-connection-data-endpoint-site-only
+++ b/projects/packages/connection/changelog/add-connection-data-endpoint-site-only
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add 'isRegistered' flag to connection data endpoint.

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -673,6 +673,7 @@ class REST_Connector {
 		$response = array(
 			'currentUser'     => $current_user_connection_data,
 			'connectionOwner' => $owner_display_name,
+			'isRegistered'    => $connection->is_connected(),
 		);
 
 		if ( $rest_response ) {

--- a/projects/packages/connection/tests/php/test-rest-endpoints.php
+++ b/projects/packages/connection/tests/php/test-rest-endpoints.php
@@ -872,6 +872,7 @@ class Test_REST_Endpoints extends TestCase {
 				),
 			),
 			'connectionOwner' => null,
+			'isRegistered'    => false,
 		);
 
 		$response_data = $response->get_data();
@@ -917,6 +918,7 @@ class Test_REST_Endpoints extends TestCase {
 				),
 			),
 			'connectionOwner' => null,
+			'isRegistered'    => true,
 		);
 
 		$response_data = $response->get_data();
@@ -968,6 +970,7 @@ class Test_REST_Endpoints extends TestCase {
 				),
 			),
 			'connectionOwner' => $user->user_login,
+			'isRegistered'    => true,
 		);
 
 		$response_data = $response->get_data();


### PR DESCRIPTION
## Proposed changes:
Add `isRegistered` flag to the `/connection/data` endpoint.
This new flag will allow API consumers to avoid additional request to `/connection` endpoint.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pf5801-1q1-p2

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Use "Jetpack Debug -> REST API Tester" to run API request to `/jetpack/v4/connection/data`.
Alternate between not connected, site-only, and fully connected Jetpack.
Confirm `isRegistered` flag shows up and reflects the connection status (`true` or `false`).