### PR TITLE
i18n: Load Atomic JS translations from widgets.wp.com for jetpack-mu-wpcom

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-atomic-path-for-translations
+++ b/projects/plugins/wpcomsh/changelog/fix-atomic-path-for-translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+i18n: load JavaScript translations for 'jetpack-mu-wpcom' from widgets.wp.com

--- a/projects/plugins/wpcomsh/i18n.php
+++ b/projects/plugins/wpcomsh/i18n.php
@@ -89,11 +89,15 @@ add_filter(
 	2
 );
 
-// Ensure use of the correct local path when loading the JavaScript translation file for a CDN'ed asset.
+// Ensure use of the correct local path when loading the JavaScript translation file for a CDN'ed or jetpack-mu-wpcom asset.
 add_filter(
 	'load_script_translation_file',
-	function ( $file, $handle ) {
+	function ( $file, $handle, $domain ) {
 		global $wp_scripts;
+		if ( 'jetpack-mu-wpcom' === $domain ) {
+			return 'https://widgets.wp.com/languages/mu-plugins/' . basename( $file );
+		}
+
 		if ( class_exists( 'Jetpack_Photon_Static_Assets_CDN' ) ) {
 			// This is a rewritten plugin URL, so load the language file from the plugins path.
 			if ( isset( $wp_scripts->registered[ $handle ] ) && wp_startswith( $wp_scripts->registered[ $handle ]->src, Jetpack_Photon_Static_Assets_CDN::CDN . 'p' ) ) {
@@ -103,7 +107,7 @@ add_filter(
 		return $file;
 	},
 	10,
-	2
+	3
 );
 
 // end of https://github.com/Automattic/jetpack/pull/14797


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/i18n-issues#875 
Related to 175075-ghe-Automattic/wpcom
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Load Atomic javascript translation files from `https://widgets.wp.com/languages/mu-plugins/` for Atomic websites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*