### PR TITLE
My Jetpack: add h1 for screen readers

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -171,6 +171,7 @@ export default function MyJetpackScreen() {
 			apiNonce={ apiNonce }
 			optionalMenuItems={ isDevVersion && userIsAdmin ? [ resetOptionsMenuItem ] : [] }
 		>
+			<h1 className="screen-reader-text">{ __( 'My Jetpack', 'jetpack-my-jetpack' ) }</h1>
 			<hr className={ styles.separator } />
 
 			<IDCModal />

--- a/projects/packages/my-jetpack/changelog/add-jp-admin-page-h1
+++ b/projects/packages/my-jetpack/changelog/add-jp-admin-page-h1
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Add h1 for screen readers
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
It's good practice to include a level 1 heading when writing accessible web pages. It provides screen reader users with more context. This PR does that on the My Jetpack page. The captures below represent the list of headings in VoiceOver, on macOS.

| Before | After |
|-|-|
|<img width="400" alt="Screenshot 2025-03-01 at 11 08 28 AM" src="https://github.com/user-attachments/assets/4fadbe45-89ff-4e53-bedc-3445f445706b" />|<img width="400" alt="Screenshot 2025-03-01 at 11 09 21 AM" src="https://github.com/user-attachments/assets/5c024dac-b3df-4dba-bf22-02244e5149a5" />|

I considered adding a heading directly inside the `AdminPage` shared component. However, I chose to harcode it on the My Jetpack page instead for consistency. Indeed, some pages already include a h1 that's visually hidden, e.g. the Jetpack settings pages.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Epic: https://github.com/Automattic/vulcan/issues/710

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a Jetpack site
- Visit `/wp-admin/admin.php?page=my-jetpack`
- If you're able to use a screen reader, notice the heading level 1 is announced
- Otherwise, verify it's present in the DOM
<img width="418" alt="Screenshot 2025-03-01 at 11 11 29 AM" src="https://github.com/user-attachments/assets/fea1a3a2-053d-42ff-a655-78afd7feab07" />


- The page shouldn't have changed visually

