### PR TITLE
Jetpack AI image extension: invalid url catch

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-image-extension-invalid-url-catch
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-image-extension-invalid-url-catch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: handle image URL errors on AI vision requests to notify the user about the issue

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
@@ -75,6 +75,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		const { getPostContent } = usePostContent();
 		const [ loading, setLoading ] = useState< LOADING_STATE >( false );
 		const { updateBlockAttributes } = useDispatch( editorStore );
+		const { createNotice } = useDispatch( 'core/notices' );
 		const wrapperRef = useRef< HTMLDivElement >( null );
 		const hasImage = !! props.attributes.url;
 
@@ -87,6 +88,15 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 
 			setLoading( type );
 		}, [] );
+
+		const showErrorNotice = useCallback(
+			( message: string ) => {
+				createNotice( 'error', message, {
+					isDismissible: true,
+				} );
+			},
+			[ createNotice ]
+		);
 
 		useEffect( () => {
 			if ( loading === false ) {
@@ -145,6 +155,9 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 					}
 				} catch ( error ) {
 					debug( `Error generating ${ type }`, error );
+					if ( error?.message ) {
+						showErrorNotice( error.message );
+					}
 				} finally {
 					setLoading( false );
 				}
@@ -157,6 +170,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 				props.attributes.url,
 				props.clientId,
 				requireUpgrade,
+				showErrorNotice,
 				startLoading,
 				updateBlockAttributes,
 			]


### PR DESCRIPTION
Depends on 175614-ghe-Automattic/wpcom

## Proposed changes:
Handle AI vision request errors for invalid URLs. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1740779390614989-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Apply 175614-ghe-Automattic/wpcom on your sandbox and sandbox the public API. Enable writing on the sandbox to allow http requests.

Enable the feature adding the filter `add_filter( 'ai_image_extension_enabled', '__return_true' ); ` and make sure you're using BETA blocks variation.

Add an image block with an image on a private blog or with a phony/inexistent URL. This happens with JT addresses as images are not accessible, otherwise, just take an image URL from a P2.

Use the AI toolbar button to get alt-text or describe the image, see the error on the network tab and the notice on the block editor:
<img width="774" alt="image" src="https://github.com/user-attachments/assets/63de307a-abba-4fb1-ad9a-5150c066d248" />

<img width="471" alt="image" src="https://github.com/user-attachments/assets/0428f9a3-4312-4a35-9d31-7a0aba95ed2d" />
