### PR TITLE
AI Assistant: Add image index information on caption generation request

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-image-extension-image-index
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-image-extension-image-index
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Added utility functions
+
+

--- a/projects/js-packages/ai-client/src/hooks/use-post-content.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-post-content.ts
@@ -28,15 +28,23 @@ const usePostContent = () => {
 		};
 	}, [] );
 
+	const getSerializedPostContent = useCallback( () => {
+		const blocks = getBlocks();
+
+		if ( blocks.length === 0 ) {
+			return '';
+		}
+
+		return serialize( blocks );
+	}, [ getBlocks ] );
+
 	const getPostContent = useCallback(
 		( preprocess?: ( serialized: string ) => string ) => {
-			const blocks = getBlocks();
+			let serialized = getSerializedPostContent();
 
-			if ( blocks.length === 0 ) {
+			if ( ! serialized ) {
 				return '';
 			}
-
-			let serialized = serialize( blocks );
 
 			if ( preprocess && typeof preprocess === 'function' ) {
 				serialized = preprocess( serialized );
@@ -47,7 +55,7 @@ const usePostContent = () => {
 		[ getBlocks ]
 	);
 
-	return { getPostContent, isEditedPostEmpty };
+	return { getPostContent, isEditedPostEmpty, getSerializedPostContent };
 };
 
 export default usePostContent;

--- a/projects/js-packages/ai-client/src/libs/get-all-blocks.ts
+++ b/projects/js-packages/ai-client/src/libs/get-all-blocks.ts
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { select } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import type { Block } from '../types.js';
+
+/**
+ * Recursively get all blocks from the post, including nested innerBlocks
+ * @return {Array} Array of all blocks in the post
+ */
+export const getAllBlocks = (): Array< Block > => {
+	const topLevelBlocks = select( 'core/block-editor' ).getBlocks();
+	const allBlocks: Array< Block > = [];
+
+	const processBlock = ( block: Block ) => {
+		allBlocks.push( block );
+
+		if ( block.innerBlocks?.length ) {
+			block.innerBlocks.forEach( processBlock );
+		}
+	};
+
+	topLevelBlocks.forEach( processBlock );
+
+	return allBlocks;
+};

--- a/projects/js-packages/ai-client/src/libs/index.ts
+++ b/projects/js-packages/ai-client/src/libs/index.ts
@@ -13,3 +13,5 @@ export { mapActionToHumanText } from './map-action-to-human-text.js';
 export { openBlockSidebar } from './open-block-sidebar.js';
 
 export { showAiAssistantSection } from './show-ai-assistant-section.js';
+
+export { getAllBlocks } from './get-all-blocks.js';

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-image-extension-image-index
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-image-extension-image-index
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Add image index information on caption generation request

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
@@ -6,7 +6,6 @@ import {
 	usePostContent,
 	openBlockSidebar,
 	useAiFeature,
-	getAllBlocks,
 } from '@automattic/jetpack-ai-client';
 import { BlockControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -145,11 +144,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 					}
 
 					if ( type === TYPE_CAPTION ) {
-						const allImageBlocks = getAllBlocks().filter( block => block.name === 'core/image' );
-						const imageIndex =
-							allImageBlocks.findIndex( block => block.clientId === props.clientId ) + 1;
-						// Index of the image in the post.
-						context.positions = [ imageIndex ];
+						context.positions = [ props.clientId ];
 					}
 
 					dequeueAsyncRequest();

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
@@ -179,7 +179,11 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 
 					increaseRequestsCount();
 
-					const parsedResponse: { texts?: string[]; captions?: string[] } = JSON.parse( response );
+					const parsedResponse: { texts?: string[]; captions?: string[] } = JSON.parse(
+						response
+							?.replace?.( /^```json\s*/, '' ) // Remove the markdown code block if it exists.
+							?.replace( /```$/, '' )
+					);
 
 					if ( type === TYPE_ALT_TEXT ) {
 						const alt = parsedResponse.texts?.[ 0 ];

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
@@ -6,6 +6,7 @@ import {
 	usePostContent,
 	openBlockSidebar,
 	useAiFeature,
+	getAllBlocks,
 } from '@automattic/jetpack-ai-client';
 import { BlockControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -137,8 +138,18 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 				startLoading( type );
 
 				try {
+					const context: { indexes?: number[] } = {};
+
 					if ( type === TYPE_ALT_TEXT ) {
 						openBlockSidebar( props.clientId );
+					}
+
+					if ( type === TYPE_CAPTION ) {
+						const allImageBlocks = getAllBlocks().filter( block => block.name === 'core/image' );
+						const imageIndex =
+							allImageBlocks.findIndex( block => block.clientId === props.clientId ) + 1;
+						// Index of the image in the post.
+						context.indexes = [ imageIndex ];
 					}
 
 					dequeueAsyncRequest();
@@ -150,8 +161,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 								context: {
 									type: type,
 									content: getPostContent( preprocessImageContent ),
-									// URL of the image for the AI to find where the image is in the post.
-									urls: [ props.attributes.url ],
+									...context,
 									images: [
 										{
 											// We convert the image to a base64 string to avoid inaccesible URLs for private images.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
@@ -138,7 +138,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 				startLoading( type );
 
 				try {
-					const context: { indexes?: number[] } = {};
+					const context: { positions?: number[] } = {};
 
 					if ( type === TYPE_ALT_TEXT ) {
 						openBlockSidebar( props.clientId );
@@ -149,7 +149,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 						const imageIndex =
 							allImageBlocks.findIndex( block => block.clientId === props.clientId ) + 1;
 						// Index of the image in the post.
-						context.indexes = [ imageIndex ];
+						context.positions = [ imageIndex ];
 					}
 
 					dequeueAsyncRequest();

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/lib/preprocess-image-content.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/lib/preprocess-image-content.ts
@@ -1,20 +1,32 @@
 /**
- * Preprocess the serialized post content to remove image URLs and alt text, adding a unique count to each image.
- * This is used to ensure that the AI is not confused by the URLs in the post content.
+ * External dependencies
+ */
+import { getAllBlocks } from '@automattic/jetpack-ai-client';
+
+/**
+ * Preprocess the serialized post content to remove image captions and alt text, changing the image urls to their clientId.
+ * This is used to ensure that the AI is not confused by URLs in the post content, while still being able to identify the image blocks.
  * @param {string} content - The content to preprocess.
  * @return {string} The preprocessed content.
  */
 export const preprocessImageContent = ( content: string ): string => {
-	let imageCounter = 0;
+	const imageBlocks = getAllBlocks().filter( block => block.name === 'core/image' );
+	let currentImageIndex = 0;
 
 	// Remove figcaption elements
 	content = content.replace( /<figcaption[^>]*>.*?<\/figcaption>/g, '' );
 
-	// Replace image URLs with a unique count and remove alt text
-	content = content.replace( /<img[^>]*>/g, () => {
-		imageCounter++;
+	// Replace the urls of images within image blocks with their clientId
+	content = content.replace( /<!-- wp:image[^>]*>.*?<img[^>]*>.*?<!-- \/wp:image -->/gs, () => {
+		// The assumption here is that the image blocks are always in the same order as the images in the post's HTML content
+		const imageBlock = imageBlocks[ currentImageIndex ];
+		currentImageIndex++;
 
-		return `<img src="image-${ imageCounter }">`;
+		if ( ! imageBlock ) {
+			return '';
+		}
+
+		return `<img src="${ imageBlock.clientId }">`;
 	} );
 
 	return content;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #42268 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds information about which image the caption is for

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with 176116-ghe-Automattic/wpcom
* Check that the generated prompt makes sense and works as expected
