### PR TITLE
Managed Plugins: Maintain list of atomic managed plugins

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-save-managed-plugin-list
+++ b/projects/plugins/wpcomsh/changelog/add-save-managed-plugin-list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Managed Plugins: maintain list of atomic managed plugins 

--- a/projects/plugins/wpcomsh/feature-plugins/managed-plugins.php
+++ b/projects/plugins/wpcomsh/feature-plugins/managed-plugins.php
@@ -580,7 +580,7 @@ function wpcomsh_update_managed_plugins(): void {
 
 	update_option( 'wpcomsh_at_managed_plugins', $managed_plugins );
 }
-add_action( 'deleted_plugin', 'wpcomsh_update_managed_plugins' );
+add_action( 'deleted_plugin', 'wpcomsh_update_managed_plugins', 100 );
 
 /**
  * Update the list of managed plugins after a plugin is installed.

--- a/projects/plugins/wpcomsh/feature-plugins/managed-plugins.php
+++ b/projects/plugins/wpcomsh/feature-plugins/managed-plugins.php
@@ -580,6 +580,7 @@ function wpcomsh_update_managed_plugins(): void {
 
 	update_option( 'wpcomsh_at_managed_plugins', $managed_plugins );
 }
+add_action( 'deleted_plugin', 'wpcomsh_update_managed_plugins' );
 
 /**
  * Update the list of managed plugins after a plugin is installed.

--- a/projects/plugins/wpcomsh/feature-plugins/managed-plugins.php
+++ b/projects/plugins/wpcomsh/feature-plugins/managed-plugins.php
@@ -559,3 +559,38 @@ function wpcomsh_remove_managed_plugins_from_update_plugins( $current ) {
 }
 
 add_filter( 'site_transient_update_plugins', 'wpcomsh_remove_managed_plugins_from_update_plugins' );
+
+/**
+ * Save the list of managed plugins to an option after the active plugins are updated.
+ * This is used to determine if a plugin is symlinked and should be auto-updated.
+ *
+ * @return void
+ */
+function wpcomsh_update_managed_plugins(): void {
+	if ( ! function_exists( 'get_plugins' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
+	if ( ! function_exists( 'wpcomsh_is_managed_plugin' ) ) {
+		return;
+	}
+
+	$plugin_files    = array_keys( get_plugins() );
+	$managed_plugins = array_filter( $plugin_files, 'wpcomsh_is_managed_plugin' );
+
+	update_option( 'wpcomsh_at_managed_plugins', $managed_plugins );
+}
+
+/**
+ * Update the list of managed plugins after a plugin is installed.
+ *
+ * @param WP_Upgrader $upgrader The upgrader object.
+ * @param array       $hook_extra Extra arguments passed to hooked filters.
+ * @return void
+ */
+function wpcomsh_handle_update_managed_plugins_list( $upgrader, $hook_extra ): void {
+	if ( isset( $hook_extra['type'] ) && $hook_extra['type'] === 'plugin' && isset( $hook_extra['action'] ) && $hook_extra['action'] === 'install' ) {
+		wpcomsh_update_managed_plugins();
+	}
+}
+add_action( 'upgrader_process_complete', 'wpcomsh_handle_update_managed_plugins_list', 10, 2 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related: https://github.com/Automattic/wp-calypso/issues/98422

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Save a list of atomic-managed plugins into a separate option. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a new Business site, mark it as a WoA Dev site, and take it Atomic.
2. Open up an SSH session to the site, and run the following commands:

```
wp shell
> get_option( 'wpcomsh_at_managed_plugins' )
```

3. This should show the following output:

```
=> bool(false)
```

4. Exit the WP shell using the `exit` command
5. Build the wpcomsh plugin and synchronize it to the WoA Dev site

```
git checkout BRANCH
composer install
jetpack rsync wpcomsh SSH_USERNAME@sftp.wp.com:htdocs/wp-content/mu-plugins
```

6. Once wpcomsh has been updated.
7. Install or remove any plugin on the site.
8. Open up an SSH session to the site, and run the following commands:

```
wp shell
> get_option( 'wpcomsh_at_managed_plugins' )
```

9. Verify that it prints a list of atomic managed plugins. 

