### PR TITLE
[gold] :: Add Donation modal warning

### DIFF
--- a/projects/plugins/jetpack/changelog/donation-block-add-warning
+++ b/projects/plugins/jetpack/changelog/donation-block-add-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Donation block: add additional information about accepting donations.

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -29,6 +29,17 @@ function register_block() {
 			)
 		);
 	}
+	// Add a meta field to the user to track if the donation warning has been dismissed.
+	\register_meta(
+		'user',
+		'jetpack_donation_warning_dismissed',
+		array(
+			'type'         => 'boolean',
+			'single'       => true,
+			'show_in_rest' => true,
+			'default'      => false,
+		)
+	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 

--- a/projects/plugins/jetpack/extensions/blocks/donations/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/edit.js
@@ -28,6 +28,8 @@ const Edit = props => {
 	const isUserConnected = useIsUserConnected();
 
 	const { lockPostSaving, unlockPostSaving } = useDispatch( 'core/editor' );
+	const { getEntityRecord, getCurrentUser } = useSelect( 'core' );
+	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( 'core' );
 	const post = useSelect( select => select( 'core/editor' ).getCurrentPost(), [] );
 	const isPostSavingLocked = useSelect(
 		select => select( 'core/editor' ).isPostSavingLocked(),
@@ -75,34 +77,28 @@ const Edit = props => {
 		);
 	};
 
+	//
 	// Check if this is the first time using the donations block
+	//
+
+	// Add this to preload the user entity
+	const currentUser = getCurrentUser();
 	useEffect( () => {
-		const checkFirstTimeUse = async () => {
-			try {
-				const response = await fetch( '/wp-json/jetpack/v4/site-meta' );
-				const data = await response.json();
-				const hasUsedDonations = data?.jetpack_donations_block_used;
+		if ( currentUser?.id ) {
+			// Ensure the user entity is loaded
+			getEntityRecord( 'root', 'user', currentUser.id );
+		}
+	}, [ currentUser?.id, getEntityRecord ] );
 
-				if ( ! hasUsedDonations ) {
-					setShowFirstTimeModal( true );
-					// Mark the block as used
-					await fetch( '/wp-json/jetpack/v4/site-meta', {
-						method: 'POST',
-						headers: {
-							'Content-Type': 'application/json',
-						},
-						body: JSON.stringify( {
-							jetpack_donations_block_used: true,
-						} ),
-					} );
-				}
-			} catch {
-				// Silently handle errors to avoid breaking the block
-			}
-		};
+	const hasDismissedDonationWarning =
+		currentUser?.meta?.jetpack_donation_warning_dismissed || false;
 
-		checkFirstTimeUse();
-	}, [] );
+	// Show the modal if the user has not dismissed the warning
+	useEffect( () => {
+		if ( currentUser?.id && hasDismissedDonationWarning === false ) {
+			setShowFirstTimeModal( true );
+		}
+	}, [ currentUser, hasDismissedDonationWarning ] );
 
 	useEffect( () => {
 		lockPostSaving( 'donations' );
@@ -188,10 +184,33 @@ const Edit = props => {
 		content = <Tabs { ...props } products={ products } />;
 	}
 
+	// When the first time modal is closed, update the user meta to mark the donation warning as dismissed
+	const handleModalClose = async () => {
+		setShowFirstTimeModal( false );
+
+		if ( ! currentUser?.id ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Cannot update user meta: User not loaded' );
+			return;
+		}
+
+		try {
+			await editEntityRecord( 'root', 'user', currentUser.id, {
+				meta: {
+					jetpack_donation_warning_dismissed: true,
+				},
+			} );
+			await saveEditedEntityRecord( 'root', 'user', currentUser.id );
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Failed to update user meta:', error );
+		}
+	};
+
 	return (
 		<div { ...blockProps }>
 			{ content }
-			{ showFirstTimeModal && <FirstTimeModal onClose={ () => setShowFirstTimeModal( false ) } /> }
+			{ showFirstTimeModal && <FirstTimeModal onClose={ handleModalClose } /> }
 		</div>
 	);
 };

--- a/projects/plugins/jetpack/extensions/blocks/donations/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/edit.js
@@ -12,6 +12,8 @@ import { store as membershipProductsStore } from '../../store/membership-product
 import { STORE_NAME as MEMBERSHIPS_PRODUCTS_STORE } from '../../store/membership-products/constants';
 import fetchDefaultProducts from './fetch-default-products';
 import fetchStatus from './fetch-status';
+import FirstTimeModal from './first-time-modal';
+import './first-time-modal.scss';
 import LoadingError from './loading-error';
 import Tabs from './tabs';
 
@@ -22,6 +24,7 @@ const Edit = props => {
 	const blockProps = useBlockProps();
 	const [ loadingError, setLoadingError ] = useState( '' );
 	const [ products, setProducts ] = useState( [] );
+	const [ showFirstTimeModal, setShowFirstTimeModal ] = useState( false );
 	const isUserConnected = useIsUserConnected();
 
 	const { lockPostSaving, unlockPostSaving } = useDispatch( 'core/editor' );
@@ -71,6 +74,35 @@ const Edit = props => {
 			intervals.includes( '1 year' )
 		);
 	};
+
+	// Check if this is the first time using the donations block
+	useEffect( () => {
+		const checkFirstTimeUse = async () => {
+			try {
+				const response = await fetch( '/wp-json/jetpack/v4/site-meta' );
+				const data = await response.json();
+				const hasUsedDonations = data?.jetpack_donations_block_used;
+
+				if ( ! hasUsedDonations ) {
+					setShowFirstTimeModal( true );
+					// Mark the block as used
+					await fetch( '/wp-json/jetpack/v4/site-meta', {
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+						},
+						body: JSON.stringify( {
+							jetpack_donations_block_used: true,
+						} ),
+					} );
+				}
+			} catch {
+				// Silently handle errors to avoid breaking the block
+			}
+		};
+
+		checkFirstTimeUse();
+	}, [] );
 
 	useEffect( () => {
 		lockPostSaving( 'donations' );
@@ -156,7 +188,12 @@ const Edit = props => {
 		content = <Tabs { ...props } products={ products } />;
 	}
 
-	return <div { ...blockProps }>{ content }</div>;
+	return (
+		<div { ...blockProps }>
+			{ content }
+			{ showFirstTimeModal && <FirstTimeModal onClose={ () => setShowFirstTimeModal( false ) } /> }
+		</div>
+	);
 };
 
 export default Edit;

--- a/projects/plugins/jetpack/extensions/blocks/donations/first-time-modal.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/first-time-modal.js
@@ -22,11 +22,11 @@ const FirstTimeModal = ( { onClose } ) => {
 						{ __( 'Learn more about donations.', 'jetpack' ) }
 					</a>
 				</p>
-				<ul>
+				<ol>
 					<li>{ __( 'Connect your Stripe account to your WordPress.com account', 'jetpack' ) }</li>
 					<li>{ __( 'Set up your business information in Stripe', 'jetpack' ) }</li>
 					<li>{ __( 'Configure your payment settings and supported currencies', 'jetpack' ) }</li>
-				</ul>
+				</ol>
 				<p>
 					{ __(
 						'Once connected, you can customize your donation form and start accepting payments.',
@@ -38,6 +38,7 @@ const FirstTimeModal = ( { onClose } ) => {
 						'Please note that accepting donations has additional requirements from Stripe. Learn more about',
 						'jetpack'
 					) }
+					&nbsp;
 					<a
 						href="https://support.stripe.com/questions/requirements-for-accepting-tips-or-donations"
 						target="_blank"

--- a/projects/plugins/jetpack/extensions/blocks/donations/first-time-modal.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/first-time-modal.js
@@ -1,0 +1,61 @@
+import { Modal, Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const FirstTimeModal = ( { onClose } ) => {
+	return (
+		<Modal
+			className="jetpack-donations-first-time-modal"
+			onRequestClose={ onClose }
+			title={ __( 'Accept Donations with Stripe', 'jetpack' ) }
+		>
+			<div className="jetpack-donations-first-time-modal__content">
+				<p>
+					{ __(
+						"To accept donations on your site, you'll need to connect your Stripe account. Here's what you need to do:",
+						'jetpack'
+					) }{ ' ' }
+					<a
+						href="https://wordpress.com/support/wordpress-editor/blocks/donations/#about-donations"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						{ __( 'Learn more about donations.', 'jetpack' ) }
+					</a>
+				</p>
+				<ul>
+					<li>{ __( 'Connect your Stripe account to your WordPress.com account', 'jetpack' ) }</li>
+					<li>{ __( 'Set up your business information in Stripe', 'jetpack' ) }</li>
+					<li>{ __( 'Configure your payment settings and supported currencies', 'jetpack' ) }</li>
+				</ul>
+				<p>
+					{ __(
+						'Once connected, you can customize your donation form and start accepting payments.',
+						'jetpack'
+					) }
+				</p>
+				<p>
+					{ __(
+						'Please note that accepting donations has additional requirements from Stripe. Learn more about',
+						'jetpack'
+					) }
+					<a
+						href="https://support.stripe.com/questions/requirements-for-accepting-tips-or-donations"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						{ __( 'requirements for accepting donations', 'jetpack' ) }
+					</a>
+					.
+				</p>
+
+				<div className="jetpack-donations-first-time-modal__actions">
+					<Button variant="primary" onClick={ onClose }>
+						{ __( 'Got it', 'jetpack' ) }
+					</Button>
+				</div>
+			</div>
+		</Modal>
+	);
+};
+
+export default FirstTimeModal;

--- a/projects/plugins/jetpack/extensions/blocks/donations/first-time-modal.scss
+++ b/projects/plugins/jetpack/extensions/blocks/donations/first-time-modal.scss
@@ -1,0 +1,24 @@
+.jetpack-donations-first-time-modal {
+	&__content {
+		padding: 16px 0;
+
+		p {
+			margin-bottom: 16px;
+		}
+
+		ul {
+			margin: 16px 0;
+			padding-left: 24px;
+
+			li {
+				margin-bottom: 8px;
+			}
+		}
+	}
+
+	&__actions {
+		display: flex;
+		justify-content: flex-end;
+		margin-top: 24px;
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 648-gh-Automattic/gold.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Display this modal on the first usage of the donation block

<img width="927" alt="image" src="https://github.com/user-attachments/assets/7cc3c828-e7e8-4fac-88fb-100767d5036a" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pNPgK-6TY-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Setup
#### Jurassic Ninja

* Create a JN site with the jetpack beta plugin and apply the `donation/add-warning` branch.
* Make sure jetpack is connected and you are using a paid jetpack plan (required for donations block)

#### WPCOM simple

* Apply the patch 176131-ghe-Automattic/wpcom (`git checkout -b donation/whitelist-user-endpoint-meta`)
* Run `~/public_html/bin/jetpack-downloader test jetpack donation/add-warning`.
* Sandbox both your site _and_ public-api.wordpress.com.
* Enable writes (e.g. `~/public_html/bin/allow-sandbox-production-writes '1 hour'`)

### Test
1. Create a post and add the donations block.
2. The first time should display the modal above. Check that it looks correct.
3. Subsequent refreshes should not show the modal.

If you want to reset it you'll need to remove the `jetpack_donation_warning_dismissed` user meta from your user. (e.g. `wp user meta delete <user-id> jetpack_donation_warning_dismissed`.)