### PR TITLE
JSON API: add REST support for users fetching endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/add-json-api-rest-users
+++ b/projects/plugins/jetpack/changelog/add-json-api-rest-users
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+JSON API: add REST support for users fetching endpoint.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -14,6 +14,8 @@ new WPCOM_JSON_API_List_Users_Endpoint(
 		'path_labels'          => array(
 			'$site' => '(int|string) Site ID or domain',
 		),
+		'rest_route'           => '/users',
+		'rest_min_jp_version'  => '14.5-a.2',
 
 		'query_parameters'     => array(
 			'number'          => '(int=20) Limit the total number of authors returned.',


### PR DESCRIPTION
## Proposed changes:
* Introduce REST support for the "fetch users" JSON API endpoint.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pf5801-18d-p2

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Make sure the checks pass.
No functional changes until WPCOM side gets deployed.

