### PR TITLE
Remove editor-specific classname from CSS

### DIFF
--- a/projects/packages/forms/changelog/fix-site-editor-styles
+++ b/projects/packages/forms/changelog/fix-site-editor-styles
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: it's a tiny styling bug
+
+

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -265,7 +265,8 @@
 		margin-bottom: -3px;
 	}
 
-	.rich-text.jetpack-field-label__input {
+	// Duplicated classname to preserve specificity level.
+	.jetpack-field-label__input.jetpack-field-label__input {
 		cursor: text;
 		font-weight: bold;
 		margin-bottom: 0.25em;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #41276.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

The bug was caused by styles in the [editor stylesheet](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/forms/src/blocks/contact-form/editor.scss) using the `rich-text` classname, which doesn't exist in the site editor preview mode. The preview mode approximates the front end in that none of the contenteditable fields are rendered, so any styles targeting those will be lost.

This PR changes the CSS rule that wasn't being applied to use only classnames that always exist.

I couldn't find any other obvious styling discrepancies. There are a couple other instances of the `rich-text` class in that file but they're applied to dropdown, which always displays closed in the preview so makes no difference.

Happy to fix any other related issues that may be detected though!

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open the site editor and click through to the home template.
* Add a contact form to the template and save.
* Open the left sidebar so the template enters preview mode
* Check that contact form styles don't change between preview and edit modes.

