### PR TITLE
Launchpad: Use heuristic to hide verify email task, regardless of experiment cohort

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-verify-email-task-visibility-no-cumulative
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-verify-email-task-visibility-no-cumulative
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Launchpad: verify email task uses heuristic for visibility, regardless of experiment cohort

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1950,16 +1950,9 @@ add_action( 'wpcom_email_verification_complete', 'wpcom_launchpad_mark_verify_em
  * verify their email at the time the site was created. That way we're not showing
  * the completed task to users who were verified before creating this site.
  *
- * @param Task  $task The task object.
- * @param bool  $is_visible Whether the task should be visible.
- * @param array $data Additional data.
  * @return bool True when the email verification task should be visible.
  */
-function wpcom_launchpad_is_email_task_visible( $task, $is_visible, $data ) {
-	if ( ! isset( $data ) || ! isset( $data['launchpad_context'] ) || $data['launchpad_context'] !== 'customer-home-treatment-cumulative' ) {
-		return $is_visible;
-	}
-
+function wpcom_launchpad_is_email_task_visible() {
 	if ( ! class_exists( 'Email_Verification' ) ) {
 		// Don't show the task if we don't have the ability to complete it
 		return false;

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/Launchpad_Task_Lists_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/Launchpad_Task_Lists_Test.php
@@ -589,68 +589,38 @@ class Launchpad_Task_Lists_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function provide_verify_email_task_visibility_test_cases() {
 		return array(
-			'unverified single-site user in cumulative cohort'    => array(
-				'customer-home-treatment-cumulative',
+			'unverified single-site user' => array(
 				'unverified',
 				1,
 				'should-be-visible',
 			),
-			'unverified single-site user in non-cumulative cohort' => array(
-				'customer-home',
-				'unverified',
-				1,
-				'should-be-visible',
-			),
-			'unverified multi-site user in cumulative cohort' => array(
-				'customer-home-treatment-cumulative',
+			'unverified multi-site user'  => array(
 				'unverified',
 				2,
 				'should-be-visible',
 			),
-			'unverified multi-site user in non-cumulative cohort' => array(
-				'customer-home',
-				'unverified',
-				2,
-				'should-be-visible',
-			),
-			'verified single-site user in cumulative cohort'    => array(
-				'customer-home-treatment-cumulative',
+			'verified single-site user'   => array(
 				'verified',
 				1,
 				'should-be-visible',
 			),
-			'verified single-site user in non-cumulative cohort' => array(
-				'customer-home',
-				'verified',
-				1,
-				'should-be-visible',
-			),
-			'verified multi-site user in cumulative cohort' => array(
-				'customer-home-treatment-cumulative',
+			'verified multi-site user'    => array(
 				'verified',
 				2,
 				'should-NOT-be-visible',
-			),
-			'verified multi-site user in non-cumulative cohort' => array(
-				'customer-home',
-				'verified',
-				2,
-				'should-be-visible',
 			),
 		);
 	}
 
 	/**
-	 * Test the visibility of the verify email task based on whether the user is likely to be new
-	 * and if they're in the cumulative cohort (see calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131 experiment).
+	 * Test the visibility of the verify email task based on whether the user is likely to be new.
 	 *
 	 * @dataProvider provide_verify_email_task_visibility_test_cases()
-	 * @param string $launchpad_context 'customer-home-treatment-cumulative' or 'customer-home'.
 	 * @param string $user_verification_status 'unverified' or something else (like 'verified').
 	 * @param int    $blog_count_for_user Number of blogs for the user.
 	 * @param string $should_be_visible 'should-be-visible' or something else (like 'should-NOT-be-visible').
 	 */
-	public function test_verify_email_task_visibility( $launchpad_context, $user_verification_status, $blog_count_for_user, $should_be_visible ) {
+	public function test_verify_email_task_visibility( $user_verification_status, $blog_count_for_user, $should_be_visible ) {
 		\Brain\Monkey\Functions\when( 'get_blog_count_for_user' )->justReturn( $blog_count_for_user );
 		\Mockery::mock( 'alias:Email_Verification' )->shouldReceive( 'is_email_unverified' )->andReturn( $user_verification_status === 'unverified' );
 
@@ -672,7 +642,7 @@ class Launchpad_Task_Lists_Test extends \WorDBless\BaseTestCase {
 			)
 		);
 
-		$result = Launchpad_Task_Lists::get_instance()->build( 'tasklist-with-verify-email-task', $launchpad_context );
+		$result = Launchpad_Task_Lists::get_instance()->build( 'tasklist-with-verify-email-task' );
 
 		if ( $should_be_visible === 'should-be-visible' ) {
 			$this->assertCount( 1, $result );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Launchpad_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Launchpad_Test.php
@@ -28,6 +28,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Test extends \WorDBless\BaseTestCase 
 	 */
 	public function set_up() {
 		parent::set_up();
+		\Brain\Monkey\setUp();
 
 		$this->admin_id = wp_insert_user(
 			array(
@@ -39,6 +40,13 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Test extends \WorDBless\BaseTestCase 
 		wp_set_current_user( 0 );
 		wpcom_register_default_launchpad_checklists();
 		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Reverting the testing environment to its original state.
+	 */
+	public function tear_down() {
+		\Brain\Monkey\tearDown();
 	}
 
 	/**
@@ -397,6 +405,9 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Test extends \WorDBless\BaseTestCase 
 	 * @covers ::get_data
 	 */
 	public function test_get_tasklist_using_goals( $site_goals, $enable_checklist_for_goals, $expected_tasklist_slug ) {
+		\Brain\Monkey\Functions\when( 'get_blog_count_for_user' )->justReturn( 1 );
+		\Mockery::mock( 'alias:Email_Verification' )->shouldReceive( 'is_email_unverified' )->andReturn( true );
+
 		wp_set_current_user( $this->admin_id );
 		update_option( 'site_goals', $site_goals );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Release the "verify email" task visibility logic to all users.

Generally the idea is if the user initially saw the "verify email" task in the launchpad, then once they verify their account we want them to see it checked off. However if the user was already verified when they create their site, then we don't want to ever show it in the launchpad. We don't store the data needed to do this reliably, so the logic here is a heuristic based on how many sites the user has.

Also adds mocks to the `WPCOM_REST_API_V2_Endpoint_Launchpad_Test` tests, since now those tests run through the logic too.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->


Similar to https://github.com/Automattic/wp-calypso/pull/100526 and https://github.com/Automattic/wp-calypso/pull/100524, this release behaviour that used to be guarded by the goals-first holdout (22180-explat-experiment) to all users. This is also related to the focused launchpad tracks audit (pfYzsZ-1KX-p2#comment-1696) because once the necessity for the `context=customer-home-treatment-cumulative` query param goes away, we're freer to re-adjust what context value the launchpad sends for tracks events.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply change to your sandbox and smoke test site creation and launchpad
* If you're using your regular test account, you shouldn't be seeing the verify email task
* If you're testing using a brand new account, you should see the verify email task