### PR TITLE
[WooCommerce Analytics] Implement Page View Tracking

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/add-page-view
+++ b/projects/packages/woocommerce-analytics/changelog/add-page-view
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Track Page Views

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -546,7 +546,7 @@ class Universal {
 	 * Track page views
 	 */
 	public function capture_page_view() {
-		$this->record_event( 'woocommerceanalytics_page_view', array( 'url' => get_permalink() ) );
+		$this->record_event( 'woocommerceanalytics_page_view', array( 'url' => $this->get_current_url() ) );
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -69,6 +69,9 @@ class Universal {
 
 		// cart page view
 		add_action( 'wp_footer', array( $this, 'capture_cart_view' ), 11 );
+
+		// page view
+		add_action( 'wp_footer', array( $this, 'capture_page_view' ), 11 );
 	}
 
 	/**
@@ -537,6 +540,13 @@ class Universal {
 				)
 			);
 		}
+	}
+
+	/**
+	 * Track page views
+	 */
+	public function capture_page_view() {
+		$this->record_event( 'woocommerceanalytics_page_view', array( 'url' => get_permalink() ) );
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -746,6 +746,7 @@ trait Woo_Analytics_Trait {
 			'woocommerceanalytics_product_purchase',
 			'woocommerceanalytics_order_confirmation_view',
 			'woocommerceanalytics_search',
+			'woocommerceanalytics_page_view',
 		);
 	}
 

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -338,7 +338,7 @@ trait Woo_Analytics_Trait {
 		if ( ! $this->get_session_id() ) {
 			$session_id         = wp_generate_uuid4();
 			$this->session_id   = $session_id;
-			$this->landing_page = sanitize_url( wp_unslash( ( empty( $_SERVER['HTTPS'] ) ? 'http' : 'https' ) . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]" ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidatedNotSanitized -- actually escaped with sanitize_url.
+			$this->landing_page = $this->get_current_url();
 			$event_js           = $this->process_event_properties( 'woocommerceanalytics_session_started' );
 			$cookie_js          = "
             const sessionData = JSON.stringify({
@@ -727,6 +727,15 @@ trait Woo_Analytics_Trait {
 	 */
 	public function get_session_cookie() {
 		return json_decode( sanitize_text_field( wp_unslash( $_COOKIE['woocommerceanalytics_session'] ?? '' ) ), true ) ?? array();
+	}
+
+	/**
+	 * Get the current request URL
+	 *
+	 * @return string
+	 */
+	public function get_current_url() {
+		return sanitize_url( wp_unslash( ( empty( $_SERVER['HTTPS'] ) ? 'http' : 'https' ) . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]" ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidatedNotSanitized -- actually escaped with sanitize_url.
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -77,7 +77,7 @@ class Woocommerce_Analytics {
 		}
 
 		// Tracking only Site pages.
-		if ( is_admin() || wp_doing_ajax() || is_login() ) {
+		if ( is_admin() || wp_doing_ajax() || wp_is_xml_request() || is_login() || is_feed() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
 			return false;
 		}
 


### PR DESCRIPTION


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Implement tracking for Page Views --> `woocommerceanalytics_page_view`. This tracking will be in both t.gif and w.gif 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout and build JP with this PR
* Go to any page (post, page, shop, product, cart, checkout, account page...): see t.gif and w.gif with `woocommerceanalytics_page_view` event.



