### PR TITLE
Stats: Init tracking of archive and search pages

### DIFF
--- a/projects/packages/stats/changelog/add-archive-tracking
+++ b/projects/packages/stats/changelog/add-archive-tracking
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Support tracking of archived pages and searches in tracking pixel.

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -118,7 +118,7 @@ class Tracking_Pixel {
 				$view_data['arch_v'] = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) ); // send the url path
 			} elseif ( $wp_the_query->is_search() ) {
 				$view_data['arch']   = 'search';
-				$view_data['arch_v'] = $wp_the_query->query['s'];
+				$view_data['arch_v'] = sanitize_text_field( $wp_the_query->query['s'] );
 			}
 		}
 

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -102,13 +102,13 @@ class Tracking_Pixel {
 					$view_data['arch_date'] = $date;
 				}
 				if ( $wp_the_query->is_category ) {
-					$view_data['arch_cat'] = $wp_the_query->query['category_name'];
+					$view_data['arch_cat'] = $wp_the_query->query['category_name'] ?? '-';
 				}
 				if ( $wp_the_query->is_tag ) {
 					$view_data['arch_tag'] = $wp_the_query->query['tag'];
 				}
 				if ( $wp_the_query->is_author ) {
-					$view_data['arch_author'] = $wp_the_query->query['author_name'];
+					$view_data['arch_author'] = $wp_the_query->query['author_name'] ?? '-';
 				}
 				if ( $wp_the_query->is_tax ) {
 					$query = $wp_the_query->query;

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -102,13 +102,13 @@ class Tracking_Pixel {
 					$view_data['arch_date'] = $date;
 				}
 				if ( $wp_the_query->is_category ) {
-					$view_data['arch_cat'] = $wp_the_query->query['category_name'] ?? '-';
+					$view_data['arch_cat'] = $wp_the_query->query['category_name'] ?? $wp_the_query->query_vars['category_name'] ?? '';
 				}
 				if ( $wp_the_query->is_tag ) {
 					$view_data['arch_tag'] = $wp_the_query->query['tag'];
 				}
 				if ( $wp_the_query->is_author ) {
-					$view_data['arch_author'] = $wp_the_query->query['author_name'] ?? '-';
+					$view_data['arch_author'] = $wp_the_query->query['author_name'] ?? '';
 				}
 				if ( $wp_the_query->is_tax ) {
 					$query = $wp_the_query->query;

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -47,12 +47,12 @@ class Tracking_Pixel {
 	public static function build_view_data() {
 		global $wp_the_query;
 
-		$blog       = Jetpack_Options::get_option( 'id' );
-		$tz         = get_option( 'gmt_offset' );
-		$v          = 'ext';
-		$blog_url   = wp_parse_url( site_url() );
-		$srv        = $blog_url['host'];
-		$is_archive = false;
+		$blog        = Jetpack_Options::get_option( 'id' );
+		$tz          = get_option( 'gmt_offset' );
+		$v           = 'ext';
+		$blog_url    = wp_parse_url( site_url() );
+		$srv         = $blog_url['host'];
+		$is_not_post = false;
 		if ( $wp_the_query->is_single || $wp_the_query->is_page || $wp_the_query->is_posts_page ) {
 			// Store and reset the queried_object and queried_object_id
 			// Otherwise, redirect_canonical() will redirect to home_url( '/' ) for show_on_front = page sites where home_url() is not all lowercase.
@@ -71,8 +71,8 @@ class Tracking_Pixel {
 				$wp_the_query->queried_object_id = $queried_object_id;
 			}
 		} else {
-			$post       = '0';
-			$is_archive = true;
+			$post        = '0';
+			$is_not_post = true;
 		}
 		$view_data = compact( 'v', 'blog', 'post', 'tz', 'srv' );
 		// Batcache removes some of the UTM params from $_GET, we need to extract them from uri directly instead.
@@ -87,7 +87,7 @@ class Tracking_Pixel {
 			}
 		}
 
-		if ( $is_archive ) {
+		if ( $is_not_post ) {
 			if ( $wp_the_query->is_home() ) {
 				$view_data['home'] = '1';
 			} elseif ( $wp_the_query->is_archive() ) {
@@ -109,7 +109,7 @@ class Tracking_Pixel {
 				if ( $wp_the_query->is_tax ) {
 					$query = $wp_the_query->query;
 					if ( is_array( $query ) && count( $query ) === 1 ) {
-						$view_data[ 'arch_' . array_keys( $query )[0] ] = array_values( $query )[0];
+						$view_data[ 'arch_tax_' . array_keys( $query )[0] ] = array_values( $query )[0];
 					}
 				}
 				$view_data['arch_results'] = $wp_the_query->posts ? count( $wp_the_query->posts ) : 0;
@@ -118,6 +118,8 @@ class Tracking_Pixel {
 			} elseif ( $wp_the_query->is_search() ) {
 				$view_data['arch_search']  = sanitize_text_field( $wp_the_query->query['s'] );
 				$view_data['arch_results'] = $wp_the_query->posts ? count( $wp_the_query->posts ) : 0;
+			} else {
+				$view_data['arch_other'] = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) );
 			}
 		}
 

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -106,8 +106,13 @@ class Tracking_Pixel {
 				} elseif ( $wp_the_query->is_author ) {
 					$view_data['arch']   = 'author';
 					$view_data['arch_v'] = $wp_the_query->query['author_name'];
+				} elseif ( $wp_the_query->is_tax ) {
+					$query = $wp_the_query->query;
+					if ( count( $query ) === 0 ) {
+						$view_data['arch']   = array_keys( $query )[0];
+						$view_data['arch_v'] = array_values( $query )[0];
+					}
 				}
-				// TODO: track custom types - is_post_type_archive() and is_tax()
 			} elseif ( $wp_the_query->is_404() ) {
 				// These do not seem to be tracked at all
 				$view_data['arch']   = 'err';

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -92,35 +92,32 @@ class Tracking_Pixel {
 				$view_data['home'] = '1';
 			} elseif ( $wp_the_query->is_archive() ) {
 				if ( $wp_the_query->is_date ) {
-					$query               = $wp_the_query->query;
-					$date_parts          = array_filter( array( $query['year'] ?? null, $query['monthnum'] ?? null, $query['day'] ?? null ) );
-					$date                = implode( '/', $date_parts );
-					$view_data['arch']   = 'date';
-					$view_data['arch_v'] = $date;
-				} elseif ( $wp_the_query->is_category ) {
-					$view_data['arch']   = 'cat';
-					$view_data['arch_v'] = $wp_the_query->query['category_name'];
-				} elseif ( $wp_the_query->is_tag ) {
-					$view_data['arch']   = 'tag';
-					$view_data['arch_v'] = $wp_the_query->query['tag'];
-				} elseif ( $wp_the_query->is_author ) {
-					$view_data['arch']   = 'author';
-					$view_data['arch_v'] = $wp_the_query->query['author_name'];
-				} elseif ( $wp_the_query->is_tax ) {
+					$query                  = $wp_the_query->query;
+					$date_parts             = array_filter( array( $query['year'] ?? null, $query['monthnum'] ?? null, $query['day'] ?? null ) );
+					$date                   = implode( '/', $date_parts );
+					$view_data['arch_date'] = $date;
+				}
+				if ( $wp_the_query->is_category ) {
+					$view_data['arch_cat'] = $wp_the_query->query['category_name'];
+				}
+				if ( $wp_the_query->is_tag ) {
+					$view_data['arch_tag'] = $wp_the_query->query['tag'];
+				}
+				if ( $wp_the_query->is_author ) {
+					$view_data['arch_author'] = $wp_the_query->query['author_name'];
+				}
+				if ( $wp_the_query->is_tax ) {
 					$query = $wp_the_query->query;
 					if ( is_array( $query ) && count( $query ) === 1 ) {
-						$view_data['arch']   = array_keys( $query )[0];
-						$view_data['arch_v'] = array_values( $query )[0];
+						$view_data[ 'arch_' . array_keys( $query )[0] ] = array_values( $query )[0];
 					}
 				}
-				$view_data['arch_res'] = count( $wp_the_query->posts );
+				$view_data['arch_results'] = $wp_the_query->posts ? count( $wp_the_query->posts ) : 0;
 			} elseif ( $wp_the_query->is_404() ) {
-				$view_data['arch']   = 'err';
-				$view_data['arch_v'] = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) ); // send the url path
+				$view_data['arch_err'] = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) );
 			} elseif ( $wp_the_query->is_search() ) {
-				$view_data['arch']     = 'search';
-				$view_data['arch_v']   = sanitize_text_field( $wp_the_query->query['s'] );
-				$view_data['arch_res'] = count( $wp_the_query->posts );
+				$view_data['arch_search']  = sanitize_text_field( $wp_the_query->query['s'] );
+				$view_data['arch_results'] = $wp_the_query->posts ? count( $wp_the_query->posts ) : 0;
 			}
 		}
 

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -47,11 +47,12 @@ class Tracking_Pixel {
 	public static function build_view_data() {
 		global $wp_the_query;
 
-		$blog     = Jetpack_Options::get_option( 'id' );
-		$tz       = get_option( 'gmt_offset' );
-		$v        = 'ext';
-		$blog_url = wp_parse_url( site_url() );
-		$srv      = $blog_url['host'];
+		$blog       = Jetpack_Options::get_option( 'id' );
+		$tz         = get_option( 'gmt_offset' );
+		$v          = 'ext';
+		$blog_url   = wp_parse_url( site_url() );
+		$srv        = $blog_url['host'];
+		$is_archive = false;
 		if ( $wp_the_query->is_single || $wp_the_query->is_page || $wp_the_query->is_posts_page ) {
 			// Store and reset the queried_object and queried_object_id
 			// Otherwise, redirect_canonical() will redirect to home_url( '/' ) for show_on_front = page sites where home_url() is not all lowercase.
@@ -70,7 +71,8 @@ class Tracking_Pixel {
 				$wp_the_query->queried_object_id = $queried_object_id;
 			}
 		} else {
-			$post = '0';
+			$post       = '0';
+			$is_archive = true;
 		}
 		$view_data = compact( 'v', 'blog', 'post', 'tz', 'srv' );
 		// Batcache removes some of the UTM params from $_GET, we need to extract them from uri directly instead.
@@ -82,6 +84,37 @@ class Tracking_Pixel {
 			if ( isset( $url_params[ $utm_parameter ] ) && is_scalar( $url_params[ $utm_parameter ] ) ) {
 				// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- UTMs are standardized parameters coming from outside WordPress, adding nonce is not possible
 				$view_data[ $utm_parameter ] = substr( sanitize_textarea_field( wp_unslash( $url_params[ $utm_parameter ] ) ), 0, 255 );
+			}
+		}
+
+		if ( $is_archive ) {
+			if ( $wp_the_query->is_home() ) {
+				$view_data['home'] = '1';
+			} elseif ( $wp_the_query->is_archive() ) {
+				if ( $wp_the_query->is_date ) {
+					$query               = $wp_the_query->query;
+					$date_parts          = array_filter( array( $query['year'] ?? null, $query['monthnum'] ?? null, $query['day'] ?? null ) );
+					$date                = implode( '/', $date_parts );
+					$view_data['arch']   = 'date';
+					$view_data['arch_v'] = $date;
+				} elseif ( $wp_the_query->is_category ) {
+					$view_data['arch']   = 'cat';
+					$view_data['arch_v'] = $wp_the_query->query['category_name'];
+				} elseif ( $wp_the_query->is_tag ) {
+					$view_data['arch']   = 'tag';
+					$view_data['arch_v'] = $wp_the_query->query['tag'];
+				} elseif ( $wp_the_query->is_author ) {
+					$view_data['arch']   = 'author';
+					$view_data['arch_v'] = $wp_the_query->query['author_name'];
+				}
+				// TODO: track custom types - is_post_type_archive() and is_tax()
+			} elseif ( $wp_the_query->is_404() ) {
+				// These do not seem to be tracked at all
+				$view_data['arch']   = 'err';
+				$view_data['arch_v'] = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) ); // send the url path
+			} elseif ( $wp_the_query->is_search() ) {
+				$view_data['arch']   = 'search';
+				$view_data['arch_v'] = $wp_the_query->query['s'];
 			}
 		}
 

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -108,13 +108,12 @@ class Tracking_Pixel {
 					$view_data['arch_v'] = $wp_the_query->query['author_name'];
 				} elseif ( $wp_the_query->is_tax ) {
 					$query = $wp_the_query->query;
-					if ( count( $query ) === 0 ) {
+					if ( is_array( $query ) && count( $query ) === 1 ) {
 						$view_data['arch']   = array_keys( $query )[0];
 						$view_data['arch_v'] = array_values( $query )[0];
 					}
 				}
 			} elseif ( $wp_the_query->is_404() ) {
-				// These do not seem to be tracked at all
 				$view_data['arch']   = 'err';
 				$view_data['arch_v'] = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) ); // send the url path
 			} elseif ( $wp_the_query->is_search() ) {

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -123,7 +123,6 @@ class Tracking_Pixel {
 				$view_data['arch_other'] = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) );
 			}
 		}
