### PR TITLE
Download translation updates for wpcomsh

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-import-translation-updates-to-wpcomsh
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-import-translation-updates-to-wpcomsh
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+i18n: download updated translations for wpcomsh

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -64,7 +64,7 @@ class Jetpack_Mu_Wpcom {
 		// These features run only on atomic sites.
 		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
 			add_action( 'plugins_loaded', array( __CLASS__, 'load_custom_css' ) );
-			add_action( 'init', array( __CLASS__, 'schedule_translation_updates' ) );
+			add_action( 'plugins_loaded', array( __CLASS__, 'schedule_translation_updates' ) );
 		}
 
 		// Unified navigation fix for changes in WordPress 6.2.
@@ -124,6 +124,7 @@ class Jetpack_Mu_Wpcom {
 		$plugins_request_data              = array();
 		$plugin_language_pack_destinations = array(
 			'jetpack-mu-wpcom' => WP_LANG_DIR . '/mu-plugins/',
+			'wpcomsh'          => WP_LANG_DIR . '/mu-plugins/',
 		);
 
 		foreach ( array_keys( $plugin_language_pack_destinations ) as $plugin_slug ) {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -64,7 +64,7 @@ class Jetpack_Mu_Wpcom {
 		// These features run only on atomic sites.
 		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
 			add_action( 'plugins_loaded', array( __CLASS__, 'load_custom_css' ) );
-			add_action( 'plugins_loaded', array( __CLASS__, 'schedule_translation_updates' ) );
+			add_action( 'init', array( __CLASS__, 'schedule_translation_updates' ) );
 		}
 
 		// Unified navigation fix for changes in WordPress 6.2.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-import-translation-updates-to-wpcomsh
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-import-translation-updates-to-wpcomsh
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+i18n: download translation updates for wpcomsh

--- a/projects/plugins/wpcomsh/changelog/add-import-translation-updates-to-wpcomsh
+++ b/projects/plugins/wpcomsh/changelog/add-import-translation-updates-to-wpcomsh
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+i18n: download updated translations for wpcomsh

--- a/projects/plugins/wpcomsh/i18n.php
+++ b/projects/plugins/wpcomsh/i18n.php
@@ -65,7 +65,7 @@ add_filter( 'load_textdomain_mofile', 'wpcomsh_wporg_to_wpcom_locale_mo_file', 9
 add_action(
 	'after_setup_theme',
 	function () {
-		load_theme_textdomain( 'wpcomsh', WP_LANG_DIR . '/mu-plugins' );
+		load_muplugin_textdomain( 'wpcomsh', 'wpcomsh/languages' );
 		load_theme_textdomain( 'jetpack-mu-wpcom', WP_LANG_DIR . '/mu-plugins' );
 	}
 );
@@ -96,7 +96,7 @@ add_filter(
 	function ( $file, $handle, $domain ) {
 		global $wp_scripts;
 
-		if ( in_array( $domain, array( 'jetpack-mu-wpcom', 'wpcomsh' ), true ) ) {
+		if ( in_array( $domain, array( 'jetpack-mu-wpcom' ), true ) ) {
 			return WP_LANG_DIR . '/mu-plugins/' . basename( $file );
 		}
 

--- a/projects/plugins/wpcomsh/i18n.php
+++ b/projects/plugins/wpcomsh/i18n.php
@@ -65,7 +65,7 @@ add_filter( 'load_textdomain_mofile', 'wpcomsh_wporg_to_wpcom_locale_mo_file', 9
 add_action(
 	'after_setup_theme',
 	function () {
-		load_muplugin_textdomain( 'wpcomsh', 'wpcomsh/languages' );
+		load_theme_textdomain( 'wpcomsh', WP_LANG_DIR . '/mu-plugins' );
 		load_theme_textdomain( 'jetpack-mu-wpcom', WP_LANG_DIR . '/mu-plugins' );
 	}
 );
@@ -96,7 +96,7 @@ add_filter(
 	function ( $file, $handle, $domain ) {
 		global $wp_scripts;
 
-		if ( 'jetpack-mu-wpcom' === $domain ) {
+		if ( in_array( $domain, array( 'jetpack-mu-wpcom', 'wpcomsh' ), true ) ) {
 			return WP_LANG_DIR . '/mu-plugins/' . basename( $file );
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/i18n-issues/issues/953 

Related to 176458-ghe-Automattic/wpcom
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Downloads updated translations for `wpcomsh`. This update will populate `WP_LANG_DIR / mu-plugins` with the latest wpcomsh language pack files from https://translate.wordpress.com/projects/wpcom/plugins/wpcomsh/ on Atomic Sites. 

A follow-up PR will make use of these files by updating https://github.com/Automattic/jetpack/blob/63413902956ff377138fcd6e74ae049fe23b9ac9/projects/plugins/wpcomsh/i18n.php#L68.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow steps 1-8 of the instructions **Develop wpcomsh using a WoA dev blog site** on PCYsg-Osp-p2 
* Examine `~/htdocs/wp-content/languages/mu-plugins`, and verify that no files begin with the name `wpcomsh`
```bash
$ ls htdocs/wp-content/languages/mu-plugins/wpcomsh*|wc -l
ls: cannot access 'htdocs/wp-content/languages/mu-plugins/wpcomsh*': No such file or directory
0
```
* Execute `wp cron event run wpcomsh_translation_update` and the CLI
* Verify that `~/htdocs/wp-content/languages/mu-plugins` contains files that begin with `wpcomsh`
```bash
ls htdocs/wp-content/languages/mu-plugins/wpcomsh*|wc -l
500
```