### PR TITLE
Social | Do not load social in the editor if blocks module is off

### DIFF
--- a/projects/packages/publicize/changelog/update-social-do-not-load-social-ui-if-blocks-module-is-off
+++ b/projects/packages/publicize/changelog/update-social-do-not-load-social-ui-if-blocks-module-is-off
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fix WSOD on post publish when blocks module is off

--- a/projects/packages/publicize/src/class-publicize-assets.php
+++ b/projects/packages/publicize/src/class-publicize-assets.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Publicize;
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Modules;
 
 /**
  * Publicize_Assets class.
@@ -33,6 +34,11 @@ class Publicize_Assets {
 		$post_type = get_post_type();
 
 		if ( empty( $post_type ) || ! post_type_supports( $post_type, 'publicize' ) ) {
+			return false;
+		}
+
+		// If Jetpack is active and the blocks module is not active, don't enqueue the block editor scripts.
+		if ( defined( 'JETPACK__VERSION' ) && ! ( new Modules() )->is_active( 'blocks' ) ) {
 			return false;
 		}
 

--- a/projects/plugins/jetpack/changelog/update-social-do-not-load-social-ui-if-blocks-module-is-off
+++ b/projects/plugins/jetpack/changelog/update-social-do-not-load-social-ui-if-blocks-module-is-off
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Social: Fix WSOD on post publish when blocks module is off


### PR DESCRIPTION
#41836 caused a slight regression - when the user has blocks module off, we still load the editor UI which caused some WSOD on pre-publish panel

Fixes #42464

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Social | Do not load social in the editor if blocks module is off

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate Jetpack and Social together
* Goto Jetpack > Settings > Writing > Composing
* Turn OFF Jetpack Blocks module
* Create a new post and click Publish
* On the pre-publish panel, confirm that there is no Social UI
* Now deactivate Jetpack
* Confirm that the pre-publish panel has the Social UI

