### PR TITLE
WPCOM users endpoint: fix miscalculation in query found count for viewers

### DIFF
--- a/projects/plugins/jetpack/changelog/update-wpcom-users-endpoint
+++ b/projects/plugins/jetpack/changelog/update-wpcom-users-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Ensure that the 'found' value accurately represents the found query count when including viewers in the result.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -107,6 +107,19 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 	public $search_columns;
 
 	/**
+	 * Constructor.
+	 *
+	 * @param array $args - the arguments.
+	 */
+	public function __construct( $args ) {
+		parent::__construct( $args );
+		add_action( 'remove_user_from_blog', array( $this, 'clear_total_users_cache' ), 10, 3 );
+		add_action( 'add_user_to_blog', array( $this, 'add_user_to_blog_clear_total_users_cache' ), 10, 3 );
+		add_action( 'remove_private_blog_user', array( $this, 'clear_total_users_cache' ), 10, 2 );
+		add_action( 'added_private_blog_user', array( $this, 'clear_total_users_cache' ), 10, 2 );
+	}
+
+	/**
 	 * API callback.
 	 *
 	 * @param string $path - the path.
@@ -241,13 +254,22 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 				// Total users from the site. Only available to users with the `list_users` capability (Super admins and admins).
 				case 'total_users':
 					if ( ! empty( $args['total_users'] ) && true === $args['total_users'] && $can_list_users ) {
+						$cache_key   = 'rest-api-list-users-' . $blog_id . '-total-count';
+						$total_users = wp_cache_get( $cache_key, 'WPCOM_JSON_API_List_Users_Endpoint' );
+						if ( false !== $total_users ) {
+							$response[ $key ] = $total_users;
+							break;
+						}
+
 						$viewer_count = 0;
 						if ( $include_viewers ) {
-							$viewer_count = $this->get_viewers_count( $viewers, $user_query->get_results(), $blog_id );
+							$viewer_count = $this->get_viewers_count( $blog_id );
 						}
 						$user             = count_users( 'time', $blog_id );
 						$total_users      = isset( $user['total_users'] ) ? (int) $user['total_users'] : 0;
-						$response[ $key ] = $total_users + $viewer_count;
+						$total_users      = $total_users + $viewer_count;
+						$response[ $key ] = $total_users;
+						wp_cache_set( $cache_key, $total_users, 'WPCOM_JSON_API_List_Users_Endpoint', DAY_IN_SECONDS );
 					}
 					break;
 			}
@@ -257,13 +279,40 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 	}
 
 	/**
+	 * Clear the total users cache.
+	 *
+	 * @param int $user_id - the user ID.
+	 * @param int $blog_id - the blog ID.
+	 */
+	public function clear_total_users_cache( $user_id, $blog_id ) {
+		$current_blog_id = get_current_blog_id();
+		if ( $current_blog_id !== $blog_id ) {
+			return;
+		}
+
+		$cache_key = 'rest-api-list-users-' . $blog_id . '-total-count';
+		wp_cache_delete( $cache_key, 'WPCOM_JSON_API_List_Users_Endpoint' );
+	}
+
+	/**
+	 * Clear the total users cache when a user is added to a blog.
+	 * Required in addition to clear_total_users_cache because the argument order is different.
+	 *
+	 * @param int    $user_id - the user ID.
+	 * @param string $role - the role.
+	 * @param int    $blog_id - the blog ID.
+	 */
+	public function add_user_to_blog_clear_total_users_cache( $user_id, $role, $blog_id ) {
+		$this->clear_total_users_cache( $user_id, $blog_id );
+	}
+
+	/**
 	 * Get the count of private blog users.
 	 *
-	 * @param array $viewers - the viewers.
-	 * @param int   $blog_id - the blog ID.
+	 * @param int $blog_id - the blog ID.
 	 * @return int
 	 */
