### PR TITLE
phpunit: Cleanup remaining `phpunit.xml.dist` files

### DIFF
--- a/projects/packages/account-protection/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/packages/account-protection/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/packages/account-protection/phpunit.xml.dist
+++ b/projects/packages/account-protection/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/packages/boost-core/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/packages/boost-core/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/packages/boost-core/phpunit.xml.dist
+++ b/projects/packages/boost-core/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/packages/calypsoify/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/packages/calypsoify/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/packages/calypsoify/phpunit.xml.dist
+++ b/projects/packages/calypsoify/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/packages/chatbot/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/packages/chatbot/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/packages/chatbot/phpunit.xml.dist
+++ b/projects/packages/chatbot/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/packages/classic-theme-helper/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/packages/classic-theme-helper/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/packages/classic-theme-helper/phpunit.xml.dist
+++ b/projects/packages/classic-theme-helper/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/packages/composer-plugin/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/packages/composer-plugin/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/packages/composer-plugin/phpunit.xml.dist
+++ b/projects/packages/composer-plugin/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/packages/explat/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/packages/explat/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/packages/explat/phpunit.xml.dist
+++ b/projects/packages/explat/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/packages/external-media/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/packages/external-media/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/packages/external-media/phpunit.xml.dist
+++ b/projects/packages/external-media/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/packages/import/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/packages/import/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/packages/import/phpunit.xml.dist
+++ b/projects/packages/import/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/packages/plugin-deactivation/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/packages/plugin-deactivation/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/packages/plugin-deactivation/phpunit.xml.dist
+++ b/projects/packages/plugin-deactivation/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/packages/plugins-installer/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/packages/plugins-installer/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/packages/plugins-installer/phpunit.xml.dist
+++ b/projects/packages/plugins-installer/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/packages/woocommerce-analytics/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/packages/woocommerce-analytics/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/packages/woocommerce-analytics/phpunit.xml.dist
+++ b/projects/packages/woocommerce-analytics/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/packages/wordads/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/packages/wordads/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/packages/wordads/phpunit.xml.dist
+++ b/projects/packages/wordads/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/packages/wp-js-data-sync/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/packages/wp-js-data-sync/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/packages/wp-js-data-sync/phpunit.xml.dist
+++ b/projects/packages/wp-js-data-sync/phpunit.xml.dist
@@ -7,7 +7,7 @@
   </coverage>
   <testsuites>
     <testsuite name="main">
-      <directory prefix="test" suffix=".php">tests/php</directory>
+      <directory suffix="Test.php">tests/php</directory>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/projects/packages/yoast-promo/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/packages/yoast-promo/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/packages/yoast-promo/phpunit.xml.dist
+++ b/projects/packages/yoast-promo/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/plugins/backup/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/plugins/backup/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/plugins/backup/phpunit.xml.dist
+++ b/projects/plugins/backup/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/plugins/classic-theme-helper-plugin/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/plugins/classic-theme-helper-plugin/phpunit.xml.dist
+++ b/projects/plugins/classic-theme-helper-plugin/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/plugins/inspect/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/plugins/inspect/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/plugins/inspect/phpunit.xml.dist
+++ b/projects/plugins/inspect/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/plugins/mu-wpcom-plugin/phpunit.xml.dist
+++ b/projects/plugins/mu-wpcom-plugin/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/plugins/protect/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/plugins/protect/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/plugins/protect/phpunit.xml.dist
+++ b/projects/plugins/protect/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/plugins/search/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/plugins/search/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/plugins/search/phpunit.xml.dist
+++ b/projects/plugins/search/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/plugins/super-cache/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/plugins/super-cache/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/plugins/super-cache/phpunit.xml.dist
+++ b/projects/plugins/super-cache/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/projects/plugins/vaultpress/changelog/fix-update-remaining-phpunit-xml-files
+++ b/projects/plugins/vaultpress/changelog/fix-update-remaining-phpunit-xml-files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Cleanup `phpunit.xml.dist` to be right for PHPUnit 10+ if someday someone adds tests here.
+
+

--- a/projects/plugins/vaultpress/phpunit.xml.dist
+++ b/projects/plugins/vaultpress/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/tools/cli/skeletons/packages/phpunit.xml.dist
+++ b/tools/cli/skeletons/packages/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/tools/cli/skeletons/plugins/phpunit.xml.dist
+++ b/tools/cli/skeletons/plugins/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
 	<testsuites>
 		<testsuite name="main">
-			<directory prefix="test" suffix=".php">tests/php</directory>
+			<directory suffix="Test.php">tests/php</directory>
 		</testsuite>
 	</testsuites>
 	<filter>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PHPUnit 10+ requires that test class names match the filename, PSR-4 style. These projects have a `phpunit.xml.dist` that needs updating even though they currently have no tests to be renamed.

This PR also updates the skeleton configs for `jetpack generate`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Preparatory for https://github.com/Automattic/jetpack/pull/41930
PT: pf4qpu-Fo-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* I suppose you might try `jetpack generate`.
