### PR TITLE
Social | Remove unused scheduled-actions endpoint routes

### DIFF
--- a/projects/packages/publicize/changelog/update-social-remove-unused-scheduled-actions-endpoint-routes
+++ b/projects/packages/publicize/changelog/update-social-remove-unused-scheduled-actions-endpoint-routes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Social | Remove unused scheduled-actions endpoint routes

--- a/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-scheduled-actions-controller.php
@@ -127,60 +127,6 @@ class Scheduled_Actions_Controller extends Base_Controller {
 				'schema' => array( $this, 'get_public_item_schema' ),
 			)
 		);
-
-		// TODO - Remove the below routes after https://github.com/Automattic/wp-calypso/pull/100984 is deployed.
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/posts/(?P<post_id>\d+)/',
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_items' ),
-					'permission_callback' => array( $this, 'get_items_permissions_check' ),
-				),
-				array(
-					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'create_item' ),
-					'permission_callback' => array( $this, 'create_item_permissions_check' ),
-					'args'                => array(
-						'message'       => array(
-							'type'     => 'string',
-							'required' => true,
-						),
-						'connection_id' => array(
-							'type'     => 'integer',
-							'required' => true,
-						),
-						'share_date'    => array(
-							'type'        => 'integer',
-							'description' => sprintf(
-								/* translators: %s is the new field name */
-								__( 'Deprecated in favor of %s.', 'jetpack-publicize-pkg' ),
-								'timestamp'
-							),
-						),
-						'timestamp'     => array(
-							'type'        => 'integer',
-							'description' => __( 'GMT/UTC Unix timestamp in seconds for the action.', 'jetpack-publicize-pkg' ),
-						),
-					),
-				),
-				'schema' => array( $this, 'get_public_item_schema' ),
-			)
-		);
-
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/posts/(?P<post_id>\d+)/(?P<action_id>\d+)',
-			array(
-				array(
-					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $this, 'delete_item' ),
-					'permission_callback' => array( $this, 'delete_item_permissions_check' ),
-				),
-				'schema' => array( $this, 'get_public_item_schema' ),
-			)
-		);
 	}
 
 	/**


### PR DESCRIPTION
In #42283, we changed the routes for scheduled-actions endpoint, but left some routes for sometime because those were used by Calypso, but those routes are now updated after https://github.com/Automattic/wp-calypso/pull/100984. So, we no longer need those routes.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Social | Remove unused scheduled-actions endpoint routes

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Nothing to really test. Those routes are not used anywhere.
* May be just a sanity check of the Social admin page and the editor

