### PR TITLE
Launchpad: Do not hide the site title task from the updated write launchpad

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-new-write-launchpad-do-not-hide-title-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-new-write-launchpad-do-not-hide-title-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Launchpad: show site title task in updated write launchpad

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -2423,7 +2423,7 @@ function wpcom_launchpad_is_front_page_updated_visible() {
 function wpcom_launchpad_is_site_title_task_visible( $task, $is_visible, $data ) {
 	// Hide the task if it's already completed on write intent
 	if (
-		( $data['launchpad_context'] !== 'focused-customer-home' || ! $data['updated_write_tasklist'] ) &&
+		( 'launched' === get_option( 'launch-status' ) || ! $data['updated_write_tasklist'] ) &&
 		get_option( 'site_intent' ) === 'write' &&
 		wpcom_launchpad_is_task_option_completed( array( 'id' => 'site_title' ) )
 	) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/101266

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The site title task was hidden for the write intent in #33291 because
the write onboarding flow already included steps for setting the site
title. This is no longer the case.

Raised in pdtkmj-3rd-p2#comment-6436

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply patch to sandbox (see https://github.com/Automattic/jetpack/pull/42410#issuecomment-2719192954)
* Test using `wpcalypso.wordpress.com`
  * Or some environment where `onboarding/enable-write-goal-features` is enabled
* Create site with `/setup/onboarding`
* Ensure you choose the "Publish a blog" goal
* The site title should appear in the focused launchpad
* Skip the focused launchpad
* The site title task should appear in the My Home launchpad card
* Create _another_ test site
* This time complete the launchpad and launch the site
* When you land on My Home with the launchpad card, the site title task shouldn't appear. Just like it currently doesn't appear in production.