### PR TITLE
Remove remaining product data from window state

### DIFF
--- a/projects/packages/my-jetpack/.phan/baseline.php
+++ b/projects/packages/my-jetpack/.phan/baseline.php
@@ -16,7 +16,6 @@ return [
     // PhanNoopNew : 6 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 4 occurrences
     // PhanTypeMismatchReturnNullable : 3 occurrences
-    // PhanUndeclaredClassMethod : 3 occurrences
     // PhanImpossibleCondition : 2 occurrences
     // PhanNonClassMethodCall : 2 occurrences
     // PhanRedundantCondition : 2 occurrences
@@ -29,7 +28,7 @@ return [
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-activitylog.php' => ['PhanTypeMismatchArgumentProbablyReal'],
-        'src/class-initializer.php' => ['PhanImpossibleCondition', 'PhanNoopNew', 'PhanRedundantCondition', 'PhanTypeMismatchReturnNullable', 'PhanUndeclaredClassMethod'],
+        'src/class-initializer.php' => ['PhanImpossibleCondition', 'PhanNoopNew', 'PhanRedundantCondition', 'PhanTypeMismatchReturnNullable'],
         'src/class-jetpack-manage.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'src/class-products.php' => ['PhanNonClassMethodCall'],
         'src/class-rest-products.php' => ['PhanPluginMixedKeyNoKey'],

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/auto-firewall-status.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/auto-firewall-status.tsx
@@ -1,78 +1,52 @@
 import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { QUERY_GET_PROTECT_DATA_KEY, REST_API_GET_PROTECT_DATA } from '../../../data/constants';
 import useProduct from '../../../data/products/use-product';
-import useSimpleQuery from '../../../data/use-simple-query';
 import useMyJetpackConnection from '../../../hooks/use-my-jetpack-connection';
 import { InfoTooltip } from '../../info-tooltip';
-import LoadingBlock from '../../loading-block';
 import baseStyles from '../style.module.scss';
 import ShieldInactive from './assets/shield-inactive.svg';
 import ShieldOff from './assets/shield-off.svg';
 import ShieldSuccess from './assets/shield-success.svg';
 import { useProtectTooltipCopy } from './use-protect-tooltip-copy';
+import type { FC } from 'react';
 
-export const AutoFirewallStatus = () => {
+interface AutoFirewallStatusProps {
+	data: ProtectData;
+}
+
+export const AutoFirewallStatus: FC< AutoFirewallStatusProps > = ( { data } ) => {
 	const slug = 'protect';
 	const { detail } = useProduct( slug );
 	const { isPluginActive = false } = detail || {};
 	const { isSiteConnected } = useMyJetpackConnection();
-	const { data: protectData } = useSimpleQuery< ProtectData >( {
-		name: QUERY_GET_PROTECT_DATA_KEY,
-		query: {
-			path: REST_API_GET_PROTECT_DATA,
-		},
-	} );
 
 	const { jetpack_waf_automatic_rules: isAutoFirewallEnabled, waf_enabled: isWafEnabled } =
-		protectData?.wafConfig || {};
+		data?.wafConfig || {};
 
 	if ( isPluginActive && isSiteConnected ) {
 		if ( isAutoFirewallEnabled && isWafEnabled ) {
-			return <WafStatus status="active" />;
+			return <WafStatus data={ data } status="active" />;
 		}
 
-		return <WafStatus status="inactive" />;
+		return <WafStatus data={ data } status="inactive" />;
 	}
 
-	return <WafStatus status="off" />;
+	return <WafStatus data={ data } status="off" />;
 };
 
-/**
- * WafStatus component
- *
- * @param props        - The component props
- * @param props.status - The status of the WAF
- *
- * @return rendered component
- */
-function WafStatus( { status }: { status: 'active' | 'inactive' | 'off' } ) {
+interface WafStatusProps {
+	data: ProtectData;
+	status: 'active' | 'inactive' | 'off';
+}
+
+const WafStatus: FC< WafStatusProps > = ( { status, data } ) => {
 	const slug = 'protect';
 	const isMobileViewport: boolean = useViewportMatch( 'medium', '<' );
 	const { detail } = useProduct( slug );
 	const { hasPaidPlanForProduct = false } = detail || {};
-	const tooltipContent = useProtectTooltipCopy();
+	const tooltipContent = useProtectTooltipCopy( data );
 	const { autoFirewallTooltip } = tooltipContent;
-	const { isLoading } = useSimpleQuery< ProtectData >( {
-		name: QUERY_GET_PROTECT_DATA_KEY,
-		query: {
-			path: REST_API_GET_PROTECT_DATA,
-		},
-	} );
-
-	if ( isLoading ) {
-		return (
-			<>
-				<div className={ baseStyles.valueSectionHeading }>
-					{ __( 'Auto-Firewall', 'jetpack-my-jetpack' ) }
-				</div>
-				<div className="value-section__data">
-					<LoadingBlock height="30px" width="75px" />
-				</div>
-			</>
-		);
-	}
 
 	if ( status === 'active' ) {
 		return (
@@ -144,4 +118,4 @@ function WafStatus( { status }: { status: 'active' | 'inactive' | 'off' } ) {
 			</div>
 		</>
 	);
-}
+};

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/auto-firewall-status.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/auto-firewall-status.tsx
@@ -1,10 +1,12 @@
 import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
+import { QUERY_GET_PROTECT_DATA_KEY, REST_API_GET_PROTECT_DATA } from '../../../data/constants';
 import useProduct from '../../../data/products/use-product';
-import { getMyJetpackWindowInitialState } from '../../../data/utils/get-my-jetpack-window-state';
+import useSimpleQuery from '../../../data/use-simple-query';
 import useMyJetpackConnection from '../../../hooks/use-my-jetpack-connection';
 import { InfoTooltip } from '../../info-tooltip';
+import LoadingBlock from '../../loading-block';
 import baseStyles from '../style.module.scss';
 import ShieldInactive from './assets/shield-inactive.svg';
 import ShieldOff from './assets/shield-off.svg';
@@ -16,11 +18,15 @@ export const AutoFirewallStatus = () => {
 	const { detail } = useProduct( slug );
 	const { isPluginActive = false } = detail || {};
 	const { isSiteConnected } = useMyJetpackConnection();
-	const {
-		protect: { wafConfig: wafData },
-	} = getMyJetpackWindowInitialState();
+	const { data: protectData } = useSimpleQuery< ProtectData >( {
+		name: QUERY_GET_PROTECT_DATA_KEY,
+		query: {
+			path: REST_API_GET_PROTECT_DATA,
+		},
+	} );
+
 	const { jetpack_waf_automatic_rules: isAutoFirewallEnabled, waf_enabled: isWafEnabled } =
-		wafData || {};
+		protectData?.wafConfig || {};
 
 	if ( isPluginActive && isSiteConnected ) {
 		if ( isAutoFirewallEnabled && isWafEnabled ) {
@@ -48,6 +54,25 @@ function WafStatus( { status }: { status: 'active' | 'inactive' | 'off' } ) {
 	const { hasPaidPlanForProduct = false } = detail || {};
 	const tooltipContent = useProtectTooltipCopy();
 	const { autoFirewallTooltip } = tooltipContent;
+	const { isLoading } = useSimpleQuery< ProtectData >( {
+		name: QUERY_GET_PROTECT_DATA_KEY,
+		query: {
+			path: REST_API_GET_PROTECT_DATA,
+		},
+	} );
+
+	if ( isLoading ) {
+		return (
+			<>
+				<div className={ baseStyles.valueSectionHeading }>
+					{ __( 'Auto-Firewall', 'jetpack-my-jetpack' ) }
+				</div>
+				<div className="value-section__data">
+					<LoadingBlock height="30px" width="75px" />
+				</div>
+			</>
+		);
+	}
 
 	if ( status === 'active' ) {
 		return (

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/logins-blocked-status.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/logins-blocked-status.tsx
@@ -1,11 +1,13 @@
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
+import { QUERY_GET_PROTECT_DATA_KEY, REST_API_GET_PROTECT_DATA } from '../../../data/constants';
 import useProduct from '../../../data/products/use-product';
-import { getMyJetpackWindowInitialState } from '../../../data/utils/get-my-jetpack-window-state';
+import useSimpleQuery from '../../../data/use-simple-query';
 import useMyJetpackConnection from '../../../hooks/use-my-jetpack-connection';
 import numberFormat from '../../../utils/format-number';
 import { isJetpackPluginActive } from '../../../utils/is-jetpack-plugin-active';
 import { InfoTooltip } from '../../info-tooltip';
+import LoadingBlock from '../../loading-block';
 import baseStyles from '../style.module.scss';
 import ShieldOff from './assets/shield-off.svg';
 import ShieldPartial from './assets/shield-partial.svg';
@@ -16,11 +18,14 @@ export const LoginsBlockedStatus = () => {
 	const { detail } = useProduct( slug );
 	const { isPluginActive: isProtectPluginActive = false } = detail || {};
 	const { isSiteConnected } = useMyJetpackConnection();
-	const {
-		protect: { wafConfig: wafData },
-	} = getMyJetpackWindowInitialState();
+	const { data: protectData } = useSimpleQuery< ProtectData >( {
+		name: QUERY_GET_PROTECT_DATA_KEY,
+		query: {
+			path: REST_API_GET_PROTECT_DATA,
+		},
+	} );
 	const { blocked_logins: blockedLoginsCount, brute_force_protection: hasBruteForceProtection } =
-		wafData || {};
+		protectData?.wafConfig || {};
 
 	// The Brute Force Protection module is available when either the Jetpack plugin Or the Protect plugin is active.
 	const isPluginActive = isProtectPluginActive || isJetpackPluginActive();
@@ -48,13 +53,29 @@ export const LoginsBlockedStatus = () => {
  * @return rendered component
  */
 function BlockedStatus( { status }: { status: 'active' | 'inactive' | 'off' } ) {
-	const {
-		protect: { wafConfig: wafData },
-	} = getMyJetpackWindowInitialState();
-	const { blocked_logins: blockedLoginsCount } = wafData || {};
+	const { data: protectData, isLoading } = useSimpleQuery< ProtectData >( {
+		name: QUERY_GET_PROTECT_DATA_KEY,
+		query: {
+			path: REST_API_GET_PROTECT_DATA,
+		},
+	} );
+	const { blocked_logins: blockedLoginsCount } = protectData?.wafConfig || {};
 
 	const tooltipContent = useProtectTooltipCopy();
 	const { blockedLoginsTooltip } = tooltipContent;
+
+	if ( isLoading ) {
+		return (
+			<>
+				<div className={ baseStyles.valueSectionHeading }>
+					{ __( 'Logins Blocked', 'jetpack-my-jetpack' ) }
+				</div>
+				<div className="value-section__data">
+					<LoadingBlock height="30px" width="75px" />
+				</div>
+			</>
+		);
+	}
 
 	if ( status === 'active' ) {
 		return blockedLoginsCount > 0 ? (

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/logins-blocked-status.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/logins-blocked-status.tsx
@@ -1,81 +1,55 @@
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { QUERY_GET_PROTECT_DATA_KEY, REST_API_GET_PROTECT_DATA } from '../../../data/constants';
 import useProduct from '../../../data/products/use-product';
-import useSimpleQuery from '../../../data/use-simple-query';
 import useMyJetpackConnection from '../../../hooks/use-my-jetpack-connection';
 import numberFormat from '../../../utils/format-number';
 import { isJetpackPluginActive } from '../../../utils/is-jetpack-plugin-active';
 import { InfoTooltip } from '../../info-tooltip';
-import LoadingBlock from '../../loading-block';
 import baseStyles from '../style.module.scss';
 import ShieldOff from './assets/shield-off.svg';
 import ShieldPartial from './assets/shield-partial.svg';
 import { useProtectTooltipCopy } from './use-protect-tooltip-copy';
+import type { FC } from 'react';
 
-export const LoginsBlockedStatus = () => {
+interface LoginsBlockedStatusProps {
+	data: ProtectData;
+}
+
+export const LoginsBlockedStatus: FC< LoginsBlockedStatusProps > = ( { data } ) => {
 	const slug = 'protect';
 	const { detail } = useProduct( slug );
 	const { isPluginActive: isProtectPluginActive = false } = detail || {};
 	const { isSiteConnected } = useMyJetpackConnection();
-	const { data: protectData } = useSimpleQuery< ProtectData >( {
-		name: QUERY_GET_PROTECT_DATA_KEY,
-		query: {
-			path: REST_API_GET_PROTECT_DATA,
-		},
-	} );
 	const { blocked_logins: blockedLoginsCount, brute_force_protection: hasBruteForceProtection } =
-		protectData?.wafConfig || {};
+		data?.wafConfig || {};
 
 	// The Brute Force Protection module is available when either the Jetpack plugin Or the Protect plugin is active.
 	const isPluginActive = isProtectPluginActive || isJetpackPluginActive();
 
 	if ( isPluginActive && isSiteConnected ) {
 		if ( hasBruteForceProtection ) {
-			return <BlockedStatus status="active" />;
+			return <BlockedStatus data={ data } status="active" />;
 		}
 
-		return <BlockedStatus status="inactive" />;
+		return <BlockedStatus data={ data } status="inactive" />;
 	}
 	if ( isSiteConnected && blockedLoginsCount > 0 ) {
 		// logins have been blocked previoulsy, but either the Jetpack or Protect plugin is not active
-		return <BlockedStatus status="inactive" />;
+		return <BlockedStatus data={ data } status="inactive" />;
 	}
-	return <BlockedStatus status="off" />;
+	return <BlockedStatus data={ data } status="off" />;
 };
 
-/**
- * BlockedStatus component
- *
- * @param props        - The component props
- * @param props.status - The status of Brute Force Protection
- *
- * @return rendered component
- */
-function BlockedStatus( { status }: { status: 'active' | 'inactive' | 'off' } ) {
-	const { data: protectData, isLoading } = useSimpleQuery< ProtectData >( {
-		name: QUERY_GET_PROTECT_DATA_KEY,
-		query: {
-			path: REST_API_GET_PROTECT_DATA,
-		},
-	} );
-	const { blocked_logins: blockedLoginsCount } = protectData?.wafConfig || {};
+interface BlockedStatusProps {
+	status: 'active' | 'inactive' | 'off';
+	data: ProtectData;
+}
 
-	const tooltipContent = useProtectTooltipCopy();
+const BlockedStatus: FC< BlockedStatusProps > = ( { status, data } ) => {
+	const { blocked_logins: blockedLoginsCount } = data?.wafConfig || {};
+
+	const tooltipContent = useProtectTooltipCopy( data );
 	const { blockedLoginsTooltip } = tooltipContent;
-
-	if ( isLoading ) {
-		return (
-			<>
-				<div className={ baseStyles.valueSectionHeading }>
-					{ __( 'Logins Blocked', 'jetpack-my-jetpack' ) }
-				</div>
-				<div className="value-section__data">
-					<LoadingBlock height="30px" width="75px" />
-				</div>
-			</>
-		);
-	}
 
 	if ( status === 'active' ) {
 		return blockedLoginsCount > 0 ? (
@@ -184,4 +158,4 @@ function BlockedStatus( { status }: { status: 'active' | 'inactive' | 'off' } ) 
 			</div>
 		</>
 	);
-}
+};

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/protect-value-section.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/protect-value-section.tsx
@@ -1,5 +1,8 @@
+import { QUERY_GET_PROTECT_DATA_KEY, REST_API_GET_PROTECT_DATA } from '../../../data/constants';
 import useProduct from '../../../data/products/use-product';
+import useSimpleQuery from '../../../data/use-simple-query';
 import { InfoTooltip } from '../../info-tooltip';
+import LoadingBlock from '../../loading-block';
 import { AutoFirewallStatus } from './auto-firewall-status';
 import { LoginsBlockedStatus } from './logins-blocked-status';
 import { ScanAndThreatStatus } from './scan-threats-status';
@@ -15,11 +18,21 @@ const ProtectValueSection = () => {
 	const lastScanText = useLastScanText();
 	const tooltipContent = useProtectTooltipCopy();
 	const { pluginsThemesTooltip } = tooltipContent;
+	const { isLoading } = useSimpleQuery< ProtectData >( {
+		name: QUERY_GET_PROTECT_DATA_KEY,
+		query: {
+			path: REST_API_GET_PROTECT_DATA,
+		},
+	} );
 
 	return (
 		<>
 			<div className="value-section__last-scan">
-				{ lastScanText && <div>{ lastScanText }</div> }
+				{ isLoading ? (
+					<LoadingBlock width="150px" height="16px" />
+				) : (
+					lastScanText && <div>{ lastScanText }</div>
+				) }
 				{ ! isPluginActive && (
 					<InfoTooltip
 						tracksEventName={ 'protect_card_tooltip_open' }

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/protect-value-section.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/protect-value-section.tsx
@@ -52,21 +52,21 @@ const ProtectValueSection = () => {
 			<div className="value-section">
 				<div className="value-section__scan-threats">
 					{ isLoading ? (
-						<LoadingBlock width="100px" height="50px" />
+						<LoadingBlock width="75px" height="50px" />
 					) : (
 						<ScanAndThreatStatus data={ protectData } />
 					) }
 				</div>
 				<div className="value-section__auto-firewall">
 					{ isLoading ? (
-						<LoadingBlock width="100px" height="50px" />
+						<LoadingBlock width="75px" height="50px" />
 					) : (
 						<AutoFirewallStatus data={ protectData } />
 					) }
 				</div>
 				<div className="value-section__logins-blocked">
 					{ isLoading ? (
-						<LoadingBlock width="100px" height="50px" />
+						<LoadingBlock width="75px" height="50px" />
 					) : (
 						<LoginsBlockedStatus data={ protectData } />
 					) }

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/protect-value-section.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/protect-value-section.tsx
@@ -13,17 +13,19 @@ import './style.scss';
 
 const ProtectValueSection = () => {
 	const slug = 'protect';
-	const { detail } = useProduct( slug );
+	const { detail, isLoading: isLoadingProduct } = useProduct( slug );
 	const { isPluginActive = false } = detail || {};
-	const lastScanText = useLastScanText();
-	const tooltipContent = useProtectTooltipCopy();
-	const { pluginsThemesTooltip } = tooltipContent;
-	const { isLoading } = useSimpleQuery< ProtectData >( {
+	const { data: protectData, isLoading: isLoadingProtectData } = useSimpleQuery< ProtectData >( {
 		name: QUERY_GET_PROTECT_DATA_KEY,
 		query: {
 			path: REST_API_GET_PROTECT_DATA,
 		},
 	} );
+	const lastScanText = useLastScanText( protectData );
+	const tooltipContent = useProtectTooltipCopy( protectData );
+	const { pluginsThemesTooltip } = tooltipContent;
+
+	const isLoading = isLoadingProduct || isLoadingProtectData;
 
 	return (
 		<>
@@ -49,13 +51,25 @@ const ProtectValueSection = () => {
 			</div>
 			<div className="value-section">
 				<div className="value-section__scan-threats">
-					<ScanAndThreatStatus />
+					{ isLoading ? (
+						<LoadingBlock width="100px" height="50px" />
+					) : (
+						<ScanAndThreatStatus data={ protectData } />
+					) }
 				</div>
 				<div className="value-section__auto-firewall">
-					<AutoFirewallStatus />
+					{ isLoading ? (
+						<LoadingBlock width="100px" height="50px" />
+					) : (
+						<AutoFirewallStatus data={ protectData } />
+					) }
 				</div>
 				<div className="value-section__logins-blocked">
-					<LoginsBlockedStatus />
+					{ isLoading ? (
+						<LoadingBlock width="100px" height="50px" />
+					) : (
+						<LoginsBlockedStatus data={ protectData } />
+					) }
 				</div>
 			</div>
 		</>

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/scan-threats-status.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/scan-threats-status.tsx
@@ -4,11 +4,13 @@ import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useMemo, useState, useCallback, useRef } from 'react';
+import { REST_API_GET_PROTECT_DATA, QUERY_GET_PROTECT_DATA_KEY } from '../../../data/constants';
 import useProduct from '../../../data/products/use-product';
-import { getMyJetpackWindowInitialState } from '../../../data/utils/get-my-jetpack-window-state';
+import useSimpleQuery from '../../../data/use-simple-query';
 import useAnalytics from '../../../hooks/use-analytics';
 import useMyJetpackConnection from '../../../hooks/use-my-jetpack-connection';
 import { InfoTooltip } from '../../info-tooltip';
+import LoadingBlock from '../../loading-block';
 import baseStyles from '../style.module.scss';
 import ShieldOff from './assets/shield-off.svg';
 import ShieldPartial from './assets/shield-partial.svg';
@@ -20,13 +22,18 @@ export const ScanAndThreatStatus = () => {
 	const { detail } = useProduct( slug );
 	const { isPluginActive = false, hasPaidPlanForProduct: hasProtectPaidPlan } = detail || {};
 	const { isSiteConnected } = useMyJetpackConnection();
-	const {
-		protect: { scanData },
-	} = getMyJetpackWindowInitialState();
-	const { plugins, themes, num_threats: numThreats = 0 } = scanData || {};
+	const { data: protectData } = useSimpleQuery< ProtectData >( {
+		name: QUERY_GET_PROTECT_DATA_KEY,
+		query: {
+			path: REST_API_GET_PROTECT_DATA,
+		},
+	} );
+
+	const { plugins, themes, num_threats: numThreats = 0 } = protectData?.scanData || {};
 
 	const criticalScanThreatCount = useMemo( () => {
-		const { core, database, files, num_plugins_threats, num_themes_threats } = scanData || {};
+		const { core, database, files, num_plugins_threats, num_themes_threats } =
+			protectData?.scanData || {};
 		const pluginsThreats = num_plugins_threats
 			? plugins.reduce( ( accum, plugin ) => accum.concat( plugin.threats ), [] )
 			: [];
@@ -37,14 +44,14 @@ export const ScanAndThreatStatus = () => {
 			...pluginsThreats,
 			...themesThreats,
 			...( core?.threats ?? [] ),
-			...database,
-			...files,
+			...( database ?? [] ),
+			...( files ?? [] ),
 		];
 		return allThreats.reduce(
 			( accum, threat ) => ( threat.severity >= 5 ? ( accum += 1 ) : accum ),
 			0
 		);
-	}, [ plugins, themes, scanData ] );
+	}, [ plugins, themes, protectData?.scanData ] );
 
 	if ( isPluginActive && isSiteConnected ) {
 		if ( hasProtectPaidPlan ) {
@@ -190,6 +197,26 @@ function ThreatStatus( {
 function ScanStatus( { status }: { status: 'success' | 'partial' | 'off' } ) {
 	const tooltipContent = useProtectTooltipCopy();
 	const { scanThreatsTooltip } = tooltipContent;
+
+	const { isLoading } = useSimpleQuery< ProtectData >( {
+		name: QUERY_GET_PROTECT_DATA_KEY,
+		query: {
+			path: REST_API_GET_PROTECT_DATA,
+		},
+	} );
+
+	if ( isLoading ) {
+		return (
+			<>
+				<div className={ baseStyles.valueSectionHeading }>
+					{ __( 'Scan', 'jetpack-my-jetpack' ) }
+				</div>
+				<div className="value-section__data">
+					<LoadingBlock height="30px" width="75px" />
+				</div>
+			</>
+		);
+	}
 
 	if ( status === 'success' ) {
 		return (

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/scan-threats-status.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/scan-threats-status.tsx
@@ -4,36 +4,31 @@ import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useMemo, useState, useCallback, useRef } from 'react';
-import { REST_API_GET_PROTECT_DATA, QUERY_GET_PROTECT_DATA_KEY } from '../../../data/constants';
 import useProduct from '../../../data/products/use-product';
-import useSimpleQuery from '../../../data/use-simple-query';
 import useAnalytics from '../../../hooks/use-analytics';
 import useMyJetpackConnection from '../../../hooks/use-my-jetpack-connection';
 import { InfoTooltip } from '../../info-tooltip';
-import LoadingBlock from '../../loading-block';
 import baseStyles from '../style.module.scss';
 import ShieldOff from './assets/shield-off.svg';
 import ShieldPartial from './assets/shield-partial.svg';
 import ShieldSuccess from './assets/shield-success.svg';
 import { useProtectTooltipCopy } from './use-protect-tooltip-copy';
+import type { FC } from 'react';
 
-export const ScanAndThreatStatus = () => {
+interface ScanAndThreatStatusProps {
+	data: ProtectData;
+}
+
+export const ScanAndThreatStatus: FC< ScanAndThreatStatusProps > = ( { data } ) => {
 	const slug = 'protect';
 	const { detail } = useProduct( slug );
 	const { isPluginActive = false, hasPaidPlanForProduct: hasProtectPaidPlan } = detail || {};
 	const { isSiteConnected } = useMyJetpackConnection();
-	const { data: protectData } = useSimpleQuery< ProtectData >( {
-		name: QUERY_GET_PROTECT_DATA_KEY,
-		query: {
-			path: REST_API_GET_PROTECT_DATA,
-		},
-	} );
 
-	const { plugins, themes, num_threats: numThreats = 0 } = protectData?.scanData || {};
+	const { plugins, themes, num_threats: numThreats = 0 } = data?.scanData || {};
 
 	const criticalScanThreatCount = useMemo( () => {
-		const { core, database, files, num_plugins_threats, num_themes_threats } =
-			protectData?.scanData || {};
+		const { core, database, files, num_plugins_threats, num_themes_threats } = data?.scanData || {};
 		const pluginsThreats = num_plugins_threats
 			? plugins.reduce( ( accum, plugin ) => accum.concat( plugin.threats ), [] )
 			: [];
@@ -51,49 +46,44 @@ export const ScanAndThreatStatus = () => {
 			( accum, threat ) => ( threat.severity >= 5 ? ( accum += 1 ) : accum ),
 			0
 		);
-	}, [ plugins, themes, protectData?.scanData ] );
+	}, [ plugins, themes, data?.scanData ] );
 
 	if ( isPluginActive && isSiteConnected ) {
 		if ( hasProtectPaidPlan ) {
 			if ( numThreats ) {
 				return (
-					<ThreatStatus numThreats={ numThreats } criticalThreatCount={ criticalScanThreatCount } />
+					<ThreatStatus
+						data={ data }
+						numThreats={ numThreats }
+						criticalThreatCount={ criticalScanThreatCount }
+					/>
 				);
 			}
-			return <ScanStatus status="success" />;
+			return <ScanStatus data={ data } status="success" />;
 		}
 		return numThreats ? (
-			<ThreatStatus numThreats={ numThreats } />
+			<ThreatStatus data={ data } numThreats={ numThreats } />
 		) : (
-			<ScanStatus status="partial" />
+			<ScanStatus data={ data } status="partial" />
 		);
 	}
 
-	return <ScanStatus status="off" />;
+	return <ScanStatus data={ data } status="off" />;
 };
 
-/**
- * ThreatStatus component
- *
- * @param props                     - The component props
- * @param props.numThreats          - The number of threats
- * @param props.criticalThreatCount - The number of critical threats
- *
- * @return  rendered component
- */
-function ThreatStatus( {
-	numThreats,
-	criticalThreatCount,
-}: {
+interface ThreatStatusProps {
+	data: ProtectData;
 	numThreats: number;
 	criticalThreatCount?: number;
-} ) {
+}
+
+const ThreatStatus: FC< ThreatStatusProps > = ( { data, numThreats, criticalThreatCount } ) => {
 	const { recordEvent } = useAnalytics();
 	const useTooltipRef = useRef< HTMLButtonElement >();
 	const isMobileViewport: boolean = useViewportMatch( 'medium', '<' );
 	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
 
-	const tooltipContent = useProtectTooltipCopy();
+	const tooltipContent = useProtectTooltipCopy( data );
 	const { scanThreatsTooltip } = tooltipContent;
 
 	const toggleTooltip = useCallback(
@@ -184,39 +174,16 @@ function ThreatStatus( {
 			</div>
 		</>
 	);
+};
+
+interface ScanStatusProps {
+	data: ProtectData;
+	status: 'success' | 'partial' | 'off';
 }
 
-/**
- * ScanStatus component
- *
- * @param props        - The component props
- * @param props.status - The number of threats
- *
- * @return  rendered component
- */
-function ScanStatus( { status }: { status: 'success' | 'partial' | 'off' } ) {
-	const tooltipContent = useProtectTooltipCopy();
+const ScanStatus: FC< ScanStatusProps > = ( { data, status } ) => {
+	const tooltipContent = useProtectTooltipCopy( data );
 	const { scanThreatsTooltip } = tooltipContent;
-
-	const { isLoading } = useSimpleQuery< ProtectData >( {
-		name: QUERY_GET_PROTECT_DATA_KEY,
-		query: {
-			path: REST_API_GET_PROTECT_DATA,
-		},
-	} );
-
-	if ( isLoading ) {
-		return (
-			<>
-				<div className={ baseStyles.valueSectionHeading }>
-					{ __( 'Scan', 'jetpack-my-jetpack' ) }
-				</div>
-				<div className="value-section__data">
-					<LoadingBlock height="30px" width="75px" />
-				</div>
-			</>
-		);
-	}
 
 	if ( status === 'success' ) {
 		return (
@@ -286,4 +253,4 @@ function ScanStatus( { status }: { status: 'success' | 'partial' | 'off' } ) {
 			</div>
 		</>
 	);
-}
+};

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/use-last-scan-text.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/use-last-scan-text.ts
@@ -1,6 +1,8 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useMemo } from 'react';
+import { QUERY_GET_PROTECT_DATA_KEY, REST_API_GET_PROTECT_DATA } from '../../../data/constants';
 import useProduct from '../../../data/products/use-product';
+import useSimpleQuery from '../../../data/use-simple-query';
 import { getMyJetpackWindowInitialState } from '../../../data/utils/get-my-jetpack-window-state';
 import { timeSince } from '../../../utils/time-since';
 
@@ -8,19 +10,21 @@ export const useLastScanText = () => {
 	const slug = 'protect';
 	const { detail } = useProduct( slug );
 	const { isPluginActive = false } = detail || {};
-	const {
-		plugins,
-		themes,
-		protect: { scanData },
-	} = getMyJetpackWindowInitialState();
+	const { data: protectData } = useSimpleQuery< ProtectData >( {
+		name: QUERY_GET_PROTECT_DATA_KEY,
+		query: {
+			path: REST_API_GET_PROTECT_DATA,
+		},
+	} );
+	const { plugins, themes } = getMyJetpackWindowInitialState();
 	const {
 		plugins: fromScanPlugins,
 		themes: fromScanThemes,
 		last_checked: lastScanTime = null,
-	} = scanData || {};
+	} = protectData?.scanData || {};
 
-	const pluginsCount = fromScanPlugins.length || Object.keys( plugins ).length;
-	const themesCount = fromScanThemes.length || Object.keys( themes ).length;
+	const pluginsCount = fromScanPlugins?.length || Object.keys( plugins ).length;
+	const themesCount = fromScanThemes?.length || Object.keys( themes ).length;
 
 	const timeSinceLastScan = lastScanTime ? timeSince( Date.parse( lastScanTime ) ) : false;
 

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/use-last-scan-text.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/use-last-scan-text.ts
@@ -1,27 +1,19 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useMemo } from 'react';
-import { QUERY_GET_PROTECT_DATA_KEY, REST_API_GET_PROTECT_DATA } from '../../../data/constants';
 import useProduct from '../../../data/products/use-product';
-import useSimpleQuery from '../../../data/use-simple-query';
 import { getMyJetpackWindowInitialState } from '../../../data/utils/get-my-jetpack-window-state';
 import { timeSince } from '../../../utils/time-since';
 
-export const useLastScanText = () => {
+export const useLastScanText = ( data: ProtectData ) => {
 	const slug = 'protect';
 	const { detail } = useProduct( slug );
 	const { isPluginActive = false } = detail || {};
-	const { data: protectData } = useSimpleQuery< ProtectData >( {
-		name: QUERY_GET_PROTECT_DATA_KEY,
-		query: {
-			path: REST_API_GET_PROTECT_DATA,
-		},
-	} );
 	const { plugins, themes } = getMyJetpackWindowInitialState();
 	const {
 		plugins: fromScanPlugins,
 		themes: fromScanThemes,
 		last_checked: lastScanTime = null,
-	} = protectData?.scanData || {};
+	} = data?.scanData || {};
 
 	const pluginsCount = fromScanPlugins?.length || Object.keys( plugins ).length;
 	const themesCount = fromScanThemes?.length || Object.keys( themes ).length;

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/use-protect-tooltip-copy.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/use-protect-tooltip-copy.ts
@@ -1,13 +1,8 @@
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useCallback, useMemo, createElement, type ReactElement } from 'react';
-import {
-	PRODUCT_SLUGS,
-	QUERY_GET_PROTECT_DATA_KEY,
-	REST_API_GET_PROTECT_DATA,
-} from '../../../data/constants';
+import { PRODUCT_SLUGS } from '../../../data/constants';
 import useProduct from '../../../data/products/use-product';
-import useSimpleQuery from '../../../data/use-simple-query';
 import { getMyJetpackWindowInitialState } from '../../../data/utils/get-my-jetpack-window-state';
 import useAnalytics from '../../../hooks/use-analytics';
 import { isJetpackPluginActive } from '../../../utils/is-jetpack-plugin-active';
@@ -24,12 +19,7 @@ export type TooltipContent = {
 	};
 };
 
-/**
- * Gets the translated tooltip copy based on Protect Scan details.
- *
- * @return {TooltipContent} An object containing each tooltip's title and text content.
- */
-export function useProtectTooltipCopy(): TooltipContent {
+export const useProtectTooltipCopy = ( data: ProtectData ): TooltipContent => {
 	const slug = PRODUCT_SLUGS.PROTECT;
 	const { detail } = useProduct( slug );
 	const {
@@ -39,26 +29,20 @@ export function useProtectTooltipCopy(): TooltipContent {
 	} = detail || {};
 	const { isStandaloneActive } = standalonePluginInfo || {};
 	const { recordEvent } = useAnalytics();
-	const { data: protectData } = useSimpleQuery< ProtectData >( {
-		name: QUERY_GET_PROTECT_DATA_KEY,
-		query: {
-			path: REST_API_GET_PROTECT_DATA,
-		},
-	} );
 	const { plugins, themes } = getMyJetpackWindowInitialState();
 	const {
 		plugins: fromScanPlugins,
 		themes: fromScanThemes,
 		num_threats: numThreats = 0,
 		threats = [],
-	} = protectData?.scanData || {};
+	} = data?.scanData || {};
 	const {
 		jetpack_waf_automatic_rules: isAutoFirewallEnabled,
 		blocked_logins: blockedLoginsCount,
 		brute_force_protection: hasBruteForceProtection,
 		waf_supported: wafSupported,
 		waf_enabled: isWafEnabled,
-	} = protectData?.wafConfig || {};
+	} = data?.wafConfig || {};
 
 	const pluginsCount = fromScanPlugins?.length || Object.keys( plugins ).length;
 	const themesCount = fromScanThemes?.length || Object.keys( themes ).length;
@@ -285,4 +269,4 @@ export function useProtectTooltipCopy(): TooltipContent {
 				  },
 		blockedLoginsTooltip: blockedLoginsTooltip,
 	};
-}
+};

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/use-protect-tooltip-copy.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/use-protect-tooltip-copy.ts
@@ -1,8 +1,13 @@
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useCallback, useMemo, createElement, type ReactElement } from 'react';
-import { PRODUCT_SLUGS } from '../../../data/constants';
+import {
+	PRODUCT_SLUGS,
+	QUERY_GET_PROTECT_DATA_KEY,
+	REST_API_GET_PROTECT_DATA,
+} from '../../../data/constants';
 import useProduct from '../../../data/products/use-product';
+import useSimpleQuery from '../../../data/use-simple-query';
 import { getMyJetpackWindowInitialState } from '../../../data/utils/get-my-jetpack-window-state';
 import useAnalytics from '../../../hooks/use-analytics';
 import { isJetpackPluginActive } from '../../../utils/is-jetpack-plugin-active';
@@ -34,27 +39,29 @@ export function useProtectTooltipCopy(): TooltipContent {
 	} = detail || {};
 	const { isStandaloneActive } = standalonePluginInfo || {};
 	const { recordEvent } = useAnalytics();
-	const {
-		plugins,
-		themes,
-		protect: { scanData, wafConfig: wafData },
-	} = getMyJetpackWindowInitialState();
+	const { data: protectData } = useSimpleQuery< ProtectData >( {
+		name: QUERY_GET_PROTECT_DATA_KEY,
+		query: {
+			path: REST_API_GET_PROTECT_DATA,
+		},
+	} );
+	const { plugins, themes } = getMyJetpackWindowInitialState();
 	const {
 		plugins: fromScanPlugins,
 		themes: fromScanThemes,
 		num_threats: numThreats = 0,
 		threats = [],
-	} = scanData || {};
+	} = protectData?.scanData || {};
 	const {
 		jetpack_waf_automatic_rules: isAutoFirewallEnabled,
 		blocked_logins: blockedLoginsCount,
 		brute_force_protection: hasBruteForceProtection,
 		waf_supported: wafSupported,
 		waf_enabled: isWafEnabled,
-	} = wafData || {};
+	} = protectData?.wafConfig || {};
 
-	const pluginsCount = fromScanPlugins.length || Object.keys( plugins ).length;
-	const themesCount = fromScanThemes.length || Object.keys( themes ).length;
+	const pluginsCount = fromScanPlugins?.length || Object.keys( plugins ).length;
+	const themesCount = fromScanThemes?.length || Object.keys( themes ).length;
 
 	const criticalThreatCount: number = useMemo( () => {
 		return threats.length

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/index.tsx
@@ -23,13 +23,16 @@ import './style.scss';
 const slug = PRODUCT_SLUGS.VIDEOPRESS;
 
 const VideopressCard: ProductCardComponent = props => {
-	const { detail } = useProduct( slug );
-	const { data: videopressData, isLoading } = useSimpleQuery< VideopressData >( {
-		name: QUERY_GET_VIDEOPRESS_DATA_KEY,
-		query: {
-			path: REST_API_GET_VIDEOPRESS_DATA,
-		},
-	} );
+	const { detail, isLoading: isLoadingProductData } = useProduct( slug );
+	const { data: videopressData, isLoading: isLoadingVideopressData } =
+		useSimpleQuery< VideopressData >( {
+			name: QUERY_GET_VIDEOPRESS_DATA_KEY,
+			query: {
+				path: REST_API_GET_VIDEOPRESS_DATA,
+			},
+		} );
+
+	const isLoading = isLoadingProductData || isLoadingVideopressData;
 
 	const { status } = detail || {};
 

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/index.tsx
@@ -4,9 +4,13 @@
 import { Text } from '@automattic/jetpack-components';
 import { useCallback, useMemo } from 'react';
 import { PRODUCT_STATUSES } from '../../../constants';
-import { PRODUCT_SLUGS } from '../../../data/constants';
+import {
+	PRODUCT_SLUGS,
+	REST_API_GET_VIDEOPRESS_DATA,
+	QUERY_GET_VIDEOPRESS_DATA_KEY,
+} from '../../../data/constants';
 import useProduct from '../../../data/products/use-product';
-import { getMyJetpackWindowInitialState } from '../../../data/utils/get-my-jetpack-window-state';
+import useSimpleQuery from '../../../data/use-simple-query';
 import ProductCard from '../../connected-product-card';
 import { InfoTooltip } from '../../info-tooltip';
 import useTooltipCopy from './use-tooltip-copy';
@@ -20,10 +24,17 @@ const slug = PRODUCT_SLUGS.VIDEOPRESS;
 
 const VideopressCard: ProductCardComponent = props => {
 	const { detail } = useProduct( slug );
+	const { data: videopressData, isLoading } = useSimpleQuery< VideopressData >( {
+		name: QUERY_GET_VIDEOPRESS_DATA_KEY,
+		query: {
+			path: REST_API_GET_VIDEOPRESS_DATA,
+		},
+	} );
+
 	const { status } = detail || {};
-	const { videopress: data } = getMyJetpackWindowInitialState();
-	const { activeAndNoVideos } = useTooltipCopy();
-	const { videoCount = 0, featuredStats } = data || {};
+
+	const { activeAndNoVideos } = useTooltipCopy( videopressData );
+	const { videoCount = 0, featuredStats } = videopressData || {};
 
 	const isPluginActive =
 		status === PRODUCT_STATUSES.ACTIVE || status === PRODUCT_STATUSES.CAN_UPGRADE;
@@ -78,7 +89,11 @@ const VideopressCard: ProductCardComponent = props => {
 			Description={ Description }
 			customLoadTracks={ customLoadTracks }
 		>
-			<VideoPressValueSection isPluginActive={ isPluginActive } data={ data } />
+			<VideoPressValueSection
+				isPluginActive={ isPluginActive }
+				data={ videopressData }
+				isLoading={ isLoading }
+			/>
 		</ProductCard>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/use-tooltip-copy.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/use-tooltip-copy.ts
@@ -2,13 +2,11 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { createElement, useCallback } from 'react';
-import { getMyJetpackWindowInitialState } from '../../../data/utils/get-my-jetpack-window-state';
 import useAnalytics from '../../../hooks/use-analytics';
 
-const useTooltipCopy = () => {
+const useTooltipCopy = ( data: VideopressData ) => {
 	const { recordEvent } = useAnalytics();
-	const { videopress: data } = getMyJetpackWindowInitialState();
-	const { featuredStats, videoCount } = data || {};
+	const { featuredStats, videoCount = 0 } = data || {};
 	const { period } = featuredStats || {};
 	const hostingRedirectLink = getRedirectUrl( 'jetpack-videopress-my-jetpack-tooltip' );
 

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/videopress-value-section.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/videopress-value-section.tsx
@@ -6,17 +6,17 @@ import useProduct from '../../../data/products/use-product';
 import formatNumber from '../../../utils/format-number';
 import formatTime from '../../../utils/format-time';
 import { InfoTooltip } from '../../info-tooltip';
+import LoadingBlock from '../../loading-block';
 import baseStyles from '../style.module.scss';
 import useTooltipCopy from './use-tooltip-copy';
 import type { FC } from 'react';
 
 import './style.scss';
 
-type VideoPressWindowData = Window[ 'myJetpackInitialState' ][ 'videopress' ];
-
 interface VideoPressValueSectionProps {
 	isPluginActive: boolean;
-	data: VideoPressWindowData;
+	data: VideopressData;
+	isLoading: boolean;
 }
 
 interface ValueSectionProps {
@@ -24,7 +24,7 @@ interface ValueSectionProps {
 	previousValue: number;
 	formattedValue: string;
 	formattedDifference: string;
-	period: VideoPressWindowData[ 'featuredStats' ][ 'period' ];
+	period: VideopressData[ 'featuredStats' ][ 'period' ];
 }
 
 const ValueSection: FC< ValueSectionProps > = ( {
@@ -54,11 +54,15 @@ const ValueSection: FC< ValueSectionProps > = ( {
 	);
 };
 
-const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginActive, data } ) => {
+const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( {
+	isPluginActive,
+	data,
+	isLoading,
+} ) => {
 	const { detail } = useProduct( PRODUCT_SLUGS.VIDEOPRESS );
 	const { status, hasPaidPlanForProduct } = detail || {};
 	const { videoCount, featuredStats } = data || {};
-	const { inactiveWithVideos, viewsWithoutPlan, viewsWithPlan, watchTime } = useTooltipCopy();
+	const { inactiveWithVideos, viewsWithoutPlan, viewsWithPlan, watchTime } = useTooltipCopy( data );
 
 	if ( ! videoCount ) {
 		return null;
@@ -76,19 +80,25 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 				<div className="videopress-card__value-section__container">
 					<span className={ baseStyles.valueSectionHeading }>
 						{ __( 'Existing videos', 'jetpack-my-jetpack' ) }
-						<InfoTooltip
-							className="videopress-card__no-video-tooltip"
-							tracksEventName={ 'videopress_card_tooltip_open' }
-							tracksEventProps={ {
-								location: 'existing_videos',
-								feature: 'jetpack-videopress',
-								status,
-								video_count: videoCount,
-							} }
-						>
-							<h3>{ inactiveWithVideos.title }</h3>
-							<p>{ inactiveWithVideos.text }</p>
-						</InfoTooltip>
+						{ isLoading ? (
+							<LoadingBlock height="32px" width="100%" />
+						) : (
+							<>
+								<InfoTooltip
+									className="videopress-card__no-video-tooltip"
+									tracksEventName={ 'videopress_card_tooltip_open' }
+									tracksEventProps={ {
+										location: 'existing_videos',
+										feature: 'jetpack-videopress',
+										status,
+										video_count: videoCount,
+									} }
+								>
+									<h3>{ inactiveWithVideos.title }</h3>
+									<p>{ inactiveWithVideos.text }</p>
+								</InfoTooltip>
+							</>
+						) }
 					</span>
 					<span className="videopress-card__video-count">{ videoCount }</span>
 				</div>
@@ -147,13 +157,17 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 					</InfoTooltip>
 				</span>
 
-				<ValueSection
-					value={ currentViews }
-					previousValue={ previousViews }
-					formattedValue={ formatNumber( currentViews ) }
-					formattedDifference={ formatNumber( viewsDifference ) }
-					period={ period }
-				/>
+				{ isLoading ? (
+					<LoadingBlock height="32px" width="100%" />
+				) : (
+					<ValueSection
+						value={ currentViews }
+						previousValue={ previousViews }
+						formattedValue={ formatNumber( currentViews ) }
+						formattedDifference={ formatNumber( viewsDifference ) }
+						period={ period }
+					/>
+				) }
 			</div>
 
 			<div className="videopress-card__value-section__container">
@@ -180,13 +194,17 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 					</InfoTooltip>
 				</span>
 
-				<ValueSection
-					value={ currentWatchTime }
-					previousValue={ previousWatchTime }
-					formattedValue={ formatTime( currentWatchTime ) }
-					formattedDifference={ formatTime( watchTimeDifference ) }
-					period={ period }
-				/>
+				{ isLoading ? (
+					<LoadingBlock height="32px" width="100%" />
+				) : (
+					<ValueSection
+						value={ currentWatchTime }
+						previousValue={ previousWatchTime }
+						formattedValue={ formatTime( currentWatchTime ) }
+						formattedDifference={ formatTime( watchTimeDifference ) }
+						period={ period }
+					/>
+				) }
 			</div>
 		</div>
 	);

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/videopress-value-section.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/videopress-value-section.tsx
@@ -64,7 +64,7 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( {
 	const { videoCount, featuredStats } = data || {};
 	const { inactiveWithVideos, viewsWithoutPlan, viewsWithPlan, watchTime } = useTooltipCopy( data );
 
-	if ( ! videoCount ) {
+	if ( ! videoCount && ! isLoading ) {
 		return null;
 	}
 
@@ -115,7 +115,7 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( {
 	const viewsDifference = Math.abs( currentViews - previousViews );
 	const watchTimeDifference = Math.abs( currentWatchTime - previousWatchTime );
 
-	if ( currentViews === undefined || currentWatchTime === undefined ) {
+	if ( ! isLoading && ( currentViews === undefined || currentWatchTime === undefined ) ) {
 		return null;
 	}
 

--- a/projects/packages/my-jetpack/_inc/data/constants.ts
+++ b/projects/packages/my-jetpack/_inc/data/constants.ts
@@ -15,6 +15,7 @@ export const REST_API_SITE_EVALUATION_RESULT = `${ REST_API_NAMESPACE }/site/rec
 export const REST_API_UPDATE_HISTORICALLY_ACTIVE_MODULES = `${ REST_API_NAMESPACE }/site/update-historically-active-modules`;
 export const REST_API_GET_JETPACK_MANAGE_DATA = `${ REST_API_NAMESPACE }/jetpack-manage/data`;
 export const REST_API_RED_BUBBLE_ALERTS = `${ REST_API_NAMESPACE }/red-bubble-notifications`;
+export const REST_API_GET_PROTECT_DATA = `${ REST_API_NAMESPACE }/site/protect/data`;
 
 export const getStatsHighlightsEndpoint = ( blogId: string ) =>
 	`${ ODYSSEY_STATS_API_NAMESPACE }/sites/${ blogId }/stats/highlights`;
@@ -38,6 +39,7 @@ export const QUERY_REMOVE_EVALUATION_KEY = 'remove site evaluation result';
 export const QUERY_UPDATE_HISTORICALLY_ACTIVE_MODULES_KEY = 'update historically active modules';
 export const QUERY_GET_JETPACK_MANAGE_DATA_KEY = 'get jetpack manage data';
 export const QUERY_RED_BUBBLE_ALERTS_KEY = 'red bubble alerts';
+export const QUERY_GET_PROTECT_DATA_KEY = 'get protect data';
 
 // Product Slugs
 export const PRODUCT_SLUGS = {

--- a/projects/packages/my-jetpack/_inc/data/constants.ts
+++ b/projects/packages/my-jetpack/_inc/data/constants.ts
@@ -16,6 +16,7 @@ export const REST_API_UPDATE_HISTORICALLY_ACTIVE_MODULES = `${ REST_API_NAMESPAC
 export const REST_API_GET_JETPACK_MANAGE_DATA = `${ REST_API_NAMESPACE }/jetpack-manage/data`;
 export const REST_API_RED_BUBBLE_ALERTS = `${ REST_API_NAMESPACE }/red-bubble-notifications`;
 export const REST_API_GET_PROTECT_DATA = `${ REST_API_NAMESPACE }/site/protect/data`;
+export const REST_API_GET_VIDEOPRESS_DATA = `${ REST_API_NAMESPACE }/site/videopress/data`;
 
 export const getStatsHighlightsEndpoint = ( blogId: string ) =>
 	`${ ODYSSEY_STATS_API_NAMESPACE }/sites/${ blogId }/stats/highlights`;
@@ -40,6 +41,7 @@ export const QUERY_UPDATE_HISTORICALLY_ACTIVE_MODULES_KEY = 'update historically
 export const QUERY_GET_JETPACK_MANAGE_DATA_KEY = 'get jetpack manage data';
 export const QUERY_RED_BUBBLE_ALERTS_KEY = 'red bubble alerts';
 export const QUERY_GET_PROTECT_DATA_KEY = 'get protect data';
+export const QUERY_GET_VIDEOPRESS_DATA_KEY = 'get videopress data';
 
 // Product Slugs
 export const PRODUCT_SLUGS = {

--- a/projects/packages/my-jetpack/_inc/data/notices/use-fetching-error-notice.ts
+++ b/projects/packages/my-jetpack/_inc/data/notices/use-fetching-error-notice.ts
@@ -4,6 +4,8 @@ import { NOTICE_PRIORITY_LOW } from '../../context/constants';
 import { NoticeContext } from '../../context/notices/noticeContext';
 import {
 	QUERY_ACTIVATE_PRODUCT_KEY,
+	QUERY_GET_PROTECT_DATA_KEY,
+	QUERY_GET_VIDEOPRESS_DATA_KEY,
 	QUERY_INSTALL_PRODUCT_KEY,
 	QUERY_PURCHASES_KEY,
 } from '../constants';
@@ -19,6 +21,8 @@ const errorNoticeWhitelist = [
 	QUERY_PURCHASES_KEY,
 	QUERY_ACTIVATE_PRODUCT_KEY,
 	QUERY_INSTALL_PRODUCT_KEY,
+	QUERY_GET_PROTECT_DATA_KEY,
+	QUERY_GET_VIDEOPRESS_DATA_KEY,
 ];
 
 export const useFetchingErrorNotice = ( { infoName, isError, overrideMessage }: ErrorNotice ) => {

--- a/projects/packages/my-jetpack/changelog/remove-remaining-product-data-from-window-state
+++ b/projects/packages/my-jetpack/changelog/remove-remaining-product-data-from-window-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Call Protect and VideoPress product data on the frontend and remove from window state

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -18,7 +18,8 @@
 		"automattic/jetpack-plans": "@dev",
 		"automattic/jetpack-status": "@dev",
 		"automattic/jetpack-sync": "@dev",
-		"automattic/jetpack-protect-status": "@dev"
+		"automattic/jetpack-protect-status": "@dev",
+		"automattic/jetpack-waf": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^1.1.1",

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -18,8 +18,7 @@
 		"automattic/jetpack-plans": "@dev",
 		"automattic/jetpack-status": "@dev",
 		"automattic/jetpack-sync": "@dev",
-		"automattic/jetpack-protect-status": "@dev",
-		"automattic/jetpack-waf": "@dev"
+		"automattic/jetpack-protect-status": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^1.1.1",

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -452,6 +452,28 @@ type ProtectData = {
 	};
 };
 
+type VideopressData = {
+	featuredStats?: {
+		label: string;
+		period: 'day' | 'year';
+		data: {
+			views: {
+				current: number;
+				previous: number;
+			};
+			impressions: {
+				current: number;
+				previous: number;
+			};
+			watch_time: {
+				current: number;
+				previous: number;
+			};
+		};
+	};
+	videoCount: number;
+};
+
 interface Window {
 	myJetpackInitialState?: {
 		siteSuffix: string;
@@ -615,27 +637,6 @@ interface Window {
 						  };
 				};
 			};
-		};
-		videopress: {
-			featuredStats?: {
-				label: string;
-				period: 'day' | 'year';
-				data: {
-					views: {
-						current: number;
-						previous: number;
-					};
-					impressions: {
-						current: number;
-						previous: number;
-					};
-					watch_time: {
-						current: number;
-						previous: number;
-					};
-				};
-			};
-			videoCount: number;
 		};
 		recommendedModules: {
 			modules: JetpackModule[] | null;

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -415,6 +415,43 @@ type Purchase = {
 	check_dns: boolean;
 };
 
+type ProtectData = {
+	scanData: {
+		core: ScanItem;
+		current_progress?: string;
+		data_source: string;
+		database: string[];
+		error: boolean;
+		error_code?: string;
+		error_message?: string;
+		files: string[];
+		has_unchecked_items: boolean;
+		last_checked: string;
+		num_plugins_threats: number;
+		num_themes_threats: number;
+		num_threats: number;
+		plugins: ScanItem[];
+		status: string;
+		themes: ScanItem[];
+		threats?: ThreatItem[];
+	};
+	wafConfig: {
+		automatic_rules_available: boolean;
+		blocked_logins: number;
+		bootstrap_path: string;
+		brute_force_protection: boolean;
+		jetpack_waf_automatic_rules: '1' | '';
+		jetpack_waf_ip_allow_list: '1' | '';
+		jetpack_waf_ip_block_list: boolean;
+		jetpack_waf_ip_list: boolean;
+		jetpack_waf_share_data: '1' | '';
+		jetpack_waf_share_debug_data: boolean;
+		standalone_mode: boolean;
+		waf_supported: boolean;
+		waf_enabled: boolean;
+	};
+};
+
 interface Window {
 	myJetpackInitialState?: {
 		siteSuffix: string;
@@ -577,42 +614,6 @@ interface Window {
 								status?: BackupStatus | RewindStatus;
 						  };
 				};
-			};
-		};
-		protect: {
-			scanData: {
-				core: ScanItem;
-				current_progress?: string;
-				data_source: string;
-				database: string[];
-				error: boolean;
-				error_code?: string;
-				error_message?: string;
-				files: string[];
-				has_unchecked_items: boolean;
-				last_checked: string;
-				num_plugins_threats: number;
-				num_themes_threats: number;
-				num_threats: number;
-				plugins: ScanItem[];
-				status: string;
-				themes: ScanItem[];
-				threats?: ThreatItem[];
-			};
-			wafConfig: {
-				automatic_rules_available: boolean;
-				blocked_logins: number;
-				bootstrap_path: string;
-				brute_force_protection: boolean;
-				jetpack_waf_automatic_rules: '1' | '';
-				jetpack_waf_ip_allow_list: '1' | '';
-				jetpack_waf_ip_block_list: boolean;
-				jetpack_waf_ip_list: boolean;
-				jetpack_waf_share_data: '1' | '';
-				jetpack_waf_share_debug_data: boolean;
-				standalone_mode: boolean;
-				waf_supported: boolean;
-				waf_enabled: boolean;
 			};
 		};
 		videopress: {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -27,7 +27,6 @@ use Automattic\Jetpack\Sync\Functions as Sync_Functions;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
 use Automattic\Jetpack\VideoPress\Stats as VideoPress_Stats;
-use Automattic\Jetpack\Waf\Waf_Runner;
 use Jetpack;
 use WP_Error;
 
@@ -232,24 +231,11 @@ class Initializer {
 		}
 		$latest_score['previousScores'] = $previous_score['scores'] ?? array();
 
-		Products::initialize_products();
-		$scan_data = Products\Protect::get_protect_data();
-
-		$waf_config     = array();
-		$waf_supported  = false;
-		$is_waf_enabled = false;
-
 		$sandboxed_domain = '';
 		$is_dev_version   = false;
 		if ( class_exists( 'Jetpack' ) ) {
 			$is_dev_version   = Jetpack::is_development_version();
 			$sandboxed_domain = defined( 'JETPACK__SANDBOX_DOMAIN' ) ? JETPACK__SANDBOX_DOMAIN : '';
-		}
-
-		if ( class_exists( 'Automattic\Jetpack\Waf\Waf_Runner' ) ) {
-			$waf_config     = Waf_Runner::get_config();
-			$is_waf_enabled = Waf_Runner::is_enabled();
-			$waf_supported  = Waf_Runner::is_supported_environment();
 		}
 
 		wp_localize_script(
@@ -293,17 +279,6 @@ class Initializer {
 				'isDevVersion'           => $is_dev_version,
 				'isAtomic'               => ( new Status_Host() )->is_woa_site(),
 				'latestBoostSpeedScores' => $latest_score,
-				'protect'                => array(
-					'scanData'  => $scan_data,
-					'wafConfig' => array_merge(
-						$waf_config,
-						array(
-							'waf_supported' => $waf_supported,
-							'waf_enabled'   => $is_waf_enabled,
-						),
-						array( 'blocked_logins' => (int) get_site_option( 'jetpack_protect_blocked_attempts', 0 ) )
-					),
-				),
 				'videopress'             => self::get_videopress_stats(),
 			)
 		);

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -26,7 +26,6 @@ use Automattic\Jetpack\Status\Host as Status_Host;
 use Automattic\Jetpack\Sync\Functions as Sync_Functions;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
-use Automattic\Jetpack\VideoPress\Stats as VideoPress_Stats;
 use Jetpack;
 use WP_Error;
 
@@ -59,8 +58,6 @@ class Initializer {
 	);
 
 	private const MY_JETPACK_SITE_INFO_TRANSIENT_KEY = 'my-jetpack-site-info';
-	private const VIDEOPRESS_STATS_KEY               = 'my-jetpack-videopress-stats';
-	private const VIDEOPRESS_PERIOD_KEY              = 'my-jetpack-videopress-period';
 
 	/**
 	 * Holds info/data about the site (from the /sites/%d endpoint)
@@ -279,7 +276,6 @@ class Initializer {
 				'isDevVersion'           => $is_dev_version,
 				'isAtomic'               => ( new Status_Host() )->is_woa_site(),
 				'latestBoostSpeedScores' => $latest_score,
-				'videopress'             => self::get_videopress_stats(),
 			)
 		);
 
@@ -299,67 +295,6 @@ class Initializer {
 		if ( self::can_use_analytics() ) {
 			Tracking::register_tracks_functions_scripts( true );
 		}
-	}
-
-	/**
-	 * Get stats for VideoPress
-	 *
-	 * @return array|WP_Error
-	 */
-	public static function get_videopress_stats() {
-		$video_count = array_sum( (array) wp_count_attachments( 'video' ) );
-
-		if ( ! class_exists( 'Automattic\Jetpack\VideoPress\Stats' ) ) {
-			return array(
-				'videoCount' => $video_count,
-			);
-		}
-
-		$featured_stats = get_transient( self::VIDEOPRESS_STATS_KEY );
-
-		if ( $featured_stats ) {
-			return array(
-				'featuredStats' => $featured_stats,
-				'videoCount'    => $video_count,
-			);
-		}
-
-		$stats_period     = get_transient( self::VIDEOPRESS_PERIOD_KEY );
-		$videopress_stats = new VideoPress_Stats();
-
-		// If the stats period exists, retrieve that information without checking the view count.
-		// If it does not, check the view count of monthly stats and determine if we want to show yearly or monthly stats.
-		if ( $stats_period ) {
-			if ( $stats_period === 'day' ) {
-				$featured_stats = $videopress_stats->get_featured_stats( 60, 'day' );
-			} else {
-				$featured_stats = $videopress_stats->get_featured_stats( 2, 'year' );
-			}
-		} else {
-			$featured_stats = $videopress_stats->get_featured_stats( 60, 'day' );
-
-			if (
-				! is_wp_error( $featured_stats ) &&
-				$featured_stats &&
-				( $featured_stats['data']['views']['current'] < 500 || $featured_stats['data']['views']['previous'] < 500 )
-			) {
-				$featured_stats = $videopress_stats->get_featured_stats( 2, 'year' );
-			}
-		}
-
-		if ( is_wp_error( $featured_stats ) || ! $featured_stats ) {
-			return array(
-				'videoCount' => $video_count,
-			);
-		}
-
-		set_transient( self::VIDEOPRESS_PERIOD_KEY, $featured_stats['period'], WEEK_IN_SECONDS );
-		set_transient( self::VIDEOPRESS_STATS_KEY, $featured_stats, DAY_IN_SECONDS );
-
-		return array(
-			'featuredStats' => $featured_stats,
-			'videoCount'    => $video_count,
-		);
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -177,19 +177,6 @@ class Products {
 	}
 
 	/**
-	 * Inititializes all products with an initialize method.
-	 *
-	 * @return void
-	 */
-	public static function initialize_products() {
-		$classes = self::get_products_classes();
-
-		foreach ( $classes as $class ) {
-			$class::initialize();
-		}
-	}
-
-	/**
 	 * Register endpoints related to product classes
 	 *
 	 * @return void

--- a/projects/packages/my-jetpack/src/class-red-bubble-notifications.php
+++ b/projects/packages/my-jetpack/src/class-red-bubble-notifications.php
@@ -376,8 +376,6 @@ class Red_Bubble_Notifications {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public static function rest_api_get_red_bubble_alerts( $request ) {
-		// Initialize products to ensure all products data is available during REST API call.
-		Products::initialize_products();
 		add_filter( 'my_jetpack_red_bubble_notification_slugs', array( __CLASS__, 'add_red_bubble_alerts' ) );
 
 		$cookies = $request->get_param( 'dismissal_cookies' );

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -162,15 +162,6 @@ abstract class Product {
 	}
 
 	/**
-	 * This method will be called in the class initializer to perform any necessary initialization
-	 *
-	 * @return void
-	 */
-	public static function initialize() {
-		// This method should be implemented in the child class.
-	}
-
-	/**
 	 * This method will be called in the class initializer to register the product's endpoints
 	 *
 	 * @return void

--- a/projects/packages/my-jetpack/src/products/class-protect.php
+++ b/projects/packages/my-jetpack/src/products/class-protect.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\My_Jetpack\Hybrid_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 use Automattic\Jetpack\Protect_Status\Status as Protect_Status;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Waf\Waf_Runner;
 use WP_Error;
 use WP_REST_Response;
 
@@ -417,10 +418,9 @@ class Protect extends Hybrid_Product {
 		$is_waf_enabled = false;
 
 		if ( class_exists( 'Automattic\Jetpack\Waf\Waf_Runner' ) ) {
-			$waf            = new \Automattic\Jetpack\Waf\Waf_Runner();
-			$waf_config     = $waf::get_config();
-			$is_waf_enabled = $waf::is_enabled();
-			$waf_supported  = $waf::is_supported_environment();
+			$waf_config     = Waf_Runner::get_config();
+			$is_waf_enabled = Waf_Runner::is_enabled();
+			$waf_supported  = Waf_Runner::is_supported_environment();
 		}
 
 		return rest_ensure_response(

--- a/projects/packages/my-jetpack/src/products/class-protect.php
+++ b/projects/packages/my-jetpack/src/products/class-protect.php
@@ -9,9 +9,11 @@ namespace Automattic\Jetpack\My_Jetpack\Products;
 
 use Automattic\Jetpack\My_Jetpack\Hybrid_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
-use Automattic\Jetpack\Protect_Models\Status_Model;
 use Automattic\Jetpack\Protect_Status\Status as Protect_Status;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Waf\Waf_Runner;
+use WP_Error;
+use WP_REST_Response;
 
 /**
  * Class responsible for handling the Protect product
@@ -93,17 +95,29 @@ class Protect extends Hybrid_Product {
 	public static $feature_identifying_paid_plan = 'scan';
 
 	/**
-	 * Holds the scan data
+	 * Backup initialization
 	 *
-	 * @var Status_Model
+	 * @return void
 	 */
-	private static $scan_data;
+	public static function register_endpoints(): void {
+		parent::register_endpoints();
+		// Get Jetpack Protect data.
+		register_rest_route(
+			'my-jetpack/v1',
+			'/site/protect/data',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => __CLASS__ . '::get_site_protect_data',
+				'permission_callback' => __CLASS__ . '::permissions_callback',
+			)
+		);
+	}
 
 	/**
-	 * Protect constructor.
+	 * Checks if the user has the correct permissions
 	 */
-	public static function initialize() {
-		self::$scan_data = Protect_Status::get_status();
+	public static function permissions_callback() {
+		return current_user_can( 'manage_options' );
 	}
 
 	/**
@@ -166,15 +180,6 @@ class Protect extends Hybrid_Product {
 			self::UPGRADED_TIER_SLUG,
 			self::FREE_TIER_SLUG,
 		);
-	}
-
-	/**
-	 * Get the normalized protect/scan data
-	 *
-	 * @return Status_Model
-	 */
-	public static function get_protect_data() {
-		return self::$scan_data;
 	}
 
 	/**
@@ -289,9 +294,10 @@ class Protect extends Hybrid_Product {
 	 */
 	public static function does_module_need_attention() {
 		$protect_threat_status = false;
+		$scan_data             = Protect_Status::get_status();
 
 		// Check if there are scan threats.
-		$protect_data = self::$scan_data;
+		$protect_data = $scan_data;
 		if ( is_wp_error( $protect_data ) ) {
 			return $protect_threat_status; // false
 		}
@@ -397,5 +403,38 @@ class Protect extends Hybrid_Product {
 	 */
 	public static function is_upgradable_by_bundle() {
 		return array( 'security', 'complete' );
+	}
+
+	/**
+	 * Return site Jetpack Protect data for the REST API.
+	 *
+	 * @return WP_Rest_Response|WP_Error
+	 */
+	public static function get_site_protect_data() {
+		$scan_data = Protect_Status::get_status();
+
+		$waf_config     = array();
+		$waf_supported  = false;
+		$is_waf_enabled = false;
+
+		if ( class_exists( 'Automattic\Jetpack\Waf\Waf_Runner' ) ) {
+			$waf_config     = Waf_Runner::get_config();
+			$is_waf_enabled = Waf_Runner::is_enabled();
+			$waf_supported  = Waf_Runner::is_supported_environment();
+		}
+
+		return rest_ensure_response(
+			array(
+				'scanData'  => $scan_data,
+				'wafConfig' => array_merge(
+					$waf_config,
+					array(
+						'waf_supported' => $waf_supported,
+						'waf_enabled'   => $is_waf_enabled,
+					),
+					array( 'blocked_logins' => (int) get_site_option( 'jetpack_protect_blocked_attempts', 0 ) )
+				),
+			)
+		);
 	}
 }

--- a/projects/packages/my-jetpack/src/products/class-protect.php
+++ b/projects/packages/my-jetpack/src/products/class-protect.php
@@ -418,9 +418,12 @@ class Protect extends Hybrid_Product {
 		$is_waf_enabled = false;
 
 		if ( class_exists( 'Automattic\Jetpack\Waf\Waf_Runner' ) ) {
-			$waf_config     = Waf_Runner::get_config();
+			// @phan-suppress-next-line PhanUndeclaredClassMethod
+			$waf_config = Waf_Runner::get_config();
+			// @phan-suppress-next-line PhanUndeclaredClassMethod
 			$is_waf_enabled = Waf_Runner::is_enabled();
-			$waf_supported  = Waf_Runner::is_supported_environment();
+			// @phan-suppress-next-line PhanUndeclaredClassMethod
+			$waf_supported = Waf_Runner::is_supported_environment();
 		}
 
 		return rest_ensure_response(

--- a/projects/packages/my-jetpack/src/products/class-protect.php
+++ b/projects/packages/my-jetpack/src/products/class-protect.php
@@ -11,7 +11,6 @@ use Automattic\Jetpack\My_Jetpack\Hybrid_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 use Automattic\Jetpack\Protect_Status\Status as Protect_Status;
 use Automattic\Jetpack\Redirect;
-use Automattic\Jetpack\Waf\Waf_Runner;
 use WP_Error;
 use WP_REST_Response;
 
@@ -418,9 +417,10 @@ class Protect extends Hybrid_Product {
 		$is_waf_enabled = false;
 
 		if ( class_exists( 'Automattic\Jetpack\Waf\Waf_Runner' ) ) {
-			$waf_config     = Waf_Runner::get_config();
-			$is_waf_enabled = Waf_Runner::is_enabled();
-			$waf_supported  = Waf_Runner::is_supported_environment();
+			$waf            = new \Automattic\Jetpack\Waf\Waf_Runner();
+			$waf_config     = $waf::get_config();
+			$is_waf_enabled = $waf::is_enabled();
+			$waf_supported  = $waf::is_supported_environment();
 		}
 
 		return rest_ensure_response(

--- a/projects/packages/my-jetpack/src/products/class-protect.php
+++ b/projects/packages/my-jetpack/src/products/class-protect.php
@@ -95,7 +95,7 @@ class Protect extends Hybrid_Product {
 	public static $feature_identifying_paid_plan = 'scan';
 
 	/**
-	 * Backup initialization
+	 * Setup Protect REST API endpoints
 	 *
 	 * @return void
 	 */
@@ -117,7 +117,7 @@ class Protect extends Hybrid_Product {
 	 * Checks if the user has the correct permissions
 	 */
 	public static function permissions_callback() {
-		return current_user_can( 'manage_options' );
+		return current_user_can( 'edit_posts' );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

* Move VideoPress and Protect data out of the window state and query them on the frontend
* These values were cached, so they didn't affect the page load every time, but this will prevent them from ever affecting it outside of the hourly red bubble slugs requests on the backend

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: pghfsA-df-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Install Query Monitor
3. First, connect your site and user account
4. After the connection, inspect Query Monitor and ensure you don't see any queries related to scan or videopress
![image](https://github.com/user-attachments/assets/0548cf1b-0083-42ea-9998-5c15aa424fe8)
6. Add at least one video to your site
7. Go to My Jetpack and ensure that the protect and videopress cards loading correctly and that it looks good
![image](https://github.com/user-attachments/assets/2d515778-16ed-487a-a510-447ea147f10c)
![image](https://github.com/user-attachments/assets/d144bf51-184a-430a-af5b-413751a37b73)
8. Try various states to make sure it is never broken, such as no user or site and make sure the result makes sense
![image](https://github.com/user-attachments/assets/95531ee0-b4d1-41bb-81e0-fa4c55859358)
![image](https://github.com/user-attachments/assets/b6552300-df7a-4e9b-af2e-ae4ad6a2af05)

Bonus:

If you'd like, create a non-admin user and login with a different email address to make sure it all looks good on a non-admin account as well

![image](https://github.com/user-attachments/assets/697e2ec1-ee45-4bdb-bec8-39b0a36816bf)


