### PR TITLE
Verbum: allow loading more broadly

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-not-loading
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-not-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Verbum: allow broader loading

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
@@ -114,7 +114,7 @@ class Verbum_Comments {
 	public function enqueue_assets() {
 		if (
 			! ( is_singular() && comments_open() )
-			&& ! ( is_front_page() && is_page() && comments_open() )
+			&& ! ( is_front_page() && comments_open() )
 		) {
 			return;
 		}

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-verbum-not-loading
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-verbum-not-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Verbum: allow broader loading

--- a/projects/plugins/wpcomsh/changelog/fix-verbum-not-loading
+++ b/projects/plugins/wpcomsh/changelog/fix-verbum-not-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Verbum: allow broader loading


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/100774

## Proposed changes:

* Stop checking `is_page()` before loading Verbum assets

This extra check is preventing Verbum from loading where the comments are expected to be at.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
na

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:

https://github.com/user-attachments/assets/26ed9014-2177-432e-8255-67a483a9e7fc

* Add a comment block to a post
* Set your blog to show latest posts
* View the front page and the comment box should be available
* Check around other pages to make sure its not loading Verbum places it shouldn't