### PR TITLE
wpcomsh: Update wc-calypso-bridge to 2.8.4

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-bridge-to-2.8.4
+++ b/projects/plugins/wpcomsh/changelog/update-bridge-to-2.8.4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update wc-calypso-bridge dependency to 2.8.4

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -9,7 +9,7 @@
 		"automattic/custom-fonts": "^3.0",
 		"automattic/custom-fonts-typekit": "^2.0",
 		"automattic/text-media-widget-styles": "^2.0",
-		"automattic/wc-calypso-bridge": "2.8.3",
+		"automattic/wc-calypso-bridge": "2.8.4",
 		"wordpress/classic-editor-plugin": "1.6.7",
 		"automattic/jetpack-composer-plugin": "@dev",
 		"automattic/jetpack-config": "@dev",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bde225c07910601bc0a5fecc33e5ed58",
+    "content-hash": "00e997ee0532ca79fa7400745740f815",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
@@ -1934,16 +1934,16 @@
         },
         {
             "name": "automattic/wc-calypso-bridge",
-            "version": "v2.8.3",
+            "version": "v2.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/wc-calypso-bridge.git",
-                "reference": "db9790112a06fe6a0c57c07a37d1e3083199baf6"
+                "reference": "cb3a1d0137f3bc6051fa95d5aa50cd93a09339d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/db9790112a06fe6a0c57c07a37d1e3083199baf6",
-                "reference": "db9790112a06fe6a0c57c07a37d1e3083199baf6",
+                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/cb3a1d0137f3bc6051fa95d5aa50cd93a09339d2",
+                "reference": "cb3a1d0137f3bc6051fa95d5aa50cd93a09339d2",
                 "shasum": ""
             },
             "require-dev": {
@@ -1982,7 +1982,7 @@
                     "phpcbf -p"
                 ]
             },
-            "time": "2025-02-05T07:13:06+00:00"
+            "time": "2025-03-11T08:53:25+00:00"
         },
         {
             "name": "scssphp/scssphp",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:

This PR bumps the version of `wc-calypso-bridge` to `2.8.4`, which includes the following change:

- https://github.com/Automattic/wc-calypso-bridge/pull/1538
- https://github.com/Automattic/wc-calypso-bridge/pull/1539
- https://github.com/Automattic/wc-calypso-bridge/pull/1540

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


The changes related to the wc-calypso-bridge were already tested in the linked PRs. Testing instructions can be found on the linked PRs above.