### PR TITLE
My Jetpack: Moving REST route registration for historically active modules

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack_history_active_api
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack_history_active_api
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Moving REST route registration to avoid a warning
+
+

--- a/projects/packages/my-jetpack/src/class-historically-active-modules.php
+++ b/projects/packages/my-jetpack/src/class-historically-active-modules.php
@@ -17,9 +17,11 @@ class Historically_Active_Modules {
 	public const UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY = 'update-historically-active-jetpack-modules';
 
 	/**
-	 * Constructor
+	 * Register the REST API routes.
+	 *
+	 * @return void
 	 */
-	public function __construct() {
+	public static function register_rest_endpoints() {
 		register_rest_route(
 			'my-jetpack/v1',
 			'site/update-historically-active-modules',

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -519,7 +519,6 @@ class Initializer {
 		new REST_Zendesk_Chat();
 		new REST_AI();
 		new REST_Recommendations_Evaluation();
-		new Historically_Active_Modules();
 
 		Products::register_product_endpoints();
 		Historically_Active_Modules::register_rest_endpoints();

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -522,6 +522,7 @@ class Initializer {
 		new Historically_Active_Modules();
 
 		Products::register_product_endpoints();
+		Historically_Active_Modules::register_rest_endpoints();
 
 		register_rest_route(
 			'my-jetpack/v1',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1741037228611419-slack-C01264051NE
Updating changes made in https://github.com/Automattic/jetpack/pull/42133 based on an issue reported here: p1741037228611419-slack-C01264051NE

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* move REST route registration from the constructor to it's own function and trigger it after instatiating the class

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout trunk to your local environment
* Navigate to My Jetpack and using `docker tail` command, verify that you see a warning reported in the Slack thread
* Check out the branch locally
* Follow the Docker log step and verify that the warning is missing and My Jetpack loads properly
* Follow steps from https://github.com/Automattic/jetpack/pull/42133 and verify that the data is available