### PR TITLE
Forms: Remove default 16px padding block

### DIFF
--- a/projects/packages/forms/changelog/update-remove-form-padding
+++ b/projects/packages/forms/changelog/update-remove-form-padding
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Remove default padding around forms.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings.js
@@ -86,9 +86,7 @@ export const salesforceLeadFormVariation = {
 			spacing: {
 				padding: {
 					top: '16px',
-					right: '16px',
 					bottom: '16px',
-					left: '16px',
 				},
 			},
 		},

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -8,7 +8,14 @@ import { getIconColor } from './util/block-icons';
 import renderMaterialIcon from './util/render-material-icon';
 
 const defaultBlockStyling = {
-	style: {},
+	style: {
+		spacing: {
+			padding: {
+				top: '16px',
+				bottom: '16px',
+			},
+		},
+	},
 };
 
 const variations = compact( [

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -8,16 +8,7 @@ import { getIconColor } from './util/block-icons';
 import renderMaterialIcon from './util/render-material-icon';
 
 const defaultBlockStyling = {
-	style: {
-		spacing: {
-			padding: {
-				top: '16px',
-				right: '16px',
-				bottom: '16px',
-				left: '16px',
-			},
-		},
-	},
+	style: {},
 };
 
 const variations = compact( [

--- a/projects/plugins/jetpack/changelog/update-remove-form-padding
+++ b/projects/plugins/jetpack/changelog/update-remove-form-padding
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Forms: Remove default padding around form block.


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack/issues/29516

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The form block currently adds 16px of padding all around the form. This was originally added to make it easier to select the parent form block when in the block editor. But on the frontend, it results in the form not being aligned on the left and right with all other content on the page. 
* This remove the left/right padding so forms stay aligned. I kept the top/bottom padding to keep spacing between the form block and other content on the page. 
* I had to update both the main defaults, and the defaults for the salesforce form which are defined separately. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Add form block to page. For comparison, add paragraphs or full width images for comparison. Publish. View the frontend. Confirm form edges are flush with other content. 

