### PR TITLE
repo-gardening: Avoid trying to add no labels with "All the things!"

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-gardening-add-labels-all-the-things-already-there
+++ b/projects/github-actions/repo-gardening/changelog/fix-gardening-add-labels-all-the-things-already-there
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add labels: Avoid trying to add no labels when "[Project] All the things!" is triggered.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -401,6 +401,12 @@ async function addLabels( payload, octokit ) {
 		labelsToAdd.splice( maxLabelsToAdd );
 	}
 
+	// Check again, as all the above may have cleared out the labels we were going to add.
+	if ( labelsToAdd.length === 0 ) {
+		debug( 'add-labels: No new labels to add to that PR. Aborting.' );
+		return;
+	}
+
 	debug( `add-labels: Adding labels ${ labelsToAdd } to PR #${ number }` );
 
 	await octokit.rest.issues.addLabels( {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When the "All the things!" fallback is triggered, the action may wind up trying to add an empty set of labels on a re-run because the Project labels it was going to add get replaced again with "All the things!" which is already present. Account for that case.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See https://github.com/Automattic/jetpack/actions/runs/13708878233/job/38340742503?pr=42266#step:7:31

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a PR targeting this branch that will trigger "All the things!", and then re-trigger the action after it adds that.