### PR TITLE
Social: Add tabbed modal component

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-social-tabbed-modal-component
+++ b/projects/js-packages/publicize-components/changelog/add-social-tabbed-modal-component
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added the TabbedModal pure component

--- a/projects/js-packages/publicize-components/src/components/tabbed-modal/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/tabbed-modal/index.tsx
@@ -1,0 +1,74 @@
+import { Modal, TabPanel } from '@wordpress/components';
+import clsx from 'clsx';
+import { ReactNode } from 'react';
+import styles from './style.module.scss';
+
+export type ModalTab = {
+	/** Unique name identifier for the tab */
+	name: string;
+
+	/** Display title of the tab */
+	title: string;
+
+	/** Content to display when tab is active */
+	content: ReactNode;
+
+	/** Additional class name for the tab */
+	className?: string;
+};
+
+export type TabbedModalProps = {
+	/** Whether the modal is open */
+	isOpen: boolean;
+
+	/** Function to call when the modal is closed */
+	onClose: () => void;
+
+	/** Modal title */
+	title: string;
+
+	/** Array of tabs to display */
+	tabs: ModalTab[];
+
+	/** Optional className to add to the modal */
+	className?: string;
+};
+
+/**
+ * TabbedModal component provides a modal dialog with tabs
+ *
+ * @param {TabbedModalProps} props - The props for the TabbedModal component
+ * @return {React.ReactElement|null} The TabbedModal component or null if not open
+ */
+export default function TabbedModal( {
+	isOpen,
+	onClose,
+	title,
+	tabs,
+	className,
+}: TabbedModalProps ) {
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	// Transform tabs to the format expected by TabPanel
+	const tabPanelTabs = tabs.map( tab => ( {
+		name: tab.name,
+		title: tab.title,
+		className: `${ styles.tab } ${ tab.className || '' }`,
+	} ) );
+
+	return (
+		<Modal title={ title } onRequestClose={ onClose } className={ clsx( styles.modal, className ) }>
+			<div className={ styles.wrapper }>
+				<TabPanel activeClass={ styles.active } tabs={ tabPanelTabs }>
+					{ activeTab => {
+						// Find the matching tab content
+						const currentTab = tabs.find( tab => tab.name === activeTab.name );
+						return <div className={ styles.tabContent }>{ currentTab?.content }</div>;
+					} }
+				</TabPanel>
+			</div>
+		</Modal>
+	);
+}

--- a/projects/js-packages/publicize-components/src/components/tabbed-modal/stories/index.stories.tsx
+++ b/projects/js-packages/publicize-components/src/components/tabbed-modal/stories/index.stories.tsx
@@ -1,0 +1,64 @@
+import { Button } from '@wordpress/components';
+import { useCallback, useState } from '@wordpress/element';
+import TabbedModal, { ModalTab, TabbedModalProps } from '../index';
+import type { StoryFn, Meta } from '@storybook/react';
+
+export default {
+	title: 'JS Packages/Publicize Components/Tabbed Modal',
+	component: TabbedModal,
+	parameters: {
+		layout: 'centered',
+	},
+} satisfies Meta< typeof TabbedModal >;
+
+// Create interactive template with open/close functionality
+const Template: StoryFn< typeof TabbedModal > = args => {
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	const openModal = useCallback( () => setIsOpen( true ), [] );
+	const closeModal = useCallback( () => setIsOpen( false ), [] );
+
+	return (
+		<>
+			<Button variant="primary" onClick={ openModal }>
+				Open Modal
+			</Button>
+			<TabbedModal { ...args } isOpen={ isOpen } onClose={ closeModal } />
+		</>
+	);
+};
+
+const sampleTabs: ModalTab[] = [
+	{
+		name: 'tab1',
+		title: 'New Share',
+		content: (
+			<div>
+				<h4>First Tab Content</h4>
+				<p>This is the content of the first tab. You can put any React components here.</p>
+			</div>
+		),
+	},
+	{
+		name: 'tab2',
+		title: 'Scheduled',
+		content: (
+			<div>
+				<h4>Second Tab Content</h4>
+				<p>This is the content of the second tab with different components.</p>
+				<Button variant="secondary">Example Button</Button>
+			</div>
+		),
+	},
+];
+
+const DefaultArgs: TabbedModalProps = {
+	isOpen: false,
+	onClose: () => {},
+	title: 'Share Post',
+	tabs: sampleTabs,
+};
+
+// Export Default story
+export const Default = Template.bind( {} );
+Default.args = DefaultArgs;

