### PR TITLE
Admin Bar: Add site badge and plan

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-site-badge-plan-admin-bar
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-site-badge-plan-admin-bar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a site badge and the site plan to the admin bar

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -8,7 +8,9 @@
  */
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use Automattic\Jetpack\Status;
 
 // The $icon-color variable for admin color schemes.
 // See: https://github.com/WordPress/wordpress-develop/blob/679cc0c4a261a77bd8fdb140cd9b0b2ff80ebf37/src/wp-admin/css/colors/_variables.scss#L9
@@ -366,3 +368,80 @@ function wpcom_edit_site_menu_override( $wp_admin_bar ) {
 	}
 }
 add_action( 'admin_bar_menu', 'wpcom_edit_site_menu_override', 41 );
+
+/**
+ * Adds site badges and plan information to the site title dropdown menu.
+ *
+ * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
+ */
+function wpcom_add_site_badges_and_plan( $wp_admin_bar ) {
+	// Get the current blog ID
+	$blog_id = get_current_blog_id();
+	$status  = new Status();
+
+	// Check for various site types
+	$badge_text = '';
+
+	// Check if this is a P2 site
+	if ( str_contains( get_stylesheet(), 'pub/p2' ) ||
+		( function_exists( '\WPForTeams\is_wpforteams_site' ) &&
+		\WPForTeams\is_wpforteams_site( $blog_id ) ) ) {
+		$badge_text = 'P2';
+	} elseif ( $status->is_staging_site() ) {
+		// Check for staging site
+		$badge_text = __( 'Staging', 'jetpack-mu-wpcom' );
+	} elseif ( function_exists( 'wpcom_site_has_feature' ) && wpcom_site_has_feature( 'trial' ) ) {
+		// Check for trial site
+		$badge_text = __( 'Trial', 'jetpack-mu-wpcom' );
+	} elseif ( ( get_option( 'launch-status' ) !== 'launched' ) || $status->is_coming_soon() ) {
+		// Check for Coming Soon site
+		$badge_text = __( 'Coming Soon', 'jetpack-mu-wpcom' );
+	} elseif ( $status->is_private_site() ) {
+		// Check for private site
+		$badge_text = __( 'Private', 'jetpack-mu-wpcom' );
+	} elseif ( ( function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'difm-lite-in-progress' ) ) ||
+		( function_exists( 'wpcomsh_is_site_sticker_active' ) && wpcomsh_is_site_sticker_active( 'difm-lite-in-progress' ) ) ) {
+		// Check for Express service
+		$badge_text = __( 'Express', 'jetpack-mu-wpcom' );
+	} elseif ( function_exists( 'is_simple_site_redirect' ) && is_simple_site_redirect( $status->get_site_suffix() ) ) {
+		// Check for Redirect site
+		$badge_text = __( 'Redirect', 'jetpack-mu-wpcom' );
+	} elseif ( ! empty( get_option( 'options' )['is_domain_only'] ) ) {
+		// Check for Domain Only site
+		$badge_text = __( 'Domain Only', 'jetpack-mu-wpcom' );
+	}
+
+	// Add badge to the site name dropdown if a badge is applicable
+	$status_text = '';
+	if ( $badge_text ) {
+		$status_text = '<div class="wp-admin-bar__site-info">
+							<span class="wp-admin-bar__site-info-label">' . __( 'Status', 'jetpack-mu-wpcom' ) . '</span>
+							<div class="wp-admin-bar__info-badges">' . esc_html( $badge_text ) . '</div>
+						</div>';
+	}
+
+	// Add plan information for non-staging sites
+	$plan_text  = '';
+	$is_staging = $status->is_staging_site();
+	if ( ! $is_staging ) {
+		$current_plan = Current_Plan::get();
+		$plan_name    = isset( $current_plan['product_name_short'] ) ? $current_plan['product_name_short'] : '';
+		if ( $plan_name ) {
+			$plan_text = '<div class="wp-admin-bar__site-info">
+							<span class="wp-admin-bar__site-info-label">' . __( 'Plan', 'jetpack-mu-wpcom' ) . '</span>
+							<div class="wp-admin-bar__info-badges">' . esc_html( $plan_name ) . '</div>
+						</div>';
+		}
+	}
+
+	if ( $status_text || $plan_text ) {
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => 'site-name',
+				'id'     => 'site-badge',
+				'title'  => '<div class="wp-admin-bar__site-infos">' . $status_text . $plan_text . '</div>',
+			)
+		);
+	}
+}
+add_action( 'admin_bar_menu', 'wpcom_add_site_badges_and_plan', 35 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -387,7 +387,7 @@ function wpcom_add_site_badges_and_plan( $wp_admin_bar ) {
 		( function_exists( '\WPForTeams\is_wpforteams_site' ) &&
 		\WPForTeams\is_wpforteams_site( $blog_id ) ) ) {
 		$badge_text = 'P2';
-	} elseif ( $status->is_staging_site() ) {
+	} elseif ( (bool) get_option( 'wpcom_is_staging_site' ) ) {
 		// Check for staging site
 		$badge_text = __( 'Staging', 'jetpack-mu-wpcom' );
 	} elseif ( function_exists( 'wpcom_site_has_feature' ) && wpcom_site_has_feature( 'trial' ) ) {
@@ -422,10 +422,10 @@ function wpcom_add_site_badges_and_plan( $wp_admin_bar ) {
 
 	// Add plan information for non-staging sites
 	$plan_text  = '';
-	$is_staging = $status->is_staging_site();
+	$is_staging = (bool) get_option( 'wpcom_is_staging_site' );
 	if ( ! $is_staging ) {
 		$current_plan = Current_Plan::get();
-		$plan_name    = isset( $current_plan['product_name_short'] ) ? $current_plan['product_name_short'] : '';
+		$plan_name    = isset( $current_plan['product_name_short'] ) ?? '';
 		if ( $plan_name ) {
 			$plan_text = '<div class="wp-admin-bar__site-info">
 							<span class="wp-admin-bar__site-info-label">' . __( 'Plan', 'jetpack-mu-wpcom' ) . '</span>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -424,8 +424,12 @@ function wpcom_add_site_badges_and_plan( $wp_admin_bar ) {
 	$plan_text  = '';
 	$is_staging = (bool) get_option( 'wpcom_is_staging_site' );
 	if ( ! $is_staging ) {
-		$current_plan = Current_Plan::get();
-		$plan_name    = $current_plan['product_name_short'] ?? '';
+		if ( class_exists( '\WPCOM_Store_API' ) ) {
+			$current_plan = WPCOM_Store_API::get_current_plan( get_current_blog_id() );
+		} else {
+			$current_plan = Current_Plan::get();
+		}
+		$plan_name = $current_plan['product_name_short'] ?? '';
 		if ( $plan_name ) {
 			$plan_text = '<div class="wp-admin-bar__site-info">
 							<span class="wp-admin-bar__site-info-label">' . __( 'Plan', 'jetpack-mu-wpcom' ) . '</span>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -425,7 +425,7 @@ function wpcom_add_site_badges_and_plan( $wp_admin_bar ) {
 	$is_staging = (bool) get_option( 'wpcom_is_staging_site' );
 	if ( ! $is_staging ) {
 		$current_plan = Current_Plan::get();
-		$plan_name    = isset( $current_plan['product_name_short'] ) ?? '';
+		$plan_name    = $current_plan['product_name_short'] ?? '';
 		if ( $plan_name ) {
 			$plan_text = '<div class="wp-admin-bar__site-info">
 							<span class="wp-admin-bar__site-info-label">' . __( 'Plan', 'jetpack-mu-wpcom' ) . '</span>
@@ -435,13 +435,33 @@ function wpcom_add_site_badges_and_plan( $wp_admin_bar ) {
 	}
 
 	if ( $status_text || $plan_text ) {
-		$wp_admin_bar->add_node(
+		$wp_admin_bar->add_group(
 			array(
 				'parent' => 'site-name',
 				'id'     => 'site-badge',
-				'title'  => '<div class="wp-admin-bar__site-infos">' . $status_text . $plan_text . '</div>',
+				'meta'   => array(
+					'class' => 'ab-sub-secondary',
+				),
 			)
 		);
+		if ( $status_text ) {
+			$wp_admin_bar->add_node(
+				array(
+					'parent' => 'site-badge',
+					'id'     => 'site-badge-status',
+					'title'  => $status_text,
+				)
+			);
+		}
+		if ( $plan_text ) {
+			$wp_admin_bar->add_node(
+				array(
+					'parent' => 'site-badge',
+					'id'     => 'site-badge-plan',
+					'title'  => $plan_text,
+				)
+			);
+		}
 	}
 }
 add_action( 'admin_bar_menu', 'wpcom_add_site_badges_and_plan', 35 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -1,4 +1,5 @@
 @import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/colors';
 
 /**
  * Allow to apply the modern scheme to elements.
@@ -120,6 +121,54 @@
     		width: 46px;
 		}
 	}
+}
+
+/**
+ * Site badge and plan info in the dropdown
+ */
+#wp-admin-bar-site-badge > .ab-item {
+	height: auto !important;
+}
+
+#wpadminbar .wp-admin-bar__site-infos {
+	box-sizing: border-box;
+	min-width: 260px;
+	margin: 6px -10px -6px;
+	padding: 12px;
+	color: #fff;
+	background-color: color-mix( in srgb, currentColor 10%, transparent );
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+#wpadminbar .wp-admin-bar__site-info {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	align-items: center;
+}
+	
+#wpadminbar .wp-admin-bar__site-info-label {
+	margin-bottom: 4px;
+}
+	
+#wpadminbar .wp-admin-bar__info-badges {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+	background-color: $gray-800;
+	color: $white;
+	border-radius: 4px;
+	box-sizing: border-box;
+	padding: 0 8px;
+    min-height: 24px;
+    border-radius: 2px;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 20px;
+	display: flex;
+	align-items: center;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -106,19 +106,19 @@
 
 #wpadminbar #wp-admin-bar-site-name {
 
-    > .ab-item:before {
+	> .ab-item:before {
 
-        /**
-    	 * Always show the House icon by the site name.
-    	 */
-	    content: "\f102" !important;
-    }
+		/**
+		 * Always show the House icon by the site name.
+		 */
+		content:"\f102" !important;
+	}
 
 	@media (max-width: 480px) {
 
-        > a.ab-item,
+		> a.ab-item,
 		> a.ab-item:before {
-    		width: 46px;
+			width: 46px;
 		}
 	}
 }
@@ -144,11 +144,11 @@
 	justify-content: space-between;
 	align-items: center;
 }
-	
+
 #wpadminbar .wp-admin-bar__site-info-label {
 	margin-bottom: 4px;
 }
-	
+
 #wpadminbar .wp-admin-bar__info-badges {
 	display: flex;
 	flex-wrap: wrap;
@@ -157,11 +157,11 @@
 	border-radius: 4px;
 	box-sizing: border-box;
 	padding: 0 8px;
-    min-height: 24px;
-    border-radius: 2px;
-    font-size: 12px;
-    font-weight: 400;
-    line-height: 20px;
+	min-height: 24px;
+	border-radius: 2px;
+	font-size: 12px;
+	font-weight: 400;
+	line-height: 20px;
 	display: flex;
 	align-items: center;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -153,8 +153,7 @@
 	display: flex;
 	flex-wrap: wrap;
 	gap: 4px;
-	background-color: $gray-900;
-	color: $white;
+	background-color: rgba(255, 255, 255, 0.1);
 	border-radius: 4px;
 	box-sizing: border-box;
 	padding: 0 8px;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -126,20 +126,16 @@
 /**
  * Site badge and plan info in the dropdown
  */
-#wp-admin-bar-site-badge > .ab-item {
-	height: auto !important;
-}
-
-#wpadminbar .wp-admin-bar__site-infos {
-	box-sizing: border-box;
-	min-width: 260px;
-	margin: 6px -10px -6px;
-	padding: 12px;
-	color: #fff;
-	background-color: color-mix( in srgb, currentColor 10%, transparent );
+#wp-admin-bar-site-badge {
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
+	min-width: 260px;
+}
+
+#wp-admin-bar-site-badge-status .ab-item,
+#wp-admin-bar-site-badge-plan .ab-item {
+	height: auto !important;
 }
 
 #wpadminbar .wp-admin-bar__site-info {
@@ -157,7 +153,7 @@
 	display: flex;
 	flex-wrap: wrap;
 	gap: 4px;
-	background-color: $gray-800;
+	background-color: $gray-900;
 	color: $white;
 	border-radius: 4px;
 	box-sizing: border-box;

--- a/projects/packages/masterbar/changelog/remove-site-card
+++ b/projects/packages/masterbar/changelog/remove-site-card
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove the site card from the admin sidebar

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/_admin.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/_admin.scss
@@ -257,6 +257,9 @@ textarea:focus {
 
 
 /* Admin Menu */
+#adminmenu {
+	padding-top: 6px;
+}
 
 #adminmenuback,
 #adminmenuwrap,

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/_overrides.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/_overrides.scss
@@ -104,55 +104,6 @@
 	#wpadminbar .ab-top-menu > li.wpnt-show > .ab-item {
 		background: $masterbar-active-background !important; // important used in masterbar.css
 	}
-
-	// Site Card - Border around Site Card
-	#adminmenu li.toplevel_page_site-card {
-		border-bottom: 1px solid $nav-unification-sidebar-border;
-		border-top: 1px solid $nav-unification-sidebar-border;
-	}
-
-	// Site Card - Keep background the same color on hover
-	#adminmenu li.toplevel_page_site-card:hover,
-	#adminmenu li.toplevel_page_site-card a:hover {
-		background: $menu-background;
-	}
-
-	// Site Card - Site title
-	.site__info .site__title {
-		color: $menu-text;
-	}
-
-	// Site Card - Site domain
-	.site__info .site__domain {
-		color: $nav-unification-sidebar-text-alternative;
-	}
-
-	// Site Card - Site icon placeholder image background on hover/focus
-	#adminmenu .toplevel_page_site-card:hover div.wp-menu-image,
-	#adminmenu .toplevel_page_site-card a:focus div.wp-menu-image {
-		background-color: $menu-current-background;
-	}
-
-	// Site Card - Fade out for content overflowing the Site Card
-	.site__info .site__title::after,
-	.site__info .site__domain::after {
-		background: linear-gradient( 90deg, rgba( $color: $menu-background, $alpha: 0 ), rgba( $color: $menu-background, $alpha: 1 ) 90% );
-	}
-
-	// Site Card - Browse Sites button text & arrow
-	#adminmenuwrap > #adminmenu .site-switcher {
-		color: $nav-unification-sidebar-text-alternative;
-
-		div.wp-menu-image:before {
-			color: $nav-unification-sidebar-text-alternative;
-		}
-
-		&:hover,
-		&:hover div.wp-menu-image:before {
-			color: $menu-highlight-text;
-		}
-	}
-
 }
 
 // Ensure sidebar is visually separate from the content in the Contrast color scheme

