### PR TITLE
[gold] :: Donations block add used flag to site settings

### DIFF
--- a/projects/packages/sync/changelog/donations-add-block-used-option
+++ b/projects/packages/sync/changelog/donations-add-block-used-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Donation block: add used flag/option.

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -65,6 +65,7 @@ class Defaults {
 		'infinite_scroll',
 		'infinite_scroll_google_analytics',
 		'jetpack-memberships-has-connected-account',
+		'jetpack_donations_block_used',
 		'jetpack-twitter-cards-site-tag',
 		'jetpack_activated',
 		'jetpack_allowed_xsite_search_ids',

--- a/projects/plugins/jetpack/changelog/donations-add-block-used-option
+++ b/projects/plugins/jetpack/changelog/donations-add-block-used-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Donation block: add used flag/option.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -500,6 +500,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'jetpack_waf_automatic_rules_last_updated_timestamp' => (int) get_option( 'jetpack_waf_automatic_rules_last_updated_timestamp' ),
 						'is_fully_managed_agency_site'     => (bool) get_option( 'is_fully_managed_agency_site' ),
 						'wpcom_hide_action_bar'            => (bool) get_option( 'wpcom_hide_action_bar' ),
+						'jetpack_donations_block_used'     => (bool) get_option( 'jetpack_donations_block_used' ),
 					);
 
 					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -1191,6 +1192,11 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					if ( update_option( $key, $coerce_value ) ) {
 						$updated[ $key ] = (bool) $coerce_value;
 					}
+					break;
+
+				case 'jetpack_donations_block_used':
+					update_option( 'jetpack_donations_block_used', (int) (bool) $value );
+					$updated[ $key ] = (int) (bool) $value;
 					break;
 
 				default:

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -148,6 +148,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'jetpack_comment_form_color_scheme'         => '(string) The color scheme for the comment form',
 			'is_fully_managed_agency_site'              => '(bool) Whether the site is a fully managed agency site',
 			'wpcom_hide_action_bar'                     => '(bool) Whether to hide the Action bar',
+			'jetpack_donations_block_used'              => '(bool) Whether the donations block has been used',
 		),
 
 		'response_format' => array(

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
@@ -282,6 +282,7 @@ class Jetpack_Sync_Options_Test extends Jetpack_Sync_TestBase {
 			'jetpack_waf_share_data'                       => true,
 			'jetpack_waf_share_debug_data'                 => false,
 			'jetpack_waf_automatic_rules_last_updated_timestamp' => 0,
+			'jetpack_donations_block_used'                 => false,
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Adds site setting needed for tracking donation warning displayed to site admin... https://github.com/Automattic/gold/issues/648

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a `jetpack_donations_block_used` setting to the site settings API.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a jurassic ninja site with jetpack-beta and apply this branch in the beta settings.
* Connect the jetpack site.
* Go to https://developer.wordpress.com/docs/api/console/
* Configure it as this screenshot does: <img width="616" alt="image" src="https://github.com/user-attachments/assets/338ebaf8-eca2-4a55-9498-54b792fc86e3" />
* Run the command and verify that `jetpack_donations_block_used` is in the list of settings returned

<img width="364" alt="image" src="https://github.com/user-attachments/assets/618dc142-c98e-4370-a681-ad5cda0994bf" />

