### PR TITLE
Boost: Delete static minification option on atomic

### DIFF
--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -159,12 +159,16 @@ class Jetpack_Boost {
 
 		update_option( 'jetpack_boost_version', JETPACK_BOOST_VERSION );
 
-		if ( jetpack_boost_minify_is_enabled() ) {
-			$setup_404_tester = Boost_Admin_Config::get_hosting_provider() !== 'atomic' && Boost_Admin_Config::get_hosting_provider() !== 'woa';
+		$is_atomic = Boost_Admin_Config::get_hosting_provider() === 'atomic';
+		$is_woa    = Boost_Admin_Config::get_hosting_provider() === 'woa';
+		if ( $is_atomic || $is_woa ) {
+			delete_site_option( 'jetpack_boost_static_minification' );
+		}
 
+		if ( jetpack_boost_minify_is_enabled() ) {
 			// We need to clear Minify scheduled events to ensure the latest scheduled jobs are only scheduled irrespective of scheduled arguments.
 			jetpack_boost_minify_clear_scheduled_events();
-			jetpack_boost_minify_activation( $setup_404_tester );
+			jetpack_boost_minify_activation( ! $is_atomic && ! $is_woa );
 		}
 	}
 

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -162,6 +162,7 @@ class Jetpack_Boost {
 		$is_atomic = Boost_Admin_Config::get_hosting_provider() === 'atomic';
 		$is_woa    = Boost_Admin_Config::get_hosting_provider() === 'woa';
 		if ( $is_atomic || $is_woa ) {
+			// Remove this option to prevent the notice from showing up.
 			delete_site_option( 'jetpack_boost_static_minification' );
 		}
 

--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -107,13 +107,15 @@ add_action( 'jetpack_boost_404_tester_cron', 'jetpack_boost_404_tester' );
  * @param bool $setup_404_tester Whether to setup the 404 tester or not.
  */
 function jetpack_boost_404_setup( $setup_404_tester = true ) {
+	if ( ! $setup_404_tester ) {
+		return;
+	}
+
 	if ( is_admin() && get_site_option( 'jetpack_boost_static_minification', 'na' ) === 'na' ) {
 		update_site_option( 'jetpack_boost_static_minification', 0 ); // Add a default value if not set to avoid an extra SQL query.
 	}
 
-	if ( $setup_404_tester ) {
-		jetpack_boost_page_optimize_schedule_404_tester();
-	}
+	jetpack_boost_page_optimize_schedule_404_tester();
 }
 
 /**

--- a/projects/plugins/boost/changelog/fix-boost-atomic-clear-minification-option
+++ b/projects/plugins/boost/changelog/fix-boost-atomic-clear-minification-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix for unreleased update.


### PR DESCRIPTION
## Proposed changes:

* On plugin update, delete static notification option, to prevent the "Serve static concatenate notice" from showing.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1741256084040749/1741178339.776799-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

You need an atomic site running 3.9.0 with Concatenate JS or CSS running.

- Update to this version and make sure you don't see this notice:

![image](https://github.com/user-attachments/assets/e66f6f2f-2eb4-4a7e-bced-413d81d065e7)
