### PR TITLE
Post by Email: fix user connection link

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-post-by-email-authorize-user
+++ b/projects/plugins/jetpack/changelog/fix-post-by-email-authorize-user
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix the user connection link in Post-by-Email module.

--- a/projects/plugins/jetpack/modules/post-by-email/class-jetpack-post-by-email.php
+++ b/projects/plugins/jetpack/modules/post-by-email/class-jetpack-post-by-email.php
@@ -143,7 +143,7 @@ class Jetpack_Post_By_Email {
 								<?php echo esc_html( wptexturize( __( "If you don't have a WordPress.com account yet, you can sign up for free in just a few seconds.", 'jetpack' ) ) ); ?>
 							</p>
 							<p>
-								<a href="<?php echo esc_url( $jetpack->build_connect_url( false, get_edit_profile_url( get_current_user_id() ) . '#post-by-email', 'unlinked-user-pbe' ) ); ?>" class="button button-connector" id="wpcom-connect"><?php esc_html_e( 'Link account with WordPress.com', 'jetpack' ); ?></a>
+								<a href="<?php echo esc_url( $jetpack->build_connect_url( true, get_edit_profile_url( get_current_user_id() ) . '#post-by-email', 'unlinked-user-pbe' ) ); ?>" class="button button-connector" id="wpcom-connect"><?php esc_html_e( 'Link account with WordPress.com', 'jetpack' ); ?></a>
 							</p>
 							<?php
 						}


### PR DESCRIPTION
## Proposed changes:
* Fix the user connection link in Post-by-Email module.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p8oabR-1Di-p2#comment-8422

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect Jetpack.
2. Go to "Jetpack -> Settings", activate "Post by Email".
3. Create another WP user, login under that account.
4. Go to "Users -> Profile", scroll down to "Post by Email" section.
5. Click "Link account with WordPress.com".
6. Go through the connection flow, confirm you get connected successfully.