### PR TITLE
build: Deepen checkout for js-packages/social-logos/src/svg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,15 +72,16 @@ jobs:
         run: |
           mapfile -t PROJECTS < <(jq -r 'to_entries[] | select( .value ) | .key' <<<"$CHANGED")
           if [[ ${#PROJECTS[@]} -gt 0 ]]; then
-            echo "Projects: ${PROJECTS[@]}"
             depth=$( git rev-list --count --first-parent HEAD )
             [[ "$depth" -lt 1000 ]] && depth=1000
             BASE=$PWD
             REF=$(git rev-parse HEAD)
             for SLUG in $(pnpm jetpack dependencies list --add-dependencies --extra="build" --ignore-root "${PROJECTS[@]}"); do
               if [[ "$SLUG" == packages/* ]]; then
+                echo "Going to check $SLUG (is a package)"
                 SUBDIR=.
               elif [[ "$SLUG" == js-packages/social-logos ]]; then
+                echo "Going to check $SLUG (is social-logos)"
                 SUBDIR=./src/svg
               else
                 echo "No need to deepen for $SLUG"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,7 @@ jobs:
             return data;
 
       # We need the tree (but not the blob) for packages that will have -alpha version numbers so the timestamp appending works right.
+      # We also need the tree for js-packages/social-logos/src/svg so the font build will work right.
       - name: Deepen tree for packages
         env:
           CHANGED: ${{ steps.changed.outputs.projects }}
@@ -76,12 +77,18 @@ jobs:
             BASE=$PWD
             REF=$(git rev-parse HEAD)
             for SLUG in $(pnpm jetpack dependencies list --add-dependencies --extra="build" --ignore-root "${PROJECTS[@]}"); do
-              [[ "$SLUG" == packages/* ]] || continue
+              if [[ "$SLUG" == packages/* ]]; then
+                SUBDIR=.
+              elif [[ "$SLUG" == js-packages/social-logos ]]; then
+                SUBDIR=./src/svg
+              else
+                continue
+              fi
               cd "$BASE/projects/$SLUG/"
               CHANGES_DIR="$(jq -r '.extra.changelogger["changes-dir"] // "changelog"' composer.json)"
               [[ -d "$CHANGES_DIR" && -n "$(ls -- "$CHANGES_DIR")" ]] || continue
               echo "Checking depth for $SLUG"
-              while git log --format='%h, %D,' -1 . | grep ', grafted,'; do
+              while git log --format='%h, %D,' -1 "$SUBDIR" | grep ', grafted,'; do
                 depth=$((depth * 2))
                 echo "::group::Deepen to $depth"
                 echo "/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=$depth --filter=blob:none origin $REF"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,7 @@ jobs:
               elif [[ "$SLUG" == js-packages/social-logos ]]; then
                 SUBDIR=./src/svg
               else
+                echo "No need to deepen for $SLUG"
                 continue
               fi
               cd "$BASE/projects/$SLUG/"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,19 +77,17 @@ jobs:
             BASE=$PWD
             REF=$(git rev-parse HEAD)
             for SLUG in $(pnpm jetpack dependencies list --add-dependencies --extra="build" --ignore-root "${PROJECTS[@]}"); do
+              cd "$BASE/projects/$SLUG/"
               if [[ "$SLUG" == packages/* ]]; then
-                echo "Going to check $SLUG (is a package)"
                 SUBDIR=.
+                # Only deepen if it'll be a -alpha, i.e. it has changelog entries
+                CHANGES_DIR="$(jq -r '.extra.changelogger["changes-dir"] // "changelog"' composer.json)"
+                [[ -d "$CHANGES_DIR" && -n "$(ls -- "$CHANGES_DIR")" ]] || continue
               elif [[ "$SLUG" == js-packages/social-logos ]]; then
-                echo "Going to check $SLUG (is social-logos)"
                 SUBDIR=./src/svg
               else
-                echo "No need to deepen for $SLUG"
                 continue
               fi
-              cd "$BASE/projects/$SLUG/"
-              CHANGES_DIR="$(jq -r '.extra.changelogger["changes-dir"] // "changelog"' composer.json)"
-              [[ -d "$CHANGES_DIR" && -n "$(ls -- "$CHANGES_DIR")" ]] || continue
               echo "Checking depth for $SLUG"
               while git log --format='%h, %D,' -1 "$SUBDIR" | grep ', grafted,'; do
                 depth=$((depth * 2))

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
         run: |
           mapfile -t PROJECTS < <(jq -r 'to_entries[] | select( .value ) | .key' <<<"$CHANGED")
           if [[ ${#PROJECTS[@]} -gt 0 ]]; then
+            echo "Projects: ${PROJECTS[@]}"
             depth=$( git rev-list --count --first-parent HEAD )
             [[ "$depth" -lt 1000 ]] && depth=1000
             BASE=$PWD


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The font for js-packages/social-logos embeds a timestamp. To avoid unnecessarily changing the file, we derive the timestamp from the latest commit to the `src/svg` directory.

Starting with 043235bd, every commit has been changing the file anyway. It turns out this is because the existing deepening of the checkout for packages' -alpha versions is typically doing 2000 commits, and that's the 2000th commit since the last commit that touched social-logos's `src/svg` dir. So the git timestamp check was returning the timestamp of the graft point rather than 7d77b839 like it's supposed to.

The solution is to make sure the checkout is deepened far enough to reach an actual commit to that `src/svg`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* The `social-logos.woff2` file in the build artifact should match that from Automattic/social-logos@c8ccd14d692c3c9c7c0371df3ff581054d7dbfff.