--- a/projects/js-packages/publicize-components/src/components/tabbed-modal/style.module.scss
+++ b/projects/js-packages/publicize-components/src/components/tabbed-modal/style.module.scss
@@ -1,0 +1,20 @@
+@import '@automattic/jetpack-base-styles/gutenberg-base-styles';
+
+.modal {
+	:global(.components-modal__header-heading) {
+		font-weight: 400;
+		font-size: 24px;
+	}	
+}
+
+.wrapper{
+	:global(.components-tab-panel__tabs) {
+		height: 48px;
+		border-bottom: 1px solid var(--jp-gray-10);
+	}
+}
+
+.tab {
+	font-size: 16px;
+	font-weight: 400;
+}

--- a/projects/js-packages/publicize-components/src/components/tabbed-modal/tests/index.test.js
+++ b/projects/js-packages/publicize-components/src/components/tabbed-modal/tests/index.test.js
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TabbedModal from '../index';
+
+// Simplified mocks
+jest.mock( '@wordpress/components', () => ( {
+	Modal: ( { title, onRequestClose, className, children } ) => (
+		<div data-testid="modal" className={ className }>
+			<h2>{ title }</h2>
+			<button data-testid="close-button" onClick={ onRequestClose }>
+				Close
+			</button>
+			{ children }
+		</div>
+	),
+	TabPanel: ( { tabs, children } ) => <div>{ children( tabs[ 0 ] ) }</div>,
+} ) );
+
+describe( 'TabbedModal', () => {
+	const mockOnClose = jest.fn();
+	const mockTabs = [
+		{
+			name: 'tab1',
+			title: 'First Tab',
+			content: <div>Tab 1 Content</div>,
+		},
+		{
+			name: 'tab2',
+			title: 'Second Tab',
+			content: <div>Tab 2 Content</div>,
+		},
+	];
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders nothing when closed', () => {
+		const { container } = render(
+			<TabbedModal isOpen={ false } onClose={ mockOnClose } title="Test" tabs={ mockTabs } />
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders with title when open', () => {
+		render(
+			<TabbedModal isOpen={ true } onClose={ mockOnClose } title="Test Title" tabs={ mockTabs } />
+		);
+		expect( screen.getByText( 'Test Title' ) ).toBeInTheDocument();
+	} );
+
+	it( 'calls onClose when close button is clicked', async () => {
+		render(
+			<TabbedModal isOpen={ true } onClose={ mockOnClose } title="Test" tabs={ mockTabs } />
+		);
+		await userEvent.click( screen.getByTestId( 'close-button' ) );
+		expect( mockOnClose ).toHaveBeenCalled();
+	} );
+
+	it( 'applies custom className to modal', () => {
+		render(
+			<TabbedModal
+				isOpen={ true }
+				onClose={ mockOnClose }
+				title="Test"
+				tabs={ mockTabs }
+				className="custom-class"
+			/>
+		);
+		expect( screen.getByTestId( 'modal' ) ).toHaveClass( 'custom-class' );
+	} );
+} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/834

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added the TabbedModal component + Unit test + Storybook

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `pnpm -F @automattic/jetpack-storybook storybook:dev`
* In the Storybook playground, goto JS Packages  > Publicize Components > Tabbed Modal
* Check that they work as expected
* Make sure the unit tests pass - CI does it

![CleanShot 2025-03-07 at 13 56 09 png](https://github.com/user-attachments/assets/e09cc05b-c5fa-43d5-bd2a-a19a7d2cce27)
