### PR TITLE
Social | Fix the share date schema for scheduled actions endpoint

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-share-date-schema-for-scheduled-action-endpoint
+++ b/projects/packages/publicize/changelog/fix-social-share-date-schema-for-scheduled-action-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social | Fix the share date schema for scheduled actions endpoint

--- a/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php
@@ -180,7 +180,7 @@ class Scheduled_Actions_Controller extends Base_Controller {
 					),
 				),
 				'timestamp'     => array(
-					'type'        => 'string',
+					'type'        => 'integer',
 					'description' => __( 'GMT/UTC Unix timestamp in seconds for the action.', 'jetpack-publicize-pkg' ),
 				),
 				'wpcom_user_id' => array(

--- a/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php
@@ -75,7 +75,18 @@ class Scheduled_Actions_Controller extends Base_Controller {
 							'type'     => 'integer',
 							'required' => true,
 						),
-						'share_date'    => array( 'type' => 'integer' ),
+						'share_date'    => array(
+							'type'        => 'integer',
+							'description' => sprintf(
+								/* translators: %s is the new field name */
+								__( 'Deprecated in favor of %s.', 'jetpack-publicize-pkg' ),
+								'timestamp'
+							),
+						),
+						'timestamp'     => array(
+							'type'        => 'integer',
+							'description' => __( 'GMT/UTC Unix timestamp in seconds for the action.', 'jetpack-publicize-pkg' ),
+						),
 					),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
