### PR TITLE
[WooCommerce Analytics] Implement Session Engagement

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/add-engagement-tracking
+++ b/projects/packages/woocommerce-analytics/changelog/add-engagement-tracking
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add Session Engagement TRacking
+Add Session Engagement Tracking

--- a/projects/packages/woocommerce-analytics/changelog/add-engagement-tracking
+++ b/projects/packages/woocommerce-analytics/changelog/add-engagement-tracking
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Session Engagement TRacking

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -88,12 +88,16 @@ class Universal {
 						'pq' => $data_instance['quantity'],
 					);
 
-					// Attach the session ID to this event in case it's saved in the Data Instance
+					// Attach the session ID, engagement status and landing_page to this event in case it's saved in the Data Instance.
+					// Otherwise, keep it unset to allow override.
 					if ( $data_instance['session_id'] ) {
 						$event_props['session_id'] = $data_instance['session_id'];
 					}
 
-					// Attach the Landing Page to this event in case it's saved in the Data Instance
+					if ( $data_instance['is_engaged'] ) {
+						$event_props['is_engaged'] = $data_instance['is_engaged'];
+					}
+
 					if ( $data_instance['landing_page'] ) {
 						$event_props['landing_page'] = $data_instance['landing_page'];
 					}
@@ -483,6 +487,7 @@ class Universal {
 			'quantity'     => (string) $quantity,
 			'session_id'   => $this->get_session_id(),
 			'landing_page' => $this->get_landing_page(),
+			'is_engaged'   => $this->is_engaged_session(),
 		);
 
 		// append new data.

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -348,7 +348,7 @@ trait Woo_Analytics_Trait {
 		}
 
 		if ( ! $this->is_initial_page_view( $event_name ) && ! $this->is_engaged_session() ) {
-			$this->record_engagement();
+			$this->record_engagement( $properties );
 		}
 
 		$js = $this->process_event_properties( $event_name, $properties, $product_id );
