### PR TITLE
Jetpack Sync: Enable sync for `wpcomsh_at_managed_plugins` option

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-enable-at-managed-plugins-list-jetpack-sync
+++ b/projects/plugins/wpcomsh/changelog/add-enable-at-managed-plugins-list-jetpack-sync
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add wpcomsh_at_managed_plugins option to allowed list for sync

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -289,6 +289,7 @@ function wpcomsh_allow_custom_wp_options( $options ) {
 	$options[] = 'jetpack_fonts';
 	$options[] = 'site_logo';
 	$options[] = 'footercredit';
+	$options[] = 'wpcomsh_at_managed_plugins';
 
 	return $options;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/98422

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Add wpcomsh_at_managed_plugins option to allowed list for sync. 
* This option has been proposed in https://github.com/Automattic/jetpack/pull/42164

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* The visual review should be good. 

