### PR TITLE
Fix: do not set default values for autoincrement columns

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-plaground-importer-autoimp-default
+++ b/projects/plugins/wpcomsh/changelog/fix-plaground-importer-autoimp-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix: do not set default values for autoincrement columns

--- a/projects/plugins/wpcomsh/imports/playground/class-sql-generator.php
+++ b/projects/plugins/wpcomsh/imports/playground/class-sql-generator.php
@@ -431,11 +431,13 @@ class SQL_Generator {
 			$ret .= ' NOT NULL';
 		}
 
-		if ( array_key_exists( 'auto_increment', $column ) && $column['auto_increment'] ) {
+		$is_auto_increment = array_key_exists( 'auto_increment', $column ) && $column['auto_increment'];
+
+		if ( $is_auto_increment ) {
 			$ret .= ' AUTO_INCREMENT';
 		}
 
-		if ( array_key_exists( 'default', $column ) && $column['default'] !== null ) {
+		if ( ! $is_auto_increment && array_key_exists( 'default', $column ) && $column['default'] !== null ) {
 			$default = $column['default'];
 
 			if ( $column['sqlite_type'] === 'integer' ) {

--- a/projects/plugins/wpcomsh/tests/imports/SQLGeneratorTest.php
+++ b/projects/plugins/wpcomsh/tests/imports/SQLGeneratorTest.php
@@ -138,7 +138,6 @@ class SQLGeneratorTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'text', $generated );
 		$this->assertStringContainsString( 'NOT NULL', $generated );
 		$this->assertStringContainsString( 'AUTO_INCREMENT', $generated );
-		$this->assertStringContainsString( 'DEFAULT', $generated );
 		$this->assertStringContainsString( 'COLLATE', $generated );
 
 		$column['type'] = 'datetime';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
The SQL importer do not work right now. This is because this syntax is not accepted:

```
ID bigint(20) unsigned NOT NULL auto_increment default 0;
```

It is not needed anymore, and PHPMyAdmin does not export the file that way. This PR remove the default value for all the SQL rows that are auto increment.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Do not add autoincrement default values to created Playground SQL files

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new Business site, mark it as a WoA Dev site, and take it Atomic.
* On https://playground.wordpress.net/ export a .zip
* `pnpm jetpack rsync wpcomsh __SITE__.wordpress.com@sftp.wp.com:htdocs/wp-content/mu-plugins/wpcomsh`
* Be sure to have `define( 'JETPACK_AUTOLOAD_DEV', true );` declared in your `wp-config.php` file
* Copy a Playground .zip exported file somewhere using sftp or similar, or use the Calypso Playground importer

From inside your WoA site:
1. `wp wpcomsh backup-import --source=/tmp/your-playground-exported-file.zip --dest=/tmp/a-random-folder-used-to-unpack-it --no-dry-run`
2. Ensure you get `Success: Import completed successfully.`
3. Check if the posts, comments, pages, have been imported
