### PR TITLE
Add Podcasting submenu item on Default sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-podcasting-menu-default
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-podcasting-menu-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Podcasting submenu item on Default sites

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -10,6 +10,7 @@
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Status\Host;
 
 /**
  * Checks if the current user has a WordPress.com account connected.
@@ -146,7 +147,80 @@ function wpcom_add_hosting_menu() {
 add_action( 'admin_menu', 'wpcom_add_hosting_menu' );
 
 /**
- * Adds WordPress.com submenu items related to Jetpack under the Jetpack admin menu.
+ * Adds WordPress.com submenu items for Default sites under the Jetpack admin menu.
+ */
+function wpcom_add_jetpack_submenu_default_sites() {
+	$uses_wp_admin_interface = get_option( 'wpcom_admin_interface' ) === 'wp-admin';
+	if ( ! $uses_wp_admin_interface ) {
+		return;
+	}
+
+	if ( ! class_exists( 'Automattic\Jetpack\Status\Host' ) ) {
+		return;
+	}
+
+	$host           = new Host();
+	$is_simple_site = $host->is_wpcom_simple();
+	$is_atomic_site = $host->is_woa_site();
+
+	if ( $is_atomic_site && ( ( new Status() )->is_offline_mode() || ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected() ) ) {
+		return;
+	}
+
+	global $submenu;
+	$domain = wpcom_get_site_slug();
+
+	if ( $is_simple_site ) {
+		/**
+		 * Simple sites: Add to the last position
+		 *
+		 * Using 999999 to ensure the item appears last in the submenu on Simple sites.
+		 * Lower priorities would place it before other items like Search and Akismet Anti-spam.
+		 */
+
+		$podcasting_position = 0;
+		if ( ! empty( $submenu['jetpack'] ) && is_array( $submenu['jetpack'] ) ) {
+			$podcasting_position = count( $submenu['jetpack'] );
+		}
+
+		add_submenu_page(
+			'jetpack',
+			esc_attr__( 'Podcasting', 'jetpack-mu-wpcom' ),
+			__( 'Podcasting', 'jetpack-mu-wpcom' ),
+			'manage_options',
+			"https://wordpress.com/podcasting/$domain",
+			null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+			$podcasting_position
+		);
+	} elseif ( $is_atomic_site ) {
+		/**
+		 * Atomic sites: Add before Settings
+		 */
+
+		$podcasting_position = 0;
+
+		if ( ! empty( $submenu['jetpack'] ) && is_array( $submenu['jetpack'] ) ) {
+			$settings_submenu_label = __( 'Settings', 'jetpack-mu-wpcom' );
+			$submenu_labels         = array_column( $submenu['jetpack'], 3 );
+			$settings_position      = array_search( $settings_submenu_label, $submenu_labels, true );
+			$podcasting_position    = $settings_position !== false ? $settings_position : count( $submenu['jetpack'] );
+		}
+
+		add_submenu_page(
+			'jetpack',
+			esc_attr__( 'Podcasting', 'jetpack-mu-wpcom' ),
+			__( 'Podcasting', 'jetpack-mu-wpcom' ),
+			'manage_options',
+			"https://wordpress.com/settings/podcasting/$domain",
+			null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+			$podcasting_position
+		);
+	}
+}
+add_action( 'admin_menu', 'wpcom_add_jetpack_submenu_default_sites', 999999 );
+
+/**
+ * Adds WordPress.com submenu items for Classic sites under the Jetpack admin menu.
  */
 function wpcom_add_jetpack_submenu() {
 	$is_simple_site          = defined( 'IS_WPCOM' ) && IS_WPCOM;

--- a/projects/packages/masterbar/changelog/update-podcasting-menu-default
+++ b/projects/packages/masterbar/changelog/update-podcasting-menu-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Podcasting submenu item on Default sites

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -338,17 +338,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		add_submenu_page( 'jetpack', esc_attr__( 'Scan', 'jetpack-masterbar' ), __( 'Scan', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/scan/' . $this->domain, null, $scan_position );
 
-		// Add the Podcasting menu item before the Settings menu item on Atomic sites.
-		$podcasting_position = $this->get_submenu_item_count( 'jetpack' );
-		if ( isset( $submenu['jetpack'] ) ) {
-			$settings_submenu_label = __( 'Settings', 'jetpack-masterbar' );
-			$submenu_labels         = array_column( $submenu['jetpack'], 3 );
-			$settings_position      = array_search( $settings_submenu_label, $submenu_labels, true );
-			$podcasting_position    = $settings_position !== false ? $settings_position : $this->get_submenu_item_count( 'jetpack' );
-		}
-		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_submenu_page( 'jetpack', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/podcasting/' . $this->domain, null, (int) $podcasting_position );
-
 		/**
 		 * Prevent duplicate menu items that link to Jetpack Backup.
 		 * Hide the one that's shown when the standalone backup plugin is not installed, since Jetpack Backup is already included in Atomic sites.

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -328,8 +328,9 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		$scan_position = $this->get_submenu_item_count( 'jetpack' ) - 1;
 
 		global $submenu;
+
+		// Add the Scan menu item after the Backup menu item
 		if ( isset( $submenu['jetpack'] ) ) {
-			// Add the Scan menu item after the Backup menu item
 			$backup_submenu_label = __( 'Backup', 'jetpack-masterbar' );
 			$submenu_labels       = array_column( $submenu['jetpack'], 3 );
 			$backup_position      = array_search( $backup_submenu_label, $submenu_labels, true );
@@ -338,15 +339,12 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		add_submenu_page( 'jetpack', esc_attr__( 'Scan', 'jetpack-masterbar' ), __( 'Scan', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/scan/' . $this->domain, null, $scan_position );
 
-		// Add the Podcasting menu item
+		// Add the Podcasting menu item before the Settings menu item on Atomic sites.
 		if ( isset( $submenu['jetpack'] ) ) {
-			/**
-			 * Add the Podcasting menu item before the Settings menu item on Atomic sites.
-			 * On Simple sites, there is no Settings menu item, so we add the Podcasting menu on the last position.
-			 */
 			$settings_submenu_label = __( 'Settings', 'jetpack-masterbar' );
+			$submenu_labels         = array_column( $submenu['jetpack'], 3 );
 			$settings_position      = array_search( $settings_submenu_label, $submenu_labels, true );
-			$podcasting_position    = $settings_position !== false ? $settings_position - 1 : $this->get_submenu_item_count( 'jetpack' );
+			$podcasting_position    = $settings_position !== false ? $settings_position : $this->get_submenu_item_count( 'jetpack' );
 		}
 		add_submenu_page( 'jetpack', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/podcasting/' . $this->domain, null, $podcasting_position );
 

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -348,7 +348,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			$settings_position      = array_search( $settings_submenu_label, $submenu_labels, true );
 			$podcasting_position    = $settings_position !== false ? $settings_position - 1 : $this->get_submenu_item_count( 'jetpack' );
 		}
-		add_submenu_page( 'jetpack', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/podcasting/' . $this->domain, null, $podcasting_position );
+		add_submenu_page( 'jetpack', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/podcasting/' . $this->domain, null, $podcasting_position );
 
 		/**
 		 * Prevent duplicate menu items that link to Jetpack Backup.

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -338,6 +338,9 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		add_submenu_page( 'jetpack', esc_attr__( 'Scan', 'jetpack-masterbar' ), __( 'Scan', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/scan/' . $this->domain, null, $scan_position );
 
+		// Add the Podcasting menu item to the last position.
+		add_submenu_page( 'jetpack', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/podcasting/' . $this->domain, null, $this->get_submenu_item_count( 'jetpack' ) );
+
 		/**
 		 * Prevent duplicate menu items that link to Jetpack Backup.
 		 * Hide the one that's shown when the standalone backup plugin is not installed, since Jetpack Backup is already included in Atomic sites.

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -325,11 +325,10 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			parent::add_jetpack_menu();
 		}
 
-		$scan_position = $this->get_submenu_item_count( 'jetpack' ) - 1;
-
 		global $submenu;
 
 		// Add the Scan menu item after the Backup menu item
+		$scan_position = $this->get_submenu_item_count( 'jetpack' ) - 1;
 		if ( isset( $submenu['jetpack'] ) ) {
 			$backup_submenu_label = __( 'Backup', 'jetpack-masterbar' );
 			$submenu_labels       = array_column( $submenu['jetpack'], 3 );
@@ -340,6 +339,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		add_submenu_page( 'jetpack', esc_attr__( 'Scan', 'jetpack-masterbar' ), __( 'Scan', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/scan/' . $this->domain, null, $scan_position );
 
 		// Add the Podcasting menu item before the Settings menu item on Atomic sites.
+		$podcasting_position = $this->get_submenu_item_count( 'jetpack' );
 		if ( isset( $submenu['jetpack'] ) ) {
 			$settings_submenu_label = __( 'Settings', 'jetpack-masterbar' );
 			$submenu_labels         = array_column( $submenu['jetpack'], 3 );
@@ -347,7 +347,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			$podcasting_position    = $settings_position !== false ? $settings_position : $this->get_submenu_item_count( 'jetpack' );
 		}
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_submenu_page( 'jetpack', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/podcasting/' . $this->domain, null, $podcasting_position );
+		add_submenu_page( 'jetpack', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/podcasting/' . $this->domain, null, (int) $podcasting_position );
 
 		/**
 		 * Prevent duplicate menu items that link to Jetpack Backup.

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -346,6 +346,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			$settings_position      = array_search( $settings_submenu_label, $submenu_labels, true );
 			$podcasting_position    = $settings_position !== false ? $settings_position : $this->get_submenu_item_count( 'jetpack' );
 		}
+		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		add_submenu_page( 'jetpack', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/podcasting/' . $this->domain, null, $podcasting_position );
 
 		/**

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -329,17 +329,26 @@ class Atomic_Admin_Menu extends Admin_Menu {
 
 		global $submenu;
 		if ( isset( $submenu['jetpack'] ) ) {
+			// Add the Scan menu item after the Backup menu item
 			$backup_submenu_label = __( 'Backup', 'jetpack-masterbar' );
 			$submenu_labels       = array_column( $submenu['jetpack'], 3 );
 			$backup_position      = array_search( $backup_submenu_label, $submenu_labels, true );
 			$scan_position        = $backup_position !== false ? $backup_position + 1 : $this->get_submenu_item_count( 'jetpack' ) - 1;
 		}
-
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		add_submenu_page( 'jetpack', esc_attr__( 'Scan', 'jetpack-masterbar' ), __( 'Scan', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/scan/' . $this->domain, null, $scan_position );
 
-		// Add the Podcasting menu item to the last position.
-		add_submenu_page( 'jetpack', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/podcasting/' . $this->domain, null, $this->get_submenu_item_count( 'jetpack' ) );
+		// Add the Podcasting menu item
+		if ( isset( $submenu['jetpack'] ) ) {
+			/**
+			 * Add the Podcasting menu item before the Settings menu item on Atomic sites.
+			 * On Simple sites, there is no Settings menu item, so we add the Podcasting menu on the last position.
+			 */
+			$settings_submenu_label = __( 'Settings', 'jetpack-masterbar' );
+			$settings_position      = array_search( $settings_submenu_label, $submenu_labels, true );
+			$podcasting_position    = $settings_position !== false ? $settings_position - 1 : $this->get_submenu_item_count( 'jetpack' );
+		}
+		add_submenu_page( 'jetpack', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/podcasting/' . $this->domain, null, $podcasting_position );
 
 		/**
 		 * Prevent duplicate menu items that link to Jetpack Backup.

--- a/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
@@ -262,14 +262,13 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		add_action(
 			'admin_menu',
 			function () {
-				// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 				add_submenu_page(
 					'jetpack',
 					esc_attr__( 'Podcasting', 'jetpack-masterbar' ),
 					__( 'Podcasting', 'jetpack-masterbar' ),
 					'manage_options',
 					'https://wordpress.com/settings/podcasting/' . $this->domain,
-					null,
+					'',
 					$this->get_submenu_item_count( 'jetpack' )
 				);
 			},
@@ -323,17 +322,17 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		$last_upgrade_submenu_position = $this->get_submenu_item_count( 'paid-upgrades.php' );
 
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_submenu_page( 'paid-upgrades.php', __( 'Domains', 'jetpack-masterbar' ), __( 'Domains', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, $last_upgrade_submenu_position - 1 );
+		add_submenu_page( 'paid-upgrades.php', __( 'Domains', 'jetpack-masterbar' ), __( 'Domains', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, '', $last_upgrade_submenu_position - 1 );
 
 		/** This filter is already documented in modules/masterbar/admin-menu/class-atomic-admin-menu.php */
 		if ( apply_filters( 'jetpack_show_wpcom_upgrades_email_menu', false ) ) {
 			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			add_submenu_page( 'paid-upgrades.php', __( 'Emails', 'jetpack-masterbar' ), __( 'Emails', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/email/' . $this->domain, null, $last_upgrade_submenu_position );
+			add_submenu_page( 'paid-upgrades.php', __( 'Emails', 'jetpack-masterbar' ), __( 'Emails', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/email/' . $this->domain, '', $last_upgrade_submenu_position );
 		}
 
 		if ( defined( 'WPCOM_ENABLE_ADD_ONS_MENU_ITEM' ) && WPCOM_ENABLE_ADD_ONS_MENU_ITEM ) {
 			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			add_submenu_page( 'paid-upgrades.php', __( 'Add-Ons', 'jetpack-masterbar' ), __( 'Add-Ons', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/add-ons/' . $this->domain, null, 1 );
+			add_submenu_page( 'paid-upgrades.php', __( 'Add-Ons', 'jetpack-masterbar' ), __( 'Add-Ons', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/add-ons/' . $this->domain, '', 1 );
 		}
 	}
 
@@ -360,7 +359,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		if ( $user_can_customize ) {
 			$customize_custom_css_url = add_query_arg( array( 'autofocus' => array( 'section' => 'jetpack_custom_css' ) ), $customize_url );
 			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			add_submenu_page( 'themes.php', esc_attr__( 'Additional CSS', 'jetpack-masterbar' ), __( 'Additional CSS', 'jetpack-masterbar' ), 'customize', esc_url( $customize_custom_css_url ), null, 20 );
+			add_submenu_page( 'themes.php', esc_attr__( 'Additional CSS', 'jetpack-masterbar' ), __( 'Additional CSS', 'jetpack-masterbar' ), 'customize', esc_url( $customize_custom_css_url ), '', 20 );
 		}
 
 		return $customize_url;
@@ -382,9 +381,9 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		$slug = current_user_can( 'list_users' ) ? 'users.php' : 'profile.php';
 		$this->update_submenus( $slug, $submenus_to_update );
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_submenu_page( 'users.php', esc_attr__( 'Add New User', 'jetpack-masterbar' ), __( 'Add New User', 'jetpack-masterbar' ), 'promote_users', 'https://wordpress.com/people/new/' . $this->domain, null, 1 );
+		add_submenu_page( 'users.php', esc_attr__( 'Add New User', 'jetpack-masterbar' ), __( 'Add New User', 'jetpack-masterbar' ), 'promote_users', 'https://wordpress.com/people/new/' . $this->domain, '', 1 );
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack-masterbar' ), __( 'Subscribers', 'jetpack-masterbar' ), 'list_users', 'https://wordpress.com/subscribers/' . $this->domain, null, 3 );
+		add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack-masterbar' ), __( 'Subscribers', 'jetpack-masterbar' ), 'list_users', 'https://wordpress.com/subscribers/' . $this->domain, '', 3 );
 	}
 
 	/**
@@ -394,7 +393,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		parent::add_options_menu();
 
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Features', 'jetpack-masterbar' ), __( 'Hosting Features', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/hosting-features/' . $this->domain, null, 10 );
+		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Features', 'jetpack-masterbar' ), __( 'Hosting Features', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/hosting-features/' . $this->domain, '', 10 );
 	}
 
 	/**

--- a/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
@@ -268,7 +268,8 @@ class WPcom_Admin_Menu extends Admin_Menu {
 					__( 'Podcasting', 'jetpack-masterbar' ),
 					'manage_options',
 					'https://wordpress.com/settings/podcasting/' . $this->domain,
-					'',
+					// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+					null,
 					$this->get_submenu_item_count( 'jetpack' )
 				);
 			},

--- a/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
@@ -248,36 +248,6 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	}
 
 	/**
-	 * Adds the Jetpack menu.
-	 */
-	public function add_jetpack_menu() {
-		parent::add_jetpack_menu();
-
-		/**
-		 * Add the Podcasting menu item to the Jetpack menu.
-		 *
-		 * Uses 999999 to ensure the item appears last in the submenu.
-		 * Lower priorities would place it before other items like Search and Akismet Anti-spam.
-		 */
-		add_action(
-			'admin_menu',
-			function () {
-				add_submenu_page(
-					'jetpack',
-					esc_attr__( 'Podcasting', 'jetpack-masterbar' ),
-					__( 'Podcasting', 'jetpack-masterbar' ),
-					'manage_options',
-					'https://wordpress.com/settings/podcasting/' . $this->domain,
-					// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-					null,
-					$this->get_submenu_item_count( 'jetpack' )
-				);
-			},
-			999999
-		);
-	}
-
-	/**
 	 * Adds Stats menu.
 	 */
 	public function add_stats_menu() {

--- a/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
@@ -254,6 +254,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		parent::add_jetpack_menu();
 
 		// Add the Podcasting menu item on the last position on Simple sites.
+		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		add_submenu_page( 'jetpack', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/podcasting/' . $this->domain, null, $this->get_submenu_item_count( 'jetpack' ) );
 	}
 

--- a/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
@@ -323,17 +323,17 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		$last_upgrade_submenu_position = $this->get_submenu_item_count( 'paid-upgrades.php' );
 
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_submenu_page( 'paid-upgrades.php', __( 'Domains', 'jetpack-masterbar' ), __( 'Domains', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, '', $last_upgrade_submenu_position - 1 );
+		add_submenu_page( 'paid-upgrades.php', __( 'Domains', 'jetpack-masterbar' ), __( 'Domains', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/domains/manage/' . $this->domain, null, $last_upgrade_submenu_position - 1 );
 
 		/** This filter is already documented in modules/masterbar/admin-menu/class-atomic-admin-menu.php */
 		if ( apply_filters( 'jetpack_show_wpcom_upgrades_email_menu', false ) ) {
 			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			add_submenu_page( 'paid-upgrades.php', __( 'Emails', 'jetpack-masterbar' ), __( 'Emails', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/email/' . $this->domain, '', $last_upgrade_submenu_position );
+			add_submenu_page( 'paid-upgrades.php', __( 'Emails', 'jetpack-masterbar' ), __( 'Emails', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/email/' . $this->domain, null, $last_upgrade_submenu_position );
 		}
 
 		if ( defined( 'WPCOM_ENABLE_ADD_ONS_MENU_ITEM' ) && WPCOM_ENABLE_ADD_ONS_MENU_ITEM ) {
 			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			add_submenu_page( 'paid-upgrades.php', __( 'Add-Ons', 'jetpack-masterbar' ), __( 'Add-Ons', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/add-ons/' . $this->domain, '', 1 );
+			add_submenu_page( 'paid-upgrades.php', __( 'Add-Ons', 'jetpack-masterbar' ), __( 'Add-Ons', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/add-ons/' . $this->domain, null, 1 );
 		}
 	}
 
@@ -360,7 +360,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		if ( $user_can_customize ) {
 			$customize_custom_css_url = add_query_arg( array( 'autofocus' => array( 'section' => 'jetpack_custom_css' ) ), $customize_url );
 			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			add_submenu_page( 'themes.php', esc_attr__( 'Additional CSS', 'jetpack-masterbar' ), __( 'Additional CSS', 'jetpack-masterbar' ), 'customize', esc_url( $customize_custom_css_url ), '', 20 );
+			add_submenu_page( 'themes.php', esc_attr__( 'Additional CSS', 'jetpack-masterbar' ), __( 'Additional CSS', 'jetpack-masterbar' ), 'customize', esc_url( $customize_custom_css_url ), null, 20 );
 		}
 
 		return $customize_url;
@@ -382,9 +382,9 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		$slug = current_user_can( 'list_users' ) ? 'users.php' : 'profile.php';
 		$this->update_submenus( $slug, $submenus_to_update );
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_submenu_page( 'users.php', esc_attr__( 'Add New User', 'jetpack-masterbar' ), __( 'Add New User', 'jetpack-masterbar' ), 'promote_users', 'https://wordpress.com/people/new/' . $this->domain, '', 1 );
+		add_submenu_page( 'users.php', esc_attr__( 'Add New User', 'jetpack-masterbar' ), __( 'Add New User', 'jetpack-masterbar' ), 'promote_users', 'https://wordpress.com/people/new/' . $this->domain, null, 1 );
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack-masterbar' ), __( 'Subscribers', 'jetpack-masterbar' ), 'list_users', 'https://wordpress.com/subscribers/' . $this->domain, '', 3 );
+		add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack-masterbar' ), __( 'Subscribers', 'jetpack-masterbar' ), 'list_users', 'https://wordpress.com/subscribers/' . $this->domain, null, 3 );
 	}
 
 	/**
@@ -394,7 +394,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		parent::add_options_menu();
 
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Features', 'jetpack-masterbar' ), __( 'Hosting Features', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/hosting-features/' . $this->domain, '', 10 );
+		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Features', 'jetpack-masterbar' ), __( 'Hosting Features', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/hosting-features/' . $this->domain, null, 10 );
 	}
 
 	/**

--- a/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
@@ -265,7 +265,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 			$settings_position      = array_search( $settings_submenu_label, $submenu_labels, true );
 			$podcasting_position    = $settings_position !== false ? $settings_position - 1 : $this->get_submenu_item_count( 'jetpack' );
 		}
-		add_submenu_page( 'jetpack', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/podcasting/' . $this->domain, null, $podcasting_position );
+		add_submenu_page( 'jetpack', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/podcasting/' . $this->domain, null, $podcasting_position );
 	}
 
 	/**

--- a/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
@@ -253,9 +253,28 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	public function add_jetpack_menu() {
 		parent::add_jetpack_menu();
 
-		// Add the Podcasting menu item on the last position on Simple sites.
-		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_submenu_page( 'jetpack', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/podcasting/' . $this->domain, null, $this->get_submenu_item_count( 'jetpack' ) );
+		/**
+		 * Add the Podcasting menu item to the Jetpack menu.
+		 *
+		 * Uses 999999 to ensure the item appears last in the submenu.
+		 * Lower priorities would place it before other items like Search and Akismet Anti-spam.
+		 */
+		add_action(
+			'admin_menu',
+			function () {
+				// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+				add_submenu_page(
+					'jetpack',
+					esc_attr__( 'Podcasting', 'jetpack-masterbar' ),
+					__( 'Podcasting', 'jetpack-masterbar' ),
+					'manage_options',
+					'https://wordpress.com/settings/podcasting/' . $this->domain,
+					null,
+					$this->get_submenu_item_count( 'jetpack' )
+				);
+			},
+			999999
+		);
 	}
 
 	/**

--- a/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
@@ -248,6 +248,27 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	}
 
 	/**
+	 * Adds the Jetpack menu.
+	 */
+	public function add_jetpack_menu() {
+		parent::add_jetpack_menu();
+
+		// Add the Podcasting menu item
+		global $submenu;
+		if ( isset( $submenu['jetpack'] ) ) {
+			/**
+			 * Add the Podcasting menu item before the Settings menu item on Atomic sites.
+			 * On Simple sites, there is no Settings menu item, so we add the Podcasting menu on the last position.
+			 */
+			$settings_submenu_label = __( 'Settings', 'jetpack-masterbar' );
+			$submenu_labels         = array_column( $submenu['jetpack'], 3 );
+			$settings_position      = array_search( $settings_submenu_label, $submenu_labels, true );
+			$podcasting_position    = $settings_position !== false ? $settings_position - 1 : $this->get_submenu_item_count( 'jetpack' );
+		}
+		add_submenu_page( 'jetpack', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/podcasting/' . $this->domain, null, $podcasting_position );
+	}
+
+	/**
 	 * Adds Stats menu.
 	 */
 	public function add_stats_menu() {

--- a/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
@@ -253,19 +253,8 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	public function add_jetpack_menu() {
 		parent::add_jetpack_menu();
 
-		// Add the Podcasting menu item
-		global $submenu;
-		if ( isset( $submenu['jetpack'] ) ) {
-			/**
-			 * Add the Podcasting menu item before the Settings menu item on Atomic sites.
-			 * On Simple sites, there is no Settings menu item, so we add the Podcasting menu on the last position.
-			 */
-			$settings_submenu_label = __( 'Settings', 'jetpack-masterbar' );
-			$submenu_labels         = array_column( $submenu['jetpack'], 3 );
-			$settings_position      = array_search( $settings_submenu_label, $submenu_labels, true );
-			$podcasting_position    = $settings_position !== false ? $settings_position - 1 : $this->get_submenu_item_count( 'jetpack' );
-		}
-		add_submenu_page( 'jetpack', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/podcasting/' . $this->domain, null, $podcasting_position );
+		// Add the Podcasting menu item on the last position on Simple sites.
+		add_submenu_page( 'jetpack', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/podcasting/' . $this->domain, null, $this->get_submenu_item_count( 'jetpack' ) );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related https://github.com/Automattic/dotcom-forge/issues/10549, https://github.com/Automattic/jetpack/pull/42174

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This PR adds Jetpack > Podcasting submenu item on Default sites.

- [ ] Follow up to remove Settings > Podcasting https://github.com/Automattic/dotcom-forge/issues/10550

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

A treatment user on Simple Classic, Atomic Classic:

* Patch this change: https://github.com/Automattic/jetpack/pull/42198#issuecomment-2696123603
	* Atomic: on Jetpack > Jetpack Beta, select Jetpack and enable the update/podcasting-menu-default branch.
	* Simple: run the commands on your sandbox.
* Hover Jetpack menu item on the sidebar 
* Observe Podcasting menu item
	* Simple
		* <img width="276" alt="Screenshot 2025-03-04 at 15 35 59" src="https://github.com/user-attachments/assets/e13554f6-964e-4612-a7e5-5200b5018a7b" />
	* Atomic
		* <img width="277" alt="Screenshot 2025-03-04 at 15 35 04" src="https://github.com/user-attachments/assets/eacc8352-b822-4147-9220-cb7433a787f0" />
* Click "Jetpack > Podcasting"
* Test enabling/disabling Podcasting

A control user:

* Observe no "Jetpack > Podcasting" menu item
