### PR TITLE
Carousel: Improve keyboard and screen reader accessibility

### DIFF
--- a/projects/plugins/jetpack/changelog/update-carousel-accessibility
+++ b/projects/plugins/jetpack/changelog/update-carousel-accessibility
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Carousel: Improve keyboard and screen reader accessibility

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -296,6 +296,8 @@ div.jp-carousel-buttons a:hover {
 	color: var(--jp-carousel-primary-color);
 	cursor: pointer;
 	transition: opacity 200ms ease-out;
+	background: unset;
+	border: unset;
 }
 
 .jp-carousel-transitions .jp-carousel-close-hint {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -308,12 +308,10 @@
 			'div.gallery, div.tiled-gallery, ul.wp-block-gallery, ul.blocks-gallery-grid, ' +
 			'figure.wp-block-gallery.has-nested-images, div.wp-block-jetpack-tiled-gallery, a.single-image-gallery';
 
-		// Selector for items within a gallery or tiled gallery.
-		var galleryItemSelector =
-			'.gallery-item, .tiled-gallery-item, .blocks-gallery-item, ' + ' .tiled-gallery__item';
-
 		// Selector for all items including single images.
-		var itemSelector = galleryItemSelector + ', .wp-block-image';
+		var itemSelector =
+			'.gallery-item, .tiled-gallery-item, .blocks-gallery-item, ' +
+			'.tiled-gallery__item, .wp-block-image';
 
 		var carousel = {};
 
@@ -378,10 +376,36 @@
 			}
 		}
 
+		/**
+		 * Update the image to improve keyboard and screen reader access.
+		 *
+		 * @param HTMLElement img
+		 */
 		function makeGalleryImageAccessible( img ) {
-			img.role = 'button';
-			img.tabIndex = 0;
-			img.ariaLabel = jetpackCarouselStrings.image_label;
+			// The tiled gallery adds attributes to the image directly.
+			if ( domUtil.closest( img, '.tiled-gallery__item' ) ) {
+				return;
+			}
+
+			// Find the link if it exists, otherwise create it.
+			let link = img.parentElement;
+			if ( ! domUtil.matches( link, 'a' ) ) {
+				link = document.createElement( 'a' );
+				link.href = img.getAttribute( 'data-permalink' );
+				link.appendChild( img.cloneNode( true ) );
+				img.replaceWith( link );
+			}
+
+			// Add aria attributes to the link.
+			link.role = 'button';
+
+			// Insert button text after the image, so that both image alt text
+			// and this label are read aloud. Prefixing with : creates a pause
+			// to separate the image alt text from the label.
+			const span = document.createElement( 'span' );
+			span.innerText = ': ' + jetpackCarouselStrings.image_label;
+			span.classList.add( 'screen-reader-text' );
+			link.appendChild( span );
 		}
 
 		function initializeCarousel() {
@@ -709,7 +733,7 @@
 				}
 
 				// Skip if image is part of a gallery.
