### PR TITLE
Update/where historically active modules is updated from

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -27,6 +27,7 @@ import {
 	QUERY_CHAT_AUTHENTICATION_KEY,
 } from '../../data/constants';
 import useEvaluationRecommendations from '../../data/evaluation-recommendations/use-evaluation-recommendations';
+import useUpdateHistoricallyActiveModules from '../../data/products/use-update-historically-active-modules';
 import useSimpleQuery from '../../data/use-simple-query';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import onKeyDownCallback from '../../data/utils/onKeyDownCallback';
@@ -112,6 +113,11 @@ export default function MyJetpackScreen() {
 		name: QUERY_CHAT_AUTHENTICATION_KEY,
 		query: { path: REST_API_CHAT_AUTHENTICATION_ENDPOINT },
 	} );
+	const updateHistoricallyActiveModules = useUpdateHistoricallyActiveModules();
+
+	useEffect( () => {
+		updateHistoricallyActiveModules();
+	}, [ updateHistoricallyActiveModules ] );
 
 	const isAvailable = availabilityData?.is_available;
 	const jwt = authData?.user?.jwt;

--- a/projects/packages/my-jetpack/_inc/data/constants.ts
+++ b/projects/packages/my-jetpack/_inc/data/constants.ts
@@ -12,6 +12,7 @@ export const REST_API_VIDEOPRESS_FEATURED_STATS = 'videopress/v1/stats/featured'
 export const REST_API_SITE_DISMISS_BANNER = `${ REST_API_NAMESPACE }/site/dismiss-welcome-banner`;
 export const REST_API_EVALUATE_SITE_RECOMMENDATIONS = `${ REST_API_NAMESPACE }/site/recommendations/evaluation`;
 export const REST_API_SITE_EVALUATION_RESULT = `${ REST_API_NAMESPACE }/site/recommendations/evaluation/result`;
+export const REST_API_UPDATE_HISTORICALLY_ACTIVE_MODULES = `${ REST_API_NAMESPACE }/site/update-historically-active-modules`;
 
 export const getStatsHighlightsEndpoint = ( blogId: string ) =>
 	`${ ODYSSEY_STATS_API_NAMESPACE }/sites/${ blogId }/stats/highlights`;
@@ -32,6 +33,7 @@ export const QUERY_PURCHASES_KEY = 'purchases';
 export const QUERY_EVALUATE_KEY = 'evaluate site recommendations';
 export const QUERY_SAVE_EVALUATION_KEY = 'save site evaluation result';
 export const QUERY_REMOVE_EVALUATION_KEY = 'remove site evaluation result';