--- a/projects/packages/masterbar/src/admin-menu/admin-menu.css
+++ b/projects/packages/masterbar/src/admin-menu/admin-menu.css
@@ -30,6 +30,7 @@
  * Fixes Gutenberg in not fullscreen mode.
  */
  @media (min-width: 783px) {
+
 	.interface-interface-skeleton,
 	.edit-post-layout .components-editor-notices__snackbar {
 		left: 272px;
@@ -37,6 +38,7 @@
 }
 
 @media (min-width: 961px) {
+
 	body:not(.folded).auto-fold .interface-interface-skeleton,
 	.auto-fold .edit-post-layout .components-editor-notices__snackbar,
 	.components-snackbar-list.edit-widgets-notices__snackbar,
@@ -78,7 +80,7 @@
 
 #adminmenu .toplevel_page_site-notices .wp-menu-image:before {
 	content: '\f534';
-	font-family: 'dashicons';
+	font-family: dashicons;
 	font-size: 20px;
 	line-height: 20px;
 	background-color: #a7aaad;
@@ -127,6 +129,7 @@
 }
 
 @media screen and (min-width: 782px) {
+
 	.folded #adminmenu .toplevel_page_site-notices .wp-menu-image {
 		display: block;
 		width: 30px;
@@ -141,6 +144,7 @@
 }
 
 @media screen and (min-width: 782px) and (max-width: 960px){
+
 	.auto-fold #adminmenu .toplevel_page_site-notices .wp-menu-image {
 		display: block;
 		width: 30px;
@@ -189,6 +193,7 @@
 
 /* Auto-folding of the admin menu */
 @media only screen and (max-width: 960px) {
+
 	#adminmenu,
 	#adminmenuwrap,
 	#adminmenuback {
@@ -209,12 +214,14 @@
 }
 
 @media screen and (min-width: 782px) and (max-width: 960px) {
+
 	.auto-fold #adminmenu a.menu-top {
 		height: 34px;
 	}
 }
 
 @media screen and (max-width: 782px) {
+
 	#adminmenu li.menu-top .wp-submenu>li>a,
 	.auto-fold #adminmenu li.menu-top .wp-submenu>li>a {
 		padding-left: 42px;
@@ -239,6 +246,7 @@
 }
 
 @media only screen and (max-width: 660px) {
+
 	#adminmenuback,
 	#adminmenuwrap,
 	#adminmenu,
@@ -286,6 +294,7 @@
 }
 
 @media screen and  (max-width: 782px) {
+
 	.screen-options-tab__dropdown {
 		right: 10px;
 		top: 47px;
@@ -293,6 +302,7 @@
 }
 
 @media screen and  (max-width: 600px) {
+
 	.screen-options-tab__dropdown {
 		top: 93px;
 	}
@@ -340,6 +350,7 @@
 	display: flex;
 	flex-direction: column;
 }
+
 #adminmenu .menu-top[class*="/start?ref=calypso-sidebar"] {
 	order: 99999;
 }

--- a/projects/packages/masterbar/src/admin-menu/admin-menu.css
+++ b/projects/packages/masterbar/src/admin-menu/admin-menu.css
@@ -59,18 +59,6 @@
 }
 
 /**
- * Site Card
- */
-#adminmenu .toplevel_page_site-card .wp-menu-name {
-	margin-left: 40px; /* icon width (32) + padding (8). */
-	padding: 0;
-}
-
-#adminmenu li.toplevel_page_site-card a {
-	padding: 10px 0 10px 8px;
-}
-
-/**
  * Site Notices
  */
 #adminmenu a.toplevel_page_site-notices:hover,
