### PR TITLE
Jetpack SEO: default filter to false

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-seo-assistant-filter-disabled
+++ b/projects/plugins/jetpack/changelog/update-jetpack-seo-assistant-filter-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO: reverting filter default back to false

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -168,7 +168,7 @@ add_action(
 	'jetpack_register_gutenberg_extensions',
 	function () {
 		if ( apply_filters( 'jetpack_ai_enabled', true ) &&
-			apply_filters( 'ai_seo_assistant_enabled', true )
+			apply_filters( 'ai_seo_assistant_enabled', false )
 		) {
 			\Jetpack_Gutenberg::set_extension_available( 'ai-seo-assistant' );
 		}


### PR DESCRIPTION
## Proposed changes:
This PR reverts the default value for seo assistant back to false while we clarify our next steps.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-vtt-p2#comment-75683

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
The SEO assistant, on the block editor's Jetpack sidebar, should not be available unless you enable it with the filter (besides using BETA blocks variation)