@@ -97,7 +108,18 @@ class Scheduled_Actions_Controller extends Base_Controller {
 					'permission_callback' => array( $this, 'update_item_permissions_check' ),
 					'args'                => array(
 						'message'    => array( 'type' => 'string' ),
-						'share_date' => array( 'type' => 'integer' ),
+						'share_date' => array(
+							'type'        => 'integer',
+							'description' => sprintf(
+								/* translators: %s is the new field name */
+								__( 'Deprecated in favor of %s.', 'jetpack-publicize-pkg' ),
+								'timestamp'
+							),
+						),
+						'timestamp'  => array(
+							'type'        => 'integer',
+							'description' => __( 'GMT/UTC Unix timestamp in seconds for the action.', 'jetpack-publicize-pkg' ),
+						),
 					),
 				),
 				array(
@@ -151,7 +173,15 @@ class Scheduled_Actions_Controller extends Base_Controller {
 				),
 				'share_date'    => array(
 					'type'        => 'string',
-					'description' => __( 'ISO 8601 formatted date for the action.', 'jetpack-publicize-pkg' ),
+					'description' => __( 'ISO 8601 formatted date for the action.', 'jetpack-publicize-pkg' ) . ' ' . sprintf(
+						/* translators: %s is the new field name */
+						__( 'Deprecated in favor of %s.', 'jetpack-publicize-pkg' ),
+						'timestamp'
+					),
+				),
+				'timestamp'     => array(
+					'type'        => 'string',
+					'description' => __( 'GMT/UTC Unix timestamp in seconds for the action.', 'jetpack-publicize-pkg' ),
 				),
 				'wpcom_user_id' => array(
 					'type'        => 'integer',
@@ -270,9 +300,15 @@ class Scheduled_Actions_Controller extends Base_Controller {
 
 			$blog_id       = get_current_blog_id();
 			$user_id       = get_current_user_id();
-			$connection_id = $request['connection_id'];
-			$message       = $request['message'];
-			$share_date    = empty( $request['share_date'] ) ? time() : $request['share_date'];
+			$connection_id = (int) $request['connection_id'];
+			$message       = sanitize_textarea_field( $request['message'] );
+
+			$timestamp = time();
+			if ( ! empty( $request['timestamp'] ) ) {
+				$timestamp = (int) $request['timestamp'];
+			} elseif ( ! empty( $request['share_date'] ) ) { // Fallback for deprecated field.
+				$timestamp = $request['share_date']; // Calypso sends this as timestamp.
+			}
 
 			$action = array(
 				'post_id'            => $post_id,
@@ -280,7 +316,7 @@ class Scheduled_Actions_Controller extends Base_Controller {
 				'user_id'            => $user_id,
 				'connection_id'      => $connection_id,
 				'message'            => $message,
-				'scheduled_datetime' => $this->format_date_for_db( $share_date ),
+				'scheduled_datetime' => $this->format_date_for_db( $timestamp ),
 			);
 
 			$action_id = \Publicize_Actions::add_scheduled_action( $action );
@@ -385,9 +421,16 @@ class Scheduled_Actions_Controller extends Base_Controller {
 			if ( is_wp_error( $action ) ) {
 				return $action;
 			}
-			$action['message']            = ! empty( $request['message'] ) ? $request['message'] : $action['message'];
-			$action['scheduled_datetime'] = ! empty( $request['share_date'] ) ? $request['share_date'] : strtotime( $action['share_date'] );
-			$action['scheduled_datetime'] = $this->format_date_for_db( $action['scheduled_datetime'] );
+			$action['message'] = ! empty( $request['message'] ) ? sanitize_textarea_field( $request['message'] ) : $action['message'];
+
+			// Retain the original timestamp by default.
+			$timestamp = $action['timestamp'];
+			if ( ! empty( $request['timestamp'] ) ) {
+				$timestamp = (int) $request['timestamp'];
+			} elseif ( ! empty( $request['share_date'] ) ) { // Fallback for deprecated field.
+				$timestamp = strtotime( $request['share_date'] );
+			}
+			$action['scheduled_datetime'] = $this->format_date_for_db( $timestamp );
 
 			$action['publicize_scheduled_action_id'] = $action['id'];
 
@@ -490,6 +533,7 @@ class Scheduled_Actions_Controller extends Base_Controller {
 			'message'       => (string) $raw_action['message'],
 			'post_id'       => (int) $raw_action['post_id'],
 			'share_date'    => (string) $this->format_date_for_output( $raw_action['scheduled_datetime'] ),
+			'timestamp'     => strtotime( $raw_action['scheduled_datetime'] ),
 			'wpcom_user_id' => (int) $raw_action['user_id'],
 		);
 	}


### PR DESCRIPTION
Currently in the scheduled-actions endpoint, we

- Expect an ISO date string in the schema

https://github.com/Automattic/jetpack/blob/f804196908e89e6589094a035c8c1437a43de7f3/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php#L152-L155

- Use a mix of `time()` and that ISO string

https://github.com/Automattic/jetpack/blob/f804196908e89e6589094a035c8c1437a43de7f3/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php#L275

- Do the arithmetic on that string

https://github.com/Automattic/jetpack/blob/f804196908e89e6589094a035c8c1437a43de7f3/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php#L542

It will cause issues moving forward and thus we need to be consistent.

Therefore, we are adding a UTC timestamp field to the schema which is consistent for both input and output.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a `timestamp` field to the schema
* Deprecate the `share_date` field.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox
* Point your JT site and the public API to your sandbox
* Goto the editor or Social admin page
* Run the following in the browser console
```js
var day_in_seconds = 24 * 60 * 60;
// Number of seconds
var timestamp = Math.floor(new Date().getTime() / 1000) + day_in_seconds;
// Round to nearest minute
timestamp = timestamp - timestamp % 60;
// Output the UTC date
console.log({date: new Date(timestamp*1000).toUTCString()});
console.log({timestamp});
await wp.apiFetch({
    method: 'POST',
    path: 'wpcom/v2/publicize/scheduled-actions/posts/59', // <<<<<<<<<<< Update post ID here
    data: {
        message: '',
        connection_id: 25553518, // <<<<<<<<<<< Update connection_id here
        timestamp,
    }
});
```
```js
await wp.apiFetch({
    path: 'wpcom/v2/publicize/scheduled-actions'
});
```
* Confirm that the responses are as expected
* Goto `https://wordpress.com/posts/:site`
* Open the scheduled share section for the above post
* Confirm that you see the share scheduled after 24 hours
* Schedule a share from here
* Confirm that it works fine

<img width="647" alt="Screenshot 2025-03-06 at 12 41 33 PM" src="https://github.com/user-attachments/assets/0dad19ef-e08c-4cb1-85b0-f31861e9ab22" />


