### PR TITLE
SEO Enhancer: Auto-generate alt text for images if enabled

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-seo-enhancer-auto-alt-text
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-seo-enhancer-auto-alt-text
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Moved a function from another place
+
+

--- a/projects/js-packages/ai-client/src/libs/get-base64-image.ts
+++ b/projects/js-packages/ai-client/src/libs/get-base64-image.ts
@@ -1,0 +1,20 @@
+/**
+ * Get the base64 representation of an image.
+ *
+ * @param {string} url - The URL of the image.
+ * @return {Promise<string>} The base64 representation of the image.
+ */
+export const getBase64Image = async ( url: string ) => {
+	try {
+		const response = await fetch( url );
+		const buffer = await response.arrayBuffer();
+		const base64String = btoa(
+			new Uint8Array( buffer ).reduce( ( data, byte ) => data + String.fromCharCode( byte ), '' )
+		);
+
+		return `data:image/png;base64,${ base64String }`;
+	} catch {
+		// If we can't fetch the image, return the original URL.
+		return url;
+	}
+};

--- a/projects/js-packages/ai-client/src/libs/index.ts
+++ b/projects/js-packages/ai-client/src/libs/index.ts
@@ -6,12 +6,10 @@ export {
 	fixes,
 } from './markdown/index.js';
 
-export type { RenderHTMLRules } from './markdown/index.js';
-
 export { mapActionToHumanText } from './map-action-to-human-text.js';
-
 export { openBlockSidebar } from './open-block-sidebar.js';
-
 export { showAiAssistantSection } from './show-ai-assistant-section.js';
-
 export { getAllBlocks } from './get-all-blocks.js';
+export { getBase64Image } from './get-base64-image.js';
+
+export type { RenderHTMLRules } from './markdown/index.js';

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-seo-enhancer-auto-alt-text
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-seo-enhancer-auto-alt-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+SEO Enhancer: Auto-generate alt text for images if enabled

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/components/image-toolbar-dropdown.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/components/image-toolbar-dropdown.tsx
@@ -17,14 +17,14 @@ import './style.scss';
 /*
  * Types
  */
-import type { LOADING_STATE } from '../../../extensions/types';
 import type { ReactElement } from 'react';
 
 type AiAssistantExtensionToolbarDropdownContentProps = {
 	onClose: () => void;
 	onRequestAltText: () => Promise< void >;
 	onRequestCaption: () => Promise< void >;
-	loading?: LOADING_STATE;
+	loadingAltText?: boolean;
+	loadingCaption?: boolean;
 };
 
 const debug = debugFactory( 'jetpack-ai:image-extension' );
