### PR TITLE
Fix cookie consent JS error

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-cookie-consent-js-error
+++ b/projects/plugins/jetpack/changelog/fix-cookie-consent-js-error
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: js error fix
+
+

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/view.js
@@ -5,6 +5,12 @@ import './style.scss';
 domReady( function () {
 	const millisInDay = 86400000;
 	const container = document.querySelector( '.wp-block-jetpack-cookie-consent' );
+
+	// The consent block might not be always available
+	if ( ! container ) {
+		return;
+	}
+
 	const expiryDaysContainer = container.querySelector( 'span' );
 	const expireDays = parseInt( expiryDaysContainer.textContent );
 	const expireTimeDate = new Date( Date.now() + expireDays * millisInDay );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to: p2EDhh-2pI-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix js error when the cookie consent block gets filtered

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open in private tab free wp website that is eligible for WordAds
* There should be only one cookie consent banner
* There should be no js error thrown in the console