### PR TITLE
Remove/agency data from initial state

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -93,8 +93,14 @@ export default function MyJetpackScreen() {
 		variation: 'control',
 	} );
 	useNotificationWatcher();
-	const { isAtomic = false, adminUrl, sandboxedDomain } = getMyJetpackWindowInitialState();
-	const { redBubbleAlerts, isDevVersion, userIsAdmin } = getMyJetpackWindowInitialState();
+	const {
+		isAtomic = false,
+		adminUrl,
+		sandboxedDomain,
+		redBubbleAlerts,
+		isDevVersion,
+		userIsAdmin,
+	} = getMyJetpackWindowInitialState();
 
 	const { isWelcomeBannerVisible } = useWelcomeBanner();
 	const { isSectionVisible } = useEvaluationRecommendations();
@@ -225,18 +231,20 @@ export default function MyJetpackScreen() {
 
 			<ProductCardsSection />
 
-			<Container horizontalSpacing={ 6 } horizontalGap={ noticeMessage ? 3 : 6 }>
-				<Col>
-					{ isJetpackManageLoading ? (
-						<LoadingBlock height="200px" width="100%" />
-					) : (
-						! isJetpackManageError &&
-						jetpackManageData.isEnabled && (
-							<JetpackManageBanner isAgencyAccount={ jetpackManageData.isAgencyAccount } />
-						)
-					) }
-				</Col>
-			</Container>
+			{ userIsAdmin && (
+				<Container horizontalSpacing={ 6 } horizontalGap={ noticeMessage ? 3 : 6 }>
+					<Col>
+						{ isJetpackManageLoading ? (
+							<LoadingBlock height="200px" width="100%" />
+						) : (
+							! isJetpackManageError &&
+							jetpackManageData.isEnabled && (
+								<JetpackManageBanner isAgencyAccount={ jetpackManageData.isAgencyAccount } />
+							)
+						) }
+					</Col>
+				</Container>
+			) }
 
 			<AdminSection>
 				<Container horizontalSpacing={ 8 }>

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -113,7 +113,11 @@ export default function MyJetpackScreen() {
 		name: QUERY_CHAT_AUTHENTICATION_KEY,
 		query: { path: REST_API_CHAT_AUTHENTICATION_ENDPOINT },
 	} );
