### PR TITLE
Add mainBodyTextDev for the body text of the Safe Mode notice in the dev mode

### DIFF
--- a/projects/js-packages/idc/changelog/fix-add-mainBodyTextDev
+++ b/projects/js-packages/idc/changelog/fix-add-mainBodyTextDev
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add mainBodyTextDev for the body text of the Safe Mode notice in the development mode

--- a/projects/js-packages/idc/components/idc-screen/screen-main.jsx
+++ b/projects/js-packages/idc/components/idc-screen/screen-main.jsx
@@ -65,7 +65,7 @@ const ScreenMain = props => {
 							}
 					  )
 					: createInterpolateElement(
-							customContent.mainBodyText ||
+							customContent.mainBodyTextDev ||
 								sprintf(
 									/* translators: %1$s: The current site domain name. %2$s: The original site domain name. */
 									__(

--- a/projects/js-packages/idc/components/idc-screen/screen-main.jsx
+++ b/projects/js-packages/idc/components/idc-screen/screen-main.jsx
@@ -70,7 +70,7 @@ const ScreenMain = props => {
 									/* translators: %1$s: The current site domain name. %2$s: The original site domain name. */
 									__(
 										'<span>Your site is in Safe Mode because <hostname>%1$s</hostname> appears to be a staging or development copy of <hostname>%2$s</hostname>.</span>' +
-											'2 sites that are telling Jetpack they’re the same site. <safeModeLink>Learn more or troubleshoot common Safe mode issues</safeModeLink>.',
+											'Two sites that are telling Jetpack they’re the same site. <safeModeLink>Learn more or troubleshoot common Safe mode issues</safeModeLink>.',
 										'jetpack-idc'
 									),
 									currentHostName,

--- a/projects/js-packages/idc/tools/custom-content-shape.jsx
+++ b/projects/js-packages/idc/tools/custom-content-shape.jsx
@@ -9,6 +9,8 @@ export default {
 	mainTitle: PropTypes.string,
 	/** The main screen body text. */
 	mainBodyText: PropTypes.string,
+	/** The main screen body text for the dev mode. */
+	mainBodyTextDev: PropTypes.string,
 	/** The "migration finished" screen title. */
 	migratedTitle: PropTypes.string,
 	/** The "migration finished" screen body text. */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

Currently, `customContent.mainBodyText` is used for the main body text for Safe Mode notice in both dev and non-dev environments. However, their texts are slightly different. 

Related: https://github.com/Automattic/woocommerce-payments/issues/9614#issuecomment-2701490551

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR introduces another property to differentiate between them, and provide consumers such as WooPayments, to customize this text.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

