### PR TITLE
i18n: Internalise legacy `getCurrencyDefaults` method from `@automattic/format-currency`

### DIFF
--- a/projects/plugins/jetpack/changelog/update-i18n-internalize-get-currency-defaults
+++ b/projects/plugins/jetpack/changelog/update-i18n-internalize-get-currency-defaults
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Added getCurrencyDefaults method to JP to allow upgrading the format-currency NPM dependency

--- a/projects/plugins/jetpack/extensions/blocks/simple-payments/deprecated/v2/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/simple-payments/deprecated/v2/edit.js
@@ -1,4 +1,3 @@
-import { getCurrencyDefaults } from '@automattic/format-currency';
 import { InspectorControls } from '@wordpress/block-editor';
 import {
 	Disabled,
@@ -16,6 +15,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import emailValidator from 'email-validator';
 import { get, isEmpty, isEqual, pick, trimEnd } from 'lodash';
+import { getCurrencyDefaults } from '../../../../shared/currencies';
 import HelpMessage from '../../../../shared/help-message';
 import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE, SUPPORTED_CURRENCY_LIST } from '../../constants';
 import FeaturedMedia from '../../featured-media';

--- a/projects/plugins/jetpack/extensions/blocks/simple-payments/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/simple-payments/edit.js
@@ -1,4 +1,3 @@
-import { getCurrencyDefaults } from '@automattic/format-currency';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
 	Disabled,
@@ -16,6 +15,7 @@ import { getWidgetIdFromBlock } from '@wordpress/widgets';
 import clsx from 'clsx';
 import emailValidator from 'email-validator';
 import { get, isEmpty, pick, trimEnd } from 'lodash';
+import { getCurrencyDefaults } from '../../shared/currencies';
 import HelpMessage from '../../shared/help-message';
 import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE, SUPPORTED_CURRENCY_LIST } from './constants';
 import { PanelControls } from './controls';

--- a/projects/plugins/jetpack/extensions/blocks/simple-payments/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/simple-payments/utils.js
@@ -1,5 +1,5 @@
-import { getCurrencyDefaults } from '@automattic/format-currency';
 import { trimEnd } from 'lodash';
+import { getCurrencyDefaults } from '../../shared/currencies';
 import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from './constants';
 
 export const isValidSimplePaymentsProduct = product =>

--- a/projects/plugins/jetpack/extensions/shared/currencies.js
+++ b/projects/plugins/jetpack/extensions/shared/currencies.js
@@ -1,8 +1,26 @@
-import { CURRENCIES, getCurrencyDefaults } from '@automattic/format-currency';
+import { CURRENCIES } from '@automattic/format-currency';
 
 // Removes all dots (`.`) from the end of a string.
 function removeTrailingDots( string ) {
 	return String( string || '' ).replace( /\.+$/, '' );
+}
+
+/**
+ * Get the currency settings for a certain currency.
+ * This is an internalized version of the function previously provided by format-currency.
+ *
+ * @param {string} code - The currency code.
+ * @return {object} - Object containing currency settings.
+ */
+export function getCurrencyDefaults( code ) {
+	return (
+		CURRENCIES[ code ] || {
+			symbol: '$',
+			decimal: '.',
+			grouping: ',',
+			precision: 2,
+		}
+	);
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of a PT: pxLjZ-9ME-p2
Partly addresses https://github.com/Automattic/i18n-issues/issues/939 and https://github.com/Automattic/i18n-issues/issues/942

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Before we can consolidate number and currency formatting in Jetpack we need to bring `@automattic/format-currency` to the latest version (`2.0.0`). We internalise some of the legacy functionality that's no longer present in `format-currency` so we upgrade.

Fixing these cases (to remove the legacy code completely) can be done separately by folks more familiar with these components. Our goal is primarily to bring the latest version into JP, then replace it with our unified number-formatters component.

**Update/Latest**: `@automattic/format-currency` is no longer in use anywhere within JP by now, so internalising these methods, albeit not the grand solution, is at least a step in the right direction (to allow us to deprecate `@automattic/format-currency` completely - remove it from the wp-calypso monorepo). All code has migrated to `@automattic/number-formatters` at this point. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Same instructions with https://github.com/Automattic/jetpack/pull/42796 apply
* The changes here affect the "simple payments" buttons in the editor. Unfortunately, I have not been able to connect a Stripe account to test this. Need to ping an expert to confirm.

<img width="728" alt="Screenshot 2025-05-07 at 2 41 19 PM" src="https://github.com/user-attachments/assets/1cd99834-bb31-4943-8393-fc5ca7b49c35" />
