### PR TITLE
Repo Gardening: make GitHub check fail when Type label is missing

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-check-description-fail-type
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-check-description-fail-type
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+PR checks: make check fail when a [Type] label is missing.

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -1,5 +1,6 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
+const { setFailed } = require( '@actions/core' );
 const moment = require( 'moment' );
 const debug = require( '../../utils/debug' );
 const getAffectedChangeloggerProjects = require( '../../utils/get-affected-changelogger-projects' );
@@ -527,6 +528,11 @@ If you have questions about anything, reach out in #jetpack-developers for guida
 	// If some of our checks are failing, remove any "Needs Review" labels and add an Needs Author Reply label.
 	if ( comment.includes( ':red_circle:' ) ) {
 		await updateLabels( payload, octokit );
+	}
+
+	// If the Type label is missing, make that task fail.
+	if ( ! statusChecks.hasTypeLabels ) {
+		setFailed( 'Your PR is missing a "[Type]" label. Please add one.' );
 	}
 }
 


### PR DESCRIPTION
## Proposed changes:

As a follow-up to #40428, let's make the GitHub check fail when the Type label is missing on a PR. I'm hoping it will be an additional incentive to add the label to your PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Merge this PR into your `trunk` branch locally, and push that version of `trunk` to a fork of this repo.
* Create an issue in your fork.
* Open a PR that makes a change to Jetpack, do not add a Type label.
    * The check should fail.
