### PR TITLE
Add tasks for new "publish a blog" tasklist

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-publish-a-blog-tasks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-publish-a-blog-tasks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adding new checklist tasks for "publish a blog" goal

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-publish-a-blog-tasks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-publish-a-blog-tasks
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Adding new checklist tasks for "publish a blog" goal
+Launchpad: Added updated_write_tasklist flag for testing changes to write launchpad

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -375,10 +375,11 @@ class Launchpad_Task_Lists {
 	 *
 	 * @param string      $id Task list id.
 	 * @param string|null $launchpad_context Optional. Screen in which launchpad is loading.
+	 * @param bool        $updated_write_tasklist Optional. Whether we're using the updated `write` task list.
 	 *
 	 * @return Task[] Collection of tasks associated with a task list.
 	 */
-	public function build( $id, $launchpad_context = null ) {
+	public function build( $id, $launchpad_context = null, $updated_write_tasklist = false ) {
 		$task_list           = $this->get_task_list( $id );
 		$tasks_for_task_list = array();
 
@@ -395,7 +396,7 @@ class Launchpad_Task_Lists {
 			$task_definition = $this->get_task( $task_id );
 
 			// if task can't be found don't add anything
-			if ( $this->is_visible( $task_definition, $launchpad_context ) ) {
+			if ( $this->is_visible( $task_definition, $launchpad_context, $updated_write_tasklist ) ) {
 				$tasks_for_task_list[] = $this->build_task( $task_definition, $launchpad_context );
 			}
 		}
@@ -409,15 +410,17 @@ class Launchpad_Task_Lists {
 	 *
 	 * @param Task        $task_definition A task definition.
 	 * @param string|null $launchpad_context Optional. Screen in which launchpad is loading.
+	 * @param bool        $updated_write_tasklist Optional. Whether we're using the updated `write` task list.
 	 * @return boolean True if task is visible, false if not.
 	 */
-	protected function is_visible( $task_definition, $launchpad_context = null ) {
+	protected function is_visible( $task_definition, $launchpad_context = null, $updated_write_tasklist = false ) {
 		if ( empty( $task_definition ) ) {
 			return false;
 		}
 
 		$data = array(
-			'launchpad_context' => $launchpad_context,
+			'launchpad_context'      => $launchpad_context,
+			'updated_write_tasklist' => $updated_write_tasklist,
 		);
 
 		return $this->load_value_from_callback( $task_definition, 'is_visible_callback', true, $data );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -389,6 +389,17 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_disabled_callback' => '__return_true',
 		),
 
+		// Publish a Blog tasks.
+		'complete_profile'                => array(
+			'get_title'            => function () {
+				return __( 'Complete your profile', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'get_calypso_path'     => function () {
+				return '/me#complete-your-profile';
+			},
+		),
+
 		// Keep Building tasks.
 		'site_title'                      => array(
 			'get_title'            => function () {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -2414,11 +2414,19 @@ function wpcom_launchpad_is_front_page_updated_visible() {
 /**
  * Determine `site_title` task visibility. The task is not visible if the name was already set.
  *
+ * @param Task  $task The task data.
+ * @param bool  $is_visible Whether the task is currently visible.
+ * @param array $data Metadata about the launchpad.
+ *
  * @return bool True if we should show the task, false otherwise.
  */
-function wpcom_launchpad_is_site_title_task_visible() {
+function wpcom_launchpad_is_site_title_task_visible( $task, $is_visible, $data ) {
 	// Hide the task if it's already completed on write intent
-	if ( get_option( 'site_intent' ) === 'write' && wpcom_launchpad_is_task_option_completed( array( 'id' => 'site_title' ) ) ) {
+	if (
+		! $data['updated_write_tasklist'] &&
+		get_option( 'site_intent' ) === 'write' &&
+		wpcom_launchpad_is_task_option_completed( array( 'id' => 'site_title' ) )
+	) {
 		return false;
 	}
 	return true;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -2423,7 +2423,7 @@ function wpcom_launchpad_is_front_page_updated_visible() {
 function wpcom_launchpad_is_site_title_task_visible( $task, $is_visible, $data ) {
 	// Hide the task if it's already completed on write intent
 	if (
-		! $data['updated_write_tasklist'] &&
+		( $data['launchpad_context'] !== 'focused-customer-home' || ! $data['updated_write_tasklist'] ) &&
 		get_option( 'site_intent' ) === 'write' &&
 		wpcom_launchpad_is_task_option_completed( array( 'id' => 'site_title' ) )
 	) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -153,6 +153,20 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
+		'publish-a-blog'          => array(
+			'get_title'           => function () {
+				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
+			},
+			'task_ids'            => array(
+				'verify_email',
+				'site_title',
+				'start_building_your_audience',
+				'complete_profile',
+				'first_post_published',
+				'site_launched',
+			),
+			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
+		),
 		'start-writing'           => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -504,15 +504,16 @@ function wpcom_is_checklist_task_complete( $task_id ) {
  *
  * @param string      $checklist_slug Checklist slug.
  * @param string|null $launchpad_context Optional. Screen where Launchpad is loading.
+ * @param bool        $updated_write_tasklist Optional. Whether we're using the updated `write` task list.
  *
  * @return Task[] Collection of tasks for a given checklist
  */
-function wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug, $launchpad_context = null ) {
+function wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug, $launchpad_context = null, $updated_write_tasklist = false ) {
 	if ( ! $checklist_slug ) {
 		return array();
 	}
 
-	return wpcom_launchpad_checklists()->build( $checklist_slug, $launchpad_context );
+	return wpcom_launchpad_checklists()->build( $checklist_slug, $launchpad_context, $updated_write_tasklist );
 }
 
 // TODO: Write code p2 post or dotcom post

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -153,7 +153,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'publish-a-blog'          => array(
+		'updated-write-tasklist'  => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -62,6 +62,12 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 							'required'    => false,
 							'default'     => array(),
 						),
+						'updated_write_tasklist'     => array(
+							'description' => 'Enable the updated write tasklist, for testing purposes',
+							'type'        => 'boolean',
+							'required'    => false,
+							'default'     => false,
+						),
 					),
 				),
 				array(
@@ -173,12 +179,20 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 			$switched_locale = switch_to_locale( $locale );
 		}
 
-		$checklist_slug = isset( $request['checklist_slug'] ) ? $request['checklist_slug'] : get_option( 'site_intent' );
-		$use_goals      = isset( $request['use_goals'] ) ? $request['use_goals'] : false;
+		$checklist_slug         = isset( $request['checklist_slug'] ) ? $request['checklist_slug'] : get_option( 'site_intent' );
+		$use_goals              = isset( $request['use_goals'] ) ? $request['use_goals'] : false;
+		$updated_write_tasklist = isset( $request['updated_write_tasklist'] ) ? $request['updated_write_tasklist'] : false;
 
 		$launchpad_context = isset( $request['launchpad_context'] )
 			? $request['launchpad_context']
 			: null;
+
+		if ( $updated_write_tasklist && $checklist_slug === 'write' ) {
+			// The updated_write_tasklist param facilitates a call-for-testing where we want
+			// to try out changes to the write tasks. The intention is that `updated-write-tasklist`
+			// will replace `write`, at which point updated_write_tasklist should be removed.
+			$checklist_slug = 'updated-write-tasklist';
+		}
 
 		if ( $use_goals ) {
 			// The user must be part of a cohort which should deterine which checklist to show soley on

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -205,7 +205,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 			'site_intent'        => get_option( 'site_intent' ),
 			'launchpad_screen'   => get_option( 'launchpad_screen' ),
 			'checklist_statuses' => get_option( 'launchpad_checklist_tasks_statuses', array() ),
-			'checklist'          => wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug, $launchpad_context ),
+			'checklist'          => wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug, $launchpad_context, $updated_write_tasklist ),
 			'is_enabled'         => wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ),
 			'is_dismissed'       => wpcom_launchpad_is_task_list_dismissed( $checklist_slug ),
 			'is_dismissible'     => wpcom_launchpad_is_task_list_dismissible( $checklist_slug ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/99455

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Create a new `publish-a-blog` task list
  * Most of the tasks re-use existing tasks, except for a new `complete_profile` task
* Create a new `complete_profile` task
  * Links to `/me` profile page

Take a look at the expected tasks for the publish a blog intent
https://docs.google.com/spreadsheets/d/1zILBEO5Yb9VVzxJmY5o1quR7XOQdOQkKlQ8G7wEQsAY/edit?gid=879791110#gid=879791110

Note that the tasklist doesn't include "add sharing options" task. If it's a block then the user should edit the share block in the template.

### Other information:

`I don't care about code coverage for this PR` because defining tasks and task lists is basically declarative code.

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Testing using Calypso PR https://github.com/Automattic/wp-calypso/pull/100971
* [Apply this diff to your sandbox](https://github.com/Automattic/jetpack/pull/42272#issuecomment-2705150208)
* `http://calypso.localhost:3000/setup/onboarding?flags=onboarding/publish-a-blog`
  * Choose "publish a blog" goal
  * When you land on the launchpad you should be getting the `publish-a-blog` checklist