### PR TITLE
Social: Clean up the MessageBoxControl component

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-clean-up-message-box
+++ b/projects/js-packages/publicize-components/changelog/update-social-clean-up-message-box
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Cleaned up the MessageBoxControl component

--- a/projects/js-packages/publicize-components/src/components/form/share-post-form.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/share-post-form.tsx
@@ -7,7 +7,11 @@ import MessageBoxControl from '../message-box-control';
 import styles from './styles.module.scss';
 
 type SharePostFormProps = {
-	analyticsData?: object;
+	/** Data for tracking analytics */
+	analyticsData?: {
+		/** The location of the analytics event */
+		location: string;
+	};
 };
 
 /**

--- a/projects/js-packages/publicize-components/src/components/form/share-post-form.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/share-post-form.tsx
@@ -1,4 +1,5 @@
 import { siteHasFeature } from '@automattic/jetpack-script-data';
+import { __ } from '@wordpress/i18n';
 import useSocialMediaMessage from '../../hooks/use-social-media-message';
 import { features } from '../../utils/constants';
 import { useIsSocialNote } from '../../utils/use-is-social-note';
@@ -28,6 +29,7 @@ export const SharePostForm: React.FC< SharePostFormProps > = ( { analyticsData =
 		<>
 			{ ! isSocialNote && (
 				<MessageBoxControl
+					label={ __( 'Message', 'jetpack-publicize-components' ) }
 					maxLength={ maxLength }
 					onChange={ updateMessage }
 					message={ message }

--- a/projects/js-packages/publicize-components/src/components/message-box-control/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/message-box-control/index.tsx
@@ -3,25 +3,54 @@ import { TextareaControl } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useCallback, useRef } from 'react';
 
+export const PLACEHOLDER_TEXT = __(
+	'Write a custom message for your social audience here. This message will override your social post content.',
+	'jetpack-publicize-components'
+);
+export const DEFAULT_LABEL = __( 'Message', 'jetpack-publicize-components' );
+
+export type MessageBoxControlProps = {
+	/** The label for the message box */
+	label?: string;
+
+	/** The placeholder text for the message box */
+	placeholder?: string;
+
+	/** The message to display */
+	message: string;
+
+	/** Callback to invoke as the message changes */
+	onChange: ( message: string ) => void;
+
+	/** Whether the control is disabled */
+	disabled?: boolean;
+
+	/** The maximum character length of the message */
+	maxLength: number;
+
+	/** Data for tracking analytics */
+	analyticsData?: {
+		/** The location of the analytics event */
+		location: string;
+	};
+};
+
 /**
  * Wrapper around a textbox to restrict the number of characters and
  * display how many are remaining.
  *
- * @param {object}   props               - The component's props.
- * @param {string}   props.message       - The message to display.
- * @param {Function} props.onChange      - Callback to invoke as the message changes.
- * @param {boolean}  [props.disabled]    - Whether the control is disabled.
- * @param {number}   props.maxLength     - The maximum character length of the message.
- * @param {object}   props.analyticsData - Data for tracking analytics.
+ * @param {MessageBoxControlProps} props - The component's props.
  * @return {object} The message box component.
  */
 export default function MessageBoxControl( {
+	label = DEFAULT_LABEL,
+	placeholder = PLACEHOLDER_TEXT,
 	message = '',
 	onChange,
 	disabled,
 	maxLength,
 	analyticsData = null,
-} ) {
+}: MessageBoxControlProps ) {
 	const { recordEvent } = useAnalytics();
 	const isFirstChange = useRef( true );
 
@@ -41,14 +70,11 @@ export default function MessageBoxControl( {
 	return (
 		<TextareaControl
 			value={ message }
-			label={ __( 'Message', 'jetpack-publicize-components' ) }
+			label={ label }
 			onChange={ handleChange }
 			disabled={ disabled }
 			maxLength={ maxLength }
-			placeholder={ __(
-				'Write a custom message for your social audience here. This message will override your social post content.',
-				'jetpack-publicize-components'
-			) }
+			placeholder={ placeholder }
 			rows={ 4 }
 			help={ sprintf(
 				/* translators: placeholder is a number. */

--- a/projects/js-packages/publicize-components/src/components/message-box-control/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/message-box-control/index.tsx
@@ -13,7 +13,7 @@ export const getDefaultLabel = () => __( 'Message', 'jetpack-publicize-component
 
 export type MessageBoxControlProps = {
 	/** The label for the message box */
-	label?: string;
+	label: string;
 
 	/** The placeholder text for the message box */
 	placeholder?: string;

--- a/projects/js-packages/publicize-components/src/components/message-box-control/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/message-box-control/index.tsx
@@ -3,11 +3,13 @@ import { TextareaControl } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useCallback, useRef } from 'react';
 
-export const PLACEHOLDER_TEXT = __(
-	'Write a custom message for your social audience here. This message will override your social post content.',
-	'jetpack-publicize-components'
-);
-export const DEFAULT_LABEL = __( 'Message', 'jetpack-publicize-components' );
+export const getPlaceholderText = () =>
+	__(
+		'Write a custom message for your social audience here. This message will override your social post content.',
+		'jetpack-publicize-components'
+	);
+
+export const getDefaultLabel = () => __( 'Message', 'jetpack-publicize-components' );
 
 export type MessageBoxControlProps = {
 	/** The label for the message box */
@@ -43,8 +45,8 @@ export type MessageBoxControlProps = {
  * @return {object} The message box component.
  */
 export default function MessageBoxControl( {
-	label = DEFAULT_LABEL,
-	placeholder = PLACEHOLDER_TEXT,
+	label = getDefaultLabel(),
+	placeholder = getPlaceholderText(),
 	message = '',
 	onChange,
 	disabled,

--- a/projects/js-packages/publicize-components/src/components/message-box-control/stories/index.stories.tsx
+++ b/projects/js-packages/publicize-components/src/components/message-box-control/stories/index.stories.tsx
@@ -1,0 +1,85 @@
+/* istanbul ignore file -- Ignore code coverage */
+import { useCallback, useState } from '@wordpress/element';
+import MessageBoxControl, { MessageBoxControlProps } from '../';
+import type { StoryFn, Meta } from '@storybook/react';
+
+export default {
+	title: 'JS Packages/Publicize Components/Message Box Control',
+	component: MessageBoxControl,
+	argTypes: {
+		onChange: { action: 'changed' },
+		maxLength: {
+			control: { type: 'number', min: 10, max: 500 },
+		},
+		disabled: {
+			control: 'boolean',
+		},
+		analyticsData: {
+			control: 'object',
+		},
+		label: {
+			control: 'text',
+		},
+		placeholder: {
+			control: 'text',
+		},
+	},
+} satisfies Meta< typeof MessageBoxControl >;
+
+const Template: StoryFn< typeof MessageBoxControl > = ( args: MessageBoxControlProps ) => {
+	const [ message, setMessage ] = useState( args.message );
+
+	const handleChange = useCallback(
+		( newMessage: string ) => {
+			setMessage( newMessage );
+			args.onChange( newMessage );
+		},
+		[ args ]
+	);
+
+	return (
+		<MessageBoxControl
+			message={ message }
+			onChange={ handleChange }
+			disabled={ args.disabled }
+			maxLength={ args.maxLength }
+			analyticsData={ args.analyticsData }
+			label={ args.label }
+			placeholder={ args.placeholder }
+		/>
+	);
+};
+
+const DefaultArgs = {
+	message: 'Check out my latest blog post!',
+	maxLength: 280,
+	disabled: false,
+	analyticsData: { location: 'storybook' },
+};
+
+// Export Default story
+export const Default = Template.bind( {} );
+Default.args = DefaultArgs;
+
+// Empty state
+export const Empty = Template.bind( {} );
+Empty.args = {
+	...DefaultArgs,
+	message: '',
+};
+
+// Disabled state
+export const Disabled = Template.bind( {} );
+Disabled.args = {
+	...DefaultArgs,
+	disabled: true,
+};
+
+// Custom Label and Placeholder
+export const CustomLabels = Template.bind( {} );
+CustomLabels.args = {
+	...DefaultArgs,
+	message: '',
+	label: 'Custom Social Message',
+	placeholder: 'Type your personalized social media post here...',
+};

--- a/projects/js-packages/publicize-components/src/components/message-box-control/tests/index.test.js
+++ b/projects/js-packages/publicize-components/src/components/message-box-control/tests/index.test.js
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import MessageBoxControl, { DEFAULT_LABEL, PLACEHOLDER_TEXT } from '../';
+import MessageBoxControl, { getDefaultLabel, getPlaceholderText } from '../';
 
 const mockRecordEvent = jest.fn();
 jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
@@ -28,7 +28,7 @@ describe( 'MessageBoxControl', () => {
 			/>
 		);
 
-		expect( screen.getByLabelText( DEFAULT_LABEL ) ).toHaveValue( mockMessage );
+		expect( screen.getByLabelText( getDefaultLabel() ) ).toHaveValue( mockMessage );
 	} );
 
 	it( 'displays correct remaining character count', () => {
@@ -53,7 +53,7 @@ describe( 'MessageBoxControl', () => {
 			/>
 		);
 
-		const textArea = screen.getByLabelText( DEFAULT_LABEL );
+		const textArea = screen.getByLabelText( getDefaultLabel() );
 		await userEvent.type( textArea, ' additional text' );
 
 		expect( mockOnChange ).toHaveBeenCalled();
@@ -69,7 +69,7 @@ describe( 'MessageBoxControl', () => {
 			/>
 		);
 
-		const textArea = screen.getByLabelText( DEFAULT_LABEL );
+		const textArea = screen.getByLabelText( getDefaultLabel() );
 		await userEvent.type( textArea, ' first change' );
 		await userEvent.type( textArea, ' second change' );
 
@@ -89,7 +89,7 @@ describe( 'MessageBoxControl', () => {
 			/>
 		);
 
-		const textArea = screen.getByLabelText( DEFAULT_LABEL );
+		const textArea = screen.getByLabelText( getDefaultLabel() );
 		await userEvent.type( textArea, ' additional text' );
 
 		expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_social_custom_message_changed', null );
@@ -105,7 +105,7 @@ describe( 'MessageBoxControl', () => {
 			/>
 		);
 
-		expect( screen.getByLabelText( DEFAULT_LABEL ) ).toBeDisabled();
+		expect( screen.getByLabelText( getDefaultLabel() ) ).toBeDisabled();
 	} );
 
 	it( 'enforces maxLength character limit', () => {
@@ -118,7 +118,7 @@ describe( 'MessageBoxControl', () => {
 			/>
 		);
 
-		const textArea = screen.getByLabelText( DEFAULT_LABEL );
+		const textArea = screen.getByLabelText( getDefaultLabel() );
 		expect( textArea ).toHaveAttribute( 'maxLength', shortMaxLength.toString() );
 	} );
 
@@ -127,7 +127,7 @@ describe( 'MessageBoxControl', () => {
 			<MessageBoxControl message="" onChange={ mockOnChange } maxLength={ mockMaxLength } />
 		);
 
-		const textArea = screen.getByPlaceholderText( PLACEHOLDER_TEXT );
+		const textArea = screen.getByPlaceholderText( getPlaceholderText() );
 		expect( textArea ).toBeInTheDocument();
 	} );
 } );

--- a/projects/js-packages/publicize-components/src/components/message-box-control/tests/index.test.js
+++ b/projects/js-packages/publicize-components/src/components/message-box-control/tests/index.test.js
@@ -1,0 +1,133 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MessageBoxControl, { DEFAULT_LABEL, PLACEHOLDER_TEXT } from '../';
+
+const mockRecordEvent = jest.fn();
+jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
+	useAnalytics: () => ( {
+		recordEvent: mockRecordEvent,
+	} ),
+} ) );
+
+describe( 'MessageBoxControl', () => {
+	const mockOnChange = jest.fn();
+	const mockMessage = 'Test message';
+	const mockMaxLength = 100;
+	const mockAnalyticsData = { location: 'test-location' };
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders with the provided message', () => {
+		render(
+			<MessageBoxControl
+				message={ mockMessage }
+				onChange={ mockOnChange }
+				maxLength={ mockMaxLength }
+			/>
+		);
+
+		expect( screen.getByLabelText( DEFAULT_LABEL ) ).toHaveValue( mockMessage );
+	} );
+
+	it( 'displays correct remaining character count', () => {
+		render(
+			<MessageBoxControl
+				message={ mockMessage }
+				onChange={ mockOnChange }
+				maxLength={ mockMaxLength }
+			/>
+		);
+
+		const remainingChars = mockMaxLength - mockMessage.length;
+		expect( screen.getByText( `${ remainingChars } characters remaining` ) ).toBeInTheDocument();
+	} );
+
+	it( 'calls onChange when text is modified', async () => {
+		render(
+			<MessageBoxControl
+				message={ mockMessage }
+				onChange={ mockOnChange }
+				maxLength={ mockMaxLength }
+			/>
+		);
+
+		const textArea = screen.getByLabelText( DEFAULT_LABEL );
+		await userEvent.type( textArea, ' additional text' );
+
+		expect( mockOnChange ).toHaveBeenCalled();
+	} );
+
+	it( 'records analytics event on first change only', async () => {
+		render(
+			<MessageBoxControl
+				message={ mockMessage }
+				onChange={ mockOnChange }
+				maxLength={ mockMaxLength }
+				analyticsData={ mockAnalyticsData }
+			/>
+		);
+
+		const textArea = screen.getByLabelText( DEFAULT_LABEL );
+		await userEvent.type( textArea, ' first change' );
+		await userEvent.type( textArea, ' second change' );
+
+		expect( mockRecordEvent ).toHaveBeenCalledTimes( 1 );
+		expect( mockRecordEvent ).toHaveBeenCalledWith(
+			'jetpack_social_custom_message_changed',
+			mockAnalyticsData
+		);
+	} );
+
+	it( 'does record analytics event when analyticsData is null', async () => {
+		render(
+			<MessageBoxControl
+				message={ mockMessage }
+				onChange={ mockOnChange }
+				maxLength={ mockMaxLength }
+			/>
+		);
+
+		const textArea = screen.getByLabelText( DEFAULT_LABEL );
+		await userEvent.type( textArea, ' additional text' );
+
+		expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_social_custom_message_changed', null );
+	} );
+
+	it( 'disables the textarea when disabled prop is true', () => {
+		render(
+			<MessageBoxControl
+				message={ mockMessage }
+				onChange={ mockOnChange }
+				maxLength={ mockMaxLength }
+				disabled={ true }
+			/>
+		);
+
+		expect( screen.getByLabelText( DEFAULT_LABEL ) ).toBeDisabled();
+	} );
+
+	it( 'enforces maxLength character limit', () => {
+		const shortMaxLength = 15;
+		render(
+			<MessageBoxControl
+				message={ mockMessage }
+				onChange={ mockOnChange }
+				maxLength={ shortMaxLength }
+			/>
+		);
+
+		const textArea = screen.getByLabelText( DEFAULT_LABEL );
+		expect( textArea ).toHaveAttribute( 'maxLength', shortMaxLength.toString() );
+	} );
+
+	it( 'shows correct placeholder text', () => {
+		render(
+			<MessageBoxControl message="" onChange={ mockOnChange } maxLength={ mockMaxLength } />
+		);
+
+		const textArea = screen.getByPlaceholderText( PLACEHOLDER_TEXT );
+		expect( textArea ).toBeInTheDocument();
+	} );
+} );

--- a/projects/js-packages/publicize-components/src/hooks/use-social-media-message/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-social-media-message/index.js
@@ -3,9 +3,9 @@ import { usePostMeta } from '../use-post-meta';
 
 /**
  * @typedef {object} MessageHook
- * @property {string}   message       - The text of the message.
- * @property {number}   maxLength     - The maximum length of the message.
- * @property {Function} updateMessage - Callback used to update the message.
+ * @property {string}                      message       - The text of the message.
+ * @property {number}                      maxLength     - The maximum length of the message.
+ * @property {( message: string ) => void} updateMessage - Callback used to update the message.
  */
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/830

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Cleaned up the MessageBoxControl component and made it purer by extracting props -- e38bb8a7f485bad8306f8ad1a9c48ea553fc8163
* Added unit tests -- 34d5a7a8b73d54662b71895e46a1a6130db8d80a
* Added story -- d200eb65347ad7e8b12c9c39f429d1432cf255d0

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `pnpm -F @automattic/jetpack-storybook storybook:dev`
* In the Storybook playground, goto JS Packages  > Publicize Components > Message Box Control
* Check that they work as expected
* Make sure the unit tests pass - CI does it
* Sanity check that the Message box component works as before in the editor

![CleanShot 2025-03-06 at 15 00 22 png](https://github.com/user-attachments/assets/460a598b-9548-4c6f-a4e2-44f42dbb9ff2)