### PR TITLE
Components: add role to Jetpack footer

### DIFF
--- a/projects/js-packages/components/changelog/update-jetpack-footer-role
+++ b/projects/js-packages/components/changelog/update-jetpack-footer-role
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add role to Jetpack footer

--- a/projects/js-packages/components/components/jetpack-footer/index.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.tsx
@@ -118,6 +118,7 @@ const JetpackFooter: React.FC< JetpackFooterProps > = ( {
 				className
 			) }
 			aria-label={ __( 'Jetpack', 'jetpack-components' ) }
+			role="contentinfo"
 			{ ...otherProps }
 		>
 			<ul>

--- a/projects/js-packages/components/components/jetpack-footer/test/__snapshots__/component.tsx.snap
+++ b/projects/js-packages/components/components/jetpack-footer/test/__snapshots__/component.tsx.snap
@@ -5,6 +5,7 @@ exports[`JetpackFooter Render the component should match the snapshot: all props
   <footer
     aria-label="Jetpack"
     class="jp-dashboard-footer sample-classname"
+    role="contentinfo"
   >
     <ul>
       <li


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR adds a `contentinfo` role to the Jetpack footer so screen reader users can access it as any other landmark. The captures below represent the list of landmarks in VoiceOver, on macOS on the My Jetpack page.

| Before | After |
|-|-|
|<img width="400" alt="Screenshot 2025-03-01 at 11 45 25 AM" src="https://github.com/user-attachments/assets/f354643c-9255-4cb3-b1a6-55bad08bd0ec" />|<img width="400" alt="Screenshot 2025-03-01 at 11 46 43 AM" src="https://github.com/user-attachments/assets/d9853ed8-8de0-4bec-b2eb-eed10551d787" />|

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Epic: https://github.com/Automattic/vulcan/issues/710

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a Jetpack site
- Visit `/wp-admin/admin.php?page=my-jetpack`
- If you're able to use a screen reader, notice Jetpack footer appears in the landmark list

