### PR TITLE
VideoPress, Invalid VP URL: Handle case when the URL doesn't contain VP GUID 

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-invalid-url
+++ b/projects/packages/videopress/changelog/fix-videopress-invalid-url
@@ -1,4 +1,5 @@
 Significance: patch
 Type: fixed
 
-https://github.com/Automattic/jetpack/issues/34741
+- Handle case when the URL doesn't contain VideoPress GUID
+- CSS: Add missing space between CTAs

--- a/projects/packages/videopress/changelog/fix-videopress-invalid-url
+++ b/projects/packages/videopress/changelog/fix-videopress-invalid-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+https://github.com/Automattic/jetpack/issues/34741

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
@@ -13,7 +13,12 @@ import { __ } from '@wordpress/i18n';
 import useResumableUploader from '../../../../../hooks/use-resumable-uploader';
 import { uploadFromLibrary } from '../../../../../hooks/use-uploader';
 import { isUserConnected } from '../../../../../lib/connection';
-import { buildVideoPressURL, pickVideoBlockAttributesFromUrl } from '../../../../../lib/url';
+import {
+	buildVideoPressURL,
+	buildVideoPressVideoByFileName,
+	pickVideoBlockAttributesFromUrl,
+	getVideoNameFromUrl,
+} from '../../../../../lib/url';
 import { VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES } from '../../constants';
 import { PlaceholderWrapper } from '../../edit';
 import { VideoPressIcon } from '../icons';
