### PR TITLE
Newspack Blocks: Fix perms issue when syncing 

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/bin/sync-newspack-blocks.sh
+++ b/projects/packages/jetpack-mu-wpcom/bin/sync-newspack-blocks.sh
@@ -205,8 +205,6 @@ rm "$PHPCSSTANDARDFILE"
 # Add textdomain to block.json
 echo "Adding textdomain to all block.json files..."
 for block_json_file in "$TARGET"/blocks/*/block.json; do
-	TMPFILE=$(mktemp)
-	jq --tab '. += {"textdomain": "jetpack-mu-wpcom"}' "$block_json_file" > "$TMPFILE"
-	mv "$TMPFILE" "$block_json_file"
+	jq --tab '. += {"textdomain": "jetpack-mu-wpcom"}' "$block_json_file" > "$block_json_file.tmp" && mv "$block_json_file.tmp" "$block_json_file"
 done
 echo Sync done.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-newspack_blocks_sync-perms_issue
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-newspack_blocks_sync-perms_issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Newspack Blocks: Fix perms issue with block.json files.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

I used `mktemp` when converting `block.json` files to the proper textdomain. This meant the resulting files had `600` permissions instead of `644`. This caused issues while doing an rsync to smoke test.

This PR switches the process to use an ad-hoc temp file instead of `mktemp`.

Discovered by @dsas during #42223.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. `cd projects/packages/jetpack-mu-wpcom`
2. ` ./bin/sync-newspack-blocks.sh --release=v4.7.0`
3. `ls -l src/features/newspack-blocks/synced-newspack-blocks/blocks/*/block.json`

With `trunk`, you'll see `600` permissions (`-rw-------`).

With the `fix/newspack_blocks_sync/perms_issue` branch, you'll see `644` permissions (`-rw-r--r--`).