### PR TITLE
i18n: Load JavaScript translations for `wpcom-options-general.js`

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-missing-translations-on-options-general
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-missing-translations-on-options-general
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+i18n: Load JS translations for 'wpcom-options-general.ts'

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -76,7 +76,7 @@ function wpcom_enqueue_options_general_assets() {
 		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-options-general/wpcom-options-general.js' ),
 		true
 	);
-
+	wp_set_script_translations( 'wpcom-options-general', 'jetpack-mu-wpcom' );
 	$site_slug           = wpcom_get_site_slug();
 	$options_general_url = admin_url( 'options-general.php' );
 	wp_add_inline_script(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to Automattic/i18n-issues#875 

Depends on 175075-ghe-Automattic/wpcom

Some UI on Simple Sites on `/wp-admin/options-general.php`, has some untranslated elements.

#### Screenshots
##### Before
![before](https://github.com/user-attachments/assets/15f8ebcd-fbdb-4039-9787-2cd1e0777b58)

##### After
![after](https://github.com/user-attachments/assets/9caf8981-b1b5-41b0-9911-edc58b7e434e)


## Proposed changes:
<!--- Explain what functional changes your PR includes -->


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox a simple site (without these changes)
* View `/wp-admin/options-general.php` 
* Verify that the `WordPress Address (URL)` is untranslated.
* Checkout these changes using `bin/jetpack-downloader test jetpack-mu-wpcom-plugin fix/missing-translations-on-options-general`
* Verify that the `WordPress Address (URL)` is translated.