### PR TITLE
 AI Assistant: Use base64 on image extension requests

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-image-extension-base64
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-image-extension-base64
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Use base64 on image extension requests

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
@@ -71,7 +71,10 @@ export function isPossibleToExtendImageBlock( blockName: string ): boolean {
 const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 	function ExtendedBlock( props ) {
 		const { increaseRequestsCount, dequeueAsyncRequest, requireUpgrade } = useAiFeature();
-		const postId = useSelect( select => select( editorStore ).getCurrentPostId(), [] );
+		const postId = useSelect(
+			select => ( select( editorStore ) as { getCurrentPostId: () => number } ).getCurrentPostId(),
+			[]
+		);
 		const { getPostContent } = usePostContent();
 		const [ loading, setLoading ] = useState< LOADING_STATE >( false );
 		const { updateBlockAttributes } = useDispatch( editorStore );
@@ -97,6 +100,16 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			},
 			[ createNotice ]
 		);
+
+		const getBase64Image = useCallback( async ( url: string ) => {
+			const response = await fetch( url );
+			const buffer = await response.arrayBuffer();
+			const base64String = btoa(
+				new Uint8Array( buffer ).reduce( ( data, byte ) => data + String.fromCharCode( byte ), '' )
+			);
+
+			return `data:image/png;base64,${ base64String }`;
+		}, [] );
 
 		useEffect( () => {
 			if ( loading === false ) {
@@ -128,9 +141,12 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 								context: {
 									type: type,
 									content: getPostContent(),
+									// URL of the image for the AI to find where the image is in the post.
+									urls: [ props.attributes.url ],
 									images: [
 										{
-											url: props.attributes.url,
+											// We convert the image to a base64 string to avoid inaccesible URLs for private images.
+											url: await getBase64Image( props.attributes.url ),
 										},
 									],
 								},
@@ -164,6 +180,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			},
 			[
 				dequeueAsyncRequest,
+				getBase64Image,
 				getPostContent,
 				increaseRequestsCount,
 				postId,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
@@ -102,13 +102,21 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		);
 
 		const getBase64Image = useCallback( async ( url: string ) => {
-			const response = await fetch( url );
-			const buffer = await response.arrayBuffer();
-			const base64String = btoa(
-				new Uint8Array( buffer ).reduce( ( data, byte ) => data + String.fromCharCode( byte ), '' )
-			);
+			try {
+				const response = await fetch( url );
+				const buffer = await response.arrayBuffer();
+				const base64String = btoa(
+					new Uint8Array( buffer ).reduce(
+						( data, byte ) => data + String.fromCharCode( byte ),
+						''
+					)
+				);
 
-			return `data:image/png;base64,${ base64String }`;
+				return `data:image/png;base64,${ base64String }`;
+			} catch {
+				// If we can't fetch the image, it must be external, so we return the original URL.
+				return url;
+			}
 		}, [] );
 
 		useEffect( () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #42208 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Sends base64 instead of image URL for Vision requests, allowing private blogs to use image extension features

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply 175782-ghe-Automattic/wpcom and sandbox the public API
* Ask for an image caption
* Check the network request, see that the base64 is sent
* Check that the URL is sent as well
* Check that the feature still works as expected
* Set your test site's visibility to Private and reload the editor
* Check that the feature works now