### PR TITLE
Jetpack SEO: add enhancer filter and draft

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-seo-enhancer-filter-and-draft
+++ b/projects/plugins/jetpack/changelog/add-jetpack-seo-enhancer-filter-and-draft
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack SEO: add first draft for SEO enhancer on JP sidebar and PrePublish

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -129,6 +129,10 @@ add_action(
 			if ( apply_filters( 'breve_enabled', true ) ) {
 				Jetpack_Gutenberg::set_extension_available( 'ai-proofread-breve' );
 			}
+
+			if ( apply_filters( 'ai_seo_enhancer_enabled', false ) ) {
+				Jetpack_Gutenberg::set_extension_available( 'ai-seo-enhancer' );
+			}
 		}
 	}
 );
@@ -186,20 +190,6 @@ add_action(
 		) {
 			\Jetpack_Gutenberg::set_extension_available( 'ai-use-chrome-ai-sometimes' );
 			add_chrome_ai_token_headers();
-		}
-	}
-);
-
-/**
- * Register the `ai-seo-enhancer` extension.
- */
-add_action(
-	'jetpack_register_gutenberg_extensions',
-	function () {
-		if ( apply_filters( 'jetpack_ai_enabled', true ) &&
-			apply_filters( 'ai_seo_enhancer_enabled', false )
-		) {
-			\Jetpack_Gutenberg::set_extension_available( 'ai-seo-enhancer' );
 		}
 	}
 );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -189,3 +189,17 @@ add_action(
 		}
 	}
 );
+
+/**
+ * Register the `ai-seo-enhancer` extension.
+ */
+add_action(
+	'jetpack_register_gutenberg_extensions',
+	function () {
+		if ( apply_filters( 'jetpack_ai_enabled', true ) &&
+			apply_filters( 'ai_seo_enhancer_enabled', false )
+		) {
+			\Jetpack_Gutenberg::set_extension_available( 'ai-seo-enhancer' );
+		}
+	}
+);

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -81,7 +81,8 @@
 		"ai-assistant-backend-prompts",
 		"ai-list-to-table-transform",
 		"ai-seo-assistant",
-		"ai-use-chrome-ai-sometimes"
+		"ai-use-chrome-ai-sometimes",
+		"ai-seo-enhancer"
 	],
 	"experimental": [],
 	"no-post-editor": [

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -65,8 +65,6 @@ const isAITitleOptimizationKeywordsFeatureAvailable = getFeatureAvailability(
 	'ai-title-optimization-keywords-support'
 );
 
-// const isSeoAssistantEnabled = getFeatureAvailability( 'ai-seo-assistant' );
-
 const JetpackAndSettingsContent = ( {
 	placement,
 	requireUpgrade,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/index.tsx
@@ -17,13 +17,10 @@ export function SeoEnhancer() {
 				onChange={ toggleHandler }
 				label={ __( 'Auto-enhance', 'jetpack' ) }
 				// __nextHasNoMarginBottom={ true }
-				help={
-					! isEnabled &&
-					__(
-						"Automattically generate SEO title, SEO description and images' alternative text.",
-						'jetpack'
-					)
-				}
+				help={ __(
+					"Automattically generate SEO title, SEO description and images' alt text.",
+					'jetpack'
+				) }
 			/>
 		</BaseControl>
 	);

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/index.tsx
@@ -1,0 +1,30 @@
+import { BaseControl, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import './style.scss';
+
+export function SeoEnhancer() {
+	const [ isEnabled, setIsEnabled ] = useState( false );
+
+	const toggleHandler = () => {
+		setIsEnabled( ! isEnabled );
+	};
+
+	return (
+		<BaseControl __nextHasNoMarginBottom={ true } className="ai-seo-enhancer-toggle">
+			<ToggleControl
+				checked={ isEnabled }
+				onChange={ toggleHandler }
+				label={ __( 'Auto-enhance', 'jetpack' ) }
+				// __nextHasNoMarginBottom={ true }
+				help={
+					! isEnabled &&
+					__(
+						"Automattically generate SEO title, SEO description and images' alternative text.",
+						'jetpack'
+					)
+				}
+			/>
+		</BaseControl>
+	);
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/style.scss
@@ -1,0 +1,6 @@
+.ai-seo-enhancer-toggle {
+	.components-toggle-control__help {
+		margin-inline-start: 0px;
+	}
+}
+

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -26,6 +26,7 @@ import {
 	SeoAssistantWizard,
 } from '../ai-assistant-plugin/components/seo-assistant';
 import { STORE_NAME } from '../ai-assistant-plugin/components/seo-assistant/store';
+import { SeoEnhancer } from '../ai-assistant-plugin/components/seo-enhancer';
 import { SeoPlaceholder } from './components/placeholder';
 import { SeoSkeletonLoader } from './components/skeleton-loader';
 import UpsellNotice from './components/upsell';
@@ -38,6 +39,9 @@ export const name = 'seo';
 
 const isSeoAssistantEnabled =
 	getJetpackExtensionAvailability( 'ai-seo-assistant' )?.available === true;
+
+const isSeoEnhancerEnabled =
+	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true;
 
 const Seo = () => {
 	const { isLoadingModules, isChangingStatus, isModuleActive, changeStatus } =
@@ -107,6 +111,7 @@ const Seo = () => {
 		title: __( 'SEO', 'jetpack' ),
 	};
 
+	// TODO: remove all code related to the SeoAssistantWizard if it's a no-go
 	return (
 		<>
 			{ isSeoAssistantEnabled &&
@@ -124,6 +129,11 @@ const Seo = () => {
 							<SeoAssistantSidebarEntrypoint disabled={ false } placement="jetpack-sidebar" />
 						</PanelRow>
 					) }
+					{ isSeoEnhancerEnabled && isViewable && (
+						<PanelRow>
+							<SeoEnhancer />
+						</PanelRow>
+					) }
 					<PanelRow>
 						<SeoTitlePanel />
 					</PanelRow>
@@ -138,6 +148,11 @@ const Seo = () => {
 
 			<PluginPrePublishPanel { ...jetpackSeoPrePublishPanelProps }>
 				<>
+					{ isSeoEnhancerEnabled && isViewable && (
+						<PanelRow>
+							<SeoEnhancer />
+						</PanelRow>
+					) }
 					<PanelRow>
 						<SeoTitlePanel />
 					</PanelRow>


### PR DESCRIPTION


## Proposed changes:
This PR adds a first draft for the new design of the SEO assistant/enhancer. It should live on JP sidebar as well as on the PrePublish sidebar.

This is just a draft/placeholder, the toggle still doesn't do anything.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-wea-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Add CodeSnippets to enable the filter:

```php
add_filter( 'ai_seo_enhancer_enabled', '__return_true' );
```

Switch to BETA blocks variation. Go to the editor and open the Jetpack sidebar. On the SEO panel, you should see a new toggle matching the designs:

<img width="316" alt="image" src="https://github.com/user-attachments/assets/1227bec3-8b6e-480f-8b81-2795941b1b00" />

Hit publish to trigger the PrePublish sidebar. See that the SEO panel carries the same new toggle.
