### PR TITLE
Improve the import page design

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/import-page-notice
+++ b/projects/packages/jetpack-mu-wpcom/changelog/import-page-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improve the import page by fixing the position of the Notice component and adding a color to it to not look disabled.

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/css/import-customizations.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/css/import-customizations.css
@@ -5,6 +5,9 @@
 .import-php .wrap > h1, .wrap > p:first-of-type {
 	order: 2; /* h1 and p are placed after the banner */
 }
+.wrap > p:last-of-type {
+	order: 3;
+}
 .import-php .wpcom-import-banner {
 	order: 1; /* Banner is placed as the first element */
 	padding: 20px;

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/css/import-customizations.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/css/import-customizations.css
@@ -3,15 +3,16 @@
 	grid-template-columns: 1fr;
 }
 .import-php .wrap > h1, .wrap > p:first-of-type {
-	order: 1; /* h1 and first p are placed first */
+	order: 2; /* h1 and p are placed after the banner */
 }
 .import-php .wpcom-import-banner {
-	order: 2; /* Banner is placed second */
+	order: 1; /* Banner is placed as the first element */
 	padding: 20px;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
 	max-width: 726px;
+	margin-top: 15px;
 }
 .import-php .wpcom-import-banner p {
 	margin: 0;

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -43,7 +43,7 @@ function import_admin_banner() {
 		wp_kses_post( $banner_content ),
 		array(
 			'paragraph_wrap'     => false,
-			'additional_classes' => array( 'wpcom-import-banner' ),
+			'additional_classes' => array( 'wpcom-import-banner', 'notice-info' ),
 		)
 	);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/100894

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR improves the import page by repositioning the notice banner to appear first and enhancing its visibility with the `notice-info` class. The CSS adjustments update the element order to ensure the banner is placed before the heading and paragraph, while the PHP changes add the necessary class for better styling.

#### Before

![Captura de Tela 2025-03-13 às 00 24 39](https://github.com/user-attachments/assets/e4832239-b770-4fc3-a4f7-e8494c7cd95f)

#### After

![Captura de Tela 2025-03-13 às 16 22 12](https://github.com/user-attachments/assets/26cb47a4-f162-4c1b-9350-c506b6df8df0)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your WoA site(p9o2xV-1r2-p2)
* Navigate to `/wp-admin/import.php`
* You should see the updated screen for the page