### PR TITLE
Revert "Fix/update relative path for jetpack mu wpcom"

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-update-relative-path-for-jetpack-mu-wpcom
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-update-relative-path-for-jetpack-mu-wpcom
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-i18n: fix missing script translations

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -27,8 +27,6 @@ class Jetpack_Mu_Wpcom {
 		if ( did_action( 'jetpack_mu_wpcom_initialized' ) ) {
 			return;
 		}
-		// Apply temporary fix for translation path MD5 mismatch due to vendor -> jetpack_vendor change in https://github.com/Automattic/jetpack/pull/41185
-		add_filter( 'load_script_textdomain_relative_path', array( __CLASS__, 'fix_translation_relative_path_mismatch_wpcom_jetpack' ), 20, 2 );
 
 		// Shared code for src/features.
 		require_once self::PKG_DIR . 'src/common/index.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
@@ -90,25 +88,6 @@ class Jetpack_Mu_Wpcom {
 		 * @since 0.1.2
 		 */
 		do_action( 'jetpack_mu_wpcom_initialized' );
-	}
-
-	/**
-	 * Fixes translation file path MD5 mismatches caused by vendor -> jetpack_vendor migration.
-	 *
-	 * WordPress generates the translation file's MD5 hash based on the script's relative path.
-	 * Since the path structure changed, we rewrite `jetpack_vendor/` back to `vendor/` before hashing.
-	 *
-	 * @param string|false $relative The relative script path (before MD5 hashing).
-	 * @param string       $src     The script's original source path (unused).
-	 * @return string|false Updated relative path that keeps WordPress's MD5 hash consistent.
-	 */
-	public static function fix_translation_relative_path_mismatch_wpcom_jetpack( $relative, $src ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		if ( $relative && str_contains( $relative, 'jetpack_vendor/automattic/jetpack-mu-wpcom/src/build/' ) ) {
-			// Rewrite "jetpack_vendor/" back to the original "vendor/" to maintain MD5 compatibility
-			$relative = str_replace( 'jetpack_vendor/', 'vendor/', $relative );
-		}
-
-		return $relative;
 	}
 
 	/**

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-update-relative-path-for-jetpack-mu-wpcom
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-update-relative-path-for-jetpack-mu-wpcom
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-i18n: fix missing script translations

--- a/projects/plugins/wpcomsh/changelog/fix-update-relative-path-for-jetpack-mu-wpcom
+++ b/projects/plugins/wpcomsh/changelog/fix-update-relative-path-for-jetpack-mu-wpcom
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-i18n: fix missing script translations


### PR DESCRIPTION
Reverts Automattic/jetpack#41861  

Now that 175075-ghe-Automattic/wpcom has been released, this change is no longer needed.  
This reversion is related to Automattic/i18n-issues#875.  

## Proposed changes:  
On Simple Sites, JavaScript translations are now loaded from the `languages/mu-plugins` directory  
instead of the `jetpack-mu-wpcom/languages` folder. As a result, we no longer rely on  
the plugin's `languages` folder for JavaScript translations.  


## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox a simple site, and change the user locale to a Mag-16 locale, e.g. Spanish
* Execute 
```sh
bin/jetpack-downloader test jetpack-mu-wpcom-plugin revert-41861-fix/update-relative-path-for-jetpack-mu-wpcom
```
* Verify that the pop-ups that appear in the UI, e.g `/wp-admin/edit.php`, remain translated

