### PR TITLE
Boost: Add more cookies to the ignorelist

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
@@ -562,7 +562,32 @@ class Boost_Cache {
 			return $params;
 		}
 
-		$default_cookies = array( 'cf_clearance', 'cf_chl_rc_i', 'cf_chl_rc_ni', 'cf_chl_rc_m', '_cfuvid', '__cfruid', '__cfwaitingroom', 'cf_ob_info', 'cf_use_ob', '__cfseq', '__cf_bm', '__cflb', 'sbjs_(.*)' );
+		$default_cookies = array(
+			'cf_clearance',
+			'cf_chl_rc_i',
+			'cf_chl_rc_ni',
+			'cf_chl_rc_m',
+			'_cfuvid',
+			'__cfruid',
+			'__cfwaitingroom',
+			'cf_ob_info',
+			'cf_use_ob',
+			'__cfseq',
+			'__cf_bm',
+			'__cflb',
+
+			// Sourcebuster
+			'sbjs_(.*)',
+
+			// Google Analytics
+			'_ga(?:_[A-Z0-9]*)?',
+
+			// AWS Load Balancer
+			'AWSELB',
+			'AWSELBCORS',
+			'AWSALB',
+			'AWSALBCORS',
+		);
 		$jetpack_cookies = array( 'tk_ai', 'tk_qs' );
 		$cookies         = array_merge( $default_cookies, $jetpack_cookies );
 

--- a/projects/plugins/boost/changelog/add-whitelist-more-cookies
+++ b/projects/plugins/boost/changelog/add-whitelist-more-cookies
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Page Cache: Added more cookies to the ignore-list for better caching.
+Page Cache: Add more cookies to the ignore-list for better caching.

--- a/projects/plugins/boost/changelog/add-whitelist-more-cookies
+++ b/projects/plugins/boost/changelog/add-whitelist-more-cookies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Page Cache: Added more cookies to the ignore-list for better caching.


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add google analytics and AWS loadbalancer cookies to the ignore list

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1741692733616109/1741690389.566549-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Add this to the front end of the site:

```js
function setRandomCookies() {
    const cookieNames = [
        'AWSALB',
        'AWSELB',
        'AWSALBCORS',
        'AWSELBCORS',
        '_ga',
        '_ga_ABCDE12345' // Hardcoded random string for _ga_randomstring
    ];
    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';

    // Helper function to generate random values
    function generateRandomValue(length) {
        let value = '';
        for (let i = 0; i < length; i++) {
            value += characters.charAt(Math.floor(Math.random() * characters.length));
        }
        return value;
    }

    // Set cookies with random values
    cookieNames.forEach((cookieName) => {
        const cookieValue = generateRandomValue(32); // Generate a 32-character random value
        document.cookie = `${cookieName}=${cookieValue}; path=/; expires=${new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toUTCString()}`;
    });

    console.log('Cookies have been set!');
}

// Example usage
setRandomCookies();
```

* Enable cache
* Make sure we are receiving cache hits