### PR TITLE
VideoPress Block: Fix undo not working

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-block-undo
+++ b/projects/packages/videopress/changelog/fix-videopress-block-undo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress Block: Fix undo not working

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -159,6 +159,7 @@ export default function VideoPressEdit( {
 	const chapter = tracks?.filter( track => track.kind === 'chapters' )?.[ 0 ];
 
 	const [ showCaption, setShowCaption ] = useState( !! caption );
+	const { replaceBlock, __unstableMarkNextChangeAsNotPersistent } = useDispatch( blockEditorStore );
 
 	const {
 		videoData,
@@ -193,6 +194,7 @@ export default function VideoPressEdit( {
 			return;
 		}
 
+		__unstableMarkNextChangeAsNotPersistent();
 		setAttributes( { cacheHtml: previewHtml } );
 	}, [ previewHtml, cacheHtml, setAttributes ] );
 
@@ -209,6 +211,7 @@ export default function VideoPressEdit( {
 			return;
 		}
 
+		__unstableMarkNextChangeAsNotPersistent();
 		setAttributes( { videoRatio: ratio } );
 	}, [ videoRatio, previewWidth, previewHeight, setAttributes ] );
 
@@ -336,13 +339,13 @@ export default function VideoPressEdit( {
 		}
 
 		// Clean the src attribute.
+		__unstableMarkNextChangeAsNotPersistent();
 		setAttributes( { src: undefined } );
 
 		// Set state to start the upload process.
 		setIsUploadingFile( true );
 		setFileToUpload( file );
 	}, [ src ] );
-	const { replaceBlock } = useDispatch( blockEditorStore );
 
 	// Replace video state
 	const [ isReplacingFile, setIsReplacingFile ] = useState< {
@@ -394,6 +397,7 @@ export default function VideoPressEdit( {
 				return;
 			}
 
+			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( newVideoData );
 		};
 

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-sync-media/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-sync-media/index.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { usePrevious } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -163,6 +164,7 @@ export function useSyncMedia(
 	const isSaving = useSelect( select => select( editorStore ).isSavingPost(), [] );
 	const wasSaving = usePrevious( isSaving );
 	const invalidateResolution = useDispatch( coreStore ).invalidateResolution;
+	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch( blockEditorStore );
 
 	const [ initialState, setState ] = useState< VideoDataProps >( {} );
 
@@ -241,6 +243,7 @@ export function useSyncMedia(
 		}
 
 		debug( 'Updating attributes: ', attributesToUpdate );
+		__unstableMarkNextChangeAsNotPersistent();
 		setAttributes( attributesToUpdate );
 	}, [ videoData, isRequestingVideoData ] );
 

--- a/projects/plugins/jetpack/changelog/fix-videopress-block-undo
+++ b/projects/plugins/jetpack/changelog/fix-videopress-block-undo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress Block: Fix undo not working

--- a/projects/plugins/videopress/changelog/fix-videopress-block-undo
+++ b/projects/plugins/videopress/changelog/fix-videopress-block-undo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress Block: Fix undo not working


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/28492

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This fixes the editor undo not working after a video is selected/uploaded. The solution is based on: https://github.com/WordPress/gutenberg/issues/8119
* I wasn't able to write unit tests for this. Not sure if there's a good way to do it that doesn't take too long.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In the editor, add a new VideoPress block.
* Upload a video, press undo, and make sure the block is removed. Now press redo - it should be back.
* Play around with the video settings (update the title, change the poster, etc.) and make sure the undo/redo actions are working.

