### PR TITLE
My Jetpack: enable screen readers to read stats

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
@@ -18,13 +18,17 @@ import styles from './style.module.scss';
  */
 
 const createStatSRText = ( countStat, count, previousCount ) => {
+	if ( typeof count !== 'number' ) {
+		return '';
+	}
+
 	const fragments = [];
 	const statCountText = sprintf( countStat( count ), formatNumber( count ) );
 
 	fragments.push( statCountText.endsWith( '.' ) ? statCountText : `${ statCountText }.` );
 	fragments.push( createStatDiffText( countStat, count, previousCount ) );
 
-	return fragments.join( ' ' );
+	return fragments.filter( Boolean ).join( ' ' );
 };
 
 /**

--- a/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
@@ -7,6 +7,16 @@ import createStatDiffText from './create-stat-diff-text';
 import eye from './eye';
 import styles from './style.module.scss';
 
+/**
+ * Creates the text read by screen readers for a stat card.
+ *
+ * @param {Function} countStat     - Function that accepts a number and calls _n() with that number to return the singular or plural form of the stat count.
+ *                                 E.g. countStat( 1 ) returns '%s view', countStat( 5 ) returns '%s views'
+ * @param {number}   count         - The current count value.
+ * @param {number}   previousCount - The previous period's count value.
+ * @return {string} Screen reader text
+ */
+
 const createStatSRText = ( countStat, count, previousCount ) => {
 	const fragments = [];
 	const statCountText = sprintf( countStat( count ), formatNumber( count ) );

--- a/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
@@ -1,9 +1,21 @@
-import { __ } from '@wordpress/i18n';
+import { sprintf, __, _n } from '@wordpress/i18n';
 import { Icon, commentContent, people, starEmpty } from '@wordpress/icons';
 import React from 'react';
+import formatNumber from '../../utils/format-number';
 import CountComparisonCard from './count-comparison-card';
+import createStatDiffText from './create-stat-diff-text';
 import eye from './eye';
 import styles from './style.module.scss';
+
+const createStatSRText = ( countStat, count, previousCount ) => {
+	const fragments = [];
+	const statCountText = sprintf( countStat( count ), formatNumber( count ) );
+
+	fragments.push( statCountText.endsWith( '.' ) ? statCountText : `${ statCountText }.` );
+	fragments.push( createStatDiffText( countStat, count, previousCount ) );
+
+	return fragments.join( ' ' );
+};
 
 /**
  * Stats cards component.
@@ -27,32 +39,60 @@ const StatsCards = ( { counts, previousCounts, headingLevel } ) => {
 				</small>
 			</Heading>
 
-			<div className={ styles[ 'cards-list' ] }>
+			<ul className={ styles[ 'cards-list' ] }>
 				<CountComparisonCard
 					heading={ __( 'Views', 'jetpack-my-jetpack' ) }
+					srText={ createStatSRText(
+						// translators: %s: number of views
+						count => _n( '%s view', '%s views', count, 'jetpack-my-jetpack' ),
+						counts?.views,
+						previousCounts?.views
+					) }
 					icon={ <Icon icon={ eye } /> }
 					count={ counts?.views }
 					previousCount={ previousCounts?.views }
+					as="li"
 				/>
 				<CountComparisonCard
 					heading={ __( 'Visitors', 'jetpack-my-jetpack' ) }
+					srText={ createStatSRText(
+						// translators: %s: number of visitors
+						count => _n( '%s visitor', '%s visitors', count, 'jetpack-my-jetpack' ),
+						counts?.visitors,
+						previousCounts?.visitors
+					) }
 					icon={ <Icon icon={ people } /> }
 					count={ counts?.visitors }
 					previousCount={ previousCounts?.visitors }
+					as="li"
 				/>
 				<CountComparisonCard
 					heading={ __( 'Likes', 'jetpack-my-jetpack' ) }
+					srText={ createStatSRText(
+						// translators: %s: number of likes
+						count => _n( '%s like', '%s likes', count, 'jetpack-my-jetpack' ),
+						counts?.likes,
+						previousCounts?.likes
+					) }
 					icon={ <Icon icon={ starEmpty } /> }
 					count={ counts?.likes }
 					previousCount={ previousCounts?.likes }
+					as="li"
 				/>
 				<CountComparisonCard
 					heading={ __( 'Comments', 'jetpack-my-jetpack' ) }
+					srText={ createStatSRText(
+						// translators: %s: number of comments
+						count => _n( '%s comment', '%s comments', count, 'jetpack-my-jetpack' ),
+						counts?.comments,
+						previousCounts?.comments
+					) }
 					icon={ <Icon icon={ commentContent } /> }
 					count={ counts?.comments }
 					previousCount={ previousCounts?.comments }
+					as="li"
 				/>
-			</div>
+			</ul>
 		</div>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/stats-section/count-comparison-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/count-comparison-card.jsx
@@ -35,9 +35,18 @@ export const percentCalculator = ( part, whole ) => {
  * @param {number}          props.previousCount - Previous count.
  * @param {React.ReactNode} props.icon          - Icon to display.
  * @param {React.ReactNode} props.heading       - Card heading.
+ * @param {string}          props.as            - Card root element type.
+ * @param {string}          props.srText        - Text for screen readers.
  * @return {object} CountComparisonCard React component.
  */
-const CountComparisonCard = ( { count = 0, previousCount = 0, icon, heading } ) => {
+const CountComparisonCard = ( {
+	count = 0,
+	previousCount = 0,
+	as = 'div',
+	icon,
+	heading,
+	srText,
+} ) => {
 	const difference = subtract( count, previousCount );
 	const differenceMagnitude = Math.abs( difference );
 	const percentage = Number.isFinite( difference )
@@ -45,44 +54,47 @@ const CountComparisonCard = ( { count = 0, previousCount = 0, icon, heading } ) 
 		: null;
 
 	return (
-		<Card className={ styles[ 'stats-card' ] }>
-			{ icon && <div className={ styles[ 'stats-card-icon' ] }>{ icon }</div> }
-			{ heading && <div className={ styles[ 'stats-card-heading' ] }>{ heading }</div> }
-			<div className={ styles[ 'stats-card-count' ] }>
-				<span
-					className={ styles[ 'stats-card-count-value' ] }
-					title={ Number.isFinite( count ) ? String( count ) : undefined }
-				>
-					{ formatNumber( count ) }
-				</span>
-				{ difference !== null ? (
+		<Card className={ styles[ 'stats-card' ] } as={ as }>
+			<span className="screen-reader-text">{ srText }</span>
+			<div aria-hidden="true">
+				{ icon && <div className={ styles[ 'stats-card-icon' ] }>{ icon }</div> }
+				{ heading && <div className={ styles[ 'stats-card-heading' ] }>{ heading }</div> }
+				<div className={ styles[ 'stats-card-count' ] }>
 					<span
-						className={ clsx( styles[ 'stats-card-difference' ], {
-							[ styles[ 'stats-card-difference--positive' ] ]: difference < 0,
-							[ styles[ 'stats-card-difference--negative' ] ]: difference > 0,
-						} ) }
+						className={ styles[ 'stats-card-count-value' ] }
+						title={ Number.isFinite( count ) ? String( count ) : undefined }
 					>
-						<span
-							className={ styles[ 'stats-card-difference-icon' ] }
-							title={ String( difference ) }
-						>
-							{ difference < 0 && <Icon size={ 18 } icon={ arrowDown } /> }
-							{ difference > 0 && <Icon size={ 18 } icon={ arrowUp } /> }
-						</span>
-						<span className={ styles[ 'stats-card-difference-absolute-value' ] }>
-							{
-								differenceMagnitude > 9999
-									? formatNumber( differenceMagnitude ) // i.e.- 10.1K
-									: formatNumber( differenceMagnitude, {} ) // passing empty object removes the compact number formatting options, i.e.- 10,100
-							}
-						</span>
-						{ percentage !== null && (
-							<span className={ styles[ 'stats-card-difference-absolute-percentage' ] }>
-								({ percentage }%)
-							</span>
-						) }
+						{ formatNumber( count ) }
 					</span>
-				) : null }
+					{ difference !== null ? (
+						<span
+							className={ clsx( styles[ 'stats-card-difference' ], {
+								[ styles[ 'stats-card-difference--positive' ] ]: difference < 0,
+								[ styles[ 'stats-card-difference--negative' ] ]: difference > 0,
+							} ) }
+						>
+							<span
+								className={ styles[ 'stats-card-difference-icon' ] }
+								title={ String( difference ) }
+							>
+								{ difference < 0 && <Icon size={ 18 } icon={ arrowDown } /> }
+								{ difference > 0 && <Icon size={ 18 } icon={ arrowUp } /> }
+							</span>
+							<span className={ styles[ 'stats-card-difference-absolute-value' ] }>
+								{
+									differenceMagnitude > 9999
+										? formatNumber( differenceMagnitude ) // i.e.- 10.1K
+										: formatNumber( differenceMagnitude, {} ) // passing empty object removes the compact number formatting options, i.e.- 10,100
+								}
+							</span>
+							{ percentage !== null && (
+								<span className={ styles[ 'stats-card-difference-absolute-percentage' ] }>
+									({ percentage }%)
+								</span>
+							) }
+						</span>
+					) : null }
+				</div>
 			</div>
 		</Card>
 	);
@@ -93,6 +105,7 @@ CountComparisonCard.propTypes = {
 	heading: PropTypes.node,
 	icon: PropTypes.node,
 	previousCount: PropTypes.number,
+	srText: PropTypes.string,
 };
 
 export default CountComparisonCard;

--- a/projects/packages/my-jetpack/_inc/components/stats-section/create-stat-diff-text.js
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/create-stat-diff-text.js
@@ -1,0 +1,59 @@
+import { sprintf, __ } from '@wordpress/i18n';
+import formatNumber from '../../utils/format-number';
+import formatPercentage from '../../utils/format-percentage';
+
+/**
+ * Creates text describing a stat difference between two periods.
+ * The text mentions both the absolute difference and the percentage difference.
+ *
+ * @param {Function} countStat     - Function that accepts a number and calls _n() with that number to return the singular or plural form of the stat count.
+ *                                 E.g. countStat( 1 ) returns '%s view', countStat( 5 ) returns '%s views'
+ * @param {number}   count         - Current period count
+ * @param {number}   previousCount - Previous period count
+ * @return {string}  Formatted text describing the difference
+ */
+const createStatDiffText = ( countStat, count, previousCount ) => {
+	const diff = count - previousCount;
+
+	if ( diff === 0 ) {
+		return __( 'No change since the previous period.', 'jetpack-my-jetpack' );
+	}
+
+	const statCount = countStat( Math.abs( diff ) ); // E.g. '%s views'
+	const statDiff = sprintf( statCount, formatNumber( Math.abs( diff ) ) ); // E.g. '5 views'
+	const absRatio = previousCount !== 0 ? Math.abs( diff / previousCount ) : null;
+
+	if ( ! absRatio ) {
+		if ( diff > 0 ) {
+			return sprintf(
+				// translators: %s: stat difference (e.g. `5 views`)
+				__( 'An increase of %s since the previous period.', 'jetpack-my-jetpack' ),
+				statDiff
+			);
+		}
+
+		return sprintf(
+			// translators: %s: stat difference (e.g. `5 views`)
+			__( 'A decrease of %s since the previous period.', 'jetpack-my-jetpack' ),
+			statDiff
+		);
+	}
+
+	if ( diff > 0 ) {
+		return sprintf(
+			// translators: %1$s: stat difference (e.g. `5 views`), %2$s: stat difference percentage (e.g. `10%`)
+			__( 'An increase of %1$s or %2$s since the previous period.', 'jetpack-my-jetpack' ),
+			statDiff,
+			formatPercentage( absRatio )
+		);
+	}
+
+	return sprintf(
+		// translators: %1$s: stat difference (e.g. `5 views`), %2$s: stat difference percentage (e.g. `10%`)
+		__( 'A decrease of %1$s or %2$s since the previous period.', 'jetpack-my-jetpack' ),
+		statDiff,
+		formatPercentage( absRatio )
+	);
+};
+
+export default createStatDiffText;

--- a/projects/packages/my-jetpack/_inc/components/stats-section/create-stat-diff-text.js
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/create-stat-diff-text.js
@@ -13,6 +13,10 @@ import formatPercentage from '../../utils/format-percentage';
  * @return {string}  Formatted text describing the difference
  */
 const createStatDiffText = ( countStat, count, previousCount ) => {
+	if ( typeof count !== 'number' || typeof previousCount !== 'number' ) {
+		return '';
+	}
+
 	const diff = count - previousCount;
 
 	if ( diff === 0 ) {

--- a/projects/packages/my-jetpack/_inc/components/stats-section/test/create-stat-diff-text.js
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/test/create-stat-diff-text.js
@@ -51,4 +51,18 @@ describe( 'createStatDiffText', () => {
 			expect( text ).not.toContain( '%' );
 		} );
 	} );
+
+	describe( 'when inputs are not numbers', () => {
+		it( 'should return empty string for non-number count', () => {
+			expect( createStatDiffText( viewsCount, '10', 5 ) ).toBe( '' );
+			expect( createStatDiffText( viewsCount, null, 5 ) ).toBe( '' );
+			expect( createStatDiffText( viewsCount, undefined, 5 ) ).toBe( '' );
+		} );
+
+		it( 'should return empty string for non-number previousCount', () => {
+			expect( createStatDiffText( viewsCount, 10, '5' ) ).toBe( '' );
+			expect( createStatDiffText( viewsCount, 10, null ) ).toBe( '' );
+			expect( createStatDiffText( viewsCount, 10, undefined ) ).toBe( '' );
+		} );
+	} );
 } );

--- a/projects/packages/my-jetpack/_inc/components/stats-section/test/create-stat-diff-text.js
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/test/create-stat-diff-text.js
@@ -1,0 +1,54 @@
+import { _n } from '@wordpress/i18n';
+import createStatDiffText from '../create-stat-diff-text';
+
+// Mock formatNumber and formatPercentage to make tests predictable
+jest.mock( '../../../utils/format-number', () => number => number.toString() );
+jest.mock( '../../../utils/format-percentage', () => ratio => `${ ratio * 100 }%` );
+
+describe( 'createStatDiffText', () => {
+	// eslint-disable-next-line @wordpress/i18n-translator-comments
+	const viewsCount = count => _n( '%s view', '%s views', count, 'jetpack-my-jetpack' );
+
+	describe( 'when there is no change', () => {
+		it( 'should not return the name of the stat', () => {
+			expect( createStatDiffText( viewsCount, 5, 5 ) ).not.toContain( 'view' );
+		} );
+	} );
+
+	describe( 'when there is an increase', () => {
+		it( 'should format message with percentage when previous count is not zero', () => {
+			const text = createStatDiffText( viewsCount, 10, 5 ).toLowerCase();
+
+			expect( text ).toContain( 'increase' );
+			expect( text ).toContain( '5 views' );
+			expect( text ).toContain( '100%' );
+		} );
+
+		it( 'should format message without percentage when previous count is zero', () => {
+			const text = createStatDiffText( viewsCount, 5, 0 ).toLowerCase();
+
+			expect( text ).toContain( 'increase' );
+			expect( text ).toContain( '5 views' );
+			expect( text ).not.toContain( '%' );
+		} );
+	} );
+
+	describe( 'when there is a decrease', () => {
+		it( 'should format message with percentage when previous count is not zero', () => {
+			const text = createStatDiffText( viewsCount, 5, 10 ).toLowerCase();
+
+			expect( text ).toContain( 'decrease' );
+			expect( text ).toContain( '5 views' );
+			expect( text ).toContain( '50%' );
+		} );
+
+		it( 'should format message without percentage when previous count is zero', () => {
+			const text = createStatDiffText( viewsCount, -5, 0 ).toLowerCase();
+			// This case shouldn't happen in practice since you can't go below zero,
+			// but we test it for completeness
+			expect( text ).toContain( 'decrease' );
+			expect( text ).toContain( '5 views' );
+			expect( text ).not.toContain( '%' );
+		} );
+	} );
+} );

--- a/projects/packages/my-jetpack/_inc/utils/format-percentage.ts
+++ b/projects/packages/my-jetpack/_inc/utils/format-percentage.ts
@@ -2,11 +2,13 @@ import { numberFormat } from '@automattic/jetpack-components';
 import type { FormatNumberFunction } from './types';
 
 const defaultConfig: Intl.NumberFormatOptions = {
-	maximumFractionDigits: 1,
-	notation: 'compact',
+	style: 'percent',
 };
 
-const formatNumber: FormatNumberFunction = ( number, config = defaultConfig ) => {
+const formatPercentage: FormatNumberFunction = ( number, config = defaultConfig ) => {
+	// Force percentage
+	config.style = 'percent';
+
 	if ( number === null || ! Number.isFinite( number ) ) {
 		return '-';
 	}
@@ -14,4 +16,4 @@ const formatNumber: FormatNumberFunction = ( number, config = defaultConfig ) =>
 	return numberFormat( number, config );
 };
 
-export default formatNumber;
+export default formatPercentage;

--- a/projects/packages/my-jetpack/_inc/utils/format-percentage.ts
+++ b/projects/packages/my-jetpack/_inc/utils/format-percentage.ts
@@ -5,13 +5,20 @@ const defaultConfig: Intl.NumberFormatOptions = {
 	style: 'percent',
 };
 
+/**
+ * Formats a number as a percentage string.
+ *
+ * @param {number}                   number   - The number to format (e.g. 0.5 for 50%)
+ * @param {Intl.NumberFormatOptions} [config] - Optional formatting configuration
+ * @return {string} The formatted percentage string (e.g. "50%")
+ */
 const formatPercentage: FormatNumberFunction = ( number, config = defaultConfig ) => {
-	// Force percentage
-	config.style = 'percent';
-
 	if ( number === null || ! Number.isFinite( number ) ) {
 		return '-';
 	}
+
+	// Force percentage
+	config.style = 'percent';
 
 	return numberFormat( number, config );
 };

--- a/projects/packages/my-jetpack/_inc/utils/types.ts
+++ b/projects/packages/my-jetpack/_inc/utils/types.ts
@@ -1,0 +1,1 @@
+export type FormatNumberFunction = ( number: number, config?: Intl.NumberFormatOptions ) => string;

--- a/projects/packages/my-jetpack/changelog/fix-stats-sr-annoucement
+++ b/projects/packages/my-jetpack/changelog/fix-stats-sr-annoucement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Emable screen readers to read stats

--- a/projects/packages/my-jetpack/changelog/fix-stats-sr-annoucement
+++ b/projects/packages/my-jetpack/changelog/fix-stats-sr-annoucement
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Emable screen readers to read stats
+Enable screen readers to read stats


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
On the My Jetpack page, screen readers can't properly announce the stats highlights; they announce a suite of numbers without context. See video below:

https://github.com/user-attachments/assets/9c8d1922-a0c7-440b-a0f3-bca426edf5e4

This PR updates the stats section so it's accessible to screen reader users. In detail:
- It implements stat cards in a list instead of a suite of divs.
- It hides visual content in stat cards to screen readers and instead renders the same information in an element that's accessible to screen readers but visually hidden.
- The information about stat difference between periods is handled by `createStatDiffText`.
- It adds a function that formats percentage.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Epic: https://github.com/Automattic/vulcan/issues/710

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a Jetpack site. For exhaustive testing, test this branch with a local site and make sure to build the `my-jetpack` package.
- If you're testing locally, open `projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx` and add the following at the top of the `StatCard` component:
```
counts.views = 10;
previousCounts.views = 5;
counts.visitors = 5;
previousCounts.visitors = 10;
counts.likes = 5;
previousCounts.likes = 5;
counts.comments = 5;
previousCounts.comments = 0;
```

- Visit `/wp-admin/admin.php?page=my-jetpack`
- Activate Jetpack
- You should see the Stats section, with populated stats if you're testing locally
- If you're able to use a screen reader, verify that the stat cards content is announced properly, as in the video below:

https://github.com/user-attachments/assets/ff11e953-d476-4f44-9879-3d55dde8862a



- Otherwise, verify the information is present in the DOM
<img width="399" alt="Screenshot 2025-03-06 at 8 26 28 PM" src="https://github.com/user-attachments/assets/bdf95693-db40-4f7a-8bcd-00b240c57f38" />


