### PR TITLE
Embed block: Include transformation notice in the edit sidebar screen

### DIFF
--- a/projects/plugins/jetpack/changelog/add-videopress-embed-notice
+++ b/projects/plugins/jetpack/changelog/add-videopress-embed-notice
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Add embed block sidebar notice to transform it to a VideoPress block

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-embed/index.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-embed/index.js
@@ -3,3 +3,4 @@ import './instagram';
 import './loom';
 import './smartframe';
 import './descript';
+import './videopress';

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-embed/test/videopress.test.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-embed/test/videopress.test.js
@@ -1,0 +1,228 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+import { dispatch } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import { VIDEO_PRIVACY } from '../../../blocks/videopress/constants';
+import { getVideoPressUrl } from '../../../blocks/videopress/url';
+import { pickGUIDFromUrl } from '../../../blocks/videopress/utils';
+import { withVideoPressSettings } from '../videopress';
+
+// Mock dependencies before imports
+jest.mock( '@wordpress/block-editor', () => ( {
+	InspectorControls: jest.fn( ( { children } ) => children ),
+} ) );
+
+jest.mock( '@wordpress/blocks', () => ( {
+	createBlock: jest.fn( ( name, attrs ) => ( { name, attributes: attrs } ) ),
+} ) );
+
+jest.mock( '@wordpress/compose', () => ( {
+	createHigherOrderComponent: jest.fn( fn => fn ),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: jest.fn( () => ( {
+		replaceBlock: jest.fn(),
+	} ) ),
+} ) );
+
+jest.mock( '@wordpress/hooks', () => ( {
+	addFilter: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: text => text,
+} ) );
+
+jest.mock( '../../../blocks/videopress/utils', () => ( {
+	pickGUIDFromUrl: jest.fn(),
+} ) );
+
+jest.mock( '../../../blocks/videopress/url', () => ( {
+	getVideoPressUrl: jest.fn(),
+} ) );
+
+describe( 'VideoPress Embed Settings', () => {
+	const mockReplaceBlock = jest.fn();
+	const mockBlockEdit = jest.fn( () => <div>Mock Block Edit</div> );
+	const EnhancedBlockEdit = withVideoPressSettings( mockBlockEdit );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		dispatch.mockReturnValue( { replaceBlock: mockReplaceBlock } );
+		getVideoPressUrl.mockReturnValue( 'https://video.wordpress.com/v/mockguid123' );
+	} );
+
+	it( 'should not render transform UI for non-embed blocks', () => {
+		render( <EnhancedBlockEdit name="core/paragraph" attributes={ {} } isSelected={ true } /> );
+
+		expect( screen.queryByText( 'Transform to VideoPress block' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should not render transform UI for non-VideoPress embed blocks', () => {
+		render(
+			<EnhancedBlockEdit
+				name="core/embed"
+				attributes={ {
+					url: 'https://youtube.com/watch?v=123',
+					providerNameSlug: 'youtube',
+				} }
+				isSelected={ true }
+			/>
+		);
+
+		expect( screen.queryByText( 'Transform to VideoPress block' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should render transform UI for VideoPress embed blocks with video.wordpress.com URL', () => {
+		render(
+			<EnhancedBlockEdit
+				name="core/embed"
+				attributes={ {
+					url: 'https://video.wordpress.com/v/abc12345',
+				} }
+				isSelected={ true }
+			/>
+		);
+
+		expect( screen.getByText( 'Transform to VideoPress block' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render transform UI for VideoPress embed blocks with videopress.com URL', () => {
+		render(
+			<EnhancedBlockEdit
+				name="core/embed"
+				attributes={ {
+					url: 'https://videopress.com/v/abc12345',
+				} }
+				isSelected={ true }
+			/>
+		);
+
+		expect( screen.getByText( 'Transform to VideoPress block' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render transform UI for VideoPress embed blocks with providerNameSlug', () => {
+		render(
+			<EnhancedBlockEdit
+				name="core/embed"
+				attributes={ {
+					url: 'https://example.com/video',
+					providerNameSlug: 'videopress',
+				} }
+				isSelected={ true }
+			/>
+		);
+
+		expect( screen.getByText( 'Transform to VideoPress block' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should transform block when clicking the transform button', async () => {
+		const mockGuid = 'abc12345';
+		const mockUrl = 'https://video.wordpress.com/v/abc12345';
+		pickGUIDFromUrl.mockReturnValue( mockGuid );
+
+		render(
+			<EnhancedBlockEdit
+				name="core/embed"
+				attributes={ {
+					url: mockUrl,
+					id: 123,
+					title: 'Test Video',
+					caption: 'Test Caption',
+					poster: 'test-poster.jpg',
+					className: 'test-class',
+					align: 'wide',
+				} }
+				isSelected={ true }
+				clientId="test-client-id"
+			/>
+		);
+
+		await userEvent.click( screen.getByText( 'Transform to VideoPress block' ) );
+
+		// Verify block creation with correct attributes
+		expect( createBlock ).toHaveBeenCalledWith( 'videopress/video', {
+			src: mockUrl,
+			id: 123,
+			guid: mockGuid,
+			title: 'Test Video',
+			caption: 'Test Caption',
+			isVideoPressExample: false,
+			autoplay: false,
+			controls: true,
+			muted: false,
+			playsinline: true,
+			preload: 'metadata',
+			useAverageColor: true,
+			poster: 'test-poster.jpg',
+			loop: false,
+			videoPressTracks: [],
+			className: 'test-class',
+			align: 'wide',
+			rating: '',
+			allowDownload: false,
+			privacySetting: VIDEO_PRIVACY.SITE_DEFAULT,
+			url: expect.any( String ),
+		} );
+
+		// Verify block replacement
+		expect( mockReplaceBlock ).toHaveBeenCalledWith( 'test-client-id', expect.any( Object ) );
+	} );
+
+	it( 'should handle missing optional attributes during transform', async () => {
+		const mockGuid = 'abc12345';
+		const mockUrl = 'https://video.wordpress.com/v/abc12345';
+		pickGUIDFromUrl.mockReturnValue( mockGuid );
+
+		render(
+			<EnhancedBlockEdit
+				name="core/embed"
+				attributes={ {
+					url: mockUrl,
+				} }
+				isSelected={ true }
+				clientId="test-client-id"
+			/>
+		);
+
+		await userEvent.click( screen.getByText( 'Transform to VideoPress block' ) );
+
+		// Verify block creation with default values for missing attributes
+		expect( createBlock ).toHaveBeenCalledWith( 'videopress/video', {
+			src: mockUrl,
+			id: null,
+			guid: mockGuid,
+			title: '',
+			caption: '',
+			isVideoPressExample: false,
+			autoplay: false,
+			controls: true,
+			muted: false,
+			playsinline: true,
+			preload: 'metadata',
+			useAverageColor: true,
+			poster: '',
+			loop: false,
+			videoPressTracks: [],
+			className: '',
+			align: '',
+			rating: '',
+			allowDownload: false,
+			privacySetting: VIDEO_PRIVACY.SITE_DEFAULT,
+			url: expect.any( String ),
+		} );
+
+		// Verify block replacement
+		expect( mockReplaceBlock ).toHaveBeenCalledWith( 'test-client-id', expect.any( Object ) );
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-embed/videopress.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-embed/videopress.js
@@ -15,7 +15,7 @@ import { getVideoPressUrl } from '../../blocks/videopress/url';
 import { pickGUIDFromUrl } from '../../blocks/videopress/utils';
 
 // Add VideoPress settings to the embed block's edit component
-const withVideoPressSettings = createHigherOrderComponent( BlockEdit => {
+export const withVideoPressSettings = createHigherOrderComponent( BlockEdit => {
 	return props => {
 		const { name, attributes, isSelected } = props;
 

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-embed/videopress.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-embed/videopress.js
@@ -1,0 +1,120 @@
+/**
+ * WordPress dependencies
+ */
+import { InspectorControls } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { dispatch } from '@wordpress/data';
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { VIDEO_PRIVACY } from '../../blocks/videopress/constants';
+import { getVideoPressUrl } from '../../blocks/videopress/url';
+import { pickGUIDFromUrl } from '../../blocks/videopress/utils';
+
+// Add VideoPress settings to the embed block's edit component
+const withVideoPressSettings = createHigherOrderComponent( BlockEdit => {
+	return props => {
+		const { name, attributes, isSelected } = props;
+
+		// Only add settings to VideoPress embed blocks
+		if ( name !== 'core/embed' ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		// Check if this is a VideoPress URL or embed
+		const isVideoPress =
+			// Check URL patterns
+			attributes?.url?.match(
+				/^https?:\/\/(?:video\.wordpress\.com\/[ve]\/|videopress\.com\/[ve]\/)[a-zA-Z\d]{8}/
+			) ||
+			// Check provider name
+			attributes?.providerNameSlug === 'videopress' ||
+			// Check if it's a VideoPress block
+			attributes?.type === 'video';
+
+		if ( ! isVideoPress ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		const { replaceBlock } = dispatch( 'core/block-editor' );
+
+		const handleTransform = () => {
+			// Extract the video URL and GUID
+			const videoUrl = attributes.url;
+			const guid = attributes.guid || pickGUIDFromUrl( videoUrl );
+
+			// Create the VideoPress block with all required attributes
+			const videoPressBlock = createBlock( 'videopress/video', {
+				// Core video attributes
+				src: videoUrl,
+				id: attributes.id || null,
+				guid: guid,
+				title: attributes.title || '',
+				caption: attributes.caption || '',
+
+				// VideoPress specific attributes
+				isVideoPressExample: false,
+				autoplay: false,
+				controls: true,
+				muted: false,
+				playsinline: true,
+				preload: 'metadata',
+				useAverageColor: true,
+				poster: attributes.poster || '',
+				loop: false,
+				videoPressTracks: [],
+				className: attributes.className || '',
+				align: attributes.align || '',
+				rating: '',
+				allowDownload: false,
+				privacySetting: VIDEO_PRIVACY.SITE_DEFAULT,
+
+				// Add preview-specific attributes
+				url: getVideoPressUrl( guid, {
+					autoplay: false,
+					controls: true,
+					loop: false,
+					muted: false,
+					playsinline: true,
+					poster: attributes.poster || '',
+					preload: 'metadata',
+					useAverageColor: true,
+				} ),
+			} );
+
+			// Replace the current block with the VideoPress block
+			replaceBlock( props.clientId, videoPressBlock );
+		};
+
+		return (
+			<>
+				<BlockEdit { ...props } />
+				{ isSelected && (
+					<InspectorControls>
+						<div className="wp-block-videopress-video-transform" style={ { padding: '16px' } }>
+							<div className="components-notice is-info">
+								<div className="components-notice__content">
+									{ __(
+										"You can transform this post's video blocks to the new VideoPress block to take advantage of new features.",
+										'jetpack'
+									) }
+								</div>
+							</div>
+							<div style={ { marginTop: '8px' } }>
+								<button className="components-button is-primary" onClick={ handleTransform }>
+									{ __( 'Transform to VideoPress block', 'jetpack' ) }
+								</button>
+							</div>
+						</div>
+					</InspectorControls>
+				) }
+			</>
+		);
+	};
+}, 'withVideoPressSettings' );
+
+// Add the settings panel
+addFilter( 'editor.BlockEdit', 'jetpack/videopress-embed-settings', withVideoPressSettings );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/28478

## Proposed changes:
* Adds transformation notice in the edit sidebar screen for the Embed block if it's VideoPress variant

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Nope

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR following instruction from [here](https://github.com/Automattic/jetpack/pull/42443#issuecomment-2722810481)
* Open editor, it can be post or page
* Add an Embed block and provide a VideoPress URL. For example: `https://video.wordpress.com/v/VmccXaww`
* Check if there is a transformation notice in the sidebar
* Click the CTA button
* Check if it transforms

<img width="705" alt="Screenshot 2025-03-13 at 23 16 55" src="https://github.com/user-attachments/assets/4e0fa33e-74a6-4ee4-8fbf-d4587db7ca03" />

<img width="1357" alt="Screenshot 2025-03-13 at 23 17 07" src="https://github.com/user-attachments/assets/6b9d303b-dd58-46e2-8106-2a5f43efc444" />

<img width="1340" alt="Screenshot 2025-03-13 at 23 17 23" src="https://github.com/user-attachments/assets/a9696ff0-112c-473a-a64a-42e2b43cab0a" />

