### PR TITLE
Update/jp dashboard currency code to check user currency

### DIFF
--- a/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/test/component.js
@@ -1,5 +1,4 @@
 import { jest } from '@jest/globals';
-import * as React from 'react';
 import analytics from 'lib/analytics';
 import { getProductsForPurchase } from 'state/initial-state';
 import { render, screen } from 'test/test-utils';

--- a/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/test/fixtures.js
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/test/fixtures.js
@@ -103,6 +103,13 @@ export function buildInitialState() {
 						],
 					},
 				},
+				userData: {
+					currentUser: {
+						wpcomUser: {
+							user_currency: 'USD',
+						},
+					},
+				},
 			},
 			products: {
 				items: {

--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -606,8 +606,8 @@ export function getStaticProductsForPurchase( state ) {
  */
 export function getProductsForPurchase( state ) {
 	const staticProducts = get( state.jetpack.initialState, 'products', {} );
-	const wpcomUser = get( state.jetpack.initialState.userData.currentUser, 'wpcomUser', {} );
-	const currencyCode = wpcomUser.user_currency || null;
+	const wpcomUser = get( state.jetpack.initialState?.userData?.currentUser, 'wpcomUser', {} );
+	const currencyCode = wpcomUser?.user_currency || null;
 	const jetpackProducts = getSiteProducts( state );
 	const products = {};
 

--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -606,6 +606,8 @@ export function getStaticProductsForPurchase( state ) {
  */
 export function getProductsForPurchase( state ) {
 	const staticProducts = get( state.jetpack.initialState, 'products', {} );
+	const wpcomUser = get( state.jetpack.initialState.userData.currentUser, 'wpcomUser', {} );
+	const currencyCode = wpcomUser.user_currency || null;
 	const jetpackProducts = getSiteProducts( state );
 	const products = {};
 
@@ -618,7 +620,7 @@ export function getProductsForPurchase( state ) {
 			features: product.features,
 			disclaimer: product.disclaimer,
 			available: get( jetpackProducts, [ product.slug, 'available' ], false ),
-			currencyCode: get( jetpackProducts, [ product.slug, 'currency_code' ], '' ),
+			currencyCode: currencyCode ?? get( jetpackProducts, [ product.slug, 'currency_code' ], '' ),
 			showPromotion: product.show_promotion,
 			promotionPercentage: product.discount_percent,
 			includedInPlans: product.included_in_plans,

--- a/projects/plugins/jetpack/changelog/update-jp-dashboard-currency-code-to-check-user-currency
+++ b/projects/plugins/jetpack/changelog/update-jp-dashboard-currency-code-to-check-user-currency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Check for user currency when getting currency code in dashboard products


### PR DESCRIPTION
## Proposed changes:

* Check wpcom user currency first before using the product currency
* Not checking the user currency was causing the currency code and the price the currency was returned in to be out of sync

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Issue: https://github.com/Automattic/jetpack/issues/42166

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Go to My Jetpack and connect your site and user
3. Go to the Store Admin and update your currency to Japanese Yen
4. Go to `/wp-admin/admin.php?page=jetpack#/product/security`
NOTE: If the user account is not connected, this page will crash with errors. This is an existing issue not related to the fix here. Seeing as I am fairly sure this page is inaccessible from the UI if the user is not connected, and that we are deprecating this dashboard soon, I don't see it as something we need to fix unless we get reports of it happening. Seeing as it's most likely been this way for quite some time, I don't think we'll get any reports if we haven't already.
5. Ensure that you see the correct price for Yen as well as the `¥` symbol rather than `$`
![image](https://github.com/user-attachments/assets/1a0c1871-9863-47fb-9967-d2151cc9893c)
