### PR TITLE
Boost: Add exceptions textarea to the Speculation Rules module

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -1,18 +1,18 @@
-import { Button, IconTooltip, Notice, getRedirectUrl } from '@automattic/jetpack-components';
+import { Button, IconTooltip, getRedirectUrl } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import Lightning from '$svg/lightning';
 import styles from './meta.module.scss';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { usePageCache, useClearPageCacheAction } from '$lib/stores/page-cache';
 import { Link } from 'react-router-dom';
-import clsx from 'clsx';
 import { useMutationNotice } from '$features/ui';
 import { useDataSyncSubset } from '@automattic/jetpack-react-data-sync-client';
 import ErrorBoundary from '$features/error-boundary/error-boundary';
 import ErrorNotice from '$features/error-notice/error-notice';
 import { recordBoostEvent } from '$lib/utils/analytics';
 import CollapsibleMeta from '$features/ui/collapsible-meta/collapsible-meta';
+import { BypassPatterns } from '$features/ui/bypass-patterns/bypass-pattern';
 
 const Meta = () => {
 	const pageCache = usePageCache();
@@ -107,12 +107,34 @@ const Meta = () => {
 		</Button>
 	);
 
+	const exclusionsLink = getRedirectUrl( 'jetpack-boost-cache-how-to-exclude' );
+
 	const content = (
 		<div className={ styles.body }>
 			<BypassPatterns
 				patterns={ bypassPatterns.join( '\n' ) }
 				setPatterns={ updatePatterns }
 				showErrorNotice={ mutateBypassPatterns.isError }
+				label={ __( 'URLs of pages and posts that will never be cached:', 'jetpack-boost' ) }
+				description={
+					<>
+						{ __(
+							'Use (.*) to address multiple URLs under a given path. Be sure each URL path is in its own line.',
+							'jetpack-boost'
+						) }
+						<br />
+						{ createInterpolateElement(
+							__( '<help>See an example</help> or <link>learn more</link>.', 'jetpack-boost' ),
+							{
+								help: <BypassPatternsExample />,
+								// eslint-disable-next-line jsx-a11y/anchor-has-content
+								link: <a href={ exclusionsLink } target="_blank" rel="noreferrer" />,
+							}
+						) }
+					</>
+				}
+				errorMessage={ __( 'Error: Invalid format', 'jetpack-boost' ) }
+				source="page_cache"
 			/>
 			<div className={ styles.section }>
 				<div className={ styles.title }>{ __( 'Logging', 'jetpack-boost' ) }</div>
@@ -152,111 +174,6 @@ const Meta = () => {
 				</CollapsibleMeta>
 			</div>
 		)
-	);
-};
-
-type BypassPatternsProps = {
-	patterns: string;
-	setPatterns: ( newValue: string ) => void;
-	showErrorNotice: boolean;
-};
-
-const BypassPatterns = ( {
-	patterns,
-	setPatterns,
-	showErrorNotice = false,
-}: BypassPatternsProps ) => {
-	const [ inputValue, setInputValue ] = useState( patterns );
-	const [ showNotice, setShowNotice ] = useState( showErrorNotice );
-	const [ inputInvalid, setInputInvalid ] = useState( false );
-
-	const exclusionsLink = getRedirectUrl( 'jetpack-boost-cache-how-to-exclude' );
-
-	const validateInputValue = ( value: string ) => {
-		setInputValue( value );
-		setInputInvalid( ! validatePatterns( value ) );
-	};
-
-	const validatePatterns = ( value: string ) => {
-		const lines = value
-			.split( '\n' )
-			.map( line => line.trim() )
-			.filter( line => line.trim() !== '' );
-
-		// check if it's a valid regex
-		try {
-			lines.forEach( line => new RegExp( line ) );
-		} catch {
-			return false;
-		}
-
-		return true;
-	};
-
-	useEffect( () => {
-		setInputValue( patterns );
-	}, [ patterns ] );
-
-	useEffect( () => {
-		setShowNotice( showErrorNotice );
-	}, [ showErrorNotice ] );
-
-	function save() {
-		recordBoostEvent( 'page_cache_exceptions_save_clicked', {} );
-		setPatterns( inputValue );
-	}
-
-	return (
-		<div
-			className={ clsx( styles.section, {
-				[ styles[ 'has-error' ] ]: inputInvalid,
-			} ) }
-		>
-			<div className={ styles.title }>{ __( 'Exceptions', 'jetpack-boost' ) }</div>
-			<label htmlFor="jb-cache-exceptions">
-				{ __( 'URLs of pages and posts that will never be cached:', 'jetpack-boost' ) }
-			</label>
-			<textarea
-				value={ inputValue }
-				rows={ 3 }
-				onChange={ e => validateInputValue( e.target.value ) }
-				id="jb-cache-exceptions"
-			/>
-			<p className={ clsx( styles.description, styles[ 'error-message' ] ) }>
-				{ __( 'Error: Invalid format', 'jetpack-boost' ) }
-			</p>
-			<div className={ styles.description }>
-				{ __(
-					'Use (.*) to address multiple URLs under a given path. Be sure each URL path is in its own line.',
-					'jetpack-boost'
-				) }
-				<br />
-				{ createInterpolateElement(
-					__( '<help>See an example</help> or <link>learn more</link>.', 'jetpack-boost' ),
-					{
-						help: <BypassPatternsExample />, // children are passed after the interpolation.
-						// eslint-disable-next-line jsx-a11y/anchor-has-content
-						link: <a href={ exclusionsLink } target="_blank" rel="noreferrer" />,
-					}
-				) }
-			</div>
-			{ showNotice && (
-				<Notice
-					level="error"
-					title={ __( 'Error: Unable to save changes.', 'jetpack-boost' ) }
-					onClose={ () => setShowNotice( false ) }
-				>
-					{ __( 'An error occurred while saving changes. Please, try again.', 'jetpack-boost' ) }
-				</Notice>
-			) }
-			<Button
-				disabled={ patterns === inputValue || inputInvalid }
-				onClick={ save }
-				className={ styles.button }
-			>
-				{ __( 'Save', 'jetpack-boost' ) }
-			</Button>
-		</div>
 	);
 };
 

