### PR TITLE
Slideshow: fix misaligned controls in site editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-slide-show-controls-align
+++ b/projects/plugins/jetpack/changelog/fix-slide-show-controls-align
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Slideshow: fix misaligned controls in site editor

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/editor.scss
@@ -69,9 +69,17 @@
 }
 
 // SWIPER WORKAROUND - START
-// Below's a workaround for https://github.com/Automattic/vulcan/issues/615.
-// Rather than including the full swiper styles in the block assets, which would increase the payload,
-// we're adding the minimum set of rules to align the slideshow controls properly.
+//
+// swiper.css is loaded only once no matter how many times the `createSwiper` JS function is called
+// (this might be related to how webpack caches assets dynamically imported). That becomes an issue
+// in the context of the site editor because when we leave a template page that contains a slideshow,
+// the swiper assets are unlinked from the site editor iframe but never added back when revisiting
+// the page (without a hard refresh).
+// See https://github.com/Automattic/vulcan/issues/615
+//
+// I haven't been able to come up with a proper fix to make sure the swiper assets are loaded when needed.
+// The next best solution is to include the minimum set of rules to align the slideshow controls properly,
+// which has minimal impact on the user experience.
 
 .swiper-button-white {
 	position: absolute;

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/editor.scss
@@ -67,3 +67,43 @@
 		opacity: 0.3;
 	}
 }
+
+// SWIPER WORKAROUND - START
+// Below's a workaround for https://github.com/Automattic/vulcan/issues/615.
+// Rather than including the full swiper styles in the block assets, which would increase the payload,
+// we're adding the minimum set of rules to align the slideshow controls properly.
+
+.swiper-button-white {
+	position: absolute;
+}
+
+.swiper-button-prev {
+	left: 10px;
+}
+
+.swiper-button-next {
+	right: 10px;
+}
+
+.swiper-notification {
+	display: none;
+}
+
+.swiper-pagination-bullet {
+	display: inline-block;
+
+	width: 8px;
+	height: 8px;
+	margin: 0;
+  padding: 0;
+
+	background: currentColor;
+	color: currentColor;
+	border-radius: 50%;
+	border: none;
+	
+	opacity: 0.5;
+	transition: opacity 250ms, transform 250ms;
+}
+
+// SWIPER WORKAROUND - END


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #https://github.com/Automattic/vulcan/issues/615

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR fixes the slideshow controls not being aligned in the site editor after navigating from the templates page to a specific template.

| Before | After |
|-|-|
|<img width="400" alt="Screenshot 2025-03-11 at 11 41 58 AM" src="https://github.com/user-attachments/assets/2e0343a4-988c-4893-a701-f207cdfb9fd5" />|<img width="400" alt="Screenshot 2025-03-11 at 12 05 32 PM" src="https://github.com/user-attachments/assets/8f6b17fd-59ae-4631-9584-981aa35e1ed4" />|

As discussed in the issue thread, the problem seems to be related to how webpack handles caching. I didn't find any reliable solution to that and the next best thing was to add the missing styles to the block directly. It's not a perfect solution but it's the one with the least impact for users as the extra payload is minimal.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test Jetpack site with a block-based theme
- Visit the Templates page in the site editor (`/wp-admin/site-editor.php?postType=wp_template`)
- Select a template or create a new one
- Add a Slideshow block with a couple of images. It should work as expected, and controls should be properly positioned.
- Save the template
- Hard refresh the page
- Check the behavior and controls position of the slideshow
- Go back to the template list by clicking the WordPress icon on the top left corner of the screen
- Click on the template you've just created or edited
- Check the slideshow again

