### PR TITLE
Jetpack SEO Enhancer: add settings toggle

### DIFF
--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -780,3 +780,13 @@ export function getNewsetterDateExample( state ) {
 export function subscriptionSiteEditSupported( state ) {
 	return !! state.jetpack.initialState.subscriptionSiteEditSupported;
 }
+
+/**
+ * Returns true if the wp-admin SEO Enhancer setting/feature is available.
+ *
+ * @param {object} state - Global state tree.
+ * @return {boolean} True if the SEO Enhancer is available.
+ */
+export function isSeoEnhancerAvailable( state ) {
+	return 'ai_seo_enhancer_enabled' in state.jetpack.initialState.getModules[ 'seo-tools' ].options;
+}

--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -1,4 +1,4 @@
-import { getRedirectUrl } from '@automattic/jetpack-components';
+import { getRedirectUrl, ToggleControl } from '@automattic/jetpack-components';
 import {
 	FacebookLinkPreview,
 	TwitterLinkPreview,
@@ -11,12 +11,13 @@ import { connect } from 'react-redux';
 import { SocialLogo } from 'social-logos';
 import Button from 'components/button';
 import FoldableCard from 'components/foldable-card';
-import { FormLabel, FormTextarea } from 'components/forms';
+import { FormLabel, FormTextarea, FormFieldset } from 'components/forms';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { ModuleToggle } from 'components/module-toggle';
 import SimpleNotice from 'components/notice';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
+import { isSeoEnhancerAvailable } from 'state/initial-state';
 import { isFetchingPluginsData, isPluginActive } from 'state/site/plugins';
 import CustomSeoTitles from './seo/custom-seo-titles.jsx';
 
@@ -64,8 +65,18 @@ export const SEO = withModuleSettingsFormHelpers(
 		constants = {
 			frontPageMetaMaxLength: 300,
 			frontPageMetaSuggestedLength: 159,
-			moduleOptionsArray: [ 'advanced_seo_front_page_description', 'advanced_seo_title_formats' ],
+			moduleOptionsArray: [
+				'advanced_seo_front_page_description',
+				'advanced_seo_title_formats',
+				'ai_seo_enhancer_enabled',
+			],
 			siteIconPreviewSize: 512,
+		};
+
+		toggleSeoEnhancer = () => {
+			this.props.updateOptions( {
+				ai_seo_enhancer_enabled: ! this.props.getOptionValue( 'ai_seo_enhancer_enabled' ),
+			} );
 		};
 
 		SocialPreviewGoogle = siteData => (
@@ -203,6 +214,25 @@ export const SEO = withModuleSettingsFormHelpers(
 								{ __( 'Customize your SEO settings', 'jetpack' ) }
 							</span>
 						</ModuleToggle>
+						{ this.props.seoEnhancerAvailable && (
+							<FormFieldset>
+								<ToggleControl
+									id="seo-enhancer"
+									disabled={ ! this.props.getOptionValue( 'seo-tools' ) }
+									toggling={ this.props.isSavingAnyOption( 'ai_seo_enhancer_enabled' ) }
+									checked={ this.props.getOptionValue( 'ai_seo_enhancer_enabled' ) }
+									onChange={ this.toggleSeoEnhancer }
+									label={
+										<span className="jp-form-toggle-explanation">
+											{ __(
+												'Automatically generate SEO title, SEO description, and image alt text for new posts',
+												'jetpack'
+											) }
+										</span>
+									}
+								/>
+							</FormFieldset>
+						) }
 					</SettingsGroup>
 					{ isSeoActive &&
 						! isFetchingPluginsData( this.props.state ) &&
@@ -327,6 +357,7 @@ export const SEO = withModuleSettingsFormHelpers(
 export default connect( state => {
 	return {
 		siteData: state.jetpack.siteData.data,
+		seoEnhancerAvailable: isSeoEnhancerAvailable( state ),
 		state,
 	};
 } )( SEO );

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -3096,6 +3096,18 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 		);
 
+		// SEO Tools - SEO Enhancer. Only available to Automatticians.
+		// TODO: either remove this or make it available to all users by moving it to the main options array.
+		if ( apply_filters( 'ai_seo_enhancer_enabled', false ) ) {
+			$options['ai_seo_enhancer_enabled'] = array(
+				'description'       => esc_html__( 'Automatically generate SEO title, SEO description, and image alt text for new posts.', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'seo-tools',
+			);
+		}
+
 		// Add modules to list so they can be toggled.
 		$modules = Jetpack::get_available_modules();
 		if ( is_array( $modules ) && ! empty( $modules ) ) {

--- a/projects/plugins/jetpack/changelog/add-jetpack-seo-enhancer-settings-toggle
+++ b/projects/plugins/jetpack/changelog/add-jetpack-seo-enhancer-settings-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack SEO: add settings toggle for automated SEO props generation


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #42334 

## Proposed changes:
WIP: this PR adds a settings toggle on Jetpack Settings page -> Traffic to enable the new automated generation for SEO props.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-wea-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add the filter `add_filter( 'ai_seo_enhancer_enabled', '__return_true' );` and check Jetpack Settings -> Traffic, there should be a new toggle there and it should work (persist) the change.