### PR TITLE
Forms: Fix issue where only the first contact form on a page could be submitted

### DIFF
--- a/projects/packages/forms/changelog/fix-multiple-forms-submission
+++ b/projects/packages/forms/changelog/fix-multiple-forms-submission
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix issue where multiple contact forms on the same page would fail to submit correctly. Ensures consistent form IDs between page load and form submission. 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -127,7 +127,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 			if ( ! isset( $attributes['id'] ) ) {
 				$attributes['id'] = '';
 			}
-			$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 ) . '-' . $page;
+
+			// When submitting the page number is not always set, so we need to handle that: TODO: This is a hack, we need to find a better way to handle form identification
+			$page_num = max( 1, intval( $page ) );
+
+			$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 ) . '-' . $page_num;
 		}
 
 		$this->hash                 = sha1( wp_json_encode( $attributes ) );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2113,7 +2113,7 @@ EOT;
 				'name'    => 'First form name 2',
 				'message' => 'First form message 2',
 			),
-			'g' . $post->ID . '-2'
+			'g' . $post->ID . '-2-1' // The 2 here is the count and 1 is now always set for page number which in this case is 1.
 		);
 
 		$form2   = new Contact_Form( array(), "[contact-field label='Name' type='name' required='1'/][contact-field label='Message' type='textarea' required='1'/]" );


### PR DESCRIPTION
Fixes: https://github.com/Automattic/jetpack/issues/42243 

For explanation see https://github.com/Automattic/jetpack/pull/42351 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix issue where only the first contact form on a page could be submitted
* Ensure consistent form IDs by normalizing page number to always be at least 1
* This resolves a bug where the form hash generated during page load wouldn't match the hash during form submission for secondary forms

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Create a page with two contact forms
* Before this fix: Only the first form could be submitted; the second form submission would fail silently
* After this fix: Both forms should submit successfully
