### PR TITLE
Forms: Fix export modal - remove jetpack footer

### DIFF
--- a/projects/packages/forms/changelog/fix-form-export-modal
+++ b/projects/packages/forms/changelog/fix-form-export-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: Remove the jetpack footer on the modal

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Assets;
-use Automattic\Jetpack\Assets\Logo;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Forms\Service\Google_Drive;
 use Automattic\Jetpack\Redirect;
@@ -142,7 +141,6 @@ class Admin {
 			return;
 		}
 
-		$jetpack_logo = new Logo();
 		?>
 		<div id="feedback-export-modal" style="display: none;">
 			<div class="feedback-export-modal__wrapper">
@@ -154,32 +152,14 @@ class Admin {
 					<?php $this->get_csv_export_section(); ?>
 					<?php $this->get_gdrive_export_section(); ?>
 				</div>
-				<div class="feedback-export-modal__footer">
-					<div class="feedback-export-modal__footer-column">
-						<a href="https://jetpack.com/support/jetpack-blocks/contact-form/" title="<?php echo esc_attr_x( 'Jetpack Forms', 'Name of Jetpack’s Contact Form feature', 'jetpack-forms' ); ?>" rel="noopener noreferer" target="_blank" class="feedback-export-modal__footer-link">
-							<?php echo $jetpack_logo->get_jp_emblem(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-						</a>
-						<a href="https://jetpack.com/support/jetpack-blocks/contact-form/" title="<?php echo esc_attr_x( 'Jetpack Forms', 'Name of Jetpack’s Contact Form feature', 'jetpack-forms' ); ?>" rel="noopener noreferer" target="_blank" class="feedback-export-modal__footer-link">
-							<?php echo esc_html_x( 'Jetpack Forms', 'Name of Jetpack’s Contact Form feature', 'jetpack-forms' ); ?>
-						</a>
-					</div>
-					<div class="feedback-export-modal__footer-column">
-						<a href="https://automattic.com" title="Automattic" rel="noopener noreferer" target="_blank" class="feedback-export-modal__footer-link">
-							<svg role="img" x="0" y="0" viewBox="0 0 935 38.2" enable-background="new 0 0 935 38.2" aria-labelledby="jp-automattic-byline-logo-title" height="7" class="jp-automattic-byline-logo">
-								<desc id="jp-automattic-byline-logo-title"><?php esc_html_e( 'An Automattic Airline', 'jetpack-forms' ); ?></desc>
-								<path d="M317.1 38.2c-12.6 0-20.7-9.1-20.7-18.5v-1.2c0-9.6 8.2-18.5 20.7-18.5 12.6 0 20.8 8.9 20.8 18.5v1.2C337.9 29.1 329.7 38.2 317.1 38.2zM331.2 18.6c0-6.9-5-13-14.1-13s-14 6.1-14 13v0.9c0 6.9 5 13.1 14 13.1s14.1-6.2 14.1-13.1V18.6zM175 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7L157 1.3h5.5L182 36.8H175zM159.7 8.2L152 23.1h15.7L159.7 8.2zM212.4 38.2c-12.7 0-18.7-6.9-18.7-16.2V1.3h6.6v20.9c0 6.6 4.3 10.5 12.5 10.5 8.4 0 11.9-3.9 11.9-10.5V1.3h6.7V22C231.4 30.8 225.8 38.2 212.4 38.2zM268.6 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H268.6zM397.3 36.8V8.7l-1.8 3.1 -14.9 25h-3.3l-14.7-25 -1.8-3.1v28.1h-6.5V1.3h9.2l14 24.4 1.7 3 1.7-3 13.9-24.4h9.1v35.5H397.3zM454.4 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7l19.2-35.5h5.5l19.5 35.5H454.4zM439.1 8.2l-7.7 14.9h15.7L439.1 8.2zM488.4 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H488.4zM537.3 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H537.3zM569.3 36.8V4.6c2.7 0 3.7-1.4 3.7-3.4h2.8v35.5L569.3 36.8 569.3 36.8zM628 11.3c-3.2-2.9-7.9-5.7-14.2-5.7 -9.5 0-14.8 6.5-14.8 13.3v0.7c0 6.7 5.4 13 15.3 13 5.9 0 10.8-2.8 13.9-5.7l4 4.2c-3.9 3.8-10.5 7.1-18.3 7.1 -13.4 0-21.6-8.7-21.6-18.3v-1.2c0-9.6 8.9-18.7 21.9-18.7 7.5 0 14.3 3.1 18 7.1L628 11.3zM321.5 12.4c1.2 0.8 1.5 2.4 0.8 3.6l-6.1 9.4c-0.8 1.2-2.4 1.6-3.6 0.8l0 0c-1.2-0.8-1.5-2.4-0.8-3.6l6.1-9.4C318.7 11.9 320.3 11.6 321.5 12.4L321.5 12.4z"></path><path d="M37.5 36.7l-4.7-8.9H11.7l-4.6 8.9H0L19.4 0.8H25l19.7 35.9H37.5zM22 7.8l-7.8 15.1h15.9L22 7.8zM82.8 36.7l-23.3-24 -2.3-2.5v26.6h-6.7v-36H57l22.6 24 2.3 2.6V0.8h6.7v35.9H82.8z"></path>
-								<path d="M719.9 37l-4.8-8.9H694l-4.6 8.9h-7.1l19.5-36h5.6l19.8 36H719.9zM704.4 8l-7.8 15.1h15.9L704.4 8zM733 37V1h6.8v36H733zM781 37c-1.8 0-2.6-2.5-2.9-5.8l-0.2-3.7c-0.2-3.6-1.7-5.1-8.4-5.1h-12.8V37H750V1h19.6c10.8 0 15.7 4.3 15.7 9.9 0 3.9-2 7.7-9 9 7 0.5 8.5 3.7 8.6 7.9l0.1 3c0.1 2.5 0.5 4.3 2.2 6.1V37H781zM778.5 11.8c0-2.6-2.1-5.1-7.9-5.1h-13.8v10.8h14.4c5 0 7.3-2.4 7.3-5.2V11.8zM794.8 37V1h6.8v30.4h28.2V37H794.8zM836.7 37V1h6.8v36H836.7zM886.2 37l-23.4-24.1 -2.3-2.5V37h-6.8V1h6.5l22.7 24.1 2.3 2.6V1h6.8v36H886.2zM902.3 37V1H935v5.6h-26v9.2h20v5.5h-20v10.1h26V37H902.3z"></path>
-							</svg>
-						</a>
-					</div>
-				</div>
+
 			</div>
 		</div>
 		<?php
 		$opener_label        = esc_html__( 'Export', 'jetpack-forms' );
 		$export_modal_opener = wp_is_mobile()
-			? "<a id='export-modal-opener' class='button button-primary' href='#TB_inline?&width=550&height=550&inlineId=feedback-export-modal'>{$opener_label}</a>"
-			: "<a id='export-modal-opener' class='button button-primary' href='#TB_inline?&width=680&height=600&inlineId=feedback-export-modal'>{$opener_label}</a>";
+			? "<a id='export-modal-opener' class='button button-primary' href='#TB_inline?&width=550&height=450&inlineId=feedback-export-modal'>{$opener_label}</a>"
+			: "<a id='export-modal-opener' class='button button-primary' href='#TB_inline?&width=680&height=500&inlineId=feedback-export-modal'>{$opener_label}</a>";
 		?>
 		<script type="text/javascript">
 			jQuery( function( $ ) {

--- a/projects/packages/forms/src/contact-form/css/grunion-admin.css
+++ b/projects/packages/forms/src/contact-form/css/grunion-admin.css
@@ -147,7 +147,6 @@
 	align-items: center;
 }
 
-/* override JP logo */
 .export-card {
 	border-radius: var(--jp-border-radius, 4px);
 	box-shadow: 0 0 0 1px var(--jp-gray-10, #c3c4c7) inset;

--- a/projects/packages/forms/src/contact-form/css/grunion-admin.css
+++ b/projects/packages/forms/src/contact-form/css/grunion-admin.css
@@ -148,26 +148,6 @@
 }
 
 /* override JP logo */
-.feedback-export-modal__footer #jetpack-logo__icon {
-	width: 16px;
-	height: 16px;
-}
-
-.feedback-export-modal__footer #jetpack-logo__icon path {
-	fill: #000000;
-}
-
-.feedback-export-modal__footer .feedback-export-modal__footer-link {
-	padding-left: 8px;
-	font-size: 12px;
-	font-weight: 600;
-	line-height: 0;
-	letter-spacing: -0.02em;
-	text-align: left;
-	color: #23282D;
-	text-decoration: none;
-}
-
 .export-card {
 	border-radius: var(--jp-border-radius, 4px);
 	box-shadow: 0 0 0 1px var(--jp-gray-10, #c3c4c7) inset;

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { JetpackFooter } from '@automattic/jetpack-components';
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 import { Modal, Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
@@ -67,10 +66,6 @@ const ExportResponsesButton = () => {
 						</p>
 						<CSVExport onExport={ onExport } />
 						<GoogleDriveExport onExport={ onExport } />
-						<JetpackFooter
-							className="jp-forms__export-modal-footer"
-							moduleName={ __( 'Jetpack Forms', 'jetpack-forms' ) }
-						/>
 					</VStack>
 				</Modal>
 			) }

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/style.scss
@@ -9,34 +9,6 @@
 	margin-bottom: 0;
 }
 
-.jp-forms__export-modal-footer {
-	box-sizing: border-box;
-	display: flex;
-	justify-content: space-between;
-	padding: 0 16px;
-}
-
-/* override JP logo */
-.jp-forms__export-modal-footer #jetpack-logo__icon {
-	width: 16px;
-	height: 16px;
-}
-
-.jp-forms__export-modal-footer #jetpack-logo__icon path {
-	fill: #000000;
-}
-
-.jp-forms__export-modal-footer .jp-forms__export-modal-footer-link {
-	padding-left: 8px;
-	font-size: 12px;
-	font-weight: 600;
-	line-height: 0;
-	letter-spacing: -0.02em;
-	text-align: left;
-	color: #23282D;
-	text-decoration: none;
-}
-
 .jp-forms__export-modal-card {
 	border-radius: var(--jp-border-radius, 4px);
 	box-shadow: 0 0 0 1px var(--jp-gray-10, #c3c4c7) inset;


### PR DESCRIPTION
This Pr removes the jetpack footer from the export modal. 

This fixes issue on mobile view. Where the modal is not looking as expected. 

<table border="1">
    <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
 <tr>
        <td>classic</td>
        <td>classic</td>
    </tr>
    <tr>
        <td>

<img width="300" src="https://github.com/user-attachments/assets/250a736b-b4ef-41e9-942c-d84c91da7fe0" />

</td>
<td>

<img width="300" src="https://github.com/user-attachments/assets/2df9c54a-97e9-4519-9ce7-65dfa4a84ddf" />


</td>
    </tr>

 <tr>
        <td>inbox</td>
        <td>inbox</td>
</tr>

 <tr>
        <td>
        
<img width="300" src="https://github.com/user-attachments/assets/cfb10d7a-b806-433e-b1eb-851e009b68a5" />

</td>
<td>

<img width="300" src="https://github.com/user-attachments/assets/a43159ad-c3ae-4357-9c3b-220a9fc17392" />

   </td>
    </tr>
</table>




## Proposed changes:
* Remove the footer from the modal. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Go to the wp-admin form responses page and click the export button. 
Does the modal look as expected for you across different browsers. 

Do the same thing for the inbox view. 
Click the export button. Does it look as expected? 


