### PR TITLE
Jetpack SEO Enhancer: add global setting toggle on sidebar

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-seo-enhancer-sidebar-toggle
+++ b/projects/plugins/jetpack/changelog/add-jetpack-seo-enhancer-sidebar-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack SEO Enhancer: add global setting toggle on the sidebar

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/index.tsx
@@ -14,12 +14,28 @@ import { __ } from '@wordpress/i18n';
 import { useState, useCallback, useEffect } from 'react';
 import './style.scss';
 
+type JetpackModuleSettings = {
+	[ module: string ]: {
+		options: {
+			[ option: string ]: {
+				current_value: boolean;
+			};
+		};
+	};
+};
+
+type JetpackModuleSelector = {
+	getJetpackModules: () => JetpackModuleSettings;
+};
+
 const useSeoModuleSettings = () => {
 	const [ isEnabled, setIsEnabled ] = useState( false );
 	const [ isToggling, setIsToggling ] = useState( false );
 
 	useEffect( () => {
-		const seoModuleSettings = select( JETPACK_MODULES_STORE_ID ).getJetpackModules()[ 'seo-tools' ];
+		const seoModuleSettings = (
+			select( JETPACK_MODULES_STORE_ID ) as JetpackModuleSelector
+		 ).getJetpackModules()[ 'seo-tools' ];
 		const enhancerAvailable =
 			seoModuleSettings && 'ai_seo_enhancer_enabled' in seoModuleSettings.options;
 		const enhancerEnabled =

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/index.tsx
@@ -1,3 +1,5 @@
+import { JETPACK_MODULES_STORE_ID } from '@automattic/jetpack-shared-extension-utils';
+import apiFetch from '@wordpress/api-fetch';
 import {
 	BaseControl,
 	ToggleControl,
@@ -7,13 +9,54 @@ import {
 	CardBody,
 	CheckboxControl,
 } from '@wordpress/components';
+import { select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import './style.scss';
 
+const useSeoModuleSettings = () => {
+	const [ isEnabled, setIsEnabled ] = useState( false );
+	const [ isToggling, setIsToggling ] = useState( false );
+
+	useEffect( () => {
+		const seoModuleSettings = select( JETPACK_MODULES_STORE_ID ).getJetpackModules()[ 'seo-tools' ];
+		const enhancerAvailable =
+			seoModuleSettings && 'ai_seo_enhancer_enabled' in seoModuleSettings.options;
+		const enhancerEnabled =
+			enhancerAvailable && seoModuleSettings.options?.ai_seo_enhancer_enabled?.current_value;
+
+		setIsEnabled( enhancerEnabled );
+	}, [] );
+
+	const toggleEnhancer = useCallback( async () => {
+		setIsToggling( true );
+		apiFetch( {
+			path: 'jetpack/v4/module/seo-tools',
+			method: 'post',
+			data: { ai_seo_enhancer_enabled: ! isEnabled },
+		} )
+			.then( () => {
+				setIsEnabled( ! isEnabled );
+			} )
+			.catch( () => {
+				// handle error
+			} )
+			.finally( () => {
+				setIsToggling( false );
+			} );
+	}, [ isEnabled ] );
+
+	return {
+		isEnabled,
+		toggleEnhancer,
+		isToggling,
+	};
+};
+
 export function SeoEnhancer() {
-	const [ isEnabled, setIsEnabled ] = useState( true );
+	const { isEnabled, toggleEnhancer, isToggling } = useSeoModuleSettings();
 	const [ isLoading, setIsLoading ] = useState( false );
+	// const [ isToggling, setIsToggling ] = useState( false );
 	const [ features, setFeatures ] = useState( [
 		{
 			name: 'meta-title',
@@ -32,6 +75,10 @@ export function SeoEnhancer() {
 		},
 	] );
 
+	const toggleSeoEnhancer = useCallback( async () => {
+		await toggleEnhancer();
+	}, [ toggleEnhancer ] );
+
 	const toggleFeature = useCallback( name => {
 		setFeatures( prevFeatures =>
 			prevFeatures.map( feature =>
@@ -39,10 +86,6 @@ export function SeoEnhancer() {
 			)
 		);
 	}, [] );
-
-	const toggleHandler = () => {
-		setIsEnabled( ! isEnabled );
-	};
 
 	const generateHandler = () => {
 		setIsLoading( true );
@@ -58,17 +101,14 @@ export function SeoEnhancer() {
 				<BaseControl __nextHasNoMarginBottom={ true } className="ai-seo-enhancer-toggle">
 					<ToggleControl
 						checked={ isEnabled }
-						onChange={ toggleHandler }
-						label={ __( 'Auto-enhance', 'jetpack' ) }
+						disabled={ isToggling }
+						onChange={ toggleSeoEnhancer }
+						label={ __( 'Auto-fill missing metatags', 'jetpack' ) }
 						__nextHasNoMarginBottom={ true }
-						help={
-							! isEnabled
-								? __(
-										"Automattically generate SEO title, SEO description and images' alt text before publishing.",
-										'jetpack'
-								  )
-								: null
-						}
+						help={ __(
+							"Automattically generate SEO title, SEO description and images' alt text before publishing.",
+							'jetpack'
+						) }
 					/>
 				</BaseControl>
 			</PanelRow>


### PR DESCRIPTION

Fixes #

## Proposed changes:
This PR adds a hook to switch the new setting from the sidebar.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
TBD