-	protected function get_viewers_count( $viewers, $blog_id ) {
+	protected function get_viewers_count( $blog_id ) {
 		/*
 		 * We can't get the count of viewers from get_count_private_blog_users because it returns a count for all viewers found,
 		 * even if the viewer has been made a site user. So we want to exclude from the total count users who are viewers.
@@ -272,12 +321,18 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 		 */
 		$duplicate_user_ids = array();
 		$viewers            = get_private_blog_users( $blog_id );
-		// Check each viewer to see if they are also a site user
+
+		// Check each viewer to see if they have any roles on the site
 		foreach ( $viewers as $viewer ) {
-			if ( is_user_member_of_blog( $viewer->ID, $blog_id ) ) {
+			$user_roles = get_user_meta( $viewer->ID, $blog_id . '_capabilities', true );
+			if ( ! empty( $user_roles ) ) {
 				$duplicate_user_ids[] = $viewer->ID;
 			}
 		}
+
+		l( '>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> get_viewers_count' );
+		l( $viewers );
+		l( $duplicate_user_ids );
 
 		return (int) count( $viewers ) - count( $duplicate_user_ids );
 	}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -36,7 +36,7 @@ new WPCOM_JSON_API_List_Users_Endpoint(
 			),
 			'authors_only'    => '(bool) Set to true to fetch authors only',
 			'include_viewers' => '(bool) Set to true to include viewers for Simple sites. When you pass in this parameter, order, order_by and search_columns are ignored. Currently, `search` is limited to the first page of results.',
-			'total_users'     => '(bool) Set to true to return the total number of site users.',
+			'total_users'     => '(bool) Set to true to return the total number of site users. This is only available to users with the `list_users` capability.',
 			'type'            => "(string) Specify the post type to query authors for. Only works when combined with the `authors_only` flag. Defaults to 'post'. Post types besides post and page need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
 			'search'          => '(string) Find matching users.',
 			'search_columns'  => "(array) Specify which columns to check for matching users. Can be any of 'ID', 'user_login', 'user_email', 'user_url', 'user_nicename', and 'display_name'. Only works when combined with `search` parameter.",
@@ -122,6 +122,8 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 		$authors_only = ( ! empty( $args['authors_only'] ) );
 
+		$can_list_users = current_user_can( 'list_users' );
+
 		if ( $args['number'] < 1 ) {
 			$args['number'] = 20;
 		} elseif ( 1000 < $args['number'] ) {
@@ -141,7 +143,7 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 			if ( ! $post_type_object || ! current_user_can( $post_type_object->cap->edit_others_posts ) ) {
 				return new WP_Error( 'unauthorized', 'User cannot view authors for specified post type', 403 );
 			}
-		} elseif ( ! current_user_can( 'list_users' ) ) {
+		} elseif ( ! $can_list_users ) {
 			return new WP_Error( 'unauthorized', 'User cannot view users for specified site', 403 );
 		}
 
@@ -248,9 +250,9 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 					$return[ $key ] = $combined_users;
 					break;
-				// Total users from the site.
+				// Total users from the site. Only available to users with the `list_users` capability (Super admins and admins).
 				case 'total_users':
-					if ( ! empty( $args['total_users'] ) && true === $args['total_users'] ) {
+					if ( ! empty( $args['total_users'] ) && true === $args['total_users'] && $can_list_users ) {
 						$viewer_count = 0;
 						if ( $include_viewers ) {
 							$viewer_count = (int) get_count_private_blog_users( $blog_id );

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -36,6 +36,7 @@ new WPCOM_JSON_API_List_Users_Endpoint(
 			),
 			'authors_only'    => '(bool) Set to true to fetch authors only',
 			'include_viewers' => '(bool) Set to true to include viewers for Simple sites. When you pass in this parameter, order, order_by and search_columns are ignored. Currently, `search` is limited to the first page of results.',
+			'total_users'     => '(bool) Set to true to return the total number of site users.',
 			'type'            => "(string) Specify the post type to query authors for. Only works when combined with the `authors_only` flag. Defaults to 'post'. Post types besides post and page need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
 			'search'          => '(string) Find matching users.',
 			'search_columns'  => "(array) Specify which columns to check for matching users. Can be any of 'ID', 'user_login', 'user_email', 'user_url', 'user_nicename', and 'display_name'. Only works when combined with `search` parameter.",
@@ -93,8 +94,9 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 * @var array
 	 */
 	public $response_format = array(
-		'found' => '(int) The total number of authors found that match the request (ignoring limits and offsets).',
-		'users' => '(array:author) Array of user objects',
+		'found'       => '(int) The total number of authors found that match the request (ignoring limits and offsets).',
+		'users'       => '(array:author) Array of user objects',
+		'total_users' => '(int) The total number of users.',
 	);
 
 	/**
@@ -207,16 +209,12 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 		$return = array();
 		foreach ( array_keys( $this->response_format ) as $key ) {
 			switch ( $key ) {
+				// Total users found in the current query.
 				case 'found':
-					$user_count = (int) $user_query->get_total();
-
+					$user_count   = (int) $user_query->get_total();
 					$viewer_count = 0;
 					if ( $include_viewers ) {
-						if ( empty( $args['search'] ) ) {
-							$viewer_count = (int) get_count_private_blog_users( $blog_id );
-						} else {
-							$viewer_count = count( $viewers );
-						}
+						$viewer_count = count( $viewers );
 					}
 
 					$return[ $key ] = $user_count + $viewer_count;
@@ -249,6 +247,18 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 					}
 
 					$return[ $key ] = $combined_users;
+					break;
+				// Total users from the site.
+				case 'total_users':
+					if ( ! empty( $args['total_users'] ) && true === $args['total_users'] ) {
+						$viewer_count = 0;
+						if ( $include_viewers ) {
+							$viewer_count = (int) get_count_private_blog_users( $blog_id );
+						}
+						$user           = count_users( 'time', $blog_id );
+						$total_users    = isset( $user['total_users'] ) ? (int) $user['total_users'] : 0;
+						$return[ $key ] = $total_users + $viewer_count;
+					}
 					break;
 			}
 		}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -96,7 +96,7 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 	public $response_format = array(
 		'found'       => '(int) The total number of authors found that match the request (ignoring limits and offsets).',
 		'users'       => '(array:author) Array of user objects',
-		'total_users' => '(int) The total number of users.',
+		'total_users' => '(int) The total number of site users.',
 	);
 
 	/**

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -265,8 +265,10 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 						if ( $include_viewers ) {
 							$viewer_count = $this->get_viewers_count( $blog_id );
 						}
-						$user             = count_users( 'time', $blog_id );
-						$total_users      = isset( $user['total_users'] ) ? (int) $user['total_users'] : 0;
+						$user        = count_users( 'time', $blog_id );
+						$total_users = isset( $user['total_users'] ) ? (int) $user['total_users'] : 0;
+						// Suppress Phan warning about duplicate expression assignment for readability.
+						// @phan-suppress-next-line PhanPluginDuplicateExpressionAssignmentOperation
 						$total_users      = $total_users + $viewer_count;
 						$response[ $key ] = $total_users;
 						wp_cache_set( $cache_key, $total_users, 'WPCOM_JSON_API_List_Users_Endpoint', DAY_IN_SECONDS );
@@ -329,10 +331,6 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 				$duplicate_user_ids[] = $viewer->ID;
 			}
 		}
-
-		l( '>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> get_viewers_count' );
-		l( $viewers );
-		l( $duplicate_user_ids );
 
 		return (int) count( $viewers ) - count( $duplicate_user_ids );
 	}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -95,7 +95,7 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 */
 	public $response_format = array(
 		'found'       => '(int) The total number of authors found that match the request (ignoring limits and offsets).',
-		'users'       => '(array:author) Array of user objects',
+		'users'       => '(array:user) Array of user objects',
 		'total_users' => '(int) The total number of site users.',
 	);
 
@@ -181,49 +181,37 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 		remove_filter( 'user_search_columns', array( $this, 'api_user_override_search_columns' ) );
 
+		$response        = array();
+		$users           = array();
 		$is_wpcom        = defined( 'IS_WPCOM' ) && IS_WPCOM;
 		$include_viewers = (bool) isset( $args['include_viewers'] ) && $args['include_viewers'] && $is_wpcom;
+		$user_query      = new WP_User_Query( $query );
+		$viewers         = $include_viewers ? $this->get_viewers( $args, $blog_id ) : array();
 
-		$page    = ( (int) ( $args['offset'] / $args['number'] ) ) + 1;
-		$viewers = $include_viewers ? get_private_blog_users(
-			$blog_id,
-			array(
-				'page'     => $page,
-				'per_page' => $args['number'],
-			)
-		) : array();
-		$viewers = array_map( array( $this, 'get_author' ), $viewers );
-
-		// When include_viewers is true, search by username or email.
-		if ( $include_viewers && ! empty( $args['search'] ) ) {
-			$viewers = array_filter(
-				$viewers,
-				function ( $viewer ) use ( $args ) {
-					// Convert to WP_User so expected fields are available.
-					$wp_viewer = new WP_User( $viewer->ID );
-					// remove special database search characters from search term
-					$search_term = str_replace( '*', '', $args['search'] );
-					return ( str_contains( $wp_viewer->user_login, $search_term ) || str_contains( $wp_viewer->user_email, $search_term ) || str_contains( $wp_viewer->display_name, $search_term ) );
-				}
-			);
-		}
-
-		$return = array();
 		foreach ( array_keys( $this->response_format ) as $key ) {
 			switch ( $key ) {
-				// Total users found in the current query.
+				/*
+				 * Total users found in the current query.
+				 * Note: This is not the total number of users, or the total number returned
+				 * in $response['users'].
+				 *
+				 * @see https://developer.wordpress.org/reference/classes/wp_user_query/#total-count-parameter
+				 */
 				case 'found':
 					$user_count   = (int) $user_query->get_total();
 					$viewer_count = 0;
+
 					if ( $include_viewers ) {
 						$viewer_count = count( $viewers );
 					}
 
-					$return[ $key ] = $user_count + $viewer_count;
+					$response[ $key ] = $user_count + $viewer_count;
 					break;
 				case 'users':
 					$users        = array();
 					$is_multisite = is_multisite();
+
+					// Get users.
 					foreach ( $user_query->get_results() as $u ) {
 						$the_user = $this->get_author( $u, true );
 						if ( $the_user && ! is_wp_error( $the_user ) ) {
@@ -248,24 +236,88 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 						);
 					}
 
-					$return[ $key ] = $combined_users;
+					$response[ $key ] = $combined_users;
 					break;
 				// Total users from the site. Only available to users with the `list_users` capability (Super admins and admins).
 				case 'total_users':
 					if ( ! empty( $args['total_users'] ) && true === $args['total_users'] && $can_list_users ) {
 						$viewer_count = 0;
 						if ( $include_viewers ) {
-							$viewer_count = (int) get_count_private_blog_users( $blog_id );
+							$viewer_count = $this->get_viewers_count( $viewers, $user_query->get_results(), $blog_id );
 						}
-						$user           = count_users( 'time', $blog_id );
-						$total_users    = isset( $user['total_users'] ) ? (int) $user['total_users'] : 0;
-						$return[ $key ] = $total_users + $viewer_count;
+						$user             = count_users( 'time', $blog_id );
+						$total_users      = isset( $user['total_users'] ) ? (int) $user['total_users'] : 0;
+						$response[ $key ] = $total_users + $viewer_count;
 					}
 					break;
 			}
 		}
 
-		return $return;
+		return $response;
+	}
+
+	/**
+	 * Get the count of private blog users.
+	 *
+	 * @param array $viewers - the viewers.
+	 * @param int   $blog_id - the blog ID.
+	 * @return int
+	 */
+	protected function get_viewers_count( $viewers, $blog_id ) {
+		/*
+		 * We can't get the count of viewers from get_count_private_blog_users because it returns a count for all viewers found,
+		 * even if the viewer has been made a site user. So we want to exclude from the total count users who are viewers.
+		 * Reason is, prior to https://github.a8c.com/Automattic/wpcom/pull/173734, viewers who were promoted to users on a site
+		 * were not removed from drama_blog_access. This function supports the legacy behavior by excluding viewers who are users from the count.
+		 */
+		$duplicate_user_ids = array();
+		$viewers            = get_private_blog_users( $blog_id );
+		// Check each viewer to see if they are also a site user
+		foreach ( $viewers as $viewer ) {
+			if ( is_user_member_of_blog( $viewer->ID, $blog_id ) ) {
+				$duplicate_user_ids[] = $viewer->ID;
+			}
+		}
+
+		return (int) count( $viewers ) - count( $duplicate_user_ids );
+	}
+
+	/**
+	 * Get viewers.
+	 *
+	 * @param array $args - query arguments.
+	 * @param int   $blog_id - the blog ID.
+	 * @return array
+	 */
+	protected function get_viewers( $args, $blog_id ) {
+		$viewers = array();
+		$page    = ( (int) ( $args['offset'] / $args['number'] ) ) + 1;
+		$viewers = get_private_blog_users(
+			$blog_id,
+			array(
+				'page'     => $page,
+				'per_page' => $args['number'],
+			)
+		);
+
+		// Returns author object. See `WPCOM_JSON_API_Endpoint::get_author` in `class.json-api-endpoints.php`.
+		$viewers = array_map( array( $this, 'get_author' ), $viewers );
+
+			// Search by username or email.
+		if ( ! empty( $args['search'] ) ) {
+			$viewers = array_filter(
+				$viewers,
+				function ( $viewer ) use ( $args ) {
+					// Convert to WP_User so expected fields are available.
+					$wp_viewer = new WP_User( $viewer->ID );
+					// remove special database search characters from search term
+					$search_term = str_replace( '*', '', $args['search'] );
+					return ( str_contains( $wp_viewer->user_login, $search_term ) || str_contains( $wp_viewer->user_email, $search_term ) || str_contains( $wp_viewer->display_name, $search_term ) );
+				}
+			);
+		}
+
+		return $viewers;
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/100628

## Proposed changes:

This PR corrects an error with the viewer found count. 

Formerly, it was grabbing the total number of viewers and not the query count length.

The "found" result therefore inaccurately represented the final query count where viewers are included in the query.

To fix this, this PR:

- add the query count values for the `found` property
- creates a new `total_users` property, added optionally by a `total_users` flag that returns the total number of users, and, where summoned, viewers, for a given site. 

The `total_users` return property is optional:

- to avoid calling `count_users` on every call
- to avoid changing the response object for existing usages


## Testing instructions:

1. You can test this endpoint in conjunction with this Calypso PR: https://github.com/Automattic/wp-calypso/pull/100674
2. Apply this PR to your sandbox
3. Ensure you have users on your test site, preferably many.
4. Head to http://calypso.localhost:3000/people/team/[YOUR_SITE]
5. Check that the totals are correct. 
6. Search for a user. Check that the results are also correct.
7. Monitor the `/users` fetch requests in your browsers console. The response body should contain the total count, e.g., `{found: 4, users: [,…], total_users: 4}` 



<img width="842" alt="Screenshot 2025-03-03 at 1 05 53 pm" src="https://github.com/user-attachments/assets/41181d92-d19e-4340-846c-1ba003ebfc51" />
<img width="797" alt="Screenshot 2025-03-03 at 1 05 46 pm" src="https://github.com/user-attachments/assets/fc6a94fa-92ea-4180-8076-de8050309cb3" />

To test that total_users, you can play around with the `number` param, which tells the endpoint how many users you want to return. 

`/sites/[YOUR_SITE_ID]/users?http_envelope=1&number=4&order=ASC&order_by=display_name&include_viewers=true&total_users=true&offset=0`

The found should correspond to the length of `users` and `total_users`, how many users the site has.

```json
{
	"found":4,
	"users":[ ...userObjects ],
	"total_users":12
}
```


### Unit tests
Because this PR uses private WPCOM methods, it requires tests on WPCOM for example 173364-ghe-Automattic/wpcom

## Does this pull request change what data or activity we track or use?

No