### PR TITLE
Like block: Fix layout shift when loading

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-like-block-layout-shift
+++ b/projects/plugins/jetpack/changelog/fix-like-block-layout-shift
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Like block: Fix layout shift when loading

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -106,7 +106,7 @@ function render_block( $attr, $content, $block ) {
 	$wrapper = sprintf( 'like-post-wrapper-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
 
 	$html = "<div class='sharedaddy sd-block sd-like jetpack-likes-widget-wrapper jetpack-likes-widget-unloaded' id='" . esc_attr( $wrapper ) . "' data-src='" . esc_attr( $src ) . "' data-name='" . esc_attr( $name ) . "' data-title='" . esc_attr( $title ) . "'>"
-		. "<div class='likes-widget-placeholder post-likes-widget-placeholder' style='height: 55px;'><span class='button'><span>" . esc_html__( 'Like', 'jetpack' ) . "</span></span> <span class='loading'>" . esc_html__( 'Loading...', 'jetpack' ) . '</span></div>'
+		. "<div class='likes-widget-placeholder post-likes-widget-placeholder' style='height: 55px;'><span class='loading'>" . esc_html__( 'Loading...', 'jetpack' ) . '</span></div>'
 		. "<span class='sd-text-color'></span><a class='sd-link-color'></a>"
 		. '</div>';
 	return sprintf(

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -106,7 +106,7 @@ function render_block( $attr, $content, $block ) {
 	$wrapper = sprintf( 'like-post-wrapper-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
 
 	$html = "<div class='sharedaddy sd-block sd-like jetpack-likes-widget-wrapper jetpack-likes-widget-unloaded' id='" . esc_attr( $wrapper ) . "' data-src='" . esc_attr( $src ) . "' data-name='" . esc_attr( $name ) . "' data-title='" . esc_attr( $title ) . "'>"
-		. "<div class='likes-widget-placeholder post-likes-widget-placeholder' style='height: 55px;'><span class='loading'>" . esc_html__( 'Loading...', 'jetpack' ) . '</span></div>'
+		. "<div class='likes-widget-placeholder post-likes-widget-placeholder' style='height: 55px;'><span class='loading'>" . esc_html__( 'Loading…', 'jetpack' ) . '</span></div>'
 		. "<span class='sd-text-color'></span><a class='sd-link-color'></a>"
 		. '</div>';
 	return sprintf(

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -165,6 +165,14 @@ function JetpackLikesMessageListener( event ) {
 			break;
 		}
 
+		case 'showCommentLikeWidget': {
+			const placeholder = document.querySelector( `#${ data.id } .likes-widget-placeholder` );
+			if ( placeholder ) {
+				placeholder.style.display = 'none';
+			}
+			break;
+		}
+
 		case 'killCommentLikes':
 			// If kill switch for comment likes is enabled remove all widgets wrappers and `Loading...` placeholders.
 			document
@@ -431,8 +439,8 @@ function jetpackLoadLikeWidgetIframe( wrapperID ) {
 
 		wrapper.classList.remove( 'jetpack-likes-widget-loading' );
 		wrapper.classList.add( 'jetpack-likes-widget-loaded' );
-		placeholder.style.display = 'none';
 		if ( postLikesFrame ) {
+			placeholder.style.display = 'none';
 			postLikesFrame.height = '55px';
 		}
 	} );

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -165,6 +165,12 @@ function JetpackLikesMessageListener( event ) {
 			break;
 		}
 
+		// We're keeping this for planned future follow ups.
+		// @see: https://github.com/Automattic/jetpack/pull/42361#discussion_r1995338815
+		case 'showCommentLikeWidget': {
+			break;
+		}
+
 		case 'killCommentLikes':
 			// If kill switch for comment likes is enabled remove all widgets wrappers and `Loading...` placeholders.
 			document

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -157,24 +157,11 @@ function JetpackLikesMessageListener( event ) {
 			break;
 
 		case 'showLikeWidget': {
-			const placeholder = document.querySelector( `#${ data.id } .likes-widget-placeholder` );
-			if ( placeholder ) {
-				placeholder.style.display = 'none';
-			}
-
 			// Add a `liked` class to the wrapper if the post already has likes.
 			if ( data.total > 0 ) {
 				document.querySelector( `#${ data.id }` ).classList.add( 'liked' );
 			}
 
-			break;
-		}
-
-		case 'showCommentLikeWidget': {
-			const placeholder = document.querySelector( `#${ data.id } .likes-widget-placeholder` );
-			if ( placeholder ) {
-				placeholder.style.display = 'none';
-			}
 			break;
 		}
 
@@ -399,15 +386,15 @@ function jetpackLoadLikeWidgetIframe( wrapperID ) {
 	wrapper.querySelectorAll( 'iframe' ).forEach( iFrame => iFrame.remove() );
 
 	const placeholder = wrapper.querySelector( '.likes-widget-placeholder' );
-
+	let postLikesFrame;
 	// Post like iframe
 	if ( placeholder && placeholder.classList.contains( 'post-likes-widget-placeholder' ) ) {
-		const postLikesFrame = document.createElement( 'iframe' );
+		postLikesFrame = document.createElement( 'iframe' );
 
 		postLikesFrame.classList.add( 'post-likes-widget', 'jetpack-likes-widget' );
 		postLikesFrame.name = wrapper.dataset.name;
 		postLikesFrame.src = wrapper.dataset.src;
-		postLikesFrame.height = '55px';
+		postLikesFrame.height = '0';
 		postLikesFrame.width = '100%';
 		postLikesFrame.frameBorder = '0';
 		postLikesFrame.scrolling = 'no';
@@ -444,6 +431,10 @@ function jetpackLoadLikeWidgetIframe( wrapperID ) {
 
 		wrapper.classList.remove( 'jetpack-likes-widget-loading' );
 		wrapper.classList.add( 'jetpack-likes-widget-loaded' );
+		placeholder.style.display = 'none';
+		if ( postLikesFrame ) {
+			postLikesFrame.height = '55px';
+		}
 	} );
 }
 

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -165,14 +165,6 @@ function JetpackLikesMessageListener( event ) {
 			break;
 		}
 
-		case 'showCommentLikeWidget': {
-			const placeholder = document.querySelector( `#${ data.id } .likes-widget-placeholder` );
-			if ( placeholder ) {
-				placeholder.style.display = 'none';
-			}
-			break;
-		}
-
 		case 'killCommentLikes':
 			// If kill switch for comment likes is enabled remove all widgets wrappers and `Loading...` placeholders.
 			document
@@ -394,15 +386,15 @@ function jetpackLoadLikeWidgetIframe( wrapperID ) {
 	wrapper.querySelectorAll( 'iframe' ).forEach( iFrame => iFrame.remove() );
 
 	const placeholder = wrapper.querySelector( '.likes-widget-placeholder' );
-	let postLikesFrame;
+
 	// Post like iframe
 	if ( placeholder && placeholder.classList.contains( 'post-likes-widget-placeholder' ) ) {
-		postLikesFrame = document.createElement( 'iframe' );
+		const postLikesFrame = document.createElement( 'iframe' );
 
 		postLikesFrame.classList.add( 'post-likes-widget', 'jetpack-likes-widget' );
 		postLikesFrame.name = wrapper.dataset.name;
 		postLikesFrame.src = wrapper.dataset.src;
-		postLikesFrame.height = '0';
+		postLikesFrame.height = '55px';
 		postLikesFrame.width = '100%';
 		postLikesFrame.frameBorder = '0';
 		postLikesFrame.scrolling = 'no';
@@ -439,10 +431,6 @@ function jetpackLoadLikeWidgetIframe( wrapperID ) {
 
 		wrapper.classList.remove( 'jetpack-likes-widget-loading' );
 		wrapper.classList.add( 'jetpack-likes-widget-loaded' );
-		if ( postLikesFrame ) {
-			placeholder.style.display = 'none';
-			postLikesFrame.height = '55px';
-		}
 	} );
 }
 

--- a/projects/plugins/jetpack/modules/likes/style.css
+++ b/projects/plugins/jetpack/modules/likes/style.css
@@ -136,11 +136,23 @@ div.sd-box {
 	border-top: 1px solid rgba(0,0,0,.13);
 }
 
+
+.jetpack-likes-widget-unloaded .likes-widget-placeholder,
+.jetpack-likes-widget-loading .likes-widget-placeholder,
+.jetpack-likes-widget-loaded iframe {
+	display: block;
+}
+
+.jetpack-likes-widget-loaded .likes-widget-placeholder,
+.jetpack-likes-widget-unloaded iframe,
+.jetpack-likes-widget-loading iframe {
+	display: none;
+}
+
 .entry-content .post-likes-widget, .post-likes-widget,
 .comment-likes-widget {
 	margin: 0;
 	border-width: 0;
-	display: block;
 }
 
 /* Loading text */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/36056


Like block is causing a layout shift when loading. This PR addresses that by setting an initial zero height to the iframe and update it on load. At the same time (on iframe load) we hide the placeholder.

I've also update the `comments like` display to happen on load, but while in theory seems right to me, I'm not 100% sure  because I couldn't figure out where this renders. Can someone help me out with this about where should I be testing?

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
1. Insert a Like block and observe that in the front-end there is no layout shift.







#### Before:
https://github.com/user-attachments/assets/676a41ee-937b-4cc6-8a51-adc84b57a41f

#### After:
https://github.com/user-attachments/assets/da758005-2ab1-4ae2-a6c7-9f2e050a93dd







