### PR TITLE
SEO Enhancer: Auto-run requests on pre-publish if enabled

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-seo-enhancer-auto-request
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-seo-enhancer-auto-request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+SEO Enhancer: Auto-run on pre-publish if enabled

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/index.ts
@@ -1,0 +1,4 @@
+import { store } from './store';
+
+export { store };
+export { SeoEnhancer } from './seo-enhancer';

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
@@ -10,12 +10,14 @@ import {
 	CardBody,
 	CheckboxControl,
 } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
+import { store } from './store';
 import { useSeoModuleSettings } from './use-seo-module-settings';
 import { useSeoRequests } from './use-seo-requests';
 import './style.scss';
@@ -23,12 +25,11 @@ import './style.scss';
  * Types
  */
 import type { PromptType } from './types';
-
 const debug = debugFactory( 'seo-enhancer:index' );
 
 export function SeoEnhancer() {
 	const { isEnabled, toggleEnhancer, isToggling } = useSeoModuleSettings();
-	const [ isLoading, setIsLoading ] = useState( false );
+	const isLoading = useSelect( select => select( store ).isBusy(), [] );
 	const [ features, setFeatures ] = useState<
 		{ name: PromptType; label: string; checked: boolean }[]
 	>( [
@@ -66,13 +67,9 @@ export function SeoEnhancer() {
 
 	const generateHandler = async () => {
 		try {
-			setIsLoading( true );
-
 			await updateSeoData();
 		} catch ( error ) {
 			debug( 'Error generating SEO data', error );
-		} finally {
-			setIsLoading( false );
 		}
 	};
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/actions.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/actions.ts
@@ -1,0 +1,6 @@
+export function setBusy( isBusy: boolean ) {
+	return {
+		type: 'SET_BUSY',
+		isBusy,
+	};
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/actions.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/actions.ts
@@ -4,3 +4,17 @@ export function setBusy( isBusy: boolean ) {
 		isBusy,
 	};
 }
+
+export function setIsTogglingAutoEnhance( isToggling: boolean ) {
+	return {
+		type: 'SET_IS_TOGGLING_AUTO_ENHANCE',
+		isToggling,
+	};
+}
+
+export function setIsAutoEnhanceEnabled( isEnabled: boolean ) {
+	return {
+		type: 'SET_IS_AUTO_ENHANCE_ENABLED',
+		isEnabled,
+	};
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/index.ts
@@ -12,13 +12,19 @@ import * as selectors from './selectors';
 import type { JetpackModuleSelector } from '../types';
 export const STORE_NAME = 'jetpack/seo-enhancer';
 
-const seoModuleSettings = (
-	select( JETPACK_MODULES_STORE_ID ) as JetpackModuleSelector
- ).getJetpackModules()[ 'seo-tools' ];
-const enhancerAvailable =
-	seoModuleSettings && 'ai_seo_enhancer_enabled' in seoModuleSettings.options;
-const enhancerEnabled =
-	enhancerAvailable && seoModuleSettings.options?.ai_seo_enhancer_enabled?.current_value;
+let enhancerEnabled;
+
+try {
+	const seoModuleSettings = (
+		select( JETPACK_MODULES_STORE_ID ) as JetpackModuleSelector
+	 ).getJetpackModules()[ 'seo-tools' ];
+	const enhancerAvailable =
+		seoModuleSettings && 'ai_seo_enhancer_enabled' in seoModuleSettings.options;
+	enhancerEnabled =
+		enhancerAvailable && seoModuleSettings.options?.ai_seo_enhancer_enabled?.current_value;
+} catch {
+	enhancerEnabled = false;
+}
 
 export const store = createReduxStore( STORE_NAME, {
 	reducer,
@@ -26,6 +32,7 @@ export const store = createReduxStore( STORE_NAME, {
 	actions,
 	initialState: {
 		isBusy: false,
+		isTogglingAutoEnhance: false,
 		isAutoEnhanceEnabled: enhancerEnabled,
 	},
 } );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/index.ts
@@ -1,15 +1,24 @@
 /**
  * External dependencies
  */
-import { createReduxStore, register } from '@wordpress/data';
+import { JETPACK_MODULES_STORE_ID } from '@automattic/jetpack-shared-extension-utils';
+import { createReduxStore, register, select } from '@wordpress/data';
 /**
  * Internal dependencies
  */
 import * as actions from './actions';
 import reducer from './reducer';
 import * as selectors from './selectors';
-
+import type { JetpackModuleSelector } from '../types';
 export const STORE_NAME = 'jetpack/seo-enhancer';
+
+const seoModuleSettings = (
+	select( JETPACK_MODULES_STORE_ID ) as JetpackModuleSelector
+ ).getJetpackModules()[ 'seo-tools' ];
+const enhancerAvailable =
+	seoModuleSettings && 'ai_seo_enhancer_enabled' in seoModuleSettings.options;
+const enhancerEnabled =
+	enhancerAvailable && seoModuleSettings.options?.ai_seo_enhancer_enabled?.current_value;
 
 export const store = createReduxStore( STORE_NAME, {
 	reducer,
@@ -17,6 +26,7 @@ export const store = createReduxStore( STORE_NAME, {
 	actions,
 	initialState: {
 		isBusy: false,
+		isAutoEnhanceEnabled: enhancerEnabled,
 	},
 } );
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/index.ts
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { createReduxStore, register } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import * as actions from './actions';
+import reducer from './reducer';
+import * as selectors from './selectors';
+
+export const STORE_NAME = 'jetpack/seo-enhancer';
+
+export const store = createReduxStore( STORE_NAME, {
+	reducer,
+	selectors,
+	actions,
+	initialState: {
+		isBusy: false,
+	},
+} );
+
+register( store );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/reducer.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/reducer.ts
@@ -1,0 +1,15 @@
+/**
+ * Types
+ */
+import type { SeoEnhancerAction, SeoEnhancerState } from '../types';
+
+export function reducer( state: SeoEnhancerState, action: SeoEnhancerAction ) {
+	switch ( action.type ) {
+		case 'SET_BUSY':
+			return { ...state, isBusy: action.isBusy };
+		default:
+			return state;
+	}
+}
+
+export default reducer;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/reducer.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/reducer.ts
@@ -7,6 +7,10 @@ export function reducer( state: SeoEnhancerState, action: SeoEnhancerAction ) {
 	switch ( action.type ) {
 		case 'SET_BUSY':
 			return { ...state, isBusy: action.isBusy };
+		case 'SET_IS_TOGGLING_AUTO_ENHANCE':
+			return { ...state, isTogglingAutoEnhance: action.isToggling };
+		case 'SET_IS_AUTO_ENHANCE_ENABLED':
+			return { ...state, isAutoEnhanceEnabled: action.isEnabled };
 		default:
 			return state;
 	}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/selectors.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/selectors.ts
@@ -1,0 +1,8 @@
+/**
+ * Types
+ */
+import type { SeoEnhancerState } from '../types';
+
+export function isBusy( state: SeoEnhancerState ) {
+	return state.isBusy;
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/selectors.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/selectors.ts
@@ -6,3 +6,11 @@ import type { SeoEnhancerState } from '../types';
 export function isBusy( state: SeoEnhancerState ) {
 	return state.isBusy;
 }
+
+export function isTogglingAutoEnhance( state: SeoEnhancerState ) {
+	return state.isTogglingAutoEnhance;
+}
+
+export function isAutoEnhanceEnabled( state: SeoEnhancerState ) {
+	return state.isAutoEnhanceEnabled;
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/types.ts
@@ -13,3 +13,12 @@ export type JetpackModuleSettings = {
 export type JetpackModuleSelector = {
 	getJetpackModules: () => JetpackModuleSettings;
 };
+
+export type SeoEnhancerState = {
+	isBusy: boolean;
+};
+
+export type SeoEnhancerAction = {
+	type: 'SET_BUSY';
+	isBusy: boolean;
+};

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/types.ts
@@ -15,10 +15,14 @@ export type JetpackModuleSelector = {
 };
 
 export type SeoEnhancerState = {
-	isBusy: boolean;
+	isBusy?: boolean;
+	isTogglingAutoEnhance?: boolean;
+	isAutoEnhanceEnabled?: boolean;
 };
 
 export type SeoEnhancerAction = {
-	type: 'SET_BUSY';
-	isBusy: boolean;
+	type: 'SET_BUSY' | 'SET_IS_TOGGLING_AUTO_ENHANCE' | 'SET_IS_AUTO_ENHANCE_ENABLED';
+	isBusy?: boolean;
+	isToggling?: boolean;
+	isEnabled?: boolean;
 };

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-module-settings.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-module-settings.ts
@@ -1,33 +1,24 @@
 /**
  * External dependencies
  */
-import { JETPACK_MODULES_STORE_ID } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
-import { select } from '@wordpress/data';
-import { useState, useCallback, useEffect } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
 import debugFactory from 'debug';
+/**
+ * Internal dependencies
+ */
+import { store } from './store';
 /**
  * Types
  */
-import type { JetpackModuleSelector } from './types';
-
 const debug = debugFactory( 'seo-enhancer:use-seo-module-settings' );
 
 export const useSeoModuleSettings = () => {
-	const [ isEnabled, setIsEnabled ] = useState( false );
-	const [ isToggling, setIsToggling ] = useState( false );
-
-	useEffect( () => {
-		const seoModuleSettings = (
-			select( JETPACK_MODULES_STORE_ID ) as JetpackModuleSelector
-		 ).getJetpackModules()[ 'seo-tools' ];
-		const enhancerAvailable =
-			seoModuleSettings && 'ai_seo_enhancer_enabled' in seoModuleSettings.options;
-		const enhancerEnabled =
-			enhancerAvailable && seoModuleSettings.options?.ai_seo_enhancer_enabled?.current_value;
-
-		setIsEnabled( enhancerEnabled );
-	}, [] );
+	const isEnabled = useSelect( select => select( store ).isAutoEnhanceEnabled(), [] );
+	const isToggling = useSelect( select => select( store ).isTogglingAutoEnhance(), [] );
+	const setIsToggling = useDispatch( store ).setIsTogglingAutoEnhance;
+	const setIsEnabled = useDispatch( store ).setIsAutoEnhanceEnabled;
 
 	const toggleEnhancer = useCallback( async () => {
 		setIsToggling( true );
@@ -44,7 +35,7 @@ export const useSeoModuleSettings = () => {
 		} finally {
 			setIsToggling( false );
 		}
-	}, [ isEnabled ] );
+	}, [ isEnabled, setIsEnabled, setIsToggling ] );
 
 	return {
 		isEnabled,

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -63,15 +63,21 @@ const Seo = () => {
 		return postTypeObject?.viewable;
 	}, [] );
 	const previousIsOpenRef = useRef( false );
-	const { isEnabled } = useSeoModuleSettings();
+	const { isEnabled, isToggling } = useSeoModuleSettings();
 
 	useEffect( () => {
-		if ( isPrePublishPanelOpen && ! previousIsOpenRef.current && ! isBusy && isEnabled ) {
+		if (
+			isPrePublishPanelOpen &&
+			! previousIsOpenRef.current &&
+			! isBusy &&
+			isEnabled &&
+			! isToggling
+		) {
 			updateSeoData();
 		}
 
 		previousIsOpenRef.current = isPrePublishPanelOpen;
-	}, [ isPrePublishPanelOpen, updateSeoData, isBusy, isEnabled ] );
+	}, [ isPrePublishPanelOpen, updateSeoData, isBusy, isEnabled, isToggling ] );
 
 	// If the post type is not viewable, do not render my plugin.
 	if ( ! isViewable ) {

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -14,7 +14,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { store as editorStore } from '@wordpress/editor';
-import { createPortal } from '@wordpress/element';
+import { createPortal, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 /**
@@ -28,6 +28,8 @@ import {
 } from '../ai-assistant-plugin/components/seo-assistant';
 import { STORE_NAME } from '../ai-assistant-plugin/components/seo-assistant/store';
 import { SeoEnhancer } from '../ai-assistant-plugin/components/seo-enhancer';
+import { useSeoModuleSettings } from '../ai-assistant-plugin/components/seo-enhancer/use-seo-module-settings';
+import { useSeoRequests } from '../ai-assistant-plugin/components/seo-enhancer/use-seo-requests';
 import { SeoPlaceholder } from './components/placeholder';
 import { SeoSkeletonLoader } from './components/skeleton-loader';
 import UpsellNotice from './components/upsell';
@@ -47,7 +49,12 @@ const isSeoEnhancerEnabled =
 const Seo = () => {
 	const { isLoadingModules, isChangingStatus, isModuleActive, changeStatus } =
 		useModuleStatus( 'seo-tools' );
+	const isPrePublishPanelOpen = useSelect(
+		select => select( editorStore ).isPublishSidebarOpened(),
+		[]
+	);
 	const isSeoAssistantOpen = useSelect( select => select( STORE_NAME ).isOpen(), [] );
+	const { updateSeoData, isBusy } = useSeoRequests();
 
 	const isViewable = useSelect( select => {
 		const postTypeName = select( editorStore ).getCurrentPostType();
@@ -55,6 +62,17 @@ const Seo = () => {
 
 		return postTypeObject?.viewable;
 	}, [] );
+	const previousIsOpenRef = useRef( false );
+	const { isEnabled } = useSeoModuleSettings();
+
+	useEffect( () => {
+		if ( isPrePublishPanelOpen && ! previousIsOpenRef.current && ! isBusy && isEnabled ) {
+			updateSeoData();
+		}
+
+		previousIsOpenRef.current = isPrePublishPanelOpen;
+	}, [ isPrePublishPanelOpen, updateSeoData, isBusy, isEnabled ] );
+
 	// If the post type is not viewable, do not render my plugin.
 	if ( ! isViewable ) {
 		return null;
@@ -110,6 +128,7 @@ const Seo = () => {
 	const jetpackSeoPrePublishPanelProps = {
 		icon: <JetpackEditorPanelLogo />,
 		title: __( 'SEO', 'jetpack' ),
+		initialOpen: isSeoEnhancerEnabled,
 	};
 
 	// TODO: remove all code related to the SeoAssistantWizard if it's a no-go


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #42408 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a store for loading state and seo module settings
* Auto-runs the requests if the toggle is on

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor with the feature enabled
* Clear out the SEO description and titles on the Jetpack sidebar, if any
* Add an image without alt text
* Open the Jetpack sidebar and disable the auto-enhance toggle
* Click on Publish
* Check that the SEO panel is open, but nothing happens
* Enable the toggle
* Check that nothing happens other than the toggle value changing. Cancel
* Check that the value was updated in the Jetpack sidebar
* Click on Publish again
* Check that the action starts automatically and the loading state is correct
