### PR TITLE
Fix SQLite default driver missing indices

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-sqlite-default-driver-missin-indices
+++ b/projects/plugins/wpcomsh/changelog/fix-sqlite-default-driver-missin-indices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix: missing SQLite default driver index sizes

--- a/projects/plugins/wpcomsh/imports/playground/class-playground-db-importer.php
+++ b/projects/plugins/wpcomsh/imports/playground/class-playground-db-importer.php
@@ -485,7 +485,7 @@ class Playground_DB_Importer {
 	 *
 	 * @return bool
 	 */
-	private function needs_191_limit( array $key_map ): bool {
+	public function needs_191_limit( array $key_map ): bool {
 		if ( $key_map['sqlite_type'] !== 'text' ) {
 			return false;
 		}
@@ -527,7 +527,7 @@ class Playground_DB_Importer {
 	 *
 	 * @return string
 	 */
-	private function get_tmp_file_name(): string {
+	public function get_tmp_file_name(): string {
 		// A random string to avoid collisions.
 		return 'sqlite-export-' . uniqid() . '.sql';
 	}
@@ -570,7 +570,7 @@ class Playground_DB_Importer {
 	 *
 	 * @return array
 	 */
-	private function hot_fix_missing_indexes( string $table_name, array $map ) {
+	public function hot_fix_missing_indexes( string $table_name, array $map ) {
 		// Fix: the default SQLite driver do not generate save index sizes.
 		$fix_map = array(
 			'wp_wc_orders'                           => array(

--- a/projects/plugins/wpcomsh/imports/playground/class-playground-db-importer.php
+++ b/projects/plugins/wpcomsh/imports/playground/class-playground-db-importer.php
@@ -323,7 +323,12 @@ class Playground_DB_Importer {
 
 		// Schema: column_or_index|mysql_type
 		while ( $column = $results->fetchArray( SQLITE3_ASSOC ) ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
-			// May by column name and MySQL type.
+			// Hot fix: the default SQLite driver sometimes generate a column named `KEY`.
+			if ( $column['column_or_index'] === 'KEY' ) {
+				continue;
+			}
+
+			// Map by column name and MySQL type.
 			$mysql_map[ $column['column_or_index'] ] = $column['mysql_type'];
 		}
 
@@ -346,6 +351,11 @@ class Playground_DB_Importer {
 
 		// Schema: cid|name|type|notnull|dflt_value|pk
 		while ( $column = $results->fetchArray( SQLITE3_ASSOC ) ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+			// Hot fix: skip `KEY` columns.
+			if ( $column['name'] === 'KEY' ) {
+				continue;
+			}
+
 			$is_primary    = $column['pk'] >= 1;
 			$field_names[] = $column['name'];
 
@@ -424,6 +434,9 @@ class Playground_DB_Importer {
 
 			$map[] = $new_index;
 		}
+
+		// Hot fix: add the missing index sizes.
+		$map = $this->hot_fix_missing_indexes( $table_name, $map );
 
 		$auto_increment = 0;
 
@@ -535,5 +548,61 @@ class Playground_DB_Importer {
 		if ( is_string( $query ) ) {
 			return $wpdb->remove_placeholder_escape( $query );
 		}
+	}
+
+	/**
+	 * Hot fix: add the missing index sizes. The default SQLite driver do not
+	 * generate index sizes and sometimes the indexes are not valid when made of
+	 * multiple text and integer columns and are more than 191 characters.
+	 *
+	 * Known columns are from WooCommerce.
+	 *
+	 * Example:
+	 * KEY `order_id_meta_key_meta_value` (`order_id`, `meta_key`, `meta_value`)
+	 *
+	 * should be:
+	 * KEY `order_id_meta_key_meta_value` (`order_id`,`meta_key`(100),`meta_value`(82))
+	 *
+	 * Once we have a better SQLite driver, we can remove this function.
+	 *
+	 * @param string $table_name The table name.
+	 * @param array  $map The columns map.
+	 *
+	 * @return array
+	 */
+	private function hot_fix_missing_indexes( string $table_name, array $map ) {
+		// Fix: the default SQLite driver do not generate save index sizes.
+		$fix_map = array(
+			'wp_wc_orders'                           => array(
+				'customer_id_billing_email' => '(`customer_id`,`billing_email`(171))',
+			),
+			'wp_wc_orders_meta'                      => array(
+				'meta_key_value'               => '(`meta_key`(100),`meta_value`(82))',
+				'order_id_meta_key_meta_value' => '(`order_id`,`meta_key`(100),`meta_value`(82))',
+			),
+			'wp_woocommerce_downloadable_product_permissions' => array(
+				'download_order_key_product' => '(`product_id`,`order_id`,`order_key`(16),`download_id`)',
+			),
+			'wp_woocommerce_shipping_zone_locations' => array(
+				'location_type_code' => '(`location_type`(10),`location_code`(20))',
+			),
+			'wp_woocommerce_tax_rate_locations'      => array(
+				'location_type_code' => '(`location_type`(10),`location_code`(20))',
+			),
+		);
+
+		if ( ! array_key_exists( $table_name, $fix_map ) ) {
+			// No fix for this table.
+			return $map;
+		}
+
+		foreach ( $map as $i => $column ) {
+			if ( array_key_exists( $column['name'], $fix_map[ $table_name ] ) ) {
+				// Hot fix: add the missing index sizes.
+				$map[ $i ]['columns'] = $fix_map[ $table_name ][ $column['name'] ];
+			}
+		}
+
+		return $map;
 	}
 }

--- a/projects/plugins/wpcomsh/tests/imports/PlaygroundDBImporterTest.php
+++ b/projects/plugins/wpcomsh/tests/imports/PlaygroundDBImporterTest.php
@@ -318,27 +318,21 @@ class PlaygroundDBImporterTest extends WP_UnitTestCase {
 		$this->assertEquals( array(), $map );
 
 		$table_name = 'wp_woocommerce_tax_rate_locations';
-		$indices    = array(
-			array(
-				'name'    => 'location_type_code',
-				'columns' => 'test',
-			),
+		$index      = array(
+			'name'    => 'location_type_code',
+			'columns' => 'test',
 		);
 
 		$map = $this->db_importer->hot_fix_missing_indexes(
 			$table_name,
-			array(
-				$table_name => $indices,
-			)
+			array( $index )
 		);
 
 		$this->assertEquals(
 			array(
-				$table_name => array(
-					array(
-						'name'    => 'location_type_code',
-						'columns' => '(`location_type`(10),`location_code`(20))',
-					),
+				array(
+					'name'    => 'location_type_code',
+					'columns' => '(`location_type`(10),`location_code`(20))',
 				),
 			),
 			$map

--- a/projects/plugins/wpcomsh/tests/imports/PlaygroundDBImporterTest.php
+++ b/projects/plugins/wpcomsh/tests/imports/PlaygroundDBImporterTest.php
@@ -290,6 +290,54 @@ class PlaygroundDBImporterTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( SQL_Generator::DEFAULT_COLLATION, $result );
 	}
 
+	public function get_needs_191_limit_test_cases() {
+		$this->assertFalse(
+			$this->db_importer->needs_191_limit(
+				array(
+					'type'        => 'text',
+					'sqlite_type' => 'text',
+				)
+			)
+		);
+		$this->assertTrue(
+			$this->db_importer->needs_191_limit(
+				array(
+					'type'        => 'varchar(255)',
+					'sqlite_type' => 'text',
+				)
+			)
+		);
+	}
+
+	public function test_get_tmp_file_name() {
+		$this->assertStringContainsString( 'sqlite-export-', $this->db_importer->get_tmp_file_name() );
+	}
+
+	public function test_hot_fix_missing_indexes() {
+		global $wpdb;
+		$map = $this->db_importer->hot_fix_missing_indexes( $wpdb->prefix . '_options', array() );
+		$this->assertEquals( array(), $map );
+
+		$table_name = $wpdb->prefix . 'woocommerce_tax_rate_locations';
+		$map        = $this->db_importer->hot_fix_missing_indexes(
+			$table_name,
+			array(
+				$table_name => array(
+					'location_id'        => 1,
+					'location_type_code' => 'test',
+				),
+			)
+		);
+
+		$this->assertEquals(
+			array(
+				'location_id'        => 1,
+				'location_type_code' => '(`location_type`(10),`location_code`(20))',
+			),
+			$map
+		);
+	}
+
 	/**
 	 * Generates a temporary file.
 	 *

--- a/projects/plugins/wpcomsh/tests/imports/PlaygroundDBImporterTest.php
+++ b/projects/plugins/wpcomsh/tests/imports/PlaygroundDBImporterTest.php
@@ -314,11 +314,10 @@ class PlaygroundDBImporterTest extends WP_UnitTestCase {
 	}
 
 	public function test_hot_fix_missing_indexes() {
-		global $wpdb;
-		$map = $this->db_importer->hot_fix_missing_indexes( $wpdb->prefix . '_options', array() );
+		$map = $this->db_importer->hot_fix_missing_indexes( 'wp_options', array() );
 		$this->assertEquals( array(), $map );
 
-		$table_name = $wpdb->prefix . 'woocommerce_tax_rate_locations';
+		$table_name = 'wp_woocommerce_tax_rate_locations';
 		$map        = $this->db_importer->hot_fix_missing_indexes(
 			$table_name,
 			array(

--- a/projects/plugins/wpcomsh/tests/imports/PlaygroundDBImporterTest.php
+++ b/projects/plugins/wpcomsh/tests/imports/PlaygroundDBImporterTest.php
@@ -318,21 +318,27 @@ class PlaygroundDBImporterTest extends WP_UnitTestCase {
 		$this->assertEquals( array(), $map );
 
 		$table_name = 'wp_woocommerce_tax_rate_locations';
-		$map        = $this->db_importer->hot_fix_missing_indexes(
+		$indices    = array(
+			array(
+				'name'    => 'location_type_code',
+				'columns' => 'test',
+			),
+		);
+
+		$map = $this->db_importer->hot_fix_missing_indexes(
 			$table_name,
 			array(
-				$table_name => array(
-					'location_id'        => 1,
-					'location_type_code' => 'test',
-				),
+				$table_name => $indices,
 			)
 		);
 
 		$this->assertEquals(
 			array(
 				$table_name => array(
-					'location_id'        => 1,
-					'location_type_code' => '(`location_type`(10),`location_code`(20))',
+					array(
+						'name'    => 'location_type_code',
+						'columns' => '(`location_type`(10),`location_code`(20))',
+					),
 				),
 			),
 			$map

--- a/projects/plugins/wpcomsh/tests/imports/PlaygroundDBImporterTest.php
+++ b/projects/plugins/wpcomsh/tests/imports/PlaygroundDBImporterTest.php
@@ -331,8 +331,10 @@ class PlaygroundDBImporterTest extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			array(
-				'location_id'        => 1,
-				'location_type_code' => '(`location_type`(10),`location_code`(20))',
+				$table_name => array(
+					'location_id'        => 1,
+					'location_type_code' => '(`location_type`(10),`location_code`(20))',
+				),
 			),
 			$map
 		);


### PR DESCRIPTION
## Bug n. 1
The default SQLite driver does not save index sizes because SQLite does not support them, which can create problems with indices from columns whose sizes summed up to generate an index longer than the one accepted ([191](https://github.com/WordPress/WordPress/blob/master/wp-admin/includes/schema.php#L51)). Right now, I've added some hot fixes for the only popular plugin that created problems.

Example:
```sql
SELECT sql FROM sqlite_master WHERE tbl_name='wp_wc_orders_meta' AND name='wp_wc_orders_meta__order_id_meta_key_meta_value';

-- Results
CREATE INDEX "wp_wc_orders_meta__order_id_meta_key_meta_value" ON "wp_wc_orders_meta" ("order_id", "meta_key", "meta_value")

-- But should be: KEY `order_id_meta_key_meta_value` (`order_id`,`meta_key`(100),`meta_value`(82))
```

## Bug n.2
The default SQLite driver sometimes saves a column named `KEY`, probably when the column has the same name as a reserved keyword (which can be done). The index can be ignored:

```sql
SELECT * from _mysql_data_types_cache where `column_or_index` LIKE 'KEY';
-- wp_wc_download_log|KEY|timestamp(timestamp)

-- But it should be wp_wc_download_log|timestamp|timestamp
``` 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a check for spurious `KEY` indices
* Add hotfix for popular plugins (only found WooCommerce). We can fix it later by adding a more complex approach to this

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install this PR (more detailed instructions [here](https://github.com/Automattic/jetpack/pull/42257))
* Export the .zip of the WordPress Playground WooCommerce [Blueprint example](https://playground.wordpress.net/?name=Blueprint+preview&blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FWordPress%2Fblueprints%2Ftrunk%2Fblueprints%2Fwoocommerce-product-feed%2Fblueprint.json&random=8h7uftyrfn7)
* Copy the playground.zip somewhere in your WoA sites by using SFTP
* Run `wp wpcomsh backup-import --source=wordpress-playground.zip --dest=temp-folder --no-dry-run`
* The importer should output `Success: Import completed successfully` and you should see your data imported in the site

