### PR TITLE
Twitter Timeline Widget: Expand deprecation handling and only enqueue scripts when needed

### DIFF
--- a/projects/plugins/jetpack/changelog/twitter-timeline-update
+++ b/projects/plugins/jetpack/changelog/twitter-timeline-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Twitter Timeline Widget: Will no longer render a broken link when using twitter's deprecated data-widget-id approach without a type set.

--- a/projects/plugins/jetpack/modules/widgets/twitter-timeline.php
+++ b/projects/plugins/jetpack/modules/widgets/twitter-timeline.php
@@ -43,7 +43,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			)
 		);
 
-		if ( is_active_widget( false, false, $this->id_base ) || is_active_widget( false, false, 'monster' ) || is_customize_preview() ) {
+		if ( is_customize_preview() ) {
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		}
 
@@ -105,7 +105,9 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 
 		// Twitter deprecated `data-widget-id` on 2018-05-25,
 		// with cease support deadline on 2018-07-27.
-		if ( isset( $instance['type'] ) && 'widget-id' === $instance['type'] ) {
+		$explicit_widget_id = isset( $instance['type'] ) && 'widget-id' === $instance['type'];
+		$implicit_widget_id = empty( $instance['type'] ) && ! empty( $instance['widget-id'] ) && is_numeric( $instance['widget-id'] );
+		if ( $explicit_widget_id || $implicit_widget_id ) {
 			if ( current_user_can( 'edit_theme_options' ) ) {
 				$output .= $args['before_widget']
 				. $args['before_title'] . esc_html__( 'Twitter Timeline', 'jetpack' ) . $args['after_title']
@@ -117,6 +119,8 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			return;
 		}
+
+		$this->enqueue_scripts();
 
 		$instance['lang'] = substr( strtoupper( get_locale() ), 0, 2 );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:

* **Expand the already-existing early exit in the `widget()` function to catch more cases of the [deprecated](https://twittercommunity.com/t/deprecating-widget-settings/102295) `data-widget-id` approach.**

Twitter deprecated the use of `data-widget-id` around 2018, moving to a simpler approach using the href attribute with a valid Twitter username (e.g., `href="https://twitter.com/username"`). Our current code tries to detect the deprecated approach and bail early by looking for a `type=widget-id` variable. 

On an old site, I found an instance where `type` was not set, but `widget-id` was set to a large string of numbers. This seems to be another entry into the deprecated (now removed) code path.

On the user's site, there are some messages in the JS console:

```
"You may have been affected by an update to settings in embedded timelines. See https://twittercommunity.com/t/deprecating-widget-settings/102295."

"[Update] There have been recent updates to Embedded X Timelines and supported parameters..."
```

And the only thing that renders is a "My Tweets" link which is broken:
<img width="205" alt="Screenshot 2025-03-12 at 12 11 36 PM" src="https://github.com/user-attachments/assets/26db4cb0-5b3b-4879-b71e-6869806cff56" />
This goes to a twitter.com/123456789012343456 URL, where the number is an unsuported "widget id". It leads to a "this account does not exist" page which tries to look up a username that is the exact long string of numbers.

Here, I've moved the existing check to:
```
$explicit_widget_id = isset( $instance['type'] ) && 'widget-id' === $instance['type'];
```
And added a new check for:
```
$implicit_widget_id = empty( $instance['type'] ) && ! empty( $instance['widget-id'] ) && is_numeric( $instance['widget-id'] );
```

Either one of them will now trigger the early exit. This looks to be safe since the new "happy path" way is setting `type=profile`.

* **Only enqueue scripts when needed**

The twitter JS is heavy and downloads and parses a lot of code. Instead of always enqueuing it on class construction when the widget is active, it is now letting the `widget()` function enque it after it passes the deprecated settings check. This way, sites with misconfigured settings won't queue up a large amount of JS that will ultimately do nothing.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

### Broken site

* On WPCOM, sandbox and visit this site on trunk: 373a5-pb/#plain
* Open the sidebar using the hamburger menu, find the "My Tweets" link and confirmed it's broken
* See the error messages about twitter deprecation in the console
* Use the debug bar to confirm the twitter timeline js was enqueued

<img width="974" alt="Screenshot 2025-03-12 at 12 21 22 PM" src="https://github.com/user-attachments/assets/59740de3-2719-44e7-b9c8-695925e69788" />

* Apply the patch
* Reload the site
* Error messages in console should be gone
* Confirm using the debug bar that the twitter timeline js is no longer enqueued
* Now there should be an error message about incorrect settings visible to admins instead of the broken "My Tweets" link

### Working site

For a site where the twitter timeline is working before this patch, it should continue to work after the patch and not trigger any new errors.

In order to set up a site, I had to unhide this:
```
diff --git a/wp-content/mu-plugins/jetpack-plugin/sun/modules/widgets/twitter-timeline.php b/wp-content/mu-plugins/jetpack-plugin/sun/modules/widgets/twitter-timeline.php
index d6769bfbb39..b6349bfb6d7 100644
--- a/wp-content/mu-plugins/jetpack-plugin/sun/modules/widgets/twitter-timeline.php
+++ b/wp-content/mu-plugins/jetpack-plugin/sun/modules/widgets/twitter-timeline.php
@@ -48,7 +48,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
                }

                add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
-               add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_widget_in_block_editor' ) );
+               /* add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_widget_in_block_editor' ) ); */
        }

        /**
```

Then go to wp-admin/widgets.php, add a legacy widget, and inside there, add a Twitter Timeline widget.

<img width="931" alt="Screenshot 2025-03-12 at 2 05 23 PM" src="https://github.com/user-attachments/assets/ea3ac404-9f4c-4efb-9745-0ce2c3192ef5" />

Sadly, even with the updated username format all this does is create a link to the page..
<img width="323" alt="Screenshot 2025-03-12 at 2 07 23 PM" src="https://github.com/user-attachments/assets/9f060994-788f-408e-bd0f-5f52c5dec1d9" />

However, the patch doesn't break this and is an improvement for sites without usernames.
