### PR TITLE
Publicize Components: Add Storybook support

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-publicize-components-storybook
+++ b/projects/js-packages/publicize-components/changelog/add-publicize-components-storybook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Publicize Components: Add Storybook support

--- a/projects/js-packages/publicize-components/src/components/connection-icon/stories/index.stories.jsx
+++ b/projects/js-packages/publicize-components/src/components/connection-icon/stories/index.stories.jsx
@@ -1,0 +1,35 @@
+import ConnectionIcon from '../index.jsx';
+import '../../../../../social-logos/src/social-logo-colors.css';
+
+export default {
+	title: 'JS Packages/Publicize Components/ConnectionIcon',
+	component: ConnectionIcon,
+	argTypes: {
+		serviceName: {
+			control: {
+				type: 'select',
+			},
+			options: [
+				'facebook',
+				'x',
+				'instagram',
+				'linkedin',
+				'nextdoor',
+				'tumblr',
+				'bluesky',
+				'mastodon',
+			],
+		},
+	},
+};
+
+const Template = args => <ConnectionIcon { ...args } />;
+
+export const _default = Template.bind( {} );
+_default.args = {
+	serviceName: 'tumblr',
+	label: 'Jetpack Social',
+	checked: true,
+	profilePicture:
+		'https://gravatar.com/avatar/5a5f21e099ba62ae525e62cd1ad859985c8170b8811431e7fa6ccbc9da22405b',
+};

--- a/projects/js-packages/storybook/changelog/add-publicize-components-storybook
+++ b/projects/js-packages/storybook/changelog/add-publicize-components-storybook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Publicize Components: Add Storybook support

--- a/projects/js-packages/storybook/storybook/projects.js
+++ b/projects/js-packages/storybook/storybook/projects.js
@@ -7,6 +7,7 @@ const projects = [
 	'../../components/components',
 	'../../connection/components',
 	'../../idc/components',
+	'../../publicize-components/src/components',
 	'../../social-logos/src/react',
 	'../../shared-extension-utils/src',
 	'../../../packages/my-jetpack/_inc/components',


### PR DESCRIPTION
In order to develop some new comonents we're adding Storybook support to the Publicize Components package. This is done by adding it to the list of projects, but this change also adds an initial story for the ConnectionIcon component.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add the publicize components package to the Storybook projects, and an initial story.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run Storybook via `pnpm -F @automattic/jetpack-storybook storybook:dev`
* Check the 'JS Packages/Publicize Components/ConnectionIcon' page renders correctly, and that you can adjust the props

