### PR TITLE
WIP: Post List: Improve behaviour on narrow screens

### DIFF
--- a/projects/packages/post-list/changelog/add-thumbnail-visibility-feature
+++ b/projects/packages/post-list/changelog/add-thumbnail-visibility-feature
@@ -1,1 +1,0 @@
-Enhancement: Added thumbnail column visibility feature that automatically hides the thumbnail column when the title column width is below a certain threshold.

--- a/projects/packages/post-list/changelog/add-thumbnail-visibility-feature
+++ b/projects/packages/post-list/changelog/add-thumbnail-visibility-feature
@@ -1,0 +1,1 @@
+Enhancement: Added thumbnail column visibility feature that automatically hides the thumbnail column when the title column width is below a certain threshold.

--- a/projects/packages/post-list/changelog/update-post-list-space
+++ b/projects/packages/post-list/changelog/update-post-list-space
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Post List: Hide thumbnail when title column too narrow

--- a/projects/packages/post-list/src/index.js
+++ b/projects/packages/post-list/src/index.js
@@ -24,8 +24,62 @@ function copyLinkQuickAction() {
 	return onClick;
 }
 
+/**
+ * Handle thumbnail column visibility based on title column width.
+ */
+function handleThumbnailVisibility() {
+	// Minimum width threshold for the title column (in pixels)
+	const minTitleWidth = 200;
+
+	// Get the table
+	const table = document.querySelector( '.wp-list-table' );
+	if ( ! table ) return;
+
+	// First, determine if we need to hide thumbnails based on title width
+	const titleHeader = table.querySelector( 'thead tr .column-title' );
+	if ( ! titleHeader ) return;
+
+	const shouldHideThumbnails = titleHeader.offsetWidth < minTitleWidth;
+
+	// Get all thumbnail cells (both header and data cells)
+	const thumbnailCells = table.querySelectorAll( '.column-thumbnail' );
+
+	// Apply visibility to all thumbnail cells
+	thumbnailCells.forEach( cell => {
+		// Use direct style manipulation to ensure it works
+		cell.style.display = shouldHideThumbnails ? 'none' : '';
+
+		// Also add/remove the hidden class for CSS that depends on it
+		if ( shouldHideThumbnails ) {
+			cell.classList.add( 'hidden' );
+		} else {
+			cell.classList.remove( 'hidden' );
+		}
+	} );
+}
+
 document.addEventListener( 'DOMContentLoaded', () => {
 	document.querySelectorAll( '.jetpack-post-list__copy-link-action' ).forEach( node => {
 		node.addEventListener( 'click', copyLinkQuickAction() );
+	} );
+
+	// Hide the thumbnail column if the title column is too narrow and setup
+	// several listeners that might effect the width of the title column.
+	handleThumbnailVisibility();
+
+	window.addEventListener( 'resize', () => {
+		// Use requestAnimationFrame to limit how often this runs during resize
+		window.requestAnimationFrame( handleThumbnailVisibility );
+	} );
+
+	document.addEventListener( 'ajaxComplete', handleThumbnailVisibility );
+
+	// Listen for changes to the column checkboxes in screen options
+	const columnCheckboxes = document.querySelectorAll( '.metabox-prefs input[type="checkbox"]' );
+	columnCheckboxes.forEach( checkbox => {
+		checkbox.addEventListener( 'change', () => {
+			// Wait a bit for the column to be shown/hidden and then check visibility
+			setTimeout( handleThumbnailVisibility, 300 );
+		} );
 	} );
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/98953


## Proposed changes:

On narrow screens with many columns selected in the post/page list the title column becomes unreadably narrow. This change mitigates that by removing the post thumbnail in those cases, in a similar way to how a CSS driven responsive designs drops details on narrower viewports.

This doesn't entirely solve the problem :/ but it does mitigate it somewhat.

 * Is this the the right target width to use?
 * Need to respect the preference to not display a thumbnail at all.
 * Does it work nicely on non-post screens?
 * Does it work nicely on mobile viewports?
 * Fix weird flickering when resizing

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Apply change to site/sandbox etc as usual
2. Go to /wp-admin/edit.php
3. Use "Screen Options" at the top to turn on all of the columns
4. Play around with the screen width
5. You should notice that the thumbnail column disappears to make space for the title column

Before | After
-------|------
<img width="1209" alt="Screenshot 2025-03-07 at 06 49 14" src="https://github.com/user-attachments/assets/3521faac-b8ce-4461-91f0-ba0df210bf2a" /> | <img width="1209" alt="Screenshot 2025-03-07 at 06 50 12" src="https://github.com/user-attachments/assets/e8df6b1e-33bf-46f2-ab8f-a2eee995fcac" />



https://github.com/user-attachments/assets/0ea786b5-2ff7-40db-9f3b-f8e377411676