-				if ( domUtil.closest( container, galleryItemSelector ) ) {
+				if ( domUtil.closest( container, gallerySelector ) ) {
 					return;
 				}
 
@@ -1584,10 +1608,12 @@
 		// Register the event listeners for starting the gallery
 		document.body.addEventListener( 'click', handleInteraction );
 		document.body.addEventListener( 'keydown', handleInteraction );
-		document.querySelectorAll( galleryItemSelector + 'img' ).forEach( function ( galleryImage ) {
-			if ( shouldOpenModal( galleryImage ) ) {
-				makeGalleryImageAccessible( galleryImage );
-			}
+		document.querySelectorAll( gallerySelector ).forEach( function ( container ) {
+			container.querySelectorAll( 'img' ).forEach( function ( galleryImage ) {
+				if ( shouldOpenModal( galleryImage ) ) {
+					makeGalleryImageAccessible( galleryImage );
+				}
+			} );
 		} );
 
 		function handleInteraction( e ) {
@@ -1598,8 +1624,7 @@
 
 			if ( e.type === 'keydown' ) {
 				const parentElement = document.activeElement.parentElement;
-				const isParentCarouselContainer =
-					parentElement && parentElement.classList.contains( 'tiled-gallery__item' );
+				const isParentCarouselContainer = domUtil.matches( parentElement, itemSelector );
 
 				if ( ( e.key === ' ' || e.key === 'Enter' ) && isParentCarouselContainer ) {
 					handleClick( e );
@@ -1658,7 +1683,14 @@
 				return;
 			}
 
-			var target = e.target;
+			// If the event happened on the link (keyboard), target is the link, but we need the image.
+			var target = domUtil.matches( e.target, 'img' )
+				? e.target
+				: e.target.querySelector( ':scope > img' );
+			if ( ! target ) {
+				return;
+			}
+
 			var gallery = domUtil.closest( target, gallerySelector );
 
 			if ( gallery ) {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -349,8 +349,48 @@
 						e.preventDefault();
 						closeCarousel();
 						break;
+					case 9: // tab
+						handleFocusTrap( e );
+						break;
 					default:
 						break;
+				}
+			}
+		}
+
+		function handleFocusTrap( e ) {
+			const focusableSelectors = [
+				'a[href]',
+				'input:not([disabled]):not([type="hidden"]):not([aria-hidden])',
+				'select:not([disabled]):not([aria-hidden])',
+				'textarea:not([disabled]):not([aria-hidden])',
+				'button:not([disabled]):not([aria-hidden])',
+				'[contenteditable]',
+				'[tabindex]:not([tabindex^="-"])',
+			];
+			// Find all focusable elements on screen.
+			const focusableElements = [
+				...carousel.overlay.querySelectorAll( focusableSelectors ),
+			].filter( el => el.offsetParent !== null );
+			const firstFocusableElement = focusableElements[ 0 ];
+			const lastFocusableElement = focusableElements[ focusableElements.length - 1 ];
+
+			if ( e.shiftKey === true ) {
+				if (
+					e.target === firstFocusableElement ||
+					false === carousel.overlay.contains( e.target )
+				) {
+					e.preventDefault();
+					lastFocusableElement.focus();
+				}
+			}
+			if ( e.shiftKey === false ) {
+				if (
+					e.target === lastFocusableElement ||
+					false === carousel.overlay.contains( e.target )
+				) {
+					e.preventDefault();
+					firstFocusableElement.focus();
 				}
 			}
 		}
@@ -468,6 +508,8 @@
 
 				carousel.overlay.addEventListener( 'jp_carousel.afterOpen', function () {
 					enableKeyboardNavigation();
+					carousel.overlay.tabIndex = '-1';
+					carousel.overlay.focus();
 
 					// Don't show navigation if there's only one image.
 					if ( carousel.slides.length <= 1 ) {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1339,6 +1339,10 @@
 					image.src = attrs.previewImage;
 				}
 
+				if ( attrs.alt ) {
+					image.alt = attrs.alt;
+				}
+
 				image.setAttribute( 'itemprop', 'image' );
 				image.setAttribute( 'data-loaded', 1 );
 			}
@@ -1434,6 +1438,7 @@
 					caption: caption || '',
 					permalink: permalinkEl && permalinkEl.getAttribute( 'href' ),
 					src: origFile || item.getAttribute( 'src' ) || '',
+					alt: item.getAttribute( 'alt' ) || '',
 				};
 
 				var tiledGalleryItem = domUtil.closest( item, '.tiled-gallery-item' );

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -371,7 +371,10 @@
 			// Find all focusable elements on screen.
 			const focusableElements = [
 				...carousel.overlay.querySelectorAll( focusableSelectors ),
-			].filter( el => el.offsetParent !== null );
+			].filter(
+				el => el.classList.contains( 'jp-carousel-close-hint' ) || el.offsetParent !== null
+			);
+
 			const firstFocusableElement = focusableElements[ 0 ];
 			const lastFocusableElement = focusableElements[ focusableElements.length - 1 ];
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -526,6 +526,16 @@
 				carousel.overlay.addEventListener( 'jp_carousel.beforeClose', function () {
 					disableKeyboardNavigation();
 
+					// Get the image position which opened this carousel, and focus it.
+					const [ container, index ] = carousel.source;
+					if ( container ) {
+						if ( domUtil.matches( container, 'a' ) ) {
+							container.focus();
+						} else {
+							container.querySelectorAll( 'a,:not(a) > img[tabindex]' )[ index ].focus();
+						}
+					}
+
 					// Fixes some themes where closing carousel brings view back to top.
 					document.documentElement.style.removeProperty( 'height' );
 
@@ -1561,6 +1571,7 @@
 			if ( settings.startIndex === -1 ) {
 				settings.startIndex = 0; // -1 returned if can't find index, so start from beginning
 			}
+			carousel.source = [ gallery, settings.startIndex ];
 
 			domUtil.emitEvent( carousel.overlay, 'jp_carousel.beforeOpen' );
 			carousel.gallery.innerHTML = '';

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -597,6 +597,17 @@ class Jetpack_Carousel {
 		<div class="jp-carousel-overlay<?php echo( $is_light ? ' jp-carousel-light' : '' ); ?>" style="display: none;">
 
 		<div class="jp-carousel-container<?php echo( $is_light ? ' jp-carousel-light' : '' ); ?>">
+			<!-- The main close buton -->
+			<button class="jp-carousel-close-hint" aria-label="<?php esc_attr_e( 'Close image', 'jetpack' ); ?>">
+				<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+					<mask id="maskClose" mask-type="alpha" maskUnits="userSpaceOnUse" x="5" y="5" width="15" height="14">
+						<path d="M19.3166 6.41L17.9135 5L12.3509 10.59L6.78834 5L5.38525 6.41L10.9478 12L5.38525 17.59L6.78834 19L12.3509 13.41L17.9135 19L19.3166 17.59L13.754 12L19.3166 6.41Z" fill="white"/>
+					</mask>
+					<g mask="url(#maskClose)">
+						<rect x="0.409668" width="23.8823" height="24" fill="#FFFFFF"/>
+					</g>
+				</svg>
+			</button>
 			<!-- The Carousel Swiper -->
 			<div
 				class="jp-carousel-wrap swiper-container jp-carousel-swiper-container jp-carousel-transitions"
@@ -623,17 +634,6 @@ class Jetpack_Carousel {
 						</g>
 					</svg>
 				</div>
-			</div>
-			<!-- The main close buton -->
-			<div class="jp-carousel-close-hint">
-				<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-					<mask id="maskClose" mask-type="alpha" maskUnits="userSpaceOnUse" x="5" y="5" width="15" height="14">
-						<path d="M19.3166 6.41L17.9135 5L12.3509 10.59L6.78834 5L5.38525 6.41L10.9478 12L5.38525 17.59L6.78834 19L12.3509 13.41L17.9135 19L19.3166 17.59L13.754 12L19.3166 6.41Z" fill="white"/>
-					</mask>
-					<g mask="url(#maskClose)">
-						<rect x="0.409668" width="23.8823" height="24" fill="#FFFFFF"/>
-					</g>
-				</svg>
 			</div>
 			<!-- Image info, comments and meta -->
 			<div class="jp-carousel-info">


### PR DESCRIPTION
Fixes #39926, though it seemed to be opposite when I tested (clicking gave the carousel, while keyboard took me to the attachment page). Throughout the images and galleries, the behavior between mouse and keyboard are now the same. This also improves the carousel keyboard behavior by creating a focus trap so that keyboard users can effectively navigate (and close) the carousel.

## Proposed changes:

- Removes the tabindex and aria label from images, this created an extra tab stop and prevented the images' alt text from being read
- Ensure all images with carousels are wrapped in links† so that they are focusable and interactive, without creating additional tab stops.
- Insert a `.screen-reader-text` span into the link, which will indicate the button's action without overwriting the alt text on the image
- Moves focus onto the overlay container when the carousel is open, so that the next interactive element is the close button
- Moves the button up in the carousel source order so that it's first in tab order (before the slide arrows)
- Sets up a focus trap so that tabbing while the carousel is open cycles through the elements on screen, nothing behind the carousel
- Moves focus back to the opening image when the carousel closes‡
- Adds any alt text to the slide image for screen readers

† These are already in links, generally, so for compatibility I stayed with links, with role=button to indicate correct keyboard interactions.

‡ This works great in "normal" cases where someone opens and closes an image, but there's an edge case if the page reloads with carousel open. If a page has the same image multiple times and is reloaded, on close it will focus back to the first instance of the photo. In general I think the focus improvement is worth this, but I'm open to feedback.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

1. Check that Carousel is enabled in Jetpack > Settings > Writing tab > Media section
2. Find or create posts with images, a gallery, a tiled gallery block, and/or gallery shortcode (this works, but it's not pretty 😆)
3. For image blocks, make sure the Link is set to "Attachment page"; gallery blocks use carousel regardless of selection (including none, see #28030)
4. View the post on the frontend
5. Click your images, you should see the carousel
6. Tab through the page
7. Each image should be only one tab stop (the link wrapper)
8. Hit space or enter, the carousel should open
9. Hit tab once, it should focus the close button
10. Tab a few times, it should cycle through the buttons on screen (you should be able to visually follow the focus with the outline)
11. Hit enter or space on the close button, it should close the carousel
12. Focus is back on the image you started on, so you can continue tabbing through the page

Try running through the same steps with a screen reader, though it's a little janky, it is a better experience. The image alt text is actually read aloud now, and is included on the large image too.

