### PR TITLE
Social: Connections schema: Remove the deprecated fields

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-remove-deprecated-fields
+++ b/projects/js-packages/publicize-components/changelog/update-social-remove-deprecated-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Social : Connections schema: Remove the deprecated fields

--- a/projects/js-packages/publicize-components/src/social-store/types.ts
+++ b/projects/js-packages/publicize-components/src/social-store/types.ts
@@ -13,48 +13,6 @@ export type Connection = {
 	shared: boolean;
 	status: ConnectionStatus;
 	wpcom_user_id: number;
-
-	/* DEPRECATED FIELDS  */
-	/**
-	 * @deprecated
-	 */
-	done?: boolean;
-	/**
-	 * @deprecated Use `status` instead.
-	 */
-	error_code?: string;
-	/**
-	 * @deprecated Use `display_name` instead.
-	 */
-	external_display?: string;
-	/**
-	 * @deprecated Use `external_handle` instead.
-	 */
-	external_name?: string;
-	/**
-	 * @deprecated Use `connection_id` instead.
-	 */
-	id?: string;
-	/**
-	 * @deprecated Use `status` instead.
-	 */
-	is_healthy?: boolean;
-	/**
-	 * @deprecated Use `service_label` instead.
-	 */
-	label?: string;
-	/**
-	 * @deprecated Use `status` instead.
-	 */
-	test_success?: boolean;
-	/**
-	 * @deprecated
-	 */
-	toggleable?: boolean;
-	/**
-	 * @deprecated Use `external_handle` instead.
-	 */
-	username?: string;
 };
 
 export type ConnectionData = {

--- a/projects/packages/publicize/changelog/update-social-remove-deprecated-fields
+++ b/projects/packages/publicize/changelog/update-social-remove-deprecated-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Social : Connections schema: Remove the deprecated fields

--- a/projects/packages/publicize/src/class-connections.php
+++ b/projects/packages/publicize/src/class-connections.php
@@ -41,10 +41,6 @@ class Connections {
 			}
 		}
 
-		// Let us add the deprecated fields for now.
-		// TODO: Remove this after https://github.com/Automattic/jetpack/pull/40539 is merged.
-		$connections = self::retain_deprecated_fields( $connections );
-
 		return $connections;
 	}
 
@@ -122,37 +118,6 @@ class Connections {
 		}
 
 		return $wpcom_user_id && $connection['wpcom_user_id'] === $wpcom_user_id;
-	}
-
-	/**
-	 * Retain deprecated fields.
-	 *
-	 * @param array $connections Connections.
-	 * @return array
-	 */
-	private static function retain_deprecated_fields( $connections ) {
-		return array_map(
-			function ( $connection ) {
-
-				$owns_connection = self::user_owns_connection( $connection );
-
-				$connection = array_merge(
-					$connection,
-					array(
-						'external_display' => $connection['display_name'],
-						'can_disconnect'   => current_user_can( 'edit_others_posts' ) || $owns_connection,
-						'label'            => $connection['service_label'],
-					)
-				);
-
-				if ( 'bluesky' === $connection['service_name'] ) {
-					$connection['external_name'] = $connection['external_handle'];
-				}
-
-				return $connection;
-			},
-			$connections
-		);
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -233,7 +233,6 @@ class Publicize extends Publicize_Base {
 	 * Get all connections for a specific user.
 	 *
 	 * @param array $args Arguments to run operations such as force refresh and connection test results.
-
 	 * @return array
 	 */
 	public function get_all_connections_for_user( $args = array() ) {


### PR DESCRIPTION
The [fields that we retained](https://github.com/Automattic/jetpack/blob/64263634af7bae1b23b709ed1807772f3cd65609/projects/packages/publicize/src/class-connections.php#L44-L46) while we were working on the connections schema changes are no longer needed/used. We should get rid of them.

Also the [deprecated fields on the front-end](https://github.com/Automattic/jetpack/blob/64263634af7bae1b23b709ed1807772f3cd65609/projects/js-packages/publicize-components/src/social-store/types.ts#L17), we should get rid of them as they are no longer used.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the deprecated and unused fields from connections UIs

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Do a sanity check of the connections management to ensure it loads fine.

