### PR TITLE
Social: Fix video preview deadlock

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-video-preview-deadlock
+++ b/projects/js-packages/publicize-components/changelog/fix-social-video-preview-deadlock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a deadlock with the media picker

--- a/projects/js-packages/publicize-components/src/components/media-picker/index.js
+++ b/projects/js-packages/publicize-components/src/components/media-picker/index.js
@@ -58,10 +58,6 @@ export default function MediaPicker( {
 	const renderPreview = useCallback(
 		open => {
 			const renderVideoPreview = isVideo( mime );
-			if ( renderVideoPreview && ! length ) {
-				return null;
-			}
-
 			return (
 				<div className={ clsx( styles[ 'preview-wrapper' ], wrapperClassName ) }>
 					<button className={ styles.remove } onClick={ onRemoveMedia }>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/853

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removed the block that returns null if there is no length. Previously we had to have that check to avoid some js errors, however it seems the media picker was changed since and it's not needed anymore.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor with the paid plan
* Pick the video from the issue. Make sure it loads. Make sure you see the length validation error.
* Pick other videos, make sure everything works fine

