### PR TITLE
Migration: fix wordpress importer link

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/migration-fix-import-wordpress-link
+++ b/projects/packages/jetpack-mu-wpcom/changelog/migration-fix-import-wordpress-link
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: redirect in internal WPCOM flow
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -25,12 +25,16 @@ add_action( 'current_screen', 'import_page_customizations_init' );
  * Displays a banner on the wp-admin/import.php page that links to the Calypso importer.
  */
 function import_admin_banner() {
-	if ( ! function_exists( 'wpcom_get_site_slug' ) ) {
+	if ( ! function_exists( 'get_wpcom_blog_id' ) ) {
 		require_once __DIR__ . '/../../utils.php';
 	}
 
-	$site_slug  = wpcom_get_site_slug();
-	$import_url = esc_url( "https://wordpress.com/setup/hosted-site-migration/site-migration-import-or-migrate?siteSlug={$site_slug}&ref=wp-admin" );
+	$blog_id = get_wpcom_blog_id();
+	if ( false === $blog_id ) {
+		return;
+	}
+
+	$import_url = esc_url( "https://wordpress.com/setup/hosted-site-migration/site-migration-import-or-migrate?siteId={$blog_id}&ref=wp-admin" );
 
 	$banner_content = sprintf(
 		'<p>%s</p><a href="%s" class="button">%s</a>',

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -30,7 +30,7 @@ function import_admin_banner() {
 	}
 
 	$site_slug  = wpcom_get_site_slug();
-	$import_url = esc_url( "https://wordpress.com/setup/hosted-site-migration?siteSlug={$site_slug}&ref=wp-admin" );
+	$import_url = esc_url( "https://wordpress.com/setup/site-migration/site-migration-import-or-migrate?siteSlug={$site_slug}&ref=wp-admin" );
 
 	$banner_content = sprintf(
 		'<p>%s</p><a href="%s" class="button">%s</a>',

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -30,7 +30,7 @@ function import_admin_banner() {
 	}
 
 	$site_slug  = wpcom_get_site_slug();
-	$import_url = esc_url( "https://wordpress.com/setup/site-migration/site-migration-import-or-migrate?siteSlug={$site_slug}&ref=wp-admin" );
+	$import_url = esc_url( "https://wordpress.com/setup/hosted-site-migration/site-migration-import-or-migrate?siteSlug={$site_slug}&ref=wp-admin" );
 
 	$banner_content = sprintf(
 		'<p>%s</p><a href="%s" class="button">%s</a>',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [#](https://github.com/Automattic/wp-calypso/issues/100896)
Should be merged after https://github.com/Automattic/wp-calypso/pull/101255

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Redirect to the `Migrate vs Import` step instead of the `enter your URL` step when clicking import from Wordpress in wp-admin to unify the behaviour with Calypso.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow instruction here PCYsg-Osp-p2 to set up this branch in a testing WoA site
* Navigate to `[YOUR_WOA_SITE]/wp-admin/import.php`
* Click `Get started`  <img width="814" alt="image" src="https://github.com/user-attachments/assets/51cd5bf4-0930-42f6-9ddb-8df6e003777a" />
* Verify you are redirected to the `Migrate vs Import` screen
* if https://github.com/Automattic/wp-calypso/pull/101255 is merged (or you are testing against that branch) clicking back should take you to `[YOUR_WOA_SITE]/wp-admin/import.php`