### PR TITLE
Boost: Fix broken edit page

### DIFF
--- a/projects/plugins/boost/app/admin/class-admin.php
+++ b/projects/plugins/boost/app/admin/class-admin.php
@@ -11,6 +11,7 @@ namespace Automattic\Jetpack_Boost\Admin;
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Boost_Speed_Score\Speed_Score;
+use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
 use Automattic\Jetpack_Boost\Lib\Analytics;
 use Automattic\Jetpack_Boost\Lib\Environment_Change_Detector;
 use Automattic\Jetpack_Boost\Lib\Premium_Features;
@@ -66,6 +67,7 @@ class Admin {
 		Premium_Features::clear_cache();
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( My_Jetpack_Initializer::class, 'enqueue_scripts' ) );
 	}
 
 	/**

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -121,7 +121,6 @@ class Jetpack_Boost {
 		$this->init_sync();
 
 		add_action( 'admin_init', array( $this, 'schedule_version_change' ) );
-		add_action( 'admin_enqueue_scripts', array( My_Jetpack_Initializer::class, 'enqueue_scripts' ) );
 
 		add_action( 'init', array( $this, 'init_textdomain' ) );
 

--- a/projects/plugins/boost/changelog/fix-boost-broken-edit-page
+++ b/projects/plugins/boost/changelog/fix-boost-broken-edit-page
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix for an unreleased feature.
+
+


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/42452

## Proposed changes:

* Update the My Jetpack assets to be enqueued only on the main Boost settings page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1741891218849169-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

### Test that the edit page is broken

- Follow the instructions in the related ticket

### Test that the edit page works

- Follow the instructions in the related ticket;
- The Critical CSS CTA still work should work:

![CleanShot 2025-03-14 at 09 57 24](https://github.com/user-attachments/assets/3c364816-733f-4c9c-a1dc-a7341b6af483)

- The page shouldn't be broken.