### PR TITLE
Forms: Adjust spacing for DataViews responses

### DIFF
--- a/projects/packages/forms/changelog/update-forms-dataviews-spacing
+++ b/projects/packages/forms/changelog/update-forms-dataviews-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Adjust spacing around DataViews table.

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -282,7 +282,7 @@ export default function InboxView() {
 	}, [ isMobile ] );
 	return (
 		<HStack
-			spacing={ 8 }
+			spacing={ 5 }
 			alignment="top"
 			justify="flex-start"
 			ref={ containerRef }

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -307,7 +307,7 @@ $action-bar-height: 88px;
 	flex-grow: 1;
 	height: 100%;
 	max-height: 100vh;
-	flex: 1 1 66%;
+	flex: 1 1 40%;
 
 	.dataviews-wrapper {
 		background: #fff;
@@ -319,7 +319,7 @@ $action-bar-height: 88px;
 	min-width: 300px !important;
 	height: 100%;
 	overflow: auto;
-	flex: 1 1 33%;
+	flex: 1 1 60%;
 }
 
 

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -294,6 +294,9 @@ $action-bar-height: 88px;
 	padding: 35px;
 	box-sizing: border-box;
 	min-height: 400px;
+	@media (max-width: 660px) {
+		padding: 24px;
+	}
 }
 
 .jp-forms__inbox__dataviews {
@@ -304,6 +307,7 @@ $action-bar-height: 88px;
 	flex-grow: 1;
 	height: 100%;
 	max-height: 100vh;
+	flex: 1 1 66%;
 
 	.dataviews-wrapper {
 		background: #fff;
@@ -312,9 +316,10 @@ $action-bar-height: 88px;
 }
 
 .jp-forms__inbox__dataviews-response {
-	width: 290px;
+	min-width: 300px !important;
 	height: 100%;
 	overflow: auto;
+	flex: 1 1 33%;
 }
 
 

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -307,7 +307,7 @@ $action-bar-height: 88px;
 	flex-grow: 1;
 	height: 100%;
 	max-height: 100vh;
-	flex: 1 1 40%;
+	flex: 1 1 50%;
 
 	.dataviews-wrapper {
 		background: #fff;
@@ -319,7 +319,7 @@ $action-bar-height: 88px;
 	min-width: 300px !important;
 	height: 100%;
 	overflow: auto;
-	flex: 1 1 60%;
+	flex: 1 1 50%;
 }
 
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack/issues/42537

UPDATE: ~Do not merge yet.~ After discussion, I pushed a change to increase the width of the single response column to 60% .... much wider. We'd like to discuss this before proceeding.

## Proposed changes:

* We recent pushed a new [DataViews implementation for form responses](https://github.com/Automattic/jetpack/pull/41602/files#diff-9db38de6e3678fb163907d4d47e3b1f38a9a74e038e9b5b9f475c190c0e8a937). This makes very minor tweaks to some spacing. 
* First it increases the width of the single response column on the right when viewing a form response. This now has flex-basis of 33%. The idea is that when someone clicks to view a single response, their main focus is on this column, and it should be a bit wider. 
* Second, it applies a min-width of 300px to that column. With the current styling it often got quite narrow when on, say, an ipad width screen. By definition HStack imposes a min-width of 0 on children to avoid content breaking out of the flex container. In this case, we don't need to worry about it because on small screens, we don't show this column and instead open the single response in a modal. 
* Third, it reduces the gap between the two columns from 32px to 20px. 
* Fourth, on small screen, it reduces the padding around the outside of the table from 35px to 20px so that the table edges stay flush with the content in the header. 

**Screenshots**
<img width="1497" alt="forms-response-spacing-1" src="https://github.com/user-attachments/assets/bfd0b91f-6688-4aab-8d55-a92b5f8a706e" />

<img width="585" alt="form-submission-spacing" src="https://github.com/user-attachments/assets/412cfe8f-831f-4f57-ba11-28686e4d49dc" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Go to the Feedback page on a site that has some form responses.
- Click on one form response to view it a separate column or modal.
- Try adjusting your screen size and confirm it looks good with various screen sizes.
