### PR TITLE
Notes: update wordpress.com/notifications URL to /reader

### DIFF
--- a/projects/plugins/jetpack/changelog/update-notifications-url
+++ b/projects/plugins/jetpack/changelog/update-notifications-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Notifications: update link URL to wordpress.com

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -205,7 +205,7 @@ class Jetpack_Notifications {
 					'class' => 'menupop',
 				),
 				'parent' => 'top-secondary',
-				'href'   => 'https://wordpress.com/notifications',
+				'href'   => 'https://wordpress.com/reader/notifications',
 			)
 		);
 	}


### PR DESCRIPTION
A recent wpcom patch (wpcom-172203) by @mehmoodak updated the `wordpress.com/notifications` link to `/reader/notification`, but that only happened in the `click` hander in the `admin-bar-v2.js` script. The markup produced by Jetpack still has the old URL in the `<a href>` attribute. This leads to confusing behavior where the browsers shows you that a link leads somewhere, but on click it navigates to a different URL.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Start with a self-hosted or WoA site that's connected to WordPress.com.
* In Firefox, click on the Notifications icon in the admin bar.
* You should be redirected to https://wordpress.com/reader/notifications