### PR TITLE
My Jetpack: enable screen readers to read Boost score

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/boost-speed-score.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/boost-speed-score.tsx
@@ -20,12 +20,26 @@ import type { SetStateAction } from 'react';
 
 import './style.scss';
 
+/**
+ * Creates the text read by screen readers for the Boost Speed Score card.
+ *
+ * @param {string} speedLetterGrade     - Letter grade for the speed score (e.g. 'A', 'B', etc)
+ * @param {number} currentSpeedScore    - Current numerical speed score (0-100)
+ * @param {number} [boostScoreIncrease] - Optional score increase/decrease amount
+ * @param {string} [cta]                - Optional call-to-action text
+ * @return {string} Screen reader text describing the speed score
+ */
+
 const createSpeedScoreSRText = (
 	speedLetterGrade: string,
 	currentSpeedScore: number,
 	boostScoreIncrease?: number,
 	cta?: string
 ) => {
+	if ( ! speedLetterGrade || typeof currentSpeedScore !== 'number' ) {
+		return '';
+	}
+
 	const fragments = [];
 
 	fragments.push(
@@ -37,7 +51,7 @@ const createSpeedScoreSRText = (
 		)
 	);
 
-	if ( boostScoreIncrease ) {
+	if ( typeof boostScoreIncrease === 'number' ) {
 		fragments.push(
 			boostScoreIncrease > 0
 				? sprintf(

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/boost-speed-score.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/boost-speed-score.tsx
@@ -6,7 +6,7 @@ import {
 import { Spinner, BoostScoreBar } from '@automattic/jetpack-components';
 import { Popover } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { arrowUp, Icon } from '@wordpress/icons';
 import { useEffect, useState, useMemo, useCallback } from 'react';
 import { PRODUCT_STATUSES } from '../../../constants';
@@ -14,11 +14,49 @@ import useProduct from '../../../data/products/use-product';
 import { getMyJetpackWindowInitialState } from '../../../data/utils/get-my-jetpack-window-state';
 import useAnalytics from '../../../hooks/use-analytics';
 import useMyJetpackConnection from '../../../hooks/use-my-jetpack-connection';
+import formatPercentage from '../../../utils/format-percentage';
 import { useBoostTooltipCopy } from './use-boost-tooltip-copy';
 import type { SpeedScores, BoostSpeedScoreType } from './types';
 import type { SetStateAction } from 'react';
 
 import './style.scss';
+
+const createSpeedScoreSRText = (
+	speedLetterGrade: string,
+	currentSpeedScore: number,
+	boostScoreIncrease?: number,
+	cta?: string
+) => {
+	const fragments = [];
+
+	fragments.push(
+		sprintf(
+			// translators: %1$s: speed grade (e.g. 'A'), %2$s: speed score percentage (e.g. '95%').
+			__( 'Your website’s overall speed score is %1$s, or %2$s.', 'jetpack-my-jetpack' ),
+			speedLetterGrade,
+			formatPercentage( currentSpeedScore / 100 )
+		)
+	);
+
+	if ( boostScoreIncrease ) {
+		fragments.push(
+			sprintf(
+				// translators: %s: score increase (e.g. '10')
+				__(
+					'Your website’s overall speed score is %s faster than the previous period.',
+					'jetpack-my-jetpack'
+				),
+				formatPercentage( boostScoreIncrease / 100 )
+			)
+		);
+	}
+
+	if ( cta ) {
+		fragments.push( cta );
+	}
+
+	return fragments.join( ' ' );
+};
 
 const BoostSpeedScore: BoostSpeedScoreType = () => {
 	const { recordEvent } = useAnalytics();
@@ -174,44 +212,54 @@ const BoostSpeedScore: BoostSpeedScoreType = () => {
 					<Spinner color="#23282d" size={ 16 } />
 				) : (
 					<>
-						<div className="mj-boost-speed-score__grade">
-							<span>{ __( 'Your website’s overall speed score:', 'jetpack-my-jetpack' ) }</span>
-							<span className="mj-boost-speed-score__grade--letter">
-								{ speedLetterGrade }
-								{ ! isLoading && shouldShowTooltip && (
-									<Popover
-										placement={ isMobileViewport ? 'top-end' : 'top-start' }
-										noArrow={ false }
-										offset={ 10 }
-									>
-										<div className={ 'boost-score-tooltip__parent' }>
-											<p className={ 'boost-score-tooltip__heading' }>
-												{ /* Add the `&nbsp;` at the end to prevent widows. */ }
-												{ __( 'Site speed performance:', 'jetpack-my-jetpack' ) }&nbsp;
-												{ speedLetterGrade }
-											</p>
-											<p className={ 'boost-score-tooltip__content' }>{ tooltipCopy }</p>
-										</div>
-									</Popover>
-								) }
-							</span>
+						<div className="screen-reader-text">
+							{ createSpeedScoreSRText(
+								speedLetterGrade,
+								currentSpeedScore,
+								boostScoreIncrease,
+								tooltipCopy
+							) }
 						</div>
-						<div className="mj-boost-speed-score__bar">
-							<BoostScoreBar
-								score={ currentSpeedScore }
-								active={ currentSpeedScore > 0 }
-								isLoading={ isLoading }
-								showPrevScores={ false }
-								scoreBarType="desktop"
-								noBoostScoreTooltip={ null }
-							/>
-						</div>
-						{ !! boostScoreIncrease && (
-							<div className="mj-boost-speed-score__increase">
-								<Icon size={ 18 } icon={ arrowUp } />
-								<span>{ boostScoreIncrease }</span>
+						<div aria-hidden="true">
+							<div className="mj-boost-speed-score__grade">
+								<span>{ __( 'Your website’s overall speed score:', 'jetpack-my-jetpack' ) }</span>
+								<span className="mj-boost-speed-score__grade--letter">
+									{ speedLetterGrade }
+									{ ! isLoading && shouldShowTooltip && (
+										<Popover
+											placement={ isMobileViewport ? 'top-end' : 'top-start' }
+											noArrow={ false }
+											offset={ 10 }
+										>
+											<div className={ 'boost-score-tooltip__parent' }>
+												<p className={ 'boost-score-tooltip__heading' }>
+													{ /* Add the `&nbsp;` at the end to prevent widows. */ }
+													{ __( 'Site speed performance:', 'jetpack-my-jetpack' ) }&nbsp;
+													{ speedLetterGrade }
+												</p>
+												<p className={ 'boost-score-tooltip__content' }>{ tooltipCopy }</p>
+											</div>
+										</Popover>
+									) }
+								</span>
 							</div>
-						) }
+							<div className="mj-boost-speed-score__bar">
+								<BoostScoreBar
+									score={ currentSpeedScore }
+									active={ currentSpeedScore > 0 }
+									isLoading={ isLoading }
+									showPrevScores={ false }
+									scoreBarType="desktop"
+									noBoostScoreTooltip={ null }
+								/>
+							</div>
+							{ !! boostScoreIncrease && (
+								<div className="mj-boost-speed-score__increase">
+									<Icon size={ 18 } icon={ arrowUp } />
+									<span>{ boostScoreIncrease }</span>
+								</div>
+							) }
+						</div>
 					</>
 				) }
 			</div>

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/boost-speed-score.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/boost-speed-score.tsx
@@ -14,7 +14,6 @@ import useProduct from '../../../data/products/use-product';
 import { getMyJetpackWindowInitialState } from '../../../data/utils/get-my-jetpack-window-state';
 import useAnalytics from '../../../hooks/use-analytics';
 import useMyJetpackConnection from '../../../hooks/use-my-jetpack-connection';
-import formatPercentage from '../../../utils/format-percentage';
 import { useBoostTooltipCopy } from './use-boost-tooltip-copy';
 import type { SpeedScores, BoostSpeedScoreType } from './types';
 import type { SetStateAction } from 'react';
@@ -31,23 +30,26 @@ const createSpeedScoreSRText = (
 
 	fragments.push(
 		sprintf(
-			// translators: %1$s: speed grade (e.g. 'A'), %2$s: speed score percentage (e.g. '95%').
-			__( 'Your website’s overall speed score is %1$s, or %2$s.', 'jetpack-my-jetpack' ),
+			// translators: %1$s: speed grade (e.g. 'A'), %2$s: numerical speed score (e.g. '95').
+			__( 'Your website’s overall speed score is %1$s, or %2$s out of 100.', 'jetpack-my-jetpack' ),
 			speedLetterGrade,
-			formatPercentage( currentSpeedScore / 100 )
+			currentSpeedScore
 		)
 	);
 
 	if ( boostScoreIncrease ) {
 		fragments.push(
-			sprintf(
-				// translators: %s: score increase (e.g. '10')
-				__(
-					'Your website’s overall speed score is %s faster than the previous period.',
-					'jetpack-my-jetpack'
-				),
-				formatPercentage( boostScoreIncrease / 100 )
-			)
+			boostScoreIncrease > 0
+				? sprintf(
+						// translators: %s: score increase (e.g. '10')
+						__( 'Your website’s overall speed score increased by %s.', 'jetpack-my-jetpack' ),
+						boostScoreIncrease
+				  )
+				: sprintf(
+						// translators: %s: score increase (e.g. '10')
+						__( 'Your website’s overall speed score decreased by %s.', 'jetpack-my-jetpack' ),
+						boostScoreIncrease
+				  )
 		);
 	}
 

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/use-boost-tooltip-copy.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/use-boost-tooltip-copy.ts
@@ -1,6 +1,5 @@
 import { __, sprintf } from '@wordpress/i18n';
 import useProduct from '../../../data/products/use-product';
-import type { ReactElement } from 'react';
 
 /**
  * Gets the translated tooltip copy based on the Boost letter grade and other factors.
@@ -8,7 +7,7 @@ import type { ReactElement } from 'react';
  * @param {object}      props                    - React props
  * @param {string}      props.speedLetterGrade   - The Boost score letter grade.
  * @param {number|null} props.boostScoreIncrease - The number of points the score increased.
- * @return {ReactElement | string} A translated JSX Element or string.
+ * @return {string} A translated JSX Element or string.
  */
 export function useBoostTooltipCopy( {
 	speedLetterGrade,
@@ -16,7 +15,7 @@ export function useBoostTooltipCopy( {
 }: {
 	speedLetterGrade: string;
 	boostScoreIncrease: number | null;
-} ): ReactElement | string {
+} ): string {
 	const slug = 'boost';
 	const { detail } = useProduct( slug );
 	const { isPluginActive, hasPaidPlanForProduct: hasBoostPaidPlan } = detail;

--- a/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
@@ -7,6 +7,16 @@ import createStatDiffText from './create-stat-diff-text';
 import eye from './eye';
 import styles from './style.module.scss';
 
+const createStatSRText = ( countStat, count, previousCount ) => {
+	const fragments = [];
+	const statCountText = sprintf( countStat( count ), formatNumber( count ) );
+
+	fragments.push( statCountText.endsWith( '.' ) ? statCountText : `${ statCountText }.` );
+	fragments.push( createStatDiffText( countStat, count, previousCount ) );
+
+	return fragments.join( ' ' );
+};
+
 /**
  * Creates the text read by screen readers for a stat card.
  *

--- a/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
@@ -7,16 +7,6 @@ import createStatDiffText from './create-stat-diff-text';
 import eye from './eye';
 import styles from './style.module.scss';
 
-const createStatSRText = ( countStat, count, previousCount ) => {
-	const fragments = [];
-	const statCountText = sprintf( countStat( count ), formatNumber( count ) );
-
-	fragments.push( statCountText.endsWith( '.' ) ? statCountText : `${ statCountText }.` );
-	fragments.push( createStatDiffText( countStat, count, previousCount ) );
-
-	return fragments.join( ' ' );
-};
-
 /**
  * Creates the text read by screen readers for a stat card.
  *

--- a/projects/packages/my-jetpack/changelog/fix-my-jp-boost-score-for-sr
+++ b/projects/packages/my-jetpack/changelog/fix-my-jp-boost-score-for-sr
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Enable screen readers to read Boost score


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
On the My Jetpack page, screen readers can't properly announce the Boost score; they announce the score with the grade, but then what appears to be random numbers (the numerical score and difference from the previous period). See video below:

https://github.com/user-attachments/assets/c390e0bc-2bbd-4263-b070-0ef7247fe098

This PR updates the Boost card so the score is accessible to screen reader users. In detail, it hides the visual content to screen readers and instead renders the same information in an element that's accessible to screen readers but visually hidden.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Epic: https://github.com/Automattic/vulcan/issues/710

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

_Note: this PR is best tested with a site that has an ongoing subscription_

- Spin up a Jetpack site with a Boost subscription
- Visit `/wp-admin/admin.php?page=my-jetpack`
- Activate Jetpack if it's not already done
- If you're able to use a screen reader, verify that the full Boost score is announced properly, as in the video below:

https://github.com/user-attachments/assets/2c86e0a3-230a-4171-9054-780ed76b2ed8

- Otherwise, verify the information is present in the DOM
<img width="411" alt="Screenshot 2025-03-07 at 12 58 24 PM" src="https://github.com/user-attachments/assets/fc0ae83d-2ce4-46fe-84de-d71e3817fd53" />




