### PR TITLE
Forms: Add Native browser date picker style

### DIFF
--- a/projects/packages/forms/changelog/add-date-native-picker-variant
+++ b/projects/packages/forms/changelog/add-date-native-picker-variant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a native browser date picker

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -543,8 +543,8 @@ export const childBlocks = [
 				},
 			},
 			styles: [
-				{ name: 'default', label: 'Default', isDefault: true },
-				{ name: 'browser-native', label: __( 'Browser Native', 'jetpack-forms' ) },
+				{ name: 'default', label: __( 'Default', 'jetpack-forms' ), isDefault: true },
+				{ name: 'browser', label: __( 'Browser', 'jetpack-forms' ) },
 			],
 		},
 	},

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -542,6 +542,10 @@ export const childBlocks = [
 					default: 'yy-mm-dd',
 				},
 			},
+			styles: [
+				{ name: 'default', label: 'Default', isDefault: true },
+				{ name: 'browser-native', label: __( 'Browser Native', 'jetpack-forms' ) },
+			],
 		},
 	},
 	{

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
@@ -54,25 +54,6 @@ const JetpackDatePicker = props => {
 	const suffix = ! isNativeBrowserStyle
 		? `(${ DATE_FORMATS.find( f => f.value === dateFormat )?.label })`
 		: '';
-	const dateFormatInput = ! isNativeBrowserStyle ? (
-		<SelectControl
-			key="date-format"
-			label={ __( 'Date Format', 'jetpack-forms' ) }
-			options={ DATE_FORMATS.map( ( { value, label: optionLabel, example } ) => ( {
-				value,
-				label: `${ optionLabel } (${ example })`,
-			} ) ) }
-			onChange={ value =>
-				setAttributes( {
-					dateFormat: value,
-				} )
-			}
-			value={ attributes.dateFormat }
-			help={ __( 'Select the format in which the date will be displayed.', 'jetpack-forms' ) }
-			__nextHasNoMarginBottom={ true }
-			__next40pxDefaultSize={ true }
-		/>
-	) : null;
 
 	const inputType = isNativeBrowserStyle ? 'date' : 'text';
 
@@ -110,13 +91,38 @@ const JetpackDatePicker = props => {
 				setAttributes={ setAttributes }
 				placeholder={ placeholder }
 				attributes={ attributes }
-				extraFieldSettings={ [
-					{
-						index: 1,
-						element: dateFormatInput,
-					},
-				] }
 				hidePlaceholder={ isNativeBrowserStyle }
+				extraFieldSettings={
+					! isNativeBrowserStyle
+						? [
+								{
+									index: 1,
+									element: (
+										<SelectControl
+											key="date-format"
+											label={ __( 'Date Format', 'jetpack-forms' ) }
+											options={ DATE_FORMATS.map( ( { value, label: optionLabel, example } ) => ( {
+												value,
+												label: `${ optionLabel } (${ example })`,
+											} ) ) }
+											onChange={ value =>
+												setAttributes( {
+													dateFormat: value,
+												} )
+											}
+											value={ attributes.dateFormat }
+											help={ __(
+												'Select the format in which the date will be displayed.',
+												'jetpack-forms'
+											) }
+											__nextHasNoMarginBottom={ true }
+											__next40pxDefaultSize={ true }
+										/>
+									),
+								},
+						  ]
+						: []
+				}
 			/>
 		</>
 	);

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
@@ -50,7 +50,7 @@ const JetpackDatePicker = props => {
 		style: blockStyle,
 	} );
 	const classNamesArray = attributes?.className ? attributes.className.split( ' ' ) : [];
-	const isNativeBrowserStyle = classNamesArray.includes( 'is-style-browser-native' );
+	const isNativeBrowserStyle = classNamesArray.includes( 'is-style-browser' );
 	const suffix = ! isNativeBrowserStyle
 		? `(${ DATE_FORMATS.find( f => f.value === dateFormat )?.label })`
 		: '';

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
@@ -116,6 +116,7 @@ const JetpackDatePicker = props => {
 						element: dateFormatInput,
 					},
 				] }
