### PR TITLE
Forms: Removes the beta salesforce badge

### DIFF
--- a/projects/packages/forms/changelog/remove-forms-remove-beta-badge-salesforce
+++ b/projects/packages/forms/changelog/remove-forms-remove-beta-badge-salesforce
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: remove the salesforce beta badge"

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings.js
@@ -150,16 +150,6 @@ export default ( { salesforceData, setAttributes, instanceId } ) => {
 		setOrganizationIdError( ! e.target.value.trim().match( /^[a-zA-Z0-9]{15,18}$/ ) );
 	};
 
-	const betaBadgeStyle = {
-		padding: '3px 6px',
-		'border-radius': '4px',
-		background: '#2FB41F',
-		color: 'white',
-		display: 'block',
-		'font-weight': 600,
-		'font-size': '11px',
-	};
-
 	return (
 		<Fragment>
 			<PanelBody title={ __( 'Salesforce', 'jetpack-forms' ) } initialOpen={ true }>
@@ -185,17 +175,6 @@ export default ( { salesforceData, setAttributes, instanceId } ) => {
 					<ExternalLink href="https://help.salesforce.com/s/articleView?id=000325251&type=1">
 						{ __( 'Where to find your Salesforce Organization ID', 'jetpack-forms' ) }
 					</ExternalLink>
-					<p style={ { 'margin-top': '32px', display: 'flex', 'font-size': '12px', gap: '8px' } }>
-						<div>
-							<span style={ betaBadgeStyle }>BETA</span>
-						</div>
-						<div>
-							{ __(
-								'This premium feature is currently free to use as it is in beta.',
-								'jetpack-forms'
-							) }
-						</div>
-					</p>
 				</BaseControl>
 			</PanelBody>
 		</Fragment>

--- a/projects/plugins/jetpack/changelog/remove-forms-remove-beta-badge-salesforce
+++ b/projects/plugins/jetpack/changelog/remove-forms-remove-beta-badge-salesforce
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: removes the salesforce beta badge


### PR DESCRIPTION
This PR Removes the beta sales force bage and copy. 

Before:

![Screenshot 2025-03-14 at 12 43 30 PM](https://github.com/user-attachments/assets/2aaa00f1-ef32-4e64-83e7-dbe9adc6bcf6)


After:

![Screenshot 2025-03-14 at 12 44 00 PM](https://github.com/user-attachments/assets/9e94722f-8f77-48fb-a3bd-7258d8bc7828)



## Proposed changes:
* Remove the copy and badge attached to saleforce integration that marks as beta and that it will be a premium feature. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Go to the block editor. 
* Insert a Form block and pick the "Salesforce lead form"
* Notice that the "beta" badge is not there any more. 

