### PR TITLE
My Jetpack: prevent displaying initial price when intro offer is not available

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial-modal/product-interstitial-my-jetpack.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial-modal/product-interstitial-my-jetpack.tsx
@@ -110,10 +110,10 @@ const ProductInterstitialPlugin: FC< ProductInterstitialPluginProps > = ( {
 			currency={ currencyCode }
 			price={ price }
 			offPrice={ productPrice }
-			showNotOffPrice={ true }
+			showNotOffPrice={ price > productPrice } // show discounted price only if the new price is greater than the product price
 			isNotConvenientPrice={ false }
 			hidePriceFraction={ false }
-			hideDiscountLabel={ productPrice > price }
+			hideDiscountLabel={ productPrice >= price }
 			legend={ priceDescription }
 		/>
 	);

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-modal-intro-pricing
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-modal-intro-pricing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: fix interstitial modal that was displaying the discounted price when user had already used up the discount


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes an issue where the intro pricing was not displayed correctly in the product interstitial modal

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds a small condition on when to display the initial price of a product if an intro offer is not available.

|Before|After|
|-|-|
|<img width="1216" alt="image" src="https://github.com/user-attachments/assets/ae3a536d-0f3c-401d-8bad-61348827e16f" />|<img width="1215" alt="image" src="https://github.com/user-attachments/assets/765ebc68-adaa-4566-8e22-2fca026c99cb" />|

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* If you have a test site that you have already used an intro offer for AI, use this site
  * Alternatively, you can: spin up a JN site
  * Connect your user
  * Purchase Jetpack AI yearly
* If your subscription is still active, cancel and remove it from your site (you can do it from the SA)
* Now, go to `/wp-admin/admin.php?page=my-jetpack#/jetpack-ai` and confirm you only see the actual price, but not the strikethrough price