-
 		return $view_data;
 	}
 
@@ -145,21 +144,26 @@ class Tracking_Pixel {
 		if ( $query->get( 'author_name' ) ) {
 			$data['author_name'] = $query->get( 'author_name' );
 		}
+		$filters = http_build_query( $data );
 
 		$the_tax_query = $query->tax_query;
+		$terms         = array();
 		if ( ! empty( $the_tax_query->queried_terms ) && is_array( $the_tax_query->queried_terms ) ) {
 			foreach ( $the_tax_query->queries as $tax_query ) {
 				if ( ! is_array( $tax_query ) || 'slug' !== $tax_query['field'] ) {
 					continue;
 				}
 				$taxonomy = $tax_query['taxonomy'];
-				if ( ! isset( $data['terms'][ $taxonomy ] ) || ! is_array( $data['terms'][ $taxonomy ] ) ) {
-					$data['terms'][ $taxonomy ] = array();
+				if ( ! isset( $terms[ $taxonomy ] ) || ! is_array( $terms[ $taxonomy ] ) ) {
+					$terms[ $taxonomy ] = array();
 				}
-				$data['terms'][ $taxonomy ] = array_merge( $data['terms'][ $taxonomy ], $tax_query['terms'] );
+				$terms[ $taxonomy ] = array_merge( $terms[ $taxonomy ], $tax_query['terms'] );
 			}
 		}
-		return http_build_query( $data );
+		if ( ! empty( $terms ) ) {
+			$filters .= '&terms=' . wp_json_encode( $terms );
+		}
+		return $filters;
 	}
 
 	/**

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -131,7 +131,7 @@ class Tracking_Pixel {
 	 * Collect the tracking data for a search page.
 	 *
 	 * @access private
-	 * @param  WP_Query $query The WP_Query object to parse all the filters from.
+	 * @param  \WP_Query $query The WP_Query object to parse all the filters from.
 	 * @return string The search filters in a URL query string format.
 	 */
 	private static function build_search_filters( $query ) {

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -113,12 +113,14 @@ class Tracking_Pixel {
 						$view_data['arch_v'] = array_values( $query )[0];
 					}
 				}
+				$view_data['arch_res'] = count( $wp_the_query->posts );
 			} elseif ( $wp_the_query->is_404() ) {
 				$view_data['arch']   = 'err';
 				$view_data['arch_v'] = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) ); // send the url path
 			} elseif ( $wp_the_query->is_search() ) {
-				$view_data['arch']   = 'search';
-				$view_data['arch_v'] = sanitize_text_field( $wp_the_query->query['s'] );
+				$view_data['arch']     = 'search';
+				$view_data['arch_v']   = sanitize_text_field( $wp_the_query->query['s'] );
+				$view_data['arch_res'] = count( $wp_the_query->posts );
 			}
 		}
 

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -90,6 +90,10 @@ class Tracking_Pixel {
 		if ( $is_not_post ) {
 			if ( $wp_the_query->is_home() ) {
 				$view_data['home'] = '1';
+			} elseif ( $wp_the_query->is_search() ) {
+				$view_data['arch_search']  = sanitize_text_field( $wp_the_query->query['s'] );
+				$view_data['arch_filters'] = sanitize_text_field( self::build_search_filters( $wp_the_query ) );
+				$view_data['arch_results'] = $wp_the_query->posts ? count( $wp_the_query->posts ) : 0;
 			} elseif ( $wp_the_query->is_archive() ) {
 				if ( $wp_the_query->is_date ) {
 					$query                  = $wp_the_query->query;
@@ -115,15 +119,47 @@ class Tracking_Pixel {
 				$view_data['arch_results'] = $wp_the_query->posts ? count( $wp_the_query->posts ) : 0;
 			} elseif ( $wp_the_query->is_404() ) {
 				$view_data['arch_err'] = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) );
-			} elseif ( $wp_the_query->is_search() ) {
-				$view_data['arch_search']  = sanitize_text_field( $wp_the_query->query['s'] );
-				$view_data['arch_results'] = $wp_the_query->posts ? count( $wp_the_query->posts ) : 0;
 			} else {
 				$view_data['arch_other'] = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) );
 			}
 		}
 
 		return $view_data;