@@ -90,7 +78,7 @@
 	background-color: #fff;
 }
 
-#adminmenu .toplevel_page_site-notices .wp-menu-image:before {
+#adminmenu .toplevel_page_site-notices .wp-menu-image::before {
 	content: '\f534';
 	font-family: dashicons;
 	font-size: 20px;
@@ -102,7 +90,7 @@
 	padding: 0;
 }
 
-#adminmenu .toplevel_page_site-notices:hover .wp-menu-image:before {
+#adminmenu .toplevel_page_site-notices:hover .wp-menu-image::before {
 	color: #fff;
 }
 
@@ -171,118 +159,8 @@
 }
 
 /* Prevent box-shadow at the top of the sidebar */
-#adminmenu .site-switcher:hover,
-#adminmenu .toplevel_page_site-card:hover,
-#adminmenu .toplevel_page_site-notices:hover {
+#adminmenu .site-switcher:hover {
 	box-shadow: none;
-}
-
-/**
- * Site icon inline-styles for height and width are defined in set_site_icon_inline_styles
- */
-#adminmenu .toplevel_page_site-card .wp-menu-image {
-	background-image: none;
-	background-position: center;
-	background-repeat: no-repeat;
-	background-size: 18px 18px;
-	transform: translateZ(0);
-	transition-property: background-image,background-color;
-	transition-duration: .2s;
-}
-
-#adminmenu a.toplevel_page_site-card:hover,
-#adminmenu li.toplevel_page_site-card:hover {
-	background-color: inherit;
-}
-
-#adminmenu .toplevel_page_site-card img {
-	opacity: initial;
-}
-
-#adminmenu .toplevel_page_site-card.has-site-icon img {
-	padding: 0;
-}
-
-#adminmenu .toplevel_page_site-card:hover div.wp-menu-image,
-#adminmenu .toplevel_page_site-card a:focus div.wp-menu-image {
-	background-image: url("data:image/svg+xml,%3Csvg class='gridicon gridicons-house' height='24' width='24' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cg%3E%3Cpath fill='%23fff' d='M22 9L12 1 2 9v2h2v10h5v-4c0-1.657 1.343-3 3-3s3 1.343 3 3v4h5V11h2V9z'/%3E%3C/g%3E%3C/svg%3E%0A");
-}
-
-#adminmenu .toplevel_page_site-card:not(.has-site-icon) .wp-menu-image {
-	background-color: #c3c4c7;
-	height: 32px;
-	width: 32px;
-}
-
-#adminmenu .toplevel_page_site-card:not(.has-site-icon) .wp-menu-image img {
-	width: 18px;
-	height: 18px;
-	padding: 7px;
-}
-
-#adminmenu .toplevel_page_site-card:hover div.wp-menu-image img,
-#adminmenu .toplevel_page_site-card a:focus div.wp-menu-image img {
-	display: none;
-}
-
-.site__info .site__title {
-	display: block;
-	font-size: 14px;
-	font-weight: 400;
-	line-height: 1.3;
-}
-
-.site__info .site__domain {
-	display: block;
-	max-width: 95%;
-	font-size: 12px;
-	line-height: 1.4;
-	margin-top: 2px;
-}
-
-.site__info .site__title,
-.site__info .site__domain {
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
-.site__info .site__title::after,
-.site__info .site__domain::after {
-	content: "";
-	display: block;
-	position: absolute;
-	-webkit-touch-callout: none;
-	-webkit-user-select: none;
-	user-select: none;
-	pointer-events: none;
-	top: 0;
-	bottom: 0;
-	right: 0;
-	left: auto;
-	width: 20%;
-	height: auto;
-}
-
-.site__info > .site__badge {
-	font-size: 12px;
-	border-radius: 12px;
-	clear: both;
-	display: inline-block;
-	margin-top: 6px;
-	margin-right: 3px;
-	padding: 1px 10px;
-}
-
-.site__info > .site__badge.site__badge-staging {
-	background-color: #f0c930;
-	color: #4f3500;
-}
-
-.site__info > .site__badge.site__badge-private {
-	background: transparent;
-	color: inherit;
-	border: solid 1px color-mix( in srgb, currentColor 50%, transparent );
 }
 
 /**
@@ -312,10 +190,6 @@
 	height: 31px;
 }
 
-.folded #adminmenu li.toplevel_page_site-card a {
-	padding-left: 0;
-}
-
 /* Auto-folding of the admin menu */
 @media only screen and (max-width: 960px) {
 
@@ -342,11 +216,6 @@
 
 	.auto-fold #adminmenu a.menu-top {
 		height: 34px;
-	}
-
-	.auto-fold #adminmenu li.toplevel_page_site-card a {
-		height: 36px;
-		padding-left: 1px;
 	}
 }
 
