### PR TITLE
Remove/my jetpack remove zendesk chat script from dom

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -7,7 +7,6 @@ import {
 	Container,
 	Col,
 	Notice,
-	ZendeskChat,
 	useBreakpointMatch,
 	ActionButton,
 	GlobalNotices,
@@ -22,10 +21,6 @@ import { useContext, useEffect, useLayoutEffect, useState } from 'react';
 import { NoticeContext } from '../../context/notices/noticeContext';
 import { NOTICE_SITE_CONNECTION_ERROR } from '../../context/notices/noticeTemplates';
 import {
-	REST_API_CHAT_AUTHENTICATION_ENDPOINT,
-	REST_API_CHAT_AVAILABILITY_ENDPOINT,
-	QUERY_CHAT_AVAILABILITY_KEY,
-	QUERY_CHAT_AUTHENTICATION_KEY,
 	QUERY_GET_JETPACK_MANAGE_DATA_KEY,
 	REST_API_GET_JETPACK_MANAGE_DATA,
 } from '../../data/constants';
@@ -113,14 +108,6 @@ export default function MyJetpackScreen() {
 		title: noticeTitle,
 		options: noticeOptions,
 	} = currentNotice || {};
-	const { data: availabilityData, isLoading: isChatAvailabilityLoading } = useSimpleQuery( {
-		name: QUERY_CHAT_AVAILABILITY_KEY,
-		query: { path: REST_API_CHAT_AVAILABILITY_ENDPOINT },
-	} );
-	const { data: authData, isLoading: isJwtLoading } = useSimpleQuery( {
-		name: QUERY_CHAT_AUTHENTICATION_KEY,
-		query: { path: REST_API_CHAT_AUTHENTICATION_ENDPOINT },
-	} );
 	const {
 		data: jetpackManageData,
 		isLoading: isJetpackManageLoading,
@@ -141,12 +128,6 @@ export default function MyJetpackScreen() {
 	useEffect( () => {
 		updateHistoricallyActiveModules();
 	}, [ updateHistoricallyActiveModules ] );
-
-	const isAvailable = availabilityData?.is_available;
-	const jwt = authData?.user?.jwt;
-
-	const shouldShowZendeskChatWidget =
-		! isJwtLoading && ! isChatAvailabilityLoading && isAvailable && jwt;
 
 	const isNewUser = useIsJetpackUserNew();
 
@@ -280,8 +261,6 @@ export default function MyJetpackScreen() {
 					</Col>
 				</Container>
 			</AdminSection>
-
-			{ shouldShowZendeskChatWidget && <ZendeskChat jwt_token={ jwt } /> }
 		</AdminPage>
 	);
 }

--- a/projects/packages/my-jetpack/changelog/remove-my-jetpack-remove-zendesk-chat-script-from-dom
+++ b/projects/packages/my-jetpack/changelog/remove-my-jetpack-remove-zendesk-chat-script-from-dom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Remove Zendesk chat script from DOM


### PR DESCRIPTION
## Proposed changes:

* Remove Zendesk chat script from the DOM

This script is not loading the chat widget, as the key it uses is no longer in use. Currently JPOP only wants this to be on the pricing page in Calypso and on jetpack.com/support pages, so removing this un-working script here is the best move. It should also, as a side effect, slightly improve performance as we are removing 2 front-end API requests and an unnecessary script from loading in the DOM

I am leaving the mechanism to load the zendesk chat in case JPOP ever wants to enable it on My Jetpack again

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Slack: p1741381212626449-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Create a Jurassic ninja site or start your local environment (install Jetpack beta on JN, but do not activate this branch yet)
2. Go to My Jetpack and connect your site and user account
3. Search the DOM for `zdassets` and see that the script is being loaded with no chat visible
![image](https://github.com/user-attachments/assets/31d195d1-615c-4174-852d-74a59aec81d2)
4. Now checkout this branch
5. Reload My Jetpack and see that it is no longer loaded
![image](https://github.com/user-attachments/assets/2b4bb33a-4b1c-49d5-a010-eecf064d8f73)
