### PR TITLE
Boost: Revert encoding fix for critical css

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-context/critical-css-context-provider.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-context/critical-css-context-provider.tsx
@@ -117,10 +117,7 @@ export function useLocalCriticalCssGenerator() {
 					},
 
 					setProviderCss: ( key: string, css: string ) => {
-						return setProviderCssAction.mutateAsync( {
-							key,
-							css,
-						} );
+						return setProviderCssAction.mutateAsync( { key, css } );
 					},
 
 					setProviderErrors: ( key: string, errors: CriticalCssErrorDetails[] ) =>

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-context/critical-css-context-provider.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-context/critical-css-context-provider.tsx
@@ -119,10 +119,7 @@ export function useLocalCriticalCssGenerator() {
 					setProviderCss: ( key: string, css: string ) => {
 						return setProviderCssAction.mutateAsync( {
 							key,
-							// Avoid WAF pitfalls as firewalls can block critical CSS due to them including `<svg xmlns`
-							// See 9566-gh-Automattic/jpop-issues
-							css: btoa( String.fromCharCode( ...new TextEncoder().encode( css ) ) ),
-							isBase64Encoded: true,
+							css,
 						} );
 					},
 

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/critical-css-state.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/critical-css-state.ts
@@ -129,7 +129,6 @@ export function useSetProviderCssAction() {
 		z.object( {
 			key: z.string(),
 			css: z.string(),
-			isBase64Encoded: z.boolean().optional(),
 		} )
 	);
 }

--- a/projects/plugins/boost/app/lib/critical-css/data-sync-actions/Set_Provider_CSS.php
+++ b/projects/plugins/boost/app/lib/critical-css/data-sync-actions/Set_Provider_CSS.php
@@ -31,11 +31,6 @@ class Set_Provider_CSS implements Data_Sync_Action {
 		$provider_key = sanitize_key( $data['key'] );
 		$css          = $data['css'];
 
-		if ( $data['isBase64Encoded'] ) {
-			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
-			$css = base64_decode( $css );
-		}
-
 		$storage = new Critical_CSS_Storage();
 		$storage->store_css( $provider_key, $css );
 

--- a/projects/plugins/boost/app/lib/critical-css/data-sync/Data_Sync_Setup.php
+++ b/projects/plugins/boost/app/lib/critical-css/data-sync/Data_Sync_Setup.php
@@ -86,9 +86,8 @@ class Data_Sync_Schema {
 	public static function critical_css_set_provider() {
 		return Schema::as_assoc_array(
 			array(
-				'key'             => Schema::as_string(),
-				'css'             => Schema::as_string(),
-				'isBase64Encoded' => Schema::as_boolean()->fallback( false ),
+				'key' => Schema::as_string(),
+				'css' => Schema::as_string(),
 			)
 		);
 	}

--- a/projects/plugins/boost/changelog/fix-boost-revert-critical-css-encoding-fix
+++ b/projects/plugins/boost/changelog/fix-boost-revert-critical-css-encoding-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Critical CSS: Fix generation.


### PR DESCRIPTION
## Proposed changes:

* Revert changes from #42245. That fix is not sufficient for the problem.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Use Boost free;
- Make sure critical css generation works.