### PR TITLE
Duplicate Views: Comment likes on Atomic

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-comment-likes-on-atomic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-comment-likes-on-atomic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added the ability to like own comments on Atomic sites

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/class-wp-rest-comment-like.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/class-wp-rest-comment-like.php
@@ -126,7 +126,7 @@ class WP_REST_Comment_Like extends WP_REST_Controller {
 
 		$body = wp_remote_retrieve_body( $response );
 
-		if ( is_wp_error( $body ) ) {
+		if ( is_wp_error( $body ) && $body instanceof WP_Error ) {
 			return $body;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/class-wp-rest-comment-like.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/class-wp-rest-comment-like.php
@@ -50,7 +50,7 @@ class WP_REST_Comment_Like extends WP_REST_Controller {
 			'/comments/(?P<comment_id>\d+)/likes/mine/delete',
 			array(
 				array(
-					'methods'             => \WP_REST_Server::CREATABLE, // DELETE method.
+					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'delete_like' ),
 					'permission_callback' => array( $this, 'permission_callback' ),
 				),
@@ -101,11 +101,11 @@ class WP_REST_Comment_Like extends WP_REST_Controller {
 		$comment_id = $request->get_param( 'comment_id' );
 		$blog_id    = \Jetpack_Options::get_option( 'id' );
 
-		// Call a remote API to delete the current user's like.
+		// Call WPCom remote API to delete the current user's like.
 		$response = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
 			"/sites/$blog_id/comments/$comment_id/likes/mine/delete",
 			'v1.1',
-			array( 'method' => 'POST' ), // Using POST here; adjust to DELETE if supported.
+			array( 'method' => 'POST' ),
 			null,
 			'rest'
 		);

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/class-wp-rest-comment-like.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/class-wp-rest-comment-like.php
@@ -121,17 +121,25 @@ class WP_REST_Comment_Like extends WP_REST_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	private function ensure_response( $response ) {
-		if ( ! $response || is_wp_error( $response ) ) {
+		if ( ! $response ) {
+			return new WP_Error( 'unknown_response', 'Empty response', 500 );
+		}
+
+		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
 
 		$body = wp_remote_retrieve_body( $response );
 
-		if ( ! $body ) {
+		if ( ! $body || is_wp_error( $body ) ) {
 			return new WP_Error( 'unknown_response', 'Empty response', 500 );
 		}
 
 		$response = json_decode( $body, true );
+
+		if ( ! $response ) {
+			return new WP_Error( 'unknown_response', 'Empty response', 500 );
+		}
 
 		// Return the response from the server.
 		return rest_ensure_response( $response );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/class-wp-rest-comment-like.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/class-wp-rest-comment-like.php
@@ -8,9 +8,10 @@
  */
 
 /**
- * Class WP_REST_Comments_Likes.
+ * Class WP_REST_Comment_Like.
  *
- * Handles endpoints for creating a new like and deleting a like.
+ * A thin wrapper around the wpcom implementation, specifically designed for comments moderation.
+ * Handles endpoints for creating a new like and deleting a like on comments.
  */
 class WP_REST_Comment_Like extends WP_REST_Controller {
 
@@ -34,12 +35,6 @@ class WP_REST_Comment_Like extends WP_REST_Controller {
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'new_like' ),
 					'permission_callback' => array( $this, 'permission_callback' ),
-					'args'                => array(
-						'_locale' => array(
-							'required' => false,
-							'type'     => 'string',
-						),
-					),
 				),
 			)
 		);

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/class-wp-rest-comment-like.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/class-wp-rest-comment-like.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * File: class-wp-rest-comments-likes.php
+ *
+ * Provides REST API endpoints for creating and deleting comment likes.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Class WP_REST_Comments_Likes.
+ *
+ * Handles endpoints for creating a new like and deleting a like.
+ */
+class WP_REST_Comment_Like extends WP_REST_Controller {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'rest/v1.1';
+	}
+
+	/**
+	 * Register available routes.
+	 */
+	public function register_routes() {
+		// Endpoint for creating a new like.
+		register_rest_route(
+			$this->namespace,
+			'/comments/(?P<comment_id>\d+)/likes/new',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'new_like' ),
+					'permission_callback' => array( $this, 'permission_callback' ),
+					'args'                => array(
+						'_locale' => array(
+							'required' => false,
+							'type'     => 'string',
+						),
+					),
+				),
+			)
+		);
+
+		// Endpoint for deleting the current user's like.
+		register_rest_route(
+			$this->namespace,
+			'/comments/(?P<comment_id>\d+)/likes/mine/delete',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE, // DELETE method.
+					'callback'            => array( $this, 'delete_like' ),
+					'permission_callback' => array( $this, 'permission_callback' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Permission callback.
+	 *
+	 * @return bool
+	 */
+	public function permission_callback(): bool {
+		return current_user_can( 'moderate_comments' );
+	}
+
+	/**
+	 * Callback for the new like endpoint.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function new_like( WP_REST_Request $request ) {
+		$comment_id = $request->get_param( 'comment_id' );
+		$blog_id    = \Jetpack_Options::get_option( 'id' );
+
+		// Call WPCom remote API to record a new like.
+		$response = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
+			"/sites/$blog_id/comments/$comment_id/likes/new",
+			'v1.1',
+			array( 'method' => 'POST' ),
+			null,
+			'rest'
+		);
+
+		return $this->ensure_response( $response );
+	}
+
+	/**
+	 * Callback for the delete like endpoint.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function delete_like( WP_REST_Request $request ) {
+		$comment_id = $request->get_param( 'comment_id' );
+		$blog_id    = \Jetpack_Options::get_option( 'id' );
+
+		// Call a remote API to delete the current user's like.
+		$response = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
+			"/sites/$blog_id/comments/$comment_id/likes/mine/delete",
+			'v1.1',
+			array( 'method' => 'POST' ), // Using POST here; adjust to DELETE if supported.
+			null,
+			'rest'
+		);
+
+		return $this->ensure_response( $response );
+	}
+
+	/**
+	 * Ensures a valid rest response.
+	 *
+	 * @param array|WP_Error $response The remote response object.
+	 *
+	 * @return WP_Error|WP_REST_Response
+	 */
+	private function ensure_response( $response ) {
+		if ( ! $response || is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+
+		if ( ! $body ) {
+			return new WP_Error( 'unknown_response', 'Empty response', 500 );
+		}
+
+		$response = json_decode( $body, true );
+
+		// Return the response from the server.
+		return rest_ensure_response( $response );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/class-wp-rest-comment-like.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/class-wp-rest-comment-like.php
@@ -59,7 +59,7 @@ class WP_REST_Comment_Like extends WP_REST_Controller {
 	 * @return bool
 	 */
 	public function permission_callback(): bool {
-		return current_user_can( 'moderate_comments' );
+		return is_user_logged_in();
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/class-wp-rest-comment-like.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/class-wp-rest-comment-like.php
@@ -117,7 +117,7 @@ class WP_REST_Comment_Like extends WP_REST_Controller {
 	 */
 	private function ensure_response( $response ) {
 		if ( ! $response ) {
-			return new WP_Error( 'unknown_response', 'Empty response', 500 );
+			return new WP_Error( 'unknown_response', 'Empty response from server', 500 );
 		}
 
 		if ( is_wp_error( $response ) ) {
@@ -126,14 +126,18 @@ class WP_REST_Comment_Like extends WP_REST_Controller {
 
 		$body = wp_remote_retrieve_body( $response );
 
-		if ( ! $body || is_wp_error( $body ) ) {
-			return new WP_Error( 'unknown_response', 'Empty response', 500 );
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+
+		if ( ! $body ) {
+			return new WP_Error( 'unknown_response', 'Empty response body from server', 500 );
 		}
 
 		$response = json_decode( $body, true );
 
 		if ( ! $response ) {
-			return new WP_Error( 'unknown_response', 'Empty response', 500 );
+			return new WP_Error( 'unknown_response', 'Empty decoded response body', 500 );
 		}
 
 		// Return the response from the server.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/wpcom-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/wpcom-comments.php
@@ -114,7 +114,7 @@ add_action( 'admin_enqueue_scripts', 'wpcom_enqueue_comment_like_script', 10, 2 
  */
 function wpcom_comments_register_like_api() {
 	require_once __DIR__ . '/class-wp-rest-comment-like.php';
-	$controller = new WP_REST_Comments_Like();
+	$controller = new WP_REST_Comment_Like();
 	$controller->register_routes();
 }
 if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/wpcom-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/wpcom-comments.php
@@ -7,7 +7,7 @@
  */
 
 if ( ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) && ( ! defined( 'IS_ATOMIC' ) || ! IS_ATOMIC ) ) {
-	return false;
+	return;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/wpcom-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/wpcom-comments.php
@@ -6,8 +6,8 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
-if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
-	return;
+if ( ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) && ( ! defined( 'IS_ATOMIC' ) || ! IS_ATOMIC ) ) {
+	return false;
 }
 
 /**
@@ -19,10 +19,39 @@ if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
  * @return array Modified array of comment classes.
  */
 function wpcom_comments_add_like_class( $classes, $css_class, $comment_id ) {
-	$blog_id = get_current_blog_id();
-	if ( Likes::comment_like_current_user_likes( $blog_id, $comment_id ) ) {
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		$blog_id = get_current_blog_id();
+		$liked   = Likes::comment_like_current_user_likes( $blog_id, $comment_id );
+	} else {
+		$blog_id  = Jetpack_Options::get_option( 'id' );
+		$response = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
+			"/sites/$blog_id/comments/$comment_id/likes",
+			'v1.1',
+			array( 'method' => 'GET' ),
+			null,
+			'rest'
+		);
+
+		// If the request fails, simply return the unmodified classes.
+		if ( is_wp_error( $response ) ) {
+			return $classes;
+		}
+
+		$response_data = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		// If the response doesn't include 'i_like', don't add the class.
+		if ( empty( $response_data['i_like'] ) ) {
+			return $classes;
+		}
+
+		$liked = $response_data['i_like'];
+	}
+
+	// Append the 'liked' class if the comment is liked.
+	if ( $liked ) {
 		$classes[] = 'liked';
 	}
+
 	return $classes;
 }
 add_filter( 'comment_class', 'wpcom_comments_add_like_class', 10, 3 );
@@ -79,3 +108,15 @@ function wpcom_enqueue_comment_like_script( $hook ) {
 	);
 }
 add_action( 'admin_enqueue_scripts', 'wpcom_enqueue_comment_like_script', 10, 2 );
+
+/**
+ * Register an API to handle Likes on Atomic sites.
+ */
+function wpcom_comments_register_like_api() {
+	require_once __DIR__ . '/class-wp-rest-comment-like.php';
+	$controller = new WP_REST_Comments_Like();
+	$controller->register_routes();
+}
+if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+	add_action( 'rest_api_init', 'wpcom_comments_register_like_api' );
+}

--- a/projects/plugins/jetpack/changelog/add-comment-likes-on-atomic
+++ b/projects/plugins/jetpack/changelog/add-comment-likes-on-atomic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+We can now use user Jetpack token for authorizing API calls.

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -275,6 +275,13 @@ abstract class WPCOM_JSON_API_Endpoint {
 	public $allow_jetpack_site_auth = false;
 
 	/**
+	 * Set to true if the endpoint should accept user based authentication.
+	 *
+	 * @var bool
+	 */
+	public $allow_jetpack_token_auth = false;
+
+	/**
 	 * Set to true if the endpoint should accept auth from an upload token.
 	 *
 	 * @var bool
@@ -359,6 +366,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 			'allow_cross_origin_request'           => false,
 			'allow_unauthorized_request'           => false,
 			'allow_jetpack_site_auth'              => false,
+			'allow_jetpack_token_auth'             => false,
 			'allow_upload_token_auth'              => false,
 			'allow_fallback_to_jetpack_blog_token' => false,
 		);
@@ -399,6 +407,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 		$this->allow_cross_origin_request           = (bool) $args['allow_cross_origin_request'];
 		$this->allow_unauthorized_request           = (bool) $args['allow_unauthorized_request'];
 		$this->allow_jetpack_site_auth              = (bool) $args['allow_jetpack_site_auth'];
+		$this->allow_jetpack_token_auth             = (bool) $args['allow_jetpack_token_auth'];
 		$this->allow_upload_token_auth              = (bool) $args['allow_upload_token_auth'];
 		$this->allow_fallback_to_jetpack_blog_token = (bool) $args['allow_fallback_to_jetpack_blog_token'];
 		$this->require_rewind_auth                  = isset( $args['require_rewind_auth'] ) ? (bool) $args['require_rewind_auth'] : false;

--- a/projects/plugins/jetpack/class.json-api.php
+++ b/projects/plugins/jetpack/class.json-api.php
@@ -977,7 +977,7 @@ class WPCOM_JSON_API {
 	 * @return void
 	 */
 	protected function maybe_switch_to_token_user_and_site() {
-		if ( ! $this->endpoint->allow_jetpack_site_auth ) {
+		if ( ! $this->endpoint->allow_jetpack_token_auth ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/class.json-api.php
+++ b/projects/plugins/jetpack/class.json-api.php
@@ -606,6 +606,7 @@ class WPCOM_JSON_API {
 	 */
 	public function process_request( WPCOM_JSON_API_Endpoint $endpoint, $path_pieces ) {
 		$this->endpoint = $endpoint;
+		$this->maybe_switch_to_token_user_and_site();
 		return call_user_func_array( array( $endpoint, 'callback' ), $path_pieces );
 	}
 
@@ -968,6 +969,35 @@ class WPCOM_JSON_API {
 		}
 
 		return $blog_id;
+	}
+
+	/**
+	 * Switch to a user and blog based on the current request's Jetpack token when the endpoint accepts this feature.
+	 *
+	 * @return void
+	 */
+	protected function maybe_switch_to_token_user_and_site() {
+		if ( ! $this->endpoint->allow_jetpack_site_auth ) {
+			return;
+		}
+
+		if ( ! class_exists( 'Jetpack_Server_Version' ) ) {
+			return;
+		}
+
+		$token = Jetpack_Server_Version::get_token_from_authorization_header();
+
+		if ( ! $token || is_wp_error( $token ) ) {
+			return;
+		}
+
+		if ( get_current_user_id() !== $token->user_id ) {
+			wp_set_current_user( $token->user_id );
+		}
+
+		if ( get_current_blog_id() !== $token->blog_id ) {
+			switch_to_blog( $token->blog_id );
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes:
- https://github.com/Automattic/wp-calypso/issues/98592

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Created a new endpoint for liking/un-liking comments on Atomic sites that runs the request as user on WPCom
* The WPCom v1 APIs now can use Jetpack tokens for authenticating calls.


https://github.com/user-attachments/assets/ef3d5001-05aa-442b-abf3-7174a65ed6da



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply 176209-ghe-Automattic/wpcom to your sandbox
* Create an Atomic site in the dev pool
* Sandbox your API on the Atomic site.
* Apply these changes to your Atomic site using Jetpack beta.
* Apply these changes to your sandbox.
* Go to wp-admin comments section.
* Test that you can like and dislike comments.
* Test on a Simple site and make sure there are no regressions.