### PR TITLE
Publicize Components: Add schedule button

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-schedule-button
+++ b/projects/js-packages/publicize-components/changelog/add-schedule-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Publicize Components: Add the schedule button

--- a/projects/js-packages/publicize-components/src/components/schedule-button/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/schedule-button/index.tsx
@@ -1,6 +1,6 @@
 import { Dropdown, Button, DateTimePicker } from '@wordpress/components';
 import { date, getSettings } from '@wordpress/date';
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { calendar } from '@wordpress/icons';
 import styles from './styles.module.scss';
@@ -38,14 +38,10 @@ const ScheduleButtonContent = ( {
 		[ onChange ]
 	);
 
-	const scheduleDate = useMemo(
-		() =>
-			date(
-				'Y-m-d\\TH:i:s',
-				scheduleTimestamp ? new Date( scheduleTimestamp * 1000 ) : new Date(),
-				getSettings().timezone.offset
-			),
-		[ scheduleTimestamp ]
+	const scheduleDate = date(
+		'Y-m-d\\TH:i:s',
+		scheduleTimestamp ? new Date( scheduleTimestamp * 1000 ) : new Date(),
+		getSettings().timezone.offset
 	);
 
 	return (

--- a/projects/js-packages/publicize-components/src/components/schedule-button/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/schedule-button/index.tsx
@@ -1,0 +1,96 @@
+import { Dropdown, Button, DateTimePicker } from '@wordpress/components';
+import { date, getSettings } from '@wordpress/date';
+import { useCallback, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { calendar } from '@wordpress/icons';
+import styles from './styles.module.scss';
+
+interface ScheduleButtonBaseProps {
+	scheduleTimestamp?: number;
+	onChange?: ( unixTimestamp: number ) => void;
+	onConfirm?: () => void;
+}
+
+interface ScheduleButtonContentProps extends ScheduleButtonBaseProps {
+	onClose: () => void;
+}
+
+interface ScheduleButtonProps extends ScheduleButtonBaseProps {
+	isBusy?: boolean; // Defaults to false
+}
+
+const ScheduleButtonContent = ( {
+	onClose,
+	scheduleTimestamp,
+	onChange,
+	onConfirm,
+}: ScheduleButtonContentProps ) => {
+	const confirmCalback = useCallback( () => {
+		onConfirm?.();
+		onClose();
+	}, [ onClose, onConfirm ] );
+
+	const changeCallback = useCallback(
+		newDate => {
+			const unixTime = +date( 'U', newDate + getSettings().timezone.abbr, 0 );
+			onChange?.( unixTime );
+		},
+		[ onChange ]
+	);
+
+	const scheduleDate = useMemo(
+		() =>
+			date(
+				'Y-m-d\\TH:i:s',
+				scheduleTimestamp ? new Date( scheduleTimestamp * 1000 ) : new Date(),
+				getSettings().timezone.offset
+			),
+		[ scheduleTimestamp ]
+	);
+
+	return (
+		<>
+			<DateTimePicker onChange={ changeCallback } currentDate={ scheduleDate } />
+			<Button variant="primary" onClick={ confirmCalback } className={ styles.confirm }>
+				{ __( 'Confirm Schedule', 'jetpack-publicize-components' ) }
+			</Button>
+		</>
+	);
+};
+
+const ScheduleButton = ( {
+	scheduleTimestamp,
+	onChange,
+	onConfirm,
+	isBusy,
+}: ScheduleButtonProps ) => {
+	const toggle = useCallback(
+		( { onToggle, isOpen } ) => (
+			<Button
+				onClick={ ! isBusy ? onToggle : null }
+				aria-expanded={ isOpen }
+				aria-live="polite"
+				icon={ calendar }
+				isSecondary
+				isBusy={ isBusy }
+			>
+				{ __( 'Schedule', 'jetpack-publicize-components' ) }
+			</Button>
+		),
+		[ isBusy ]
+	);
+	const content = useCallback(
+		( { onClose } ) => (
+			<ScheduleButtonContent
+				onClose={ onClose }
+				scheduleTimestamp={ scheduleTimestamp }
+				onChange={ onChange }
+				onConfirm={ onConfirm }
+			/>
+		),
+		[ scheduleTimestamp, onChange, onConfirm ]
+	);
+	return <Dropdown position="bottom left" renderToggle={ toggle } renderContent={ content } />;
+};
+
+export default ScheduleButton;

--- a/projects/js-packages/publicize-components/src/components/schedule-button/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/schedule-button/index.tsx
@@ -8,7 +8,7 @@ import styles from './styles.module.scss';
 interface ScheduleButtonBaseProps {
 	scheduleTimestamp?: number;
 	onChange?: ( unixTimestamp: number ) => void;
-	onConfirm?: () => void;
+	onConfirm?: ( unixTimestamp: number ) => void;
 }
 
 interface ScheduleButtonContentProps extends ScheduleButtonBaseProps {
@@ -26,12 +26,12 @@ const ScheduleButtonContent = ( {
 	onConfirm,
 }: ScheduleButtonContentProps ) => {
 	const confirmCalback = useCallback( () => {
-		onConfirm?.();
+		onConfirm?.( scheduleTimestamp );
 		onClose();
-	}, [ onClose, onConfirm ] );
+	}, [ onClose, onConfirm, scheduleTimestamp ] );
 
 	const changeCallback = useCallback(
-		newDate => {
+		( newDate: string ) => {
 			const unixTime = +date( 'U', newDate + getSettings().timezone.abbr, 0 );
 			onChange?.( unixTime );
 		},
@@ -90,7 +90,13 @@ const ScheduleButton = ( {
 		),
 		[ scheduleTimestamp, onChange, onConfirm ]
 	);
-	return <Dropdown position="bottom left" renderToggle={ toggle } renderContent={ content } />;
+	return (
+		<Dropdown
+			popoverProps={ { placement: 'bottom-start' } }
+			renderToggle={ toggle }
+			renderContent={ content }
+		/>
+	);
 };
 
 export default ScheduleButton;

--- a/projects/js-packages/publicize-components/src/components/schedule-button/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/schedule-button/index.tsx
@@ -1,7 +1,7 @@
 import { Dropdown, Button, DateTimePicker } from '@wordpress/components';
 import { date, getSettings } from '@wordpress/date';
 import { useCallback } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { calendar } from '@wordpress/icons';
 import styles from './styles.module.scss';
 
@@ -48,7 +48,11 @@ const ScheduleButtonContent = ( {
 		<>
 			<DateTimePicker onChange={ changeCallback } currentDate={ scheduleDate } />
 			<Button variant="primary" onClick={ confirmCalback } className={ styles.confirm }>
-				{ __( 'Confirm Schedule', 'jetpack-publicize-components' ) }
+				{ _x(
+					'Confirm',
+					'Confirms the date and time selected to be used to share the post',
+					'jetpack-publicize-components'
+				) }
 			</Button>
 		</>
 	);

--- a/projects/js-packages/publicize-components/src/components/schedule-button/stories/index.stories.jsx
+++ b/projects/js-packages/publicize-components/src/components/schedule-button/stories/index.stories.jsx
@@ -10,4 +10,5 @@ const Template = args => <ScheduleButton { ...args } />;
 export const _default = Template.bind( {} );
 _default.args = {
 	scheduleTimestamp: Date.now() / 1000,
+	isBusy: false,
 };

--- a/projects/js-packages/publicize-components/src/components/schedule-button/stories/index.stories.jsx
+++ b/projects/js-packages/publicize-components/src/components/schedule-button/stories/index.stories.jsx
@@ -1,0 +1,13 @@
+import ScheduleButton from '../index.tsx';
+
+export default {
+	title: 'JS Packages/Publicize Components/ScheduleButton',
+	component: ScheduleButton,
+};
+
+const Template = args => <ScheduleButton { ...args } />;
+
+export const _default = Template.bind( {} );
+_default.args = {
+	scheduleTimestamp: Date.now() / 1000,
+};

--- a/projects/js-packages/publicize-components/src/components/schedule-button/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/schedule-button/styles.module.scss
@@ -1,0 +1,6 @@
+.confirm {
+	width:100%;
+	text-align: center;
+	justify-content: center;
+	margin-top: 0.6em;
+}

--- a/projects/js-packages/publicize-components/src/components/schedule-button/test/index.test.tsx
+++ b/projects/js-packages/publicize-components/src/components/schedule-button/test/index.test.tsx
@@ -35,11 +35,8 @@ describe( 'ScheduleButton', () => {
 			<ScheduleButton onChange={ mockOnChange } scheduleTimestamp={ initialUnixTimestamp } />
 		);
 
-		// Click the Schedule button to open the dropdown
 		const scheduleButton = screen.getByRole( 'button', { name: /schedule/i } );
 		await user.click( scheduleButton );
-
-		// Use a query that targets the DateTimePicker directly
 
 		expect(
 			screen.getByRole( 'button', { name: 'October 1, 2023. Selected' } )
@@ -63,11 +60,8 @@ describe( 'ScheduleButton', () => {
 			<ScheduleButton onChange={ mockOnChange } scheduleTimestamp={ initialUnixTimestamp } />
 		);
 
-		// Click the Schedule button to open the dropdown
 		const scheduleButton = screen.getByRole( 'button', { name: /schedule/i } );
 		await user.click( scheduleButton );
-
-		// Use a query that targets the DateTimePicker directly
 
 		expect(
 			screen.getByRole( 'button', { name: 'October 1, 2023. Selected' } )
@@ -84,7 +78,6 @@ describe( 'ScheduleButton', () => {
 
 		render( <ScheduleButton onConfirm={ mockOnConfirm } /> );
 
-		// Click the Schedule button to open the dropdown
 		const scheduleButton = screen.getByRole( 'button', { name: /schedule/i } );
 		await user.click( scheduleButton );
 

--- a/projects/js-packages/publicize-components/src/components/schedule-button/test/index.test.tsx
+++ b/projects/js-packages/publicize-components/src/components/schedule-button/test/index.test.tsx
@@ -63,13 +63,20 @@ describe( 'ScheduleButton', () => {
 		const scheduleButton = screen.getByRole( 'button', { name: /schedule/i } );
 		await user.click( scheduleButton );
 
+		const hoursInput = screen.getByLabelText( 'Hours' );
+		const minutesInput = screen.getByLabelText( 'Minutes' );
+
 		expect(
 			screen.getByRole( 'button', { name: 'October 1, 2023. Selected' } )
 		).toBeInTheDocument();
+		expect( hoursInput ).toHaveValue( 12 );
+		expect( minutesInput ).toHaveValue( 0 );
 		const datePicker = screen.getByRole( 'button', { name: 'October 2, 2023' } );
 		await user.click( datePicker );
 
 		expect( mockOnChange ).toHaveBeenCalledWith( expectedUnixTimestamp );
+		expect( hoursInput ).toHaveValue( 12 );
+		expect( minutesInput ).toHaveValue( 0 );
 	} );
 
 	it( 'should call onConfirm when confirm button is clicked', async () => {

--- a/projects/js-packages/publicize-components/src/components/schedule-button/test/index.test.tsx
+++ b/projects/js-packages/publicize-components/src/components/schedule-button/test/index.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import * as wpdate from '@wordpress/date';
+import ScheduleButton from '../index';
+
+const originalGetSettings = wpdate.getSettings;
+
+const mockGetSettings = ( abbr = '+00', offset = 0, offsetFormatted = '0', string = 'UTC' ) => {
+	jest.spyOn( wpdate, 'getSettings' ).mockImplementation( () => ( {
+		...originalGetSettings(),
+		timezone: {
+			abbr,
+			offset,
+			offsetFormatted,
+			string,
+		},
+	} ) );
+};
+
+describe( 'ScheduleButton', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should convert date string to correct unix timestamp on change', async () => {
+		const initialDate = new Date( '2023-10-01T12:00:00Z' );
+		const expectedDate = new Date( '2023-10-02T12:00:00Z' );
+		const initialUnixTimestamp = Math.floor( initialDate.getTime() / 1000 );
+		const expectedUnixTimestamp = Math.floor( expectedDate.getTime() / 1000 );
+		const user = userEvent.setup();
+
+		const mockOnChange = jest.fn();
+		mockGetSettings();
+		render(
+			<ScheduleButton onChange={ mockOnChange } scheduleTimestamp={ initialUnixTimestamp } />
+		);
+
+		// Click the Schedule button to open the dropdown
+		const scheduleButton = screen.getByRole( 'button', { name: /schedule/i } );
+		await user.click( scheduleButton );
+
+		// Use a query that targets the DateTimePicker directly
+
+		expect(
+			screen.getByRole( 'button', { name: 'October 1, 2023. Selected' } )
+		).toBeInTheDocument();
+		const datePicker = screen.getByRole( 'button', { name: 'October 2, 2023' } );
+		await user.click( datePicker );
+
+		expect( mockOnChange ).toHaveBeenCalledWith( expectedUnixTimestamp );
+	} );
+
+	it( 'should convert date string to correct unix timestamp, in the current timezone, on change', async () => {
+		const initialDate = new Date( '2023-10-01T12:00:00+05:00' );
+		const expectedDate = new Date( '2023-10-02T12:00:00+05:00' );
+		const initialUnixTimestamp = Math.floor( initialDate.getTime() / 1000 );
+		const expectedUnixTimestamp = Math.floor( expectedDate.getTime() / 1000 );
+		const user = userEvent.setup();
+
+		const mockOnChange = jest.fn();
+		mockGetSettings( '+05', 5, '5', 'Indian/Maldives' );
+		render(
+			<ScheduleButton onChange={ mockOnChange } scheduleTimestamp={ initialUnixTimestamp } />
+		);
+
+		// Click the Schedule button to open the dropdown
+		const scheduleButton = screen.getByRole( 'button', { name: /schedule/i } );
+		await user.click( scheduleButton );
+
+		// Use a query that targets the DateTimePicker directly
+
+		expect(
+			screen.getByRole( 'button', { name: 'October 1, 2023. Selected' } )
+		).toBeInTheDocument();
+		const datePicker = screen.getByRole( 'button', { name: 'October 2, 2023' } );
+		await user.click( datePicker );
+
+		expect( mockOnChange ).toHaveBeenCalledWith( expectedUnixTimestamp );
+	} );
+
+	it( 'should call onConfirm when confirm button is clicked', async () => {
+		const user = userEvent.setup();
+		const mockOnConfirm = jest.fn();
+
+		render( <ScheduleButton onConfirm={ mockOnConfirm } /> );
+
+		// Click the Schedule button to open the dropdown
+		const scheduleButton = screen.getByRole( 'button', { name: /schedule/i } );
+		await user.click( scheduleButton );
+
+		const confirmButton = screen.getByText( 'Confirm Schedule' );
+		await user.click( confirmButton );
+
+		expect( mockOnConfirm ).toHaveBeenCalled();
+	} );
+} );

--- a/projects/js-packages/publicize-components/src/components/schedule-button/test/index.test.tsx
+++ b/projects/js-packages/publicize-components/src/components/schedule-button/test/index.test.tsx
@@ -88,7 +88,7 @@ describe( 'ScheduleButton', () => {
 		const scheduleButton = screen.getByRole( 'button', { name: /schedule/i } );
 		await user.click( scheduleButton );
 
-		const confirmButton = screen.getByText( 'Confirm Schedule' );
+		const confirmButton = screen.getByText( 'Confirm' );
 		await user.click( confirmButton );
 
 		expect( mockOnConfirm ).toHaveBeenCalled();

--- a/projects/plugins/jetpack/changelog/add-schedule-button
+++ b/projects/plugins/jetpack/changelog/add-schedule-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Publicize Components: Add the schedule button

--- a/projects/plugins/social/changelog/add-schedule-button
+++ b/projects/plugins/social/changelog/add-schedule-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Publicize Components: Add the schedule button


### PR DESCRIPTION
Fixes Automattic/jetpack-reach#835

## Proposed changes:
This change adds a button component for selecting a date to schedule a share.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Run storybook with `pnpm -F @automattic/jetpack-storybook storybook:dev`
- Goto Publicize Components > Schedule Button
- Check that you can select a date and time, and that you can't select a date in the busy state


![CleanShot 2025-03-07 at 22 00 30@2x](https://github.com/user-attachments/assets/cd8332eb-bfbd-4a15-9898-0b591077c6b2)


