### PR TITLE
Big Sky Free Trial: Allow Global Styles

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-big-sky-free-trial-global-styles-exception
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-big-sky-free-trial-global-styles-exception
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: MU Plugin: No impact
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -60,6 +60,12 @@ function wpcom_should_limit_global_styles( $blog_id = 0 ) {
 		return false;
 	}
 
+	// Do not limit Global Styles on Big Sky free trial sites. Those sites will
+	// have their own paywall to go through.
+	if ( wpcom_global_styles_has_blog_sticker( 'big-sky-free-trial', $blog_id ) ) {
+		return false;
+	}
+
 	// Do not limit Global Styles if the site paid for it.
 	if ( wpcom_site_has_global_styles_feature( $blog_id ) ) {
 		return false;

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-big-sky-free-trial-global-styles-exception
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-big-sky-free-trial-global-styles-exception
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: MU Plugin: No impact
+
+

--- a/projects/plugins/wpcomsh/changelog/add-big-sky-free-trial-global-styles-exception
+++ b/projects/plugins/wpcomsh/changelog/add-big-sky-free-trial-global-styles-exception
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: MU Plugin: No impact
+
+


### PR DESCRIPTION
## Proposed changes:
Allow Big Sky Free Trial sites to use Global Styles.

All these sites will either end up with a Premium plan or will be abandoned, so there's no need to gate access to Global Styles during the site creation phase.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Create a new free simple site.
2. Add the sticker to it.
3. See if you have access to Global Styles :)