### PR TITLE
withUpgradeBanner: fix maxWidth warning

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-max-width-error
+++ b/projects/plugins/jetpack/changelog/fix-max-width-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
@@ -80,7 +80,7 @@ const withUpgradeBanner = createHigherOrderComponent(
 
 		const blockProps = useBlockProps();
 		// Fix for width of cover block because otherwise the div defaults to content-size as max width
-		const cssFixForCoverBlock = { 'max-width': 'unset' };
+		const cssFixForCoverBlock = { maxWidth: 'unset' };
 
 		return (
 			<PaidBlockProvider


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

<img width="1464" alt="image" src="https://github.com/user-attachments/assets/7d6091b1-9d0d-4bef-9ee1-3d1e3f5781c0" />


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix the error, it's hard to see if there's other errors with this one.



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add some jetpack blocks like jetpack forms to a post and open the site editor.
