### PR TITLE
ci: Run plugin upgrade tests in parallel

### DIFF
--- a/.github/files/test-plugin-update/prepare-zips.sh
+++ b/.github/files/test-plugin-update/prepare-zips.sh
@@ -7,68 +7,65 @@ jq -e '.' <<<"$BETAJSON" &>/dev/null
 
 mkdir work
 mkdir zips
-while IFS=$'\t' read -r SRC MIRROR SLUG; do
-	if [[ "$SLUG" == wpcomsh ]]; then
-		echo "Skipping $SLUG, doesn't work on self-hosted sites."
-		continue
-	fi
 
-	echo "::group::Creating $SLUG-dev.zip"
-	mv "build/$MIRROR" "work/$SLUG"
-	touch "work/$SLUG/ci-flag.txt"
-	(cd work && zip -r "../zips/${SLUG}-dev.zip" "$SLUG")
-	rm -rf "work/$SLUG"
-	echo "::endgroup::"
+if [[ "$PLUGIN_SLUG" == wpcomsh ]]; then
+	echo "Skipping $PLUGIN_SLUG, doesn't work on self-hosted sites."
+	exit 0
+fi
 
-	echo "::group::Fetching $SLUG-trunk.zip..."
-	BETASLUG="$(jq -r '.extra["beta-plugin-slug"] // .extra["wp-plugin-slug"] // ""' "commit/$SRC/composer.json")"
-	if [[ -z "$BETASLUG" ]]; then
-		echo "No beta-plugin-slug or wp-plugin-slug in composer.json, skipping"
+echo "::group::Creating $PLUGIN_SLUG-dev.zip"
+mv "build/$PLUGIN_MIRROR" "work/$PLUGIN_SLUG"
+touch "work/$PLUGIN_SLUG/ci-flag.txt"
+(cd work && zip -r "../zips/${PLUGIN_SLUG}-dev.zip" "$PLUGIN_SLUG")
+rm -rf "work/$PLUGIN_SLUG"
+echo "::endgroup::"
+
+echo "::group::Fetching $PLUGIN_SLUG-trunk.zip..."
+BETASLUG="$(jq -r '.extra["beta-plugin-slug"] // .extra["wp-plugin-slug"] // ""' "commit/$PLUGIN_SRC/composer.json")"
+if [[ -z "$BETASLUG" ]]; then
+	echo "No beta-plugin-slug or wp-plugin-slug in composer.json, skipping"
+else
+	URL="$(jq -r --arg slug "$BETASLUG" '.[$slug].manifest_url // ""' <<<"$BETAJSON")"
+	if [[ -z "$URL" ]]; then
+		echo "Beta slug $BETASLUG is not in plugins.json, skipping"
 	else
-		URL="$(jq -r --arg slug "$BETASLUG" '.[$slug].manifest_url // ""' <<<"$BETAJSON")"
-		if [[ -z "$URL" ]]; then
-			echo "Beta slug $BETASLUG is not in plugins.json, skipping"
-		else
-			JSON="$(curl -L --fail --url "$URL")"
-			if jq -e '.' <<<"$JSON" &>/dev/null; then
-				URL="$(jq -r '.trunk.download_url // .master.download_url // ""' <<<"$JSON")"
-				if [[ -z "$URL" ]]; then
-					echo "Plugin has no trunk build."
-				else
-					curl -L --fail --url "$URL" --output "work/tmp.zip" 2>&1
-					(cd work && unzip -q tmp.zip)
-					mv "work/$BETASLUG-dev" "work/$SLUG"
-					(cd work && zip -qr "../zips/${SLUG}-trunk.zip" "$SLUG")
-					rm -rf "work/$SLUG" "work/tmp.zip"
-				fi
+		JSON="$(curl -L --fail --url "$URL")"
+		if jq -e '.' <<<"$JSON" &>/dev/null; then
+			URL="$(jq -r '.trunk.download_url // .master.download_url // ""' <<<"$JSON")"
+			if [[ -z "$URL" ]]; then
+				echo "Plugin has no trunk build."
 			else
