### PR TITLE
Safe Mode: fix custom string for development sites

### DIFF
--- a/projects/js-packages/idc/changelog/fix-safe-mode-custom-text
+++ b/projects/js-packages/idc/changelog/fix-safe-mode-custom-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Making sure custom text works on dev Safe Mode.

--- a/projects/js-packages/idc/components/card-fresh/index.jsx
+++ b/projects/js-packages/idc/components/card-fresh/index.jsx
@@ -102,7 +102,7 @@ const CardFresh = props => {
 								}
 						  )
 						: createInterpolateElement(
-								customContent.startFreshCardBodyText ||
+								customContent.startFreshCardBodyTextDev ||
 									sprintf(
 										/* translators: %1$s: The current site domain name. %2$s: The original site domain name. */
 										__(

--- a/projects/js-packages/idc/components/safe-mode/index.jsx
+++ b/projects/js-packages/idc/components/safe-mode/index.jsx
@@ -144,7 +144,7 @@ const SafeMode = props => {
 
 						<div>
 							{ createInterpolateElement(
-								customContent.startFreshCardBodyText ||
+								customContent.safeModeCardBodyText ||
 									/* translators: %1$s: The current site domain name. %2$s: The original site domain name. */
 									__(
 										'<p><strong>Recommended for</strong></p>' +

--- a/projects/js-packages/idc/tools/custom-content-shape.jsx
+++ b/projects/js-packages/idc/tools/custom-content-shape.jsx
@@ -24,6 +24,10 @@ export default {
 	/** The "start fresh" card body. */
 	startFreshCardBodyText: PropTypes.string,
 	/** The "start fresh" card button label. */
+	safeModeCardBodyText: PropTypes.string,
+	/** The "stay in safe mode" card button label. */
+	startFreshCardBodyTextDev: PropTypes.string,
+	/** The "start fresh" for dev sites card button label. */
 	startFreshButtonLabel: PropTypes.string,
 	/** The "non admin" screen title. */
 	nonAdminTitle: PropTypes.string,


### PR DESCRIPTION
Making changes related to WCPay problems with custom Safe Mode text: https://github.com/Automattic/woocommerce-payments/issues/9614#top

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Make sure two newer cards in safe mode can display custom text.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