@@ -392,15 +261,11 @@
 		margin-left: 0;
 	}
 
-	ul#adminmenu a.wp-has-current-submenu:after,
-	ul#adminmenu>li.current>a.current:after,
-	ul#adminmenu li:hover a.wp-has-current-submenu:after,
-	.auto-fold ul#adminmenu li:hover a.wp-has-current-submenu:after {
+	ul#adminmenu a.wp-has-current-submenu::after,
+	ul#adminmenu>li.current>a.current::after,
+	ul#adminmenu li:hover a.wp-has-current-submenu::after,
+	.auto-fold ul#adminmenu li:hover a.wp-has-current-submenu::after {
 		display: none;
-	}
-
-	.auto-fold #adminmenu li.toplevel_page_site-card a {
-		padding: 18px 0 18px 12px;
 	}
 }
 
@@ -495,7 +360,6 @@ body:not(.folded) #adminmenu .menu-top[class*="/start?ref=calypso-sidebar"] {
 }
 
 body:not(.folded) #adminmenu .menu-top[class*="/start?ref=calypso-sidebar"] a {
-	background: transparent;
 	border-color: var(--transparent-button-text-color, currentcolor);
 	display: flex;
 	justify-content: center;

--- a/projects/packages/masterbar/src/admin-menu/admin-menu.css
+++ b/projects/packages/masterbar/src/admin-menu/admin-menu.css
@@ -30,7 +30,6 @@
  * Fixes Gutenberg in not fullscreen mode.
  */
  @media (min-width: 783px) {
-
 	.interface-interface-skeleton,
 	.edit-post-layout .components-editor-notices__snackbar {
 		left: 272px;
@@ -38,7 +37,6 @@
 }
 
 @media (min-width: 961px) {
-
 	body:not(.folded).auto-fold .interface-interface-skeleton,
 	.auto-fold .edit-post-layout .components-editor-notices__snackbar,
 	.components-snackbar-list.edit-widgets-notices__snackbar,
@@ -78,9 +76,9 @@
 	background-color: #fff;
 }
 
-#adminmenu .toplevel_page_site-notices .wp-menu-image::before {
+#adminmenu .toplevel_page_site-notices .wp-menu-image:before {
 	content: '\f534';
-	font-family: dashicons;
+	font-family: 'dashicons';
 	font-size: 20px;
 	line-height: 20px;
 	background-color: #a7aaad;
@@ -90,7 +88,7 @@
 	padding: 0;
 }
 
