### PR TITLE
Themes: Use new REST API endpoint

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-use-new-rest-api
+++ b/projects/plugins/wpcomsh/changelog/update-use-new-rest-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use a new endpoint to get the list of themes from WordPress.com

--- a/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-api.php
+++ b/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-api.php
@@ -14,7 +14,7 @@ class WPCom_Themes_Api {
 	/**
 	 * The URL of the WordPress.com themes API.
 	 */
-	const WP_COM_THEMES_API_URL = 'https://public-api.wordpress.com/rest/v1.2/themes?http_envelope=1&page=1&number=1000';
+	const WP_COM_THEMES_API_URL = 'https://public-api.wordpress.com/wpcom/v2/themes?_envelope=1&page=1&number=1000';
 
 	/**
 	 * The URL of the WordPress.com theme API.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* I recently created a new /themes REST API endpoint in the WordPress REST API. This PR switches wpcomsh to use the new endpoint instead of the old one.
* See 173632-ghe-Automattic/wpcom to see where the new endpoint was added.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to wp-admin/theme-install.php and confirm that you see the list of themes in the same order as on WordPress.com.themes, not the default list from WordPress.org.


