### PR TITLE
Fix fatal error during critical css generation

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-context/critical-css-context-provider.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-context/critical-css-context-provider.tsx
@@ -121,7 +121,7 @@ export function useLocalCriticalCssGenerator() {
 							key,
 							// Avoid WAF pitfalls as firewalls can block critical CSS due to them including `<svg xmlns`
 							// See 9566-gh-Automattic/jpop-issues
-							css: btoa( css ),
+							css: btoa( String.fromCharCode( ...new TextEncoder().encode( css ) ) ),
 							isBase64Encoded: true,
 						} );
 					},

--- a/projects/plugins/boost/changelog/fix-boost-critical-css-btoa
+++ b/projects/plugins/boost/changelog/fix-boost-critical-css-btoa
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Critical CSS: Fix fatal error during generation.


### PR DESCRIPTION
## Proposed changes:

* Fix error during critical css generation.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1741273801322809-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Setup boost free (this branch);
- Install `rowling` theme;
- Setup a Social menu (from Appearance -> Menus) to make the Search icon show up;
- Try to generate critical css - it should work.