-				echo "::error::Unexpected response from betadownload.jetpack.me for $SLUG"
-				echo "$JSON"
-				echo "info=❌ Unexpected response from betadownload.jetpack.me for $SLUG" >> "$GITHUB_OUTPUT"
-				exit 1
+				curl -L --fail --url "$URL" --output "work/tmp.zip" 2>&1
+				(cd work && unzip -q tmp.zip)
+				mv "work/$BETASLUG-dev" "work/$PLUGIN_SLUG"
+				(cd work && zip -qr "../zips/${PLUGIN_SLUG}-trunk.zip" "$PLUGIN_SLUG")
+				rm -rf "work/$PLUGIN_SLUG" "work/tmp.zip"
 			fi
-		fi
-	fi
-	echo "::endgroup::"
-
-	echo "::group::Fetching $SLUG-stable.zip..."
-	JSON="$(curl "https://api.wordpress.org/plugins/info/1.0/$SLUG.json")"
-	if jq -e --arg slug "$SLUG" '.slug == $slug' <<<"$JSON" &>/dev/null; then
-		URL="$(jq -r '.download_link // ""' <<<"$JSON")"
-		if [[ -z "$URL" ]]; then
-			echo "Plugin has no stable release."
 		else
-			curl -L --fail --url "$URL" --output "zips/$SLUG-stable.zip" 2>&1
+			echo "::error::Unexpected response from betadownload.jetpack.me for $PLUGIN_SLUG"
+			echo "$JSON"
+			echo "❌ Unexpected response from betadownload.jetpack.me for $PLUGIN_SLUG" >> "$GITHUB_STEP_SUMMARY"
+			exit 1
 		fi
-	elif jq -e '.error == "Plugin not found."' <<<"$JSON" &>/dev/null; then
-		echo "Plugin is not published."
-	else
-		echo "::error::Unexpected response from WordPress.org API for $SLUG"
-		echo "$JSON"
-		echo "info=❌ Unexpected response from WordPress.org API for $SLUG" >> "$GITHUB_OUTPUT"
-		exit 1
 	fi
-	echo "::endgroup::"
-done < build/plugins.tsv
+fi
+echo "::endgroup::"
 
-echo 'info=' >> "$GITHUB_OUTPUT"
+echo "::group::Fetching $PLUGIN_SLUG-stable.zip..."
+JSON="$(curl "https://api.wordpress.org/plugins/info/1.0/$PLUGIN_SLUG.json")"
+if jq -e --arg slug "$PLUGIN_SLUG" '.slug == $slug' <<<"$JSON" &>/dev/null; then
+	URL="$(jq -r '.download_link // ""' <<<"$JSON")"
+	if [[ -z "$URL" ]]; then
+		echo "Plugin has no stable release."
+	else
+		curl -L --fail --url "$URL" --output "zips/$PLUGIN_SLUG-stable.zip" 2>&1
+	fi
+elif jq -e '.error == "Plugin not found."' <<<"$JSON" &>/dev/null; then
+	echo "Plugin is not published."
+else
+	echo "::error::Unexpected response from WordPress.org API for $PLUGIN_SLUG"
+	echo "$JSON"
+	echo "❌ Unexpected response from WordPress.org API for $PLUGIN_SLUG" >> "$GITHUB_STEP_SUMMARY"
+	exit 1
+fi
+echo "::endgroup::"

--- a/.github/files/test-plugin-update/test.sh
+++ b/.github/files/test-plugin-update/test.sh
@@ -14,19 +14,17 @@ for ZIP in *-dev.zip; do
 done
 
 FINISHED=false
-OUTPUT=()
 
 function onexit {
 	if ! "$FINISHED"; then
-		OUTPUT+=( "💣 The testing script exited unexpectedly." )
+		echo "💣 The testing script exited unexpectedly." >> "$GITHUB_STEP_SUMMARY"
 	fi
-	gh_set_output info "$( printf "%s\n" "${OUTPUT[@]}" )"
 }
 trap "onexit" EXIT
 
 function failed {
 	ERRMSG="$1"
-	OUTPUT+=( "❌ $ERRMSG" )
+	echo "❌ $ERRMSG" >> "$GITHUB_STEP_SUMMARY"
 	FAILED=1
 	EXIT=1
 }
@@ -143,7 +141,7 @@ for SLUG in "${SLUGS[@]}"; do
 			wp --allow-root --quiet option delete fake_plugin_update_url
 
 			if [[ -z "$FAILED" ]]; then
