### PR TITLE
i18n: Internalise legacy CURRENCIES object from `@automattic/format-currency`

### DIFF
--- a/projects/js-packages/components/changelog/update-i18n-internalize-currencies-object
+++ b/projects/js-packages/components/changelog/update-i18n-internalize-currencies-object
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-internalize currencies object as legacy no longer exported or present in this form from @automattic/format-currency package
+Internalize CURRENCIES object as legacy no longer exported or present in this form from @automattic/format-currency package. These cases should migrate to @automattic/number-formatters package but the internal object differs.

--- a/projects/js-packages/components/changelog/update-i18n-internalize-currencies-object
+++ b/projects/js-packages/components/changelog/update-i18n-internalize-currencies-object
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+internalize currencies object as legacy no longer exported or present in this form from @automattic/format-currency package

--- a/projects/js-packages/components/components/product-price/stories/index.stories.tsx
+++ b/projects/js-packages/components/components/product-price/stories/index.stories.tsx
@@ -1,6 +1,30 @@
-import { CURRENCIES } from '@automattic/format-currency';
 import ProductPrice from '../index.tsx';
 import type { StoryFn, Meta } from '@storybook/react';
+
+/**
+ * Local array of currency codes so we don't need to import from format-currency
+ * This is the subset of currencies that are supported by Jetpack
+ * See js-packages/plugins/jetpack/extensions/shared/currencies.js
+ */
+const currencies = [
+	'USD',
+	'AUD',
+	'BRL',
+	'CAD',
+	'CHF',
+	'DKK',
+	'EUR',
+	'GBP',
+	'HKD',
+	'INR',
+	'JPY',
+	'MXN',
+	'NOK',
+	'NZD',
+	'PLN',
+	'SEK',
+	'SGD',
+];
 
 const meta: Meta< typeof ProductPrice > = {
 	title: 'JS Packages/Components/Product Price',
@@ -8,7 +32,7 @@ const meta: Meta< typeof ProductPrice > = {
 	argTypes: {
 		currency: {
 			control: { type: 'select' },
-			options: Object.keys( CURRENCIES ),
+			options: currencies,
 		},
 	},
 };

--- a/projects/plugins/jetpack/changelog/update-i18n-internalize-currencies-object
+++ b/projects/plugins/jetpack/changelog/update-i18n-internalize-currencies-object
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Internalize CURRENCIES object as legacy no longer exported or present in this form from @automattic/format-currency package. These cases should migrate to number-formatters package but the internal object differs
+Internalize CURRENCIES object as legacy no longer exported or present in this form from @automattic/format-currency package. These cases should migrate to @automattic/number-formatters package but the internal object differs.

--- a/projects/plugins/jetpack/changelog/update-i18n-internalize-currencies-object
+++ b/projects/plugins/jetpack/changelog/update-i18n-internalize-currencies-object
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Internalise CURRENCIES object from format-currency to replace legacy v1 uses of format-currency. These should migrate to number-formatters package but the internal object differs

--- a/projects/plugins/jetpack/changelog/update-i18n-internalize-currencies-object
+++ b/projects/plugins/jetpack/changelog/update-i18n-internalize-currencies-object
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Internalise CURRENCIES object from format-currency to replace legacy v1 uses of format-currency. These should migrate to number-formatters package but the internal object differs
+Internalize CURRENCIES object as legacy no longer exported or present in this form from @automattic/format-currency package. These cases should migrate to number-formatters package but the internal object differs

--- a/projects/plugins/jetpack/extensions/blocks/donations/amount.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/amount.js
@@ -1,9 +1,12 @@
-import { CURRENCIES } from '@automattic/format-currency';
 import { formatCurrency } from '@automattic/number-formatters';
 import { RichText } from '@wordpress/block-editor';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import clsx from 'clsx';
-import { minimumTransactionAmountForCurrency, parseAmount } from '../../shared/currencies';
+import {
+	LEGACY_CURRENCIES,
+	minimumTransactionAmountForCurrency,
+	parseAmount,
+} from '../../shared/currencies';
 
 const Amount = ( {
 	className = null,
@@ -98,7 +101,7 @@ const Amount = ( {
 			onClick={ setFocus }
 			onKeyDown={ setFocus }
 		>
-			{ CURRENCIES[ currency ].symbol }
+			{ LEGACY_CURRENCIES[ currency ].symbol }
 			{ disabled ? (
 				<div className="donations__amount-value">
 					{ formatCurrency( value ? value : defaultValue, currency, { symbol: '' } ) }

--- a/projects/plugins/jetpack/extensions/blocks/donations/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/controls.js
@@ -1,4 +1,3 @@
-import { CURRENCIES } from '@automattic/format-currency';
 import { getSiteFragment } from '@automattic/jetpack-shared-extension-utils';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
 import {
@@ -18,6 +17,7 @@ import { DOWN } from '@wordpress/keycodes';
 import {
 	getDefaultDonationAmountsForCurrency,
 	SUPPORTED_CURRENCIES,
+	LEGACY_CURRENCIES,
 } from '../../shared/currencies';
 
 const Controls = props => {
@@ -74,7 +74,7 @@ const Controls = props => {
 											className="jetpack-donations__currency-toggle"
 											icon={
 												<>
-													{ currency + ' - ' + CURRENCIES[ currency ].symbol }
+													{ currency + ' - ' + LEGACY_CURRENCIES[ currency ].symbol }
 													<Dashicon icon="arrow-down" />
 												</>
 											}
@@ -96,7 +96,7 @@ const Controls = props => {
 												} }
 												key={ `jetpack-donations-currency-${ ccy }` }
 											>
-												{ ccy + ' - ' + CURRENCIES[ ccy ].symbol }
+												{ ccy + ' - ' + LEGACY_CURRENCIES[ ccy ].symbol }
 											</MenuItem>
 										) ) }
 									</MenuGroup>

--- a/projects/plugins/jetpack/extensions/blocks/donations/deprecated/v1/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/deprecated/v1/index.js
@@ -1,8 +1,10 @@
-import { CURRENCIES } from '@automattic/format-currency';
 import { formatCurrency } from '@automattic/number-formatters';
 import { RichText } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { minimumTransactionAmountForCurrency } from '../../../../shared/currencies';
+import {
+	LEGACY_CURRENCIES,
+	minimumTransactionAmountForCurrency,
+} from '../../../../shared/currencies';
 
 export default {
 	attributes: {
@@ -149,7 +151,7 @@ export default {
 								<>
 									<RichText.Content tagName="p" value={ customAmountText } />
 									<div className="donations__amount donations__custom-amount">
-										{ CURRENCIES[ currency ].symbol }
+										{ LEGACY_CURRENCIES[ currency ].symbol }
 										<div
 											className="donations__amount-value"
 											data-currency={ currency }

--- a/projects/plugins/jetpack/extensions/shared/currencies.js
+++ b/projects/plugins/jetpack/extensions/shared/currencies.js
@@ -1,9 +1,119 @@
-import { CURRENCIES } from '@automattic/format-currency';
-
 // Removes all dots (`.`) from the end of a string.
 function removeTrailingDots( string ) {
 	return String( string || '' ).replace( /\.+$/, '' );
 }
+
+/**
+ * Currency data for formatting currencies.
+ * This is an internalized version of the CURRENCIES object previously imported from format-currency.
+ */
+export const LEGACY_CURRENCIES = {
+	USD: {
+		symbol: '$',
+		decimal: '.',
+		grouping: ',',
+		precision: 2,
+	},
+	AUD: {
+		symbol: 'A$',
+		decimal: '.',
+		grouping: ',',
+		precision: 2,
+	},
+	BRL: {
+		symbol: 'R$',
+		decimal: ',',
+		grouping: '.',
+		precision: 2,
+	},
+	CAD: {
+		symbol: 'C$',
+		decimal: '.',
+		grouping: ',',
+		precision: 2,
+	},
+	CHF: {
+		symbol: 'CHF',
+		decimal: '.',
+		grouping: "'",
+		precision: 2,
+	},
+	DKK: {
+		symbol: 'kr.',
+		decimal: ',',
+		grouping: '.',
+		precision: 2,
+	},
+	EUR: {
+		symbol: '€',
+		decimal: ',',
+		grouping: '.',
+		precision: 2,
+	},
+	GBP: {
+		symbol: '£',
+		decimal: '.',
+		grouping: ',',
+		precision: 2,
+	},
+	HKD: {
+		symbol: 'HK$',
+		decimal: '.',
+		grouping: ',',
+		precision: 2,
+	},
+	INR: {
+		symbol: '₹',
+		decimal: '.',
+		grouping: ',',
+		precision: 2,
+	},
+	JPY: {
+		symbol: '¥',
+		decimal: '.',
+		grouping: ',',
+		precision: 0,
+	},
+	MXN: {
+		symbol: 'MX$',
+		decimal: '.',
+		grouping: ',',
+		precision: 2,
+	},
+	NOK: {
+		symbol: 'kr',
+		decimal: ',',
+		grouping: ' ',
+		precision: 2,
+	},
+	NZD: {
+		symbol: 'NZ$',
+		decimal: '.',
+		grouping: ',',
+		precision: 2,
+	},
+	PLN: {
+		symbol: 'zł',
+		decimal: ',',
+		grouping: ' ',
+		precision: 2,
+	},
+	SEK: {
+		symbol: 'kr',
+		decimal: ',',
+		grouping: ' ',
+		precision: 2,
+	},
+	SGD: {
+		symbol: 'S$',
+		decimal: '.',
+		grouping: ',',
+		precision: 2,
+	},
+};
+
+// For backward compatibility, also export as CURRENCIES
+export const CURRENCIES = LEGACY_CURRENCIES;
 
 /**
  * Get the currency settings for a certain currency.
@@ -14,7 +124,7 @@ function removeTrailingDots( string ) {
  */
 export function getCurrencyDefaults( code ) {
 	return (
-		CURRENCIES[ code ] || {
+		LEGACY_CURRENCIES[ code ] || {
 			symbol: '$',
 			decimal: '.',
 			grouping: ',',
@@ -113,10 +223,10 @@ export function parseAmount( amount, currency ) {
 	}
 
 	let ungrouped_amount = amount;
-	if ( CURRENCIES[ currency ].grouping ) {
+	if ( LEGACY_CURRENCIES[ currency ].grouping ) {
 		// Remove any thousand grouping separator.
 		ungrouped_amount = amount.replace(
-			new RegExp( '\\' + CURRENCIES[ currency ].grouping, 'g' ),
+			new RegExp( '\\' + LEGACY_CURRENCIES[ currency ].grouping, 'g' ),
 			''
 		);
 	}
@@ -124,7 +234,7 @@ export function parseAmount( amount, currency ) {
 	amount = parseFloat(
 		ungrouped_amount
 			// Replace the localized decimal separator with a dot (the standard decimal separator in float numbers).
-			.replace( new RegExp( '\\' + CURRENCIES[ currency ].decimal, 'g' ), '.' )
+			.replace( new RegExp( '\\' + LEGACY_CURRENCIES[ currency ].decimal, 'g' ), '.' )
 	);
 
 	if ( isNaN( amount ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of a PT: pxLjZ-9ME-p2
Partly addresses https://github.com/Automattic/i18n-issues/issues/939 and https://github.com/Automattic/i18n-issues/issues/942
Based off https://github.com/Automattic/jetpack/pull/42456

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Before we can consolidate number and currency formatting in Jetpack we need to bring `@automattic/format-currency` to the latest version (`2.0.0`). We internalise some of the legacy functionality that's no longer present in `format-currency` so we upgrade.

Fixing these cases (to remove the legacy code completely) can be done separately by folks more familiar with these components. Our goal is primarily to bring the latest version into JP, then replace it with our unified number-formatters component.

**Update/Latest**: `@automattic/format-currency` is no longer in use anywhere within JP by now, so internalising these methods, albeit not the grand solution, is at least a step in the right direction (to allow us to deprecate `@automattic/format-currency` completely - remove it from the wp-calypso monorepo). All code has migrated to `@automattic/number-formatters` at this point. This is just a follow-up on https://github.com/Automattic/jetpack/pull/42456

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Same context with https://github.com/Automattic/jetpack/pull/42456