### PR TITLE
VideoPress Block: Fix critical error in the core Video block

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-videopress-core-block-crash
+++ b/projects/plugins/jetpack/changelog/fix-videopress-core-block-crash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress Block: Fix critical error in the core Video block.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -949,19 +949,15 @@ const VideoPressEdit = CoreVideoEdit =>
 			return (
 				<Fragment>
 					{ blockSettings }
-					{ shouldRenderLoadingBlock && (
-						<Loading text={ __( 'Generating preview…', 'jetpack' ) } />
-					) }
-					{ ! shouldRenderLoadingBlock && (
-						<VpBlock
-							{ ...this.props }
-							hideOverlay={ this.hideOverlay }
-							html={ html }
-							scripts={ scripts }
-							interactive={ interactive }
-							caption={ caption }
-						/>
-					) }
+					<VpBlock
+						{ ...this.props }
+						hideOverlay={ this.hideOverlay }
+						html={ html }
+						scripts={ scripts }
+						interactive={ interactive }
+						caption={ caption }
+						shouldRenderLoadingBlock={ shouldRenderLoadingBlock }
+					/>
 				</Fragment>
 			);
 		}
@@ -1034,7 +1030,16 @@ const UploaderBlock = props => {
 // In a separate function component so that `useBlockProps` could be called.
 export const VpBlock = props => {
 	let { scripts } = props;
-	const { html, interactive, caption, isSelected, hideOverlay, attributes, setAttributes } = props;
+	const {
+		html,
+		interactive,
+		caption,
+		isSelected,
+		hideOverlay,
+		attributes,
+		setAttributes,
+		shouldRenderLoadingBlock,
+	} = props;
 
 	const { align, className, videoPressClassNames, maxWidth } = attributes;
 
@@ -1070,6 +1075,14 @@ export const VpBlock = props => {
 		);
 
 		scripts.push( URL.createObjectURL( videopresAjaxURLBlob ), window.videopressAjax.bridgeUrl );
+	}
+
+	if ( shouldRenderLoadingBlock ) {
+		return (
+			<figure { ...blockProps }>
+				<Loading text={ __( 'Generating preview…', 'jetpack' ) } />
+			</figure>
+		);
 	}
 
 	return (


### PR DESCRIPTION
Fixes #39417
Alternatives to https://github.com/WordPress/gutenberg/pull/69152

This PR fixes a critical error that occurs when converting from a VideoPress block to a core video block.

> [!NOTE]
> I'm not very familiar with the Jetpack codebase, so I'd appreciate it if you could test this PR to make sure it doesn't introduce any unintended issues.

The VideoPress block extends the core block and implements the `VideoPressEdit` component as a higher-level component. This component is a class component, so it cannot use the `useBlockProps` hook. Therefore, it uses the `useBlockProps` hook in the `VpBlock` component, which is an internal functional component.

Meanwhile, while fetching a resource, it renders the `Loading` component instead of the `VpBlock` component. The `Loading` component does not have a `useBlockProps` hook.

My guess is that the `useBlockProps` hook is not applied consistently to the block, which will cause issues like those reported in https://github.com/Automattic/jetpack/issues/39417.

## Proposed changes:

Move the `Loading` component inside the `VpBlock`. Wrap the `Loading` component in a `figure` element with the `useBlockProps` hook applied to it, so that the hook will always be applied to the block, regardless of whether the block is rendering or not.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Insert a VideoPress block.
- Apply some video.
- Convert it to a core video block.
- Verify that no errors occur.

