### PR TITLE
Repo Gardening: do not add label to assigned issues

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/rm-repo-gardening-assignment-progress-label
+++ b/projects/github-actions/repo-gardening/changelog/rm-repo-gardening-assignment-progress-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Issue Assignment: stop adding the "[Status] In Progress" label to issues when a PR is opened to close that issue.

--- a/projects/github-actions/repo-gardening/src/tasks/assign-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/assign-issues/index.js
@@ -24,15 +24,6 @@ async function assignIssues( payload, octokit ) {
 			issue_number: +issue,
 			assignees: [ payload.pull_request.user.login ],
 		} );
-
-		debug( `assign-issues: Applying '[Status] In Progress' label to issue #${ issue }` );
-
-		await octokit.rest.issues.addLabels( {
-			owner: payload.repository.owner.login,
-			repo: payload.repository.name,
-			issue_number: +issue,
-			labels: [ '[Status] In Progress' ],
-		} );
 	}
 }
 

--- a/projects/github-actions/repo-gardening/src/tasks/assign-issues/readme.md
+++ b/projects/github-actions/repo-gardening/src/tasks/assign-issues/readme.md
@@ -1,6 +1,6 @@
 # Assign Issues
 
-Adds assignee for issues which are being worked on, and adds the "[Status] In Progress" label.
+Adds assignee for issues which are being worked on.
 
 ## Rationale
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/studio/issues/1012

## Proposed changes:

Until now, when a PR was opened to close a specific issue, the assignIssues task did 2 things:

1. Assign the issue to the person working on the PR, to indicate to everyone following the issue that it is being worked on, and to hold the person opening the PR accountable.
2. Add the "[Status] In Progress" label to indicate that the issue is being worked on.

With the GitHub UI improvements in the past few years, PRs opened to close a specific issue are a lot more visible than they once were. The "In Progress" label is consequently not that useful anymore. Let's remove it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* https://github.com/Automattic/studio/issues/1012 
* p1741202034661009-slack-C06DRMD6VPZd

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Merge this PR into your `trunk` branch locally, and push that version of `trunk` to a fork of this repo.
* Create an issue in your fork.
* Open a PR that makes a change, and includes "Fixes #xxx" in the PR description.
* Observe that you get automatically assigned to the issue, **but no progress label is added**.
