### PR TITLE
Add _wp_old_date to post meta sync whitelist

### DIFF
--- a/projects/packages/sync/changelog/try-add-wp-old-date-post-meta-in-sync
+++ b/projects/packages/sync/changelog/try-add-wp-old-date-post-meta-in-sync
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+add _wp_old_date to meta sync

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -769,6 +769,7 @@ class Defaults {
 		'_wp_attachment_is_custom_background',
 		'_wp_attachment_is_custom_header',
 		'_wp_attachment_metadata',
+		'_wp_old_date',
 		'_wp_page_template',
 		'_wp_trash_meta_comments_status',
 		'_wpas_feature_enabled',

--- a/projects/packages/sync/src/modules/class-search.php
+++ b/projects/packages/sync/src/modules/class-search.php
@@ -68,6 +68,9 @@ class Search extends Module {
 	 * @var array
 	 */
 	private static $postmeta_to_sync = array(
+		// Core
+		'_wp_old_date'                           => array(),
+
 		// jetpack.
 		'jetpack-search-meta0'                   => array( 'searchable_in_all_content' => true ),
 		'jetpack-search-meta1'                   => array( 'searchable_in_all_content' => true ),
@@ -458,7 +461,6 @@ class Search extends Module {
 		'_wp_attachment_is_custom_header'            => array(),
 		'_wp_attachment_metadata'                    => array(),
 		'_wp_desired_post_slug'                      => array(),
-		'_wp_old_date'                               => array(),
 		'_wp_old_slug'                               => array(),
 		'_wp_page_template'                          => array(),
 

--- a/projects/packages/sync/src/modules/class-search.php
+++ b/projects/packages/sync/src/modules/class-search.php
@@ -68,9 +68,6 @@ class Search extends Module {
 	 * @var array
 	 */
 	private static $postmeta_to_sync = array(
-		// Core
-		'_wp_old_date'                           => array(),
-
 		// jetpack.
 		'jetpack-search-meta0'                   => array( 'searchable_in_all_content' => true ),
 		'jetpack-search-meta1'                   => array( 'searchable_in_all_content' => true ),
@@ -461,6 +458,7 @@ class Search extends Module {
 		'_wp_attachment_is_custom_header'            => array(),
 		'_wp_attachment_metadata'                    => array(),
 		'_wp_desired_post_slug'                      => array(),
+		'_wp_old_date'                               => array(),
 		'_wp_old_slug'                               => array(),
 		'_wp_page_template'                          => array(),
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Adds `_wp_old_date` to the whitelist for post meta.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Im not entirely sure how to test this yet, but this is my initial understanding:
* Apply this build on your test site
* Apply wpcom PR 176977 to your sandbox.
* sandbox the public-api
* apply `JETPACK__SANDBOX_DOMAIN` on your jetpack site.
* Publish a new post, republish a post as well to update the publish date.
* ?? wait for sync ?? (this is where im not yet seeing the new or changed posts)
* verify the republished post shows `_wp_old_date` in the metadata.
    * Im not seeing my new/updated posts while doing these steps (yet), but was initially checking in the reader at /reader/blogs/{blogId} for them to appear.

