### PR TITLE
Forms: Remove the beta label from the export modal. 

### DIFF
--- a/projects/packages/forms/changelog/remove-forms-remove-beta-badge
+++ b/projects/packages/forms/changelog/remove-forms-remove-beta-badge
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Remove the beta from the google dri

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -307,7 +307,6 @@ class Admin {
 					<path d="M11.8387 1.16016H2C1.44772 1.16016 1 1.60787 1 2.16016V21.8053V21.8376C1 22.3899 1.44772 22.8376 2 22.8376H16C16.5523 22.8376 17 22.3899 17 21.8376V5.80532M11.8387 1.16016V5.80532H17M11.8387 1.16016L17 5.80532M4.6129 13.0311V16.1279H9.25806M4.6129 13.0311V9.93435H9.25806M4.6129 13.0311H13.9032M13.9032 13.0311V9.93435H9.25806M13.9032 13.0311V16.1279H9.25806M9.25806 9.93435V16.1279" stroke="#008710" stroke-width="1.5"/>
 				</svg>
 				<div class="export-card__header-title"><?php esc_html_e( 'Google Sheets', 'jetpack-forms' ); ?></div>
-				<div class="export-card__beta-badge">BETA</div>
 			</div>
 			<div class="export-card__body">
 				<div class="export-card__body-description">
@@ -322,7 +321,6 @@ class Admin {
 						);
 						?>
 					</div>
-					<p class="export-card__body-description-footer"><?php esc_html_e( 'This premium feature is currently free to use in beta.', 'jetpack-forms' ); ?></p>
 				</div>
 				<div class="export-card__body-cta">
 					<?php

--- a/projects/packages/forms/src/contact-form/css/grunion-admin.css
+++ b/projects/packages/forms/src/contact-form/css/grunion-admin.css
@@ -194,15 +194,6 @@
 	color: inherit;
 }
 
-.export-card__body-description-footer {
-	font-style: normal;
-	font-weight: 400;
-	font-size: 12px;
-	line-height: 150%;
-	color: #757575;
-	margin-bottom: 0px;
-}
-
 .export-card__body-cta {
 	align-self: flex-end;
 }
@@ -215,19 +206,4 @@
 	background: #000000;
 	border: 1px solid #FFFFFF;
 	border-radius: 4px;
-}
-
-.export-card__beta-badge {
-	background: #2FB41F;
-	border-radius: 2px;
-	font-style: normal;
-	font-weight: 600;
-	font-size: 11px;
-	line-height: 150%;
-	/* identical to box height, or 16px */
-
-	text-align: right;
-	text-transform: uppercase;
-	padding: 4px 8px;
-	color: #FFFFFF;
 }

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
@@ -85,7 +85,6 @@ const GoogleDriveExport = ( { onExport } ) => {
 				<div className="jp-forms__export-modal-card-header-title">
 					{ __( 'Google Sheets', 'jetpack-forms' ) }
 				</div>
-				<div className="jp-forms__export-modal-card-beta-badge">BETA</div>
 			</div>
 			<div className="jp-forms__export-modal-card-body">
 				<div className="jp-forms__export-modal-card-body-description">
@@ -101,9 +100,6 @@ const GoogleDriveExport = ( { onExport } ) => {
 							{ __( 'You need to connect to Google Drive.', 'jetpack-forms' ) }
 						</a>
 					</div>
-					<p className="jp-forms__export-modal-card-body-description-footer">
-						{ __( 'This premium feature is currently free to use in beta.', 'jetpack-forms' ) }
-					</p>
 				</div>
 				<div className="jp-forms__export-modal-card-body-cta">
 					{ isConnected && (

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/style.scss
@@ -56,30 +56,6 @@
 	color: inherit;
 }
 
-.jp-forms__export-modal-card-body-description-footer {
-	font-style: normal;
-	font-weight: 400;
-	font-size: 12px;
-	line-height: 150%;
-	color: #757575;
-	margin-bottom: 0px;
-}
-
 .jp-forms__export-modal-card-body-cta {
 	align-self: flex-end;
-}
-
-.jp-forms__export-modal-card-beta-badge {
-	background: #2FB41F;
-	border-radius: 2px;
-	font-style: normal;
-	font-weight: 600;
-	font-size: 11px;
-	line-height: 150%;
-	/* identical to box height, or 16px */
-
-	text-align: right;
-	text-transform: uppercase;
-	padding: 4px 8px;
-	color: #FFFFFF;
 }

--- a/projects/plugins/jetpack/changelog/remove-forms-remove-beta-badge
+++ b/projects/plugins/jetpack/changelog/remove-forms-remove-beta-badge
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: remove the beta label form the google drive export feature
+
+


### PR DESCRIPTION
This PR removed the beta label from the export modals. 

Before:
![Screenshot 2025-03-14 at 12 36 51 PM](https://github.com/user-attachments/assets/e665f0d5-b6a7-482a-8b59-a7b1c08d5a2f)

![Screenshot 2025-03-14 at 12 36 42 PM](https://github.com/user-attachments/assets/873b4402-65d9-4903-a700-92d1773dfa8e)

After:

![Screenshot 2025-03-14 at 12 33 09 PM](https://github.com/user-attachments/assets/c3462b1a-1a06-4aa7-bb21-5f36e364b87e)

![Screenshot 2025-03-14 at 12 32 25 PM](https://github.com/user-attachments/assets/a34aa82e-c51a-47c5-82d4-47c392924675)


## Proposed changes:
* Remove the "Beta" badge and the corresponding css. As well as the copy that indicates that this is a beta period feature. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:


* Go to feedback dashboards. (classis and modern) and notice that when you view the export modal it appears as expected. 


