### PR TITLE
Social | Update scheduled-actions endpoint making compatible with getEntityRecords

### DIFF
--- a/projects/packages/publicize/changelog/update-social-scheduled-actions-endpoint
+++ b/projects/packages/publicize/changelog/update-social-scheduled-actions-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated the scheduled-actions endpoint making compatible with getEntityRecords

--- a/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php
@@ -261,14 +261,10 @@ class Scheduled_Actions_Controller extends Base_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error
 	 */
-	public function get_items_permissions_check( $request ) {
+	public function get_items_permissions_check( $request ) {// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 
 		if ( ! $this->basic_permissions_check() ) {
-			return new WP_Error(
-				'rest_forbidden_context',
-				__( 'Sorry, you are not allowed to do that.', 'jetpack-publicize-pkg' ),
-				array( 'status' => rest_authorization_required_code() )
-			);
+			return false;
 		}
 		$post_id = $request->get_param( 'post_id' );
 
@@ -281,7 +277,7 @@ class Scheduled_Actions_Controller extends Base_Controller {
 				);
 			}
 			// Ensure that the user can edit the post.
-			return current_user_can_for_site( get_current_blog_id(), 'edit_post', $post_id );
+			return current_user_can_for_blog( get_current_blog_id(), 'edit_post', $post_id );
 		}
 
 		return true;
@@ -332,13 +328,9 @@ class Scheduled_Actions_Controller extends Base_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has access to create items, WP_Error object otherwise.
 	 */
