### PR TITLE
Update extend cookie life my jetpack dismissals

### DIFF
--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-backup-needs-attention-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-backup-needs-attention-notice.tsx
@@ -5,6 +5,7 @@ import { useContext, useEffect, useCallback } from 'react';
 import { NOTICE_PRIORITY_HIGH } from '../../context/constants';
 import { NoticeContext } from '../../context/notices/noticeContext';
 import { applyTimezone } from '../../utils/apply-timezone';
+import createCookie from '../../utils/create-cookie';
 import preventWidows from '../../utils/prevent-widows';
 import useAnalytics from '../use-analytics';
 import { useGetReadableFailedBackupReason } from './use-get-readable-failed-backup-reason';
@@ -37,8 +38,7 @@ const useBackupNeedsAttentionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 	const noticeTitle = __( 'Oops! We couldn’t back up your site', 'jetpack-my-jetpack' );
 
 	const onCloseClick = useCallback( () => {
-		// Session cookie. Expires at session end.
-		document.cookie = `backup_failure_dismissed=1; SameSite=None; Secure`;
+		createCookie( 'backup_failure_dismissed', 7 );
 		delete redBubbleAlerts.backup_failure;
 		resetNotice();
 	}, [ redBubbleAlerts.backup_failure, resetNotice ] );

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-expiring-plans-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-expiring-plans-notice.tsx
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { useContext, useEffect, useCallback } from 'react';
 import { NOTICE_PRIORITY_MEDIUM } from '../../context/constants';
 import { NoticeContext } from '../../context/notices/noticeContext';
+import createCookie from '../../utils/create-cookie';
 import useAnalytics from '../use-analytics';
 import { useGetExpiringNoticeContent } from './use-get-expiring-notice-content';
 import type { NoticeOptions } from '../../context/notices/types';
@@ -51,7 +52,7 @@ const useExpiringPlansNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 			? `${ productSlug }--plan_expired`
 			: `${ productSlug }--plan_expiring_soon`;
 		// Session cookie. Expires when session ends.
-		document.cookie = `${ cookieKey }_dismissed=1; SameSite=None; Secure`;
+		createCookie( `${ cookieKey }_dismissed`, 7 );
 		delete redBubbleAlerts[ alertToDisplay ];
 		resetNotice();
 	}, [ alertToDisplay, isExpiredAlert, productSlug, redBubbleAlerts, resetNotice ] );

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-paid-plan-needs-plugin-install-activation-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-paid-plan-needs-plugin-install-activation-notice.tsx
@@ -10,15 +10,13 @@ import useInstallPlugins from '../../data/products/use-install-plugins';
 import useSimpleQuery from '../../data/use-simple-query';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
+import createCookie from '../../utils/create-cookie';
 import useAnalytics from '../use-analytics';
 import { useGetPaidPlanNeedsPluginsContent } from './get-paid-plan-needs-plugins-content';
 import type { NoticeOptions } from '../../context/notices/types';
 import type { MyJetpackInitialState } from '../../data/types';
 
 type RedBubbleAlerts = MyJetpackInitialState[ 'redBubbleAlerts' ];
-
-// The notice will not show again for 14 days (when clicking the close(X) button).
-const NUM_DAYS_COOKIE_EXPIRES = 14;
 
 const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 	const { setNotice, resetNotice } = useContext( NoticeContext );
@@ -146,8 +144,7 @@ const usePaidPlanNeedsPluginInstallActivationNotice = ( redBubbleAlerts: RedBubb
 	);
 
 	const onCloseClick = useCallback( () => {
-		const expireDate = new Date( Date.now() + 1000 * 3600 * 24 * NUM_DAYS_COOKIE_EXPIRES );
-		document.cookie = `${ planSlug }--plugins_needing_installed_dismissed=1; expires=${ expireDate.toString() }; SameSite=None; Secure`;
+		createCookie( `${ planSlug }--plugins_needing_installed_dismissed`, 14 );
 		delete redBubbleAlerts[ pluginsNeedingActionAlerts[ 0 ] ];
 		resetNotice();
 	}, [ planSlug, pluginsNeedingActionAlerts, redBubbleAlerts, resetNotice ] );

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-protect-threats-detected-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-protect-threats-detected-notice.tsx
@@ -4,6 +4,7 @@ import { useContext, useEffect, useCallback } from 'react';
 import { NOTICE_PRIORITY_MEDIUM } from '../../context/constants';
 import { NoticeContext } from '../../context/notices/noticeContext';
 import useProduct from '../../data/products/use-product';
+import createCookie from '../../utils/create-cookie';
 import preventWidows from '../../utils/prevent-widows';
 import useAnalytics from '../use-analytics';
 import type { NoticeOptions } from '../../context/notices/types';
@@ -41,8 +42,7 @@ const useProtectThreatsDetectedNotice = ( redBubbleAlerts: RedBubbleAlerts ) => 
 	);
 
 	const onCloseClick = useCallback( () => {
-		// Session cookie. Expires at session end.
-		document.cookie = `protect_threats_detected_dismissed=1; SameSite=None; Secure`;
+		createCookie( 'protect_threats_detected_dismissed', 7 );
 		delete redBubbleAlerts.protect_has_threats;
 		resetNotice();
 	}, [ redBubbleAlerts.protect_has_threats, resetNotice ] );

--- a/projects/packages/my-jetpack/_inc/utils/create-cookie.ts
+++ b/projects/packages/my-jetpack/_inc/utils/create-cookie.ts
@@ -1,0 +1,7 @@
+const createCookie = ( cookieKey: string, expirationDays: number ) => {
+	const expireDate = new Date( Date.now() + 1000 * 3600 * 24 * expirationDays );
+
+	document.cookie = `${ cookieKey }=1; expires=${ expireDate.toString() }; SameSite=None; Secure`;
+};
+
+export default createCookie;

--- a/projects/packages/my-jetpack/changelog/update-extend-cookie-life-my-jetpack-dismissals
+++ b/projects/packages/my-jetpack/changelog/update-extend-cookie-life-my-jetpack-dismissals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Persist cookies for dismissable banners longer than session


### PR DESCRIPTION
## Proposed changes:

* Add expiration date to all dismissible notice cookies so users don't need to dismiss it every session

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Slack: p1741266498880779-slack-CS8UYNPEE

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment. If you use JN, make sure the Jetpack Debug tools are installed
2. Connect your site and user
3. Purchase a Security plan however you'd like
4. During the site's first backup, or a subsequent backup you trigger, disconnect your site to force the backup to fail
5. Install the Jetpack Debug tools and activate the Scan Helper. Add 5 EICAR threats to your site
![image](https://github.com/user-attachments/assets/8516d738-912e-4cd4-a762-b297e9cc5aa4)
6. Start a scan to discover these threats
7. Go to Store Admin, and on your Backup plan (or a different plan if you'd like), set your plan to expire within the next week, or set it as expired already (either one is fine)

These steps should trigger all of the dismissible notices (other than the welcome banner)

8. Go to My Jetpack and ensure you see the failed backup notice
![image](https://github.com/user-attachments/assets/e6667c68-402c-4f96-98c1-ddd2a41517c4)

9. Dismiss the banner and open the Dev tools and go to the Application tab. Find the cookie and ensure that it's expiration date is set to 7 days in the future

![image](https://github.com/user-attachments/assets/91abc379-75cf-4418-bb73-89dd396f4fc7)

10. Dismiss all the banners and check the expiration date for all of them

![image](https://github.com/user-attachments/assets/5eabcdc5-0beb-4159-8ffb-a30e05cf8d91)
