### PR TITLE
Plugin search: update card design to match Core.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-plugin-search-design
+++ b/projects/plugins/jetpack/changelog/update-plugin-search-design
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Feature suggestions: improve the design of the cards to better match WordPress Core's design.

--- a/projects/plugins/jetpack/modules/plugin-search.php
+++ b/projects/plugins/jetpack/modules/plugin-search.php
@@ -238,7 +238,6 @@ class Jetpack_Plugin_Search {
 			array(
 				'nonce'          => wp_create_nonce( 'wp_rest' ),
 				'base_rest_url'  => rest_url( '/jetpack/v4' ),
-				'poweredBy'      => esc_html__( 'by Jetpack (installed)', 'jetpack' ),
 				'manageSettings' => esc_html__( 'Configure', 'jetpack' ),
 				'activateModule' => esc_html__( 'Activate Module', 'jetpack' ),
 				'getStarted'     => esc_html__( 'Get started', 'jetpack' ),
@@ -418,6 +417,7 @@ class Jetpack_Plugin_Search {
 						$jetpack_modules_list[ $matching_module ]['name']
 					),
 					'short_description'   => $jetpack_modules_list[ $matching_module ]['short_description'],
+					'author'              => esc_attr__( 'Jetpack (installed)', 'jetpack' ),
 					'requires_connection' => (bool) $jetpack_modules_list[ $matching_module ]['requires_connection'],
 					'slug'                => self::$slug,
 					'version'             => JETPACK__VERSION,

--- a/projects/plugins/jetpack/modules/plugin-search/plugin-search.css
+++ b/projects/plugins/jetpack/modules/plugin-search/plugin-search.css
@@ -1,27 +1,4 @@
-.plugin-card-jetpack-plugin-search h3 {
-	margin: 0 0 4px 0;
-}
-
-.plugin-card-jetpack-plugin-search .column-name,
-.plugin-card-jetpack-plugin-search .column-description {
-	margin-right: 20px;
-}
-
-.plugin-card-jetpack-plugin-search .action-links {
-	overflow: auto;
-	position: static;
-}
-
-@media screen and (max-width: 1100px) and (min-width: 782px), (max-width: 480px) {
-	.plugin-card-jetpack-plugin-search .action-links {
-		margin-left: 0;
-	}
-}
-
 .plugin-card-jetpack-plugin-search .plugin-action-buttons {
-	margin: 0;
-	width: 100%;
-	text-align: left;
 	white-space: nowrap;
 }
 
@@ -56,15 +33,6 @@
 .jetpack-plugin-search__text {
 	flex: 1;
 	margin: 0 24px 0 16px;
-}
-
-@media screen and (max-width: 1100px) and (min-width: 782px), (max-width: 480px) {
-	.plugin-card-jetpack-plugin-search .plugin-action-buttons li {
-		display: block;
-	}
-	.plugin-card-jetpack-plugin-search .plugin-action-buttons li button {
-		margin-right: 0;
-	}
 }
 
 /* Hides the link to dismiss cards when it's in action links are before being moved to bottom row*/

--- a/projects/plugins/jetpack/modules/plugin-search/plugin-search.js
+++ b/projects/plugins/jetpack/modules/plugin-search/plugin-search.js
@@ -38,38 +38,6 @@ var JetpackPSH = {};
 		},
 
 		/**
-		 * Update title of the card to add a mention that the result is from the Jetpack plugin.
-		 */
-		updateCardTitle: function () {
-			var hint = JetpackPSH.getCard();
-
-			if ( 'object' === typeof hint && null !== hint ) {
-				var title = hint.querySelector( '.column-name h3' );
-				title.outerHTML =
-					title.outerHTML + '<strong>' + jetpackPluginSearch.poweredBy + '</strong>';
-			}
-		},
-
-		/**
-		 * Move action links below description.
-		 */
-		moveActionLinks: function () {
-			var hint = JetpackPSH.getCard();
-			if ( 'object' === typeof hint && null !== hint ) {
-				var descriptionContainer = hint.querySelector( '.column-description' );
-				// Keep only the first paragraph. The second is the plugin author.
-				var descriptionText = descriptionContainer.querySelector( 'p:first-child' );
-				var actionLinks = hint.querySelector( '.action-links' );
-
-				// Change the contents of the description, to keep the description text and the action links.
-				descriptionContainer.innerHTML = descriptionText.outerHTML + actionLinks.outerHTML;
-
-				// Remove the action links from their default location.
-				actionLinks.parentNode.removeChild( actionLinks );
-			}
-		},
-
-		/**
 		 * Replace bottom row of the card to insert logo, text and link to dismiss the card.
 		 */
 		replaceCardBottom: function () {
@@ -97,7 +65,7 @@ var JetpackPSH = {};
 		},
 
 		/**
-		 * Check if plugin card list nodes changed. If there's a Jetpack PSH card, replace the title and the bottom row.
+		 * Check if plugin card list nodes changed. If there's a Jetpack PSH card, replace the bottom row.
 		 * @param {array} mutationsList
 		 */
 		replaceOnNewResults: function ( mutationsList ) {
@@ -106,8 +74,6 @@ var JetpackPSH = {};
 					'childList' === mutation.type &&
 					1 === document.querySelectorAll( '.plugin-card-jetpack-plugin-search' ).length
 				) {
-					JetpackPSH.updateCardTitle();
-					JetpackPSH.moveActionLinks();
 					JetpackPSH.replaceCardBottom();
 				}
 			} );
@@ -213,12 +179,6 @@ var JetpackPSH = {};
 			if ( JetpackPSH.$pluginFilter.length < 1 ) {
 				return;
 			}
-
-			// Update title to show that the suggestion is from Jetpack.
-			JetpackPSH.updateCardTitle();
-
-			// Update the description and action links.
-			JetpackPSH.moveActionLinks();
 
 			// Replace PSH bottom row on page load
 			JetpackPSH.replaceCardBottom();


### PR DESCRIPTION
## Proposed changes:

The layout is currently a bit janky because of customizations that were added in #11909 when Core's design was different.

This brings us back to a design that's closer to core:

- The author is back at the bottom of the card.
- The buttons are moved on the right-hand side, just like Core's.

| **Before** | **After** |
|--------|--------|
| <img width="1393" alt="image" src="https://github.com/user-attachments/assets/5e039ccf-3294-4fa8-852f-8033962231c3" /> | <img width="1387" alt="image" src="https://github.com/user-attachments/assets/af873002-a69d-4f53-9d98-d83ce714a52a" /> | 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site that's connected to WordPress.com.
* Go to Plugins > Add New
* Search for `jetpack videopress`
    * Ensure that the layout of the results is correct (see screenshot above).
