### PR TITLE
Fix: mobile file upload UI

### DIFF
--- a/projects/packages/external-media/changelog/fix-mobile-file-upload-ui
+++ b/projects/packages/external-media/changelog/fix-mobile-file-upload-ui
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Jetpack App: Uploader fix spacing

--- a/projects/packages/external-media/src/shared/sources/jetpack-app-media/style.scss
+++ b/projects/packages/external-media/src/shared/sources/jetpack-app-media/style.scss
@@ -8,6 +8,7 @@
 	color:var( --jp-gray-100 );
 
 }
+
 .jetpack-external-media-wrapper__jetpack_app_media-description {
 	font-size: 14px;
 	font-weight: 400;
@@ -25,6 +26,9 @@
 			max-width: calc( 100% - 300px );
 		}
 	}
+}
+.jetpack-external-media-browser__modal-content .jetpack-app-icon {
+	width: 80px;
 }
 
 .jetpack-external-media-wrapper__jetpack_app_media-qr-code canvas {
@@ -49,6 +53,7 @@
 	justify-content: space-between;
 	align-items: center;
 	flex-grow: 1;
+	padding-bottom: 32px;
 }
 
 .jetpack-external-media-wrapper__jetpack_app_media .jetpack-external-media-browser__empty {

--- a/projects/plugins/jetpack/changelog/fix-mobile-file-upload-ui
+++ b/projects/plugins/jetpack/changelog/fix-mobile-file-upload-ui
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: A small fix
+
+


### PR DESCRIPTION
This PR fixes the spacing in the App load via the app modal. 

Before:
![Screenshot 2025-03-14 at 7 07 00 AM](https://github.com/user-attachments/assets/5003e3d7-5d9c-40c5-932a-ed89a95a1142)

After:

![Screenshot 2025-03-14 at 9 58 14 AM](https://github.com/user-attachments/assets/e578585c-670d-44ed-bc2e-7a89c90399c0)


## Proposed changes:

* Add bottom spacing and make the jetpack logo smaller. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Visit the post/page editor. 
* Add the image block. 
* Select the Your Phone from the Select Image drop-down. 
* Notice that the modal looks not broken. 
