### PR TITLE
Forms: add step option to number field

### DIFF
--- a/projects/packages/forms/changelog/update-number-field-step
+++ b/projects/packages/forms/changelog/update-number-field-step
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add step option to number field

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -435,6 +435,10 @@ export const childBlocks = [
 					type: 'number',
 					default: '',
 				},
+				step: {
+					type: 'string', // Valid values are numbers and string "any"
+					default: '1',
+				},
 			},
 		},
 	},

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-number.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-number.js
@@ -1,6 +1,6 @@
 import { useBlockProps } from '@wordpress/block-editor';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
-import { __experimentalNumberControl as NumberControl } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { __experimentalNumberControl as NumberControl, FormToggle } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
@@ -24,6 +24,7 @@ const JetpackNumberField = props => {
 		placeholder,
 		min,
 		max,
+		step = 1, // Default value "1" behaves like no "step" value is set at all
 		width,
 		insertBlocksAfter,
 	} = props;
@@ -58,6 +59,7 @@ const JetpackNumberField = props => {
 					placeholder={ placeholder }
 					min={ min }
 					max={ max }
+					step={ step }
 					onKeyDown={ event => {
 						if ( event.defaultPrevented || event.key !== 'Enter' ) {
 							return;
@@ -113,6 +115,45 @@ const JetpackNumberField = props => {
 								__nextHasNoMarginBottom={ true }
 								__next40pxDefaultSize={ true }
 								help={ __( 'The maximum value to accept in the input.', 'jetpack-forms' ) }
+							/>
+						),
+					},
+					{
+						index: 3,
+						element: (
+							<NumberControl
+								key="step"
+								label={ __( 'Step', 'jetpack-forms' ) }
+								value={ attributes.step }
+								onChange={ value =>
+									setAttributes( {
+										step: value,
+									} )
+								}
+								disabled={ attributes.step === 'any' }
+								__nextHasNoMarginBottom={ true }
+								__next40pxDefaultSize={ true }
+								help={ __(
+									'Specifies the granularity that the value must adhere to; defaults to 1.',
+									'jetpack-forms'
+								) }
+							/>
+						),
+					},
+					{
+						index: 4,
+						element: (
+							<FormToggle
+								key="step-any"
+								label={ __( 'Accept any numerical value', 'jetpack-forms' ) }
+								onChange={ () =>
+									setAttributes( {
+										step: 'any',
+									} )
+								}
+								checked={ attributes.step === 'any' }
+								__nextHasNoMarginBottom={ true }
+								__next40pxDefaultSize={ true }
 							/>
 						),
 					},

--- a/projects/plugins/jetpack/changelog/update-number-field-step
+++ b/projects/plugins/jetpack/changelog/update-number-field-step
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: add step option to number field


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of https://github.com/Automattic/jetpack/issues/40961

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add "step" option to number field

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

