### PR TITLE
Include Business sites in Classic Search

### DIFF
--- a/projects/plugins/wpcomsh/changelog/Add business sites to Classic Search
+++ b/projects/plugins/wpcomsh/changelog/Add business sites to Classic Search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add business sites back to Classic Search, essentially reverting an old change. This is because until we actually support business sites on Instant Search, we need to keep supporting Classic Search.

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -578,7 +578,7 @@ class WPCOM_Features {
 			self::WPCOM_PRO_PLANS,
 		),
 		self::CLASSIC_SEARCH                    => array(
-			self::WPCOM_WOOEXPRESS_PLANS,
+			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
 			self::WPCOM_PRO_PLANS,
 			self::JETPACK_SEARCH_PLANS,
 			self::JETPACK_COMPLETE_PLANS,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [#42227](https://github.com/Automattic/jetpack/issues/42227)

## Proposed changes:
We recently removed the business plans from Classic Search as we wanted to add these plans to Instant Search. However this was a premature move as we still need the business plans in Classic Search until we make the full transition.

This is probably causing https://github.com/Automattic/jetpack/issues/42227 as well and shows that we need to think more about how we are going to make transition and what toggles (search/instant search) each site is going to see. Testing an atomic site with our sandboxes is a challenge and since we seem to need this change anyway and the issue is of high priority we can make the change and take it from there.

## Testing instructions:
This PR is required because of the change of the Classic Search plans on WPCOM.

## Does this pull request change what data or activity we track or use?
Adds business sites content to the global index, where we used to have them.