### PR TITLE
Jetpack Boost: update Learn More URL to use Jetpack Redirect

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/upgrade-cta/interstitial-modal-cta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/upgrade-cta/interstitial-modal-cta.tsx
@@ -1,3 +1,4 @@
+import getRedirectUrl from '@automattic/jetpack-components/tools/jp-redirect';
 import { ProductInterstitialMyJetpack } from '@automattic/jetpack-my-jetpack/components/product-interstitial-modal';
 import boostImage from '@automattic/jetpack-my-jetpack/components/product-interstitial/boost.png';
 import { __ } from '@wordpress/i18n';
@@ -14,6 +15,8 @@ const InterstitialModalCTA = ( {
 	identifier,
 	customModalTrigger,
 }: InterstitialModalCTAProps ) => {
+	const learnMoreUrl = getRedirectUrl( 'jetpack-boost-interstitial-modal-learn-more' );
+
 	return (
 		<ProductInterstitialMyJetpack
 			slug="boost"
@@ -27,7 +30,7 @@ const InterstitialModalCTA = ( {
 					<img src={ boostImage } alt="Boost" />
 				</div>
 			}
-			secondaryButtonHref="https://jetpack.com/boost/"
+			secondaryButtonHref={ learnMoreUrl }
 			description={ __(
 				'Unlock the full potential of Jetpack Boost with automated performance optimization tools and more.',
 				'jetpack-boost'

--- a/projects/plugins/boost/changelog/fix-interstitial-modal-learn-more-jetpack-redirect
+++ b/projects/plugins/boost/changelog/fix-interstitial-modal-learn-more-jetpack-redirect
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Boost: update interstitial modal secondary button to use URL from Jetpack Redirect


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-marketing/issues/1194

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR updates the URL for the Learn More link in the Boost interstitial modal to get the URL from the Jetpack Redirect

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with Jetpack Beta having this branch checked out for the Boost plugin
* Go to My Jetpack and connect your site (you'll be redirected to the pricing page)
* Go to Boost admin and click on any of the CTAs (enabling the critical CSS shows up one CTA)

<img width="775" alt="image" src="https://github.com/user-attachments/assets/36cb1299-a6b5-4435-a407-9007e758e924" />

* After the modal is open, click on "Learn more" and confirm it redirects to the Boost page on Jetpack.com

<img width="1218" alt="image" src="https://github.com/user-attachments/assets/2950f1d0-46f2-40e6-864e-a0a65490c07a" />


