### PR TITLE
Forms: Fix bullets not show for list blocks

### DIFF
--- a/projects/packages/forms/changelog/fix-list-bullets-in-form-block
+++ b/projects/packages/forms/changelog/fix-list-bullets-in-form-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix list bullets not showing.

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -41,14 +41,14 @@
 		}
 	}
 
-	.block-editor-block-list__layout:not(.wp-block-list-item) {
+	.block-editor-block-list__layout:not(.wp-block-list,.wp-block-list-item) {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: flex-start;
 		flex-direction: row;
 		gap: var(--wp--style--block-gap, 1.5rem);
 
-		.wp-block {
+		.wp-block:not(.wp-block-list-item) {
 			flex: 0 0 100%;
 			margin-top: 0;
 			margin-bottom: 0;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -41,7 +41,7 @@
 		}
 	}
 
-	.block-editor-block-list__layout {
+	.block-editor-block-list__layout:not(.wp-block-list-item) {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: flex-start;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -456,7 +456,7 @@
 	.wp-block-jetpack-field-option-radio {
 		display: flex;
 		align-items: baseline; /* Align input with first label line */
-		flex-wrap: nowrap;
+		flex-wrap: nowrap !important; // Needed to override :not() on .block-editor-block-list__layout
 
 		.jetpack-option__type:before {
 			display: block; /* display: flex causes baselines to not align */

--- a/projects/plugins/jetpack/changelog/fix-list-bullets-in-form-block
+++ b/projects/plugins/jetpack/changelog/fix-list-bullets-in-form-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix list bullets not showing.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #42344

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
**Issue:** If you add a core list block within a form block, no bullets or numbers show on the list. In investigating, I found there were other changes to core lists, like spacing between list items. We use the same generic CSS classes as core lists for our radio and multi-checkbox fields, and we apply extra styles to those classes break core lists.

**Fix:** This PR updates CSS to exclude core list items using :not so we don't affect core lists.

**Alternative:** One could argue that we should not changing the CSS on core block classes like `.wp-block` and `.block-editor-block-list__layout`. If so, an alternative fix is to ensure we only apply CSS rules to our own classes. I opted for the first approach because it is simpler. We're essentially using .block-editor-block-list__layout to apply css to all blocks within the forms block, and there are other specific overrides for some block types. 

**Before**
<img width="1248" alt="form-block-bullets-before" src="https://github.com/user-attachments/assets/4634d324-7a0b-479f-8f95-ee6de5a6502a" />

**After**
<img width="1286" alt="forms-block-bullets-after-3" src="https://github.com/user-attachments/assets/b6788637-c9bf-4a20-b48a-ff19d2ee8ed6" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form to a page or post.
* Add a core list block with a couple options so you have a comparative reference.
* Add a core list block as a child within the form and confirm bullets and numbers show for the list, and that styling matches the list block outside of forms.
* Confirm radio and multi-checkbox fields continue to display exactly the same as before.