### PR TITLE
Full sync: Don't send normal full sync actions while pull is in progress

### DIFF
--- a/projects/packages/sync/changelog/update-full-sync-don-t-send-normal-full-sync-actions-while-pull-is-in-progress
+++ b/projects/packages/sync/changelog/update-full-sync-don-t-send-normal-full-sync-actions-while-pull-is-in-progress
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Sync: Don't send normal Full Sync actions while a Full Sync Pull is in progress

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -1131,6 +1131,8 @@ class Actions {
 		delete_transient( Dedicated_Sender::DEDICATED_SYNC_TEMPORARY_DISABLE_FLAG );
 		// Lock for disabling Sync sending temporarily.
 		delete_transient( Sender::TEMP_SYNC_DISABLE_TRANSIENT_NAME );
+		// Lock for disabling Full Sync sending temporarily.
+		delete_transient( Sender::TEMP_FULL_SYNC_DISABLE_TRANSIENT_NAME );
 
 		// Queue locks.
 		// Note that we are just unlocking the queues here, not reseting them.

--- a/projects/packages/sync/src/class-rest-sender.php
+++ b/projects/packages/sync/src/class-rest-sender.php
@@ -102,7 +102,9 @@ class REST_Sender {
 		Sender::get_instance()->set_enqueue_wait_time( 0 );
 		remove_filter( 'jetpack_sync_send_data', $original_send_data_cb );
 		add_filter( 'jetpack_sync_send_data', $temp_send_data_cb, 10, 6 );
+		delete_transient( Sender::TEMP_FULL_SYNC_DISABLE_TRANSIENT_NAME );
 		Sender::get_instance()->do_full_sync();
+		set_transient( Sender::TEMP_FULL_SYNC_DISABLE_TRANSIENT_NAME, time(), Sender::TEMP_FULL_SYNC_DISABLE_TRANSIENT_EXPIRY );
 		remove_filter( 'jetpack_sync_send_data', $temp_send_data_cb );
 		add_filter( 'jetpack_sync_send_data', $original_send_data_cb, 10, 6 );
 

--- a/projects/packages/sync/src/class-sender.php
+++ b/projects/packages/sync/src/class-sender.php
@@ -25,7 +25,7 @@ class Sender {
 	const NEXT_SYNC_TIME_OPTION_NAME = 'jetpack_next_sync_time';
 
 	/**
-	 * Name of the transient responsible for temprorarily disabling Sync sending during Pulls.
+	 * Name of the transient responsible for temporarily disabling Sync sending during Pulls.
 	 *
 	 * @access public
 	 *
@@ -34,13 +34,31 @@ class Sender {
 	const TEMP_SYNC_DISABLE_TRANSIENT_NAME = 'jetpack_disable_sync_sending';
 
 	/**
-	 * Expiry of the transient responsible for temprorarily disabling Sync sending during Pulls.
+	 * Expiry of the transient responsible for temporarily disabling Sync sending during Pulls.
 	 *
 	 * @access public
 	 *
 	 * @var int
 	 */
 	const TEMP_SYNC_DISABLE_TRANSIENT_EXPIRY = MINUTE_IN_SECONDS;
+
+	/**
+	 * Name of the transient responsible for temporarily disabling Full Sync sending during Pulls.
+	 *
+	 * @access public
+	 *
+	 * @var string
+	 */
+	const TEMP_FULL_SYNC_DISABLE_TRANSIENT_NAME = 'jetpack_disable_full_sync_sending';
+
+	/**
+	 * Expiry of the transient responsible for temporarily disabling Full Sync sending during Pulls.
+	 *
+	 * @access public
+	 *
+	 * @var int
+	 */
+	const TEMP_FULL_SYNC_DISABLE_TRANSIENT_EXPIRY = MINUTE_IN_SECONDS;
 
 	/**
 	 * Sync timeout after a WPCOM error.
@@ -299,6 +317,10 @@ class Sender {
 		// Full Sync Disabled.
 		if ( ! Settings::get_setting( 'full_sync_sender_enabled' ) ) {
 			return;
+		}
+
+		if ( get_transient( self::TEMP_FULL_SYNC_DISABLE_TRANSIENT_NAME ) ) {
+			return new WP_Error( 'sender_temporarily_disabled_while_pulling' );
 		}
 
 		// Don't sync if request is marked as read only.

--- a/projects/packages/sync/tests/php/Actions_Test.php
+++ b/projects/packages/sync/tests/php/Actions_Test.php
@@ -134,6 +134,8 @@ class Actions_Test extends BaseTestCase {
 		$this->assertTrue( $full_sync_queue->lock() );
 		// Lock for disabling Sync sending temporarily.
 		set_transient( Sender::TEMP_SYNC_DISABLE_TRANSIENT_NAME, time() );
+		// Lock for disabling Sync sending temporarily.
+		set_transient( Sender::TEMP_FULL_SYNC_DISABLE_TRANSIENT_NAME, time() );
 
 		Actions::reset_sync_locks();
 
@@ -145,6 +147,7 @@ class Actions_Test extends BaseTestCase {
 		$this->assertFalse( $sync_queue->is_locked() );
 		$this->assertFalse( $full_sync_queue->is_locked() );
 		$this->assertFalse( get_transient( Sender::TEMP_SYNC_DISABLE_TRANSIENT_NAME ) );
+		$this->assertFalse( get_transient( Sender::TEMP_FULL_SYNC_DISABLE_TRANSIENT_NAME ) );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/vulcan/issues/664

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Similar to how for incremental actions we don't send actions while a pull is in progress, do the same for full sync pulls.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
- Run a full sync and while the pull is in progress you should not see any other full sync actions happening.

