### PR TITLE
Forms: Prevent custom label font size from preventing scaling in animated and outline block styles

### DIFF
--- a/projects/packages/forms/changelog/fix-relative-font-sizes-for-form-block-styles
+++ b/projects/packages/forms/changelog/fix-relative-font-sizes-for-form-block-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Prevent custom label font sizes preventing animated label font size reduction

--- a/projects/packages/forms/src/blocks/contact-form/components/use-jetpack-field-styles.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/use-jetpack-field-styles.js
@@ -27,8 +27,8 @@ export const useJetpackFieldStyles = attributes => {
 
 	const labelStyle = {
 		color: attributes.labelColor,
-		fontSize: attributes.labelFontSize,
 		lineHeight: attributes.labelLineHeight,
+		'--jetpack--contact-form--label--font-size': attributes.labelFontSize,
 	};
 
 	const fieldStyle = {

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -942,3 +942,13 @@
 .block-editor-block-inspector .components-base-control .components-base-control:last-child {
 	margin-bottom: 0;
 }
+
+.is-style-outlined .jetpack-field.is-selected .notched-label__label[style*="font-size"] > *,
+.is-style-outlined .jetpack-field.has-placeholder .notched-label__label[style*="font-size"] > * {
+    font-size: 0.8em;
+}
+
+.is-style-animated .jetpack-field.is-selected .animated-label__label[style*="font-size"] > *,
+.is-style-animated .jetpack-field.has-placeholder .animated-label__label[style*="font-size"] > * {
+    font-size: 0.75em;
+}

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -289,6 +289,10 @@
 	.components-toggle-control .components-base-control__field {
 		margin-bottom: 0;
 	}
+
+	&[style*="--jetpack--contact-form--label--font-size"] {
+		font-size: var(--jetpack--contact-form--label--font-size);
+	}
 }
 
 .jetpack-field-label__input {
@@ -943,12 +947,12 @@
 	margin-bottom: 0;
 }
 
-.is-style-outlined .jetpack-field.is-selected .notched-label__label[style*="font-size"] > *,
-.is-style-outlined .jetpack-field.has-placeholder .notched-label__label[style*="font-size"] > * {
-    font-size: 0.8em;
+.is-style-outlined .jetpack-field.is-selected .notched-label__label[style*="--jetpack--contact-form--label--font-size"],
+.is-style-outlined .jetpack-field.has-placeholder .notched-label__label[style*="--jetpack--contact-form--label--font-size"] {
+    font-size: calc(var(--jetpack--contact-form--label--font-size) * 0.8);
 }
 
-.is-style-animated .jetpack-field.is-selected .animated-label__label[style*="font-size"] > *,
-.is-style-animated .jetpack-field.has-placeholder .animated-label__label[style*="font-size"] > * {
-    font-size: 0.75em;
+.is-style-animated .jetpack-field.is-selected .animated-label__label[style*="--jetpack--contact-form--label--font-size"],
+.is-style-animated .jetpack-field.has-placeholder .animated-label__label[style*="--jetpack--contact-form--label--font-size"] {
+    font-size: calc(var(--jetpack--contact-form--label--font-size) * 0.75);
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -347,7 +347,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$this->label_styles .= 'color: ' . esc_attr( $this->get_attribute( 'labelcolor' ) ) . ';';
 		}
 		if ( ! empty( $this->get_attribute( 'labelfontsize' ) ) ) {
-			$this->label_styles .= 'font-size: ' . esc_attr( $this->get_attribute( 'labelfontsize' ) ) . ';';
+			$this->label_styles .= '--jetpack--contact-form--label--font-size:' . esc_attr( $this->get_attribute( 'labelfontsize' ) ) . ';';
 		}
 		if ( is_numeric( $this->get_attribute( 'labellineheight' ) ) ) {
 			$this->label_styles .= 'line-height: ' . (int) $this->get_attribute( 'labellineheight' ) . ';';

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -107,6 +107,10 @@
 	flex: 1;
 }
 
+.contact-form label[style*="--jetpack--contact-form--label--font-size"] {
+	font-size: var(--jetpack--contact-form--label--font-size);
+}
+
 .contact-form .grunion-checkbox-multiple-options,
 .contact-form .grunion-radio-options {
 	display: flex;
@@ -522,13 +526,14 @@ on production builds, the attributes are being reordered, causing side-effects
 	font-size: 0.8em;
 }
 
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:focus ~ .notched-label .notched-label__label[style*="font-size"] > *,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:not(:placeholder-shown) ~ .notched-label .notched-label__label[style*="font-size"] > *,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-field.has-placeholder ~ .notched-label .notched-label__label[style*="font-size"] > *,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options ~ .notched-label .notched-label__label[style*="font-size"] > *,
-.contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options ~ .notched-label .notched-label__label[style*="font-size"] > *,
-.contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .notched-label__label[style*="font-size"] > * {
-    font-size: 0.8em;
+/* The following is scoped by the presence of the custom font size CSS var to avoid needing conditional fallback within the var() */
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:focus ~ .notched-label .notched-label__label[style*="--jetpack--contact-form--label--font-size"],
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:not(:placeholder-shown) ~ .notched-label .notched-label__label[style*="--jetpack--contact-form--label--font-size"],
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field.has-placeholder ~ .notched-label .notched-label__label[style*="--jetpack--contact-form--label--font-size"],
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options ~ .notched-label .notched-label__label[style*="--jetpack--contact-form--label--font-size"],
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options ~ .notched-label .notched-label__label[style*="--jetpack--contact-form--label--font-size"],
+.contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .notched-label__label[style*="--jetpack--contact-form--label--font-size"] {
+	font-size: calc(var(--jetpack--contact-form--label--font-size) * 0.8);
 }
 
 .contact-form .is-style-outlined .grunion-field-wrap > input,
@@ -599,11 +604,12 @@ on production builds, the attributes are being reordered, causing side-effects
 	top: calc(2px + var(--jetpack--contact-form--border-size));
 }
 
-.contact-form .is-style-animated .grunion-field-wrap .grunion-field:focus ~ .animated-label__label[style*="font-size"] > *,
-.contact-form .is-style-animated .grunion-field-wrap .grunion-field:not(:placeholder-shown) ~ .animated-label__label[style*="font-size"] > *,
-.contact-form .is-style-animated .grunion-field-wrap .grunion-field.has-placeholder ~ .animated-label__label[style*="font-size"] > *,
-.contact-form .is-style-animated .grunion-field-wrap.grunion-field-select-wrap .animated-label__label[style*="font-size"] > * {
-    font-size: 0.75em;
+/* The following is scoped by the presence of the custom font size CSS var to avoid needing conditional fallback within the var() */
+.contact-form .is-style-animated .grunion-field-wrap .grunion-field:focus ~ .animated-label__label[style*="--jetpack--contact-form--label--font-size"],
+.contact-form .is-style-animated .grunion-field-wrap .grunion-field:not(:placeholder-shown) ~ .animated-label__label[style*="--jetpack--contact-form--label--font-size"],
+.contact-form .is-style-animated .grunion-field-wrap .grunion-field.has-placeholder ~ .animated-label__label[style*="--jetpack--contact-form--label--font-size"],
+.contact-form .is-style-animated .grunion-field-wrap.grunion-field-select-wrap .animated-label__label[style*="--jetpack--contact-form--label--font-size"] {
+	font-size: calc(var(--jetpack--contact-form--label--font-size) * 0.75);
 }
 
 .contact-form .is-style-animated .grunion-field-wrap .grunion-checkbox-multiple-options ~ .animated-label__label,

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -522,6 +522,15 @@ on production builds, the attributes are being reordered, causing side-effects
 	font-size: 0.8em;
 }
 
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:focus ~ .notched-label .notched-label__label[style*="font-size"] > *,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:not(:placeholder-shown) ~ .notched-label .notched-label__label[style*="font-size"] > *,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field.has-placeholder ~ .notched-label .notched-label__label[style*="font-size"] > *,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options ~ .notched-label .notched-label__label[style*="font-size"] > *,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options ~ .notched-label .notched-label__label[style*="font-size"] > *,
+.contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .notched-label__label[style*="font-size"] > * {
+    font-size: 0.8em;
+}
+
 .contact-form .is-style-outlined .grunion-field-wrap > input,
 .contact-form .is-style-outlined .grunion-field-wrap > textarea,
 .contact-form .is-style-outlined .grunion-field-wrap select
@@ -588,6 +597,13 @@ on production builds, the attributes are being reordered, causing side-effects
 	font-size: 0.75em;
 	transform: translateY(0);
 	top: calc(2px + var(--jetpack--contact-form--border-size));
+}
+
+.contact-form .is-style-animated .grunion-field-wrap .grunion-field:focus ~ .animated-label__label[style*="font-size"] > *,
+.contact-form .is-style-animated .grunion-field-wrap .grunion-field:not(:placeholder-shown) ~ .animated-label__label[style*="font-size"] > *,
+.contact-form .is-style-animated .grunion-field-wrap .grunion-field.has-placeholder ~ .animated-label__label[style*="font-size"] > *,
+.contact-form .is-style-animated .grunion-field-wrap.grunion-field-select-wrap .animated-label__label[style*="font-size"] > * {
+    font-size: 0.75em;
 }
 
 .contact-form .is-style-animated .grunion-field-wrap .grunion-checkbox-multiple-options ~ .animated-label__label,


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/28881

## Proposed changes:

When a custom font size is applied to form field labels in Jetpack Forms, it currently overrides the font size reduction that occurs when using the "Outlined" or "Animated" block styles. This PR fixes that by leveraging a new CSS custom property applied to the label.

### How the proposed changes work

1. Replaces current inline `font-size` style with new CSS var `--jetpack--contact-form--label--font-size`
2. Adds default styles to use the CSS var for the font size when it is available
3. Adds new styles to scale the font size defined by `--jetpack--contact-form--label--font-size` for the animated and outlined block styles
4. New styles will only take effect when the custom font size is set by the CSS var allowing previous styling to continue otherwise

### Alternative approach considered

**Targeting inner elements**

This was the slightly cleaner and less risky option until the discrepancy between the markup in the editor and frontend was [highlighted](https://github.com/Automattic/jetpack/pull/42248#pullrequestreview-2665840783).

My understanding is the editor has different markup as the label and required text need to be edited separately, so are siblings. On the frontend, the desire was for the label and required text to become a single string label for accessibility.

## Does this pull request change what data or activity we track or use?

No changes.

## Testing instructions:

1. Add a contact form to a post and select it
2. Apply either the animated or outlined block style
3. Click into one of the form fields on the canvas and note the label font size reduces as it is repositioned
4. Apply a custom label font size to the field.
5. Confirm the label font size is scaled down appropriately both when field is selected or has a placeholder
6. Double check the label font sizes are as expected on the frontend
8. Test out other form field types e.g. checkboxes etc.

**⚠️ Note: There is a discrepancy with the field heights between the editor and frontend as well.** 
- This is present on trunk for all form block styles including the default
- It is caused by inconsistent padding
- The editor is the more visually pleasing to my eye but making the frontend match could be a breaking change
- Removing the padding from the editor might make interacting with the fields more difficult
- I'll create a separate follow-up issue for this and give design a chance to way in
- This doesn't need to block fixing the font size scaling for animated/outlined block styles.

## Demo

https://github.com/user-attachments/assets/d83b2d44-468b-4872-87c2-bc173724a66b


