### PR TITLE
Plugin search: remove standalone plugins when suggesting features

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-plugin-search-standalone-plugins
+++ b/projects/plugins/jetpack/changelog/fix-plugin-search-standalone-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Feature Suggestions: do not suggest Jetpack standalone plugins when a matching feature already exists in the Jetpack plugin.

--- a/projects/plugins/jetpack/modules/plugin-search.php
+++ b/projects/plugins/jetpack/modules/plugin-search.php
@@ -431,8 +431,14 @@ class Jetpack_Plugin_Search {
 				// Splice in the base module data.
 				$inject = array_merge( $inject, $jetpack_modules_list[ $matching_module ], $overrides );
 
-				// Add it to the top of the list.
+				/*
+				 * Remove standalone plugins from the list,
+				 * since they offer features that are already available in Jetpack.
+				 * Also remove the Jetpack plugin card from the list since it is already installed and active.
+				 */
 				$result->plugins = array_filter( $result->plugins, array( $this, 'filter_cards' ) );
+
+				// Add our feature suggestion to the top of the list.
 				array_unshift( $result->plugins, $inject );
 			}
 		}
@@ -440,11 +446,14 @@ class Jetpack_Plugin_Search {
 	}
 
 	/**
-	 * Remove cards for Jetpack plugins since we don't want duplicates.
+	 * When the user searches for a plugin, we don't want to show:
+	 * - the Jetpack plugin card, since it is already installed and active.
+	 * - standalone plugins, since they offer features that are already available in Jetpack.
 	 *
 	 * @since 7.1.0
 	 * @since 7.2.0 Only remove Jetpack.
 	 * @since 7.4.0 Simplify for WordPress 5.1+.
+	 * @since $$next-version$$ Remove standalone plugins.
 	 *
 	 * @param array|object $plugin WordPress search result card.
 	 *
@@ -465,7 +474,18 @@ class Jetpack_Plugin_Search {
 			return false;
 		}
 
-		return ! in_array( $slug, array( 'jetpack' ), true );
+		return ! in_array(
+			$slug,
+			array(
+				'jetpack',
+				'jetpack-boost',
+				'jetpack-protect',
+				'jetpack-search',
+				'jetpack-social',
+				'jetpack-videopress',
+			),
+			true
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/plugin-search.php
+++ b/projects/plugins/jetpack/modules/plugin-search.php
@@ -478,6 +478,7 @@ class Jetpack_Plugin_Search {
 			$slug,
 			array(
 				'jetpack',
+				'jetpack-backup',
 				'jetpack-boost',
 				'jetpack-protect',
 				'jetpack-search',


### PR DESCRIPTION
Fixes #27103

## Proposed changes:

> [!NOTE]
> I'm marking this PR as proposal, since I would like to be sure we want to remove standalone plugins from plugin search results when one searches for a feature that's already available in the Jetpack plugin.

When one has the Jetpack plugin active, and searches for a feature that is already available in Jetpack and is also available in a standalone plugin, let's not suggest the standalone plugin to avoid confusion. Let's only suggest using Jetpack.

| **Before** | **After** |
|--------|--------|
| <img width="1403" alt="image" src="https://github.com/user-attachments/assets/843759fe-ecb1-43ec-ac09-cf62c4f90819" /> | <img width="1395" alt="image" src="https://github.com/user-attachments/assets/5c6a2143-7d9d-4a38-b5d9-b927d2c7261c" /> |

> [!NOTE]
> The design is currently a bit janky. I'm addressing this in https://github.com/Automattic/jetpack/pull/42301

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

No

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Start with a site where the Jetpack plugin is installed, active, and connected to WordPress.com.
* Go to Plugins > Add New
* Search for `videopress`
    * You should see a suggestion to try the VideoPress feature **in Jetpack** as the first result, and you should not see any Jetpack VideoPress plugin in the rest of the search results.
* Repeat the experiment with `publicize` (no Jetpack Social plugin should be suggested)
* Search for a term that does not currently return any suggestion (e.g. `WPScan` since the Jetpack plugin does not ship with WPScan)
    * You should see the Jetpack Protect plugin among the search results.
