### PR TITLE
Newsletter Dashboard Widget: add hash to import subscribers href

### DIFF
--- a/projects/plugins/jetpack/changelog/update-newsletter-widget-import-link
+++ b/projects/plugins/jetpack/changelog/update-newsletter-widget-import-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter Dashboard Widget: update href to import subscribers

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/newsletter-widget.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/newsletter-widget.tsx
@@ -120,7 +120,8 @@ export const NewsletterWidget = ( {
 						<li>
 							<a
 								href={ getRedirectUrl(
-									buildJPRedirectSource( `subscribers/${ site }`, isWpcomSite )
+									buildJPRedirectSource( `subscribers/${ site }`, isWpcomSite ),
+									{ anchor: 'add-subscribers' }
 								) }
 							>
 								{ __( 'Import subscribers', 'jetpack' ) }

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/newsletter-widget.test.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/newsletter-widget.test.tsx
@@ -71,7 +71,9 @@ describe( 'NewsletterWidget', () => {
 			},
 			{
 				text: 'Import subscribers',
-				href: getRedirectUrl( `https://${ redirectDomain }/subscribers/${ defaultProps.site }` ),
+				href: getRedirectUrl( `https://${ redirectDomain }/subscribers/${ defaultProps.site }`, {
+					anchor: 'add-subscribers',
+				} ),
 			},
 			{
 				text: 'Manage subscribers',
@@ -111,7 +113,9 @@ describe( 'NewsletterWidget', () => {
 			},
 			{
 				text: 'Import subscribers',
-				href: getRedirectUrl( `https://${ redirectDomain }/subscribers/${ defaultProps.site }` ),
+				href: getRedirectUrl( `https://${ redirectDomain }/subscribers/${ defaultProps.site }`, {
+					anchor: 'add-subscribers',
+				} ),
 			},
 			{
 				text: 'Manage subscribers',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to Automattic/loop#552 Automattic/wp-calypso#100900

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a hash (anchor) to the "Import subscribers" link in the newsletter widget
* This will allow us to "deep link" to that flow by opening the add subscribers modal on the page

https://github.com/user-attachments/assets/14bfb403-21fe-412e-a4b7-38b67424fe8f

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pe7F0s-2wU-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the widget on your sandbox by adding `define( 'JETPACK_NEWSLETTER_WIDGET', true );` to `0-sandbox.php` on you sandbox
* Sandbox your site and enable this branch
* Navigate to wp-admin on your site
* Click the "Import subscribers" link in the widget footer
* Verify the "add-subscribers" is present in the url hash after the Jetpack redirect.

