### PR TITLE
AI Assistant: Update usage of usePostContent for only when necessary

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-audit-get-post-content
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-audit-get-post-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Client: Refactor usePostContent hook to expose isEditedPostEmpty

--- a/projects/js-packages/ai-client/src/components/ai-image/components/ai-image-modal.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-image/components/ai-image-modal.tsx
@@ -41,7 +41,6 @@ type AiImageModalProps = {
 	isUnlimited: boolean;
 	upgradeDescription: string;
 	hasError: boolean;
-	postContent?: string | boolean | null;
 	handlePreviousImage: () => void;
 	handleNextImage: () => void;
 	acceptButton: React.JSX.Element;

--- a/projects/js-packages/ai-client/src/components/ai-image/featured-image.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-image/featured-image.tsx
@@ -57,8 +57,7 @@ export default function FeaturedImage( {
 		placement === PLACEMENT_MEDIA_SOURCE_DROPDOWN
 	);
 	const siteType = useSiteType();
-	const { getPostContent } = usePostContent();
-	const postContent = getPostContent();
+	const { getPostContent, isEditedPostEmpty } = usePostContent();
 	const { postTitle, postFeaturedMediaId, isEditorPanelOpened } = useSelect( select => {
 		return {
 			postTitle: select( editorStore ).getEditedPostAttribute( 'title' ),
@@ -134,10 +133,10 @@ export default function FeaturedImage( {
 	 */
 	const handleGuessStyle = useCallback(
 		userPrompt => {
-			const content = postTitle + '\n\n' + postContent;
+			const content = postTitle + '\n\n' + getPostContent();
 			return guessStyle( userPrompt, 'featured-image-guess-style', content );
 		},
-		[ postContent, postTitle, guessStyle ]
+		[ postTitle, getPostContent, guessStyle ]
 	);
 
 	const handleGenerate = useCallback(
@@ -160,7 +159,7 @@ export default function FeaturedImage( {
 			setIsFeaturedImageModalVisible( true );
 			return processImageGeneration( {
 				userPrompt,
-				postContent: postTitle + '\n\n' + postContent,
+				postContent: postTitle + '\n\n' + getPostContent(),
 				notEnoughRequests,
 				style,
 			} ).catch( error => {
@@ -179,7 +178,7 @@ export default function FeaturedImage( {
 			featuredImageActiveModel,
 			siteType,
 			processImageGeneration,
-			postContent,
+			getPostContent,
 			notEnoughRequests,
 			postTitle,
 		]
@@ -210,7 +209,7 @@ export default function FeaturedImage( {
 			setCurrent( () => images.length );
 			processImageGeneration( {
 				userPrompt,
-				postContent: postTitle + '\n\n' + postContent,
+				postContent: postTitle + '\n\n' + getPostContent(),
 				notEnoughRequests,
 				style,
 			} ).catch( error => {
@@ -232,7 +231,7 @@ export default function FeaturedImage( {
 			setCurrent,
 			processImageGeneration,
 			postTitle,
-			postContent,
+			getPostContent,
 			notEnoughRequests,
 			images,
 		]
@@ -250,7 +249,7 @@ export default function FeaturedImage( {
 
 			processImageGeneration( {
 				userPrompt,
-				postContent: postTitle + '\n\n' + postContent,
+				postContent: postTitle + '\n\n' + getPostContent(),
 				notEnoughRequests,
 				style,
 			} ).catch( error => {
@@ -269,7 +268,7 @@ export default function FeaturedImage( {
 			featuredImageActiveModel,
 			siteType,
 			processImageGeneration,
-			postContent,
+			getPostContent,
 			notEnoughRequests,
 			postTitle,
 		]
@@ -347,7 +346,7 @@ export default function FeaturedImage( {
 	const generateAgainText = __( 'Generate another image', 'jetpack-ai-client' );
 	const generateText = __( 'Generate', 'jetpack-ai-client' );
 
-	const hasContent = postContent.trim?.() || postTitle.trim?.() ? true : false;
+	const hasContent = ! isEditedPostEmpty() || postTitle.trim?.() ? true : false;
 	const hasPrompt = hasContent ? prompt.length >= 0 : prompt.length >= 3;
 	const disableInput = notEnoughRequests || currentPointer?.generating || requireUpgrade;
 	const disableAction = disableInput || ( ! hasContent && ! hasPrompt );
@@ -397,7 +396,6 @@ export default function FeaturedImage( {
 				</>
 			) }
 			<AiImageModal
-				postContent={ hasContent }
 				autoStart={ hasContent && ! postFeaturedMediaId }
 				autoStartAction={ handleFirstGenerate }
 				images={ images }

--- a/projects/js-packages/ai-client/src/components/ai-image/general-purpose-image.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-image/general-purpose-image.tsx
@@ -55,7 +55,6 @@ export default function GeneralPurposeImage( {
 	const [ isFeaturedImageModalVisible, setIsFeaturedImageModalVisible ] = useState( true );
 	const siteType = useSiteType();
 	const { getPostContent } = usePostContent();
-	const postContent = getPostContent();
 	const { saveToMediaLibrary } = useSaveToMediaLibrary();
 	const { tracks } = useAnalytics();
 	const { recordEvent } = tracks;
@@ -112,17 +111,20 @@ export default function GeneralPurposeImage( {
 				site_type: siteType,
 				style,
 			} );
-			processImageGeneration( { userPrompt, postContent, notEnoughRequests, style } ).catch(
-				error => {
-					recordEvent( 'jetpack_ai_general_image_generation_error', {
-						placement,
-						error: error?.message,
-						model: generalImageActiveModel,
-						site_type: siteType,
-						style,
-					} );
-				}
-			);
+			processImageGeneration( {
+				userPrompt,
+				postContent: getPostContent(),
+				notEnoughRequests,
+				style,
+			} ).catch( error => {
+				recordEvent( 'jetpack_ai_general_image_generation_error', {
+					placement,
+					error: error?.message,
+					model: generalImageActiveModel,
+					site_type: siteType,
+					style,
+				} );
+			} );
 		},
 		[
 			recordEvent,
@@ -130,7 +132,7 @@ export default function GeneralPurposeImage( {
 			generalImageActiveModel,
 			siteType,
 			processImageGeneration,
-			postContent,
+			getPostContent,
 			notEnoughRequests,
 		]
 	);
@@ -147,16 +149,19 @@ export default function GeneralPurposeImage( {
 			} );
 
 			setCurrent( crrt => crrt + 1 );
-			processImageGeneration( { userPrompt, postContent, notEnoughRequests, style } ).catch(
-				error => {
-					recordEvent( 'jetpack_ai_general_image_generation_error', {
-						placement,
-						error: error?.message,
-						model: generalImageActiveModel,
-						site_type: siteType,
-					} );
-				}
-			);
+			processImageGeneration( {
+				userPrompt,
+				postContent: getPostContent(),
+				notEnoughRequests,
+				style,
+			} ).catch( error => {
+				recordEvent( 'jetpack_ai_general_image_generation_error', {
+					placement,
+					error: error?.message,
+					model: generalImageActiveModel,
+					site_type: siteType,
+				} );
+			} );
 		},
 		[
 			recordEvent,
@@ -164,7 +169,7 @@ export default function GeneralPurposeImage( {
 			generalImageActiveModel,
 			siteType,
 			processImageGeneration,
-			postContent,
+			getPostContent,
 			notEnoughRequests,
 			setCurrent,
 		]
@@ -181,16 +186,19 @@ export default function GeneralPurposeImage( {
 				style,
 			} );
 
-			processImageGeneration( { userPrompt, postContent, notEnoughRequests, style } ).catch(
-				error => {
-					recordEvent( 'jetpack_ai_general_image_generation_error', {
-						placement,
-						error: error?.message,
-						model: generalImageActiveModel,
-						site_type: siteType,
-					} );
-				}
-			);
+			processImageGeneration( {
+				userPrompt,
+				postContent: getPostContent(),
+				notEnoughRequests,
+				style,
+			} ).catch( error => {
+				recordEvent( 'jetpack_ai_general_image_generation_error', {
+					placement,
+					error: error?.message,
+					model: generalImageActiveModel,
+					site_type: siteType,
+				} );
+			} );
 		},
 		[
 			recordEvent,
@@ -198,7 +206,7 @@ export default function GeneralPurposeImage( {
 			generalImageActiveModel,
 			siteType,
 			processImageGeneration,
-			postContent,
+			getPostContent,
 			notEnoughRequests,
 		]
 	);
@@ -267,7 +275,6 @@ export default function GeneralPurposeImage( {
 
 	return (
 		<AiImageModal
-			postContent={ true }
 			images={ images }
 			currentIndex={ current }
 			title={ __( 'Generate an image with AI', 'jetpack-ai-client' ) }

--- a/projects/js-packages/ai-client/src/hooks/use-post-content.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-post-content.ts
@@ -9,17 +9,22 @@ import { useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import { renderMarkdownFromHTML } from '../libs/markdown/index.js';
+/**
+ * Types
+ */
+import type * as BlockEditorSelectors from '@wordpress/block-editor/store/selectors.js';
 
 /*
  * Simple helper to get the post content as markdown
  */
 const usePostContent = () => {
 	const { getBlocks, isEditedPostEmpty } = useSelect( select => {
-		const blockEditorSelect = select( editorStore );
+		const blockEditorSelect = select( 'core/block-editor' ) as typeof BlockEditorSelectors;
+		const coreEditorSelect = select( editorStore );
 
 		return {
 			getBlocks: blockEditorSelect.getBlocks,
-			isEditedPostEmpty: blockEditorSelect.isEditedPostEmpty,
+			isEditedPostEmpty: coreEditorSelect.isEditedPostEmpty,
 		};
 	}, [] );
 

--- a/projects/js-packages/ai-client/src/hooks/use-post-content.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-post-content.ts
@@ -3,31 +3,33 @@
  */
 import { serialize } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import { useCallback } from '@wordpress/element';
-/**
- * Types
- */
-import { renderMarkdownFromHTML } from '../libs/markdown/index.js';
-import type * as BlockEditorSelectors from '@wordpress/block-editor/store/selectors.js';
 /**
  * Internal dependencies
  */
+import { renderMarkdownFromHTML } from '../libs/markdown/index.js';
 
 /*
  * Simple helper to get the post content as markdown
  */
 const usePostContent = () => {
-	const blocks = useSelect(
-		select => ( select( 'core/block-editor' ) as typeof BlockEditorSelectors ).getBlocks(),
-		[]
-	);
+	const { getBlocks, isEditedPostEmpty } = useSelect( select => {
+		const blockEditorSelect = select( editorStore );
+
+		return {
+			getBlocks: blockEditorSelect.getBlocks,
+			isEditedPostEmpty: blockEditorSelect.isEditedPostEmpty,
+		};
+	}, [] );
 
 	const getPostContent = useCallback( () => {
-		return blocks?.length ? renderMarkdownFromHTML( { content: serialize( blocks ) } ) : '';
-	}, [ blocks ] );
+		const blocks = getBlocks();
 
-	// TODO: Check all the places that use this hook and optimize them for performance
-	return { getPostContent };
+		return blocks?.length ? renderMarkdownFromHTML( { content: serialize( blocks ) } ) : '';
+	}, [ getBlocks ] );
+
+	return { getPostContent, isEditedPostEmpty };
 };
 
 export default usePostContent;

--- a/projects/js-packages/shared-extension-utils/changelog/update-jetpack-ai-audit-get-post-content
+++ b/projects/js-packages/shared-extension-utils/changelog/update-jetpack-ai-audit-get-post-content
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed a required parameter on a hook where it should be optional
+
+

--- a/projects/js-packages/shared-extension-utils/src/hooks/use-autosave-and-redirect/index.js
+++ b/projects/js-packages/shared-extension-utils/src/hooks/use-autosave-and-redirect/index.js
@@ -24,7 +24,7 @@ function redirect( url, callback, shouldOpenNewWindow = false ) {
  * @param {Function} onRedirect  - To handle the redirection.
  * @return {object} - Object containing properties to handle autosave and redirect.
  */
-export default function useAutosaveAndRedirect( redirectUrl, onRedirect = noop ) {
+export default function useAutosaveAndRedirect( redirectUrl = null, onRedirect = noop ) {
 	const [ isRedirecting, setIsRedirecting ] = useState( false );
 
 	const { isAutosaveablePost, isDirtyPost, currentPost } = useSelect( select => {
@@ -95,7 +95,9 @@ export default function useAutosaveAndRedirect( redirectUrl, onRedirect = noop )
 		setIsRedirecting( true );
 
 		autosave( event ).then( () => {
-			redirect( redirectUrl, onRedirect, isWidgetEditor );
+			if ( redirectUrl ) {
+				redirect( redirectUrl, onRedirect, isWidgetEditor );
+			}
 		} );
 	};
 

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-audit-get-post-content
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-audit-get-post-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Update usage of usePostContent for only when necessary

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/feedback/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/feedback/index.tsx
@@ -28,8 +28,7 @@ export default function Feedback( {
 	const { tracks } = useAnalytics();
 
 	const postId = useSelect( select => select( editorStore ).getCurrentPostId(), [] );
-	const { getPostContent } = usePostContent();
-	const postContent = getPostContent();
+	const { getPostContent, isEditedPostEmpty } = usePostContent();
 
 	const toggleFeedbackModal = () => {
 		setIsFeedbackModalVisible( ! isFeedbackModalVisible );
@@ -70,7 +69,7 @@ export default function Feedback( {
 				role: 'jetpack-ai' as const,
 				context: {
 					type: 'proofread-plugin', // Legacy name, do not change
-					content: postContent,
+					content: getPostContent(),
 				},
 			},
 		];
@@ -103,7 +102,7 @@ export default function Feedback( {
 			<Button
 				onClick={ handleRequest }
 				variant="secondary"
-				disabled={ ! postContent || disabled }
+				disabled={ isEditedPostEmpty() || disabled }
 				isBusy={ busy }
 				__next40pxDefaultSize
 			>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/seo-assistant-wizard.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/seo-assistant-wizard.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
 /**
  * Internal dependencies
  */
@@ -20,13 +19,15 @@ import './style.scss';
  */
 import type { SeoAssistantDispatch } from './types';
 import type { Block } from '@automattic/jetpack-ai-client';
+import type * as BlockEditorSelectors from '@wordpress/block-editor/store/selectors.js';
 
 export default function SeoAssistantWizard() {
 	const imageBlocks = useSelect(
 		select =>
-			select( editorStore )
+			( select( 'core/block-editor' ) as typeof BlockEditorSelectors )
 				.getBlocks()
-				.filter( ( block: Block ) => block.name === 'core/image' ),
+				.filter( ( block: Block ) => block.name === 'core/image' )
+				.filter( ( block: Block ) => !! block.attributes.url ),
 		[]
 	);
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-alt-text-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-alt-text-step.tsx
@@ -67,7 +67,6 @@ export const useAltTextStep = ( {
 		imageBlocks.length
 	);
 	const { getPostContent } = usePostContent();
-	const postContent = getPostContent();
 	const postId = useSelect( select => select( editorStore ).getCurrentPostId(), [] );
 	const { tracks } = useAnalytics();
 	const prevStepHasChanged = useMemo( () => keywords !== lastValue, [ keywords, lastValue ] );
@@ -91,7 +90,7 @@ export const useAltTextStep = ( {
 						role: 'jetpack-ai' as const,
 						context: {
 							type: 'images-alt-text',
-							content: postContent,
+							content: getPostContent(),
 							keywords: keywords.split( ',' ),
 							images: [
 								{
@@ -107,7 +106,7 @@ export const useAltTextStep = ( {
 				}
 			);
 		},
-		[ mockRequests, tracks, keywords, postId, postContent ]
+		[ mockRequests, tracks, keywords, postId, getPostContent ]
 	);
 
 	const handleAltTextSelect = useCallback(

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-alt-text-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-alt-text-step.tsx
@@ -62,7 +62,7 @@ export const useAltTextStep = ( {
 		'generate' | 'regenerate' | null
 	>( imageBlocks.map( () => null ) );
 	const [ lastValue, setLastValue ] = useState< string >( '' );
-	const { updateBlockAttributes } = useDispatch( editorStore );
+	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
 	const { getMessages, setMessages, addMessage, editLastMessage, setSelectedMessage } = useMessages(
 		imageBlocks.length
 	);

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-description-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-description-step.tsx
@@ -53,7 +53,6 @@ export const useDescriptionStep = ( {
 		useMessages();
 	const { editPost } = useDispatch( editorStore );
 	const { getPostContent } = usePostContent();
-	const postContent = getPostContent();
 	const postId = useSelect( select => select( editorStore ).getCurrentPostId(), [] );
 	const [ generatedCount, setGeneratedCount ] = useState( 0 );
 	const [ hasFailed, setHasFailed ] = useState( false );
@@ -80,7 +79,7 @@ export const useDescriptionStep = ( {
 					role: 'jetpack-ai' as const,
 					context: {
 						type: 'seo-meta-description',
-						content: postContent,
+						content: getPostContent(),
 						keywords: keywords.split( ',' ),
 						count: 1,
 					},
@@ -91,7 +90,7 @@ export const useDescriptionStep = ( {
 				feature: 'jetpack-seo-assistant',
 			}
 		);
-	}, [ keywords, postContent, postId, mockRequests, tracks ] );
+	}, [ keywords, getPostContent, postId, mockRequests, tracks ] );
 
 	const handleDescriptionSelect = useCallback(
 		( option: OptionMessage ) => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-assistant/use-title-step.tsx
@@ -44,7 +44,6 @@ export const useTitleStep = ( {
 		useMessages();
 	const [ lastValue, setLastValue ] = useState< string >( '' );
 	const { getPostContent } = usePostContent();
-	const postContent = getPostContent();
 	const postId = useSelect( select => select( editorStore ).getCurrentPostId(), [] );
 	const [ generatedCount, setGeneratedCount ] = useState( 0 );
 	const [ hasFailed, setHasFailed ] = useState( false );
@@ -71,7 +70,7 @@ export const useTitleStep = ( {
 					role: 'jetpack-ai' as const,
 					context: {
 						type: 'seo-title',
-						content: postContent,
+						content: getPostContent(),
 						keywords: keywords.split( ',' ),
 					},
 				},
@@ -81,7 +80,7 @@ export const useTitleStep = ( {
 				feature: 'jetpack-seo-assistant',
 			}
 		);
-	}, [ keywords, postContent, postId, mockRequests, tracks ] );
+	}, [ keywords, getPostContent, postId, mockRequests, tracks ] );
 
 	const handleTitleSelect = useCallback(
 		( option: OptionMessage ) => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/index.tsx
@@ -97,8 +97,7 @@ export default function TitleOptimization( {
 		? SEOSidebarButtonLabel
 		: currentSidebarButtonLabel;
 
-	const { getPostContent } = usePostContent();
-	const postContent = getPostContent();
+	const { getPostContent, isEditedPostEmpty } = usePostContent();
 	const [ selected, setSelected ] = useState( null );
 	const [ isTitleOptimizationModalVisible, setIsTitleOptimizationModalVisible ] = useState( false );
 	const [ generating, setGenerating ] = useState( false );
@@ -159,7 +158,7 @@ export default function TitleOptimization( {
 					role: 'jetpack-ai' as const,
 					context: {
 						type: 'title-optimization',
-						content: postContent,
+						content: getPostContent(),
 						keywords: optimizationKeywords,
 					},
 				},
@@ -167,7 +166,7 @@ export default function TitleOptimization( {
 
 			request( messages, { feature: 'jetpack-ai-title-optimization' } );
 		},
-		[ recordEvent, placement, postContent, optimizationKeywords, request ]
+		[ recordEvent, placement, getPostContent, optimizationKeywords, request ]
 	);
 
 	const handleTitleOptimization = useCallback( () => {
@@ -231,7 +230,7 @@ export default function TitleOptimization( {
 			<p className="jetpack-ai-assistant__help-text">{ sidebarDescription }</p>
 			<Button
 				isBusy={ busy }
-				disabled={ ! postContent || disabled }
+				disabled={ isEditedPostEmpty() || disabled }
 				onClick={ handleTitleOptimization }
 				variant="secondary"
 				__next40pxDefaultSize


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #42148

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Exposes `isEditedPostEmpty` on `usePostContent` for a performant way of determining when to disable buttons
* Change `getPostContent` calls to happen only when necessary

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use the Featured Image, Image, Feedback and SEO features
* On an empty post, the sidebar should still show disabled buttons and a notice that content is necessary for some functions
* On a post with content, the features should work as expected
