### PR TITLE
[WooCommerce Analytics] Set session expiration to 30 mins or midnight

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/tweak-session-expiration-30-mins-midnight
+++ b/projects/packages/woocommerce-analytics/changelog/tweak-session-expiration-30-mins-midnight
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set expiration time for session cookie to 30 mins or midnight UTC

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -8,8 +8,6 @@
 namespace Automattic\Woocommerce_Analytics;
 
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
-use DateTime;
-use DateTimeZone;
 use WC_Order_Item;
 use WC_Order_Item_Product;
 use WC_Payment_Gateway;
@@ -363,9 +361,8 @@ trait Woo_Analytics_Trait {
 	public function get_session_expiration_time() {
 		$thirty_minutes_from_now = time() + ( 30 * 60 ); // 30 minutes from now
 		$midnight                = strtotime( 'tomorrow UTC' ) - 1; // 1 second before midnight
-		$expiration_time         = min( $thirty_minutes_from_now, $midnight );
-		$date                    = new DateTime( "@$expiration_time", new DateTimeZone( 'UTC' ) );
-		return $date->format( 'D, d M Y H:i:s \G\M\T' );
+		$expiration_time         = min( $thirty_minutes_from_now, $midnight ); // Get the earliest expiration time
+		return gmdate( 'D, d M Y H:i:s \G\M\T', $expiration_time );
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -8,6 +8,8 @@
 namespace Automattic\Woocommerce_Analytics;
 
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
+use DateTime;
+use DateTimeZone;
 use WC_Order_Item;
 use WC_Order_Item_Product;
 use WC_Payment_Gateway;
@@ -339,17 +341,31 @@ trait Woo_Analytics_Trait {
 			$session_id         = wp_generate_uuid4();
 			$this->session_id   = $session_id;
 			$this->landing_page = sanitize_url( wp_unslash( ( empty( $_SERVER['HTTPS'] ) ? 'http' : 'https' ) . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]" ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidatedNotSanitized -- actually escaped with sanitize_url.
+			$session_expiration = $this->get_session_expiration_time();
 			$event_js           = $this->process_event_properties( 'woocommerceanalytics_session_started' );
 			$cookie_js          = "
             const sessionData = JSON.stringify({
                     session_id: '{$this->session_id}',
                     landing_page: encodeURIComponent('{$this->landing_page}'),
             });
-            document.cookie = `woocommerceanalytics_session=\${sessionData}; path=/; secure; samesite=strict`;
+            document.cookie = `woocommerceanalytics_session=\${sessionData}; expires={$session_expiration}; path=/; secure; samesite=strict`;
             ";
 			wc_enqueue_js( $cookie_js ); // save the session cookie for further events in the session
 			wc_enqueue_js( "_wca.push({$event_js});" ); // trigger session started event
 		}
+	}
+
+	/**
+	 * Get a 30 minutes expiration time from now or at midnight UTC, whichever comes first.
+	 *
+	 * @return string
+	 */
+	public function get_session_expiration_time() {
+		$thirty_minutes_from_now = time() + ( 30 * 60 ); // 30 minutes from now
+		$midnight                = strtotime( 'tomorrow UTC' ) - 1; // 1 second before midnight
+		$expiration_time         = min( $thirty_minutes_from_now, $midnight );
+		$date                    = new DateTime( "@$expiration_time", new DateTimeZone( 'UTC' ) );
+		return $date->format( 'D, d M Y H:i:s \G\M\T' );
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -340,7 +340,7 @@ trait Woo_Analytics_Trait {
 		if ( ! $this->get_session_id() ) {
 			$session_id         = wp_generate_uuid4();
 			$this->session_id   = $session_id;
-      $this->landing_page = $this->get_current_url();
+			$this->landing_page = $this->get_current_url();
 			$session_expiration = $this->get_session_expiration_time();
 			$event_js           = $this->process_event_properties( 'woocommerceanalytics_session_started' );
 			$cookie_js          = "


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Set `wocommerceanalytics_session` expiration to 30 mins or midnight UTC (whatever comes first) 

Discussion reference: p1741259768755129/1740481006.536889-slack-C06FSDTSN82

ℹ️  This PR doesn't cover other fixes like Add to cart issues or session creation issues. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this PR and build & sync JP
* Remove `wocommerceanalytics_session` cookie in case you have it
* Go to a Product Page 
* See the session is created with an expiration of 30 (UTC) from the time you are.
* Change the code the PR `$thirty_minutes_from_now = time() + ( 30 * 60 ); // 30 minutes from now` into `$thirty_minutes_from_now = time() + ( 60 * 60 *24 ); // 24 hours` to ensure a time after midnight.
* Remove `wocommerceanalytics_session` cookie in case you have it
*  Go to a Product Page 
* See the session is created with an expiration at Midnight - 1 second (UTC).

