### PR TITLE
Fix error with videos uploaded through the Video block

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-video-to-videopress
+++ b/projects/plugins/jetpack/changelog/fix-video-to-videopress
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix error with videos uploaded through the Video block

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -1062,6 +1062,14 @@ export const VpBlock = props => {
 		setAttributes( { maxWidth: newMaxWidth } );
 	};
 
+	if ( shouldRenderLoadingBlock ) {
+		return (
+			<figure { ...blockProps }>
+				<Loading text={ __( 'Generating preview…', 'jetpack' ) } />
+			</figure>
+		);
+	}
+
 	if ( typeof scripts !== 'object' ) {
 		scripts = [];
 	}
@@ -1075,14 +1083,6 @@ export const VpBlock = props => {
 		);
 
 		scripts.push( URL.createObjectURL( videopresAjaxURLBlob ), window.videopressAjax.bridgeUrl );
-	}
-
-	if ( shouldRenderLoadingBlock ) {
-		return (
-			<figure { ...blockProps }>
-				<Loading text={ __( 'Generating preview…', 'jetpack' ) } />
-			</figure>
-		);
 	}
 
 	return (

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -35,6 +35,7 @@ import {
 	createRef,
 	Fragment,
 	useEffect,
+	useCallback,
 } from '@wordpress/element';
 import { escapeHTML } from '@wordpress/escape-html';
 import { __, _x, sprintf } from '@wordpress/i18n';
@@ -1029,7 +1030,7 @@ const UploaderBlock = props => {
 // The actual, final rendered video player markup
 // In a separate function component so that `useBlockProps` could be called.
 export const VpBlock = props => {
-	let { scripts } = props;
+	const { scripts } = props;
 	const {
 		html,
 		interactive,
@@ -1049,6 +1050,35 @@ export const VpBlock = props => {
 		} ),
 	} );
 
+	const getSandboxScripts = useCallback( () => {
+		const sandboxScripts = Array.isArray( scripts ) ? scripts : [];
+
+		if ( window.videopressAjax ) {
+			const videopresAjaxURLBlob = new Blob(
+				[ `var videopressAjax = ${ JSON.stringify( window.videopressAjax ) };` ],
+				{
+					type: 'text/javascript',
+				}
+			);
+
+			return [
+				...sandboxScripts,
+				URL.createObjectURL( videopresAjaxURLBlob ),
+				window.videopressAjax.bridgeUrl,
+			];
+		}
+
+		return sandboxScripts;
+	}, [ scripts ] );
+
+	if ( shouldRenderLoadingBlock ) {
+		return (
+			<figure { ...blockProps }>
+				<Loading text={ __( 'Generating preview…', 'jetpack' ) } />
+			</figure>
+		);
+	}
+
 	const onBlockResize = ( event, direction, elem ) => {
 		let newMaxWidth = getComputedStyle( elem ).width;
 		const parentElement = elem.parentElement;
@@ -1061,29 +1091,6 @@ export const VpBlock = props => {
 
 		setAttributes( { maxWidth: newMaxWidth } );
 	};
-
-	if ( shouldRenderLoadingBlock ) {
-		return (
-			<figure { ...blockProps }>
-				<Loading text={ __( 'Generating preview…', 'jetpack' ) } />
-			</figure>
-		);
-	}
-
-	if ( typeof scripts !== 'object' ) {
-		scripts = [];
-	}
-
-	if ( window.videopressAjax ) {
-		const videopresAjaxURLBlob = new Blob(
-			[ `var videopressAjax = ${ JSON.stringify( window.videopressAjax ) };` ],
-			{
-				type: 'text/javascript',
-			}
-		);
-
-		scripts.push( URL.createObjectURL( videopresAjaxURLBlob ), window.videopressAjax.bridgeUrl );
-	}
 
 	return (
 		<figure { ...blockProps }>
@@ -1100,7 +1107,7 @@ export const VpBlock = props => {
 					style={ { margin: 'auto' } }
 					onResizeStop={ onBlockResize }
 				>
-					<SandBox html={ html } scripts={ scripts } type={ videoPressClassNames } />
+					<SandBox html={ html } scripts={ getSandboxScripts() } type={ videoPressClassNames } />
 				</ResizableBox>
 			</div>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #42401

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This started breaking recently, after this PR: https://github.com/Automattic/jetpack/pull/42216

An error was happening because sometimes the variable `scripts` is `null`, and we were doing a push on that. Now we are returning the loading state earlier to avoid modifying the `scripts` variable when it's not ready.

Also, the `scripts` variable was a prop coming to the component and it was being mutated with the `push`, so I did a small refactor to avoid this.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor.
* Add the Video block.
* Upload a video, and make sure the block doesn't crash.
* Convert the block to VideoPress and then convert back to video to make sure we didn't break this fix: https://github.com/Automattic/jetpack/pull/42216.

