### PR TITLE
Tweak SSO login wording

### DIFF
--- a/projects/packages/connection/changelog/tweak-sso-login-wording
+++ b/projects/packages/connection/changelog/tweak-sso-login-wording
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: It's a small wording change
+
+

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -622,7 +622,7 @@ class SSO {
 
 					<?php if ( $display_name && $gravatar ) : ?>
 					<a rel="nofollow" class="jetpack-sso-wrap__reauth" href="<?php echo esc_url( $this->build_sso_button_url( array( 'force_reauth' => '1' ) ) ); ?>">
-						<?php esc_html_e( 'Log in as a different WordPress.com user', 'jetpack-connection' ); ?>
+						<?php esc_html_e( 'Log in with another WordPress.com account', 'jetpack-connection' ); ?>
 					</a>
 				<?php else : ?>
 					<p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/100437

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Change the wording on the SSO login screen from "Log in as a different WordPress.com user" → "Log in with another WordPress.com account"

This brings the wording closer in line with the other link "Log in with username and password"

Before | After
-------|------
<img width="477" alt="Screenshot 2025-03-12 at 10 02 43" src="https://github.com/user-attachments/assets/7ef9b317-2037-4773-9696-acf9d95c5045" /> | <img width="477" alt="Screenshot 2025-03-12 at 10 01 01" src="https://github.com/user-attachments/assets/df149021-2954-4f6c-95f8-6617b3d95aac" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Apply changes to your atomic site following the instructions below
2. Ensure that your site has a "local" user, that is a user that is not connected to WordPress.com on the user page.
3. From any /wp-admin screen, hover over the greeting in the top right, and then press "Log out"