--- a/projects/plugins/boost/app/assets/src/js/features/speculation-rules/speculation-method.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/speculation-rules/speculation-method.module.scss
@@ -1,14 +1,9 @@
 .wrapper {
-	margin-bottom: 10px;
+	margin-bottom: 1em;
 }
 
 .title {
 	display: flex;
-}
-
-.beta {
-	position: relative;
-	top: 4px;
 }
 
 .toggle-control {

--- a/projects/plugins/boost/app/assets/src/js/features/speculation-rules/speculation-rules-meta.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/speculation-rules/speculation-rules-meta.module.scss
@@ -1,0 +1,63 @@
+.wrapper {
+	font-size: 14px;
+	line-height: 22px;
+	margin-top: 1em;
+
+	:global(button ~ button) {
+		margin-left: 20px !important;
+	}
+
+	.body {
+		margin-top: 16px;
+
+		.section {
+			padding: 16px;
+			border-radius: 4px;
+			background-color: var(--gray-0);
+
+			& ~ .section {
+				margin-top: 16px;
+			}
+
+			.title {
+				margin-bottom: 16px;
+				font-size: 16px;
+				line-height: 1;
+				font-weight: 600;
+			}
+
+			textarea {
+				display: block;
+				margin-bottom: 8px;
+				width: 100%;
+				padding: 12px 16px;
+				border-radius: 4px;
+				border: 1px solid var( --gray-10 );
+				background: var( --primary-white );
+				color: #000;
+			}
+
+			.description {
+				margin-top: 8px;
+				font-size: 14px;
+				line-height: 1.5;
+				color: var( --gray-60 );
+				font-weight: 400;
+			}
+
+			label {
+				display: block;
+				font-size: 16px;
+				line-height: 1.5;
+
+				&:not(:last-child) {
+					margin-bottom: 8px;
+				}
+			}
+		}
+
+		.button {
+			margin-top: 16px;
+		}
+	}
+} 

--- a/projects/plugins/boost/app/assets/src/js/features/speculation-rules/speculation-rules-meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/speculation-rules/speculation-rules-meta.tsx
@@ -1,0 +1,137 @@
+import { Button, Notice } from '@automattic/jetpack-components';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { useEffect, useState } from 'react';
+import { useDataSyncSubset } from '@automattic/jetpack-react-data-sync-client';
+import { useSpeculationRules } from '$lib/stores/speculation-rules';
+import ErrorBoundary from '$features/error-boundary/error-boundary';
+import ErrorNotice from '$features/error-notice/error-notice';
+import { recordBoostEvent } from '$lib/utils/analytics';
+import CollapsibleMeta from '$features/ui/collapsible-meta/collapsible-meta';
+import styles from './speculation-rules-meta.module.scss';
+
+const Meta = () => {
+	const speculationRules = useSpeculationRules();
+	const [ exceptions, mutateExceptions ] = useDataSyncSubset( speculationRules, 'exceptions' );
+	const totalExceptions = exceptions?.length || 0;
+
+	const getSummary = () => {
+		return totalExceptions > 0
+			? sprintf(
+					/* translators: %d is the number of exception patterns. */
+					_n( '%d exception.', '%d exceptions.', totalExceptions, 'jetpack-boost' ),
+					totalExceptions
+			  )
+			: __( 'No exceptions.', 'jetpack-boost' );
+	};
+
+	const updateExceptions = ( newValue: string ) => {
+		const newExceptions = newValue
+			.split( '\n' )
+			.map( line => line.trim() )
+			.filter( line => line !== '' );
+
+		recordBoostEvent( 'speculation_rules_exceptions', {
+			total: newExceptions.length,
+		} );
+		mutateExceptions.mutate( newExceptions );
+	};
+
+	const content = (
+		<div className={ styles.body }>
+			<Exceptions
+				exceptions={ exceptions.join( '\n' ) }
+				setExceptions={ updateExceptions }
+				showErrorNotice={ mutateExceptions.isError }
+			/>
+		</div>
+	);
+
+	return (
+		speculationRules && (
+			<div className={ styles.wrapper } data-testid="speculation-rules-meta">
+				<CollapsibleMeta
+					headerText={ getSummary() }
+					toggleText={ __( 'Show Options', 'jetpack-boost' ) }
+					tracksEvent={ 'speculation_rules_exceptions_panel_toggle' }
+				>
+					{ content }
+				</CollapsibleMeta>
+			</div>
+		)
+	);
+};
+
+interface ExceptionsProps {
+	exceptions: string;
+	setExceptions: ( value: string ) => void;
+	showErrorNotice?: boolean;
+}
+
+const Exceptions = ( { exceptions, setExceptions, showErrorNotice = false }: ExceptionsProps ) => {
+	const [ inputValue, setInputValue ] = useState( exceptions );
+	const [ showNotice, setShowNotice ] = useState( showErrorNotice );
+
+	useEffect( () => {
+		setInputValue( exceptions );
+	}, [ exceptions ] );
+
+	useEffect( () => {
+		setShowNotice( showErrorNotice );
+	}, [ showErrorNotice ] );
+
+	function save() {
+		recordBoostEvent( 'speculation_rules_exceptions_save_clicked', {} );
+		setExceptions( inputValue );
+	}
+
+	return (
+		<div className={ styles.section }>
+			<div className={ styles.title }>{ __( 'Exceptions', 'jetpack-boost' ) }</div>
+			<label htmlFor="jb-speculation-rules-exceptions">
+				{ __(
+					'URLs of pages and posts that will not have speculation rules applied:',
+					'jetpack-boost'
+				) }
+			</label>
+			<textarea
+				value={ inputValue }
+				rows={ 3 }
+				onChange={ e => setInputValue( e.target.value ) }
+				id="jb-speculation-rules-exceptions"
+			/>
+			<div className={ styles.description }>
+				{ __(
+					'Enter one URL per line. These pages will not have speculation rules applied to them.',
+					'jetpack-boost'
+				) }
+			</div>
+			{ showNotice && (
+				<Notice
+					level="error"
+					title={ __( 'Error: Unable to save changes.', 'jetpack-boost' ) }
+					onClose={ () => setShowNotice( false ) }
+				>
+					{ __( 'An error occurred while saving changes. Please, try again.', 'jetpack-boost' ) }
+				</Notice>
+			) }
+			<Button disabled={ exceptions === inputValue } onClick={ save } className={ styles.button }>
+				{ __( 'Save', 'jetpack-boost' ) }
+			</Button>
+		</div>
+	);
+};
+
+export default () => {
+	return (
+		<ErrorBoundary
+			fallback={
+				<ErrorNotice
+					title={ __( 'Error', 'jetpack-boost' ) }
+					error={ new Error( __( 'Unable to load Speculation Rules settings.', 'jetpack-boost' ) ) }
+				/>
+			}
+		>
+			<Meta />
+		</ErrorBoundary>
+	);
+};

--- a/projects/plugins/boost/app/assets/src/js/features/speculation-rules/speculation-rules-meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/speculation-rules/speculation-rules-meta.tsx
@@ -8,40 +8,44 @@ import ErrorNotice from '$features/error-notice/error-notice';
 import { recordBoostEvent } from '$lib/utils/analytics';
 import CollapsibleMeta from '$features/ui/collapsible-meta/collapsible-meta';
 import styles from './speculation-rules-meta.module.scss';
+import clsx from 'clsx';
 
 const Meta = () => {
 	const speculationRules = useSpeculationRules();
-	const [ exceptions, mutateExceptions ] = useDataSyncSubset( speculationRules, 'bypass_patterns' );
-	const totalExceptions = exceptions?.length || 0;
+	const [ patterns, mutateBypassPatterns ] = useDataSyncSubset(
+		speculationRules,
+		'bypass_patterns'
+	);
+	const totalBypassPatterns = patterns?.length || 0;
 
 	const getSummary = () => {
-		return totalExceptions > 0
+		return totalBypassPatterns > 0
 			? sprintf(
-					/* translators: %d is the number of exception patterns. */
-					_n( '%d exception.', '%d exceptions.', totalExceptions, 'jetpack-boost' ),
-					totalExceptions
+					/* translators: %d is the number of bypass patterns. */
+					_n( '%d exception.', '%d exceptions.', totalBypassPatterns, 'jetpack-boost' ),
+					totalBypassPatterns
 			  )
 			: __( 'No exceptions.', 'jetpack-boost' );
 	};
 
-	const updateExceptions = ( newValue: string ) => {
-		const newExceptions = newValue
+	const updatePatterns = ( newValue: string ) => {
+		const newPatterns = newValue
 			.split( '\n' )
 			.map( line => line.trim() )
 			.filter( line => line !== '' );
 
-		recordBoostEvent( 'speculation_rules_exceptions', {
-			total: newExceptions.length,
+		recordBoostEvent( 'speculation_rules_bypass_patterns', {
+			total: newPatterns.length,
 		} );
-		mutateExceptions.mutate( newExceptions );
+		mutateBypassPatterns.mutate( newPatterns );
 	};
 
 	const content = (
 		<div className={ styles.body }>
-			<Exceptions
-				exceptions={ exceptions.join( '\n' ) }
-				setExceptions={ updateExceptions }
-				showErrorNotice={ mutateExceptions.isError }
+			<BypassPatterns
+				patterns={ patterns.join( '\n' ) }
+				setPatterns={ updatePatterns }
+				showErrorNotice={ mutateBypassPatterns.isError }
 			/>
 		</div>
 	);
@@ -61,19 +65,45 @@ const Meta = () => {
 	);
 };
 
-interface ExceptionsProps {
-	exceptions: string;
-	setExceptions: ( value: string ) => void;
+interface BypassPatternsProps {
+	patterns: string;
+	setPatterns: ( value: string ) => void;
 	showErrorNotice?: boolean;
 }
 
-const Exceptions = ( { exceptions, setExceptions, showErrorNotice = false }: ExceptionsProps ) => {
-	const [ inputValue, setInputValue ] = useState( exceptions );
+const BypassPatterns = ( {
+	patterns,
+	setPatterns,
+	showErrorNotice = false,
+}: BypassPatternsProps ) => {
+	const [ inputValue, setInputValue ] = useState( patterns );
 	const [ showNotice, setShowNotice ] = useState( showErrorNotice );
+	const [ inputInvalid, setInputInvalid ] = useState( false );
+
+	const validateInputValue = ( value: string ) => {
+		setInputValue( value );
+		setInputInvalid( ! validatePatterns( value ) );
+	};
+
+	const validatePatterns = ( value: string ) => {
+		const lines = value
+			.split( '\n' )
+			.map( line => line.trim() )
+			.filter( line => line.trim() !== '' );
+
+		// check if it's a valid regex
+		try {
+			lines.forEach( line => new RegExp( line ) );
+		} catch {
+			return false;
+		}
+
+		return true;
+	};
 
 	useEffect( () => {
-		setInputValue( exceptions );
-	}, [ exceptions ] );
+		setInputValue( patterns );
+	}, [ patterns ] );
 
 	useEffect( () => {
 		setShowNotice( showErrorNotice );
@@ -81,11 +111,15 @@ const Exceptions = ( { exceptions, setExceptions, showErrorNotice = false }: Exc
 
 	function save() {
 		recordBoostEvent( 'speculation_rules_exceptions_save_clicked', {} );
-		setExceptions( inputValue );
+		setPatterns( inputValue );
 	}
 
 	return (
-		<div className={ styles.section }>
+		<div
+			className={ clsx( styles.section, {
+				[ styles[ 'has-error' ] ]: inputInvalid,
+			} ) }
+		>
 			<div className={ styles.title }>{ __( 'Exceptions', 'jetpack-boost' ) }</div>
 			<label htmlFor="jb-speculation-rules-exceptions">
 				{ __(
@@ -96,7 +130,7 @@ const Exceptions = ( { exceptions, setExceptions, showErrorNotice = false }: Exc
 			<textarea
 				value={ inputValue }
 				rows={ 3 }
-				onChange={ e => setInputValue( e.target.value ) }
+				onChange={ e => validateInputValue( e.target.value ) }
 				id="jb-speculation-rules-exceptions"
 			/>
 			<div className={ styles.description }>
@@ -114,7 +148,7 @@ const Exceptions = ( { exceptions, setExceptions, showErrorNotice = false }: Exc
 					{ __( 'An error occurred while saving changes. Please, try again.', 'jetpack-boost' ) }
 				</Notice>
 			) }
-			<Button disabled={ exceptions === inputValue } onClick={ save } className={ styles.button }>
+			<Button disabled={ patterns === inputValue } onClick={ save } className={ styles.button }>
 				{ __( 'Save', 'jetpack-boost' ) }
 			</Button>
 		</div>

--- a/projects/plugins/boost/app/assets/src/js/features/speculation-rules/speculation-rules-meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/speculation-rules/speculation-rules-meta.tsx
@@ -1,14 +1,12 @@
-import { Button, Notice } from '@automattic/jetpack-components';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useEffect, useState } from 'react';
 import { useDataSyncSubset } from '@automattic/jetpack-react-data-sync-client';
 import { useSpeculationRules } from '$lib/stores/speculation-rules';
 import ErrorBoundary from '$features/error-boundary/error-boundary';
 import ErrorNotice from '$features/error-notice/error-notice';
 import { recordBoostEvent } from '$lib/utils/analytics';
 import CollapsibleMeta from '$features/ui/collapsible-meta/collapsible-meta';
+import { BypassPatterns } from '$features/ui/bypass-patterns/bypass-pattern';
 import styles from './speculation-rules-meta.module.scss';
-import clsx from 'clsx';
 
 const Meta = () => {
 	const speculationRules = useSpeculationRules();
@@ -46,6 +44,16 @@ const Meta = () => {
 				patterns={ patterns.join( '\n' ) }
 				setPatterns={ updatePatterns }
 				showErrorNotice={ mutateBypassPatterns.isError }
+				label={ __(
+					'URLs of pages and posts that will not have speculation rules applied:',
+					'jetpack-boost'
+				) }
+				description={ __(
+					'Enter one URL per line. These pages will not have speculation rules applied to them.',
+					'jetpack-boost'
+				) }
+				errorMessage={ __( 'Error: Invalid format', 'jetpack-boost' ) }
+				source="speculation_rules"
 			/>
 		</div>
 	);
@@ -62,96 +70,6 @@ const Meta = () => {
 				</CollapsibleMeta>
 			</div>
 		)
-	);
-};
-
-interface BypassPatternsProps {
-	patterns: string;
-	setPatterns: ( value: string ) => void;
-	showErrorNotice?: boolean;
-}
-
-const BypassPatterns = ( {
-	patterns,
-	setPatterns,
-	showErrorNotice = false,
-}: BypassPatternsProps ) => {
-	const [ inputValue, setInputValue ] = useState( patterns );
-	const [ showNotice, setShowNotice ] = useState( showErrorNotice );
-	const [ inputInvalid, setInputInvalid ] = useState( false );
-
-	const validateInputValue = ( value: string ) => {
-		setInputValue( value );
-		setInputInvalid( ! validatePatterns( value ) );
-	};
-
-	const validatePatterns = ( value: string ) => {
-		const lines = value
-			.split( '\n' )
-			.map( line => line.trim() )
-			.filter( line => line.trim() !== '' );
-
-		// check if it's a valid regex
-		try {
-			lines.forEach( line => new RegExp( line ) );
-		} catch {
-			return false;
-		}
-
-		return true;
-	};
-
-	useEffect( () => {
-		setInputValue( patterns );
-	}, [ patterns ] );
-
-	useEffect( () => {
-		setShowNotice( showErrorNotice );
-	}, [ showErrorNotice ] );
-
-	function save() {
-		recordBoostEvent( 'speculation_rules_exceptions_save_clicked', {} );
-		setPatterns( inputValue );
-	}
-
-	return (
-		<div
-			className={ clsx( styles.section, {
-				[ styles[ 'has-error' ] ]: inputInvalid,
-			} ) }
-		>
-			<div className={ styles.title }>{ __( 'Exceptions', 'jetpack-boost' ) }</div>
-			<label htmlFor="jb-speculation-rules-exceptions">
-				{ __(
-					'URLs of pages and posts that will not have speculation rules applied:',
-					'jetpack-boost'
-				) }
-			</label>
-			<textarea
-				value={ inputValue }
-				rows={ 3 }
-				onChange={ e => validateInputValue( e.target.value ) }
-				id="jb-speculation-rules-exceptions"
-			/>
-			<div className={ styles.description }>
-				{ __(
-					'Enter one URL per line. These pages will not have speculation rules applied to them.',
-					'jetpack-boost'
-				) }
-			</div>
-			{ showNotice && (
-				<Notice
-					level="error"
-					title={ __( 'Error: Unable to save changes.', 'jetpack-boost' ) }
-					onClose={ () => setShowNotice( false ) }
-				>
-					{ __( 'An error occurred while saving changes. Please, try again.', 'jetpack-boost' ) }
-				</Notice>
-			) }
-			<Button disabled={ patterns === inputValue } onClick={ save } className={ styles.button }>
-				{ __( 'Save', 'jetpack-boost' ) }
-			</Button>
-		</div>
 	);
 };
 

--- a/projects/plugins/boost/app/assets/src/js/features/speculation-rules/speculation-rules-meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/speculation-rules/speculation-rules-meta.tsx
@@ -11,7 +11,7 @@ import styles from './speculation-rules-meta.module.scss';
 
 const Meta = () => {
 	const speculationRules = useSpeculationRules();
-	const [ exceptions, mutateExceptions ] = useDataSyncSubset( speculationRules, 'exceptions' );
+	const [ exceptions, mutateExceptions ] = useDataSyncSubset( speculationRules, 'bypass_patterns' );
 	const totalExceptions = exceptions?.length || 0;
 
 	const getSummary = () => {

--- a/projects/plugins/boost/app/assets/src/js/features/speculation-rules/speculation-rules-notice.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/speculation-rules/speculation-rules-notice.tsx
@@ -1,0 +1,33 @@
+import { Notice } from '@automattic/jetpack-components';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+
+type SpeculationRulesNoticeProps = {
+	showNotice: boolean;
+};
+
+const SpeculationRulesNotice = ( { showNotice }: SpeculationRulesNoticeProps ) => {
+	const [ isDismissed, setIsDismissed ] = useState( false );
+
+	// Only show the notice if it should be shown and hasn't been dismissed
+	if ( ! showNotice || isDismissed ) {
+		return null;
+	}
+
+	return (
+		<Notice
+			level="warning"
+			title={ __( 'Cornerstone Pages will be prerendered', 'jetpack-boost' ) }
+			onClose={ () => setIsDismissed( true ) }
+		>
+			<p>
+				{ __(
+					'Prerender mode may cause inflated statistics and increased server load as it fully loads pages in the background. Monitor your site performance and server resources carefully.',
+					'jetpack-boost'
+				) }
+			</p>
+		</Notice>
+	);
+};
+
+export default SpeculationRulesNotice;

--- a/projects/plugins/boost/app/assets/src/js/features/ui/bypass-patterns/bypass-pattern.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/ui/bypass-patterns/bypass-pattern.tsx
@@ -1,0 +1,123 @@
+import { Button, Notice } from '@automattic/jetpack-components';
+import { __ } from '@wordpress/i18n';
+import { useEffect, useState, ReactNode } from 'react';
+import clsx from 'clsx';
+import { recordBoostEvent } from '$lib/utils/analytics';
+import styles from './bypass-patterns.module.scss';
+
+export interface BypassPatternsProps {
+	patterns: string;
+	setPatterns: ( value: string ) => void;
+	showErrorNotice?: boolean;
+	label: string;
+	description: ReactNode;
+	errorMessage?: string;
+	buttonText?: string;
+	onSave?: () => void;
+	source: 'page_cache' | 'speculation_rules';
+}
+
+export const BypassPatterns = ( {
+	patterns,
+	setPatterns,
+	showErrorNotice = false,
+	label,
+	description,
+	errorMessage,
+	buttonText = __( 'Save', 'jetpack-boost' ),
+	onSave,
+	source,
+}: BypassPatternsProps ) => {
+	const [ inputValue, setInputValue ] = useState( patterns );
+	const [ showNotice, setShowNotice ] = useState( showErrorNotice );
+	const [ inputInvalid, setInputInvalid ] = useState( false );
+
+	const validateInputValue = ( value: string ) => {
+		setInputValue( value );
+		setInputInvalid( ! validatePatterns( value ) );
+	};
+
+	const validatePatterns = ( value: string ) => {
+		const lines = value
+			.split( '\n' )
+			.map( line => line.trim() )
+			.filter( line => line.trim() !== '' );
+
+		// check if it's a valid regex
+		try {
+			lines.forEach( line => {
+				if ( source === 'speculation_rules' ) {
+					// For Speculation Rules, only accept * wildcards
+					if ( line.includes( '(.*)' ) ) {
+						throw new Error( 'Invalid pattern' );
+					}
+					// Convert * to (.*) for regex validation
+					const regexLine = line.replace( /\*/g, '(.*)' );
+					const regex = new RegExp( regexLine );
+					regex.test( '' );
+				} else {
+					// For Page Cache, accept only (.*) or none
+					const regex = new RegExp( line );
+					regex.test( '' );
+				}
+			} );
+		} catch {
+			return false;
+		}
+
+		return true;
+	};
+
+	useEffect( () => {
+		setInputValue( patterns );
+	}, [ patterns ] );
+
+	useEffect( () => {
+		setShowNotice( showErrorNotice );
+	}, [ showErrorNotice ] );
+
+	function save() {
+		if ( onSave ) {
+			onSave();
+		}
+		recordBoostEvent( 'bypass_patterns_save_clicked', {} );
+		setPatterns( inputValue );
+	}
+
+	return (
+		<div
+			className={ clsx( styles.section, {
+				[ styles[ 'has-error' ] ]: inputInvalid,
+			} ) }
+		>
+			<div className={ styles.title }>{ __( 'Exceptions', 'jetpack-boost' ) }</div>
+			<label htmlFor="jb-bypass-patterns">{ label }</label>
+			<textarea
+				value={ inputValue }
+				rows={ 3 }
+				onChange={ e => validateInputValue( e.target.value ) }
+				id="jb-bypass-patterns"
+			/>
+			{ inputInvalid && errorMessage && (
+				<p className={ clsx( styles.description, styles[ 'error-message' ] ) }>{ errorMessage }</p>
+			) }
+			<div className={ styles.description }>{ description }</div>
+			{ showNotice && (
+				<Notice
+					level="error"
+					title={ __( 'Error: Unable to save changes.', 'jetpack-boost' ) }
+					onClose={ () => setShowNotice( false ) }
+				>
+					{ __( 'An error occurred while saving changes. Please, try again.', 'jetpack-boost' ) }
+				</Notice>
+			) }
+			<Button
+				disabled={ patterns === inputValue || inputInvalid }
+				onClick={ save }
+				className={ styles.button }
+			>
+				{ buttonText }
+			</Button>
+		</div>
+	);
+};

--- a/projects/plugins/boost/app/assets/src/js/features/ui/bypass-patterns/bypass-patterns.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/ui/bypass-patterns/bypass-patterns.module.scss
@@ -1,0 +1,83 @@
+.section {
+	padding: 16px;
+	border-radius: 4px;
+	background-color: var(--gray-0);
+	margin-bottom: 16px;
+
+	&.has-error {
+		textarea {
+			border-color: var(--red-40);
+		}
+
+		.error-message {
+			display: block;
+			color: var(--red-40);
+		}
+	}
+
+	.title {
+		margin-bottom: 16px;
+		font-size: 16px;
+		line-height: 1;
+		font-weight: 600;
+	}
+
+	textarea {
+		display: block;
+		margin-bottom: 8px;
+		width: 100%;
+		padding: 12px 16px;
+		border-radius: 4px;
+		border: 1px solid var(--gray-10);
+		background: var(--primary-white);
+		color: #000;
+	}
+
+	.error-message {
+		display: none;
+	}
+
+	.description {
+		margin-top: 8px;
+		font-size: 14px;
+		line-height: 1.5;
+		color: var(--gray-60);
+		font-weight: 400;
+	}
+
+	label {
+		display: block;
+		font-size: 16px;
+		line-height: 1.5;
+
+		&:not(:last-child) {
+			margin-bottom: 8px;
+		}
+	}
+}
+
+.button {
+	margin-top: 16px;
+}
+
+// Example tooltip styles
+.example-wrapper {
+	position: relative;
+	display: inline;
+
+	.example-button {
+		position: relative;
+		z-index: 10;
+	}
+
+	.tooltip-wrapper {
+		position: absolute;
+		top: 0;
+		left: -10px;
+		z-index: 9;
+
+		.tooltip :global(.icon-tooltip-container .components-popover__content) {
+			width: 150px;
+		}
+	}
+} 

--- a/projects/plugins/boost/app/assets/src/js/lib/stores/speculation-rules.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/stores/speculation-rules.ts
@@ -2,7 +2,7 @@ import { useDataSync } from '@automattic/jetpack-react-data-sync-client';
 import { z } from 'zod';
 
 export const SpeculationRulesSchema = z.object( {
-	exceptions: z.array( z.string() ),
+	bypass_patterns: z.array( z.string() ),
 } );
 
 export const useSpeculationRules = () => {

--- a/projects/plugins/boost/app/assets/src/js/lib/stores/speculation-rules.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/stores/speculation-rules.ts
@@ -1,0 +1,10 @@
+import { useDataSync } from '@automattic/jetpack-react-data-sync-client';
+import { z } from 'zod';
+
+export const SpeculationRulesSchema = z.object( {
+	exceptions: z.array( z.string() ),
+} );
+
+export const useSpeculationRules = () => {
+	return useDataSync( 'jetpack_boost_ds', 'speculation_rules', SpeculationRulesSchema );
+};

--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
@@ -12,6 +12,7 @@ import PageCacheModule from '$features/page-cache/page-cache';
 import PremiumTooltip from '$features/premium-tooltip/premium-tooltip';
 import SpeculationMethod from '$features/speculation-rules/speculation-method';
 import SpeculationRulesMeta from '$features/speculation-rules/speculation-rules-meta';
+import SpeculationRulesNotice from '$features/speculation-rules/speculation-rules-notice';
 import Pill from '$features/ui/pill/pill';
 import Upgraded from '$features/ui/upgraded/upgraded';
 import UpgradeCTA from '$features/upgrade-cta/upgrade-cta';
@@ -20,7 +21,7 @@ import { recordBoostEvent } from '$lib/utils/analytics';
 import { Notice, getRedirectUrl } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import React from 'react';
+import React, { useState } from 'react';
 import styles from './index.module.scss';
 
 const Index = () => {
@@ -31,6 +32,7 @@ const Index = () => {
 	const [ isaState ] = useSingleModuleState( 'image_size_analysis' );
 	const [ imageCdn ] = useSingleModuleState( 'image_cdn' );
 	const regenerateCssAction = useRegenerateCriticalCssAction();
+	const [ showSpeculationNotice, setShowSpeculationNotice ] = useState( false );
 
 	const requestRegenerateCriticalCss = () => {
 		regenerateCssAction.mutate();
@@ -153,6 +155,7 @@ const Index = () => {
 			<Module
 				slug="speculation_rules"
 				title={ __( 'Speculation Rules', 'jetpack-boost' ) }
+				onEnable={ () => setShowSpeculationNotice( true ) }
 				description={
 					<>
 						<p>
@@ -177,6 +180,7 @@ const Index = () => {
 					</>
 				}
 			>
+				<SpeculationRulesNotice showNotice={ showSpeculationNotice } />
 				<SpeculationMethod />
 				<SpeculationRulesMeta />
 			</Module>

--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
@@ -11,6 +11,7 @@ import Module from '$features/module/module';
 import PageCacheModule from '$features/page-cache/page-cache';
 import PremiumTooltip from '$features/premium-tooltip/premium-tooltip';
 import SpeculationMethod from '$features/speculation-rules/speculation-method';
+import SpeculationRulesMeta from '$features/speculation-rules/speculation-rules-meta';
 import Pill from '$features/ui/pill/pill';
 import Upgraded from '$features/ui/upgraded/upgraded';
 import UpgradeCTA from '$features/upgrade-cta/upgrade-cta';
@@ -153,28 +154,31 @@ const Index = () => {
 				slug="speculation_rules"
 				title={ __( 'Speculation Rules', 'jetpack-boost' ) }
 				description={
-					<p>
-						{ createInterpolateElement(
-							__(
-								'Prefetch pages that are likely to be visited next, so they load faster when the user clicks on them. Browser support is limited to Chrome based browsers. Read more on <link>mdn web docs</link>.',
-								'jetpack-boost'
-							),
-							{
-								link: (
-									// eslint-disable-next-line jsx-a11y/anchor-has-content
-									<a
-										onClick={ () => recordBoostEvent( 'speculation_rules_link_clicked', {} ) }
-										href={ speculationRulesLink }
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
+					<>
+						<p>
+							{ createInterpolateElement(
+								__(
+									'Prefetch pages that are likely to be visited next, so they load faster when the user clicks on them. Browser support is limited to Chrome based browsers. Read more on <link>mdn web docs</link>.',
+									'jetpack-boost'
 								),
-							}
-						) }
-					</p>
+								{
+									link: (
+										// eslint-disable-next-line jsx-a11y/anchor-has-content
+										<a
+											onClick={ () => recordBoostEvent( 'speculation_rules_link_clicked', {} ) }
+											href={ speculationRulesLink }
+											target="_blank"
+											rel="noreferrer"
+										/>
+									),
+								}
+							) }
+						</p>
+					</>
 				}
 			>
 				<SpeculationMethod />
+				<SpeculationRulesMeta />
 			</Module>
 			<Module
 				slug="render_blocking_js"

--- a/projects/plugins/boost/app/lib/class-cli.php
+++ b/projects/plugins/boost/app/lib/class-cli.php
@@ -27,7 +27,7 @@ class CLI {
 	 */
 	private $jetpack_boost;
 
-	const MAKE_E2E_TESTS_WORK_MODULES = array( 'critical_css', 'render_blocking_js', 'page_cache', 'minify_js', 'minify_css', 'image_cdn', 'image_guide' );
+	const MAKE_E2E_TESTS_WORK_MODULES = array( 'critical_css', 'render_blocking_js', 'page_cache', 'minify_js', 'minify_css', 'image_cdn', 'image_guide', 'speculation_rules' );
 
 	/**
 	 * CLI constructor.

--- a/projects/plugins/boost/app/lib/class-excludes-urls-utils.php
+++ b/projects/plugins/boost/app/lib/class-excludes-urls-utils.php
@@ -16,7 +16,7 @@ class Excludes_URLs_Utils {
 	 *
 	 * @return array The sanitized value.
 	 */
-	public static function sanitize_value( $value, $checks = array( 'wildcards' => true ) ) {
+	public static function sanitize_value( $value, $checks = array( 'wildcards' => 'regex' ) ) {
 		if ( ! is_array( $value ) ) {
 			return array();
 		}
@@ -51,9 +51,9 @@ class Excludes_URLs_Utils {
 			// Make sure there's a leading slash
 			$path = '/' . ltrim( $path, '/' );
 
-			if ( in_array( 'wildcards', $checks, true ) && $checks['wildcards'] === true ) {
+			if ( isset( $checks['wildcards'] ) ) {
 				// Fix up any wildcards
-				$path = self::sanitize_wildcards( $path );
+				$path = self::sanitize_wildcards( $path, $checks['wildcards'] );
 			}
 		}
 
@@ -66,19 +66,28 @@ class Excludes_URLs_Utils {
 	 * @param string $path The path to sanitize.
 	 * @return string The sanitized path.
 	 */
-	private static function sanitize_wildcards( $path ) {
+	private static function sanitize_wildcards( $path, $wildcards_type ) {
 		if ( ! $path ) {
 			return '';
 		}
 
 		$path_components = explode( '/', $path );
-		$arr             = array(
-			'.*'   => '(.*)',
-			'*'    => '(.*)',
-			'(*)'  => '(.*)',
-			'(.*)' => '(.*)',
-		);
 
+		if ( $wildcards_type === 'regex' ) {
+			$arr = array(
+				'.*'   => '(.*)',
+				'*'    => '(.*)',
+				'(*)'  => '(.*)',
+				'(.*)' => '(.*)',
+			);
+		} else {
+			$arr = array(
+				'.*'   => '*',
+				'*'    => '*',
+				'(*)'  => '*',
+				'(.*)' => '*',
+			);
+		}
 		foreach ( $path_components as &$path_component ) {
 			$path_component = strtr( $path_component, $arr );
 		}

--- a/projects/plugins/boost/app/lib/class-excludes-urls-utils.php
+++ b/projects/plugins/boost/app/lib/class-excludes-urls-utils.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Lib;
+
+/**
+ * Utility class to handle excludes URLs sanitization and validation
+ * for various modules like Speculation Rules and Page Cache
+ *
+ * @since $$next-version$$
+ */
+class Excludes_URLs_Utils {
+	/**
+	 * Sanitizes the given value, ensuring that it is list of valid patterns.
+	 *
+	 * @param mixed $value The value to sanitize.
+	 *
+	 * @return array The sanitized value.
+	 */
+	public static function sanitize_value( $value ) {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		// Remove duplicates, empty values, trim whitespace, and convert to lowercase
+		$value = array_values( array_unique( array_filter( array_map( 'trim', array_map( 'strtolower', $value ) ) ) ) );
+
+		$home_url = home_url( '/' );
+
+		foreach ( $value as &$path ) {
+			// Strip home URL (both secure and non-secure)
+			$path = str_ireplace(
+				array(
+					$home_url,
+					str_replace( 'http:', 'https:', $home_url ),
+				),
+				array(
+					'/',
+					'/',
+				),
+				$path
+			);
+
+			// Remove double slashes
+			$path = str_replace( '//', '/', $path );
+
+			// Remove symbols, as they are included in the regex check
+			$path = ltrim( $path, '^' );
+			$path = rtrim( $path, '$' );
+			$path = preg_replace( '/\/\?$/', '', $path );
+
+			// Make sure there's a leading slash
+			$path = '/' . ltrim( $path, '/' );
+
+			// Fix up any wildcards
+			$path = self::sanitize_wildcards( $path );
+		}
+
+		return array_values( array_unique( array_filter( $value ) ) );
+	}
+
+	/**
+	 * Sanitize wildcards in a given path.
+	 *
+	 * @param string $path The path to sanitize.
+	 * @return string The sanitized path.
+	 */
+	private static function sanitize_wildcards( $path ) {
+		if ( ! $path ) {
+			return '';
+		}
+
+		$path_components = explode( '/', $path );
+		$arr             = array(
+			'.*'   => '(.*)',
+			'*'    => '(.*)',
+			'(*)'  => '(.*)',
+			'(.*)' => '(.*)',
+		);
+
+		foreach ( $path_components as &$path_component ) {
+			$path_component = strtr( $path_component, $arr );
+		}
+		$path = implode( '/', $path_components );
+
+		return $path;
+	}
+}

--- a/projects/plugins/boost/app/lib/class-excludes-urls-utils.php
+++ b/projects/plugins/boost/app/lib/class-excludes-urls-utils.php
@@ -16,7 +16,7 @@ class Excludes_URLs_Utils {
 	 *
 	 * @return array The sanitized value.
 	 */
-	public static function sanitize_value( $value ) {
+	public static function sanitize_value( $value, $checks = array( 'wildcards' => true ) ) {
 		if ( ! is_array( $value ) ) {
 			return array();
 		}
@@ -51,8 +51,10 @@ class Excludes_URLs_Utils {
 			// Make sure there's a leading slash
 			$path = '/' . ltrim( $path, '/' );
 
-			// Fix up any wildcards
-			$path = self::sanitize_wildcards( $path );
+			if ( in_array( 'wildcards', $checks, true ) && $checks['wildcards'] === true ) {
+				// Fix up any wildcards
+				$path = self::sanitize_wildcards( $path );
+			}
 		}
 
 		return array_values( array_unique( array_filter( $value ) ) );

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/data-sync/Page_Cache_Entry.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/data-sync/Page_Cache_Entry.php
@@ -4,6 +4,7 @@ namespace Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Data_Sync;
 
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Get;
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Set;
+use Automattic\Jetpack_Boost\Lib\Excludes_URLs_Utils;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress\Boost_Cache_Settings;
 
 class Page_Cache_Entry implements Entry_Can_Get, Entry_Can_Set {
@@ -21,85 +22,8 @@ class Page_Cache_Entry implements Entry_Can_Get, Entry_Can_Set {
 	public function set( $value ) {
 		$cache_settings = Boost_Cache_Settings::get_instance();
 
-		$value['bypass_patterns'] = $this->sanitize_value( $value['bypass_patterns'] );
+		$value['bypass_patterns'] = Excludes_URLs_Utils::sanitize_value( $value['bypass_patterns'] );
 
 		$cache_settings->set( $value );
-	}
-
-	/**
-	 * Sanitizes the given value, ensuring that it is list of valid patterns.
-	 *
-	 * @param mixed $value The value to sanitize.
-	 *
-	 * @return array The sanitized value.
-	 */
-	private function sanitize_value( $value ) {
-		if ( is_array( $value ) ) {
-			$value = array_values( array_unique( array_filter( array_map( 'trim', array_map( 'strtolower', $value ) ) ) ) );
-
-			$home_url = home_url( '/' );
-
-			foreach ( $value as &$path ) {
-				// Strip home URL (both secure and non-secure).
-				$path = str_ireplace(
-					array(
-						$home_url,
-						str_replace( 'http:', 'https:', $home_url ),
-					),
-					array(
-						'/',
-						'/',
-					),
-					$path
-				);
-
-				// Remove double shashes.
-				$path = str_replace( '//', '/', $path );
-
-				// Remove symbols, as they are included in the regex check.
-				$path = ltrim( $path, '^' );
-				$path = rtrim( $path, '$' );
-				$path = preg_replace( '/\/\?$/', '', $path );
-
-				// Make sure there's a leading slash.
-				$path = '/' . ltrim( $path, '/' );
-
-				// Fix up any wildcards.
-				$path = $this->sanitize_wildcards( $path );
-			}
-
-			$value = array_values( array_unique( array_filter( $value ) ) );
-		} else {
-			$value = array();
-		}
-
-		return $value;
-	}
-
-	/**
-	 * Sanitize wildcards in a given path.
-	 *
-	 * @param string $path The path to sanitize.
-	 * @return string The sanitized path.
-	 */
-	private function sanitize_wildcards( $path ) {
-		if ( ! $path ) {
-			return '';
-		}
-
-		$path_components = explode( '/', $path );
-		$arr             = array(
-			'.*'   => '(.*)',
-			'*'    => '(.*)',
-			'(*)'  => '(.*)',
-			'(.*)' => '(.*)',
-		);
-
-		foreach ( $path_components as &$path_component ) {
-			$path_component = strtr( $path_component, $arr );
-		}
-		$path = implode( '/', $path_components );
-
-		return $path;
 	}
 }

--- a/projects/plugins/boost/app/modules/optimizations/speculation-rules/Speculation_Rules.php
+++ b/projects/plugins/boost/app/modules/optimizations/speculation-rules/Speculation_Rules.php
@@ -34,6 +34,18 @@ class Speculation_Rules implements Pluggable, Optimization, Changes_Page_Output,
 		// Get the fetch speculation method setting
 		$use_prerender = (bool) jetpack_boost_ds_get( 'speculation_method' );
 
+		// Get the exceptions list
+		$exceptions = jetpack_boost_ds_get( array( 'speculation_rules', 'exceptions' ) );
+		$exceptions = is_array( $exceptions ) ? $exceptions : array();
+
+		// Convert exceptions to regex patterns
+		$exception_patterns = array_map(
+			function ( $url ) {
+				return preg_quote( $url, '/' );
+			},
+			$exceptions
+		);
+
 		// Determine the fetch speculation method based on the setting
 		$fetch_method = $use_prerender ? 'prerender' : 'prefetch';
 
@@ -44,7 +56,11 @@ class Speculation_Rules implements Pluggable, Optimization, Changes_Page_Output,
 				{
 					"source": "document",
 					"where": {
-						"href_matches": "/*"
+						"href_matches": "/*"' .
+						( ! empty( $exception_patterns ) ? ',
+						"not": {
+							"href_matches": ' . wp_json_encode( $exception_patterns ) . '
+						}' : '' ) . '
 					}
 				}
 			]
@@ -71,5 +87,13 @@ class Speculation_Rules implements Pluggable, Optimization, Changes_Page_Output,
 	 */
 	public function register_data_sync( Data_Sync $instance ) {
 		$instance->register( 'speculation_method', Schema::as_boolean()->fallback( false ) );
+		$instance->register(
+			'speculation_rules',
+			Schema::as_assoc_array(
+				array(
+					'exceptions' => Schema::as_array( Schema::as_string() )->fallback( array() ),
+				)
+			)->fallback( array( 'exceptions' => array() ) )
+		);
 	}
 }

--- a/projects/plugins/boost/app/modules/optimizations/speculation-rules/Speculation_Rules.php
+++ b/projects/plugins/boost/app/modules/optimizations/speculation-rules/Speculation_Rules.php
@@ -38,10 +38,16 @@ class Speculation_Rules implements Pluggable, Optimization, Changes_Page_Output,
 		$rules      = jetpack_boost_ds_get( 'speculation_rules' );
 		$exceptions = isset( $rules['exceptions'] ) && is_array( $rules['exceptions'] ) ? $rules['exceptions'] : array();
 
-		// Convert exceptions to regex patterns
-		$exception_patterns = array_map(
+		// Prepare the exceptions for the speculation rules
+		$exceptions = array_map(
 			function ( $url ) {
-				return preg_quote( $url, '/' );
+				static $home_url;
+				if ( ! $home_url ) {
+					$home_url = home_url();
+				}
+				$url = str_replace( $home_url, '', $url );
+				$url = trailingslashit( $url ) . '*';
+				return $url;
 			},
 			$exceptions
 		);
@@ -49,18 +55,22 @@ class Speculation_Rules implements Pluggable, Optimization, Changes_Page_Output,
 		// Determine the fetch speculation method based on the setting
 		$fetch_method = $use_prerender ? 'prerender' : 'prefetch';
 
+		if ( ! empty( $exceptions ) ) {
+			$not_exceptions = '{ "not": { "href_matches": [ "' . implode( '", "', $exceptions ) . '" ] } }';
+		} else {
+			$not_exceptions = '';
+		}
+
 		// Generate the speculation rules script
 		$script = '<script type="speculationrules">
 		{
 			"' . esc_js( $fetch_method ) . '": [
 				{
-					"source": "document",
 					"where": {
-						"href_matches": "/*"' .
-						( ! empty( $exception_patterns ) ? ',
-						"not": {
-							"href_matches": ' . wp_json_encode( $exception_patterns ) . '
-						}' : '' ) . '
+						"and": [
+							{ "href_matches": "/*" },' .
+							$not_exceptions . '
+						]
 					}
 				}
 			]

--- a/projects/plugins/boost/app/modules/optimizations/speculation-rules/Speculation_Rules.php
+++ b/projects/plugins/boost/app/modules/optimizations/speculation-rules/Speculation_Rules.php
@@ -56,7 +56,7 @@ class Speculation_Rules implements Pluggable, Optimization, Changes_Page_Output,
 		$fetch_method = $use_prerender ? 'prerender' : 'prefetch';
 
 		if ( ! empty( $exceptions ) ) {
-			$not_exceptions = '{ "not": { "href_matches": [ "' . implode( '", "', $exceptions ) . '" ] } }';
+			$not_exceptions = '{ "not": { "href_matches": [ "' . implode( '", "', array_map( 'esc_js', $exceptions ) ) . '" ] } }';
 		} else {
 			$not_exceptions = '';
 		}
@@ -66,12 +66,14 @@ class Speculation_Rules implements Pluggable, Optimization, Changes_Page_Output,
 		{
 			"' . esc_js( $fetch_method ) . '": [
 				{
+					"source":"document",
 					"where": {
 						"and": [
-							{ "href_matches": "/*" },' .
+							{ "href_matches": "\/*" },' .
 							$not_exceptions . '
 						]
-					}
+					},
+					"eagerness":"moderate"
 				}
 			]
 		}

--- a/projects/plugins/boost/app/modules/optimizations/speculation-rules/Speculation_Rules.php
+++ b/projects/plugins/boost/app/modules/optimizations/speculation-rules/Speculation_Rules.php
@@ -8,6 +8,7 @@ use Automattic\Jetpack_Boost\Contracts\Changes_Page_Output;
 use Automattic\Jetpack_Boost\Contracts\Has_Data_Sync;
 use Automattic\Jetpack_Boost\Contracts\Optimization;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Speculation_Rules\Data_Sync\Speculation_Rules_Excludes_Entry;
 
 class Speculation_Rules implements Pluggable, Optimization, Changes_Page_Output, Has_Data_Sync {
 	public static function is_available() {
@@ -31,12 +32,9 @@ class Speculation_Rules implements Pluggable, Optimization, Changes_Page_Output,
 	 * Inject speculation rules script in the footer.
 	 */
 	public function inject_speculation_rules() {
-		// Get the fetch speculation method setting
-		$use_prerender = (bool) jetpack_boost_ds_get( 'speculation_method' );
-
 		// Get the exceptions list
-		$rules      = jetpack_boost_ds_get( 'speculation_rules' );
-		$exceptions = isset( $rules['exceptions'] ) && is_array( $rules['exceptions'] ) ? $rules['exceptions'] : array();
+		$rules      = jetpack_boost_ds_get( 'speculation_rules', array( 'bypass_patterns' => array() ) );
+		$exceptions = isset( $rules['bypass_patterns'] ) && is_array( $rules['bypass_patterns'] ) ? $rules['bypass_patterns'] : array();
 
 		// Prepare the exceptions for the speculation rules
 		$exceptions = array_map(
@@ -52,9 +50,6 @@ class Speculation_Rules implements Pluggable, Optimization, Changes_Page_Output,
 			$exceptions
 		);
 
-		// Determine the fetch speculation method based on the setting
-		$fetch_method = $use_prerender ? 'prerender' : 'prefetch';
-
 		if ( ! empty( $exceptions ) ) {
 			$not_exceptions = '{ "not": { "href_matches": [ "' . implode( '", "', array_map( 'esc_js', $exceptions ) ) . '" ] } }';
 		} else {
@@ -64,7 +59,7 @@ class Speculation_Rules implements Pluggable, Optimization, Changes_Page_Output,
 		// Generate the speculation rules script
 		$script = '<script type="speculationrules">
 		{
-			"' . esc_js( $fetch_method ) . '": [
+			"prefetch": [
 				{
 					"source":"document",
 					"where": {
@@ -103,9 +98,10 @@ class Speculation_Rules implements Pluggable, Optimization, Changes_Page_Output,
 			'speculation_rules',
 			Schema::as_assoc_array(
 				array(
-					'exceptions' => Schema::as_array( Schema::as_string() )->fallback( array() ),
+					'bypass_patterns' => Schema::as_array( Schema::as_string() )->fallback( array() ),
 				)
-			)->fallback( array( 'exceptions' => array() ) )
+			)->fallback( array( 'bypass_patterns' => array() ) ),
+			new Speculation_Rules_Excludes_Entry()
 		);
 	}
 }

--- a/projects/plugins/boost/app/modules/optimizations/speculation-rules/Speculation_Rules.php
+++ b/projects/plugins/boost/app/modules/optimizations/speculation-rules/Speculation_Rules.php
@@ -35,8 +35,8 @@ class Speculation_Rules implements Pluggable, Optimization, Changes_Page_Output,
 		$use_prerender = (bool) jetpack_boost_ds_get( 'speculation_method' );
 
 		// Get the exceptions list
-		$exceptions = jetpack_boost_ds_get( array( 'speculation_rules', 'exceptions' ) );
-		$exceptions = is_array( $exceptions ) ? $exceptions : array();
+		$rules      = jetpack_boost_ds_get( 'speculation_rules' );
+		$exceptions = isset( $rules['exceptions'] ) && is_array( $rules['exceptions'] ) ? $rules['exceptions'] : array();
 
 		// Convert exceptions to regex patterns
 		$exception_patterns = array_map(

--- a/projects/plugins/boost/app/modules/optimizations/speculation-rules/data-sync/Speculation_Rules_Excludes_Entry.php
+++ b/projects/plugins/boost/app/modules/optimizations/speculation-rules/data-sync/Speculation_Rules_Excludes_Entry.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Modules\Optimizations\Speculation_Rules\Data_Sync;
+
+use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Get;
+use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Set;
+use Automattic\Jetpack_Boost\Lib\Excludes_URLs_Utils;
+
+/**
+ * Class to handle Speculation Rules data entry
+ *
+ * @since $$next-version$$
+ */
+class Speculation_Rules_Excludes_Entry implements Entry_Can_Get, Entry_Can_Set {
+
+	/**
+	 * The option key used to store the Speculation Rules Excludes option.
+	 *
+	 * @var string
+	 */
+	private $option_key;
+
+	/**
+	 * Constructs a new instance of the Speculation_Rules_Excludes_Entry class.
+	 */
+	public function __construct() {
+		$this->option_key = 'jetpack_boost_ds_speculation_rules_excludes';
+	}
+
+	/**
+	 * Get the list of URL patterns to exclude
+	 *
+	 * @return array List of URL patterns
+	 */
+	public function get( $fallback_value = false ) {
+		if ( $fallback_value !== false ) {
+			return get_option( $this->option_key, $fallback_value );
+		}
+		return get_option( $this->option_key );
+	}
+
+	/**
+	 * Set the list of URL patterns to exclude
+	 *
+	 * @param array $settings List of settings.
+	 * @return void
+	 */
+	public function set( $settings ) {
+		$settings['bypass_patterns'] = Excludes_URLs_Utils::sanitize_value( $settings['bypass_patterns'] );
+		update_option(
+			$this->option_key,
+			(array) apply_filters(
+				'jetpack_boost_speculation_rules_excludes',
+				$settings
+			)
+		);
+	}
+}

--- a/projects/plugins/boost/app/modules/optimizations/speculation-rules/data-sync/Speculation_Rules_Excludes_Entry.php
+++ b/projects/plugins/boost/app/modules/optimizations/speculation-rules/data-sync/Speculation_Rules_Excludes_Entry.php
@@ -46,7 +46,7 @@ class Speculation_Rules_Excludes_Entry implements Entry_Can_Get, Entry_Can_Set {
 	 * @return void
 	 */
 	public function set( $settings ) {
-		$settings['bypass_patterns'] = Excludes_URLs_Utils::sanitize_value( $settings['bypass_patterns'] );
+		$settings['bypass_patterns'] = Excludes_URLs_Utils::sanitize_value( $settings['bypass_patterns'], array( 'wildcards' => false ) );
 		update_option(
 			$this->option_key,
 			(array) apply_filters(

--- a/projects/plugins/boost/changelog/add-boost-speculation-rules-exclusions
+++ b/projects/plugins/boost/changelog/add-boost-speculation-rules-exclusions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Speculation Rules: Added exceptions textarea to settings page module.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds a textarea to the Speculation Rules module where URLs can be added. These URLs will be added to the speculationrules printed to the browser so that they won't be prefetched or prerendered.

This module is based on the exceptions textarea used by PageCache, so both modules really should use the same one.

Fixes #41916

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes the space below the Speculation Rules module.
* Adds styling of the module.
* Adds a new Meta module containing the textarea.
* Add a new SpeculationRulesSchema schema.
* Call the SpeculationRulesMeta module from the main index.tsx
* Add speculation_rules to the list of e2e modules so we can add testing code in the future.
* Register "exceptions" store for the array of URLs.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pc9hqz-3ny-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply PR.
* Enable the Speculation Rules module.
* Click on "Show Options" and confirm you can add, edit and save URLs.
* View the HTML source of the page to confirm the rules appear there.
