### PR TITLE
Use inline `before` script for Jetpack Stats to preserve `defer` loading strategy

### DIFF
--- a/projects/packages/stats/changelog/patch-3
+++ b/projects/packages/stats/changelog/patch-3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tracking Pixel: ensure the tracking script can be deferred, so it is not blocking.

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -150,7 +150,7 @@ _stq.push([ "clickTrackerInit", "%2$s", "%3$s" ]);',
 		wp_add_inline_script(
 			'jetpack-stats',
 			$triggers,
-			'after'
+			'before'
 		);
 	}
 


### PR DESCRIPTION
On my blog I discovered the Jetpack Stats script is registered with the `defer` strategy and yet it is also being printed with inline `after` script. In core this currently forces the script to fall back to blocking (but see [Core-58632](https://core.trac.wordpress.org/ticket/58632) for what would have made this possible). Nevertheless, the current `defer` on the script is not doing anything because of this fallback behavior:

```html
<script src="https://stats.wp.com/e-202509.js" id="jetpack-stats-js" data-wp-strategy="defer"></script>
<script id="jetpack-stats-js-after">
_stq = window._stq || [];
_stq.push([ "view", JSON.parse("{\"v\":\"ext\",\"blog\":\"59681501\",\"post\":\"0\",\"tz\":\"-8\",\"srv\":\"[weston.ruter.net\",\"j\":\"1:14.3\](about:blank)"}") ]);
_stq.push([ "clickTrackerInit", "59681501", "0" ]);
</script>
```

However, the entire `_stq = window._stq || []` bit here is designed so that the inline script can execute any any time. Therefore, I suggest the inline `after` script be switched to be a `before` script instead.

In fact, I implemented this as a fix in a plugin on my blog:

```php
<?php
/**
 * Plugin Name: Jetpack Fix Deferred Stats Script
 * Author: Weston Ruter
 * Update URI: false
 */

add_action(
	'wp_enqueue_scripts',
	static function () {
		$script = wp_scripts()->query( 'jetpack-stats' );
		if ( ! $script ) {
			return;
		}

		$after = wp_scripts()->get_inline_script_data( $script->handle, 'after' );
		if ( $after ) {
			wp_scripts()->add_inline_script( $script->handle, $after, 'before' );
			unset( $script->extra['after'] );
		}
	},
	PHP_INT_MAX
);
```

You can see there that it is output as:

```html
<script id="jetpack-stats-js-before">
_stq = window._stq || [];
_stq.push([ "view", JSON.parse("{\"v\":\"ext\",\"blog\":\"59681501\",\"post\":\"0\",\"tz\":\"-8\",\"srv\":\"weston.ruter.net\",\"j\":\"1:14.3\"}") ]);
_stq.push([ "clickTrackerInit", "59681501", "0" ]);
</script>
<script src="https://stats.wp.com/e-202510.js" id="jetpack-stats-js" defer data-wp-strategy="defer"></script>
```

With this change, the script is no longer blocking on the page and there is no JS error.

## Proposed changes:

* Use an inline `before` script instead of an inline `after` script for Jetpack Stats to ensure script can use the `defer` loading strategy.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?

No

<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable Jetpack Stats
* Ensure that `defer` attribute is on the `jetpack-stats-js` script tag.
* Ensure there are no JS errors on the page.