@@ -111,15 +116,21 @@ const VideoPressUploader = ( {
 	function onSelectURL( videoSource, id ) {
 		// If the video source is a VideoPress URL, we can use it directly.
 		const { guid: guidFromSource, url: srcFromSource } = buildVideoPressURL( videoSource );
-		if ( ! guidFromSource ) {
-			setUploadErrorDataState( {
-				data: { message: __( 'Invalid VideoPress URL', 'jetpack-videopress-pkg' ) },
-			} );
-			return;
-		}
 
-		const attrs = pickVideoBlockAttributesFromUrl( srcFromSource );
-		handleDoneUpload( { ...attrs, guid: guidFromSource, id } );
+		if ( guidFromSource ) {
+			const attrs = pickVideoBlockAttributesFromUrl( srcFromSource );
+			handleDoneUpload( { ...attrs, guid: guidFromSource, id } );
+		} else {
+			// If the video source is not a VideoPress URL, try to build it from the file name.
+			const videoName = getVideoNameFromUrl( videoSource );
+			buildVideoPressVideoByFileName( videoName ).then( attrs => {
+				attrs
+					? handleDoneUpload( { ...attrs, id } )
+					: setUploadErrorDataState( {
+							data: { message: __( 'Invalid VideoPress URL', 'jetpack-videopress-pkg' ) },
+					  } );
+			} );
+		}
 	}
 
 	const startUpload = file => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
@@ -116,6 +116,7 @@ const VideoPressUploader = ( {
 	function onSelectURL( videoSource, id ) {
 		// If the video source is a VideoPress URL, we can use it directly.
 		const { guid: guidFromSource, url: srcFromSource } = buildVideoPressURL( videoSource );
+		const invalidUrlMessage = __( 'Invalid VideoPress URL', 'jetpack-videopress-pkg' );
 
 		if ( guidFromSource ) {
 			const attrs = pickVideoBlockAttributesFromUrl( srcFromSource );
@@ -123,13 +124,16 @@ const VideoPressUploader = ( {
 		} else {
 			// If the video source is not a VideoPress URL, try to build it from the file name.
 			const videoName = getVideoNameFromUrl( videoSource );
-			buildVideoPressVideoByFileName( videoName ).then( attrs => {
-				attrs
-					? handleDoneUpload( { ...attrs, id } )
-					: setUploadErrorDataState( {
-							data: { message: __( 'Invalid VideoPress URL', 'jetpack-videopress-pkg' ) },
-					  } );
-			} );
+
+			if ( ! videoName ) {
+				setUploadErrorDataState( { data: { message: invalidUrlMessage } } );
+			} else {
+				buildVideoPressVideoByFileName( videoName ).then( attrs => {
+					attrs
+						? handleDoneUpload( { ...attrs, id } )
+						: setUploadErrorDataState( { data: { message: invalidUrlMessage } } );
+				} );
+			}
 		}
 	}
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/style.scss
@@ -42,10 +42,15 @@
 		transition: width 0.3s ease;
 	}
 
-	&__actions {
+	&__actions,
+	&__error-actions {
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
+	}
+	
+	&__error-actions {
+		gap: 16px;
 	}
 }
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-error.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-error.js
@@ -38,7 +38,7 @@ const UploadError = ( { errorData, onRetry, onCancel } ) => {
 
 	return (
 		<PlaceholderWrapper errorMessage={ message } onNoticeRemove={ onCancel }>
-			<div className="videopress-uploader__error-actions">
+			<div className="videopress-uploader-progress__error-actions">
 				<Button variant="primary" onClick={ onRetry }>
 					{ __( 'Try again', 'jetpack-videopress-pkg' ) }
 				</Button>

--- a/projects/packages/videopress/src/client/lib/url/index.ts
+++ b/projects/packages/videopress/src/client/lib/url/index.ts
@@ -1,3 +1,4 @@
+import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { VideoBlockAttributes, VideoGUID } from '../../block-editor/blocks/video/types';
 
@@ -157,6 +158,37 @@ export function buildVideoPressURL(
 	}
 
 	return {};
+}
+
+/**
+ * Search for a VideoPress video by filename in the media library
+ *
+ * @param {string}               fileName            - The name of the video file to search for
+ * @param {VideoBlockAttributes} attributes          - Optional VideoPress URL attributes
+ * @return {Promise<BuildVideoPressURLProps | null>} The VideoPress URL and GUID if found, null otherwise
+ */
+export async function buildVideoPressVideoByFileName(
+	fileName: string,
+	attributes: VideoBlockAttributes = {}
+): Promise< BuildVideoPressURLProps | null > {
+	try {
+		const results = await apiFetch< Array< { jetpack_videopress_guid?: string } > >( {
+			path: `/wp/v2/media?mime_type=video&search=${ encodeURIComponent( fileName ) }`,
+		} );
+
+		const videoFile = results.find( item => item.jetpack_videopress_guid );
+
+		if ( videoFile?.jetpack_videopress_guid ) {
+			return {
+				url: getVideoPressUrl( videoFile.jetpack_videopress_guid, attributes ),
+				guid: videoFile.jetpack_videopress_guid,
+			};
+		}
+
+		return null;
+	} catch {
+		return null;
+	}
 }
 
 export const removeFileNameExtension = ( name: string ) => {

--- a/projects/packages/videopress/src/client/lib/url/index.ts
+++ b/projects/packages/videopress/src/client/lib/url/index.ts
@@ -163,8 +163,8 @@ export function buildVideoPressURL(
 /**
  * Search for a VideoPress video by filename in the media library
  *
- * @param {string}               fileName            - The name of the video file to search for
- * @param {VideoBlockAttributes} attributes          - Optional VideoPress URL attributes
+ * @param {string}               fileName   - The name of the video file to search for
+ * @param {VideoBlockAttributes} attributes - Optional VideoPress URL attributes
  * @return {Promise<BuildVideoPressURLProps | null>} The VideoPress URL and GUID if found, null otherwise
  */
 export async function buildVideoPressVideoByFileName(
@@ -209,6 +209,29 @@ export function getVideoUrlBasedOnPrivacy( guid: VideoGUID, isPrivate: boolean )
 	}
 
 	return `https://videopress.com/v/${ guid }`;
+}
+
+/**
+ * Extract the video filename with extension from a URL
+ *
+ * @param {string} url - The URL containing the video filename
+ * @return {string}    The video filename with extension, or empty string if not found
+ */
+export function getVideoNameFromUrl( url: string ): string {
+	try {
+		// Create URL object to parse the URL
+		const urlObj = new URL( url );
+
+		// Split the pathname by '/' and get the last segment
+		const segments = urlObj.pathname.split( '/' );
+		const fileName = segments[ segments.length - 1 ];
+
+		// Return the filename if it exists, otherwise empty string
+		return fileName || '';
+	} catch {
+		// Return empty string if URL parsing fails
+		return '';
+	}
 }
 
 /**

--- a/projects/packages/videopress/src/client/lib/url/index.ts
+++ b/projects/packages/videopress/src/client/lib/url/index.ts
@@ -219,17 +219,14 @@ export function getVideoUrlBasedOnPrivacy( guid: VideoGUID, isPrivate: boolean )
  */
 export function getVideoNameFromUrl( url: string ): string {
 	try {
-		// Create URL object to parse the URL
 		const urlObj = new URL( url );
 
 		// Split the pathname by '/' and get the last segment
 		const segments = urlObj.pathname.split( '/' );
 		const fileName = segments[ segments.length - 1 ];
 
-		// Return the filename if it exists, otherwise empty string
 		return fileName || '';
 	} catch {
-		// Return empty string if URL parsing fails
 		return '';
 	}
 }

--- a/projects/packages/videopress/src/client/lib/url/test/index.ts
+++ b/projects/packages/videopress/src/client/lib/url/test/index.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { buildVideoPressURL, pickVideoBlockAttributesFromUrl } from '..';
+import { buildVideoPressURL, pickVideoBlockAttributesFromUrl, getVideoNameFromUrl } from '..';
 
 describe( 'buildVideoPressURL', () => {
 	it( 'should return empty object when invalid URL', () => {
@@ -122,5 +122,17 @@ describe( 'pickVideoBlockAttributesFromUrl', () => {
 		expect( attributes.poster ).toBe(
 			'http://localhost/wp-content/uploads/2023/04/pexels-photo-2693212.jpg'
 		);
+	} );
+} );
+
+describe( 'getVideoNameFromUrl', () => {
+	it( 'should return empty string when no URL', () => {
+		expect( getVideoNameFromUrl( '' ) ).toBe( '' );
+	} );
+
+	it( 'should return video name from URL', () => {
+		expect(
+			getVideoNameFromUrl( 'https://test.wordpres.com/xxxx-photo-2693212/video-file.mp4' )
+		).toBe( 'video-file.mp4' );
 	} );
 } );

--- a/projects/packages/videopress/src/client/lib/url/test/index.ts
+++ b/projects/packages/videopress/src/client/lib/url/test/index.ts
@@ -1,7 +1,12 @@
 /**
  * Internal dependencies
  */
-import { buildVideoPressURL, pickVideoBlockAttributesFromUrl, getVideoNameFromUrl } from '..';
+import {
+	buildVideoPressURL,
+	pickVideoBlockAttributesFromUrl,
+	getVideoNameFromUrl,
+	removeFileNameExtension,
+} from '..';
 
 describe( 'buildVideoPressURL', () => {
 	it( 'should return empty object when invalid URL', () => {
@@ -140,5 +145,27 @@ describe( 'getVideoNameFromUrl', () => {
 		expect( getVideoNameFromUrl( 'https://test.wordpres.com/xxxx-photo-2693212/video-file' ) ).toBe(
 			'video-file'
 		);
+	} );
+} );
+
+describe( 'removeFileNameExtension', () => {
+	it( 'should remove extension from a simple filename', () => {
+		expect( removeFileNameExtension( 'video.mp4' ) ).toBe( 'video' );
+	} );
+
+	it( 'should remove extension from a filename with multiple dots', () => {
+		expect( removeFileNameExtension( 'my.awesome.video.mp4' ) ).toBe( 'my.awesome.video' );
+	} );
+
+	it( 'should handle filenames without extension', () => {
+		expect( removeFileNameExtension( 'video' ) ).toBe( 'video' );
+	} );
+
+	it( 'should handle filenames starting with a dot', () => {
+		expect( removeFileNameExtension( '.htaccess' ) ).toBe( '' );
+	} );
+
+	it( 'should handle empty string', () => {
+		expect( removeFileNameExtension( '' ) ).toBe( '' );
 	} );
 } );

--- a/projects/packages/videopress/src/client/lib/url/test/index.ts
+++ b/projects/packages/videopress/src/client/lib/url/test/index.ts
@@ -6,6 +6,7 @@ import {
 	pickVideoBlockAttributesFromUrl,
 	getVideoNameFromUrl,
 	removeFileNameExtension,
+	isVideoPressUrl,
 } from '..';
 
 describe( 'buildVideoPressURL', () => {
@@ -167,5 +168,44 @@ describe( 'removeFileNameExtension', () => {
 
 	it( 'should handle empty string', () => {
 		expect( removeFileNameExtension( '' ) ).toBe( '' );
+	} );
+} );
+
+describe( 'isVideoPressUrl', () => {
+	describe( 'should return true for valid VideoPress URLs', () => {
+		const validUrls = [
+			'https://videopress.com/v/xyrdcYF4',
+			'https://videopress.com/v/xyrdcYF4/',
+			'https://videopress.com/embed/xyrdcYF4',
+			'https://v.wordpress.com/xyrdcYF4/',
+			'https://video.wordpress.com/v/xyrdcYF4',
+			'https://video.wordpress.com/embed/xyrdcYF4/',
+			'http://videopress.com/v/xyrdcYF4', // HTTP protocol
+		];
+
+		validUrls.forEach( url => {
+			it( `should validate ${ url }`, () => {
+				expect( isVideoPressUrl( url ) ).toBe( true );
+			} );
+		} );
+	} );
+
+	describe( 'should return false for invalid URLs', () => {
+		const invalidUrls = [
+			'https://example.com',
+			'',
+			'https://videopress.com/invalid/xyrdcYF4', // Invalid path
+			'https://videopress.com/v/xyz', // Invalid GUID (too short)
+			'https://videopress.com/v/xyrdcYF4extra', // Invalid GUID (too long)
+			'https://videopress.com/v/', // Missing GUID
+			'https://fakevideo.wordpress.com/v/xyrdcYF4', // Invalid subdomain
+			'videopress.com/v/xyrdcYF4', // Missing protocol
+		];
+
+		invalidUrls.forEach( url => {
+			it( `should not validate ${ url || '(empty string)' }`, () => {
+				expect( isVideoPressUrl( url ) ).toBe( false );
+			} );
+		} );
 	} );
 } );

--- a/projects/packages/videopress/src/client/lib/url/test/index.ts
+++ b/projects/packages/videopress/src/client/lib/url/test/index.ts
@@ -128,11 +128,17 @@ describe( 'pickVideoBlockAttributesFromUrl', () => {
 describe( 'getVideoNameFromUrl', () => {
 	it( 'should return empty string when no URL', () => {
 		expect( getVideoNameFromUrl( '' ) ).toBe( '' );
+
+		expect( getVideoNameFromUrl( 'wrong-url' ) ).toBe( '' );
 	} );
 
 	it( 'should return video name from URL', () => {
 		expect(
 			getVideoNameFromUrl( 'https://test.wordpres.com/xxxx-photo-2693212/video-file.mp4' )
 		).toBe( 'video-file.mp4' );
+
+		expect( getVideoNameFromUrl( 'https://test.wordpres.com/xxxx-photo-2693212/video-file' ) ).toBe(
+			'video-file'
+		);
 	} );
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/34741

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Handles cases where the entered URL doesn't contain VidePress GUID.
* The extended approach will try to find the video by filename;
* Added missing gap between buttons

**NOTE: This fix only handles files from the same site since the media search API works in the site context.**

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/issues/34741

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run your sandbox
* Apply changes from this PR; [check for the instructions](https://github.com/Automattic/jetpack/pull/42237#issuecomment-2701682450)
* Upload a video file to your website with the Premium plan
* Create a new post/page
* Insert a VideoPress block. Click the `Insert From URL` link and `paste the video's link` and submit.
* Check if Video appears

<img width="687" alt="Screenshot 2025-03-05 at 18 57 49" src="https://github.com/user-attachments/assets/08adf097-41f8-4159-8aa0-f8a84bf0da6f" />

* Try entering a wrong URL (for example, url to the image media)
* Check the the gap between buttons

| Before | After |
|--------|--------|
| <img width="522" alt="Screenshot 2025-03-05 at 19 22 54" src="https://github.com/user-attachments/assets/e20af3ff-1016-4099-9d5a-071da1d88fa7" /> | <img width="538" alt="Screenshot 2025-03-05 at 19 22 38" src="https://github.com/user-attachments/assets/90ea7a63-081e-487e-99f7-c357b01274a8" /> | 