+				hidePlaceholder={ isNativeBrowserStyle }
 			/>
 		</>
 	);

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
@@ -49,6 +49,32 @@ const JetpackDatePicker = props => {
 		} ),
 		style: blockStyle,
 	} );
+	const classNamesArray = attributes?.className ? attributes.className.split( ' ' ) : [];
+	const isNativeBrowserStyle = classNamesArray.includes( 'is-style-browser-native' );
+	const suffix = ! isNativeBrowserStyle
+		? `(${ DATE_FORMATS.find( f => f.value === dateFormat )?.label })`
+		: '';
+	const dateFormatInput = ! isNativeBrowserStyle ? (
+		<SelectControl
+			key="date-format"
+			label={ __( 'Date Format', 'jetpack-forms' ) }
+			options={ DATE_FORMATS.map( ( { value, label: optionLabel, example } ) => ( {
+				value,
+				label: `${ optionLabel } (${ example })`,
+			} ) ) }
+			onChange={ value =>
+				setAttributes( {
+					dateFormat: value,
+				} )
+			}
+			value={ attributes.dateFormat }
+			help={ __( 'Select the format in which the date will be displayed.', 'jetpack-forms' ) }
+			__nextHasNoMarginBottom={ true }
+			__next40pxDefaultSize={ true }
+		/>
+	) : null;
+
+	const inputType = isNativeBrowserStyle ? 'date' : 'text';
 
 	return (
 		<>
@@ -56,7 +82,7 @@ const JetpackDatePicker = props => {
 				<JetpackFieldLabel
 					attributes={ attributes }
 					label={ label }
-					suffix={ `(${ DATE_FORMATS.find( f => f.value === dateFormat )?.label })` }
+					suffix={ suffix }
 					required={ required }
 					requiredText={ requiredText }
 					setAttributes={ setAttributes }
@@ -66,7 +92,7 @@ const JetpackDatePicker = props => {
 					className="jetpack-field__input"
 					onChange={ e => setAttributes( { placeholder: e.target.value } ) }
 					style={ fieldStyle }
-					type="text"
+					type={ inputType }
 					value={ placeholder }
 					onKeyDown={ event => {
 						if ( event.defaultPrevented || event.key !== 'Enter' ) {
@@ -87,28 +113,7 @@ const JetpackDatePicker = props => {
 				extraFieldSettings={ [
 					{
 						index: 1,
-						element: (
-							<SelectControl
-								key="date-format"
-								label={ __( 'Date Format', 'jetpack-forms' ) }
-								options={ DATE_FORMATS.map( ( { value, label: optionLabel, example } ) => ( {
-									value,
-									label: `${ optionLabel } (${ example })`,
-								} ) ) }
-								onChange={ value =>
-									setAttributes( {
-										dateFormat: value,
-									} )
-								}
-								value={ attributes.dateFormat }
-								help={ __(
-									'Select the format in which the date will be displayed.',
-									'jetpack-forms'
-								) }
-								__nextHasNoMarginBottom={ true }
-								__next40pxDefaultSize={ true }
-							/>
-						),
+						element: dateFormatInput,
 					},
 				] }
 			/>

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -897,13 +897,20 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			),
 		);
 
+		$is_native_browser_style = $this->is_style_variant( 'is-style-browser-native' );
+
+		$input_type = 'text';
+		if ( $is_native_browser_style ) {
+			$input_type = 'date';
+		}
+
 		$date_format = $this->get_attribute( 'dateformat' );
 		$date_format = isset( $date_format ) && ! empty( $date_format ) ? $date_format : 'yy-mm-dd';
-		$label       = isset( $formats[ $date_format ] ) ? $label . ' (' . $formats[ $date_format ]['label'] . ')' : $label;
+		$label       = isset( $formats[ $date_format ] ) && ! $is_native_browser_style ? $label . ' (' . $formats[ $date_format ]['label'] . ')' : $label;
 		$extra_attrs = array( 'data-format' => $date_format );
 
 		$field  = $this->render_label( 'date', $id, $label, $required, $required_field_text );
-		$field .= $this->render_input_field( 'text', $id, $value, $class, $placeholder, $required, $extra_attrs );
+		$field .= $this->render_input_field( $input_type, $id, $value, $class, $placeholder, $required, $extra_attrs );
 
 		/* For AMP requests, use amp-date-picker element: https://amp.dev/documentation/components/amp-date-picker */
 		if ( class_exists( 'Jetpack_AMP_Support' ) && \Jetpack_AMP_Support::is_amp_request() ) {
@@ -913,6 +920,10 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				esc_attr( $id ),
 				$field
 			);
+		}
+
+		if ( $is_native_browser_style ) {
+			return $field;
 		}
 
 		Assets::register_script(
@@ -929,6 +940,18 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		wp_enqueue_style( 'jp-jquery-ui-datepicker', plugins_url( '../../dist/contact-form/css/jquery-ui-datepicker.css', __FILE__ ), array( 'dashicons' ), '1.0' );
 
 		return $field;
+	}
+
+	/**
+	 * Return whether the a style variant is present.
+	 *
+	 * @param string $needle - key to find in the class attributes.
+	 *
+	 * @return boolean
+	 */
+	private function is_style_variant( $needle ) {
+		$class_names_array = explode( ' ', $this->get_attribute( 'class' ) );
+		return in_array( $needle, $class_names_array, true );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -907,7 +907,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$date_format = $this->get_attribute( 'dateformat' );
 		$date_format = isset( $date_format ) && ! empty( $date_format ) ? $date_format : 'yy-mm-dd';
 		$label       = isset( $formats[ $date_format ] ) && ! $is_native_browser_style ? $label . ' (' . $formats[ $date_format ]['label'] . ')' : $label;
-		$extra_attrs = array( 'data-format' => $date_format );
+
+		$extra_attrs = $is_native_browser_style ? array() : array( 'data-format' => $date_format );
 
 		$field  = $this->render_label( 'date', $id, $label, $required, $required_field_text );
 		$field .= $this->render_input_field( $input_type, $id, $value, $class, $placeholder, $required, $extra_attrs );

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -897,7 +897,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			),
 		);
 
-		$is_native_browser_style = $this->is_style_variant( 'is-style-browser-native' );
+		$is_native_browser_style = $this->is_style_variant( 'is-style-browser' );
 
 		$input_type = 'text';
 		if ( $is_native_browser_style ) {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -34,6 +34,7 @@
 	.contact-form input[type='tel'],
 	.contact-form input[type='url'],
 	.contact-form input[type='number'],
+	.contact-form input[type='date'],
 	.contact-form textarea
 ) {
 	box-sizing: border-box;
@@ -206,12 +207,14 @@
 .textwidget .contact-form input[type='tel'],
 .textwidget .contact-form input[type='url'],
 .textwidget .contact-form input[type='number'],
+.textwidget .contact-form input[type='date'],
 .textwidget .contact-form textarea,
 .wp-block-column .contact-form input[type='text'],
 .wp-block-column .contact-form input[type='email'],
 .wp-block-column .contact-form input[type='tel'],
 .wp-block-column .contact-form input[type='url'],
 .wp-block-column .contact-form input[type='number'],
+.wp-block-column .contact-form input[type='date'],
 .wp-block-column .contact-form textarea {
 	width: 100%;
 }
@@ -315,6 +318,7 @@
 	.contact-form input[type='email'],
 	.contact-form input[type='tel'],
 	.contact-form input[type='url'],
+	.contact-form input[type='date'],
 	.contact-form input[type='number'] {
 		width: 50%;
 	}
@@ -328,6 +332,7 @@
 	.wp-block-jetpack-contact-form input[type='email'],
 	.wp-block-jetpack-contact-form input[type='tel'],
 	.wp-block-jetpack-contact-form input[type='url'],
+	.wp-block-jetpack-contact-form input[type='date'],
 	.wp-block-jetpack-contact-form input[type='number'] {
 		width: 100%;
 	}

--- a/projects/packages/forms/src/contact-form/js/grunion-frontend.js
+++ b/projects/packages/forms/src/contact-form/js/grunion-frontend.js
@@ -1,5 +1,5 @@
 jQuery( function ( $ ) {
-	const $input = $( '.contact-form input.jp-contact-form-date' );
+	const $input = $( '.contact-form input[type="text"].jp-contact-form-date' );
 	$input.each( function () {
 		const el = $( this );
 		const dateFormat = el.attr( 'data-format' ) || 'yy-mm-dd';

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -848,6 +848,26 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test for date field_renders
+	 *
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 */
+	public function test_make_sure_browser_native_date_field_renders_as_expected() {
+		$attributes = array(
+			'label'       => 'fun',
+			'type'        => 'date',
+			'class'       => 'foo is-style-browser',
+			'default'     => '',
+			'placeholder' => '',
+			'id'          => 'funID',
+			'format'      => '',
+		);
+
+		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'date' ) );
+		$this->assertValidField( $this->render_field( $attributes ), $expected_attributes );
+	}
+
+	/**
 	 * Test for textarea field_renders
 	 *
 	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
@@ -1015,9 +1035,10 @@ class Contact_Form_Test extends BaseTestCase {
 	 *                                                       and radio buttons.
 	 */
 	public function assertFieldLabel( $wrapper_div, $attributes, $tag_name = 'label' ) {
-		$type     = $attributes['type'];
-		$label    = $this->getFirstElement( $wrapper_div, $tag_name );
-		$expected = 'date' === $type ? $attributes['label'] . ' ' . $attributes['format'] : $attributes['label'];
+		$type  = $attributes['type'];
+		$label = $this->getFirstElement( $wrapper_div, $tag_name );
+
+		$expected = 'date' === $type ? trim( $attributes['label'] . ' ' . $attributes['format'] ) : $attributes['label'];
 
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$this->assertEquals( $expected, trim( (string) $label->nodeValue ), 'Label is not what we expect it to be...' );

--- a/projects/plugins/jetpack/changelog/add-date-native-picker-variant
+++ b/projects/plugins/jetpack/changelog/add-date-native-picker-variant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Forms: Add native browser date picker field style


### PR DESCRIPTION
This PR adds the native date picker style when choosing the date input. 

Fixes https://github.com/Automattic/jetpack/issues/41811

Before:
<img src="https://github.com/user-attachments/assets/e8e0896d-b169-4728-b637-83198a3c1536" width="400px" />

After:

![Screenshot 2025-03-13 at 12 20 34 PM](https://github.com/user-attachments/assets/265b3714-3fde-4a99-9e64-329609d968e9)

Things that are a bit odd with this PR. Placeholders. 
the native date picker doesn't support placeholders. 
We could hack with JS but wanted to discuss it first. 

@Automattic/zap  Any ideas how this should work? Here are some possible solutions offered in stackoverflow. 
https://stackoverflow.com/questions/20321202/not-showing-placeholder-for-input-type-date-field. 

We could also just remove the placeholder input . 

One thing to note is that the new date input normalizes formats the date to `YYYY-MM-DD` when submitting the form. 

## Proposed changes:
* Adds the date picker as a style option. 
* Removed the date format as a choice from the date picker because date input doesn't have a format option. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Load this PR and navigate to the block  editor. 
* Add the date picker. Choose the "native browser" date picker style. 
* Does it work as expected in the editor?
* Does it work as expected on the front end as well? 