-#adminmenu .toplevel_page_site-notices:hover .wp-menu-image::before {
+#adminmenu .toplevel_page_site-notices:hover .wp-menu-image:before {
 	color: #fff;
 }
 
@@ -129,7 +127,6 @@
 }
 
 @media screen and (min-width: 782px) {
-
 	.folded #adminmenu .toplevel_page_site-notices .wp-menu-image {
 		display: block;
 		width: 30px;
@@ -144,7 +141,6 @@
 }
 
 @media screen and (min-width: 782px) and (max-width: 960px){
-
 	.auto-fold #adminmenu .toplevel_page_site-notices .wp-menu-image {
 		display: block;
 		width: 30px;
@@ -159,7 +155,8 @@
 }
 
 /* Prevent box-shadow at the top of the sidebar */
-#adminmenu .site-switcher:hover {
+#adminmenu .site-switcher:hover,
+#adminmenu .toplevel_page_site-notices:hover {
 	box-shadow: none;
 }
 
@@ -192,7 +189,6 @@
 
 /* Auto-folding of the admin menu */
 @media only screen and (max-width: 960px) {
-
 	#adminmenu,
 	#adminmenuwrap,
 	#adminmenuback {
@@ -213,14 +209,12 @@
 }
 
 @media screen and (min-width: 782px) and (max-width: 960px) {
-
 	.auto-fold #adminmenu a.menu-top {
 		height: 34px;
 	}
 }
 
 @media screen and (max-width: 782px) {
-
 	#adminmenu li.menu-top .wp-submenu>li>a,
 	.auto-fold #adminmenu li.menu-top .wp-submenu>li>a {
 		padding-left: 42px;
@@ -245,7 +239,6 @@
 }
 
 @media only screen and (max-width: 660px) {
-
 	#adminmenuback,
 	#adminmenuwrap,
 	#adminmenu,
@@ -261,10 +254,10 @@
 		margin-left: 0;
 	}
 
