### PR TITLE
Tools: Ignore Storybook files from the Jest coverage

### DIFF
--- a/tools/js-tools/jest/config.coverage.js
+++ b/tools/js-tools/jest/config.coverage.js
@@ -12,5 +12,6 @@ module.exports = {
 		'!<rootDir>/**/__tests__/**/*.[jt]s?(x)',
 		'!<rootDir>/**/?(*.)+(spec|test).[jt]s?(x)',
 		'!<rootDir>/**/test/*.[jt]s?(x)',
+		'!<rootDir>/**/stories/*.[jt]s?(x)',
 	],
 };

--- a/tools/js-tools/jest/config.coverage.js
+++ b/tools/js-tools/jest/config.coverage.js
@@ -12,6 +12,8 @@ module.exports = {
 		'!<rootDir>/**/__tests__/**/*.[jt]s?(x)',
 		'!<rootDir>/**/?(*.)+(spec|test).[jt]s?(x)',
 		'!<rootDir>/**/test/*.[jt]s?(x)',
+
+		// Exclude storybook stories too.
 		'!<rootDir>/**/stories/*.[jt]s?(x)',
 	],
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1741271111262979-slack-CDLH4C1UZ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ignore **stories files from the coverage

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sanity check the regex.
* You could also run `jetpack test coverage js-packages/ai-client` and make sure the stories files are not in the report, whereas they are on trunk.