### PR TITLE
POC: Social Image Generator on WPCOM

### DIFF
--- a/projects/js-packages/publicize-components/src/components/generated-image-preview/index.js
+++ b/projects/js-packages/publicize-components/src/components/generated-image-preview/index.js
@@ -76,7 +76,7 @@ export default function GeneratedImagePreview( {
 				}
 
 				const sig_token = await apiFetch( {
-					path: '/jetpack/v4/social-image-generator/generate-preview-token',
+					path: '/wpcom/v2/publicize/social-image-generator/generate-preview-token',
 					method: 'POST',
 					data: {
 						text: imageTitle,

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -43,6 +43,7 @@ class Publicize_Setup {
 			REST_API\Scheduled_Actions_Controller::class,
 			REST_API\Services_Controller::class,
 			REST_API\Share_Post_Controller::class,
+			REST_API\Social_Image_Generator_Controller::class,
 		);
 
 		// Load the REST controllers.

--- a/projects/packages/publicize/src/rest-api/class-social-image-generator-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-social-image-generator-controller.php
@@ -7,8 +7,113 @@
 
 namespace Automattic\Jetpack\Publicize\REST_API;
 
+use Automattic\Jetpack\Connection\Traits\WPCOM_REST_API_Proxy_Request;
+use Automattic\Jetpack\Publicize\Publicize_Utils as Utils;
+use Automattic\Jetpack\Publicize\Social_Image_Generator\Templates;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Server;
+
 /**
  * Publicize: Social Image Generator Controller class.
  */
 class Social_Image_Generator_Controller extends Base_Controller {
+
+	use WPCOM_REST_API_Proxy_Request;
+
+	/**
+	 * The constructor sets the route namespace, rest_base, and registers our API route and endpoint.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->base_api_path = 'wpcom';
+		$this->version       = 'v2';
+
+		$this->namespace = "{$this->base_api_path}/{$this->version}";
+		$this->rest_base = 'publicize/social-image-generator';
+
+		$this->allow_requests_as_blog = true;
+
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register the routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/generate-preview-token',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'generate_preview_token' ),
+				'permission_callback' => array( $this, 'permissions_check' ),
+				'args'                => array(
+					'text'      => array(
+						'description' => __( 'The text to be used to generate the image.', 'jetpack-publicize-pkg' ),
+						'type'        => 'string',
+						'required'    => true,
+					),
+					'image_url' => array(
+						'description' => __( 'The URL of the background image to use when generating the social image.', 'jetpack-publicize-pkg' ),
+						'oneOf'       => array(
+							array(
+								'type' => 'string',
+							),
+							array(
+								'type' => 'null',
+							),
+						),
+					),
+					'template'  => array(
+						'description' => __( 'The template slug.', 'jetpack-publicize-pkg' ),
+						'type'        => 'string',
+						'enum'        => Templates::TEMPLATES,
+					),
+				),
+				'schema'              => array(
+					'$schema' => 'http://json-schema.org/draft-04/schema#',
+					'title'   => 'publicize-sig-generate-token',
+					'type'    => 'string',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Ensure the user has proper permissions.
+	 *
+	 * @return boolean
+	 */
+	public function permissions_check() {
+		return current_user_can( 'edit_posts' ) || self::is_authorized_blog_request();
+	}
+
+	/**
+	 * Passes the request parameters to the WPCOM endpoint to generate a preview image token.
+	 *
+	 * @param WP_REST_Request $request The request object, which includes the parameters.
+	 * @return array|WP_Error The token or an error.
+	 */
+	public function generate_preview_token( $request ) {
+		if ( ! Utils::is_wpcom() ) {
+			return rest_ensure_response(
+				$this->proxy_request_to_wpcom_as_blog( $request, 'generate-preview-token' )
+			);
+		}
+
+		$text      = $request->get_param( 'text' );
+		$image_url = $request->get_param( 'image_url' );
+		$template  = $request->get_param( 'template' );
+
+		require_lib( 'social-image-generator-token' );
+		$token            = new \Social_Image_Generator\Token();
+		$token->text      = $text;
+		$token->image_url = $image_url ?? utf8_uri_encode( $image_url );
+		$token->template  = $template;
+		$token->blog_id   = get_current_blog_id();
+
+		return rest_ensure_response( \Social_Image_Generator\encode_token( $token, SIG_TOKEN_SECRET ) );
+	}
 }

--- a/projects/packages/publicize/src/rest-api/class-social-image-generator-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-social-image-generator-controller.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Publicize: Social Image Generator Controller
+ *
+ * @package automattic/jetpack-publicize
+ */
+
+namespace Automattic\Jetpack\Publicize\REST_API;
+
+/**
+ * Publicize: Social Image Generator Controller class.
+ */
+class Social_Image_Generator_Controller extends Base_Controller {
+}

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -1080,6 +1080,7 @@ class WPCOM_Features {
 			self::JETPACK_SOCIAL_V1_PLANS,
 			self::JETPACK_SOCIAL_PLANS,
 			self::JETPACK_GROWTH_PLANS,
+			self::WPCOM_PREMIUM_AND_HIGHER_PLANS,
 		),
 		self::SOCIAL_ADMIN_PAGE                 => array(
 			self::WPCOM_ALL_SITES,


### PR DESCRIPTION
This is a Proof of Concept for enabling SIG on WPCOM

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout 177083-ghe-Automattic/wpcom on your sandbox
* Apply this PR to your sandbox on top of the above one
* Point your Simple site with a Premium plan and the public API to your sandbox
* Goto Social admin page on the Simple site
* Confirm that you see the SIG related settings
* Turn ON SIG
* Goto editor
* Confirm that SIG shows up
* Confirm that it works fine for the post
* Share the post to Instagram and some other networks
* Confirm that it works