### PR TITLE
Revert "Jetpack SEO Enhancer: add global setting toggle on sidebar (#42378)"

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-seo-enhancer-sidebar-toggle
+++ b/projects/plugins/jetpack/changelog/add-jetpack-seo-enhancer-sidebar-toggle
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Jetpack SEO Enhancer: add global setting toggle on the sidebar


### PR DESCRIPTION
This reverts commit 9f3659d3dc6cee04e2336a5a62dd223ea64d8249.

## Description
Reverts this commit as it was undeployed and blocking other deployments.

Original PR - #42378

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:
Impossible to say, as the original PR had none.