### PR TITLE
Avoid warning newspack blocks api accessing attachment images

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-avoid-warning-newspack-blocks-api-accessing-attachment-images
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-avoid-warning-newspack-blocks-api-accessing-attachment-images
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Newspack Blocks Api: Check to avoid Warnings when accessing attachment image src

--- a/projects/packages/jetpack-mu-wpcom/src/features/newspack-blocks/synced-newspack-blocks/class-newspack-blocks-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/newspack-blocks/synced-newspack-blocks/class-newspack-blocks-api.php
@@ -28,7 +28,7 @@ class Newspack_Blocks_API {
 			'large',
 			false
 		);
-		$featured_image_set['large'] = $feat_img_array_large[0];
+		$featured_image_set['large'] = $feat_img_array_large[0] ?? null;
 
 		// Landscape image.
 		$landscape_size = Newspack_Blocks::image_size_for_orientation( 'landscape' );
@@ -38,7 +38,7 @@ class Newspack_Blocks_API {
 			$landscape_size,
 			false
 		);
-		$featured_image_set['landscape'] = $feat_img_array_landscape[0];
+		$featured_image_set['landscape'] = $feat_img_array_landscape[0] ?? null;
 
 		// Portrait image.
 		$portrait_size = Newspack_Blocks::image_size_for_orientation( 'portrait' );
@@ -48,7 +48,7 @@ class Newspack_Blocks_API {
 			$portrait_size,
 			false
 		);
-		$featured_image_set['portrait'] = $feat_img_array_portrait[0];
+		$featured_image_set['portrait'] = $feat_img_array_portrait[0] ?? null;
 
 		// Square image.
 		$square_size = Newspack_Blocks::image_size_for_orientation( 'square' );
@@ -58,7 +58,7 @@ class Newspack_Blocks_API {
 			$square_size,
 			false
 		);
-		$featured_image_set['square'] = $feat_img_array_square[0];
+		$featured_image_set['square'] = $feat_img_array_square[0] ?? null;
 
 		// Uncropped image.
 		$uncropped_size = 'newspack-article-block-uncropped';
@@ -68,7 +68,7 @@ class Newspack_Blocks_API {
 			$uncropped_size,
 			false
 		);
-		$featured_image_set['uncropped'] = $feat_img_array_uncropped[0];
+		$featured_image_set['uncropped'] = $feat_img_array_uncropped[0] ?? null;
 
 		return $featured_image_set;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes **Warnings** in newspack blocks API when accessing attachment images arrays that returned false.
>  Trying to access array offset on value of type bool

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added null coalescing operator when

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1741335065431469-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code Review should suffice