### PR TITLE
wpcom-global-styles: Fetch the plan names more efficiently

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-get-plan-short-name
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-get-plan-short-name
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Added Plans::get_plan_short_name() for WPCOM environments.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -192,11 +192,12 @@ function wpcom_global_styles_enqueue_block_editor_assets() {
 	}
 
 	// @TODO Remove this once the global styles are available for all users on the Personal Plan.
-	$upgrade_url = "$calypso_domain/plans/$site_slug?plan=value_bundle&feature=style-customization";
-	$plan_name   = Plans::get_plan( 'value_bundle' )->product_name_short;
 	if ( is_global_styles_on_personal_plan() ) {
-		$plan_name   = Plans::get_plan( 'personal-bundle' )->product_name_short;
+		$plan_name   = Plans::get_plan_short_name( 'personal-bundle' );
 		$upgrade_url = "$calypso_domain/plans/$site_slug?plan=personal-bundle&feature=style-customization";
+	} else {
+		$plan_name   = Plans::get_plan_short_name( 'value_bundle' );
+		$upgrade_url = "$calypso_domain/plans/$site_slug?plan=value_bundle&feature=style-customization";
 	}
 
 	wp_localize_script(

--- a/projects/packages/plans/changelog/add-get-plan-short-name
+++ b/projects/packages/plans/changelog/add-get-plan-short-name
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Added Plans::get_plan_short_name() for WPCOM environments.

--- a/projects/packages/plans/src/class-plans.php
+++ b/projects/packages/plans/src/class-plans.php
@@ -83,8 +83,6 @@ class Plans {
 	/**
 	 * Efficiently get the short name of a plan from a slug.
 	 *
-	 * @since-jetpack $$next-version$$
-	 *
 	 * @param string $plan_slug Plan slug.
 	 * @return string|null Short product name or null if not round.
 	 */

--- a/projects/packages/plans/src/class-plans.php
+++ b/projects/packages/plans/src/class-plans.php
@@ -79,4 +79,35 @@ class Plans {
 			}
 		}
 	}
+
+	/**
+	 * Efficiently get the short name of a plan from a slug.
+	 *
+	 * @since-jetpack $$next-version$$
+	 *
+	 * @param string $plan_slug Plan slug.
+	 * @return string|null Short product name or null if not round.
+	 */
+	public static function get_plan_short_name( $plan_slug ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			if ( ! class_exists( 'Store_Product_List' ) ) {
+				require WP_CONTENT_DIR . '/admin-plugins/wpcom-billing/store-product-list.php';
+			}
+
+			// Skip additional work like processing of coupons, since we only need the plan's short name.
+			$products = Store_Product_List::get();
+
+			foreach ( $products as $product ) {
+				if ( isset( $product['product_slug'] ) && $product['product_slug'] === $plan_slug ) {
+					return $product['product_name_short'] ?? null;
+				}
+			}
+
+			return null;
+		}
+
+		// Fallback to less efficient method for Jetpack environments.
+		$plan = self::get_plan( $plan_slug );
+		return $plan->product_name_short ?? null;
+	}
 }


### PR DESCRIPTION
## Proposed changes:

This PR introduces a new `Plans::get_plan_short_name()`, which calls directly into `Store_Product_List::get()` on WPCOM, but falls back to the old method of `Plans::get_plan()` on a non-wpcom environment.

I found that running ` Plans::get_plan( 'value_bundle' )->product_name_short` on wpcom is pretty slow (around 80ms sandbox time). 

By using `Store_Product_List::get()` directly, we can avoid the unneeded processing of calling `get_store_product()` on a large number of products in a loop.  The new method can fetch the short name in about ~8ms, which isn't great, but is better than the ~80ms it was before.

Additionally, the pattern of:
```php
$plan_name = Plans::get_plan_short_name( 'value_bundle' );
if ( is_global_styles_on_personal_plan() ) {
  $plan_name   = Plans::get_plan_short_name( 'personal-bundle' );
}
```
Is reworked to:
```php
if ( is_global_styles_on_personal_plan() ) {
  $plan_name   = Plans::get_plan_short_name( 'personal-bundle' );
} else {
  $plan_name = Plans::get_plan_short_name( 'value_bundle' );
}
```
To avoid making an expensive call and throwing away the data in some cases.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On trunk, on your sandbox, add timing and logging to the plan name fetch. (This diff is sun, you might have to change moon depending on what's active)
```diff
diff --git a/wp-content/mu-plugins/jetpack-mu-wpcom-plugin/sun/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php b/wp-content/mu-plugins/jetpack-mu-wpcom-plugin/sun/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
index 32337d24887..0c04af81e2c 100644
--- a/wp-content/mu-plugins/jetpack-mu-wpcom-plugin/sun/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/wp-content/mu-plugins/jetpack-mu-wpcom-plugin/sun/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -192,8 +192,11 @@ function wpcom_global_styles_enqueue_block_editor_assets() {
        }

        // @TODO Remove this once the global styles are available for all users on the Personal Plan.
+       ac_start('get plan name');
        $upgrade_url = "$calypso_domain/plans/$site_slug?plan=value_bundle&feature=style-customization";
        $plan_name   = Plans::get_plan( 'value_bundle' )->product_name_short;
+       ac_stop('get plan name');
+       error_log(json_encode(compact('plan_name')));
        if ( is_global_styles_on_personal_plan() ) {
                $plan_name   = Plans::get_plan( 'personal-bundle' )->product_name_short;
                $upgrade_url = "$calypso_domain/plans/$site_slug?plan=personal-bundle&feature=style-customization";
```
* Sandbox and visit a p2 like 3741d-pb/#js
* See the name and timing
```
[14-Mar-2025 21:38:17 UTC] {"plan_name":"Premium"}
[14-Mar-2025 21:38:17 UTC] AC Debug Summary for: /
Label                |    Count | Total (ms) |   Avg (ms) | Median (ms) |   Min (ms) |   Max (ms)
----------------------------------------------------------------------------------------------------
get plan name        |        1 |      71.97 |      71.97 |      71.97 |      71.97 |      71.97
----------------------------------------------------------------------------------------------------
```
* Apply the diff to your sandbox using the two jetpack-downloader commands in the bot comments below
* Create a similar diff adding error_log and ac_start/ac_stop commands
* See the same name and better timing
```
[14-Mar-2025 21:39:34 UTC] {"plan_name":"Premium"}
[14-Mar-2025 21:39:34 UTC] AC Debug Summary for: /
Label                |    Count | Total (ms) |   Avg (ms) | Median (ms) |   Min (ms) |   Max (ms)
----------------------------------------------------------------------------------------------------
get plan name        |        1 |       3.84 |       3.84 |       3.84 |       3.84 |       3.84
----------------------------------------------------------------------------------------------------
```