### PR TITLE
Social | Configure data store to handle scheduled shares

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-configure-store-4-scheduled-shares
+++ b/projects/js-packages/publicize-components/changelog/update-social-configure-store-4-scheduled-shares
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Social | Configure data store to handle scheduled shares

--- a/projects/js-packages/publicize-components/src/social-store/actions/index.ts
+++ b/projects/js-packages/publicize-components/src/social-store/actions/index.ts
@@ -1,5 +1,6 @@
 import * as connectionData from './connection-data';
 import * as pricingPageSettings from './pricing-page';
+import * as scheduledSharesActions from './scheduled-shares';
 import * as servicesActions from './services';
 import * as shareStatus from './share-status';
 import * as sigActions from './social-image-generator';
@@ -16,6 +17,7 @@ const actions = {
 	...pricingPageSettings,
 	...socialModuleSettings,
 	...servicesActions,
+	...scheduledSharesActions,
 };
 
 export default actions;

--- a/projects/js-packages/publicize-components/src/social-store/actions/scheduled-shares.ts
+++ b/projects/js-packages/publicize-components/src/social-store/actions/scheduled-shares.ts
@@ -1,0 +1,35 @@
+import { store as coreStore } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Deletes a scheduled share.
+ *
+ * @param id - The ID of the scheduled share to delete.
+ *
+ * @return A thunk.
+ */
+export function deleteScheduledShare( id: number ) {
+	return async function ( { registry } ) {
+		const { deleteEntityRecord } = registry.dispatch( coreStore );
+		const { getLastEntityDeleteError } = registry.select( coreStore );
+		const { createErrorNotice } = registry.dispatch( noticesStore );
+
+		const success = await deleteEntityRecord( 'wpcom/v2', 'publicize/scheduled-actions', id );
+
+		// If the deletion was not successful, show an error notice.
+		if ( ! success ) {
+			const lastError = getLastEntityDeleteError( 'wpcom/v2', 'publicize/scheduled-actions', id );
+
+			let message = __( 'There was an error deleting the item.', 'jetpack-publicize-components' );
+
+			if ( lastError?.message ) {
+				message += ' ' + lastError.message;
+			}
+
+			createErrorNotice( message, {
+				type: 'snackbar',
+			} );
+		}
+	};
+}

--- a/projects/js-packages/publicize-components/src/social-store/hydrate-stores.ts
+++ b/projects/js-packages/publicize-components/src/social-store/hydrate-stores.ts
@@ -60,4 +60,15 @@ export async function hydrateStores() {
 
 		await finishResolution( 'getEntityRecords', [ 'wpcom/v2', 'publicize/services' ] );
 	}
+
+	if ( ! wpcomEntities.some( ( { name } ) => name === 'publicize/scheduled-actions' ) ) {
+		await addEntities( [
+			{
+				kind: 'wpcom/v2',
+				name: 'publicize/scheduled-actions',
+				baseURL: '/wpcom/v2/publicize/scheduled-actions',
+				label: __( 'Publicize scheduled actions', 'jetpack-publicize-components' ),
+			},
+		] );
+	}
 }

--- a/projects/js-packages/publicize-components/src/social-store/selectors/index.ts
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/index.ts
@@ -1,4 +1,5 @@
 import * as connectionDataSelectors from './connection-data';
+import * as scheduledSharesSelectors from './scheduled-shares';
 import * as servicesSelectors from './services';
 import * as shareStatusSelectors from './share-status';
 import * as socialModuleSelectors from './social-module-settings';
@@ -10,6 +11,7 @@ const selectors = {
 	...socialModuleSelectors,
 	...socialSettingsSelectors,
 	...servicesSelectors,
+	...scheduledSharesSelectors,
 };
 
 export default selectors;

--- a/projects/js-packages/publicize-components/src/social-store/selectors/scheduled-shares.ts
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/scheduled-shares.ts
@@ -1,0 +1,53 @@
+import { store as coreStore } from '@wordpress/core-data';
+import { createRegistrySelector } from '@wordpress/data';
+import { ScheduledShare } from '../types';
+
+/**
+ * Get the list of scheduled shares for a post.
+ *
+ * @param state - State object.
+ *
+ * @return The list of services.
+ */
+export const getScheduledSharesForPost = createRegistrySelector( select => {
+	return ( state: unknown, post_id: number ) => {
+		const data = select( coreStore ).getEntityRecords< ScheduledShare >(
+			'wpcom/v2',
+			'publicize/scheduled-actions',
+			{ post_id }
+		);
+
+		return data ?? [];
+	};
+} );
+
+/**
+ * Returns whether the scheduled shares for a post are being fetched.
+ */
+export const isFetchingScheduledSharesForPost = createRegistrySelector( select => {
+	return ( state: unknown, post_id: number ): boolean => {
+		const {
+			// @ts-expect-error isResolving does exist but is not typed
+			isResolving,
+		} = select( coreStore );
+
+		return isResolving( 'getEntityRecords', [
+			'wpcom/v2',
+			'publicize/scheduled-actions',
+			{ post_id },
+		] );
+	};
+} );
+
+/**
+ * Returns whether a scheduled share is being deleted.
+ */
+export const isDeletingScheduledShare = createRegistrySelector( select => {
+	return ( state: unknown, id: number ): boolean => {
+		return select( coreStore ).isDeletingEntityRecord(
+			'wpcom/v2',
+			'publicize/scheduled-actions',
+			id
+		);
+	};
+} );

--- a/projects/js-packages/publicize-components/src/social-store/types.ts
+++ b/projects/js-packages/publicize-components/src/social-store/types.ts
@@ -153,3 +153,13 @@ export type SocialSettingsFields = {
 	jetpack_social_notes_config: SocialNotesConfig;
 	[ 'jetpack-social_show_pricing_page' ]: boolean;
 };
+
+export type ScheduledShare = {
+	id: number;
+	blog_id: number;
+	connection_id: number;
+	message: string;
+	post_id: number;
+	timestamp: number;
+	wpcom_user_id: number;
+};


### PR DESCRIPTION
This PR needs the changes from #42283 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Configure the social data store to handle (CRUD) operations for scheduled shares

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to block editor for a post
* Open the Network tab and Console in your browser
* Enter this in the console
```js
const postId = 109; // Replace this with the correct post ID
wp.data.select( 'jetpack-social-plugin' ).getScheduledSharesForPost( postId )
```
* Check the request in the Network tab
* Wait for it to finish
* Then run the above code again
* Confirm that it returns the list of scheduled shares if any
* Run this
```js
const id = 3274192; // Replace this with the correct ID for a particular share that you wish to delete
await wp.data.dispatch( 'jetpack-social-plugin' ).deleteScheduledShare(id)
```
* Confirm that it deletes the share successfully

<img width="689" alt="image" src="https://github.com/user-attachments/assets/e02ea59d-f737-46cc-8635-5b035713efdd" />