-	const { data: jetpackManageData, isLoading: isJetpackManageLoading } = useSimpleQuery( {
+	const {
+		data: jetpackManageData,
+		isLoading: isJetpackManageLoading,
+		isError: isJetpackManageError,
+	} = useSimpleQuery( {
 		name: QUERY_GET_JETPACK_MANAGE_DATA_KEY,
 		query: { path: REST_API_GET_JETPACK_MANAGE_DATA },
 	} );
@@ -226,6 +230,7 @@ export default function MyJetpackScreen() {
 					{ isJetpackManageLoading ? (
 						<LoadingBlock height="200px" width="100%" />
 					) : (
+						! isJetpackManageError &&
 						jetpackManageData.isEnabled && (
 							<JetpackManageBanner isAgencyAccount={ jetpackManageData.isAgencyAccount } />
 						)

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -26,6 +26,8 @@ import {
 	REST_API_CHAT_AVAILABILITY_ENDPOINT,
 	QUERY_CHAT_AVAILABILITY_KEY,
 	QUERY_CHAT_AUTHENTICATION_KEY,
+	QUERY_GET_JETPACK_MANAGE_DATA_KEY,
+	REST_API_GET_JETPACK_MANAGE_DATA,
 } from '../../data/constants';
 import useEvaluationRecommendations from '../../data/evaluation-recommendations/use-evaluation-recommendations';
 import useUpdateHistoricallyActiveModules from '../../data/products/use-update-historically-active-modules';
@@ -42,6 +44,7 @@ import ConnectionsSection from '../connections-section';
 import EvaluationRecommendations from '../evaluation-recommendations';
 import IDCModal from '../idc-modal';
 import JetpackManageBanner from '../jetpack-manage-banner';
+import LoadingBlock from '../loading-block';
 import PlansSection from '../plans-section';
 import ProductCardsSection from '../product-cards-section';
 import WelcomeFlow from '../welcome-flow';
@@ -90,12 +93,7 @@ export default function MyJetpackScreen() {
 		variation: 'control',
 	} );
 	useNotificationWatcher();
-	const {
-		isAtomic = false,
-		jetpackManage = {},
-		adminUrl,
-		sandboxedDomain,
-	} = getMyJetpackWindowInitialState();
+	const { isAtomic = false, adminUrl, sandboxedDomain } = getMyJetpackWindowInitialState();
 	const { redBubbleAlerts, isDevVersion, userIsAdmin } = getMyJetpackWindowInitialState();
 
 	const { isWelcomeBannerVisible } = useWelcomeBanner();
@@ -114,6 +112,10 @@ export default function MyJetpackScreen() {
 	const { data: authData, isLoading: isJwtLoading } = useSimpleQuery( {
 		name: QUERY_CHAT_AUTHENTICATION_KEY,
 		query: { path: REST_API_CHAT_AUTHENTICATION_ENDPOINT },
+	} );
+	const { data: jetpackManageData, isLoading: isJetpackManageLoading } = useSimpleQuery( {
+		name: QUERY_GET_JETPACK_MANAGE_DATA_KEY,
+		query: { path: REST_API_GET_JETPACK_MANAGE_DATA },
 	} );
 	const updateHistoricallyActiveModules = useUpdateHistoricallyActiveModules();
 
@@ -219,13 +221,17 @@ export default function MyJetpackScreen() {
 
 			<ProductCardsSection />
 
-			{ jetpackManage.isEnabled && (
-				<Container horizontalSpacing={ 6 } horizontalGap={ noticeMessage ? 3 : 6 }>
-					<Col>
-						<JetpackManageBanner isAgencyAccount={ jetpackManage.isAgencyAccount } />
-					</Col>
-				</Container>
-			) }
+			<Container horizontalSpacing={ 6 } horizontalGap={ noticeMessage ? 3 : 6 }>
+				<Col>
+					{ isJetpackManageLoading ? (
+						<LoadingBlock height="200px" width="100%" />
+					) : (
+						jetpackManageData.isEnabled && (
+							<JetpackManageBanner isAgencyAccount={ jetpackManageData.isAgencyAccount } />
+						)
+					) }
+				</Col>
+			</Container>
 
 			<AdminSection>
 				<Container horizontalSpacing={ 8 }>

--- a/projects/packages/my-jetpack/_inc/data/constants.ts
+++ b/projects/packages/my-jetpack/_inc/data/constants.ts
@@ -13,6 +13,7 @@ export const REST_API_SITE_DISMISS_BANNER = `${ REST_API_NAMESPACE }/site/dismis
 export const REST_API_EVALUATE_SITE_RECOMMENDATIONS = `${ REST_API_NAMESPACE }/site/recommendations/evaluation`;
 export const REST_API_SITE_EVALUATION_RESULT = `${ REST_API_NAMESPACE }/site/recommendations/evaluation/result`;
 export const REST_API_UPDATE_HISTORICALLY_ACTIVE_MODULES = `${ REST_API_NAMESPACE }/site/update-historically-active-modules`;
+export const REST_API_GET_JETPACK_MANAGE_DATA = `${ REST_API_NAMESPACE }/jetpack-manage/data`;
 
 export const getStatsHighlightsEndpoint = ( blogId: string ) =>
 	`${ ODYSSEY_STATS_API_NAMESPACE }/sites/${ blogId }/stats/highlights`;
@@ -34,6 +35,7 @@ export const QUERY_EVALUATE_KEY = 'evaluate site recommendations';
 export const QUERY_SAVE_EVALUATION_KEY = 'save site evaluation result';
 export const QUERY_REMOVE_EVALUATION_KEY = 'remove site evaluation result';
 export const QUERY_UPDATE_HISTORICALLY_ACTIVE_MODULES_KEY = 'update historically active modules';
+export const QUERY_GET_JETPACK_MANAGE_DATA_KEY = 'get jetpack manage data';
 
 // Product Slugs
 export const PRODUCT_SLUGS = {

--- a/projects/packages/my-jetpack/changelog/remove-agency-data-from-initial-state
+++ b/projects/packages/my-jetpack/changelog/remove-agency-data-from-initial-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Load agency data from frontend instead of backend

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -217,10 +217,6 @@ interface Window {
 		isStatsModuleActive: string;
 		canUserViewStats: boolean;
 		isUserFromKnownHost: string;
-		jetpackManage: {
-			isAgencyAccount: boolean;
-			isEnabled: boolean;
-		};
 		loadAddLicenseScreen: string;
 		myJetpackCheckoutUri: string;
 		myJetpackFlags: {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -293,14 +293,9 @@ class Initializer {
 				),
 				'isStatsModuleActive'    => $modules->is_active( 'stats' ),
 				'canUserViewStats'       => current_user_can( 'manage_options' ) || current_user_can( 'view_stats' ),
-				'isCommercial'           => self::is_commercial_site(),
 				'sandboxedDomain'        => $sandboxed_domain,
 				'isDevVersion'           => $is_dev_version,
 				'isAtomic'               => ( new Status_Host() )->is_woa_site(),
-				'jetpackManage'          => array(
-					'isEnabled'       => Jetpack_Manage::could_use_jp_manage(),
-					'isAgencyAccount' => Jetpack_Manage::is_agency_account(),
-				),
 				'latestBoostSpeedScores' => $latest_score,
 				'protect'                => array(
 					'scanData'  => $scan_data,
@@ -522,6 +517,7 @@ class Initializer {
 
 		Products::register_product_endpoints();
 		Historically_Active_Modules::register_rest_endpoints();
+		Jetpack_Manage::register_rest_endpoints();
 
 		register_rest_route(
 			'my-jetpack/v1',

--- a/projects/packages/my-jetpack/src/class-jetpack-manage.php
+++ b/projects/packages/my-jetpack/src/class-jetpack-manage.php
@@ -91,7 +91,7 @@ class Jetpack_Manage {
 	 *
 	 * @return bool Return true if the user has enough sites to be able to use Jetpack Manage.
 	 */
-	private static function could_use_jp_manage( $min_sites = 2 ) {
+	public static function could_use_jp_manage( $min_sites = 2 ) {
 		// Only proceed if the user is connected to WordPress.com.
 		if ( ! ( new Connection_Manager() )->is_user_connected() ) {
 			return false;
@@ -121,15 +121,14 @@ class Jetpack_Manage {
 	 *
 	 * @return bool Return true if the user is a partner/agency, otherwise false.
 	 */
-	private static function is_agency_account() {
+	public static function is_agency_account() {
 		// Only proceed if the user is connected to WordPress.com.
 		if ( ! ( new Connection_Manager() )->is_user_connected() ) {
 			return false;
 		}
 
 		// Get the cached partner data.
-		$partner = false;
-		get_transient( 'jetpack_partner_data' );
+		$partner = get_transient( 'jetpack_partner_data' );
 
 		if ( $partner === false ) {
 			$wpcom_response = Client::wpcom_json_api_request_as_user( '/jetpack-partners' );

--- a/projects/packages/my-jetpack/src/class-jetpack-manage.php
+++ b/projects/packages/my-jetpack/src/class-jetpack-manage.php
@@ -13,6 +13,8 @@ use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Redirect;
+use WP_Error;
+use WP_Rest_Response;
 
 /**
  * Jetpack Manage features in My Jetpack.
@@ -23,6 +25,35 @@ class Jetpack_Manage {
 	 */
 	public static function init() {
 		add_action( 'admin_menu', array( self::class, 'add_submenu_jetpack' ) );
+	}
+
+	/**
+	 * Register the REST API routes.
+	 *
+	 * @return void
+	 */
+	public static function register_rest_endpoints() {
+		register_rest_route(
+			'my-jetpack/v1',
+			'jetpack-manage/data',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => __CLASS__ . '::get_jetpack_manage_data',
+				'permission_callback' => __CLASS__ . '::permissions_callback',
+			)
+		);
+	}
+
+	/**
+	 * Check user capabilities to access historically active modules.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @return true|WP_Error
+	 */
+	public static function permissions_callback() {
+		return current_user_can( 'manage_options' );
 	}
 
 	/**
@@ -60,7 +91,7 @@ class Jetpack_Manage {
 	 *
 	 * @return bool Return true if the user has enough sites to be able to use Jetpack Manage.
 	 */
-	public static function could_use_jp_manage( $min_sites = 2 ) {
+	private static function could_use_jp_manage( $min_sites = 2 ) {
 		// Only proceed if the user is connected to WordPress.com.
 		if ( ! ( new Connection_Manager() )->is_user_connected() ) {
 			return false;
@@ -90,14 +121,15 @@ class Jetpack_Manage {
 	 *
 	 * @return bool Return true if the user is a partner/agency, otherwise false.
 	 */
-	public static function is_agency_account() {
+	private static function is_agency_account() {
 		// Only proceed if the user is connected to WordPress.com.
 		if ( ! ( new Connection_Manager() )->is_user_connected() ) {
 			return false;
 		}
 
 		// Get the cached partner data.
-		$partner = get_transient( 'jetpack_partner_data' );
+		$partner = false;
+		get_transient( 'jetpack_partner_data' );
 
 		if ( $partner === false ) {
 			$wpcom_response = Client::wpcom_json_api_request_as_user( '/jetpack-partners' );
@@ -120,5 +152,22 @@ class Jetpack_Manage {
 		}
 
 		return $partner->partner_type === 'agency';
+	}
+
+	/**
+	 * Get Jetpack Manage data for REST API.
+	 *
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public static function get_jetpack_manage_data() {
+		$is_enabled        = self::could_use_jp_manage();
+		$is_agency_account = self::is_agency_account();
+
+		return rest_ensure_response(
+			array(
+				'isEnabled'       => $is_enabled,
+				'isAgencyAccount' => $is_agency_account,
+			)
+		);
 	}
 }


### PR DESCRIPTION
## Proposed changes:

* The agency data, while only queried once a day, is stilled a render blocking HTTP request when queried. This PR moves that data to a frontend async call to avoid that

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: pghfsA-df-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Go to My Jetpack and scroll to where the agency banner loads. Ensure you see a loading block until the data is loaded

https://github.com/user-attachments/assets/508bafba-7cdc-4019-a123-b36a56370533

