### PR TITLE
Forms: Update default forms view to DataViews

### DIFF
--- a/projects/packages/forms/changelog/update-change-forms-default-view
+++ b/projects/packages/forms/changelog/update-change-forms-default-view
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Change default submissions view to dataviews.

--- a/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
@@ -262,7 +262,7 @@ CSS
 	public function get_preferred_view() {
 		$preferred_view = get_user_option( 'jetpack_forms_admin_preferred_view' );
 
-		return in_array( $preferred_view, array( self::CLASSIC_VIEW, self::MODERN_VIEW ), true ) ? $preferred_view : self::CLASSIC_VIEW;
+		return in_array( $preferred_view, array( self::CLASSIC_VIEW, self::MODERN_VIEW ), true ) ? $preferred_view : self::MODERN_VIEW;
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-change-forms-default-view
+++ b/projects/plugins/jetpack/changelog/update-change-forms-default-view
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Update default forms view to dataviews.


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We recently merged a PR that adds DataViews for viewing form submission. See #41602

This PR changes the default forms submissions view for new users from the old classic view (standard custom post types) to the new Jetpack Inbox view that has the DataViews table. The default view will not change for existing users who already have a stored preference, only new users. 

New default:
<img width="1286" alt="image" src="https://github.com/user-attachments/assets/9f9acc7b-e851-4778-a110-25f7ceb4957c" />

Old default:
<img width="1288" alt="image" src="https://github.com/user-attachments/assets/42e73656-5cd0-4755-88a0-b28e8806c15d" />

Users can still switch the view from the dropdown:

<img width="267" alt="image" src="https://github.com/user-attachments/assets/3697eb19-2b60-4d78-a4b9-fbea067beb14" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install Jetpack on a new site. To be able to test a jetpack branch on a new site you can use [Jurassic Ninja](https://jurassic.ninja/)
* Got to the 'Feedback' page on the main menu, and confirm you get the 'modern' Jetpack Inbox view with DataViews, rather than the older standard custom post type list. 
* Confirm that you can still change to the classic view using the "View" settings on the upper right of the page. 
* As bonus, test this when creating a new simple site by using the instructions below to load this branch in your sandbox.

