### PR TITLE
Newsletter Dashboard Widget: add translations

### DIFF
--- a/projects/plugins/jetpack/changelog/add-translations-newsletter-widget
+++ b/projects/plugins/jetpack/changelog/add-translations-newsletter-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter Dashboard Widget: add translations

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/newsletter-widget.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/newsletter-widget.tsx
@@ -1,6 +1,8 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import './style.scss';
 import { Icon } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { envelope, payment } from '@wordpress/icons';
 
 interface NewsletterWidgetProps {
@@ -52,7 +54,7 @@ export const NewsletterWidget = ( {
 											: `${ adminUrl }admin.php?page=stats#!/stats/subscribers/${ site }`
 									}
 								>
-									email subscriptions
+									{ __( 'email subscriptions', 'jetpack' ) }
 								</a>
 							</span>
 						</span>
@@ -71,7 +73,7 @@ export const NewsletterWidget = ( {
 											: `${ adminUrl }admin.php?page=stats#!/stats/subscribers/${ site }`
 									}
 								>
-									paid subscriptions
+									{ __( 'paid subscriptions', 'jetpack' ) }
 								</a>
 							</span>
 						</span>
@@ -80,21 +82,29 @@ export const NewsletterWidget = ( {
 			</div>
 			<div className="newsletter-widget__footer">
 				<p className="newsletter-widget__footer-msg">
-					Effortlessly turn posts into emails with our Newsletter feature-expand your reach, engage
-					readers, and monetize your writing. No coding required.{ ' ' }
-					<a
-						href={ getRedirectUrl(
-							buildJPRedirectSource( 'learn/courses/newsletters-101/wordpress-com-newsletter' )
-						) }
-					>
-						Learn more
-					</a>
+					{ createInterpolateElement(
+						__(
+							'Effortlessly turn posts into emails with our Newsletter feature-expand your reach, engage readers, and monetize your writing. No coding required. <link>Learn more</link>',
+							'jetpack'
+						),
+						{
+							link: (
+								<a
+									href={ getRedirectUrl(
+										buildJPRedirectSource(
+											'learn/courses/newsletters-101/wordpress-com-newsletter'
+										)
+									) }
+								/>
+							),
+						}
+					) }
 				</p>
 				<div>
-					<h3>Quick Links</h3>
+					<h3>{ __( 'Quick Links', 'jetpack' ) }</h3>
 					<ul className="newsletter-widget__footer-list">
 						<li>
-							<a href={ `${ adminUrl }edit.php` }>Publish your next post</a>
+							<a href={ `${ adminUrl }edit.php` }>{ __( 'Publish your next post', 'jetpack' ) }</a>
 						</li>
 						<li>
 							<a
@@ -104,7 +114,7 @@ export const NewsletterWidget = ( {
 										: `${ adminUrl }admin.php?page=stats#!/stats/subscribers/${ site }`
 								}
 							>
-								View subscriber stats
+								{ __( 'View subscriber stats', 'jetpack' ) }
 							</a>
 						</li>
 						<li>
@@ -113,7 +123,7 @@ export const NewsletterWidget = ( {
 									buildJPRedirectSource( `subscribers/${ site }`, isWpcomSite )
 								) }
 							>
-								Import subscribers
+								{ __( 'Import subscribers', 'jetpack' ) }
 							</a>
 						</li>
 						<li>
@@ -122,7 +132,7 @@ export const NewsletterWidget = ( {
 									buildJPRedirectSource( `subscribers/${ site }`, isWpcomSite )
 								) }
 							>
-								Manage subscribers
+								{ __( 'Manage subscribers', 'jetpack' ) }
 							</a>
 						</li>
 						<li>
@@ -134,7 +144,7 @@ export const NewsletterWidget = ( {
 									)
 								) }
 							>
-								Monetize
+								{ __( 'Monetize', 'jetpack' ) }
 							</a>
 						</li>
 						<li>
@@ -145,7 +155,7 @@ export const NewsletterWidget = ( {
 										: `${ adminUrl }admin.php?page=jetpack#newsletter`
 								}
 							>
-								Newsletter settings
+								{ __( 'Newsletter settings', 'jetpack' ) }
 							</a>
 						</li>
 					</ul>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to pe7F0s-2wU-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add translation calls to widget

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Verify strings are still rendering correctly. They won't be translated until this is merged into Jetpack and the i18n team picks it up.

