### PR TITLE
Jetpack SEO: run enhancer automatically when enabled and prepublish shows

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-seo-enhancer-auto-run-pre-publish
+++ b/projects/plugins/jetpack/changelog/add-jetpack-seo-enhancer-auto-run-pre-publish
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack SEO Enhancer: run automatically when enabled and prepublish shows

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/index.tsx
@@ -10,7 +10,7 @@ import {
 	CardBody,
 	CheckboxControl,
 } from '@wordpress/components';
-import { useState, useCallback } from '@wordpress/element';
+import { useState, useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
 /**
@@ -26,7 +26,7 @@ import type { PromptType } from './types';
 
 const debug = debugFactory( 'seo-enhancer:index' );
 
-export function SeoEnhancer() {
+export function SeoEnhancer( { autoRun = false }: { autoRun?: boolean } ) {
 	const { isEnabled, toggleEnhancer, isToggling } = useSeoModuleSettings();
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ features, setFeatures ] = useState<
@@ -64,7 +64,7 @@ export function SeoEnhancer() {
 		);
 	}, [] );
 
-	const generateHandler = async () => {
+	const generateHandler = useCallback( async () => {
 		try {
 			setIsLoading( true );
 
@@ -74,7 +74,13 @@ export function SeoEnhancer() {
 		} finally {
 			setIsLoading( false );
 		}
-	};
+	}, [ updateSeoData ] );
+
+	useEffect( () => {
+		if ( isEnabled && autoRun ) {
+			debug( 'generateHandler', generateHandler );
+		}
+	}, [ isEnabled, autoRun, generateHandler ] );
 
 	return (
 		<>

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -157,7 +157,7 @@ const Seo = () => {
 
 			<PluginPrePublishPanel { ...jetpackSeoPrePublishPanelProps }>
 				<>
-					{ isSeoEnhancerEnabled && isViewable && <SeoEnhancer /> }
+					{ isSeoEnhancerEnabled && isViewable && <SeoEnhancer autoRun={ true } /> }
 					<PanelRow>
 						<SeoTitlePanel />
 					</PanelRow>


### PR DESCRIPTION

Fixes #

## Proposed changes:
WIP

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
TBD