### PR TITLE
[WooCommerce Analytics] Fix update cart not being triggered

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/fix-update-cart
+++ b/projects/packages/woocommerce-analytics/changelog/fix-update-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix update cart not being triggered

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -165,10 +165,10 @@ class Universal {
 	public function capture_cart_quantity_update( $cart_item_key, $quantity, $old_quantity, $cart ) {
 		$product_id = $cart->cart_contents[ $cart_item_key ]['product_id'];
 		if ( $quantity > $old_quantity ) {
-			$this->capture_event_in_session_data( $product_id, $quantity - $old_quantity, 'woocommerceanalytics_add_to_cart' );
+			$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_add_to_cart' );
 			$this->lock_add_to_cart_events = true;
 		} else {
-			$this->capture_event_in_session_data( $product_id, $old_quantity - $quantity, 'woocommerceanalytics_remove_from_cart' );
+			$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_remove_from_cart' );
 		}
 	}
 

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -36,6 +36,7 @@ class Universal {
 
 		// Capture cart events.
 		add_action( 'woocommerce_add_to_cart', array( $this, 'capture_add_to_cart' ), 10, 6 );
+		add_action( 'woocommerce_after_cart_item_quantity_update', array( $this, 'capture_cart_quantity_update' ), 10, 4 );
 		add_action( 'woocommerce_cart_item_removed', array( $this, 'capture_remove_from_cart' ), 10, 2 );
 		add_action( 'woocommerce_after_cart', array( $this, 'remove_from_cart' ) );
 		add_action( 'woocommerce_after_mini_cart', array( $this, 'remove_from_cart' ) );
@@ -139,7 +140,7 @@ class Universal {
 	}
 
 	/**
-	 * Capture remove from cart events in mini-cart and cart blocls
+	 * Capture remove from cart events in mini-cart and cart blocks
 	 *
 	 * @param string   $cart_item_key The cart item removed.
 	 * @param \WC_Cart $cart The cart.
@@ -150,6 +151,25 @@ class Universal {
 		$item = $cart->removed_cart_contents[ $cart_item_key ] ?? null;
 		$this->record_event( 'woocommerceanalytics_remove_from_cart' );
 		$this->capture_event_in_session_data( (int) $item['product_id'], (int) $item['quantity'], 'woocommerceanalytics_remove_from_cart' );
+	}
+
+	/**
+	 * Capture remove/add from cart events using the Cart Controller
+	 *
+	 * @param string   $cart_item_key The cart item updated.
+	 * @param int      $quantity Contains the new quantity of the item.
+	 * @param int      $old_quantity Contains the old quantity of the item.
+	 * @param \WC_Cart $cart The cart.
+	 *
+	 * @return void
+	 */
+	public function capture_cart_quantity_update( $cart_item_key, $quantity, $old_quantity, $cart ) {
+		$product_id = $cart->cart_contents[ $cart_item_key ]['product_id'];
+		if ( $quantity > $old_quantity ) {
+			$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_add_to_cart' );
+		} else {
+			$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_remove_from_cart' );
+		}
 	}
 
 	/**
@@ -423,15 +443,7 @@ class Universal {
 	 * @param array  $variation Variation attributes..
 	 * @param array  $cart_item_data Other cart data.
 	 */
-	public function capture_add_to_cart( $cart_item_key, $product_id, $quantity, $variation_id, $variation, $cart_item_data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$referer_postid = isset( $_SERVER['HTTP_REFERER'] ) ? url_to_postid( esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) ) : 0;
-		// if the referring post is not a product OR the product being added is not the same as post.
-		// (eg. related product list on single product page) then include a product view event.
-		$product_by_referer_postid = wc_get_product( $referer_postid );
-		if ( ! $product_by_referer_postid instanceof WC_Product || (int) $product_id !== $referer_postid ) {
-			$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_product_view' );
-		}
-		// add cart event to the session data.
+	public function capture_add_to_cart( $cart_item_key, $product_id, $quantity, $variation_id = 0, $variation = 0, $cart_item_data = array() ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_add_to_cart' );
 	}
 

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -165,10 +165,10 @@ class Universal {
 	public function capture_cart_quantity_update( $cart_item_key, $quantity, $old_quantity, $cart ) {
 		$product_id = $cart->cart_contents[ $cart_item_key ]['product_id'];
 		if ( $quantity > $old_quantity ) {
-			$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_add_to_cart' );
+			$this->capture_event_in_session_data( $product_id, $quantity - $old_quantity, 'woocommerceanalytics_add_to_cart' );
 			$this->lock_add_to_cart_events = true;
 		} else {
-			$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_remove_from_cart' );
+			$this->capture_event_in_session_data( $product_id, $old_quantity - $quantity, 'woocommerceanalytics_remove_from_cart' );
 		}
 	}
 

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -149,7 +149,6 @@ class Universal {
 	 */
 	public function capture_remove_from_cart( $cart_item_key, $cart ) {
 		$item = $cart->removed_cart_contents[ $cart_item_key ] ?? null;
-		$this->record_event( 'woocommerceanalytics_remove_from_cart' );
 		$this->capture_event_in_session_data( (int) $item['product_id'], (int) $item['quantity'], 'woocommerceanalytics_remove_from_cart' );
 	}
 

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -166,6 +166,7 @@ class Universal {
 		$product_id = $cart->cart_contents[ $cart_item_key ]['product_id'];
 		if ( $quantity > $old_quantity ) {
 			$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_add_to_cart' );
+			$this->lock_add_to_cart_events = true;
 		} else {
 			$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_remove_from_cart' );
 		}
@@ -443,6 +444,9 @@ class Universal {
 	 * @param array  $cart_item_data Other cart data.
 	 */
 	public function capture_add_to_cart( $cart_item_key, $product_id, $quantity, $variation_id, $variation, $cart_item_data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( $this->lock_add_to_cart_events ) {
+			return;
+		}
 		$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_add_to_cart' );
 	}
 

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -442,7 +442,7 @@ class Universal {
 	 * @param array  $variation Variation attributes..
 	 * @param array  $cart_item_data Other cart data.
 	 */
-	public function capture_add_to_cart( $cart_item_key, $product_id, $quantity, $variation_id = 0, $variation = 0, $cart_item_data = array() ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function capture_add_to_cart( $cart_item_key, $product_id, $quantity, $variation_id, $variation, $cart_item_data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_add_to_cart' );
 	}
 

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -67,6 +67,14 @@ trait Woo_Analytics_Trait {
 	protected $landing_page = '';
 
 	/**
+	 *  Locks Add to Cart Events Tracking in the current request avoiding duplications.
+	 *  i.e If update_cart and add_to_cart actions happens in the same request.
+	 *
+	 *  @var bool If true. Cart events are locked for the current request.
+	 */
+	protected $lock_add_to_cart_events = false;
+
+	/**
 	 * Format Cart Items or Order Items to an array
 	 *
 	 * @param array|WC_Order_Item[] $items Cart Items or Order Items.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes a bug when the Add to cart event is not triggered if there are events in the cart
* Record add/remove events when modifying the quantity in the cart
* Fixes bug creating an extra session when removing an item from cart
* Removes undesired product_view event after adding to cart


https://github.com/user-attachments/assets/313a7336-1e24-4665-9007-2a3875bea026





### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this PR and build Jetpack
* Go to the shop. Add some products
* Refresh the shop. Remove manually woocommerceanalytics_session from the cookies
* Add a product that was never added clicking "Add to cart"
* Add a product that is already in the cart clicking "x in cart"
* Open the minicart and reduce quantity of a product
* Open the minicart and remove an item from the cart
* Refresh the page
* See the next events with the same session_id: session_started, add_to_cart (x2), remove_from_cart (x2), page_view



