### PR TITLE
Jetpack: activate REST for posts fetching JSON API endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/add-restful-json-api-fetch-posts
+++ b/projects/plugins/jetpack/changelog/add-restful-json-api-fetch-posts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+JSON API: activate REST for posts fetching endpoint.

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -2820,7 +2820,9 @@ abstract class WPCOM_JSON_API_Endpoint {
 			return new WP_Error( 'site_not_connected' );
 		}
 
-		if ( ( $this->allow_jetpack_site_auth && Rest_Authentication::is_signed_with_blog_token() ) || ( get_current_user_id() && Rest_Authentication::is_signed_with_user_token() ) ) {
+		if ( ( ( $this->allow_jetpack_site_auth || $this->allow_fallback_to_jetpack_blog_token ) && Rest_Authentication::is_signed_with_blog_token() )
+			|| ( get_current_user_id() && Rest_Authentication::is_signed_with_user_token() )
+		) {
 			$custom_permission_result = $this->rest_permission_callback_custom();
 
 			// Successful custom permission check.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-endpoint.php
@@ -16,6 +16,8 @@ new WPCOM_JSON_API_List_Posts_Endpoint(
 		'path_labels'                          => array(
 			'$site' => '(int|string) Site ID or domain',
 		),
+		'rest_route'                           => '/posts',
+		'rest_min_jp_version'                  => '14.5-a.1',
 
 		'allow_fallback_to_jetpack_blog_token' => true,
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -17,6 +17,8 @@ new WPCOM_JSON_API_List_Posts_v1_1_Endpoint(
 		'path_labels'                          => array(
 			'$site' => '(int|string) Site ID or domain',
 		),
+		'rest_route'                           => '/posts',
+		'rest_min_jp_version'                  => '14.5-a.1',
 
 		'allow_fallback_to_jetpack_blog_token' => true,
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
@@ -17,6 +17,8 @@ new WPCOM_JSON_API_List_Posts_v1_2_Endpoint(
 		'path_labels'                          => array(
 			'$site' => '(int|string) Site ID or domain',
 		),
+		'rest_route'                           => '/posts',
+		'rest_min_jp_version'                  => '14.5-a.1',
 
 		'allow_fallback_to_jetpack_blog_token' => true,
 


### PR DESCRIPTION
## Proposed changes:
* Make the posts fetching JSON API endpoint RESTful.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pf5801-18d-p2

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
See 176262-ghe-Automattic/wpcom