### PR TITLE
Forms: Add 'Message' as default label for textarea fields

### DIFF
--- a/projects/packages/forms/changelog/add-form-text-as-default-label-for-textarea
+++ b/projects/packages/forms/changelog/add-form-text-as-default-label-for-textarea
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Minor fix that only impacts users that insert the textarea field
+
+

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -623,7 +623,7 @@ export const childBlocks = [
 				...FieldDefaults.attributes,
 				label: {
 					type: 'string',
-					default: __( 'Text', 'jetpack-forms' ),
+					default: __( 'Message', 'jetpack-forms' ),
 					role: 'content',
 				},
 			},

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -621,6 +621,11 @@ export const childBlocks = [
 			edit: EditTextarea,
 			attributes: {
 				...FieldDefaults.attributes,
+				label: {
+					type: 'string',
+					default: __( 'Text', 'jetpack-forms' ),
+					role: 'content',
+				},
 			},
 		},
 	},

--- a/projects/plugins/jetpack/changelog/add-form-text-as-default-label-for-textarea
+++ b/projects/plugins/jetpack/changelog/add-form-text-as-default-label-for-textarea
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Forms: add a default label for multi text field


### PR DESCRIPTION
Currently when you insert the text area field you don't get a label. 

This PR fixes this by adding the same label as the text field. 

Before:

![Screenshot 2025-03-14 at 12 26 43 PM](https://github.com/user-attachments/assets/44debdad-ebf1-4e8f-8f16-56cb81a7d645)


After:
![Screenshot 2025-03-17 at 12 36 58 PM](https://github.com/user-attachments/assets/23259f89-26dc-4ef8-9fef-f1880809aa56)

Frontend (should stay the same as before)
![Screenshot 2025-03-17 at 12 37 59 PM](https://github.com/user-attachments/assets/dabbc006-a331-492b-80b9-f546309aba0b)



## Proposed changes:
* Add a default label attribute. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Go to block editor. 
* Insert a form block. 
* Add the textarea (multi line text) field. 
* Notice that it now has the "Text" label applied. 

* Save the post/page and notice that on the front end the label matches the default one. 

