### PR TITLE
Forms: fix variations previews

### DIFF
--- a/projects/packages/forms/changelog/fix-form-previews-variations
+++ b/projects/packages/forms/changelog/fix-form-previews-variations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: update the preview for the different block variations

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings.js
@@ -93,6 +93,42 @@ export const salesforceLeadFormVariation = {
 			},
 		},
 	},
+	example: {
+		innerBlocks: [
+			{
+				name: 'jetpack/field-email',
+				attributes: { required: true, label: __( 'Business Email', 'jetpack-forms' ) },
+			},
+			{
+				name: 'jetpack/field-name',
+				attributes: { required: true, label: __( 'First Name', 'jetpack-forms' ) },
+			},
+			{
+				name: 'jetpack/field-name',
+				attributes: { required: true, label: __( 'Last Name', 'jetpack-forms' ) },
+			},
+			{
+				name: 'jetpack/field-text',
+				attributes: { required: true, label: __( 'Job Title', 'jetpack-forms' ) },
+			},
+			{
+				name: 'jetpack/field-text',
+				attributes: { required: true, label: __( 'Company', 'jetpack-forms' ) },
+			},
+			{
+				name: 'jetpack/field-telephone',
+				attributes: { required: true, label: __( 'Phone Number', 'jetpack-forms' ) },
+			},
+			{
+				name: 'jetpack/button',
+				attributes: {
+					text: __( 'Submit', 'jetpack-forms' ),
+					element: 'button',
+					lock: { remove: true },
+				},
+			},
+		],
+	},
 };
 
 export default ( { salesforceData, setAttributes, instanceId } ) => {

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -105,6 +105,38 @@ const variations = compact( [
 			...defaultBlockStyling,
 			subject: __( 'A new RSVP from your website', 'jetpack-forms' ),
 		},
+		example: {
+			innerBlocks: [
+				{
+					name: 'jetpack/field-name',
+					attributes: { required: true, label: __( 'Name', 'jetpack-forms' ) },
+				},
+				{
+					name: 'jetpack/field-email',
+					attributes: { required: true, label: __( 'Email', 'jetpack-forms' ) },
+				},
+				{
+					name: 'jetpack/field-radio',
+					attributes: {
+						label: __( 'Attending?', 'jetpack-forms' ),
+						required: true,
+						options: [ __( 'Yes', 'jetpack-forms' ), __( 'No', 'jetpack-forms' ) ],
+					},
+				},
+				{
+					name: 'jetpack/field-textarea',
+					attributes: { label: __( 'Other Details', 'jetpack-forms' ) },
+				},
+				{
+					name: 'jetpack/button',
+					attributes: {
+						text: __( 'Send RSVP', 'jetpack-forms' ),
+						element: 'button',
+						lock: { remove: true },
+					},
+				},
+			],
+		},
 	},
 	{
 		name: 'registration-form',
@@ -159,6 +191,47 @@ const variations = compact( [
 			...defaultBlockStyling,
 			subject: __( 'A new registration from your website', 'jetpack-forms' ),
 		},
+		example: {
+			innerBlocks: [
+				{
+					name: 'jetpack/field-name',
+					attributes: { required: true, label: __( 'Name', 'jetpack-forms' ) },
+				},
+				{
+					name: 'jetpack/field-email',
+					attributes: { required: true, label: __( 'Email', 'jetpack-forms' ) },
+				},
+				{
+					name: 'jetpack/field-telephone',
+					attributes: { required: true, label: __( 'Phone', 'jetpack-forms' ) },
+				},
+				{
+					name: 'jetpack/field-select',
+					attributes: {
+						label: __( 'How did you hear about us?', 'jetpack-forms' ),
+						options: [
+							__( 'Search Engine', 'jetpack-forms' ),
+							__( 'Social Media', 'jetpack-forms' ),
+							__( 'TV', 'jetpack-forms' ),
+							__( 'Radio', 'jetpack-forms' ),
+							__( 'Friend or Family', 'jetpack-forms' ),
+						],
+					},
+				},
+				{
+					name: 'jetpack/field-textarea',
+					attributes: { label: __( 'Other Details', 'jetpack-forms' ) },
+				},
+				{
+					name: 'jetpack/button',
+					attributes: {
+						text: __( 'Send', 'jetpack-forms' ),
+						element: 'button',
+						lock: { remove: true },
+					},
+				},
+			],
+		},
 	},
 	{
 		name: 'appointment-form',
@@ -210,6 +283,46 @@ const variations = compact( [
 		attributes: {
 			...defaultBlockStyling,
 			subject: __( 'A new appointment booked from your website', 'jetpack-forms' ),
+		},
+		example: {
+			innerBlocks: [
+				{
+					name: 'jetpack/field-name',
+					attributes: { required: true, label: __( 'Name', 'jetpack-forms' ) },
+				},
+				{
+					name: 'jetpack/field-email',
+					attributes: { required: true, label: __( 'Email', 'jetpack-forms' ) },
+				},
+				{
+					name: 'jetpack/field-telephone',
+					attributes: { required: true, label: __( 'Phone', 'jetpack-forms' ) },
+				},
+				{
+					name: 'jetpack/field-date',
+					attributes: { required: true, label: __( 'Date', 'jetpack-forms' ) },
+				},
+				{
+					name: 'jetpack/field-radio',
+					attributes: {
+						label: __( 'Time', 'jetpack-forms' ),
+						required: true,
+						options: [ __( 'Morning', 'jetpack-forms' ), __( 'Afternoon', 'jetpack-forms' ) ],
+					},
+				},
+				{
+					name: 'jetpack/field-textarea',
+					attributes: { label: __( 'Notes', 'jetpack-forms' ) },
+				},
+				{
+					name: 'jetpack/button',
+					attributes: {
+						text: __( 'Book Appointment', 'jetpack-forms' ),
+						element: 'button',
+						lock: { remove: true },
+					},
+				},
+			],
 		},
 	},
 	{
@@ -275,6 +388,44 @@ const variations = compact( [
 			...defaultBlockStyling,
 			subject: __( 'New feedback received from your website', 'jetpack-forms' ),
 		},
+		example: {
+			innerBlocks: [
+				{
+					name: 'jetpack/field-name',
+					attributes: { required: true, label: __( 'Name', 'jetpack-forms' ) },
+				},
+				{
+					name: 'jetpack/field-email',
+					attributes: { required: true, label: __( 'Email', 'jetpack-forms' ) },
+				},
+				{
+					name: 'jetpack/field-radio',
+					attributes: {
+						label: __( 'Please rate our website', 'jetpack-forms' ),
+						required: true,
+						options: [
+							__( '1 - Very Bad', 'jetpack-forms' ),
+							__( '2 - Poor', 'jetpack-forms' ),
+							__( '3 - Average', 'jetpack-forms' ),
+							__( '4 - Good', 'jetpack-forms' ),
+							__( '5 - Excellent', 'jetpack-forms' ),
+						],
+					},
+				},
+				{
+					name: 'jetpack/field-textarea',
+					attributes: { label: __( 'How could we improve?', 'jetpack-forms' ) },
+				},
+				{
+					name: 'jetpack/button',
+					attributes: {
+						text: __( 'Send Feedback', 'jetpack-forms' ),
+						element: 'button',
+						lock: { remove: true },
+					},
+				},
+			],
+		},
 	},
 	! ( isAtomicSite() || isSimpleSite() ) && {
 		name: 'lead-capture-form',
@@ -304,6 +455,30 @@ const variations = compact( [
 		],
 		attributes: {
 			...defaultBlockStyling,
+		},
+		example: {
+			innerBlocks: [
+				{
+					name: 'jetpack/field-name',
+					attributes: { required: true, label: __( 'Name', 'jetpack-forms' ) },
+				},
+				{
+					name: 'jetpack/field-email',
+					attributes: { required: true, label: __( 'Email', 'jetpack-forms' ) },
+				},
+				{
+					name: 'jetpack/field-consent',
+					attributes: {},
+				},
+				{
+					name: 'jetpack/button',
+					attributes: {
+						text: __( 'Subscribe', 'jetpack-forms' ),
+						element: 'button',
+						lock: { remove: true },
+					},
+				},
+			],
 		},
 	},
 	salesforceLeadFormVariation,

--- a/projects/plugins/jetpack/changelog/fix-form-previews-variations
+++ b/projects/plugins/jetpack/changelog/fix-form-previews-variations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: update the variation previews to match the current inputs structure


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/42342

Currently when you mouse over the different form variation the preview doesn't match what you end up with. 
 
## Proposed changes:
* Update the example in the block to match the preview. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Go to Block editor.
* Try to inset different block variations. Notice that the preview matched what you end up with. 

