### PR TITLE
VideoPress: Fix other files not getting uploaded when there is a Video file among dragged files

### DIFF
--- a/projects/packages/videopress/changelog/fix-transformer-breaking-multiple-file-upload
+++ b/projects/packages/videopress/changelog/fix-transformer-breaking-multiple-file-upload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fixed other files not getting uploaded when video files are in dragged files

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -20,7 +20,7 @@
 		"clean": "rm -rf build/",
 		"validate": "pnpm exec validate-es build/",
 		"watch": "pnpm build && pnpm build-client --watch",
-		"test": "NODE_OPTIONS=--experimental-vm-modules jest",
+		"test": "jest",
 		"test-coverage": "pnpm run test --coverage"
 	},
 	"devDependencies": {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
@@ -3,7 +3,7 @@
  */
 import { createBlobURL } from '@wordpress/blob';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, findTransform, getBlockTransforms } from '@wordpress/blocks';
 import { dispatch, select } from '@wordpress/data';
 import clsx from 'clsx';
 /**
@@ -18,7 +18,7 @@ import {
 /**
  * Types
  */
-import { filterVideoFiles, isVideoFile } from '../../../utils/video';
+import { isVideoFile } from '../../../utils/video';
 import { CoreEmbedVideoPressVariationBlockAttributes, VideoBlockAttributes } from '../types';
 
 const transformFromCoreEmbed = {
@@ -62,12 +62,35 @@ const transformFromFile = {
 	},
 
 	priority: 8, // higher priority (lower number) than v5's core/video transform (9).
-	transform: ( files: File[] ) =>
-		filterVideoFiles( files ).map( ( file: File ) =>
+	transform: ( files: File[] ) => {
+		const fromTransforms = getBlockTransforms( 'from' );
+		const [ videoFiles, nonVideoFiles ] = files.reduce(
+			( accumulator, file ) => {
+				accumulator[ isVideoFile( file ) ? 0 : 1 ].push( file );
+				return accumulator;
+			},
+			[ [], [] ] as [ File[], File[] ]
+		);
+
+		const otherBlocks = nonVideoFiles
+			.map( file => {
+				const transformation = findTransform(
+					fromTransforms,
+					transform => transform.type === 'files' && transform.isMatch( [ file ] )
+				);
+				return transformation ? transformation.transform( [ file ] ) : null;
+			} )
+			.filter( Boolean )
+			.flat();
+
+		const videoBlocks = videoFiles.map( file =>
 			createBlock( 'videopress/video', {
 				src: createBlobURL( file ),
 			} )
-		),
+		);
+
+		return [ ...videoBlocks, ...otherBlocks ];
+	},
 };
 
 const transformToCoreEmbed = {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
@@ -64,32 +64,26 @@ const transformFromFile = {
 	priority: 8, // higher priority (lower number) than v5's core/video transform (9).
 	transform: ( files: File[] ) => {
 		const fromTransforms = getBlockTransforms( 'from' );
-		const [ videoFiles, nonVideoFiles ] = files.reduce(
-			( accumulator, file ) => {
-				accumulator[ isVideoFile( file ) ? 0 : 1 ].push( file );
-				return accumulator;
-			},
-			[ [], [] ] as [ File[], File[] ]
-		);
 
-		const otherBlocks = nonVideoFiles
-			.map( file => {
-				const transformation = findTransform(
-					fromTransforms,
-					transform => transform.type === 'files' && transform.isMatch( [ file ] )
-				);
-				return transformation ? transformation.transform( [ file ] ) : null;
-			} )
-			.filter( Boolean )
-			.flat();
+		// Categorize and process files while preserving their original order.
+		const blocks = files.flatMap( file => {
+			// Transform video files into 'videopress/video' blocks.
+			if ( isVideoFile( file ) ) {
+				return createBlock( 'videopress/video', { src: createBlobURL( file ) } );
+			}
 
-		const videoBlocks = videoFiles.map( file =>
-			createBlock( 'videopress/video', {
-				src: createBlobURL( file ),
-			} )
-		);
+			// Find a matching transform for non-video files.
+			const transformation = findTransform(
+				fromTransforms,
+				transform => transform.type === 'files' && transform.isMatch( [ file ] )
+			);
 
-		return [ ...videoBlocks, ...otherBlocks ];
+			// If a transform exists, apply it; otherwise, return an empty array.
+			return transformation ? transformation.transform( [ file ] ) : [];
+		} );
+
+		// Return all generated blocks (video + non-video) in the original file order.
+		return blocks;
 	},
 };
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/test/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/test/index.tsx
@@ -1,0 +1,122 @@
+/**
+ * External dependencies
+ */
+import { jest } from '@jest/globals';
+import '@testing-library/jest-dom';
+import { createBlobURL } from '@wordpress/blob';
+import { createBlock, getBlockTransforms, findTransform } from '@wordpress/blocks';
+/**
+ * Internal dependencies
+ */
+import transforms from '../index';
+
+jest.mock( '@wordpress/blob', () => ( {
+	createBlobURL: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/blocks', () => ( {
+	createBlock: jest.fn(),
+	getBlockTransforms: jest.fn(),
+	findTransform: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	store: 'core/block-editor',
+} ) );
+
+type MockFile = File & { type: string };
+
+interface MockFileArray extends Array< MockFile >, HTMLDivElement {
+	className: string;
+	allowResponsive: boolean;
+	providerNameSlug: 'videopress';
+	responsive: boolean;
+	type: 'video';
+	url: string;
+}
+
+describe( 'transforms', () => {
+	describe( 'transformFromFile', () => {
+		const transformFromFile = transforms.from.find( transform => transform.type === 'files' );
+
+		beforeEach( () => {
+			jest.clearAllMocks();
+			( findTransform as jest.Mock ).mockReturnValue( null );
+		} );
+
+		it( 'should return false when no files are provided', () => {
+			expect( transformFromFile.isMatch( [] ) ).toBe( false );
+			expect( transformFromFile.isMatch( null ) ).toBe( false );
+		} );
+
+		it( 'should return true if at least one video file is present', () => {
+			const files: MockFile[] = [
+				new File( [ '' ], 'video.mp4', { type: 'video/mp4' } ),
+				new File( [ '' ], 'document.txt', { type: 'text/plain' } ),
+			];
+
+			expect( transformFromFile.isMatch( files ) ).toBe( true );
+		} );
+
+		it( 'should transform video files into videopress/video blocks and handle other file types appropriately', () => {
+			const videoFile = new File( [ '' ], 'video.mp4', { type: 'video/mp4' } );
+			const textFile = new File( [ '' ], 'document.txt', { type: 'text/plain' } );
+			const files = [ videoFile, textFile ] as unknown as MockFileArray;
+
+			// Mock implementations
+			( createBlobURL as jest.Mock ).mockReturnValue( 'blob:video-url' );
+			( createBlock as jest.Mock ).mockImplementation( ( blockName, attrs ) => ( {
+				blockName,
+				attrs,
+			} ) );
+
+			const mockTransform = {
+				type: 'files',
+				isMatch: () => true,
+				transform: () => createBlock( 'core/file' ),
+			};
+
+			( getBlockTransforms as jest.Mock ).mockReturnValue( [ mockTransform ] );
+			( findTransform as jest.Mock ).mockReturnValue( mockTransform );
+
+			const result = transformFromFile.transform( files );
+
+			// Verify video block creation
+			expect( createBlock ).toHaveBeenCalledWith( 'videopress/video', { src: 'blob:video-url' } );
+
+			// Ensure two blocks are returned: one video, one file
+			expect( result ).toHaveLength( 2 );
+			expect( result[ 0 ] ).toEqual( {
+				blockName: 'videopress/video',
+				attrs: { src: 'blob:video-url' },
+			} );
+			expect( result[ 1 ] ).toEqual( { blockName: 'core/file', attrs: undefined } );
+		} );
+
+		it( 'should ignore files without matching transforms and only process valid ones', () => {
+			const videoFile = new File( [ '' ], 'video.mp4', { type: 'video/mp4' } );
+			const unknownFile = new File( [ '' ], 'unknown.xyz', { type: 'application/unknown' } );
+			const files = [ videoFile, unknownFile ] as unknown as MockFileArray;
+
+			Object.assign( files, {
+				className: '',
+				allowResponsive: true,
+				providerNameSlug: 'videopress',
+				responsive: true,
+				type: 'video',
+				url: 'test-url',
+			} );
+
+			// Mock behavior
+			( createBlobURL as jest.Mock ).mockReturnValue( 'blob:video-url' );
+			( getBlockTransforms as jest.Mock ).mockReturnValue( [] );
+
+			const result = transformFromFile.transform( files );
+
+			// Only the video file should create a block
+			expect( result ).toHaveLength( 1 );
+			expect( createBlock ).toHaveBeenCalledTimes( 1 );
+			expect( createBlock ).toHaveBeenCalledWith( 'videopress/video', { src: 'blob:video-url' } );
+		} );
+	} );
+} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/test/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/test/index.tsx
@@ -118,5 +118,89 @@ describe( 'transforms', () => {
 			expect( createBlock ).toHaveBeenCalledTimes( 1 );
 			expect( createBlock ).toHaveBeenCalledWith( 'videopress/video', { src: 'blob:video-url' } );
 		} );
+
+		it( 'should preserve the order of transformed files', () => {
+			const videoFile1 = new File( [ '' ], 'video1.mp4', { type: 'video/mp4' } );
+			const textFile = new File( [ '' ], 'document.txt', { type: 'text/plain' } );
+			const videoFile2 = new File( [ '' ], 'video2.mp4', { type: 'video/mp4' } );
+			const files = [ videoFile1, textFile, videoFile2 ] as unknown as MockFileArray;
+
+			// Mock implementations
+			( createBlobURL as jest.Mock ).mockImplementation( ( file: File ) => `blob:${ file.name }` );
+			( createBlock as jest.Mock ).mockImplementation( ( blockName, attrs ) => ( {
+				blockName,
+				attrs,
+			} ) );
+
+			const mockTransform = {
+				type: 'files',
+				isMatch: () => true,
+				transform: () => createBlock( 'core/file' ),
+			};
+
+			( getBlockTransforms as jest.Mock ).mockReturnValue( [ mockTransform ] );
+			( findTransform as jest.Mock ).mockReturnValue( mockTransform );
+
+			const result = transformFromFile.transform( files );
+
+			// Ensure the transformed blocks maintain the original file order
+			expect( result ).toEqual( [
+				{ blockName: 'videopress/video', attrs: { src: 'blob:video1.mp4' } },
+				{ blockName: 'core/file', attrs: undefined },
+				{ blockName: 'videopress/video', attrs: { src: 'blob:video2.mp4' } },
+			] );
+		} );
+
+		it( 'should return an empty array when no valid transformations exist', () => {
+			const unknownFile = new File( [ '' ], 'unknown.xyz', { type: 'application/unknown' } );
+			const files = [ unknownFile ] as unknown as MockFileArray;
+
+			// No transforms available
+			( getBlockTransforms as jest.Mock ).mockReturnValue( [] );
+			( findTransform as jest.Mock ).mockReturnValue( null );
+
+			const result = transformFromFile.transform( files );
+
+			// Should return an empty array
+			expect( result ).toHaveLength( 0 );
+		} );
+
+		it( 'should transform valid files and ignore unmatched files while preserving order', () => {
+			const videoFile = new File( [ '' ], 'video.mp4', { type: 'video/mp4' } );
+			const textFile = new File( [ '' ], 'document.txt', { type: 'text/plain' } );
+			const unknownFile = new File( [ '' ], 'unknown.xyz', { type: 'application/unknown' } );
+			const files = [ videoFile, textFile, unknownFile ] as unknown as MockFileArray;
+
+			// Mock implementations
+			( createBlobURL as jest.Mock ).mockImplementation( ( file: File ) => `blob:${ file.name }` );
+			( createBlock as jest.Mock ).mockImplementation( ( blockName, attrs ) => ( {
+				blockName,
+				attrs,
+			} ) );
+
+			// Mock a valid transform for text files but no transform for unknown files
+			const mockTransform = {
+				type: 'files',
+				isMatch: ( inputFiles: File[] ) => inputFiles[ 0 ].type === 'text/plain',
+				transform: () => createBlock( 'core/file' ),
+			};
+
+			( getBlockTransforms as jest.Mock ).mockReturnValue( [ mockTransform ] );
+			( findTransform as jest.Mock ).mockImplementation(
+				( _, predicate: ( t: typeof mockTransform ) => boolean ) =>
+					predicate( mockTransform ) ? mockTransform : null
+			);
+
+			const result = transformFromFile.transform( files );
+
+			// Ensure that only the video and text file are transformed, while the unknown file is ignored
+			expect( result ).toEqual( [
+				{ blockName: 'videopress/video', attrs: { src: 'blob:video.mp4' } },
+				{ blockName: 'core/file', attrs: undefined }, // text file transformed successfully
+			] );
+
+			// Ensure the unmatched file didn't cause issues
+			expect( result ).toHaveLength( 2 );
+		} );
 	} );
 } );

--- a/projects/plugins/videopress/changelog/fix-transformer-breaking-multiple-file-upload
+++ b/projects/plugins/videopress/changelog/fix-transformer-breaking-multiple-file-upload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fixed other files not getting uploaded when video files are in dragged files


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/40469

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We found that the transformation added here https://github.com/Automattic/jetpack/pull/32084 was causing the issue. basically we filtered out the Video files with a higher priority and transformed them only. So all the other files got stranded and didn't get dropped in the editor.

Now we transform the video files like before, but additionally, we find out the proper transformation for the other files as well and apply them.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure you have Jetpack and Jetpack videopress enabled
* Open a post or page in Gutenberg editor
* Drag and drop a bunch of files together in there, at least one of those files should be a video file
* Make sure all of those files get added in the editor
* Try with only videos (multiple)
* Try with only one video
* Try with other files
* Try uploading media normally in media library

## Does this pull request change what data or activity we track or use?

No

