### PR TITLE
Jetpack footer: switch focus selector for focus-visible

### DIFF
--- a/projects/js-packages/components/changelog/fix-jp-footer-focus-selector
+++ b/projects/js-packages/components/changelog/fix-jp-footer-focus-selector
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Jetpack footer: updated focus pseudo selector
+
+

--- a/projects/js-packages/components/components/jetpack-footer/style.scss
+++ b/projects/js-packages/components/components/jetpack-footer/style.scss
@@ -24,7 +24,7 @@
 			text-decoration-thickness: 1.5px;
 		}
 
-		&:focus {
+		&:focus-visible {
 			border-radius: 2px;
 			box-shadow: none;
 			outline: 1.5px solid currentColor;

--- a/projects/js-packages/components/components/jetpack-footer/style.scss
+++ b/projects/js-packages/components/components/jetpack-footer/style.scss
@@ -24,6 +24,11 @@
 			text-decoration-thickness: 1.5px;
 		}
 
+		&:focus {
+			box-shadow: none;
+			outline-width: 0;
+		}
+
 		&:focus-visible {
 			border-radius: 2px;
 			box-shadow: none;

--- a/projects/plugins/jetpack/_inc/client/components/footer/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/footer/style.scss
@@ -101,6 +101,11 @@
 			&.is-external {
 				padding-right: 20px;
 			}
+
+			&:focus {
+				box-shadow: none;
+				outline-width: 0;
+			}
 		
 			&:focus-visible {
 				border-radius: 2px;

--- a/projects/plugins/jetpack/_inc/client/components/footer/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/footer/style.scss
@@ -102,7 +102,7 @@
 				padding-right: 20px;
 			}
 		
-			&:focus {
+			&:focus-visible {
 				border-radius: 2px;
 				outline-offset: 3px;
 				outline: 1.5px solid var( --jp-black );

--- a/projects/plugins/jetpack/changelog/fix-jp-footer-focus-selector
+++ b/projects/plugins/jetpack/changelog/fix-jp-footer-focus-selector
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Jetpack footer: switch focus selector for focus-visible
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/37616

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR updates the CSS pseudo-selector used on the Jetpack footer links so that the focus styles are only applied when a link is focused via the keyboard.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a Jetpack site
- Visit `/wp-admin/admin.php?page=my-jetpack`
- Click on a link in the footer. You **shouldn't** see any outline like in the capture below as you click:
<img width="297" alt="Screenshot 2025-03-14 at 2 26 52 PM" src="https://github.com/user-attachments/assets/e49b6283-ec61-4cbf-bd68-6bcfaf942c78" />

- This should be the case for the Jetpack logo and other links