@@ -358,23 +358,24 @@ trait Woo_Analytics_Trait {
 	/**
 	 * Record woocommerceanalytics_session_engagement event and set a flag in the session cookie.
 	 *
+	 * @param array $properties Optional array of (key => value) event properties.
 	 * @return void
 	 */
-	public function record_engagement() {
-		$event_js                    = $this->process_event_properties( 'woocommerceanalytics_session_engagement' );
+	public function record_engagement( $properties = array() ) {
+		$event_js                    = $this->process_event_properties( 'woocommerceanalytics_session_engagement', $properties );
 		$add_engagement_to_cookie_js = "
-				const cookies = document.cookie.split('; ').reduce((acc, cookie) => {
-					const [name, value] = cookie.split('=');
-					acc[name] = value;
-					return acc;
-    			}, {});
+		    const cookies = document.cookie.split('; ').reduce((acc, cookie) => {
+	            const [name, value] = cookie.split('=');
+			    acc[name] = value;
+				return acc;
+    		}, {});
 
-    			if (cookies.woocommerceanalytics_session) {
-            		let sessionData = JSON.parse(decodeURIComponent(cookies.woocommerceanalytics_session));
-                    sessionData.is_engaged = true;
-           			document.cookie = `woocommerceanalytics_session=\${JSON.stringify(sessionData)}; expires=\${sessionData.expires}; path=/; secure; samesite=strict`;
-   		 		}
-            ";
+    		if (cookies.woocommerceanalytics_session) {
+            	let sessionData = JSON.parse(decodeURIComponent(cookies.woocommerceanalytics_session));
+                sessionData.is_engaged = true;
+           	    document.cookie = `woocommerceanalytics_session=\${JSON.stringify(sessionData)}; expires=\${sessionData.expires}; path=/; secure; samesite=strict`;
+   		 	}
+        ";
 
 		wc_enqueue_js( $add_engagement_to_cookie_js );
 		wc_enqueue_js( "_wca.push({$event_js});" );

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -67,6 +67,20 @@ trait Woo_Analytics_Trait {
 	protected $landing_page = '';
 
 	/**
+	 *  Indicates when a session is engaged in the current request.
+	 *
+	 *  @var bool
+	 */
+	protected $engaged_session = false;
+
+	/**
+	 *  Indicates when a session is created in the current request.
+	 *
+	 *  @var bool
+	 */
+	protected $is_new_session = false;
+
+	/**
 	 * Format Cart Items or Order Items to an array
 	 *
 	 * @param array|WC_Order_Item[] $items Cart Items or Order Items.
@@ -270,7 +284,7 @@ trait Woo_Analytics_Trait {
 			'blog_id'                            => Jetpack_Connection::get_site_id(),
 			'store_id'                           => defined( '\\WC_Install::STORE_ID_OPTION' ) ? get_option( \WC_Install::STORE_ID_OPTION ) : false,
 			'ui'                                 => $this->get_user_id(),
-			'url'                                => home_url(),
+			'url'                                => $this->get_current_url(),
 			'landing_page'                       => $landing_page,
 			'woo_version'                        => WC()->version,
 			'wp_version'                         => get_bloginfo( 'version' ),
@@ -325,8 +339,41 @@ trait Woo_Analytics_Trait {
 			$this->maybe_start_session();
 		}
 
+		$this->maybe_record_engagement();
+
 		$js = $this->process_event_properties( $event_name, $properties, $product_id );
 		wc_enqueue_js( "_wca.push({$js});" );
+	}
+
+	/**
+	 * In case of events in the current session record engagement event.
+	 *
+	 * @return void
+	 */
+	public function maybe_record_engagement() {
+		// Don't engage for new sessions or if the session is already engaged
+		if ( $this->is_engaged_session() || ! $this->get_session_id() || $this->is_new_session ) {
+			return;
+		}
+
+		$event_js                    = $this->process_event_properties( 'woocommerceanalytics_session_engagement' );
+		$add_engagement_to_cookie_js = "
+				const cookies = document.cookie.split('; ').reduce((acc, cookie) => {
+					const [name, value] = cookie.split('=');
+					acc[name] = value;
+					return acc;
+    			}, {});
+
+    			if (cookies.woocommerceanalytics_session) {
+            		let sessionData = JSON.parse(decodeURIComponent(cookies.woocommerceanalytics_session));
+                    sessionData.is_engaged = true;
+           			document.cookie = `woocommerceanalytics_session=\${JSON.stringify(sessionData)}; expires=\${sessionData.expires}; path=/; secure; samesite=strict`;
+   		 		}
+            ";
+
+		wc_enqueue_js( $add_engagement_to_cookie_js );
+		wc_enqueue_js( "_wca.push({$event_js});" );
+		$this->engaged_session = true;
 	}
 
 	/**
@@ -336,17 +383,20 @@ trait Woo_Analytics_Trait {
 	 */
 	public function maybe_start_session() {
 		if ( ! $this->get_session_id() ) {
-			$session_id         = wp_generate_uuid4();
-			$this->session_id   = $session_id;
-			$this->landing_page = $this->get_current_url();
+			$session_id           = wp_generate_uuid4();
+			$this->session_id     = $session_id;
+			$this->landing_page   = $this->get_current_url();
+			$this->is_new_session = true;
+
 			$session_expiration = $this->get_session_expiration_time();
 			$event_js           = $this->process_event_properties( 'woocommerceanalytics_session_started' );
 			$cookie_js          = "
             const sessionData = JSON.stringify({
-                    session_id: '{$this->session_id}',
-                    landing_page: encodeURIComponent('{$this->landing_page}'),
+                    session_id: '$this->session_id',
+                    landing_page: encodeURIComponent('$this->landing_page'),
+                    expires: '$session_expiration',
             });
-            document.cookie = `woocommerceanalytics_session=\${sessionData}; expires={$session_expiration}; path=/; secure; samesite=strict`;
+            document.cookie = `woocommerceanalytics_session=\${sessionData}; expires=$session_expiration; path=/; secure; samesite=strict`;
             ";
 			wc_enqueue_js( $cookie_js ); // save the session cookie for further events in the session
 			wc_enqueue_js( "_wca.push({$event_js});" ); // trigger session started event
@@ -601,16 +651,16 @@ trait Woo_Analytics_Trait {
 		return $info;
 	}
 
-		/**
-		 * Search a specific post for text content.
-		 *
-		 * Note: similar code is in a WooCommerce core PR:
-		 * https://github.com/woocommerce/woocommerce/pull/25932
-		 *
-		 * @param integer $post_id The id of the post to search.
-		 * @param string  $text    The text to search for.
-		 * @return integer 1 if post contains $text (otherwise 0).
-		 */
+	/**
+	 * Search a specific post for text content.
+	 *
+	 * Note: similar code is in a WooCommerce core PR:
+	 * https://github.com/woocommerce/woocommerce/pull/25932
+	 *
+	 * @param integer $post_id The id of the post to search.
+	 * @param string  $text    The text to search for.
+	 * @return integer 1 if post contains $text (otherwise 0).
+	 */
 	public function post_contains_text( $post_id, $text ) {
 		global $wpdb;
 
@@ -723,6 +773,16 @@ trait Woo_Analytics_Trait {
 	}
 
 	/**
+	 * Check if the session is engaged.
+	 *
+	 * @return bool
+	 */
+	public function is_engaged_session() {
+		$cookie = $this->get_session_cookie();
+		return $cookie['is_engaged'] ?? $this->engaged_session;
+	}
+
+	/**
 	 * Return the landing page.
 	 * First try to get it from the cookie. Fallback to $this->landing_page.
 	 *
@@ -759,6 +819,7 @@ trait Woo_Analytics_Trait {
 	private function get_clickhouse_events() {
 		return array(
 			'woocommerceanalytics_session_started',
+			'woocommerceanalytics_session_engagement',
 			'woocommerceanalytics_product_view',
 			'woocommerceanalytics_cart_view',
 			'woocommerceanalytics_add_to_cart',

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -74,7 +74,7 @@ trait Woo_Analytics_Trait {
 	protected $engaged_session = false;
 
 	/**
-	 *  Indicates when a session is created in the current request.
+	 *  Indicates when a new session has been created in the current request.
 	 *
 	 *  @var bool
 	 */
@@ -82,7 +82,7 @@ trait Woo_Analytics_Trait {
 
 	/**
 	 *  Locks Add to Cart Events Tracking in the current request avoiding duplications.
-	 *  i.e If update_cart and add_to_cart actions happens in the same request.
+	 *  i.e. If update_cart and add_to_cart actions happens in the same request.
 	 *
 	 *  @var bool If true. Cart events are locked for the current request.
 	 */
@@ -347,23 +347,20 @@ trait Woo_Analytics_Trait {
 			$this->maybe_start_session();
 		}
 
-		$this->maybe_record_engagement();
+		if ( ! $this->is_initial_page_view( $event_name ) && ! $this->is_engaged_session() ) {
+			$this->record_engagement();
+		}
 
 		$js = $this->process_event_properties( $event_name, $properties, $product_id );
 		wc_enqueue_js( "_wca.push({$js});" );
 	}
 
 	/**
-	 * In case of events in the current session record engagement event.
+	 * Record woocommerceanalytics_session_engagement event and set a flag in the session cookie.
 	 *
 	 * @return void
 	 */
-	public function maybe_record_engagement() {
-		// Don't engage for new sessions or if the session is already engaged
-		if ( $this->is_engaged_session() || ! $this->get_session_id() || $this->is_new_session ) {
-			return;
-		}
-
+	public function record_engagement() {
 		$event_js                    = $this->process_event_properties( 'woocommerceanalytics_session_engagement' );
 		$add_engagement_to_cookie_js = "
 				const cookies = document.cookie.split('; ').reduce((acc, cookie) => {
@@ -849,5 +846,16 @@ trait Woo_Analytics_Trait {
 	 */
 	private function is_clickhouse( $event ) {
 		return in_array( $event, $this->get_clickhouse_events(), true );
+	}
+
+	/**
+	 * Check if the event is the initial page view event starting the session.
+	 *
+	 * @param string $event The event name.
+	 * @return bool
+	 */
+	private function is_initial_page_view( $event ) {
+		$initial_events = array( 'woocommerceanalytics_page_view', 'woocommerceanalytics_product_view', 'woocommerceanalytics_cart_view' );
+		return in_array( $event, $initial_events, true ) && ( ! $this->get_session_id() || $this->is_new_session );
 	}
 }

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -347,7 +347,7 @@ trait Woo_Analytics_Trait {
 			$this->maybe_start_session();
 		}
 
-		if ( ! $this->is_initial_page_view( $event_name ) && ! $this->is_engaged_session() ) {
+		if ( ! $this->is_initial_page_view( $event_name ) && ! isset( $properties['is_engaged'] ) && ! $this->is_engaged_session() ) {
 			$this->record_engagement( $properties );
 		}
 


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a new event `woocommerce_session_engagement`.

This event is triggered when a new event happens after the first request when:

- Any event happening in the next request (i.e A new page view)
- A non-initial page view event happening, even in the first request (i.e Checkout visit, add to cart, order completed)

The event shouldn't trigger when

- The event is the initial page view 
- The session is engaged already

ℹ️  This PR doesn't include the requirement to engage after 10 seconds of the beginning session.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
YEs. we do track a new event `woocommerce_session_engagement` and save "is_enagaged" param as well as "expires" param in the session cookie. This will be handled in the JP Docs as suggested. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Clear woocommerceanalytics_session cookie
* Visit the shop. See the session cookie created. And page_view and session_started events created.  See session_engagement event NOT triggered.
* Refresh or visit any other page. See session_engagement event triggered.
* Refresh again or visit any page.  See session_engagement event NOT triggered.
* Clear the session cookie. 
* Add some async actions like Add something to cart, remove to cart etc. 
* Refresh again or visit any page.  See session_engagement event triggered, session_started and also the other async events.

