### PR TITLE
Tooling: Fix jetpack cli link and unlink

### DIFF
--- a/tools/cli/commands/cli.js
+++ b/tools/cli/commands/cli.js
@@ -47,6 +47,8 @@ function cliLink( options ) {
 						[
 							{
 								title: chalkJetpackGreen( `Enabling global access to the CLI` ),
+								// Theoretically we shouldn't need the --global as of v10.0, but there was a bug until 10.5.
+								// It shouldn't hurt to leave this.
 								task: () => command( 'pnpm link --global', options.v, path.resolve( 'tools/cli' ) ),
 							},
 						],
@@ -87,6 +89,8 @@ function cliUnlink( options ) {
 						[
 							{
 								title: chalkJetpackGreen( `Removing global access to the CLI` ),
+								// In theory unlink should work, but it doesn't (and there are dozens of issues related
+								// to link/unlink in the pnpm repo. This works well.
 								task: () => command( 'pnpm uninstall --global jetpack-cli', options.v ),
 							},
 						],

--- a/tools/cli/commands/cli.js
+++ b/tools/cli/commands/cli.js
@@ -47,7 +47,7 @@ function cliLink( options ) {
 						[
 							{
 								title: chalkJetpackGreen( `Enabling global access to the CLI` ),
-								task: () => command( 'pnpm link', options.v, path.resolve( 'tools/cli' ) ),
+								task: () => command( 'pnpm link --global', options.v, path.resolve( 'tools/cli' ) ),
 							},
 						],
 						opts
@@ -87,7 +87,7 @@ function cliUnlink( options ) {
 						[
 							{
 								title: chalkJetpackGreen( `Removing global access to the CLI` ),
-								task: () => command( 'pnpm unlink', options.v, path.resolve( 'tools/cli' ) ),
+								task: () => command( 'pnpm uninstall --global jetpack-cli', options.v ),
 							},
 						],
 						opts


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This fixes `pnpm jetpack cli link` and `jetpack cli unlink`.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

In #41821 we upgraded `pnpm` to v10 and removed the `--global` flag when linking since it wasn't supposed to need it anymore, but apparently this version didn't work as described. In `pnpm` v10.5 [this was resolved](https://github.com/pnpm/pnpm/releases/tag/v10.5.0) (though that introduced a separate regression [resolved in 10.5.2](https://github.com/pnpm/pnpm/releases/tag/v10.5.2)).

For now, we'll just keep the `--global` for the link. The `unlink` never seemed to work, and `uninstall` seems to work just as well, so I changed the script to use that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Ensure `jetpack` isn't in your path/linked/aliased already (e.g. `jetpack` should give a "not found" error).
2. Run `pnpm jetpack cli link`.
3. Ensure `jetpack` runs as expected.
4. Run `jetpack cli unlink`.
5. Ensure `jetpack` no longer runs. Note that the error might have residual references to an `npm` path until you start a new terminal session; fixing that is out of scope and is likely a side effect of `pnpm` in general.