### PR TITLE
Forms: Make field style panels consistent with colors and allow resetting

### DIFF
--- a/projects/packages/forms/changelog/update-allow-resetting-of-field-controls
+++ b/projects/packages/forms/changelog/update-allow-resetting-of-field-controls
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Allow field and option style controls to be reset and consistent with color panel

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -7,11 +7,12 @@ import {
 	PanelColorSettings,
 } from '@wordpress/block-editor';
 import {
-	BaseControl,
 	PanelBody,
 	TextControl,
 	ToggleControl,
 	RangeControl,
+	__experimentalToolsPanel as ToolsPanel, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { isValidElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -19,6 +20,8 @@ import { useFormStyle, FORM_STYLE, getBlockStyle } from '../util/form';
 import ToolbarRequiredGroup from './block-controls/toolbar-required-group';
 import JetpackFieldWidth from './jetpack-field-width';
 import JetpackManageResponsesSettings from './jetpack-manage-responses-settings';
+
+const hasNumericValue = value => typeof value === 'number' || !! value;
 
 const JetpackFieldControls = ( {
 	attributes,
@@ -176,17 +179,27 @@ const JetpackFieldControls = ( {
 					initialOpen={ false }
 					colorSettings={ colorSettings }
 				/>
-				<PanelBody title={ stylesPanelTitle } initialOpen={ false }>
-					<BaseControl>
+				<ToolsPanel label={ stylesPanelTitle } panelId={ clientId }>
+					<ToolsPanelItem
+						hasValue={ () => !! attributes.fieldFontSize }
+						label={ __( 'Font Size', 'jetpack-forms' ) }
+						onDeselect={ () => setAttributes( { fieldFontSize: undefined } ) }
+						panelId={ clientId }
+					>
 						<FontSizePicker
-							withReset={ true }
 							size="__unstable-large"
 							__nextHasNoMarginBottom
 							onChange={ fieldFontSize => setAttributes( { fieldFontSize } ) }
 							value={ attributes.fieldFontSize }
 						/>
-					</BaseControl>
-					<BaseControl>
+					</ToolsPanelItem>
+
+					<ToolsPanelItem
+						hasValue={ () => hasNumericValue( attributes.lineHeight ) }
+						label={ __( 'Line Height', 'jetpack-forms' ) }
+						onDeselect={ () => setAttributes( { lineHeight: undefined } ) }
+						panelId={ clientId }
+					>
 						<LineHeightControl
 							__nextHasNoMarginBottom={ true }
 							__unstableInputWidth="100%"
@@ -194,63 +207,108 @@ const JetpackFieldControls = ( {
 							onChange={ setNumberAttribute( 'lineHeight', parseFloat ) }
 							size="__unstable-large"
 						/>
-					</BaseControl>
+					</ToolsPanelItem>
+
 					{ ( isChoicesBlock || blockStyle === 'button' ) && (
 						<>
-							<RangeControl
+							<ToolsPanelItem
+								hasValue={ () => hasNumericValue( attributes.buttonBorderWidth ) }
 								label={ __( 'Button Border Width', 'jetpack-forms' ) }
-								value={ attributes.buttonBorderWidth }
-								initialPosition={ 1 }
-								onChange={ setNumberAttribute( 'buttonBorderWidth' ) }
-								min={ 0 }
-								max={ 100 }
-								__nextHasNoMarginBottom={ true }
-							/>
-							<RangeControl
+								onDeselect={ () => setAttributes( { buttonBorderWidth: undefined } ) }
+								panelId={ clientId }
+							>
+								<RangeControl
+									label={ __( 'Button Border Width', 'jetpack-forms' ) }
+									value={ attributes.buttonBorderWidth }
+									initialPosition={ 1 }
+									onChange={ setNumberAttribute( 'buttonBorderWidth' ) }
+									min={ 0 }
+									max={ 100 }
+									__nextHasNoMarginBottom={ true }
+								/>
+							</ToolsPanelItem>
+
+							<ToolsPanelItem
+								hasValue={ () => hasNumericValue( attributes.buttonBorderRadius ) }
 								label={ __( 'Button Border Radius', 'jetpack-forms' ) }
-								value={ attributes.buttonBorderRadius }
-								initialPosition={ 0 }
-								onChange={ setNumberAttribute( 'buttonBorderRadius' ) }
-								min={ 0 }
-								max={ 100 }
-								__nextHasNoMarginBottom={ true }
-							/>
+								onDeselect={ () => setAttributes( { buttonBorderRadius: undefined } ) }
+								panelId={ clientId }
+							>
+								<RangeControl
+									label={ __( 'Button Border Radius', 'jetpack-forms' ) }
+									value={ attributes.buttonBorderRadius }
+									initialPosition={ 0 }
+									onChange={ setNumberAttribute( 'buttonBorderRadius' ) }
+									min={ 0 }
+									max={ 100 }
+									__nextHasNoMarginBottom={ true }
+								/>
+							</ToolsPanelItem>
 						</>
 					) }
+
 					{ ( ! isChoicesBlock || formStyle === FORM_STYLE.OUTLINED ) && (
 						<>
-							<RangeControl
+							<ToolsPanelItem
+								hasValue={ () => hasNumericValue( attributes.borderWidth ) }
 								label={ __( 'Border Width', 'jetpack-forms' ) }
-								value={ attributes.borderWidth }
-								initialPosition={ 1 }
-								onChange={ setNumberAttribute( 'borderWidth' ) }
-								min={ 0 }
-								max={ 100 }
-								__nextHasNoMarginBottom={ true }
-							/>
-							<RangeControl
+								onDeselect={ () => setAttributes( { borderWidth: undefined } ) }
+								panelId={ clientId }
+							>
+								<RangeControl
+									label={ __( 'Border Width', 'jetpack-forms' ) }
+									value={ attributes.borderWidth }
+									initialPosition={ 1 }
+									onChange={ setNumberAttribute( 'borderWidth' ) }
+									min={ 0 }
+									max={ 100 }
+									__nextHasNoMarginBottom={ true }
+								/>
+							</ToolsPanelItem>
+
+							<ToolsPanelItem
+								hasValue={ () => hasNumericValue( attributes.borderRadius ) }
 								label={ __( 'Border Radius', 'jetpack-forms' ) }
-								value={ attributes.borderRadius }
-								initialPosition={ 0 }
-								onChange={ setNumberAttribute( 'borderRadius' ) }
-								min={ 0 }
-								max={ 100 }
-								__nextHasNoMarginBottom={ true }
-							/>
+								onDeselect={ () => setAttributes( { borderRadius: undefined } ) }
+								panelId={ clientId }
+							>
+								<RangeControl
+									label={ __( 'Border Radius', 'jetpack-forms' ) }
+									value={ attributes.borderRadius }
+									initialPosition={ 0 }
+									onChange={ setNumberAttribute( 'borderRadius' ) }
+									min={ 0 }
+									max={ 100 }
+									__nextHasNoMarginBottom={ true }
+								/>
+							</ToolsPanelItem>
 						</>
 					) }
-				</PanelBody>
-				<PanelBody title={ __( 'Label Styles', 'jetpack-forms' ) } initialOpen={ false }>
-					<BaseControl>
+				</ToolsPanel>
+				<ToolsPanel
+					label={ __( 'Label Styles', 'jetpack-forms' ) }
+					panelId={ `${ clientId }-label` }
+				>
+					<ToolsPanelItem
+						hasValue={ () => !! attributes.labelFontSize }
+						label={ __( 'Label Font Size', 'jetpack-forms' ) }
+						onDeselect={ () => setAttributes( { labelFontSize: undefined } ) }
+						panelId={ `${ clientId }-label` }
+					>
 						<FontSizePicker
-							withReset={ true }
 							size="__unstable-large"
 							__nextHasNoMarginBottom
 							onChange={ labelFontSize => setAttributes( { labelFontSize } ) }
 							value={ attributes.labelFontSize }
 						/>
-					</BaseControl>
-					<BaseControl>
+					</ToolsPanelItem>
+
+					<ToolsPanelItem
+						hasValue={ () => hasNumericValue( attributes.labelLineHeight ) }
+						label={ __( 'Label Line Height', 'jetpack-forms' ) }
+						onDeselect={ () => setAttributes( { labelLineHeight: undefined } ) }
+						panelId={ `${ clientId }-label` }
+					>
 						<LineHeightControl
 							__unstableInputWidth="100%"
 							__nextHasNoMarginBottom={ true }
@@ -258,8 +316,8 @@ const JetpackFieldControls = ( {
 							onChange={ setNumberAttribute( 'labelLineHeight', parseFloat ) }
 							size="__unstable-large"
 						/>
-					</BaseControl>
-				</PanelBody>
+					</ToolsPanelItem>
+				</ToolsPanel>
 			</InspectorControls>
 
 			<InspectorAdvancedControls>


### PR DESCRIPTION
Fixes: https://github.com/Automattic/jetpack/issues/41205

## Proposed changes:

Replace the style PanelBody components in Jetpack Field Controls with Gutenberg's ToolsPanel components for better consistency with core UI patterns, the existing color panel, and to allow easier resetting of all controls..

#### Change breakdown

1. Migrated style controls to ToolsPanel components
    - Replaced PanelBody with ToolsPanel for field/option styles and label styles
    - Wrapped controls in ToolsPanelItem with appropriate props, removing excessive `BaseControl` wrappers as needed
2. Improved numeric value handling
    - Added `hasNumericValue` helper to ensure proper state tracking for values that can legitimately be `0`
3. Standardized reset behavior
    - Removed `withReset` prop from FontSizePicker components
    - Reset functionality is now consistently handled through the ToolsPanel menu
    - All controls can now be reset individually or as a group

## Does this pull request change what data or activity we track or use?

No changes.

## Testing instructions:

1. Add a form to a post
2. Select a field and adjust both field and label styles
3. Confirm values can be reset, both individually and via the "reset all" option in the panel dropdown
5. Ensure that no tools panel items display by default
6. After setting values switch block selections and confirm those controls with custom values are displayed by default on re-selection
7. Double check `0` values for controls like border width show as having a value i.e. after setting to zero the control still displays by default and the item in the panel menu shows it has a value

| Before | After |
|---|---|
| <img width="279" alt="Screenshot 2025-03-06 at 1 26 38 pm" src="https://github.com/user-attachments/assets/8448ee1b-3243-41f8-b495-51bcfb29c954" /> | <img width="281" alt="Screenshot 2025-03-06 at 1 26 17 pm" src="https://github.com/user-attachments/assets/90477031-1612-4dd0-95c0-debb4f8d4f46" /> |


## Demo


https://github.com/user-attachments/assets/9380bd09-e764-4b63-916e-efc7e689a3a6