-				OUTPUT+=( "✅ Upgrade of $SLUG from $FROM via $HOW succeeded!" )
+				echo "✅ Upgrade of $SLUG from $FROM via $HOW succeeded!" >> "$GITHUB_STEP_SUMMARY"
 			fi
 		done
 	done

--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -234,47 +234,21 @@ jobs:
             Post-build run skipped because no plugins were built.
           token: ${{ steps.get_token.outputs.token }}
 
-  upgrade_test:
-    name: Test plugin upgrades
+  prepare_upgrade_test:
+    name: Prepare plugin upgrades matrix
     runs-on: ubuntu-latest
     needs: [ setup, find_artifact ]
     if: needs.find_artifact.outputs.any_plugins == 'true'
-    timeout-minutes: 15  # 2022-08-26: Successful runs seem to take about 6 minutes, but give some extra time for the downloads.
-    services:
-      db:
-        image: mariadb:lts
-        env:
-          MARIADB_ROOT_PASSWORD: wordpress
-        ports:
-          - 3306:3306
-        options: --health-cmd="healthcheck.sh --su-mysql --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=5
-    container:
-      image: ghcr.io/automattic/jetpack-wordpress-dev:latest
-      env:
-        WP_DOMAIN: localhost
-        WP_ADMIN_USER: wordpress
-        WP_ADMIN_EMAIL: wordpress@example.com
-        WP_ADMIN_PASSWORD: wordpress
-        WP_TITLE: Hello World
-        MYSQL_HOST: db:3306
-        MYSQL_DATABASE: wordpress
-        MYSQL_USER: root
-        MYSQL_PASSWORD: wordpress
-        HOST_PORT: 80
-      ports:
-        - 80:80
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    timeout-minutes: 5  # 2025-03-13: Should be just a few seconds.
+
     steps:
       - uses: actions/checkout@v4
-        with:
-          path: trunk
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_commit.id }}
-          path: commit
 
       - name: Get token
         id: get_token
-        uses: ./trunk/.github/actions/gh-app-token
+        uses: ./.github/actions/gh-app-token
         env:
           # Work around a weird node 16/openssl 3 issue in the docker env
           OPENSSL_CONF: '/dev/null'
@@ -283,7 +257,7 @@ jobs:
           private_key: ${{ secrets.JP_LAUNCH_CONTROL_KEY }}
 
       - name: Notify check in progress
-        uses: ./trunk/.github/actions/check-run
+        uses: ./.github/actions/check-run
         with:
           id: ${{ needs.setup.outputs.upgrade_check }}
           status: in_progress
@@ -314,30 +288,121 @@ jobs:
           done
           [[ ! -e "artifact.zip" ]] && { echo "::error::Failed to download artifact."; exit 1; }
           unzip artifact.zip
