### PR TITLE
Stats: add highlights heading level as prop

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
@@ -16,18 +16,16 @@ import styles from './style.module.scss';
  * @return {object} StatsCards React component.
  */
 const StatsCards = ( { counts, previousCounts, headingLevel } ) => {
+	const Heading = `h${ headingLevel >= 1 && headingLevel <= 6 ? headingLevel : 3 }`;
+
 	return (
 		<div className={ styles[ 'section-stats-highlights' ] }>
-			{ React.createElement(
-				`h${ headingLevel >= 1 && headingLevel <= 6 ? headingLevel : 3 }`,
-				{ className: styles[ 'section-title' ] },
-				<>
-					<span>{ __( '7-day highlights', 'jetpack-my-jetpack' ) }</span>
-					<small className={ styles[ 'section-description' ] }>
-						{ __( 'Compared to previous period', 'jetpack-my-jetpack' ) }
-					</small>
-				</>
-			) }
+			<Heading className={ styles[ 'section-title' ] }>
+				<span>{ __( '7-day highlights', 'jetpack-my-jetpack' ) }</span>
+				<small className={ styles[ 'section-description' ] }>
+					{ __( 'Compared to previous period', 'jetpack-my-jetpack' ) }
+				</small>
+			</Heading>
 
 			<div className={ styles[ 'cards-list' ] }>
 				<CountComparisonCard

--- a/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
@@ -11,19 +11,23 @@ import styles from './style.module.scss';
  * @param {object} props                - Component props.
  * @param {object} props.counts         - Counts object for the current period.
  * @param {object} props.previousCounts - Counts object for the previous period.
+ * @param {number} props.headingLevel   - Heading level between 1 and 6.
  *
  * @return {object} StatsCards React component.
  */
-const StatsCards = ( { counts, previousCounts } ) => {
+const StatsCards = ( { counts, previousCounts, headingLevel } ) => {
 	return (
 		<div className={ styles[ 'section-stats-highlights' ] }>
-			<h3 className={ styles[ 'section-title' ] }>
-				<span>{ __( '7-day highlights', 'jetpack-my-jetpack' ) }</span>
-
-				<small className={ styles[ 'section-description' ] }>
-					{ __( 'Compared to previous period', 'jetpack-my-jetpack' ) }
-				</small>
-			</h3>
+			{ React.createElement(
+				`h${ headingLevel >= 1 && headingLevel <= 6 ? headingLevel : 3 }`,
+				{ className: styles[ 'section-title' ] },
+				<>
+					<span>{ __( '7-day highlights', 'jetpack-my-jetpack' ) }</span>
+					<small className={ styles[ 'section-description' ] }>
+						{ __( 'Compared to previous period', 'jetpack-my-jetpack' ) }
+					</small>
+				</>
+			) }
 
 			<div className={ styles[ 'cards-list' ] }>
 				<CountComparisonCard

--- a/projects/packages/my-jetpack/_inc/components/stats-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/index.jsx
@@ -68,7 +68,7 @@ const StatsSection = () => {
 			secondaryAction={ viewStatsButton }
 			showMenu
 		>
-			<StatsCards counts={ counts } previousCounts={ previousCounts } />
+			<StatsCards counts={ counts } previousCounts={ previousCounts } headingLevel={ 4 } />
 		</ProductCard>
 	);
 };

--- a/projects/packages/my-jetpack/changelog/update-stats-card-heading-level
+++ b/projects/packages/my-jetpack/changelog/update-stats-card-heading-level
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Stats: add highlights heading level as prop


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
On the My Jetpack page (once Jetpack is activated), the heading `7-day highlights` of the Stats card is a level 3 heading.
<img width="400" alt="Screenshot 2025-03-01 at 12 00 59 PM" src="https://github.com/user-attachments/assets/f949a97c-86d7-4b94-bd93-102f1f20a588" />


It should be a level 4 heading since the card heading is level 3 already. The captures below represent the list of headings in VoiceOver, on macOS.

| Before | After |
|-|-|
|<img width="400" alt="Screenshot 2025-03-01 at 11 55 50 AM" src="https://github.com/user-attachments/assets/214ee117-0284-4e54-a025-8cab10e3ed67" />|<img width="400" alt="Screenshot 2025-03-01 at 11 56 11 AM" src="https://github.com/user-attachments/assets/e5119364-d618-4063-bbe6-595ff2d3fe3d" />|

This PR adds a `headingLevel` prop to the `StatsCard` component.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Epic: https://github.com/Automattic/vulcan/issues/710

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a Jetpack site
- Visit `/wp-admin/admin.php?page=my-jetpack`
- Activate Jetpack
- If you're able to use a screen reader, notice the Stats highlights is announced as a heading level 4
- Otherwise, verify it's the case in the DOM
<img width="347" alt="Screenshot 2025-03-01 at 11 56 31 AM" src="https://github.com/user-attachments/assets/b301796d-a5ea-4287-8ad5-e694cacd9b0a" />