@@ -40,7 +40,8 @@ const AiAssistantImageExtensionToolbarDropdownContent = forwardRef(
 			onClose,
 			onRequestAltText,
 			onRequestCaption,
-			loading = false,
+			loadingAltText,
+			loadingCaption,
 		}: AiAssistantExtensionToolbarDropdownContentProps,
 		ref: React.RefObject< HTMLDivElement >
 	) => {
@@ -78,20 +79,20 @@ const AiAssistantImageExtensionToolbarDropdownContent = forwardRef(
 			>
 				<MenuGroup>
 					<MenuItem
-						icon={ loading === TYPE_ALT_TEXT ? <Spinner /> : altTextIcon }
+						icon={ loadingAltText ? <Spinner /> : altTextIcon }
 						iconPosition="left"
 						key="key-ai-assistant-alt-text"
 						onClick={ handleRequestAltText }
-						disabled={ !! loading || requireUpgrade }
+						disabled={ !! loadingAltText || requireUpgrade }
 					>
 						{ __( 'Generate alt text', 'jetpack' ) }
 					</MenuItem>
 					<MenuItem
-						icon={ loading === TYPE_CAPTION ? <Spinner /> : captionIcon }
+						icon={ loadingCaption ? <Spinner /> : captionIcon }
 						iconPosition="left"
 						key="key-ai-assistant-caption"
 						onClick={ handleRequestCaption }
-						disabled={ !! loading || requireUpgrade }
+						disabled={ !! loadingCaption || requireUpgrade }
 					>
 						{ __( 'Generate caption', 'jetpack' ) }
 					</MenuItem>
@@ -105,14 +106,16 @@ export default function AiAssistantImageExtensionToolbarDropdown( {
 	label = __( 'AI Assistant', 'jetpack' ),
 	onRequestAltText,
 	onRequestCaption,
-	loading = false,
+	loadingAltText = false,
+	loadingCaption = false,
 	disabled = false,
 	wrapperRef,
 }: {
 	label?: string;
 	onRequestAltText: () => Promise< void >;
 	onRequestCaption: () => Promise< void >;
-	loading?: LOADING_STATE;
+	loadingAltText?: boolean;
+	loadingCaption?: boolean;
 	disabled?: boolean;
 	wrapperRef: React.RefObject< HTMLDivElement >;
 } ): ReactElement {
@@ -164,7 +167,8 @@ export default function AiAssistantImageExtensionToolbarDropdown( {
 					onClose={ onClose }
 					onRequestAltText={ handleRequestAltText }
 					onRequestCaption={ handleRequestCaption }
-					loading={ loading }
+					loadingAltText={ loadingAltText }
+					loadingCaption={ loadingCaption }
 				/>
 			) }
 		/>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
@@ -18,16 +18,13 @@ import debugFactory from 'debug';
 /*
  * Internal dependencies
  */
+import { store as seoStore } from '../../../../plugins/ai-assistant-plugin/components/seo-enhancer/store';
 import useBlockModuleStatus from '../../hooks/use-block-module-status';
 import { getFeatureAvailability } from '../../lib/utils/get-feature-availability';
 import { canAIAssistantBeEnabled } from '../lib/can-ai-assistant-be-enabled';
 import { preprocessImageContent } from '../lib/preprocess-image-content';
 import { TYPE_ALT_TEXT, TYPE_CAPTION } from '../types';
 import AiAssistantImageExtensionToolbarDropdown from './components/image-toolbar-dropdown';
-/*
- * Types
- */
-import type { LOADING_STATE } from '../types';
 
 const debug = debugFactory( 'jetpack-ai:image-extension' );
 
@@ -73,25 +70,46 @@ export function isPossibleToExtendImageBlock( blockName: string ): boolean {
 const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 	function ExtendedBlock( props ) {
 		const { increaseRequestsCount, dequeueAsyncRequest, requireUpgrade } = useAiFeature();
-		const postId = useSelect(
-			select => ( select( editorStore ) as { getCurrentPostId: () => number } ).getCurrentPostId(),
-			[]
+		const { getCurrentPostId, isImageBusy } = useSelect(
+			select => {
+				const { getCurrentPostId: getPostId } = select( editorStore ) as {
+					getCurrentPostId: () => number;
+				};
+				const isBusy = select( seoStore )?.isImageBusy( props.clientId ) ?? false;
+
+				return { getCurrentPostId: getPostId, isImageBusy: isBusy };
+			},
+			[ props.clientId ]
 		);
 		const { getPostContent } = usePostContent();
-		const [ loading, setLoading ] = useState< LOADING_STATE >( false );
+		const [ loadingAltText, setLoadingAltText ] = useState< boolean >( isImageBusy );
+		const [ loadingCaption, setLoadingCaption ] = useState< boolean >( false );
 		const { updateBlockAttributes } = useDispatch( editorStore );
 		const { createNotice } = useDispatch( 'core/notices' );
 		const wrapperRef = useRef< HTMLDivElement >( null );
 		const hasImage = !! props.attributes.url;
+		const loading = loadingAltText || loadingCaption;
+
+		useEffect( () => {
+			setLoadingAltText( isImageBusy );
+		}, [ isImageBusy ] );
+
+		const setLoading = ( type: typeof TYPE_ALT_TEXT | typeof TYPE_CAPTION, value: boolean ) => {
+			if ( type === TYPE_ALT_TEXT ) {
+				setLoadingAltText( value );
+			} else if ( type === TYPE_CAPTION ) {
+				setLoadingCaption( value );
+			}
+		};
 
 		// When the dropdown is open, we need to focus the wrapper element to prevent it from closing.
-		const startLoading = useCallback( ( type: LOADING_STATE ) => {
+		const startLoading = useCallback( ( type: typeof TYPE_ALT_TEXT | typeof TYPE_CAPTION ) => {
 			if ( wrapperRef.current ) {
 				wrapperRef.current.setAttribute( 'tabindex', '0' );
 				wrapperRef.current.focus();
 			}
 
-			setLoading( type );
+			setLoading( type, true );
 		}, [] );
 
 		const showErrorNotice = useCallback(
@@ -104,7 +122,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		);
 
 		useEffect( () => {
-			if ( loading === false ) {
+			if ( ! loading ) {
 				if ( wrapperRef.current ) {
 					wrapperRef.current.setAttribute( 'tabindex', '-1' );
 				}
@@ -155,7 +173,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 							},
 						],
 						{
-							postId,
+							postId: getCurrentPostId(),
 							feature: 'jetpack-ai-image-extension',
 						}
 					);
@@ -176,7 +194,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 						updateBlockAttributes( props.clientId, { caption } );
 					}
 
-					setLoading( false );
+					setLoading( type, false );
 				} catch ( error ) {
 					if ( error?.message.includes( 'The image URL is invalid' ) && ! useBase64Image ) {
 						debug( 'Retrying with base64 image' );
@@ -189,14 +207,14 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 						showErrorNotice( error.message );
 					}
 
-					setLoading( false );
+					setLoading( type, false );
 				}
 			},
 			[
 				dequeueAsyncRequest,
+				getCurrentPostId,
 				getPostContent,
 				increaseRequestsCount,
-				postId,
 				props.attributes.url,
 				props.clientId,
 				requireUpgrade,
@@ -213,7 +231,8 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 					<AiAssistantImageExtensionToolbarDropdown
 						onRequestAltText={ () => request( TYPE_ALT_TEXT ) }
 						onRequestCaption={ () => request( TYPE_CAPTION ) }
-						loading={ loading }
+						loadingAltText={ loadingAltText }
+						loadingCaption={ loadingCaption }
 						disabled={ ! hasImage }
 						wrapperRef={ wrapperRef }
 					/>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
@@ -6,6 +6,7 @@ import {
 	usePostContent,
 	openBlockSidebar,
 	useAiFeature,
+	getBase64Image,
 } from '@automattic/jetpack-ai-client';
 import { BlockControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -102,24 +103,6 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			[ createNotice ]
 		);
 
-		const getBase64Image = useCallback( async ( url: string ) => {
-			try {
-				const response = await fetch( url );
-				const buffer = await response.arrayBuffer();
-				const base64String = btoa(
-					new Uint8Array( buffer ).reduce(
-						( data, byte ) => data + String.fromCharCode( byte ),
-						''
-					)
-				);
-
-				return `data:image/png;base64,${ base64String }`;
-			} catch {
-				// If we can't fetch the image, it must be external, so we return the original URL.
-				return url;
-			}
-		}, [] );
-
 		useEffect( () => {
 			if ( loading === false ) {
 				if ( wrapperRef.current ) {
@@ -129,7 +112,10 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		}, [ loading ] );
 
 		const request = useCallback(
-			async ( type: typeof TYPE_ALT_TEXT | typeof TYPE_CAPTION ) => {
+			async (
+				type: typeof TYPE_ALT_TEXT | typeof TYPE_CAPTION,
+				useBase64Image: boolean = false
+			) => {
 				if ( requireUpgrade ) {
 					return;
 				}
@@ -160,7 +146,9 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 									images: [
 										{
 											// We convert the image to a base64 string to avoid inaccesible URLs for private images.
-											url: await getBase64Image( props.attributes.url ),
+											url: useBase64Image
+												? await getBase64Image( props.attributes.url )
+												: props.attributes.url,
 										},
 									],
 								},
@@ -187,18 +175,25 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 						const caption = parsedResponse.captions?.[ 0 ];
 						updateBlockAttributes( props.clientId, { caption } );
 					}
+
+					setLoading( false );
 				} catch ( error ) {
+					if ( error?.message.includes( 'The image URL is invalid' ) && ! useBase64Image ) {
+						debug( 'Retrying with base64 image' );
+						return request( type, true );
+					}
+
 					debug( `Error generating ${ type }`, error );
+
 					if ( error?.message ) {
 						showErrorNotice( error.message );
 					}
-				} finally {
+
 					setLoading( false );
 				}
 			},
 			[
 				dequeueAsyncRequest,
-				getBase64Image,
 				getPostContent,
 				increaseRequestsCount,
 				postId,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/types.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/types.ts
@@ -5,4 +5,3 @@ export type BlockBehavior = 'dropdown' | 'action' | CustomBlockBehavior;
 
 export const TYPE_ALT_TEXT = 'images-alt-text' as const;
 export const TYPE_CAPTION = 'images-caption' as const;
-export type LOADING_STATE = typeof TYPE_ALT_TEXT | typeof TYPE_CAPTION | false;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/index.ts
@@ -1,4 +1,5 @@
 import { store } from './store';
+import './with-seo-auto-generation';
 
 export { store };
 export { SeoEnhancer } from './seo-enhancer';

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
@@ -29,7 +29,12 @@ const debug = debugFactory( 'seo-enhancer:index' );
 
 export function SeoEnhancer() {
 	const { isEnabled, toggleEnhancer, isToggling } = useSeoModuleSettings();
-	const isLoading = useSelect( select => select( store ).isBusy(), [] );
+	const isLoading = useSelect( select => {
+		const isBusy = select( store ).isBusy();
+		const isAnyImageBusy = select( store ).isAnyImageBusy();
+
+		return isBusy || isAnyImageBusy;
+	}, [] );
 	const [ features, setFeatures ] = useState<
 		{ name: PromptType; label: string; checked: boolean }[]
 	>( [

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/actions.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/actions.ts
@@ -18,3 +18,11 @@ export function setIsAutoEnhanceEnabled( isEnabled: boolean ) {
 		isEnabled,
 	};
 }
+
+export function setImageBusy( clientId: string, isBusy: boolean ) {
+	return {
+		type: 'SET_IMAGE_BUSY',
+		clientId,
+		isBusy,
+	};
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/index.ts
@@ -34,6 +34,7 @@ export const store = createReduxStore( STORE_NAME, {
 		isBusy: false,
 		isTogglingAutoEnhance: false,
 		isAutoEnhanceEnabled: enhancerEnabled,
+		busyImages: {},
 	},
 } );
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/reducer.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/reducer.ts
@@ -11,6 +11,8 @@ export function reducer( state: SeoEnhancerState, action: SeoEnhancerAction ) {
 			return { ...state, isTogglingAutoEnhance: action.isToggling };
 		case 'SET_IS_AUTO_ENHANCE_ENABLED':
 			return { ...state, isAutoEnhanceEnabled: action.isEnabled };
+		case 'SET_IMAGE_BUSY':
+			return { ...state, busyImages: { ...state.busyImages, [ action.clientId ]: action.isBusy } };
 		default:
 			return state;
 	}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/selectors.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/selectors.ts
@@ -14,3 +14,7 @@ export function isTogglingAutoEnhance( state: SeoEnhancerState ) {
 export function isAutoEnhanceEnabled( state: SeoEnhancerState ) {
 	return state.isAutoEnhanceEnabled;
 }
+
+export function isImageBusy( state: SeoEnhancerState, clientId: string ) {
+	return state.busyImages[ clientId ] ?? false;
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/selectors.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/selectors.ts
@@ -18,3 +18,7 @@ export function isAutoEnhanceEnabled( state: SeoEnhancerState ) {
 export function isImageBusy( state: SeoEnhancerState, clientId: string ) {
 	return state.busyImages[ clientId ] ?? false;
 }
+
+export function isAnyImageBusy( state: SeoEnhancerState ) {
+	return Object.values( state.busyImages ).some( busy => busy );
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/types.ts
@@ -18,11 +18,17 @@ export type SeoEnhancerState = {
 	isBusy?: boolean;
 	isTogglingAutoEnhance?: boolean;
 	isAutoEnhanceEnabled?: boolean;
+	busyImages?: Record< string, boolean >;
 };
 
 export type SeoEnhancerAction = {
-	type: 'SET_BUSY' | 'SET_IS_TOGGLING_AUTO_ENHANCE' | 'SET_IS_AUTO_ENHANCE_ENABLED';
+	type:
+		| 'SET_BUSY'
+		| 'SET_IS_TOGGLING_AUTO_ENHANCE'
+		| 'SET_IS_AUTO_ENHANCE_ENABLED'
+		| 'SET_IMAGE_BUSY';
 	isBusy?: boolean;
 	isToggling?: boolean;
 	isEnabled?: boolean;
+	clientId?: string;
 };

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/with-seo-auto-generation.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/with-seo-auto-generation.tsx
@@ -1,0 +1,86 @@
+/*
+ * External dependencies
+ */
+import {
+	getJetpackExtensionAvailability,
+	useModuleStatus,
+} from '@automattic/jetpack-shared-extension-utils';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { addFilter } from '@wordpress/hooks';
+/*
+ * Internal dependencies
+ */
+import { useSeoModuleSettings } from './use-seo-module-settings';
+import { useSeoRequests } from './use-seo-requests';
+/*
+ * Types
+ */
+import type { Block } from '@automattic/jetpack-ai-client';
+
+const isSeoEnhancerEnabled =
+	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true;
+
+function isPossibleToExtendImageBlock( blockName: string ): boolean {
+	return blockName === 'core/image' && isSeoEnhancerEnabled;
+}
+
+const blockEditWithSeoAutoGeneration = createHigherOrderComponent( BlockEdit => {
+	function ExtendedBlock( props ) {
+		const { updateAltText } = useSeoRequests();
+		const { isEnabled: isAutoEnhanceEnabled } = useSeoModuleSettings();
+		const { getBlock } = useSelect(
+			select => select( 'core/block-editor' ) as { getBlock: ( clientId: string ) => Block },
+			[]
+		);
+
+		// Automatically update the alt text when an image is added without alt text.
+		useEffect( () => {
+			if ( props.attributes.url && ! props.attributes.alt && isAutoEnhanceEnabled ) {
+				const block = getBlock( props.clientId );
+
+				if ( block ) {
+					updateAltText( block );
+				}
+			}
+		}, [
+			props.attributes.url,
+			props.attributes.alt,
+			props.clientId,
+			getBlock,
+			updateAltText,
+			isAutoEnhanceEnabled,
+		] );
+
+		return <BlockEdit { ...props } />;
+	}
+
+	return props => {
+		const { isModuleActive } = useModuleStatus( 'seo-tools' );
+
+		if ( ! isModuleActive ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		return <ExtendedBlock { ...props } />;
+	};
+}, 'blockEditWithSeoAutoGeneration' );
+
+export function blockWithSeoAutoGenerationExtension( settings, name: string ) {
+	if ( ! isPossibleToExtendImageBlock( name ) ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		edit: blockEditWithSeoAutoGeneration( settings.edit ),
+	};
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'jetpack/ai-assistant-support/with-seo-auto-generation',
+	blockWithSeoAutoGenerationExtension,
+	100
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #42444 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds data on the SEO store about loading state for images
* Changes the behavior of both the image extension and the SEO enhancer to try using the image URL first and only use base64 on retry as it is much slower
* Extends the image block to react to changes in image url without alt text

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This one requires more attention as it also touches on the image extension, which is live in production.

* Without the feature flag, go to the block editor and add some images
* Generate alt text and captions. Check that each action has a separate loading indicator and can be done in parallel
* Enable the feature flag and disable the auto-enhance toggle
* Check that images do not have their alt text generated immediately
* Enable the auto-enhance toggle
* Check that images without alt text send requests for alt text immediately
* Check that the SEO title and description are generated on pre-publish