+	}
+
+	/**
+	 * Collect the tracking data for a search page.
+	 *
+	 * @access private
+	 * @param  WP_Query $query The WP_Query object to parse all the filters from.
+	 * @return string The search filters in a URL query string format.
+	 */
+	private static function build_search_filters( $query ) {
+		$data = array(
+			'posts_per_page' => $query->get( 'posts_per_page' ),
+			'paged'          => ( $query->get( 'paged' ) ) ? absint( $query->get( 'paged' ) ) : 1,
+			'orderby'        => $query->get( 'orderby' ),
+			'order'          => $query->get( 'order' ),
+		);
+
+		if ( $query->get( 'author_name' ) ) {
+			$data['author_name'] = $query->get( 'author_name' );
+		}
+
+		$the_tax_query = $query->tax_query;
+		if ( ! empty( $the_tax_query->queried_terms ) && is_array( $the_tax_query->queried_terms ) ) {
+			foreach ( $the_tax_query->queries as $tax_query ) {
+				if ( ! is_array( $tax_query ) || 'slug' !== $tax_query['field'] ) {
+					continue;
+				}
+				$taxonomy = $tax_query['taxonomy'];
+				if ( ! isset( $data['terms'][ $taxonomy ] ) || ! is_array( $data['terms'][ $taxonomy ] ) ) {
+					$data['terms'][ $taxonomy ] = array();
+				}
+				$data['terms'][ $taxonomy ] = array_merge( $data['terms'][ $taxonomy ], $tax_query['terms'] );
+			}
+		}
+		return http_build_query( $data );
 	}
 
 	/**

--- a/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
+++ b/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
@@ -163,15 +163,15 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 		$wp_the_query->posts = array( 'post1', 'post2', 'post3' );
 		$view_data           = Tracking_Pixel::build_view_data();
 		$expected_view_data  = array(
-			'v'            => 'ext',
-			'blog'         => 1234,
-			'post'         => '0',
-			'tz'           => false,
-			'srv'          => 'example.org',
-			'utm_id'       => 'some_id',
-			'utm_source'   => 'a_source',
-			'arch_testtax' => 'testterm',
-			'arch_results' => 3,
+			'v'                => 'ext',
+			'blog'             => 1234,
+			'post'             => '0',
+			'tz'               => false,
+			'srv'              => 'example.org',
+			'utm_id'           => 'some_id',
+			'utm_source'       => 'a_source',
+			'arch_tax_testtax' => 'testterm',
+			'arch_results'     => 3,
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 	}
@@ -194,6 +194,26 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 			'utm_id'     => 'some_id',
 			'utm_source' => 'a_source',
 			'arch_err'   => $_SERVER['REQUEST_URI'],
+		);
+		$this->assertSame( $expected_view_data, $view_data );
+	}
+
+	/**
+	 * Test for Tracking_Pixel::build_view_data with an undefined type of page
+	 *
+	 * @covers \Automattic\Jetpack\Stats\Tracking_Pixel::build_view_data
+	 */
+	public function test_build_view_data_with_undefined_type() {
+		$view_data          = Tracking_Pixel::build_view_data();
+		$expected_view_data = array(
+			'v'          => 'ext',
+			'blog'       => 1234,
+			'post'       => '0',
+			'tz'         => false,
+			'srv'        => 'example.org',
+			'utm_id'     => 'some_id',
+			'utm_source' => 'a_source',
+			'arch_other' => $_SERVER['REQUEST_URI'],
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 	}
@@ -237,6 +257,7 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 			'srv'        => 'example.org',
 			'utm_id'     => 'some_id',
 			'utm_source' => 'a_source',
+			'arch_other' => $_SERVER['REQUEST_URI'],
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 	}

