### PR TITLE
Forms: Fix core list bullets not showing

### DIFF
--- a/projects/packages/forms/changelog/update-form-list-css
+++ b/projects/packages/forms/changelog/update-form-list-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix core list bullets not showing.

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -41,7 +41,9 @@
 		}
 	}
 
-	.block-editor-block-list__layout {
+	.jetpack-contact-form,
+	.wp-block-jetpack-field-option-radio,
+	.wp-block-jetpack-field-option-checkbox {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: flex-start;
@@ -108,8 +110,8 @@
 		}
 	}
 
-	.block-editor-block-list__layout.wp-block-jetpack-field-option-radio,
-	.block-editor-block-list__layout.wp-block-jetpack-field-option-checkbox  {
+	.wp-block-jetpack-field-option-radio,
+	.wp-block-jetpack-field-option-checkbox  {
 		gap: 0;
 
 		> .wp-block {
@@ -117,7 +119,7 @@
 		}
 	}
 
-	.block-editor-block-list__layout.wp-block-jetpack-field-option-checkbox {
+	.wp-block-jetpack-field-option-checkbox {
 		align-items: center;
 	}
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -42,7 +42,7 @@
 	}
 
 	.jetpack-contact-form,
-	.block-editor-block-list__layout[class*="wp-block-jetpack-field-option"] {
+	[class*="wp-block-jetpack-field-option"] {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: flex-start;
@@ -109,8 +109,8 @@
 		}
 	}
 
-	.block-editor-block-list__layout[class*="wp-block-jetpack-field-option"] {
-		flex-wrap: nowrap;
+	.wp-block-jetpack-field-option-radio,
+	.wp-block-jetpack-field-option-checkbox {
 		gap: 0;
 
 		> .wp-block {

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -42,8 +42,7 @@
 	}
 
 	.jetpack-contact-form,
-	.wp-block-jetpack-field-option-radio,
-	.wp-block-jetpack-field-option-checkbox {
+	.block-editor-block-list__layout[class*="wp-block-jetpack-field-option"] {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: flex-start;
@@ -110,8 +109,8 @@
 		}
 	}
 
-	.wp-block-jetpack-field-option-radio,
-	.wp-block-jetpack-field-option-checkbox  {
+	.block-editor-block-list__layout[class*="wp-block-jetpack-field-option"] {
+		flex-wrap: nowrap;
 		gap: 0;
 
 		> .wp-block {

--- a/projects/plugins/jetpack/changelog/update-form-list-css
+++ b/projects/plugins/jetpack/changelog/update-form-list-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix core list bullets not showing.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #42344

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
**Issue:** If you add a core list block within a form block, no bullets or numbers show on the list. This happens because we are overriding the CSS for `.block-editor-block-list__layout`, a Gutenberg core CSS class that is automatically added to any container with a list of blocks. I removed that from the CSS and updated it with the forms-specific CSS classes where it applies.

It's likely this change fixes other as yet undetected bugs. The CSS were were applying would have affected lists, columns, or any other block with children. 

**Before**
<img width="1248" alt="form-block-bullets-before" src="https://github.com/user-attachments/assets/4634d324-7a0b-479f-8f95-ee6de5a6502a" />

**After**
<img width="1286" alt="forms-block-bullets-after-3" src="https://github.com/user-attachments/assets/b6788637-c9bf-4a20-b48a-ff19d2ee8ed6" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a core list block with a couple options so you have a comparative reference.
* Add a form to a page or post.
* Add a core list block within the form and confirm bullets and numbers show for the list, and that styling matches the list block outside of forms.
* Confirm radio and multi-checkbox fields continue to display exactly the same as before.