### PR TITLE
refactor: Register jetpack-connection scripts absolutely

### DIFF
--- a/projects/packages/connection/actions.php
+++ b/projects/packages/connection/actions.php
@@ -5,11 +5,6 @@
  * @package automattic/jetpack-connection
  */
 
-if ( function_exists( 'is_admin' ) && ! is_admin() && ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) ) {
-	// Don't initialize the assets in the frontend on self-hosted and WoA.
-	return;
-}
-
 // If WordPress's plugin API is available already, use it. If not,
 // drop data into `$wp_filter` for `WP_Hook::build_preinitialized_hooks()`.
 if ( function_exists( 'add_action' ) ) {

--- a/projects/packages/connection/changelog/register-jetpack-connection-scripts-absolutely
+++ b/projects/packages/connection/changelog/register-jetpack-connection-scripts-absolutely
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Connection: register assets absolutely


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Revert https://github.com/Automattic/jetpack/pull/39604. 

Conditional registration was added to address *perceived* performance
issues, rather than *actual* performance issues. The changes were made
to reduce the total number of Jetpack hooks and associated functions. 
While unnecessarily enqueueing assets comes at a network cost, 
registration should not, in theory, incur such a cost. Registration is a 
light-weight operation.

Conditionally registered assets are problematic as they are difficult to
query globally. If an asset is conditionally registered within a
specific context, it will be unavailable outside of that context. E.g.,
a REST API endpoint is unable to query an asset conditionally registered
within WP Admin.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A, none available. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Perform the testing outlined in the following relevant PRs:

- https://github.com/Automattic/jetpack/pull/39604
- https://github.com/Automattic/jetpack/pull/39870

