### PR TITLE
Jetpack SEO Enhancer: add switch trigger toggle

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-seo-enhancer-switch-trigger-toggle
+++ b/projects/plugins/jetpack/changelog/add-jetpack-seo-enhancer-switch-trigger-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack SEO: add action trigger when toggle is off

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/index.tsx
@@ -1,10 +1,10 @@
-import { BaseControl, ToggleControl } from '@wordpress/components';
+import { BaseControl, ToggleControl, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import './style.scss';
 
 export function SeoEnhancer() {
-	const [ isEnabled, setIsEnabled ] = useState( false );
+	const [ isEnabled, setIsEnabled ] = useState( true );
 
 	const toggleHandler = () => {
 		setIsEnabled( ! isEnabled );
@@ -18,10 +18,22 @@ export function SeoEnhancer() {
 				label={ __( 'Auto-enhance', 'jetpack' ) }
 				// __nextHasNoMarginBottom={ true }
 				help={ __(
-					"Automattically generate SEO title, SEO description and images' alt text.",
+					"Automattically generate SEO title, SEO description and images' alt text on publish.",
 					'jetpack'
 				) }
 			/>
+			{ ! isEnabled && (
+				<Button
+					style={ { width: '100%', justifyContent: 'center' } }
+					isBusy={ false }
+					disabled={ false }
+					onClick={ () => {} }
+					variant="secondary"
+					__next40pxDefaultSize
+				>
+					{ __( 'Generate SEO properties', 'jetpack' ) }
+				</Button>
+			) }
 		</BaseControl>
 	);
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/index.tsx
@@ -18,7 +18,7 @@ export function SeoEnhancer() {
 				label={ __( 'Auto-enhance', 'jetpack' ) }
 				// __nextHasNoMarginBottom={ true }
 				help={ __(
-					"Automattically generate SEO title, SEO description and images' alt text on publish.",
+					"Automattically generate SEO title, SEO description and images' alt text.",
 					'jetpack'
 				) }
 			/>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/style.scss
@@ -1,4 +1,5 @@
 .ai-seo-enhancer-toggle {
+	margin-bottom: 8px;
 	.components-toggle-control__help {
 		margin-inline-start: 0px;
 	}


### PR DESCRIPTION
## Proposed changes:
This PR adds the trigger button for enhancing SEO properties. It's shown when toggle is off.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1741621427029909-slack-C054LN8RNVA
p1HpG7-wea-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Enable the filter `add_filter( 'ai_seo_enhancer_enabled', '__return_true' );`. 

Go to the editor and open the JP sidebar. On the SEO panel, see the toggle. Toggling on/off should show/hide the action trigger button.

The component is also rendered on the PrePublish sidebar. Hit publish and look for the SEO panel there.

<img width="291" alt="image" src="https://github.com/user-attachments/assets/f0793ea4-6eb3-4c95-8366-b30d44128a7e" />

<img width="293" alt="image" src="https://github.com/user-attachments/assets/bed1030b-6bd6-41eb-8048-411d8db520ef" />
