### PR TITLE
Newsletter Widget: update newsletter widget default placement in dashboard

### DIFF
--- a/projects/plugins/jetpack/changelog/update-newsletter-widget-default-placement
+++ b/projects/plugins/jetpack/changelog/update-newsletter-widget-default-placement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter Widget: hint dashboard placement for widget to be 2nd column, near the top

--- a/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
@@ -107,7 +107,11 @@ class Jetpack_Newsletter_Dashboard_Widget {
 			wp_add_dashboard_widget(
 				self::$widget_id,
 				$widget_title,
-				array( static::class, 'render' )
+				array( static::class, 'render' ),
+				null,
+				null,
+				'side',
+				'high'
 			);
 		}
 	}

--- a/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
@@ -108,8 +108,9 @@ class Jetpack_Newsletter_Dashboard_Widget {
 				self::$widget_id,
 				$widget_title,
 				array( static::class, 'render' ),
+				// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 				null,
-				null,
+				array(),
 				'side',
 				'high'
 			);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

See p1741357305204799-slack-C083ZPVVDTK

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Provides arguments for the `context` and `priority` params of `wp_add_dashboard_widget()` to roughly place the widget near the top of the 2nd column

<img width="2287" alt="image" src="https://github.com/user-attachments/assets/7d0b3fda-ec1f-4dbb-a773-12492bbf7ff4" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1741357305204799-slack-C083ZPVVDTK

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Simple
* Sandbox your site
* Run `bin/jetpack-downloader test jetpack update/update-newsletter-widget-default-placement` on your sandbox to activate this branch
* Make sure your wp-admin dashboard widget order is reset to the default
  * You can do this for your primary user by deleting the metadata in the wp cli on your sandbox `wp user meta delete {YOUR_USER_ID} meta-box-order_dashboard`
  * Or you can create a fresh administrator user for your site and verify when logged in as them
* The newsletter widget should be in the second column, near the top by default
* You should still be able to dismiss, move, and/or collapse the widget as normal, and those changes should persist.

### Atomic
* Enable the newsletter widget by adding `define( 'JETPACK_NEWSLETTER_WIDGET', true )` to your your `wp-config.php` on your site.
  * You can do this by SSH'ing into the box and editing that file.
* Activate this branch using the [Jetpack Beta plugin](https://jetpack.com/download-jetpack-beta/)
* Make sure your wp-admin dashboard widget order is reset to the default
  * I did this by creating a fresh administrator user for your site and verify when logged in as them
* The newsletter widget should be in the second column, near the top by default
* You should still be able to dismiss, move, and/or collapse the widget as normal, and those changes should persist.