--- a/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
+++ b/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
@@ -58,8 +58,6 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 
 	/**
 	 * Test for Tracking_Pixel::build_view_data with home
-	 *
-	 * @covers \Automattic\Jetpack\Stats\Tracking_Pixel::build_view_data
 	 */
 	public function test_build_view_data_with_home() {
 		global $wp_the_query;
@@ -80,8 +78,6 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 
 	/**
 	 * Test for Tracking_Pixel::build_view_data with archives
-	 *
-	 * @covers \Automattic\Jetpack\Stats\Tracking_Pixel::build_view_data
 	 */
 	public function test_build_view_data_with_archives() {
 		// testing author archives
@@ -178,8 +174,6 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 
 	/**
 	 * Test for Tracking_Pixel::build_view_data with error
-	 *
-	 * @covers \Automattic\Jetpack\Stats\Tracking_Pixel::build_view_data
 	 */
 	public function test_build_view_data_with_error() {
 		global $wp_the_query;
@@ -200,8 +194,6 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 
 	/**
 	 * Test for Tracking_Pixel::build_view_data with an undefined type of page
-	 *
-	 * @covers \Automattic\Jetpack\Stats\Tracking_Pixel::build_view_data
 	 */
 	public function test_build_view_data_with_undefined_type() {
 		$view_data          = Tracking_Pixel::build_view_data();
@@ -220,8 +212,6 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 
 	/**
 	 * Test for Tracking_Pixel::build_view_data with search
-	 *
-	 * @covers \Automattic\Jetpack\Stats\Tracking_Pixel::build_view_data
 	 */
 	public function test_build_view_data_with_search() {
 		global $wp_the_query;

--- a/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
+++ b/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
@@ -22,6 +22,7 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 		parent::set_up();
 
 		$_SERVER['REQUEST_URI'] = 'index.html?utm_source=a_source&utm_id=some_id';
+		register_taxonomy( 'testtax', array( 'testterm' ) );
 	}
 
 	/**
@@ -32,6 +33,7 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 		global $wp_the_query;
 		$wp_the_query           = new WP_Query();
 		$_SERVER['REQUEST_URI'] = '';
+		unregister_taxonomy( 'testtax' );
 	}
 
 	/**
@@ -152,6 +154,23 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 			'utm_source' => 'a_source',
 			'arch'       => 'tag',
 			'arch_v'     => 'testtag',
+		);
+		$this->assertSame( $expected_view_data, $view_data );
+
+		// testing taxonomy
+		$wp_the_query->is_tag = false;
+		$wp_the_query->parse_query( 'testtax=testterm' );
+		$view_data          = Tracking_Pixel::build_view_data();
+		$expected_view_data = array(
+			'v'          => 'ext',
+			'blog'       => 1234,
+			'post'       => '0',
+			'tz'         => false,
+			'srv'        => 'example.org',
+			'utm_id'     => 'some_id',
+			'utm_source' => 'a_source',
+			'arch'       => 'testtax',
+			'arch_v'     => 'testterm',
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 	}

--- a/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
+++ b/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
@@ -226,7 +226,7 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 	public function test_build_view_data_with_search() {
 		global $wp_the_query;
 		$wp_the_query->is_search = true;
-		$wp_the_query->parse_query( 's=term&posts_per_page=10&paged=2&orderby=date&order=ASC' );
+		$wp_the_query->parse_query( 's=term&posts_per_page=10&paged=2&orderby=date&order=ASC&author_name=author&testtax=testterm' );
 		$wp_the_query->posts = array( 'post1', 'post2' );
 		$view_data           = Tracking_Pixel::build_view_data();
 		$expected_view_data  = array(
@@ -238,8 +238,26 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 			'utm_id'       => 'some_id',
 			'utm_source'   => 'a_source',
 			'arch_search'  => 'term',
-			'arch_filters' => 'posts_per_page=10&paged=2&orderby=date&order=ASC',
+			'arch_filters' => 'posts_per_page=10&paged=2&orderby=date&order=ASC&author_name=author&terms=' . wp_json_encode( array( 'testtax' => array( 'testterm' ) ) ),
 			'arch_results' => 2,
+		);
+		$this->assertSame( $expected_view_data, $view_data );
+
+		// testing search with non-existing taxonomy
+		$wp_the_query->parse_query( 's=term&posts_per_page=10&paged=2&orderby=date&order=ASC&no-testtax=testterm' );
+		$wp_the_query->posts = array( 'post1', 'post2', 'post3' );
+		$view_data           = Tracking_Pixel::build_view_data();
+		$expected_view_data  = array(
+			'v'            => 'ext',
+			'blog'         => 1234,
+			'post'         => '0',
+			'tz'           => false,
+			'srv'          => 'example.org',
+			'utm_id'       => 'some_id',
+			'utm_source'   => 'a_source',
+			'arch_search'  => 'term',
+			'arch_filters' => 'posts_per_page=10&paged=2&orderby=date&order=ASC',
+			'arch_results' => 3,
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 	}

--- a/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
+++ b/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
@@ -91,15 +91,15 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 		$wp_the_query->query      = array( 'author_name' => 'some_author' );
 		$view_data                = Tracking_Pixel::build_view_data();
 		$expected_view_data       = array(
-			'v'          => 'ext',
-			'blog'       => 1234,
-			'post'       => '0',
-			'tz'         => false,
-			'srv'        => 'example.org',
-			'utm_id'     => 'some_id',
-			'utm_source' => 'a_source',
-			'arch'       => 'author',
-			'arch_v'     => 'some_author',
+			'v'            => 'ext',
+			'blog'         => 1234,
+			'post'         => '0',
+			'tz'           => false,
+			'srv'          => 'example.org',
+			'utm_id'       => 'some_id',
+			'utm_source'   => 'a_source',
+			'arch_author'  => 'some_author',
+			'arch_results' => 0,
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 
@@ -109,15 +109,15 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 		$wp_the_query->parse_query( 'year=2019&monthnum=12&day=31' );
 		$view_data          = Tracking_Pixel::build_view_data();
 		$expected_view_data = array(
-			'v'          => 'ext',
-			'blog'       => 1234,
-			'post'       => '0',
-			'tz'         => false,
-			'srv'        => 'example.org',
-			'utm_id'     => 'some_id',
-			'utm_source' => 'a_source',
-			'arch'       => 'date',
-			'arch_v'     => '2019/12/31',
+			'v'            => 'ext',
+			'blog'         => 1234,
+			'post'         => '0',
+			'tz'           => false,
+			'srv'          => 'example.org',
+			'utm_id'       => 'some_id',
+			'utm_source'   => 'a_source',
+			'arch_date'    => '2019/12/31',
+			'arch_results' => 0,
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 
@@ -127,15 +127,15 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 		$wp_the_query->parse_query( 'cat=testcategory&category_name=testcategory' );
 		$view_data          = Tracking_Pixel::build_view_data();
 		$expected_view_data = array(
-			'v'          => 'ext',
-			'blog'       => 1234,
-			'post'       => '0',
-			'tz'         => false,
-			'srv'        => 'example.org',
-			'utm_id'     => 'some_id',
-			'utm_source' => 'a_source',
-			'arch'       => 'cat',
-			'arch_v'     => 'testcategory',
+			'v'            => 'ext',
+			'blog'         => 1234,
+			'post'         => '0',
+			'tz'           => false,
+			'srv'          => 'example.org',
+			'utm_id'       => 'some_id',
+			'utm_source'   => 'a_source',
+			'arch_cat'     => 'testcategory',
+			'arch_results' => 0,
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 
@@ -145,32 +145,33 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 		$wp_the_query->parse_query( 'tag=testtag' );
 		$view_data          = Tracking_Pixel::build_view_data();
 		$expected_view_data = array(
-			'v'          => 'ext',
-			'blog'       => 1234,
-			'post'       => '0',
-			'tz'         => false,
-			'srv'        => 'example.org',
-			'utm_id'     => 'some_id',
-			'utm_source' => 'a_source',
-			'arch'       => 'tag',
-			'arch_v'     => 'testtag',
+			'v'            => 'ext',
+			'blog'         => 1234,
+			'post'         => '0',
+			'tz'           => false,
+			'srv'          => 'example.org',
+			'utm_id'       => 'some_id',
+			'utm_source'   => 'a_source',
+			'arch_tag'     => 'testtag',
+			'arch_results' => 0,
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 
 		// testing taxonomy
 		$wp_the_query->is_tag = false;
 		$wp_the_query->parse_query( 'testtax=testterm' );
-		$view_data          = Tracking_Pixel::build_view_data();
-		$expected_view_data = array(
-			'v'          => 'ext',
-			'blog'       => 1234,
-			'post'       => '0',
-			'tz'         => false,
-			'srv'        => 'example.org',
-			'utm_id'     => 'some_id',
-			'utm_source' => 'a_source',
-			'arch'       => 'testtax',
-			'arch_v'     => 'testterm',
+		$wp_the_query->posts = array( 'post1', 'post2', 'post3' );
+		$view_data           = Tracking_Pixel::build_view_data();
+		$expected_view_data  = array(
+			'v'            => 'ext',
+			'blog'         => 1234,
+			'post'         => '0',
+			'tz'           => false,
+			'srv'          => 'example.org',
+			'utm_id'       => 'some_id',
+			'utm_source'   => 'a_source',
+			'arch_testtax' => 'testterm',
+			'arch_results' => 3,
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 	}
@@ -192,8 +193,7 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 			'srv'        => 'example.org',
 			'utm_id'     => 'some_id',
 			'utm_source' => 'a_source',
-			'arch'       => 'err',
-			'arch_v'     => $_SERVER['REQUEST_URI'],
+			'arch_err'   => $_SERVER['REQUEST_URI'],
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 	}
@@ -207,17 +207,18 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 		global $wp_the_query;
 		$wp_the_query->is_search = true;
 		$wp_the_query->parse_query( 's=term' );
-		$view_data          = Tracking_Pixel::build_view_data();
-		$expected_view_data = array(
-			'v'          => 'ext',
-			'blog'       => 1234,
-			'post'       => '0',
-			'tz'         => false,
-			'srv'        => 'example.org',
-			'utm_id'     => 'some_id',
-			'utm_source' => 'a_source',
-			'arch'       => 'search',
-			'arch_v'     => 'term',
+		$wp_the_query->posts = array( 'post1', 'post2' );
+		$view_data           = Tracking_Pixel::build_view_data();
+		$expected_view_data  = array(
+			'v'            => 'ext',
+			'blog'         => 1234,
+			'post'         => '0',
+			'tz'           => false,
+			'srv'          => 'example.org',
+			'utm_id'       => 'some_id',
+			'utm_source'   => 'a_source',
+			'arch_search'  => 'term',
+			'arch_results' => 2,
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 	}

--- a/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
+++ b/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
@@ -226,7 +226,7 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 	public function test_build_view_data_with_search() {
 		global $wp_the_query;
 		$wp_the_query->is_search = true;
-		$wp_the_query->parse_query( 's=term' );
+		$wp_the_query->parse_query( 's=term&posts_per_page=10&paged=2&orderby=date&order=ASC' );
 		$wp_the_query->posts = array( 'post1', 'post2' );
 		$view_data           = Tracking_Pixel::build_view_data();
 		$expected_view_data  = array(
@@ -238,6 +238,7 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 			'utm_id'       => 'some_id',
 			'utm_source'   => 'a_source',
 			'arch_search'  => 'term',
+			'arch_filters' => 'posts_per_page=10&paged=2&orderby=date&order=ASC',
 			'arch_results' => 2,
 		);
 		$this->assertSame( $expected_view_data, $view_data );

--- a/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
+++ b/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
@@ -55,6 +55,155 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 	}
 
 	/**
+	 * Test for Tracking_Pixel::build_view_data with home
+	 *
+	 * @covers \Automattic\Jetpack\Stats\Tracking_Pixel::build_view_data
+	 */
+	public function test_build_view_data_with_home() {
+		global $wp_the_query;
+		$wp_the_query->is_home = true;
+		$view_data             = Tracking_Pixel::build_view_data();
+		$expected_view_data    = array(
+			'v'          => 'ext',
+			'blog'       => 1234,
+			'post'       => '0',
+			'tz'         => false,
+			'srv'        => 'example.org',
+			'utm_id'     => 'some_id',
+			'utm_source' => 'a_source',
+			'home'       => '1',
+		);
+		$this->assertSame( $expected_view_data, $view_data );
+	}
+
+	/**
+	 * Test for Tracking_Pixel::build_view_data with archives
+	 *
+	 * @covers \Automattic\Jetpack\Stats\Tracking_Pixel::build_view_data
+	 */
+	public function test_build_view_data_with_archives() {
+		// testing author archives
+		global $wp_the_query;
+		$wp_the_query->is_archive = true;
+		$wp_the_query->is_author  = true;
+		$wp_the_query->query      = array( 'author_name' => 'some_author' );
+		$view_data                = Tracking_Pixel::build_view_data();
+		$expected_view_data       = array(
+			'v'          => 'ext',
+			'blog'       => 1234,
+			'post'       => '0',
+			'tz'         => false,
+			'srv'        => 'example.org',
+			'utm_id'     => 'some_id',
+			'utm_source' => 'a_source',
+			'arch'       => 'author',
+			'arch_v'     => 'some_author',
+		);
+		$this->assertSame( $expected_view_data, $view_data );
+
+		// testing date archives
+		$wp_the_query->is_author = false;
+		$wp_the_query->is_date   = true;
+		$wp_the_query->parse_query( 'year=2019&monthnum=12&day=31' );
+		$view_data          = Tracking_Pixel::build_view_data();
+		$expected_view_data = array(
+			'v'          => 'ext',
+			'blog'       => 1234,
+			'post'       => '0',
+			'tz'         => false,
+			'srv'        => 'example.org',
+			'utm_id'     => 'some_id',
+			'utm_source' => 'a_source',
+			'arch'       => 'date',
+			'arch_v'     => '2019/12/31',
+		);
+		$this->assertSame( $expected_view_data, $view_data );
+
+		// testing category archives
+		$wp_the_query->is_date     = false;
+		$wp_the_query->is_category = true;
+		$wp_the_query->parse_query( 'cat=testcategory&category_name=testcategory' );
+		$view_data          = Tracking_Pixel::build_view_data();
+		$expected_view_data = array(
+			'v'          => 'ext',
+			'blog'       => 1234,
+			'post'       => '0',
+			'tz'         => false,
+			'srv'        => 'example.org',
+			'utm_id'     => 'some_id',
+			'utm_source' => 'a_source',
+			'arch'       => 'cat',
+			'arch_v'     => 'testcategory',
+		);
+		$this->assertSame( $expected_view_data, $view_data );
+
+		// testing tag archives
+		$wp_the_query->is_category = false;
+		$wp_the_query->is_tag      = true;
+		$wp_the_query->parse_query( 'tag=testtag' );
+		$view_data          = Tracking_Pixel::build_view_data();
+		$expected_view_data = array(
+			'v'          => 'ext',
+			'blog'       => 1234,
+			'post'       => '0',
+			'tz'         => false,
+			'srv'        => 'example.org',
+			'utm_id'     => 'some_id',
+			'utm_source' => 'a_source',
+			'arch'       => 'tag',
+			'arch_v'     => 'testtag',
+		);
+		$this->assertSame( $expected_view_data, $view_data );
+	}
+
+	/**
+	 * Test for Tracking_Pixel::build_view_data with error
+	 *
+	 * @covers \Automattic\Jetpack\Stats\Tracking_Pixel::build_view_data
+	 */
+	public function test_build_view_data_with_error() {
+		global $wp_the_query;
+		$wp_the_query->is_404 = true;
+		$view_data            = Tracking_Pixel::build_view_data();
+		$expected_view_data   = array(
+			'v'          => 'ext',
+			'blog'       => 1234,
+			'post'       => '0',
+			'tz'         => false,
+			'srv'        => 'example.org',
+			'utm_id'     => 'some_id',
+			'utm_source' => 'a_source',
+			'arch'       => 'err',
+			'arch_v'     => $_SERVER['REQUEST_URI'],
+		);
+		$this->assertSame( $expected_view_data, $view_data );
+	}
+
+	/**
+	 * Test for Tracking_Pixel::build_view_data with search
+	 *
+	 * @covers \Automattic\Jetpack\Stats\Tracking_Pixel::build_view_data
+	 */
+	public function test_build_view_data_with_search() {
+		global $wp_the_query;
+		$wp_the_query->is_search = true;
+		$wp_the_query->parse_query( 's=term' );
+		$view_data          = Tracking_Pixel::build_view_data();
+		$expected_view_data = array(
+			'v'          => 'ext',
+			'blog'       => 1234,
+			'post'       => '0',
+			'tz'         => false,
+			'srv'        => 'example.org',
+			'utm_id'     => 'some_id',
+			'utm_source' => 'a_source',
+			'arch'       => 'search',
+			'arch_v'     => 'term',
+		);
+		$this->assertSame( $expected_view_data, $view_data );
+	}
+
+	/**
 	 * Test for Tracking_Pixel::build_view_data with gmt offset
 	 */
 	public function test_build_view_data_with_gmt_offset() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR adds homepage, archive, error and search parameters to the pixel requests sent to wp.com, so that we can enhance statistics provided to the site owners.

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pgbpWj-8u-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
It adds additional parameters to tracking, but we already mention tracking "posts" and "search engine terms", which parameters are part of.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Log out from your admin account
* Visit the homepage, any archive page (examples `/category/CATEGORY_NAME`, `/CUSTOM_TAXONOMY/TAXONOMY`, `/?s=SEARCH_TERM`) and a non-existent URL.
* Add Jetpack Search but disable the Instant Search toggle and install a theme that supports the search widget (e.g. Twenty Twenty-One).
* Try different searches with (or without) different terms and filters.
* Verify that the request to pixel.wp.com includes the relevant parameters.

