### PR TITLE
Jetpack Search: fix activating on wpcom

### DIFF
--- a/projects/packages/search/changelog/fix-jetpack-search-activation-on-wpcom
+++ b/projects/packages/search/changelog/fix-jetpack-search-activation-on-wpcom
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Jetpack Search: fix activation on wpcom
+
+

--- a/projects/packages/search/src/class-module-control.php
+++ b/projects/packages/search/src/class-module-control.php
@@ -80,10 +80,11 @@ class Module_Control {
 	 * Activiate Search module
 	 */
 	public function activate() {
+		$is_wpcom = defined( 'IS_WPCOM' ) && IS_WPCOM;
 		if ( ( new Status() )->is_offline_mode() ) {
 			return new WP_Error( 'site_offline', __( 'Jetpack Search can not be used in offline mode.', 'jetpack-search-pkg' ) );
 		}
-		if ( ! $this->connection_manager->is_connected() ) {
+		if ( ! $is_wpcom && ! $this->connection_manager->is_connected() ) {
 			return new WP_Error( 'connection_required', __( 'Connect your site to use Jetpack Search.', 'jetpack-search-pkg' ) );
 		}
 		if ( ! $this->plan->supports_search() ) {


### PR DESCRIPTION
Fixes error described in https://github.com/Automattic/jetpack/issues/42227#issuecomment-2705598409. The error wasn't breaking anything, but it was being shown to users, which was confusing.

## Proposed changes:
* Don't check whether site is connected when activating Search on wpcom

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the change on wpcom sanbox
* Sandbox a simple site with business plan
* Activate and deactivate instant search

You should see a success message with this change applied:

![image](https://github.com/user-attachments/assets/6c82ea9b-9fad-4bfe-b153-f7436966ff3f)

Without it, you would see an error when enabling instant search.