+export const QUERY_UPDATE_HISTORICALLY_ACTIVE_MODULES_KEY = 'update historically active modules';
 
 // Product Slugs
 export const PRODUCT_SLUGS = {

--- a/projects/packages/my-jetpack/_inc/data/products/use-update-historically-active-modules.ts
+++ b/projects/packages/my-jetpack/_inc/data/products/use-update-historically-active-modules.ts
@@ -1,0 +1,27 @@
+import {
+	QUERY_UPDATE_HISTORICALLY_ACTIVE_MODULES_KEY,
+	REST_API_UPDATE_HISTORICALLY_ACTIVE_MODULES,
+} from '../constants';
+import useSimpleMutation from '../use-simple-mutation';
+
+const useUpdateHistoricallyActiveModules = () => {
+	const { mutate: updateHistoricallyActiveModules } = useSimpleMutation< JetpackModule[] >( {
+		name: QUERY_UPDATE_HISTORICALLY_ACTIVE_MODULES_KEY,
+		query: {
+			path: REST_API_UPDATE_HISTORICALLY_ACTIVE_MODULES,
+			method: 'POST',
+		},
+		options: {
+			onSuccess: data => {
+				// Update window state with new data
+				if ( data.length > 0 ) {
+					window.myJetpackInitialState.lifecycleStats.historicallyActiveModules = data;
+				}
+			},
+		},
+	} );
+
+	return updateHistoricallyActiveModules;
+};
+
+export default useUpdateHistoricallyActiveModules;

--- a/projects/packages/my-jetpack/changelog/update-where-historically-active-modules-is-updated-from
+++ b/projects/packages/my-jetpack/changelog/update-where-historically-active-modules-is-updated-from
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Move update to historically active modules to frontend

--- a/projects/packages/my-jetpack/src/class-historically-active-modules.php
+++ b/projects/packages/my-jetpack/src/class-historically-active-modules.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Sets up the Historically Active Modules rest api endpoint and helper functions
+ *
+ * @package automattic/my-jetpack
+ */
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use WP_Error;
+
+/**
+ * Registers REST route for updating historically active modules
+ * and includes all helper functions for triggering an update elsewhere
+ */
+class Historically_Active_Modules {
+	public const UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY = 'update-historically-active-jetpack-modules';
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		register_rest_route(
+			'my-jetpack/v1',
+			'site/update-historically-active-modules',
+			array(
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => __CLASS__ . '::rest_trigger_historically_active_modules_update',
+				'permission_callback' => __CLASS__ . '::permissions_callback',
+			)
+		);
+	}
+
+	/**
+	 * Check user capabilities to access historically active modules.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @return true|WP_Error
+	 */
+	public static function permissions_callback() {
+		return current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Update historically active Jetpack plugins
+	 * Historically active is defined as the Jetpack plugins that are installed and active with the required connections
+	 * This array will consist of any plugins that were active at one point in time and are still enabled on the site
+	 *
+	 * @return void
+	 */
+	public static function update_historically_active_jetpack_modules() {
+		$historically_active_modules = \Jetpack_Options::get_option( 'historically_active_modules', array() );
+		$products                    = Products::get_products();
+		$product_classes             = Products::get_products_classes();
+
+		foreach ( $products as $product ) {
+			$product_slug = $product['slug'];
+			$status       = $product_classes[ $product_slug ]::get_status();
+			// We want to leave modules in the array if they've been active in the past
+			// and were not manually disabled by the user.
+			if ( in_array( $status, Products::$broken_module_statuses, true ) ) {
+				continue;
+			}
+
+			// If the module is active and not already in the array, add it
+			if (
+				in_array( $status, Products::$active_module_statuses, true ) &&
+				! in_array( $product_slug, $historically_active_modules, true )
+			) {
+					$historically_active_modules[] = $product_slug;
+			}
+
+			// If the module has been disabled due to a manual user action,
+			// or because of a missing plan error, remove it from the array
+			if ( in_array( $status, Products::$disabled_module_statuses, true ) ) {
+				$historically_active_modules = array_values( array_diff( $historically_active_modules, array( $product_slug ) ) );
+			}
+		}
+
+		\Jetpack_Options::update_option( 'historically_active_modules', array_unique( $historically_active_modules ) );
+	}
+
+	/**
+	 * REST API endpoint to trigger an update to the historically active Jetpack modules
+	 *
+	 * @return WP_Error|\WP_REST_Response
+	 */
+	public static function rest_trigger_historically_active_modules_update() {
+		self::update_historically_active_jetpack_modules();
+		$historically_active_modules = \Jetpack_Options::get_option( 'historically_active_modules', array() );
+		return rest_ensure_response( $historically_active_modules );
+	}
+
+	/**
+	 * Set transient to queue an update to the historically active Jetpack modules on the next wp-admin load
+	 *
+	 * @param string $plugin The plugin that triggered the update. This will be present if the function was queued by a plugin activation.
+	 *
+	 * @return void
+	 */
+	public static function queue_historically_active_jetpack_modules_update( $plugin = null ) {
+		$plugin_filenames = Products::get_all_plugin_filenames();
+
+		if ( ! $plugin || in_array( $plugin, $plugin_filenames, true ) ) {
+			set_transient( self::UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY, true );
+		}
+	}
+}

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -59,12 +59,11 @@ class Initializer {
 		'jetpack-search',
 	);
 
-	private const MY_JETPACK_SITE_INFO_TRANSIENT_KEY             = 'my-jetpack-site-info';
-	private const UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY = 'update-historically-active-jetpack-modules';
-	private const MISSING_CONNECTION_NOTIFICATION_KEY            = 'missing-connection';
-	private const VIDEOPRESS_STATS_KEY                           = 'my-jetpack-videopress-stats';
-	private const VIDEOPRESS_PERIOD_KEY                          = 'my-jetpack-videopress-period';
-	private const MY_JETPACK_RED_BUBBLE_TRANSIENT_KEY            = 'my-jetpack-red-bubble-transient';
+	private const MY_JETPACK_SITE_INFO_TRANSIENT_KEY  = 'my-jetpack-site-info';
+	private const MISSING_CONNECTION_NOTIFICATION_KEY = 'missing-connection';
+	private const VIDEOPRESS_STATS_KEY                = 'my-jetpack-videopress-stats';
+	private const VIDEOPRESS_PERIOD_KEY               = 'my-jetpack-videopress-period';
+	private const MY_JETPACK_RED_BUBBLE_TRANSIENT_KEY = 'my-jetpack-red-bubble-transient';
 
 	/**
 	 * Holds info/data about the site (from the /sites/%d endpoint)
@@ -237,8 +236,6 @@ class Initializer {
 
 		Products::initialize_products();
 		$scan_data = Products\Protect::get_protect_data();
-
-		self::update_historically_active_jetpack_modules();
 
 		$waf_config     = array();
 		$waf_supported  = false;
@@ -546,6 +543,7 @@ class Initializer {
 		new REST_Zendesk_Chat();
 		new REST_AI();
 		new REST_Recommendations_Evaluation();
+		new Historically_Active_Modules();
 
 		Products::register_product_endpoints();
 
@@ -608,30 +606,17 @@ class Initializer {
 	}
 
 	/**
-	 * Set transient to queue an update to the historically active Jetpack modules on the next wp-admin load
-	 *
-	 * @param string $plugin The plugin that triggered the update. This will be present if the function was queued by a plugin activation.
-	 *
-	 * @return void
-	 */
-	public static function queue_historically_active_jetpack_modules_update( $plugin = null ) {
-		$plugin_filenames = Products::get_all_plugin_filenames();
-
-		if ( ! $plugin || in_array( $plugin, $plugin_filenames, true ) ) {
-			set_transient( self::UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY, true );
-		}
-	}
-
-	/**
 	 * Hook into several connection-based actions to update the historically active Jetpack modules
 	 * If the transient that indicates the list needs to be synced, update it and delete the transient
 	 *
 	 * @return void
 	 */
 	public static function setup_historically_active_jetpack_modules_sync() {
-		if ( get_transient( self::UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY ) && ! wp_doing_ajax() ) {
-			self::update_historically_active_jetpack_modules();
-			delete_transient( self::UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY );
+		// yummmm. ham.
+		$ham = new Historically_Active_Modules();
+		if ( get_transient( $ham::UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY ) && ! wp_doing_ajax() ) {
+			$ham::update_historically_active_jetpack_modules();
+			delete_transient( $ham::UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY );
 		}
 
 		$actions = array(
@@ -641,50 +626,11 @@ class Initializer {
 		);
 
 		foreach ( $actions as $action ) {
-			add_action( $action, array( __CLASS__, 'queue_historically_active_jetpack_modules_update' ), 5 );
+			add_action( $action, array( $ham, 'queue_historically_active_jetpack_modules_update' ), 5 );
 		}
 
 		// Modules are often updated async, so we need to update them right away as there will sometimes be no page reload.
-		add_action( 'jetpack_activate_module', array( __CLASS__, 'update_historically_active_jetpack_modules' ), 5 );
-	}
-
-	/**
-	 * Update historically active Jetpack plugins
-	 * Historically active is defined as the Jetpack plugins that are installed and active with the required connections
-	 * This array will consist of any plugins that were active at one point in time and are still enabled on the site
-	 *
-	 * @return void
-	 */
-	public static function update_historically_active_jetpack_modules() {
-		$historically_active_modules = \Jetpack_Options::get_option( 'historically_active_modules', array() );
-		$products                    = Products::get_products();
-		$product_classes             = Products::get_products_classes();
-
-		foreach ( $products as $product ) {
-			$product_slug = $product['slug'];
-			$status       = $product_classes[ $product_slug ]::get_status();
-			// We want to leave modules in the array if they've been active in the past
-			// and were not manually disabled by the user.
-			if ( in_array( $status, Products::$broken_module_statuses, true ) ) {
-				continue;
-			}
-
-			// If the module is active and not already in the array, add it
-			if (
-				in_array( $status, Products::$active_module_statuses, true ) &&
-				! in_array( $product_slug, $historically_active_modules, true )
-			) {
-					$historically_active_modules[] = $product_slug;
-			}
-
-			// If the module has been disabled due to a manual user action,
-			// or because of a missing plan error, remove it from the array
-			if ( in_array( $status, Products::$disabled_module_statuses, true ) ) {
-				$historically_active_modules = array_values( array_diff( $historically_active_modules, array( $product_slug ) ) );
-			}
-		}
-
-		\Jetpack_Options::update_option( 'historically_active_modules', array_unique( $historically_active_modules ) );
+		add_action( 'jetpack_activate_module', array( $ham, 'update_historically_active_jetpack_modules' ), 5 );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

* Currently the `update_historically_active_jetpack_modules` function is being triggered on every page load in the class function that sets the window state. This is not ideal as that function relies on `get_status` which relies on https requests on the backend
* This PR moves the historically active modules data to its own class, registers and endpoint to update the modules, and calls it on the frontend instead. The update will still be triggered in the following scenarios:
   * Plugin Activation
   * Module Activation
   * Site Connection
   * User Connection
* Since the above scenarios can happen outside of My Jetpack, they need to be kept so that an update can be queued at the time of activation or connection. These updates don't usually block the page load of My Jetpack, so I think it's okay to keep them the way they are. This PR only moves the update that happens on every page load of My Jetpack, and sends a POST request from the frontend that can be done async. It also updates the window state when it is done.

NOTE: We are still passing this value to the frontend via the window state, this is because the value comes from a saved value in Jetpack Options, and doesn't require an http request to return the value. Additionally, the historically active modules are also used to inform the red bubble slugs when a product is broken, but that also uses the Jetpack Option value rather than any sort of https request, so that's okay to keep too.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: pghfsA-df-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Go to My Jetpack and connect at least your site to Jetpack
3. After connecting your site, ensure you see the following active modules. To see that, you can go to the console and type `myJetpackInitialState.lifecycleStats.historicallyActiveModules`
![image](https://github.com/user-attachments/assets/79042f67-b6e9-4601-9477-57dfcd6adb04)
4. Now go to `wp-admin/plugin-install.php` and install and activate any Jetpack standalone plugin. Jetpack Boost for example. Make sure no error is thrown and when you go back to My Jetpack, boost shows up in the historically active modules data in the window state. 
![image](https://github.com/user-attachments/assets/ae74ce2d-8283-4ee3-994c-51f48f8acf30)
5. Feel free to run this locally and log out the data returned [here](https://github.com/Automattic/jetpack/pull/42133/files#diff-a36d4361651f4c1bdd15de8b7a3735af9637244c10a2100195813e82b9266a79R15) to ensure that it is accurate if you want to do some additional testing

Overall [this is the important line that we are removing](https://github.com/Automattic/jetpack/pull/42133/files#diff-2be902912ee7edeeeed04156e4456f5966e480fea3067586ff451c63b2bf2624L241) so that we can avoid an update to this data blocking the initial pageload