### PR TITLE
Form: Fix show variation picker if empty

### DIFF
--- a/projects/packages/forms/changelog/fix-remove-form-if-empty
+++ b/projects/packages/forms/changelog/fix-remove-form-if-empty
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Revert back to the variation picker if the form only has the submit button.

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -157,6 +157,8 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 				hasAnyInnerBlocks: innerBlocksData.length > 0,
 				postAuthorEmail: authorEmail,
 				selectedBlockClientId: selectedStepBlockId,
+				onlySubmitBlock:
+					innerBlocksData.length === 1 && innerBlocksData[ 0 ].name === 'jetpack/button',
 			};
 		},
 		[ clientId ]
@@ -625,7 +627,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 				/>
 			);
 		}
-	} else if ( ! hasAnyInnerBlocks ) {
+	} else if ( ! hasAnyInnerBlocks || onlySubmitBlock ) {
 		elt = (
 			<VariationPicker
 				blockName={ name }
@@ -634,6 +636,12 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 				classNames={ formClassnames }
 			/>
 		);
+
+		// Reset the padding of the block. Once the user picks a variation this padding gets set to the default one.
+		blockProps.style.paddingTop = 0;
+		blockProps.style.paddingBottom = 0;
+		blockProps.style.paddingLeft = 0;
+		blockProps.style.paddingRight = 0;
 	} else {
 		elt = (
 			<>

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -6,6 +6,7 @@ import {
 	InspectorAdvancedControls,
 	InspectorControls,
 	useBlockProps,
+	InnerBlocks,
 	useInnerBlocksProps,
 	store as blockEditorStore,
 	BlockControls,
@@ -221,6 +222,47 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		select => select( blockEditorStore ).getBlocks( clientId ),
 		[ clientId ]
 	);
+
+	// Track previous block count to detect insertions
+	const previousBlockCountRef = useRef( currentInnerBlocks.length );
+
+	// Effect to handle block insertion and reordering
+	useEffect( () => {
+		const currentBlockCount = currentInnerBlocks.length;
+		const previousBlockCount = previousBlockCountRef.current;
+
+		// Detect if a block was just inserted
+		const blockWasInserted = currentBlockCount > previousBlockCount;
+
+		if ( blockWasInserted && currentInnerBlocks.length > 1 ) {
+			// Find the submit button
+			const submitButtonIndex = currentInnerBlocks.findIndex(
+				block =>
+					block.name === 'jetpack/button' &&
+					( block.attributes?.customVariant === 'submit' || block.attributes?.element === 'button' )
+			);
+
+			// If there's a submit button and it's not the last block, reorder
+			if ( submitButtonIndex !== -1 && submitButtonIndex === currentInnerBlocks.length - 2 ) {
+				// Move the submit button to the end
+				const reorderedBlocks = [ ...currentInnerBlocks ];
+				const [ submitButtonBlock ] = reorderedBlocks.splice( submitButtonIndex, 1 );
+				reorderedBlocks.push( submitButtonBlock );
+
+				// Update the blocks without creating an undo step
+				__unstableMarkNextChangeAsNotPersistent();
+				replaceInnerBlocks( clientId, reorderedBlocks, false );
+			}
+		}
+
+		// Update the previous block count
+		previousBlockCountRef.current = currentBlockCount;
+	}, [
+		currentInnerBlocks,
+		clientId,
+		replaceInnerBlocks,
+		__unstableMarkNextChangeAsNotPersistent,
+	] );
 
 	// Deep-scan helper – user might drop a Step block inside nested structures.
 	const containsMultistepBlock = useCallback( function hasMultistep( blocks ) {
@@ -628,7 +670,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 				/>
 			);
 		}
-	} else if ( ! hasAnyInnerBlocks || onlySubmitBlock ) {
+	} else if ( ! hasAnyInnerBlocks ) {
 		elt = (
 			<VariationPicker
 				blockName={ name }
@@ -636,6 +678,15 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 				clientId={ clientId }
 				classNames={ formClassnames }
 			/>
+		);
+	} else if ( onlySubmitBlock ) {
+		elt = (
+			<>
+				<div className="is-form-empty">
+					<InnerBlocks.ButtonBlockAppender />
+				</div>
+				<div { ...innerBlocksProps } />
+			</>
 		);
 	} else {
 		elt = (

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -637,12 +637,6 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 				classNames={ formClassnames }
 			/>
 		);
-
-		// Reset the padding of the block. Once the user picks a variation this padding gets set to the default one.
-		blockProps.style.paddingTop = 0;
-		blockProps.style.paddingBottom = 0;
-		blockProps.style.paddingLeft = 0;
-		blockProps.style.paddingRight = 0;
 	} else {
 		elt = (
 			<>

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -128,6 +128,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		hasAnyInnerBlocks,
 		postAuthorEmail,
 		selectedBlockClientId,
+		onlySubmitBlock,
 	} = useSelect(
 		select => {
 			const { getBlocks, getBlock, getSelectedBlockClientId, getBlockParentsByBlockName } =

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -201,6 +201,10 @@
 	}
 }
 
+.is-form-empty .block-editor-inserter {
+	width: 100%;
+}
+
 .form-placeholder__patterns-modal {
 	max-width: 1200px;
 

--- a/projects/plugins/jetpack/changelog/fix-remove-form-if-empty
+++ b/projects/plugins/jetpack/changelog/fix-remove-form-if-empty
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Forms: Show the form variation picker if you only have the submit button.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
@@ -236,7 +236,3 @@
 	justify-content: flex-end;
 	gap: 8px;
 }
-
-.jetpack-contact-form {
-	margin-top: 16px;
-}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
@@ -236,3 +236,7 @@
 	justify-content: flex-end;
 	gap: 8px;
 }
+
+.jetpack-contact-form {
+	margin-top: 16px;
+}


### PR DESCRIPTION
This PR tries to fix the state where a user is shown a form with just the submit button and it is not clear how to proceed next. 

This PR instead will show the variation picker instead of just the submit button. 



https://github.com/user-attachments/assets/39985e8c-7196-40f3-89d9-4c5e2c432fb4



## Proposed changes:

* If we detect that we are just showing the submit button in the inner block. We show the button inserter that takes up the whole width of the page. 
* When you insert a block using a form inserted the field shows up as you would expect it to. (Before the submit button)
Unless you intentionally moved the submit button to not be the last element. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Go to the block editor. 
* Insert the form block. Or just insteard a email field for example. 
* Remove all the input fields (expect for the submit button) 
* You should now see button inserter. 
* add a field. notice that it shows up as expected. ( before the button field but in the last place) 
* Add another field. Notice that is shows up as expected. ( before the button field but in the last place) 
* Move the button to not be the last block. Notice that the field shows up after the button block. 
