### PR TITLE
Forms: Add Feedback link to admin bar

### DIFF
--- a/projects/packages/forms/changelog/add-form-responses-to-admin-bar
+++ b/projects/packages/forms/changelog/add-form-responses-to-admin-bar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add a quick link to the admin bar to form entries

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -268,9 +268,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 				'group'  => null,
 				'title'  => __( 'Form Responses', 'jetpack-forms' ),
 				'href'   => $url,
-				'meta'   => array(
-					'title' => __( 'Form Responses', 'jetpack-forms' ),
-				),
 			)
 		);
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -266,10 +266,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 				'id'     => 'jetpack-forms',
 				'parent' => null,
 				'group'  => null,
-				'title'  => __( 'Feedback', 'jetpack-forms' ),
+				'title'  => __( 'Form Responses', 'jetpack-forms' ),
 				'href'   => $url,
 				'meta'   => array(
-					'title' => __( 'Feedback', 'jetpack-forms' ),
+					'title' => __( 'Form Responses', 'jetpack-forms' ),
 				),
 			)
 		);

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -293,7 +293,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		if ( is_singular() ) {
-			add_action( 'admin_bar_menu', array( __CLASS__, 'add_quick_link_to_admin_bar' ), 500 );
+			add_action( 'admin_bar_menu', array( __CLASS__, 'add_quick_link_to_admin_bar' ), 100 ); // We use priority 100 so that the link that is added gets added after the "Edit Page" link.
 		}
 		// Create a new Contact_Form object (this class)
 		$form = new Contact_Form( $attributes, $content );

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -251,9 +251,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 	/**
 	 * Adds a quick link to the admin bar for the contact form entries.
 	 *
-	 * @param WP_Admin_Bar $admin_bar The admin bar object.
+	 * @param \WP_Admin_Bar $admin_bar The admin bar object.
 	 */
-	public static function add_quick_link_to_admin_bar( $admin_bar ) {
+	public static function add_quick_link_to_admin_bar( \WP_Admin_Bar $admin_bar ) {
 
 		if ( ! current_user_can( 'edit_pages' ) ) {
 			return;

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -266,7 +266,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				'id'     => 'jetpack-forms',
 				'parent' => null,
 				'group'  => null,
-				'title'  => __( 'Form Responses', 'jetpack-forms' ),
+				'title'  => '<span class="dashicons dashicons-feedback" style="font: normal 20px/1 dashicons; display: block; float: left; margin-top: 6px; color: rgba(240, 246, 252, 0.6); margin-right: 6px;"></span><span class="ab-label">' . esc_html__( 'Form Responses', 'jetpack-forms' ) . '</span>',
 				'href'   => $url,
 			)
 		);

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
 use Automattic\Jetpack\Sync\Settings;
 use PHPMailer\PHPMailer\PHPMailer;
 use WP_Error;
@@ -247,6 +248,32 @@ class Contact_Form extends Contact_Form_Shortcode {
 	public static function style_on() {
 		return self::style( true );
 	}
+	/**
+	 * Adds a quick link to the admin bar for the contact form entries.
+	 *
+	 * @param WP_Admin_Bar $admin_bar The admin bar object.
+	 */
+	public static function add_quick_link_to_admin_bar( $admin_bar ) {
+
+		if ( ! current_user_can( 'edit_pages' ) ) {
+			return;
+		}
+
+		$url = ( new Dashboard_View_Switch() )->get_forms_admin_url();
+
+		$admin_bar->add_menu(
+			array(
+				'id'     => 'jetpack-forms',
+				'parent' => null,
+				'group'  => null,
+				'title'  => __( 'Feedback', 'jetpack-forms' ),
+				'href'   => $url,
+				'meta'   => array(
+					'title' => __( 'Feedback', 'jetpack-forms' ),
+				),
+			)
+		);
+	}
 
 	/**
 	 * The contact-form shortcode processor
@@ -266,6 +293,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 			if ( is_array( $attributes ) ) {
 				$attributes['block_template_part'] = $GLOBALS['grunion_block_template_part_id'];
 			}
+		}
+
+		if ( is_singular() ) {
+			add_action( 'admin_bar_menu', array( __CLASS__, 'add_quick_link_to_admin_bar' ), 500 );
 		}
 		// Create a new Contact_Form object (this class)
 		$form = new Contact_Form( $attributes, $content );

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -266,7 +266,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				'id'     => 'jetpack-forms',
 				'parent' => null,
 				'group'  => null,
-				'title'  => '<span class="dashicons dashicons-feedback" style="font: normal 20px/1 dashicons; display: block; float: left; margin-top: 6px; color: rgba(240, 246, 252, 0.6); margin-right: 6px;"></span><span class="ab-label">' . esc_html__( 'Form Responses', 'jetpack-forms' ) . '</span>',
+				'title'  => '<span class="dashicons dashicons-feedback ab-icon" style="top: 2px;"></span><span class="ab-label">' . esc_html__( 'Form Responses', 'jetpack-forms' ) . '</span>',
 				'href'   => $url,
 			)
 		);

--- a/projects/plugins/jetpack/changelog/add-form-responses-to-admin-bar
+++ b/projects/plugins/jetpack/changelog/add-form-responses-to-admin-bar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Add quick link in the admin bar for form entries


### PR DESCRIPTION
This PR adds a quick link to the admin bar if the user is visiting a single page or post on the frontend and is someone that should have access to the dashboard. 

It only shows up if we are also going to render the form. 

On single page with a form on. 

![Screenshot 2025-03-14 at 10 35 23 AM](https://github.com/user-attachments/assets/a53dcc34-65a7-48b5-9d56-3c982ac42c4d)

On a single page without a form. 

![Screenshot 2025-03-14 at 10 35 17 AM](https://github.com/user-attachments/assets/51d74162-c800-4a9e-9cc5-5c7717732d5c)

To disable the newly added quick_link menu you can 
do the following:

```
function my_plugin_prefix_disable_jetpack_contact_admin_bar( $html ) {
	remove_action( 'admin_bar_menu', array( 'Automattic\Jetpack\Forms\ContactForm\Contact_Form', 'add_quick_link_to_admin_bar' ), 500 );
	return $html;
}
add_filter( 'jetpack_contact_form_html', 'my_plugin_prefix_disable_jetpack_contact_admin_bar' );
```

## Proposed changes:
* Adds the Feedback quick link to the admin bar. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* As a logged in editor or admin user visit a single page or post that has a form on. Notice that you see the feeedback link in the Admin bar. 
* As a visitor notice that you don't see it. 
* Pages without a form shouldn't display the feedback link. The link should take you to your preferred feedback view ( classic or modern) 
* 