-	ul#adminmenu a.wp-has-current-submenu::after,
-	ul#adminmenu>li.current>a.current::after,
-	ul#adminmenu li:hover a.wp-has-current-submenu::after,
-	.auto-fold ul#adminmenu li:hover a.wp-has-current-submenu::after {
+	ul#adminmenu a.wp-has-current-submenu:after,
+	ul#adminmenu>li.current>a.current:after,
+	ul#adminmenu li:hover a.wp-has-current-submenu:after,
+	.auto-fold ul#adminmenu li:hover a.wp-has-current-submenu:after {
 		display: none;
 	}
 }
@@ -293,7 +286,6 @@
 }
 
 @media screen and  (max-width: 782px) {
-
 	.screen-options-tab__dropdown {
 		right: 10px;
 		top: 47px;
@@ -301,7 +293,6 @@
 }
 
 @media screen and  (max-width: 600px) {
-
 	.screen-options-tab__dropdown {
 		top: 93px;
 	}
@@ -349,7 +340,6 @@
 	display: flex;
 	flex-direction: column;
 }
-
 #adminmenu .menu-top[class*="/start?ref=calypso-sidebar"] {
 	order: 99999;
 }

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -12,7 +12,6 @@ use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
 use Automattic\Jetpack\JITMS\JITM;
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Redirect;
-use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Subscribers_Dashboard\Dashboard as Subscribers_Dashboard;
 
 require_once __DIR__ . '/class-admin-menu.php';
@@ -76,7 +75,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 
 		// Not needed outside of wp-admin.
 		if ( ! $this->is_api_request ) {
-			$this->add_site_card_menu();
 			$this->add_new_site_link();
 		}
 
