### PR TITLE
Boost: Disable 404 tester on Atomic/WoA sites

### DIFF
--- a/projects/plugins/boost/app/admin/class-config.php
+++ b/projects/plugins/boost/app/admin/class-config.php
@@ -78,7 +78,7 @@ class Config {
 	 *
 	 * @return string The hosting provider.
 	 */
-	private static function get_hosting_provider() {
+	public static function get_hosting_provider() {
 		$host = new Host();
 
 		if ( $host->is_woa_site() ) {

--- a/projects/plugins/boost/app/assets/src/js/features/image-size-analysis/multi-progress/multi-progress.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/image-size-analysis/multi-progress/multi-progress.module.scss
@@ -23,7 +23,7 @@
 		'bubble category category'
 		'bubble status status';
 
-	a {
+	a:global(.jb-navigator-link) {
 		text-decoration: none;
 	}
 }

--- a/projects/plugins/boost/app/assets/src/js/features/minify-meta/minify-meta.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/minify-meta/minify-meta.module.scss
@@ -27,6 +27,7 @@
 
 	.section {
 		margin-top: 16px;
+		margin-bottom: 16px;
 		padding: 16px;
 		border-radius: 4px;
 		background-color: var(--gray-0);

--- a/projects/plugins/boost/app/assets/src/js/features/ui/collapsible-meta/collapsible-meta.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/ui/collapsible-meta/collapsible-meta.module.scss
@@ -5,7 +5,7 @@
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
-		margin-bottom: 10px;
+		margin-bottom: 1em;
 		@media screen and ( max-width: 530px ) {
 			flex-direction: column;
 			align-items: flex-start;

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -19,6 +19,7 @@ use Automattic\Jetpack\Image_CDN\Image_CDN_Core;
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
 use Automattic\Jetpack\Plugin_Deactivation\Deactivation_Handler;
 use Automattic\Jetpack_Boost\Admin\Admin;
+use Automattic\Jetpack_Boost\Admin\Config as Boost_Admin_Config;
 use Automattic\Jetpack_Boost\Admin\Regenerate_Admin_Notice;
 use Automattic\Jetpack_Boost\Data_Sync\Getting_Started_Entry;
 use Automattic\Jetpack_Boost\Lib\Analytics;
@@ -159,9 +160,11 @@ class Jetpack_Boost {
 		update_option( 'jetpack_boost_version', JETPACK_BOOST_VERSION );
 
 		if ( jetpack_boost_minify_is_enabled() ) {
+			$disable_404_tester = Boost_Admin_Config::get_hosting_provider() !== 'atomic' && Boost_Admin_Config::get_hosting_provider() !== 'woa';
+
 			// We need to clear Minify scheduled events to ensure the latest scheduled jobs are only scheduled irrespective of scheduled arguments.
 			jetpack_boost_minify_clear_scheduled_events();
-			jetpack_boost_minify_activation();
+			jetpack_boost_minify_activation( $disable_404_tester );
 		}
 	}
 

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -160,11 +160,11 @@ class Jetpack_Boost {
 		update_option( 'jetpack_boost_version', JETPACK_BOOST_VERSION );
 
 		if ( jetpack_boost_minify_is_enabled() ) {
-			$disable_404_tester = Boost_Admin_Config::get_hosting_provider() !== 'atomic' && Boost_Admin_Config::get_hosting_provider() !== 'woa';
+			$setup_404_tester = Boost_Admin_Config::get_hosting_provider() !== 'atomic' && Boost_Admin_Config::get_hosting_provider() !== 'woa';
 
 			// We need to clear Minify scheduled events to ensure the latest scheduled jobs are only scheduled irrespective of scheduled arguments.
 			jetpack_boost_minify_clear_scheduled_events();
-			jetpack_boost_minify_activation( $disable_404_tester );
+			jetpack_boost_minify_activation( $setup_404_tester );
 		}
 	}
 

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -350,15 +350,15 @@ function jetpack_boost_minify_serve_concatenated() {
  *
  * This handles scheduling cache cleanup, and setting up the cronjob to periodically test for the 404 handler.
  *
- * @param bool $disable_404_tester Whether to disable the 404 tester.
+ * @param bool $setup_404_tester Whether to setup the 404 tester.
  * @return void
  */
-function jetpack_boost_minify_activation( $disable_404_tester = false ) {
+function jetpack_boost_minify_activation( $setup_404_tester = true ) {
 	// Schedule cache cleanup.
 	jetpack_boost_page_optimize_schedule_cache_cleanup();
 
 	// Setup the cronjob to periodically test for the 404 handler.
-	jetpack_boost_404_setup( $disable_404_tester );
+	jetpack_boost_404_setup( $setup_404_tester );
 }
 
 function jetpack_boost_minify_is_enabled() {

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -350,14 +350,15 @@ function jetpack_boost_minify_serve_concatenated() {
  *
  * This handles scheduling cache cleanup, and setting up the cronjob to periodically test for the 404 handler.
  *
+ * @param bool $disable_404_tester Whether to disable the 404 tester.
  * @return void
  */
-function jetpack_boost_minify_activation() {
+function jetpack_boost_minify_activation( $disable_404_tester = false ) {
 	// Schedule cache cleanup.
 	jetpack_boost_page_optimize_schedule_cache_cleanup();
 
 	// Setup the cronjob to periodically test for the 404 handler.
-	jetpack_boost_404_setup();
+	jetpack_boost_404_setup( $disable_404_tester );
 }
 
 function jetpack_boost_minify_is_enabled() {

--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -103,17 +103,17 @@ add_action( 'jetpack_boost_404_tester_cron', 'jetpack_boost_404_tester' );
  * Schedule the 404 tester if the concatenation modules
  * haven't been toggled since this feature was released.
  * Only run this in wp-admin to avoid excessive updates to the option.
+ *
+ * @param bool $setup_404_tester Whether to setup the 404 tester or not.
  */
-function jetpack_boost_404_setup( $disable_404_tester = false ) {
+function jetpack_boost_404_setup( $setup_404_tester = true ) {
 	if ( is_admin() && get_site_option( 'jetpack_boost_static_minification', 'na' ) === 'na' ) {
 		update_site_option( 'jetpack_boost_static_minification', 0 ); // Add a default value if not set to avoid an extra SQL query.
 	}
 
-	if ( $disable_404_tester ) {
-		return;
+	if ( $setup_404_tester ) {
+		jetpack_boost_page_optimize_schedule_404_tester();
 	}
-
-	jetpack_boost_page_optimize_schedule_404_tester();
 }
 
 /**

--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -1,6 +1,5 @@
 <?php
 
-use Automattic\Jetpack_Boost\Admin\Config as Boost_Config;
 use Automattic\Jetpack_Boost\Lib\Minify;
 use Automattic\Jetpack_Boost\Lib\Minify\Config;
 use Automattic\Jetpack_Boost\Lib\Minify\File_Paths;
@@ -71,23 +70,6 @@ function jetpack_boost_check_404_handler( $request_uri ) {
 }
 
 /**
- * This function checks if the 404 tester should be disabled.
- *
- * @return bool True if the 404 tester is disabled, false otherwise.
- */
-function jetpack_boost_minify_disable_404_tester() {
-	if ( Boost_Config::get_hosting_provider() === 'atomic' || Boost_Config::get_hosting_provider() === 'woa' ) {
-		return true;
-	}
-
-	if ( defined( 'JETPACK_BOOST_DISABLE_404_TESTER' ) && JETPACK_BOOST_DISABLE_404_TESTER ) {
-		return true;
-	}
-
-	return false;
-}
-
-/**
  * This function is used to test if is_404() is working in wp-content/
  * It sends a request to a non-existent URL, that will execute the 404 handler
  * in jetpack_boost_check_404_handler().
@@ -97,7 +79,7 @@ function jetpack_boost_minify_disable_404_tester() {
  * This function is called when the Minify_CSS or Minify_JS module is activated, and once per day.
  */
 function jetpack_boost_404_tester() {
-	if ( jetpack_boost_minify_disable_404_tester() ) {
+	if ( defined( 'JETPACK_BOOST_DISABLE_404_TESTER' ) && JETPACK_BOOST_DISABLE_404_TESTER ) {
 		return;
 	}
 
@@ -122,10 +104,15 @@ add_action( 'jetpack_boost_404_tester_cron', 'jetpack_boost_404_tester' );
  * haven't been toggled since this feature was released.
  * Only run this in wp-admin to avoid excessive updates to the option.
  */
-function jetpack_boost_404_setup() {
+function jetpack_boost_404_setup( $disable_404_tester = false ) {
 	if ( is_admin() && get_site_option( 'jetpack_boost_static_minification', 'na' ) === 'na' ) {
 		update_site_option( 'jetpack_boost_static_minification', 0 ); // Add a default value if not set to avoid an extra SQL query.
 	}
+
+	if ( $disable_404_tester ) {
+		return;
+	}
+
 	jetpack_boost_page_optimize_schedule_404_tester();
 }
 

--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\Jetpack_Boost\Admin\Config as Boost_Config;
 use Automattic\Jetpack_Boost\Lib\Minify;
 use Automattic\Jetpack_Boost\Lib\Minify\Config;
 use Automattic\Jetpack_Boost\Lib\Minify\File_Paths;
@@ -70,6 +71,23 @@ function jetpack_boost_check_404_handler( $request_uri ) {
 }
 
 /**
+ * This function checks if the 404 tester should be disabled.
+ *
+ * @return bool True if the 404 tester is disabled, false otherwise.
+ */
+function jetpack_boost_minify_disable_404_tester() {
+	if ( Boost_Config::get_hosting_provider() === 'atomic' || Boost_Config::get_hosting_provider() === 'woa' ) {
+		return true;
+	}
+
+	if ( defined( 'JETPACK_BOOST_DISABLE_404_TESTER' ) && JETPACK_BOOST_DISABLE_404_TESTER ) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
  * This function is used to test if is_404() is working in wp-content/
  * It sends a request to a non-existent URL, that will execute the 404 handler
  * in jetpack_boost_check_404_handler().
@@ -79,7 +97,7 @@ function jetpack_boost_check_404_handler( $request_uri ) {
  * This function is called when the Minify_CSS or Minify_JS module is activated, and once per day.
  */
 function jetpack_boost_404_tester() {
-	if ( defined( 'JETPACK_BOOST_DISABLE_404_TESTER' ) && JETPACK_BOOST_DISABLE_404_TESTER ) {
+	if ( jetpack_boost_minify_disable_404_tester() ) {
 		return;
 	}
 

--- a/projects/plugins/boost/app/modules/optimizations/minify/Minify.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/Minify.php
@@ -1,6 +1,7 @@
 <?php
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Minify;
 
+use Automattic\Jetpack_Boost\Admin\Config as Boost_Admin_Config;
 use Automattic\Jetpack_Boost\Contracts\Has_Activate;
 use Automattic\Jetpack_Boost\Contracts\Has_Deactivate;
 use Automattic\Jetpack_Boost\Contracts\Optimization;
@@ -33,7 +34,8 @@ class Minify implements Pluggable, Optimization, Has_Activate, Has_Deactivate {
 	 * This is called when either minify module is activated
 	 */
 	public static function activate() {
-		jetpack_boost_minify_activation();
+		$disable_404_tester = Boost_Admin_Config::get_hosting_provider() !== 'atomic' && Boost_Admin_Config::get_hosting_provider() !== 'woa';
+		jetpack_boost_minify_activation( $disable_404_tester );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/optimizations/minify/Minify.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/Minify.php
@@ -34,8 +34,8 @@ class Minify implements Pluggable, Optimization, Has_Activate, Has_Deactivate {
 	 * This is called when either minify module is activated
 	 */
 	public static function activate() {
-		$disable_404_tester = Boost_Admin_Config::get_hosting_provider() !== 'atomic' && Boost_Admin_Config::get_hosting_provider() !== 'woa';
-		jetpack_boost_minify_activation( $disable_404_tester );
+		$setup_404_tester = Boost_Admin_Config::get_hosting_provider() !== 'atomic' && Boost_Admin_Config::get_hosting_provider() !== 'woa';
+		jetpack_boost_minify_activation( $setup_404_tester );
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/fix-boost-concat-notice
+++ b/projects/plugins/boost/changelog/fix-boost-concat-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix missing spacing for Concat notice. Disable 404 tester on Atomic and WoA sites.
+
+

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -99,7 +99,8 @@ add_action( 'admin_init', 'jetpack_boost_initialize_datasync' );
 jetpack_boost_register_readonly_option(
 	'minify_legacy_notice',
 	function () {
-		if ( jetpack_boost_minify_disable_404_tester() ) {
+		// If the JETPACK_BOOST_DISABLE_404_TESTER is set and true, we don't need to show the legacy notice.
+		if ( defined( 'JETPACK_BOOST_DISABLE_404_TESTER' ) && JETPACK_BOOST_DISABLE_404_TESTER ) {
 			return false;
 		}
 

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -99,8 +99,7 @@ add_action( 'admin_init', 'jetpack_boost_initialize_datasync' );
 jetpack_boost_register_readonly_option(
 	'minify_legacy_notice',
 	function () {
-		// If the JETPACK_BOOST_DISABLE_404_TESTER is set and true, we don't need to show the legacy notice.
-		if ( defined( 'JETPACK_BOOST_DISABLE_404_TESTER' ) && JETPACK_BOOST_DISABLE_404_TESTER ) {
+		if ( jetpack_boost_minify_disable_404_tester() ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Proposed changes:

* Disable the 404 tester on Atomic/WoA sites. Users can't really do anything about that;
* Add spacing to concate notice and exceptions section (when expanded);
* Remove underline from links in ISA summary section.

![CleanShot 2025-03-05 at 16 30 29](https://github.com/user-attachments/assets/2e95660f-538f-4ff7-b6c5-ec8d102dc4ea)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1741178339776799-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Setup this branch;
- If you're testing on Atomic, enable Concatenate JS or CSS. There should be no notice under either modules;
- Run ISA and make sure to get some image errors in there. There should be no underlined links in the summary section (see above screenshot).

**Don't use Atomic (or WoA) for this test.**

Get the notice to show up (you can edit the `jetpack_boost_static_minification` option to `0` from `wp-admin/options.php`.

- Expand the Exceptions and make sure there's spacing between the section and the notice.