-	public function create_item_permissions_check( $request ) {
+	public function create_item_permissions_check( $request ) {// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		if ( ! $this->basic_permissions_check() ) {
-			return new WP_Error(
-				'rest_forbidden_context',
-				__( 'Sorry, you are not allowed to do that.', 'jetpack-publicize-pkg' ),
-				array( 'status' => rest_authorization_required_code() )
-			);
+			return false;
 		}
 
 		$post_id = $request->get_param( 'post_id' );

--- a/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php
@@ -48,32 +48,28 @@ class Scheduled_Actions_Controller extends Base_Controller {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_items' ),
 					'permission_callback' => array( $this, 'get_items_permissions_check' ),
-				),
-				'schema' => array( $this, 'get_public_item_schema' ),
-			)
-		);
-
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/posts/(?P<postId>\d+)/',
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_items_for_post' ),
-					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => array(
+						'post_id' => array(
+							'type'        => 'integer',
+							'description' => __( 'The post ID to filter the items by.', 'jetpack-publicize-pkg' ),
+						),
+					),
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'create_item' ),
 					'permission_callback' => array( $this, 'create_item_permissions_check' ),
 					'args'                => array(
-						'message'       => array(
-							'type'     => 'string',
+						'post_id'       => array(
+							'type'     => 'integer',
 							'required' => true,
 						),
 						'connection_id' => array(
 							'type'     => 'integer',
 							'required' => true,
+						),
+						'message'       => array(
+							'type' => 'string',
 						),
 						'share_date'    => array(
 							'type'        => 'integer',
@@ -95,7 +91,7 @@ class Scheduled_Actions_Controller extends Base_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/posts/(?P<postId>\d+)/(?P<actionId>\d+)',
+			'/' . $this->rest_base . '/(?P<action_id>\d+)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
@@ -223,13 +219,30 @@ class Scheduled_Actions_Controller extends Base_Controller {
 	 * @return WP_REST_Response|WP_Error The response
 	 */
 	public function get_items( $request ) {
+
 		if ( Utils::is_wpcom() ) {
+			$post_id = $request->get_param( 'post_id' );
 
 			require_lib( 'publicize/class.publicize-actions' );
 
-			$scheduled_actions = \Publicize_Actions::get_scheduled_actions_by_blog_id(
-				get_current_blog_id()
-			);
+			if ( $post_id ) {
+				if ( ! get_blog_post( get_current_blog_id(), $post_id ) ) {
+					return new WP_Error(
+						'post_not_found',
+						__( 'Post not found.', 'jetpack-publicize-pkg' ),
+						array( 'status' => 400 )
+					);
+				}
+
+				$scheduled_actions = \Publicize_Actions::get_scheduled_actions_by_blog_and_post_id(
+					get_current_blog_id(),
+					$post_id
+				);
+			} else {
+				$scheduled_actions = \Publicize_Actions::get_scheduled_actions_by_blog_id(
+					get_current_blog_id()
+				);
+			}
 
 			if ( is_wp_error( $scheduled_actions ) ) {
 				return $scheduled_actions;
@@ -242,37 +255,6 @@ class Scheduled_Actions_Controller extends Base_Controller {
 
 		return rest_ensure_response(
 			$this->proxy_request_to_wpcom_as_user( $request )
-		);
-	}
-
-	/**
-	 * Fetch the list of scheduled actions for a post
-	 *
-	 * @param  WP_REST_Request $request Full details about the request.
-	 * @return WP_Error|array The actions (under `items`) and the count (under `total`)
-	 */
-	public function get_items_for_post( $request ) {
-		$post_id = $request['postId'];
-
-		if ( Utils::is_wpcom() ) {
-			require_lib( 'publicize/class.publicize-actions' );
-
-			$scheduled_actions = \Publicize_Actions::get_scheduled_actions_by_blog_and_post_id(
-				get_current_blog_id(),
-				$post_id
-			);
-
-			if ( is_wp_error( $scheduled_actions ) ) {
-				return $scheduled_actions;
-			}
-
-			return rest_ensure_response(
-				$this->prepare_items_for_response( $scheduled_actions, $request )
-			);
-		}
-
-		return rest_ensure_response(
-			$this->proxy_request_to_wpcom_as_user( $request, "/posts/{$post_id}" )
 		);
 	}
 
@@ -293,15 +275,15 @@ class Scheduled_Actions_Controller extends Base_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function create_item( $request ) {
-		$post_id = $request['postId'];
 
 		if ( Utils::is_wpcom() ) {
 			require_lib( 'publicize/class.publicize-actions' );
 
+			$post_id       = $request['post_id'];
 			$blog_id       = get_current_blog_id();
 			$user_id       = get_current_user_id();
 			$connection_id = (int) $request['connection_id'];
-			$message       = sanitize_textarea_field( $request['message'] );
+			$message       = sanitize_textarea_field( $request['message'] ?? '' );
 
 			$timestamp = time();
 			if ( ! empty( $request['timestamp'] ) ) {
@@ -335,7 +317,7 @@ class Scheduled_Actions_Controller extends Base_Controller {
 		}
 
 		return rest_ensure_response(
-			$this->proxy_request_to_wpcom_as_user( $request, "/posts/{$post_id}" )
+			$this->proxy_request_to_wpcom_as_user( $request )
 		);
 	}
 
@@ -356,10 +338,9 @@ class Scheduled_Actions_Controller extends Base_Controller {
 			return true;
 		}
 
-		$post_id   = $request['postId'];
-		$action_id = $request['actionId'];
+		$action_id = $request['action_id'];
 
-		$action = $this->wpcom_get_action_by_post_id_and_action_id( $post_id, $action_id );
+		$action = $this->wpcom_get_action( $action_id );
 
 		if ( is_wp_error( $action ) ) {
 			return $action;
@@ -376,18 +357,17 @@ class Scheduled_Actions_Controller extends Base_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_item( $request ) {
-		$post_id   = $request['postId'];
-		$action_id = $request['actionId'];
+		$action_id = $request['action_id'];
 
 		if ( Utils::is_wpcom() ) {
 
 			return rest_ensure_response(
-				$this->wpcom_get_action_by_post_id_and_action_id( $post_id, $action_id )
+				$this->wpcom_get_action( $action_id )
 			);
 		}
 
 		return rest_ensure_response(
-			$this->proxy_request_to_wpcom_as_user( $request, "/posts/{$post_id}/$action_id" )
+			$this->proxy_request_to_wpcom_as_user( $request, $action_id )
 		);
 	}
 
@@ -410,13 +390,12 @@ class Scheduled_Actions_Controller extends Base_Controller {
 	 */
 	public function update_item( $request ) {
 
-		$post_id   = $request['postId'];
-		$action_id = $request['actionId'];
+		$action_id = $request['action_id'];
 
 		if ( Utils::is_wpcom() ) {
 			require_lib( 'publicize/class.publicize-actions' );
 
-			$action = $this->wpcom_get_action_by_post_id_and_action_id( $post_id, $action_id );
+			$action = $this->wpcom_get_action( $action_id );
 
 			if ( is_wp_error( $action ) ) {
 				return $action;
@@ -444,7 +423,7 @@ class Scheduled_Actions_Controller extends Base_Controller {
 		}
 
 		return rest_ensure_response(
-			$this->proxy_request_to_wpcom_as_user( $request, "/posts/{$post_id}/$action_id" )
+			$this->proxy_request_to_wpcom_as_user( $request, $action_id )
 		);
 	}
 
@@ -467,13 +446,12 @@ class Scheduled_Actions_Controller extends Base_Controller {
 	 */
 	public function delete_item( $request ) {
 
-		$post_id   = $request['postId'];
-		$action_id = $request['actionId'];
+		$action_id = $request['action_id'];
 
 		if ( Utils::is_wpcom() ) {
 			require_lib( 'publicize/class.publicize-actions' );
 
-			$action = $this->wpcom_get_action_by_post_id_and_action_id( $post_id, $action_id );
+			$action = $this->wpcom_get_action( $action_id );
 			if ( is_wp_error( $action ) ) {
 				return $action;
 			}
@@ -488,7 +466,7 @@ class Scheduled_Actions_Controller extends Base_Controller {
 		}
 
 		return rest_ensure_response(
-			$this->proxy_request_to_wpcom_as_user( $request, "/posts/{$post_id}/$action_id" )
+			$this->proxy_request_to_wpcom_as_user( $request, $action_id )
 		);
 	}
 
@@ -539,13 +517,12 @@ class Scheduled_Actions_Controller extends Base_Controller {
 	}
 
 	/**
-	 * Return a formatted action by post_id and action_id
+	 * Return a formatted action by action_id
 	 *
-	 * @param int $post_id   The post ID.
 	 * @param int $action_id The action ID.
 	 * @return WP_Error|array The action
 	 */
-	private function wpcom_get_action_by_post_id_and_action_id( $post_id, $action_id ) {
+	private function wpcom_get_action( $action_id ) {
 		// Ensure that we are on WPCOM.
 		Utils::assert_is_wpcom( __METHOD__ );
 
@@ -555,11 +532,9 @@ class Scheduled_Actions_Controller extends Base_Controller {
 			return $action;
 		}
 		if ( ! isset( $action['publicize_scheduled_action_id'] ) ) {
-			return new WP_Error( 'not_found', 'Could not find that action', array( 'status' => 404 ) );
+			return new WP_Error( 'not_found', __( 'Could not find that scheduled action.', 'jetpack-publicize-pkg' ), array( 'status' => 404 ) );
 		}
-		if ( $action['post_id'] !== $post_id ) {
-			return new WP_Error( 'not_found', 'Could not find that action', array( 'status' => 404 ) );
-		}
+
 		return $this->prepare_action_for_response( $action );
 	}
 

--- a/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php
@@ -261,10 +261,14 @@ class Scheduled_Actions_Controller extends Base_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error
 	 */
-	public function get_items_permissions_check( $request ) {// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function get_items_permissions_check( $request ) {
 
 		if ( ! $this->basic_permissions_check() ) {
-			return false;
+			return new WP_Error(
+				'rest_forbidden_context',
+				__( 'Sorry, you are not allowed to do that.', 'jetpack-publicize-pkg' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
 		}
 		$post_id = $request->get_param( 'post_id' );
 
@@ -277,7 +281,7 @@ class Scheduled_Actions_Controller extends Base_Controller {
 				);
 			}
 			// Ensure that the user can edit the post.
-			return current_user_can_for_blog( get_current_blog_id(), 'edit_post', $post_id );
+			return current_user_can_for_site( get_current_blog_id(), 'edit_post', $post_id );
 		}
 
 		return true;
@@ -328,9 +332,13 @@ class Scheduled_Actions_Controller extends Base_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has access to create items, WP_Error object otherwise.
 	 */
-	public function create_item_permissions_check( $request ) {// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function create_item_permissions_check( $request ) {
 		if ( ! $this->basic_permissions_check() ) {
-			return false;
+			return new WP_Error(
+				'rest_forbidden_context',
+				__( 'Sorry, you are not allowed to do that.', 'jetpack-publicize-pkg' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
 		}
 
 		$post_id = $request->get_param( 'post_id' );

--- a/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php
@@ -126,6 +126,60 @@ class Scheduled_Actions_Controller extends Base_Controller {
 				'schema' => array( $this, 'get_public_item_schema' ),
 			)
 		);
+
+		// TODO - Remove the below routes after https://github.com/Automattic/wp-calypso/pull/100984 is deployed.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/posts/(?P<post_id>\d+)/',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'args'                => array(
+						'message'       => array(
+							'type'     => 'string',
+							'required' => true,
+						),
+						'connection_id' => array(
+							'type'     => 'integer',
+							'required' => true,
+						),
+						'share_date'    => array(
+							'type'        => 'integer',
+							'description' => sprintf(
+								/* translators: %s is the new field name */
+								__( 'Deprecated in favor of %s.', 'jetpack-publicize-pkg' ),
+								'timestamp'
+							),
+						),
+						'timestamp'     => array(
+							'type'        => 'integer',
+							'description' => __( 'GMT/UTC Unix timestamp in seconds for the action.', 'jetpack-publicize-pkg' ),
+						),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/posts/(?P<post_id>\d+)/(?P<action_id>\d+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
 	}
 
 	/**

--- a/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php
@@ -262,25 +262,7 @@ class Scheduled_Actions_Controller extends Base_Controller {
 	 * @return true|WP_Error
 	 */
 	public function get_items_permissions_check( $request ) {// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-
-		if ( ! $this->basic_permissions_check() ) {
-			return false;
-		}
-		$post_id = $request->get_param( 'post_id' );
-
-		if ( $post_id ) {
-			if ( ! get_blog_post( get_current_blog_id(), $post_id ) ) {
-				return new WP_Error(
-					'post_not_found',
-					__( 'Post not found.', 'jetpack-publicize-pkg' ),
-					array( 'status' => 400 )
-				);
-			}
-			// Ensure that the user can edit the post.
-			return current_user_can_for_blog( get_current_blog_id(), 'edit_post', $post_id );
-		}
-
-		return true;
+		return $this->basic_permissions_check();
 	}
 
 	/**
@@ -298,6 +280,14 @@ class Scheduled_Actions_Controller extends Base_Controller {
 			require_lib( 'publicize/class.publicize-actions' );
 
 			if ( $post_id ) {
+				if ( ! get_blog_post( get_current_blog_id(), $post_id ) ) {
+					return new WP_Error(
+						'post_not_found',
+						__( 'Post not found.', 'jetpack-publicize-pkg' ),
+						array( 'status' => 400 )
+					);
+				}
+
 				$scheduled_actions = \Publicize_Actions::get_scheduled_actions_by_blog_and_post_id(
 					get_current_blog_id(),
 					$post_id
@@ -329,21 +319,7 @@ class Scheduled_Actions_Controller extends Base_Controller {
 	 * @return true|WP_Error True if the request has access to create items, WP_Error object otherwise.
 	 */
 	public function create_item_permissions_check( $request ) {// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		if ( ! $this->basic_permissions_check() ) {
-			return false;
-		}
-
-		$post_id = $request->get_param( 'post_id' );
-
-		if ( ! get_post( $post_id ) ) {
-			return new WP_Error(
-				'post_not_found',
-				__( 'Post not found.', 'jetpack-publicize-pkg' ),
-				array( 'status' => 400 )
-			);
-		}
-		// Ensure that the user can edit the post.
-		return current_user_can( 'edit_post', $post_id );
+		return $this->basic_permissions_check();
 	}
 
 	/**
@@ -424,8 +400,8 @@ class Scheduled_Actions_Controller extends Base_Controller {
 			return $action;
 		}
 
-		// Ensure that the action is for the current blog and the user can edit the post.
-		return get_current_blog_id() === $action['blog_id'] && current_user_can( 'edit_post', $action['post_id'] );
+		// Ensure that the action is for the current blog.
+		return get_current_blog_id() === $action['blog_id'];
 	}
 
 	/**

--- a/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php
@@ -262,7 +262,25 @@ class Scheduled_Actions_Controller extends Base_Controller {
 	 * @return true|WP_Error
 	 */
 	public function get_items_permissions_check( $request ) {// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		return $this->basic_permissions_check();
+
+		if ( ! $this->basic_permissions_check() ) {
+			return false;
+		}
+		$post_id = $request->get_param( 'post_id' );
+
+		if ( $post_id ) {
+			if ( ! get_blog_post( get_current_blog_id(), $post_id ) ) {
+				return new WP_Error(
+					'post_not_found',
+					__( 'Post not found.', 'jetpack-publicize-pkg' ),
+					array( 'status' => 400 )
+				);
+			}
+			// Ensure that the user can edit the post.
+			return current_user_can_for_blog( get_current_blog_id(), 'edit_post', $post_id );
+		}
+
+		return true;
 	}
 
 	/**
@@ -280,14 +298,6 @@ class Scheduled_Actions_Controller extends Base_Controller {
 			require_lib( 'publicize/class.publicize-actions' );
 
 			if ( $post_id ) {
-				if ( ! get_blog_post( get_current_blog_id(), $post_id ) ) {
-					return new WP_Error(
-						'post_not_found',
-						__( 'Post not found.', 'jetpack-publicize-pkg' ),
-						array( 'status' => 400 )
-					);
-				}
-
 				$scheduled_actions = \Publicize_Actions::get_scheduled_actions_by_blog_and_post_id(
 					get_current_blog_id(),
 					$post_id
@@ -319,7 +329,21 @@ class Scheduled_Actions_Controller extends Base_Controller {
 	 * @return true|WP_Error True if the request has access to create items, WP_Error object otherwise.
 	 */
 	public function create_item_permissions_check( $request ) {// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		return $this->basic_permissions_check();
+		if ( ! $this->basic_permissions_check() ) {
+			return false;
+		}
+
+		$post_id = $request->get_param( 'post_id' );
+
+		if ( ! get_post( $post_id ) ) {
+			return new WP_Error(
+				'post_not_found',
+				__( 'Post not found.', 'jetpack-publicize-pkg' ),
+				array( 'status' => 400 )
+			);
+		}
+		// Ensure that the user can edit the post.
+		return current_user_can( 'edit_post', $post_id );
 	}
 
 	/**
@@ -400,8 +424,8 @@ class Scheduled_Actions_Controller extends Base_Controller {
 			return $action;
 		}
 
-		// Ensure that the action is for the current blog.
-		return get_current_blog_id() === $action['blog_id'];
+		// Ensure that the action is for the current blog and the user can edit the post.
+		return get_current_blog_id() === $action['blog_id'] && current_user_can( 'edit_post', $action['post_id'] );
 	}
 
 	/**


### PR DESCRIPTION
<details>
<summary>From the related issue</summary>
Since `postId` is a [part of the URL](https://github.com/Automattic/jetpack/blob/2b831dceef473106ee4c6c9755c303cd697e2792/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php#L58) for all the CRUD operations on the scheduled shares, core getEntityRecords doesn’t handle that part well, because it can handle the actual share ID that we pass when we want to fetch or delete it like `getEntityRecord( key, name, ID)` but there is no way to pass the post ID to make it a part of the URL.
So, this won’t work unless we pass the post ID upfront, which may not be good when we work on the post list screen

```ts
await addEntities( [
	{
		kind: 'wpcom/v2',
		name: 'publicize/scheduled-actions/posts/:post_id',
		baseURL: '/wpcom/v2/publicize/scheduled-actions/posts/:post_id',
		label: __( 'Scheduled shares' ),
	},
] );
```

Thus, it’s better to have `post_id` as a required param (query/body) instead of route param

Slack thread: p1741251568102319-slack-C02JJ910CNL
</details>

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Make `post_id` a query param, rather than a route param

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the test instructions given in https://github.com/Automattic/wp-calypso/pull/100984