### PR TITLE
Social | Fix stylesheets loaded on the front-end

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-assets-loaded-on-the-front-end
+++ b/projects/packages/publicize/changelog/fix-social-assets-loaded-on-the-front-end
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social | Fix stylesheets loaded on the front-end when not needed.

--- a/projects/packages/publicize/src/class-publicize-assets.php
+++ b/projects/packages/publicize/src/class-publicize-assets.php
@@ -20,7 +20,7 @@ class Publicize_Assets {
 	public static function configure() {
 		Publicize_Script_Data::configure();
 
-		add_action( 'enqueue_block_assets', array( __CLASS__, 'enqueue_block_editor_scripts' ), 15 );
+		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_scripts' ), 15 );
 	}
 
 	/**


### PR DESCRIPTION

Fixes #42288

#41836 apparently caused a slight regression where the stylesheets meant for wp-admin and block editor are loaded for public pages of the sites due to the usage of a hook (`enqueue_block_assets`) that enqueues assets to the public facing pages as well. Thus, we need to use `enqueue_block_editor_assets` instead because we need the assets only for the block editor.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Switch from `enqueue_block_assets` to `enqueue_block_editor_assets` for loading publicize editor assets.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor
* Confirm that the Social UI in the Jetpack sidebar loads fine
* Open the site on the front-end (public pages)
* Confirm that the stylesheets like `forms` and `common` are not loaded.

