### PR TITLE
Forms: Fix submission when multiple forms are on a page

### DIFF
--- a/projects/packages/forms/changelog/fix-multi-forms-on-page
+++ b/projects/packages/forms/changelog/fix-multi-forms-on-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix submission when multiple forms are on the page.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -127,7 +127,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 			if ( ! isset( $attributes['id'] ) ) {
 				$attributes['id'] = '';
 			}
-			$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 ) . '-' . $page;
+			$page_number      = isset( $page ) && $page > 0 ? $page : 1;
+			$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 ) . '-' . $page_number;
 		}
 
 		$this->hash                 = sha1( wp_json_encode( $attributes ) );

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -127,8 +127,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			if ( ! isset( $attributes['id'] ) ) {
 				$attributes['id'] = '';
 			}
-			$page_number      = isset( $page ) && $page > 0 ? $page : 1;
-			$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 ) . '-' . $page_number;
+			$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 ) . '-' . max( 1, $page );
 		}
 
 		$this->hash                 = sha1( wp_json_encode( $attributes ) );

--- a/projects/plugins/jetpack/changelog/fix-multi-forms-on-page
+++ b/projects/plugins/jetpack/changelog/fix-multi-forms-on-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix submission when multiple forms are on the page.


### PR DESCRIPTION
Fixes #42243

## Proposed changes:
Fixes a regression when multiple forms are on a page, which unfortunately seems to have been introduced in my PR #41947.

### Explainer
Forms rely on having the same reproducible id across their lifecycle (before submission, during submission and after submission). The pertinent code is here:
https://github.com/Automattic/jetpack/blob/8239b3847ce8a294dae76029bf5898a5d104f552/projects/packages/forms/src/contact-form/class-contact-form.php#L125-L131

This code says that when there are multiple forms, some extra information is appended onto the id:
```php
( count( self::$forms ) + 1 ) . '-' . $page;
```

This includes the $page. The problem that  #41947 caused, is that because it omits the `page` query param from the form's POST action, when that post action is being handled, the $page global variable is not set.

It means that forms that aren't first on the page will have a different id generated during submission compared to the one they have before/after submission and that's what causes #42243.

## The fix

During submission the $page global will be `0` if we're in a non-paginated post. The solution in this PR is to make sure that part of the Id can only be a minimum of `1` by using the `max` function.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Create a post
2. Add a form block and choose a contact form in the placeholder
3. Duplicate the contact form
4. Publish and view the post
5. Fill out and submit the second contact form

Expected: It should submit successfully
In trunk: Nothing happens

