### PR TITLE
Newsletter Dashboard Widget: handle singular/plural forms of labels

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-count-labels
+++ b/projects/plugins/jetpack/changelog/fix-count-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Handled singular/plural forms of labels

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/components/newsletter-widget.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/components/newsletter-widget.tsx
@@ -2,7 +2,7 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 import '../style.scss';
 import { Icon } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, sprintf, _n } from '@wordpress/i18n';
 import { envelope, payment } from '@wordpress/icons';
 import { buildJPRedirectSource, formatNumber, getSubscriberStatsUrl } from '../helpers';
 import { SubscribersChart } from './subscribers-chart';
@@ -46,7 +46,12 @@ export const NewsletterWidget = ( {
 									<a href={ getSubscriberStatsUrl( site, isWpcomSite, adminUrl ) }>
 										{ sprintf(
 											//translators: %1$s is the total number of subscribers, %2$s is the number of email subscribers
-											__( '%1$s subscribers (%2$s via email)', 'jetpack' ),
+											_n(
+												'%1$s subscriber (%2$s via email)',
+												'%1$s subscribers (%2$s via email)',
+												allSubscribers,
+												'jetpack'
+											),
 											formatNumber( allSubscribers ),
 											formatNumber( emailSubscribers )
 										) }
@@ -63,7 +68,7 @@ export const NewsletterWidget = ( {
 									<a href={ getSubscriberStatsUrl( site, isWpcomSite, adminUrl ) }>
 										{ sprintf(
 											//translators: %s is the number of paid subscribers
-											__( '%s paid subscriptions', 'jetpack' ),
+											_n( '%s paid subscriber', '%s paid subscribers', paidSubscribers, 'jetpack' ),
 											formatNumber( paidSubscribers )
 										) }
 									</a>

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/newsletter-widget.test.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/newsletter-widget.test.tsx
@@ -47,7 +47,7 @@ describe( 'NewsletterWidget', () => {
 
 		// Check for paid subscriptions label
 		expect(
-			screen.getByText( `${ defaultProps.paidSubscribers } paid subscriptions` )
+			screen.getByText( `${ defaultProps.paidSubscribers } paid subscribers` )
 		).toBeInTheDocument();
 	} );
 
@@ -163,7 +163,7 @@ describe( 'NewsletterWidget', () => {
 		it( 'shows stats section when paidSubscribers > 0', () => {
 			render( <NewsletterWidget { ...defaultProps } allSubscribers={ 0 } paidSubscribers={ 5 } /> );
 
-			expect( screen.getByText( '5 paid subscriptions' ) ).toBeInTheDocument();
+			expect( screen.getByText( '5 paid subscribers' ) ).toBeInTheDocument();
 		} );
 
 		it( 'hides stats section when allSubscribers and paidSubscribers are 0', () => {
@@ -178,7 +178,35 @@ describe( 'NewsletterWidget', () => {
 
 			expect( screen.queryByText( /subscribers \(\d+ via email\)/ ) ).not.toBeInTheDocument();
 
-			expect( screen.queryByText( /paid subscriptions/ ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( /paid subscribers/ ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'shows stats section when allSubscribers = 1', () => {
+			render(
+				<NewsletterWidget
+					{ ...defaultProps }
+					allSubscribers={ 1 }
+					emailSubscribers={ 1 }
+					paidSubscribers={ 0 }
+				/>
+			);
+
+			expect( screen.getByText( '1 subscriber (1 via email)' ) ).toBeInTheDocument();
+			expect( screen.getByText( '0 paid subscribers' ) ).toBeInTheDocument();
+		} );
+
+		it( 'shows stats section when paidSubscribers = 1', () => {
+			render(
+				<NewsletterWidget
+					{ ...defaultProps }
+					allSubscribers={ 10 }
+					emailSubscribers={ 7 }
+					paidSubscribers={ 1 }
+				/>
+			);
+
+			expect( screen.getByText( '10 subscribers (7 via email)' ) ).toBeInTheDocument();
+			expect( screen.getByText( '1 paid subscriber' ) ).toBeInTheDocument();
 		} );
 	} );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/loop/issues/568

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Handle singular/plural forms of labels
* Updated label to say 'subscribers' instead of 'subscriptions' for consistency

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a simple or a jetpack site, test this branch with a single subscriber - you just need to boot up a new site on this branch to test that. 
* If you have a single subscriber, you should see the labels as shown below. On trunk, you will see the plural form being used for the label when there is just 1 subscriber. 

<img width="507" alt="Screenshot 2025-03-10 at 4 23 30 PM" src="https://github.com/user-attachments/assets/04179b5a-37ae-475b-9431-332aea892e08" />


<img width="519" alt="Screenshot 2025-03-10 at 4 52 38 PM" src="https://github.com/user-attachments/assets/503d1462-7676-4649-880c-6f6dc2cb8e7d" />