@@ -213,75 +211,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		add_menu_page( __( 'Add New Site', 'jetpack-masterbar' ), __( 'Add New Site', 'jetpack-masterbar' ), 'read', 'https://wordpress.com/start?ref=calypso-sidebar', null, 'dashicons-plus-alt' );
-	}
-
-	/**
-	 * Adds site card component.
-	 */
-	public function add_site_card_menu() {
-		$default        = plugins_url( 'globe-icon.svg', __FILE__ );
-		$icon           = get_site_icon_url( 32, $default );
-		$blog_name      = get_option( 'blogname' ) !== '' ? get_option( 'blogname' ) : $this->domain;
-		$is_coming_soon = ( new Status() )->is_coming_soon();
-
-		$badge = '';
-
-		if ( get_option( 'wpcom_is_staging_site' ) ) {
-			$badge .= '<span class="site__badge site__badge-staging">' . esc_html__( 'Staging', 'jetpack-masterbar' ) . '</span>';
-		}
-
-		if ( ( function_exists( '\Private_Site\site_is_private' ) && \Private_Site\site_is_private() ) || $is_coming_soon ) {
-			$badge .= sprintf(
-				'<span class="site__badge site__badge-private">%s</span>',
-				$is_coming_soon ? esc_html__( 'Coming Soon', 'jetpack-masterbar' ) : esc_html__( 'Private', 'jetpack-masterbar' )
-			);
-		}
-
-		$site_card = '
-<div class="site__info">
-	<div class="site__title">%1$s</div>
-	<div class="site__domain">%2$s</div>
-	%3$s
-</div>';
-
-		$site_card = sprintf(
-			$site_card,
-			$blog_name,
-			$this->domain,
-			$badge
-		);
-
-		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_menu_page( 'site-card', $site_card, 'read', get_home_url(), null, $icon, 1 );
-		add_filter( 'add_menu_classes', array( $this, 'set_site_card_menu_class' ) );
-	}
-
-	/**
-	 * Adds a custom element class and id for Site Card's menu item.
-	 *
-	 * @param array $menu Associative array of administration menu items.
-	 *
-	 * @return array
-	 */
-	public function set_site_card_menu_class( array $menu ) {
-		foreach ( $menu as $key => $menu_item ) {
-			if ( 'site-card' !== $menu_item[3] ) {
-				continue;
-			}
-
-			$classes = ' toplevel_page_site-card';
-
-			// webclip.png is the default on WoA sites. Anything other than that means we have a custom site icon.
-			if ( has_site_icon() && 'https://s0.wp.com/i/webclip.png' !== get_site_icon_url( 512 ) ) {
-				$classes .= ' has-site-icon';
-			}
-
-			$menu[ $key ][4] = $menu_item[4] . $classes;
-			$menu[ $key ][5] = 'toplevel_page_site_card';
-			break;
-		}
-
-		return $menu;
 	}
 
 	/**

--- a/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
@@ -76,7 +76,6 @@ abstract class Base_Admin_Menu {
 		if ( ! $this->is_api_request ) {
 			add_filter( 'admin_menu', array( $this, 'override_svg_icons' ), 99999 );
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 11 );
-			add_action( 'admin_head', array( $this, 'set_site_icon_inline_styles' ) );
 			add_action( 'in_admin_header', array( $this, 'add_dashboard_switcher' ) );
 			add_action( 'admin_footer', array( $this, 'dashboard_switcher_scripts' ) );
 			add_action( 'admin_menu', array( $this, 'handle_preferred_view' ), 99997 );
@@ -281,20 +280,6 @@ abstract class Base_Admin_Menu {
 	 */
 	public function configure_colors_for_rtl_stylesheets() {
 		wp_style_add_data( 'colors', 'rtl', $this->is_rtl() );
-	}
-
-	/**
-	 * Injects inline-styles for site icon for when third-party plugins remove enqueued stylesheets.
-	 * Unable to use wp_add_inline_style as plugins remove styles from all non-standard handles
-	 */
-	public function set_site_icon_inline_styles() {
-		echo '<style>
-			#adminmenu .toplevel_page_site-card .wp-menu-image,
-			#adminmenu .toplevel_page_site-card .wp-menu-image img {
-				height: 32px;
-				width: 32px;
-			}
-		</style>';
 	}
 
 	/**

--- a/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Masterbar;
 
-use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Subscribers_Dashboard\Dashboard as Subscribers_Dashboard;
 use Jetpack_Custom_CSS;
 use JITM;
@@ -50,7 +49,6 @@ class WPcom_Admin_Menu extends Admin_Menu {
 
 		// Not needed outside of wp-admin.
 		if ( ! $this->is_api_request ) {
-			$this->add_site_card_menu();
 			$this->add_new_site_link();
 		}
 
@@ -131,81 +129,6 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		$this->add_admin_menu_separator();
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		add_menu_page( __( 'Add New Site', 'jetpack-masterbar' ), __( 'Add New Site', 'jetpack-masterbar' ), 'read', 'https://wordpress.com/start?ref=calypso-sidebar', null, 'dashicons-plus-alt' );
-	}
-
-	/**
-	 * Adds site card component.
-	 */
-	public function add_site_card_menu() {
-		$default         = plugins_url( 'globe-icon.svg', __FILE__ );
-		$icon            = get_site_icon_url( 32, $default );
-		$blog_name       = get_option( 'blogname' ) !== '' ? get_option( 'blogname' ) : $this->domain;
-		$status          = new Status();
-		$is_private_site = $status->is_private_site();
-		$is_coming_soon  = $status->is_coming_soon();
-
-		if ( $default === $icon && blavatar_exists( $this->domain ) ) {
-			$icon = blavatar_url( $this->domain, 'img', 32 );
-		}
-
-		$badge = '';
-		if ( $is_private_site || $is_coming_soon ) {
-			$badge .= sprintf(
-				'<span class="site__badge site__badge-private">%s</span>',
-				$is_coming_soon ? esc_html__( 'Coming Soon', 'jetpack-masterbar' ) : esc_html__( 'Private', 'jetpack-masterbar' )
-			);
-		}
-
-		if ( function_exists( 'is_simple_site_redirect' ) && is_simple_site_redirect( $this->domain ) ) {
-			$badge .= '<span class="site__badge site__badge-redirect">' . esc_html__( 'Redirect', 'jetpack-masterbar' ) . '</span>';
-		}
-
-		if ( ! empty( get_option( 'options' )['is_domain_only'] ) ) {
-			$badge .= '<span class="site__badge site__badge-domain-only">' . esc_html__( 'Domain', 'jetpack-masterbar' ) . '</span>';
-		}
-
-		$site_card = '
-<div class="site__info">
-	<div class="site__title">%1$s</div>
-	<div class="site__domain">%2$s</div>
-	%3$s
-</div>';
-
-		$site_card = sprintf(
-			$site_card,
-			$blog_name,
-			$this->domain,
-			$badge
-		);
-
-		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_menu_page( 'site-card', $site_card, 'read', get_home_url(), null, $icon, 1 );
-		add_filter( 'add_menu_classes', array( $this, 'set_site_card_menu_class' ) );
-	}
-
-	/**
-	 * Adds a custom element class and id for Site Card's menu item.
-	 *
-	 * @param array $menu Associative array of administration menu items.
-	 * @return array
-	 */
-	public function set_site_card_menu_class( array $menu ) {
-		foreach ( $menu as $key => $menu_item ) {
-			if ( 'site-card' !== $menu_item[3] ) {
-				continue;
-			}
-
-			$classes = ' toplevel_page_site-card';
-			if ( blavatar_exists( $this->domain ) ) {
-				$classes .= ' has-site-icon';
-			}
-
-			$menu[ $key ][4] = $menu_item[4] . $classes;
-			$menu[ $key ][5] = 'toplevel_page_site_card';
-			break;
-		}
-
-		return $menu;
 	}
 
 	/**

--- a/projects/packages/masterbar/tests/php/Atomic_Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/Atomic_Admin_Menu_Test.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Masterbar;
 
 use Automattic\Jetpack\Status;
-use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Users as WorDBless_Users;
@@ -123,101 +122,6 @@ class Atomic_Admin_Menu_Test extends TestCase {
 		$this->assertSame( array_pop( $menu ), $new_site_menu_item );
 
 		delete_user_option( static::$user_id, 'wpcom_site_count' );
-	}
-
-	/**
-	 * Tests add_site_card_menu
-	 */
-	public function test_add_site_card_menu() {
-		global $menu;
-
-		static::$admin_menu->add_site_card_menu();
-
-		$home_url            = home_url();
-		$site_card_menu_item = array(
-			'
-<div class="site__info">
-	<div class="site__title">' . get_option( 'blogname' ) . '</div>
-	<div class="site__domain">' . static::$domain . "</div>\n\t\n</div>",
-			'read',
-			$home_url,
-			'site-card',
-			'menu-top toplevel_page_' . $home_url,
-			'toplevel_page_' . $home_url,
-			plugins_url( 'src/admin-menu/globe-icon.svg', dirname( __DIR__ ) ),
-		);
-
-		$this->assertEquals( $site_card_menu_item, $menu[1] );
-	}
-
-	/**
-	 * Tests add_site_card_menu for Private sites
-	 */
-	public function test_add_site_card_menu_private_site() {
-		global $menu;
-
-		Functions\expect( '\Private_Site\site_is_private' )
-				->andReturn( true );
-
-		static::$admin_menu->add_site_card_menu();
-
-		$home_url            = home_url();
-		$site_card_menu_item = array(
-			'
-<div class="site__info">
-	<div class="site__title">' . get_option( 'blogname' ) . '</div>
-	<div class="site__domain">' . static::$domain . "</div>\n\t<span class=\"site__badge site__badge-private\">Private</span>\n</div>",
-			'read',
-			$home_url,
-			'site-card',
-			'menu-top toplevel_page_' . $home_url,
-			'toplevel_page_' . $home_url,
-			plugins_url( 'src/admin-menu/globe-icon.svg', dirname( __DIR__ ) ),
-		);
-
-		$this->assertEquals( $site_card_menu_item, $menu[1] );
-	}
-
-	/**
-	 * Tests set_site_card_menu_class
-	 */
-	public function test_set_site_card_menu_class() {
-		global $menu;
-
-		static::$admin_menu->add_site_card_menu();
-
-		$menu = static::$admin_menu->set_site_card_menu_class( $menu );
-		$this->assertStringNotContainsString( 'has-site-icon', $menu[1][4] );
-
-		// Atomic fallback site icon counts as no site icon.
-		add_filter( 'get_site_icon_url', array( $this, 'wpcomsh_site_icon_url' ) );
-		$menu = static::$admin_menu->set_site_card_menu_class( $menu );
-		remove_filter( 'get_site_icon_url', array( $this, 'wpcomsh_site_icon_url' ) );
-		$this->assertStringNotContainsString( 'has-site-icon', $menu[1][4] );
-
-		// Custom site icon triggers CSS class.
-		add_filter( 'get_site_icon_url', array( $this, 'custom_site_icon_url' ) );
-		$menu = static::$admin_menu->set_site_card_menu_class( $menu );
-		remove_filter( 'get_site_icon_url', array( $this, 'custom_site_icon_url' ) );
-		$this->assertStringContainsString( 'has-site-icon', $menu[1][4] );
-	}
-
-	/**
-	 * Shim wpcomsh fallback site icon.
-	 *
-	 * @return string
-	 */
-	public function wpcomsh_site_icon_url() {
-		return 'https://s0.wp.com/i/webclip.png';
-	}
-
-	/**
-	 * Custom site icon.
-	 *
-	 * @return string
-	 */
-	public function custom_site_icon_url() {
-		return 'https://s0.wp.com/i/jetpack.png';
 	}
 
 	/**

--- a/projects/packages/masterbar/tests/php/WPcom_Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/WPcom_Admin_Menu_Test.php
@@ -142,68 +142,6 @@ class WPcom_Admin_Menu_Test extends TestCase {
 	}
 
 	/**
-	 * Tests add_site_card_menu
-	 */
-	public function test_add_site_card_menu() {
-		global $menu;
-
-		if ( ! static::$is_wpcom ) {
-			$this->markTestSkipped( 'Only used on WP.com.' );
-		}
-
-		static::$admin_menu->add_site_card_menu();
-
-		$home_url            = home_url();
-		$site_card_menu_item = array(
-			'
-<div class="site__info">
-	<div class="site__title">' . get_option( 'blogname' ) . '</div>
-	<div class="site__domain">' . static::$domain . '</div>
-
-</div>',
-			'read',
-			$home_url,
-			'site-card',
-			'menu-top toplevel_page_' . $home_url,
-			'toplevel_page_' . $home_url,
-			plugins_url( 'src/admin-menu/globe-icon.svg', dirname( __DIR__ ) ),
-		);
-
-		$this->assertEquals( $menu[1], $site_card_menu_item );
-	}
-
-	/**
-	 * Tests set_site_card_menu_class
-	 */
-	public function test_set_site_card_menu_class() {
-		global $menu;
-
-		if ( ! static::$is_wpcom ) {
-			$this->markTestSkipped( 'Only used on WP.com.' );
-		}
-
-		static::$admin_menu->add_site_card_menu();
-
-		$menu = static::$admin_menu->set_site_card_menu_class( $menu );
-		$this->assertStringNotContainsString( 'has-site-icon', $menu[1][4] );
-
-		// Custom site icon triggers CSS class.
-		add_filter( 'get_site_icon_url', array( $this, 'custom_site_icon_url' ) );
-		$menu = static::$admin_menu->set_site_card_menu_class( $menu );
-		remove_filter( 'get_site_icon_url', array( $this, 'custom_site_icon_url' ) );
-		$this->assertStringContainsString( 'has-site-icon', $menu[1][4] );
-	}
-
-	/**
-	 * Custom site icon.
-	 *
-	 * @return string
-	 */
-	public function custom_site_icon_url() {
-		return 'https://s0.wp.com/i/jetpack.png';
-	}
-
-	/**
 	 * Tests add_upgrades_menu
 	 */
 	public function test_add_upgrades_menu() {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/98900 
Companion PR to https://github.com/Automattic/wp-calypso/pull/100764

##  Summary

This PR implements a UI improvement to the WordPress.com admin interface by adding site status badges to the site dropdown in the admin bar. 

## Testing instructions:

- Check all kind of websites, private, public, coming soon, P2, trial, staging... Atomic and on different plans and check how the "site name" dropdown menu in the admin looks.
- Also check using different use color schemes.

<img width="274" alt="Screenshot 2025-03-17 at 2 02 44 PM" src="https://github.com/user-attachments/assets/cbef9fb1-ac22-4a14-99bc-8a26c8379b57" />

## Does this pull request change what data or activity we track or use?

no