### PR TITLE
Sync: Don't send any old full sync actions if full sync has been restarted

### DIFF
--- a/projects/packages/sync/changelog/update-stop-full-sync-when-restarted
+++ b/projects/packages/sync/changelog/update-stop-full-sync-when-restarted
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Don't send any old full sync actions if full sync has been restarted.

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -392,6 +392,8 @@ class Full_Sync_Immediately extends Module {
 
 		$progress = $this->get_status()['progress'];
 
+		$started = $this->get_status()['started'];
+
 		foreach ( $this->get_remaining_modules_to_send() as $module ) {
 			$progress[ $module->name() ] = $module->send_full_sync_actions( $config[ $module->name() ], $progress[ $module->name() ], $send_until );
 			if ( isset( $progress[ $module->name() ]['error'] ) ) {
@@ -401,6 +403,10 @@ class Full_Sync_Immediately extends Module {
 			} elseif ( ! $progress[ $module->name() ]['finished'] ) {
 				$this->update_status( array( 'progress' => $progress ) );
 				return true;
+			}
+			if ( $this->get_status()['started'] !== $started ) {
+				// Full sync was restarted, stop sending.
+				return false;
 			}
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/vulcan/issues/750

When a Full Sync is running and another Full Sync is started, the previous one [gets cancelled and the config gets reset](https://github.com/Automattic/jetpack/blob/6d85754d846673f9b4b3038ca4811534ba04f4d9/projects/packages/sync/src/modules/class-full-sync-immediately.php#L69-L81).

Above scenario doesn't work well if a [do_full_sync](https://github.com/Automattic/jetpack/blob/d2c7b02f9ccf51c7390e0aa36ae1f520377c2108/projects/packages/sync/src/class-sender.php#L293) is already in progress in the remote site for the previous Full Sync and we end up finishing the full sync. The code when sending the `jetpack_full_sync_end` action also takes care of updating the status to finished which makes that the new scheduled Full Sync, never runs or only runs a few amount of actions.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When finishing processing a module, prior to send any new full sync actions, let's ensure we have the same timestamp for the `status['started']` value. If not, just return early since we don't want to send or process those actions, especially the `jetpack_full_sync_end` one.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Since this is a complex scenario to test without tweaking a bit the timings, it is better if we add a sleep in the foreach module and we update the `send_until` variable for the tests. This patch 373d8-pb/, shows the changes for this branch, similar ones can be done in trunk to test it.

#### Testing in trunk
- Apply similar changes to the patch to your testing site.
- Go to Debugger.
- Initiate a Full Sync for `options, constants, functions and updates` which should take ~20s.
- In less than 20 sec, before letting it finish, run a Full Sync for `everything`.
- Wait for all actions to finish.
- If you check in the corresponding ES logs, you will see that the `jetpack_full_sync_end` will be sent shortly after the `options, constants, functions and updates` actions have been sent. You might see some actions triggered for the new full sync, but not all of them. There will be no `jetpack_full_sync_end` after these actions (in case there are any)
 **Note:** In Debugger, the config for everything will be marked as finished, and also all items in everything will be updated in the **Last Completed Syncs per Module** section but this is not correct. This info relies on a combination of the new  config and the fact the `jetpack_full_sync_end` has been processed in wpcom. The changes in this branch should help with it.
- 
#### Testing in this branch
- Apply similar changes to the patch to your testing site.
- Go to Debugger.
- Initiate a Full Sync for `options, constants, functions and updates` which should take ~20s.
- In less than 20 sec, before letting it finish, run a Full Sync for `everything`.
- If you check in the corresponding ES logs, you will see that probably (unless you waited for more than 15 secs to run the second Full Sync), not all actions for the initial full sync will happen. All of the actions for the new full sync should appear in the ES logs (there is caching in 5 minutes so if one of the ones from the 1st full sync is not shown, don't worry).  The `jetpack_full_sync_end` should appear after all action for all modules have been sent.