### PR TITLE
Search: ensure the dashboard card offers the right options.

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/search.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/search.jsx
@@ -1,6 +1,6 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { noop } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -11,10 +11,7 @@ import DashItem from 'components/dash-item';
 import JetpackBanner from 'components/jetpack-banner';
 import analytics from 'lib/analytics';
 import { getJetpackProductUpsellByFeature, FEATURE_SEARCH_JETPACK } from 'lib/plans/constants';
-import {
-	getProductDescriptionUrl,
-	isSearchNewPricingLaunched202208,
-} from 'product-descriptions/utils';
+import { getProductDescriptionUrl } from 'product-descriptions/utils';
 import { hasConnectedOwner, isOfflineMode, connectUser } from 'state/connection';
 import { currentThemeIsBlockTheme } from 'state/initial-state';
 import { siteHasFeature, isFetchingSitePurchases } from 'state/site';
@@ -42,9 +39,9 @@ const renderCard = props => (
 		} }
 		className={ props.className }
 		status={ props.status }
-		isModule={ props.pro_inactive }
-		pro={ true }
 		overrideContent={ props.overrideContent }
+		isModule={ props.pro_inactive }
+		noToggle={ props.pro_inactive }
 	>
 		<p className="jp-dash-item__description">{ props.content }</p>
 	</DashItem>
@@ -121,11 +118,7 @@ class DashSearch extends Component {
 				pro_inactive: true,
 				overrideContent: (
 					<JetpackBanner
-						callToAction={
-							isSearchNewPricingLaunched202208()
-								? __( 'Start for free', 'jetpack' )
-								: _x( 'Upgrade', 'Call to action to buy a new plan', 'jetpack' )
-						}
+						callToAction={ __( 'Start for free', 'jetpack' ) }
 						title={ SEARCH_DESCRIPTION }
 						disableHref="false"
 						href={ this.props.upgradeUrl }
@@ -150,8 +143,6 @@ class DashSearch extends Component {
 							link: getRedirectUrl( 'jetpack-support-search' ),
 						} }
 						className="jp-dash-item__is-active"
-						isModule={ false }
-						pro={ true }
 					>
 						<p className="jp-dash-item__description">
 							{ __( 'Jetpack Search is powering search on your site.', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
@@ -575,7 +575,8 @@
 	box-shadow: none;
 }
 
-.jp-dash-item__videopress .jp-dash-item__card {
+.jp-dash-item__videopress .jp-dash-item__card,
+.jp-dash-item__search .jp-dash-item__card {
 	flex-direction: column;
 }
 

--- a/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
@@ -26,10 +26,7 @@ import {
 	FEATURE_JETPACK_EARN,
 } from 'lib/plans/constants';
 import ProStatus from 'pro-status';
-import {
-	getProductDescriptionUrl,
-	isSearchNewPricingLaunched202208,
-} from 'product-descriptions/utils';
+import { getProductDescriptionUrl } from 'product-descriptions/utils';
 import { isAkismetKeyValid, isCheckingAkismetKey, getVaultPressData } from 'state/at-a-glance';
 import {
 	hasConnectedOwner as hasConnectedOwnerSelector,
@@ -376,11 +373,7 @@ export const SettingsCard = inprops => {
 
 				return (
 					<JetpackBanner
-						callToAction={
-							isSearchNewPricingLaunched202208()
-								? __( 'Start for free', 'jetpack' )
-								: _x( 'Upgrade', 'Call to action to buy a new plan', 'jetpack' )
-						}
+						callToAction={ __( 'Start for free', 'jetpack' ) }
 						title={ __(
 							'Help visitors quickly find answers with highly relevant instant search results and powerful filtering.',
 							'jetpack'

--- a/projects/plugins/jetpack/_inc/client/product-descriptions/utils.js
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/utils.js
@@ -2,17 +2,6 @@ import { getSiteAdminUrl } from 'state/initial-state';
 import { productDescriptionRoutes, myJetpackRoutes } from './constants';
 
 /**
- * This affects search "Upgrade" buttons, and changes them into "Start for free".
- * It should use API to check if feature is enabled, but we didn't make it in time.
- *
- * Todo: Make it return true once we fully ship and enable new search pricing.
- *
- * @return {boolean} Whether new search pricing and free plan is forced by URL parameter.
- */
-export const isSearchNewPricingLaunched202208 = () =>
-	URLSearchParams && !! new URLSearchParams( window.location?.search ).get( 'new_pricing_202208' );
-
-/**
  * Get product description URL by product key.
  *
  * A product key differs from slugs since "jetpack-backup-daily" => "backups".
@@ -26,7 +15,6 @@ export const getProductDescriptionUrl = ( state, productKey ) => {
 	const baseUrl = `${ getSiteAdminUrl( state ) }admin.php?page=jetpack#`;
 	const myJetpackUrl = `${ getSiteAdminUrl( state ) }admin.php?page=my-jetpack#`;
 
-	// TODO: remove the && condition on Search new pricing launch.
 	if ( productKey === 'search' ) {
 		return `${ getSiteAdminUrl( state ) }admin.php?page=jetpack-search`;
 	}

--- a/projects/plugins/jetpack/changelog/fix-search-card
+++ b/projects/plugins/jetpack/changelog/fix-search-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Dashboard: ensure the Search settings can be toggled on and off regardless of the Jetpack Search plan installed on the site.


### PR DESCRIPTION
Fixes #42227

## Proposed changes:

- When you don't have a Search plan, we should offer you to go to the Search page and pick a plan (including the free one).
- When you have a plan, you should be able to turn the feature off and back on.

Related: #26807 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Test this on a site with no plan whatsoever.
* Go to Jetpack > Dashboard and connect your site to your WordPress.com.
* Go back to Jetpack > Dashboard 
    * You should see a CTA to go to the Search page to "Start for free"
* Pick a free Jetpack Search plan 
* Go back to Jetpack > Dashboard
    * You should see the toggle to turn the feature off.
* Turn the Search feature off
    * You should see the option to turn it back on.
* In Store Admin, remove the Jetpack search plan from your site.
* Now purchase a Jetpack Complete plan
* Go back to Jetpack > Dashboard
    * You should see the toggle to turn the feature off.
* Turn the feature off
    * You should see an invitation to "start for free".
    
