### PR TITLE
Boost: Update Historical Performance CTA with a modal

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/performance-history/graph-component/graph-component.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/performance-history/graph-component/graph-component.tsx
@@ -5,6 +5,7 @@ import {
 	Popover,
 	Spinner,
 } from '@automattic/jetpack-components';
+import InterstitialModalCTA from '$features/upgrade-cta/interstitial-modal-cta';
 import { __ } from '@wordpress/i18n';
 import styles from './graph-component.module.scss';
 import { PerformanceHistoryData } from '../lib/types';
@@ -52,7 +53,12 @@ const GraphComponent = ( {
 				<Popover
 					icon={ <Gridicon icon="lock" /> }
 					action={
-						<Button onClick={ handleUpgrade }>{ __( 'Upgrade now!', 'jetpack-boost' ) }</Button>
+						<InterstitialModalCTA
+							identifier="historical-performance"
+							customModalTrigger={
+								<Button onClick={ handleUpgrade }>{ __( 'Upgrade now!', 'jetpack-boost' ) }</Button>
+							}
+						/>
 					}
 				>
 					<p>

--- a/projects/plugins/boost/app/assets/src/js/features/upgrade-cta/interstitial-modal-cta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/upgrade-cta/interstitial-modal-cta.tsx
@@ -4,15 +4,22 @@ import { __ } from '@wordpress/i18n';
 import UpgradeCTA from '$features/upgrade-cta/upgrade-cta';
 
 type InterstitialModalCTAProps = {
-	description: string;
+	description?: string;
 	identifier: string;
+	customModalTrigger?: React.ReactNode;
 };
 
-const InterstitialModalCTA = ( { description, identifier }: InterstitialModalCTAProps ) => {
+const InterstitialModalCTA = ( {
+	description = '',
+	identifier,
+	customModalTrigger,
+}: InterstitialModalCTAProps ) => {
 	return (
 		<ProductInterstitialMyJetpack
 			slug="boost"
-			customModalTrigger={ <UpgradeCTA identifier={ identifier } description={ description } /> }
+			customModalTrigger={
+				customModalTrigger ?? <UpgradeCTA identifier={ identifier } description={ description } />
+			}
 			buttonLabel={ __( 'Upgrade now', 'jetpack-boost' ) }
 			isWithVideo={ false }
 			secondaryColumn={

--- a/projects/plugins/boost/changelog/update-my-jetpack_historical_perf
+++ b/projects/plugins/boost/changelog/update-my-jetpack_historical_perf
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+UI: replace old upgrade page with a new modal.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-roadmap/issues/2327

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replace Historical Performance upgrade page redirect with new modal

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* apply the branch to a JN instance using the beta plugin
* connect Jetpack and get free version of Jetpack Boost
* go to Boost details page open `Historical performance` toggle below the main performance sliders
* click on the upgrade button that show up
* verify that the upgrade content show up in a modal rather than another page
* verify that the price in the modal matches the price in the upgrade block that you clicked

Trigger block:
<img width="906" alt="SCR-20250313-ozuk" src="https://github.com/user-attachments/assets/d7115ff8-e5f5-49f3-a681-e22fed7eb92a" />

Modal content:
<img width="1120" alt="SCR-20250313-ozxt" src="https://github.com/user-attachments/assets/915750dd-119f-48b8-8431-792a501aa821" />