+          tar --xz -xvvf build.tar.xz build/plugins.tsv
+
+      - name: Prepare matrix
+        id: matrix
+        run: |
+          RET=$( jq -c -s --raw-input 'split( "\n" )[0:-1] | map( split( "\t" ) | { src: .[0], mirror: .[1], slug: .[2] } )' build/plugins.tsv )
+          jq '.' <<<"$RET"
+          echo "matrix=$RET" >> "$GITHUB_OUTPUT"
+
+  upgrade_test:
+    name: Test upgrades for ${{ matrix.slug }}
+    runs-on: ubuntu-latest
+    needs: [ setup, find_artifact, prepare_upgrade_test ]
+    if: needs.find_artifact.outputs.any_plugins == 'true'
+    timeout-minutes: 15  # 2022-08-26: Successful runs seem to take about 6 minutes, but give some extra time for the downloads.
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson( needs.prepare_upgrade_test.outputs.matrix ) }}
+    env:
+      PLUGIN_SRC: ${{ matrix.src }}
+      PLUGIN_MIRROR: ${{ matrix.mirror }}
+      PLUGIN_SLUG: ${{ matrix.slug }}
+    services:
+      db:
+        image: mariadb:lts
+        env:
+          MARIADB_ROOT_PASSWORD: wordpress
+        ports:
+          - 3306:3306
+        options: --health-cmd="healthcheck.sh --su-mysql --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=5
+    container:
+      image: ghcr.io/automattic/jetpack-wordpress-dev:latest
+      env:
+        WP_DOMAIN: localhost
+        WP_ADMIN_USER: wordpress
+        WP_ADMIN_EMAIL: wordpress@example.com
+        WP_ADMIN_PASSWORD: wordpress
+        WP_TITLE: Hello World
+        MYSQL_HOST: db:3306
+        MYSQL_DATABASE: wordpress
+        MYSQL_USER: root
+        MYSQL_PASSWORD: wordpress
+        HOST_PORT: 80
+      ports:
+        - 80:80
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: trunk
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_commit.id }}
+          path: commit
+
+      - name: Download build artifact
+        env:
+          TOKEN: ${{ github.token }}
+          ZIPURL: ${{ needs.find_artifact.outputs.zip_url }}
+        shell: bash
+        run: |
+          for (( i=1; i<=2; i++ )); do
+            [[ $i -gt 1 ]] && sleep 10
+            echo "::group::Downloading artifact (attempt $i/2)"
+            curl -v -L --get \
+              --header "Authorization: token $TOKEN" \
+              --url "$ZIPURL" \
+              --output "artifact.zip"
+            echo "::endgroup::"
+            if [[ -e "artifact.zip" ]] && zipinfo artifact.zip &>/dev/null; then
+              break
+            fi
+          done
+          [[ ! -e "artifact.zip" ]] && { echo "::error::Failed to download artifact."; exit 1; }
+          unzip artifact.zip
           tar --xz -xvvf build.tar.xz build
 
       - name: Setup WordPress
         run: trunk/.github/files/test-plugin-update/setup.sh
 
       - name: Prepare plugin zips
-        id: zips
         run: trunk/.github/files/test-plugin-update/prepare-zips.sh
 
       - name: Test upgrades
-        id: tests
         run: trunk/.github/files/test-plugin-update/test.sh
 
+  post_upgrade_test:
+    name: Finalize plugin test
+    runs-on: ubuntu-latest
+    needs: [ setup, find_artifact, upgrade_test ]
+    if: always() && needs.find_artifact.outputs.any_plugins == 'true'
+    timeout-minutes: 5  # 2025-03-13: Should be just a few seconds.
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get token
+        id: get_token
+        uses: ./.github/actions/gh-app-token
+        env:
+          # Work around a weird node 16/openssl 3 issue in the docker env
+          OPENSSL_CONF: '/dev/null'
+        with:
+          app_id: ${{ secrets.JP_LAUNCH_CONTROL_ID }}
+          private_key: ${{ secrets.JP_LAUNCH_CONTROL_KEY }}
+
       - name: Notify final status
-        if: always()
-        uses: ./trunk/.github/actions/check-run
+        uses: ./.github/actions/check-run
         with:
           id: ${{ needs.setup.outputs.upgrade_check }}
-          conclusion: ${{ job.status }}
-          title: ${{ job.status == 'success' && 'Tests passed' || job.status == 'cancelled' && 'Cancelled' || 'Tests failed' }}
+          conclusion: ${{ needs.upgrade_test.result }}
+          title: ${{ needs.upgrade_test.result == 'success' && 'Tests passed' || needs.upgrade_test.result == 'cancelled' && 'Cancelled' || 'Tests failed' }}
           summary: |
             ${{ env.SUMMARY }}
-
-            ${{ steps.zips.outputs.info }}${{ steps.tests.outputs.info }}
 
             See run [#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
           token: ${{ steps.get_token.outputs.token }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The plugin upgrade tests for all the plugins on a trunk build take around 8-10 minutes. We should be able to speed it up a bit by testing each plugin in parallel.

Unfortunately this does make the "details" link from the PR a bit less informative.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up the needed secrets in a forked repo, then merge this into trunk. See how it works.
  * [x] https://github.com/anomiex/jetpack/actions/runs/13848684518, https://github.com/anomiex/jetpack/runs/38752017752
* Also try a PR that will fail an upgrade.
  * [x] https://github.com/anomiex/jetpack/actions/runs/13848563819, https://github.com/anomiex/jetpack/pull/42/checks?check_run_id=38751675922