### PR TITLE
Update/jp dashboard update how expiry status is checked

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/product-expiration/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/product-expiration/index.jsx
@@ -1,6 +1,6 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
-import { dateI18n, isInTheFuture } from '@wordpress/date';
+import { dateI18n } from '@wordpress/date';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
@@ -22,7 +22,8 @@ class ProductExpiration extends React.PureComponent {
 	};
 
 	render() {
-		const { expiryDate, purchaseDate, isRefundable, dateFormat, isGift, purchaseID } = this.props;
+		const { expiryDate, expiryStatus, purchaseDate, isRefundable, dateFormat, isGift, purchaseID } =
+			this.props;
 
 		// Return null if we don't have any dates.
 		if ( ! expiryDate && ! purchaseDate ) {
@@ -65,7 +66,7 @@ class ProductExpiration extends React.PureComponent {
 		}
 
 		// If the expiry date is in the past, show the expiration date.
-		if ( ! isInTheFuture( expiryDateObj ) ) {
+		if ( expiryStatus === 'expired' ) {
 			return createInterpolateElement(
 				sprintf(
 					/* translators: %d is a count of how many new (unread) recommendations are available. */

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
@@ -1,6 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
-import { isInTheFuture } from '@wordpress/date';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, _x, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
@@ -61,6 +60,7 @@ class MyPlanHeader extends React.Component {
 					// Add key because this goes to `details` as array.
 					key="product-expiration"
 					dateFormat={ dateFormat }
+					expiryStatus={ purchase.expiry_status }
 					expiryDate={ purchase.expiry_date }
 					purchaseDate={ purchase.subscribed_date }
 					isRefundable={ purchase.is_refundable }
@@ -71,7 +71,7 @@ class MyPlanHeader extends React.Component {
 			if ( purchase.active === '1' ) {
 				// Purchases might not have an expiration date, so we need to check
 				// for their existence (e.g.: lifetime plan like Golden Token).
-				if ( ! isInTheFuture( purchase.expiry_date ) && purchase.expiry_date !== null ) {
+				if ( purchase.expiry_status === 'expired' && purchase.expiry_date !== null ) {
 					activation = <ProductActivated key="product-expired" type="product-expired" />;
 				} else {
 					activation = (

--- a/projects/plugins/jetpack/changelog/update-jp-dashboard-update-how-expiry-status-is-checked
+++ b/projects/plugins/jetpack/changelog/update-jp-dashboard-update-how-expiry-status-is-checked
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix bug where subscription was showing incorrectly as expired in certain timezones


### PR DESCRIPTION
## Proposed changes:

* Update expired plan check in the dashboard to rely on the `expiry_status` rather than the `expiry_date` to avoid showing product as `expired` incorrectly in certain timezones

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Slack: p1740936840371679-slack-C02BEP610

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Do not yet checkout this branch on your JN site or local environment
2. Purchase a Jetpack Security plan for your site (or add it via the Store Admin)
3. Go to `/wp-admin/admin.php?page=jetpack#/my-plan` and ensure you see your plan and that it is active
![image](https://github.com/user-attachments/assets/5812efab-2d26-46c5-bef3-a872f0c0ce84)

The following steps can probably done in several different ways, but the easiest way I found to test this was the following

4. In the Store Admin, update the expiration date on your plan to be tomorrow
![image](https://github.com/user-attachments/assets/e096fc98-b759-42dc-b53c-81d6a68c36d2)

5. Now, on your computer, go to your settings and turn off the automatic date and time. Adjust your computer time to be past the expiration date and time
![image](https://github.com/user-attachments/assets/11706daa-0679-4268-8c20-bb57b761901e)

6. Now go to `/wp-admin/admin.php?page=jetpack#/my-plan` and see that the plan now says `expired` as your computer time is now in the future

![image](https://github.com/user-attachments/assets/8c14fdb5-1126-4855-a1f2-d4888fcd0c10)

7. Now, checkout this branch locally, or check out this branch on the beta plugin on your JN site
8. Go back to `/wp-admin/admin.php?page=jetpack#/my-plan` and refresh the page. Ensure the subscription no longer shows as expired as the actual subscription on the backend is not expired
![image](https://github.com/user-attachments/assets/4ba2a793-8c90-4df4-a829-5ab695706bf4)
