### PR TITLE
Boost: Base64 encode critical CSS payload

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-context/critical-css-context-provider.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-context/critical-css-context-provider.tsx
@@ -117,7 +117,13 @@ export function useLocalCriticalCssGenerator() {
 					},
 
 					setProviderCss: ( key: string, css: string ) => {
-						return setProviderCssAction.mutateAsync( { key, css } );
+						return setProviderCssAction.mutateAsync( {
+							key,
+							// Avoid WAF pitfalls as firewalls can block critical CSS due to them including `<svg xmlns`
+							// See 9566-gh-Automattic/jpop-issues
+							css: btoa( css ),
+							isBase64Encoded: true,
+						} );
 					},
 
 					setProviderErrors: ( key: string, errors: CriticalCssErrorDetails[] ) =>

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/critical-css-state.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/critical-css-state.ts
@@ -129,6 +129,7 @@ export function useSetProviderCssAction() {
 		z.object( {
 			key: z.string(),
 			css: z.string(),
+			isBase64Encoded: z.boolean().optional(),
 		} )
 	);
 }

--- a/projects/plugins/boost/app/lib/critical-css/data-sync-actions/Set_Provider_CSS.php
+++ b/projects/plugins/boost/app/lib/critical-css/data-sync-actions/Set_Provider_CSS.php
@@ -31,6 +31,11 @@ class Set_Provider_CSS implements Data_Sync_Action {
 		$provider_key = sanitize_key( $data['key'] );
 		$css          = $data['css'];
 
+		if ( $data['isBase64Encoded'] ) {
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+			$css = base64_decode( $css );
+		}
+
 		$storage = new Critical_CSS_Storage();
 		$storage->store_css( $provider_key, $css );
 

--- a/projects/plugins/boost/app/lib/critical-css/data-sync/Data_Sync_Setup.php
+++ b/projects/plugins/boost/app/lib/critical-css/data-sync/Data_Sync_Setup.php
@@ -86,8 +86,9 @@ class Data_Sync_Schema {
 	public static function critical_css_set_provider() {
 		return Schema::as_assoc_array(
 			array(
-				'key' => Schema::as_string(),
-				'css' => Schema::as_string(),
+				'key'             => Schema::as_string(),
+				'css'             => Schema::as_string(),
+				'isBase64Encoded' => Schema::as_boolean()->fallback( false ),
 			)
 		);
 	}

--- a/projects/plugins/boost/changelog/fix-critical-css-waf-issue
+++ b/projects/plugins/boost/changelog/fix-critical-css-waf-issue
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Critical CSS: Implement a workaround for WAS interfearing with critical CSS.
+Critical CSS: Implement a workaround for WAF interfering with critical CSS.

--- a/projects/plugins/boost/changelog/fix-critical-css-waf-issue
+++ b/projects/plugins/boost/changelog/fix-critical-css-waf-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Critical CSS: Implement a workaround for WAS interfearing with critical CSS.


### PR DESCRIPTION
Related to Automattic/jpop-issues#9566

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Base64 encode critical CSS payload.

Critical CSS can often contain inline SVG elements. As a result, it can contain string like `<svg xmlns`. However, WAFs may block this string, resulting in blocking the request. To avoid this, the generated critical CSS is now base64 encoded.

However, critical CSS will still accept non-encoding data for backward compatibility with cloud CSS.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Open Network tab of your browser devtools.
* Look for a request to `<domain>/wp-json/jetpack-boost-ds/critical-css-state/action/set-provider-css`
* Ensure the payload is base64 encoded like below.
![image](https://github.com/user-attachments/assets/ad5b1dae-66ec-4707-ae7c-53cfe74e06f6)

* After generation finishes, go to the front-end of the site and check `style#jetpack-boost-critical-css` to make sure it displays decoded text.

