### PR TITLE
Social | Use service status to display unsupported networks notice

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-improve-unsupported-services-notices
+++ b/projects/js-packages/publicize-components/changelog/update-social-improve-unsupported-services-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Use service status to display unsupported networks notice

--- a/projects/js-packages/publicize-components/src/components/connection-management/connection-status.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/connection-status.tsx
@@ -79,7 +79,7 @@ export function ConnectionStatus( { connection, service }: ConnectionStatusProps
 				} )( isUnsupported, connection.status ) }
 			</span>
 			&nbsp;
-			{ ! isUnsupported ? (
+			{ ! isUnsupported && service ? (
 				<Reconnect connection={ connection } service={ service } />
 			) : (
 				<Disconnect connection={ connection } variant="link" isDestructive={ false } />

--- a/projects/js-packages/publicize-components/src/components/connection-management/connection-status.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/connection-status.tsx
@@ -2,7 +2,7 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { store as socialStore } from '../../social-store';
 import { Connection } from '../../social-store/types';
 import { SupportedService } from '../services/use-supported-services';
@@ -66,9 +66,14 @@ export function ConnectionStatus( { connection, service }: ConnectionStatusProps
 					}
 
 					return status === 'broken'
-						? __( 'There is an issue with this connection.', 'jetpack-publicize-components' )
-						: __(
+						? _x(
+								'There is an issue with this connection.',
+								'This notice is shown when a social media connection is broken.',
+								'jetpack-publicize-components'
+						  )
+						: _x(
 								'To keep sharing with this connection, please reconnect it.',
+								'This notice is shown when a social media connection needs to be reconnected.',
 								'jetpack-publicize-components'
 						  );
 				} )( isUnsupported, connection.status ) }

--- a/projects/js-packages/publicize-components/src/components/connection-management/connection-status.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/connection-status.tsx
@@ -1,7 +1,9 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { store as socialStore } from '../../social-store';
 import { Connection } from '../../social-store/types';
 import { SupportedService } from '../services/use-supported-services';
 import { Disconnect } from './disconnect';
@@ -20,24 +22,33 @@ export type ConnectionStatusProps = {
  * @return {import('react').ReactNode} - React element
  */
 export function ConnectionStatus( { connection, service }: ConnectionStatusProps ) {
-	if ( connection.status !== 'broken' && connection.status !== 'must_reauth' ) {
+	const isUnsupported = useSelect(
+		select => {
+			return select( socialStore )
+				.getServicesBy( 'status', 'unsupported' )
+				.some( ( { id } ) => id === connection.service_name );
+		},
+		[ connection ]
+	);
+
+	const showStatus =
+		// If it's broken.
+		connection.status === 'broken' ||
+		// If it needs re-authentication.
+		connection.status === 'must_reauth' ||
+		// If it's unsupported.
+		isUnsupported;
+
+	if ( ! showStatus ) {
 		return null;
 	}
-
-	const statusMessage =
-		connection.status === 'broken'
-			? __( 'There is an issue with this connection.', 'jetpack-publicize-components' )
-			: __(
-					'To keep sharing with this connection, please reconnect it.',
-					'jetpack-publicize-components'
-			  );
 
 	return (
 		<div>
 			<span className="description">
-				{ service
-					? statusMessage
-					: createInterpolateElement(
+				{ ( ( unsupported, status ) => {
+					if ( unsupported ) {
+						return createInterpolateElement(
 							sprintf(
 								'%1$s %2$s',
 								__( 'This platform is no longer supported.', 'jetpack-publicize-components' ),
@@ -51,10 +62,19 @@ export function ConnectionStatus( { connection, service }: ConnectionStatusProps
 									<ExternalLink href={ getRedirectUrl( 'jetpack-social-manual-sharing-help' ) } />
 								),
 							}
-					  ) }
+						);
+					}
+
+					return status === 'broken'
+						? __( 'There is an issue with this connection.', 'jetpack-publicize-components' )
+						: __(
+								'To keep sharing with this connection, please reconnect it.',
+								'jetpack-publicize-components'
+						  );
+				} )( isUnsupported, connection.status ) }
 			</span>
 			&nbsp;
-			{ service ? (
+			{ ! isUnsupported ? (
 				<Reconnect connection={ connection } service={ service } />
 			) : (
 				<Disconnect connection={ connection } variant="link" isDestructive={ false } />

--- a/projects/js-packages/publicize-components/src/components/form/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/form/styles.module.scss
@@ -65,3 +65,8 @@
 .share-post-form__media-section {
 	margin-top: 1rem;
 }
+
+.unsupported-connections-list {
+	margin-inline-start: 1rem;
+	list-style-type: disc;
+}

--- a/projects/js-packages/publicize-components/src/components/form/unsupported-connections-notice.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/unsupported-connections-notice.tsx
@@ -1,33 +1,35 @@
 import { ExternalLink } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import { usePublicizeConfig } from '../../..';
-import useSocialMediaConnections from '../../hooks/use-social-media-connections';
+import { useSelect } from '@wordpress/data';
+import { __, _x } from '@wordpress/i18n';
+import { store as socialStore } from '../../social-store';
+import { getSocialAdminPageUrl } from '../../utils';
 import Notice from '../notice';
+import styles from './styles.module.scss';
 
 export const UnsupportedConnectionsNotice: React.FC = () => {
-	const { connections } = useSocialMediaConnections();
-	const { connectionsPageUrl } = usePublicizeConfig();
+	const unsupportedServices = useSelect( select => {
+		return select( socialStore ).getServicesBy( 'status', 'unsupported' );
+	}, [] );
 
-	const hasTwitterConnection = connections.some(
-		( { service_name } ) => 'twitter' === service_name
-	);
-
-	if ( ! hasTwitterConnection ) {
+	if ( ! unsupportedServices.length ) {
 		return null;
 	}
 
 	return (
 		<Notice type="error">
-			{ createInterpolateElement(
-				__(
-					'Twitter is not supported anymore. <moreInfo>Learn more here</moreInfo>.',
-					'jetpack-publicize-components'
-				),
-				{
-					moreInfo: <ExternalLink href={ connectionsPageUrl } />,
-				}
+			{ _x(
+				'Following platforms are not supported anymore:',
+				'Followed by a list of social media platforms that are no longer supported by Publicize.',
+				'jetpack-publicize-components'
 			) }
+			<ul className={ styles[ 'unsupported-connections-list' ] }>
+				{ unsupportedServices.map( service => (
+					<li key={ service.id }>{ service.label }</li>
+				) ) }
+			</ul>
+			<ExternalLink href={ getSocialAdminPageUrl() }>
+				{ __( 'Learn more', 'jetpack-publicize-components' ) }
+			</ExternalLink>
 		</Notice>
 	);
 };

--- a/projects/js-packages/publicize-components/src/social-store/selectors/services.ts
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/services.ts
@@ -41,3 +41,20 @@ export const isFetchingServicesList = createRegistrySelector( select => (): bool
 
 	return isResolving( 'getEntityRecords', [ 'wpcom/v2', 'publicize/services' ] );
 } );
+
+/**
+ * Get the list of services filtered by a key and value.
+ *
+ * @param state - State object.
+ * @param key   - The key to filter by.
+ * @param value - The value to filter by.
+ *
+ * @return The list of services.
+ */
+export function getServicesBy< Key extends keyof ConnectionService >(
+	state: unknown,
+	key: Key,
+	value: ConnectionService[ Key ]
+) {
+	return getServicesList().filter( service => service[ key ] === value );
+}

--- a/projects/js-packages/publicize-components/src/types.ts
+++ b/projects/js-packages/publicize-components/src/types.ts
@@ -31,6 +31,7 @@ export type ConnectionService = {
 		additional_users: boolean;
 		additional_users_only: boolean;
 	};
+	status: 'ok' | 'unsupported';
 };
 
 export interface ApiPaths {


### PR DESCRIPTION
Currently, we check if the connection is for Twitter to display the unsupported connections notice, which is great but not that great if any other network becomes unsupported.

We have `status: unsupported` for such services

fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Syvo%2Srkgreany%2Qpbaarpgvbaf.cuc%3Se%3Q8455q799%23307%2Q323-og

We need to update the logic to make use of that status field

See https://github.com/Automattic/jetpack/pull/41907/files#r1964419471

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Social - Use `service.status === 'unsupported'`  to display unsupported networks notice

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add at least 3 connections to your site.
* Add this code before the return statement in `Automattic\Jetpack\Publicize\Connections::wpcom_get_connections` to simulate the different statuses.

```php
// Make th changes as per your connections
foreach ( $items as &$connection ) {
	if ( 'facebook' === $connection['service_name'] ) {
		$connection['status'] = 'broken';
	}

	if ( 'linkedin' === $connection['service_name'] ) {
		$connection['status'] = 'must_reauth';
	}

	// Uncomment and update this if you don't have a Twitter connection
	if ( 'tumblr' === $connection['service_name'] ) {
		// $connection['service_name'] = 'twitter';
	}
}
```
* `jetpack rsync` the changes to your sandbox
* Point your site and public API to your sandbox
* Goto editor
* Confirm that you see the updated notice saying: `Following platforms are not supported anymore:`
* Goto Social admin page
* Confirm that you see the connection status as expected

- Editor

| BEFORE | AFTER |
|--------|--------|
| <img width="273" alt="Screenshot 2025-03-13 at 1 04 42 PM" src="https://github.com/user-attachments/assets/aa97715e-a4e9-4804-9af1-d25580f5f7b8" /> | <img width="272" alt="Screenshot 2025-03-13 at 1 03 39 PM" src="https://github.com/user-attachments/assets/c3cc2006-5461-418c-95de-fcf64b28bb0c" /> | 

- Social Admin page

<img width="734" alt="Screenshot 2025-03-13 at 1 06 48 PM" src="https://github.com/user-attachments/assets/914d20db-7621-441a-bd18-bfc63bef951c" />
