### PR TITLE
Plugin search: add suggestion for WAF feature.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-plugin-search-waf
+++ b/projects/plugins/jetpack/changelog/update-plugin-search-waf
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Feature suggestions: ensure that we show a suggestion for the WAF feature.

--- a/projects/plugins/jetpack/modules/plugin-search.php
+++ b/projects/plugins/jetpack/modules/plugin-search.php
@@ -353,6 +353,7 @@ class Jetpack_Plugin_Search {
 				'vaultpress',
 				'videopress',
 				'search',
+				'waf',
 			);
 
 			/*

--- a/projects/plugins/jetpack/modules/waf.php
+++ b/projects/plugins/jetpack/modules/waf.php
@@ -7,6 +7,7 @@
  * Requires Connection: Yes
  * Auto Activate: No
  * Module Tags: Firewall, WAF
+ * Additional Search Queries: waf, security, firewall, web application firewall
  * Feature: Security
  *
  * @package automattic/jetpack


### PR DESCRIPTION
> [!WARNING]
> On hold pending #42337

## Proposed changes:

Now that Jetpack includes a WAF feature, we should let our users know, when they search for "WAF" in their plugin screen.

| **Before** | **After** |
|--------|--------|
| <img width="1396" alt="Screenshot 2025-03-07 at 16 55 29" src="https://github.com/user-attachments/assets/15cbd72e-91a6-444a-8882-96f7d0fc70ac" /> | <img width="1386" alt="Screenshot 2025-03-07 at 16 55 23" src="https://github.com/user-attachments/assets/8c8394f3-6d61-4b7a-8d9c-56dc11236ac7" /> | 

> [!NOTE]
> The design is currently a bit janky. I'm addressing this in https://github.com/Automattic/jetpack/pull/42301

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site that's connected to WordPress.com, and running the Jetpack plugin.
* Go to Plugins > Add New
* Search for `WAF`
    * See that we return a suggestion to use Jetpack's WAF as the first result (see screenshot above)

