### PR TITLE
ci: Have packagist proxy explicitly listen only on localhost

### DIFF
--- a/.github/actions/tool-setup/packagist-proxy.mjs
+++ b/.github/actions/tool-setup/packagist-proxy.mjs
@@ -73,6 +73,10 @@ server.on( 'request', ( req, res ) => {
 	}
 
 	// Make remote request.
+	// If you're looking at this because some "security" scanner complained
+	// about this code using user input to build the request path, it's fine.
+	// This proxy only runs on localhost inside of CI, any attacker could just
+	// make their bad request directly.
 	const upstreamUrl = upstreamHost + req.url.replace( /^\//, '' );
 	console.log( `!![${ reqid }] Proxying to ${ upstreamUrl }` );
 	const upstreamReq = https.request( upstreamUrl, {
@@ -149,7 +153,7 @@ server.on( 'request', ( req, res ) => {
 	req.pipe( upstreamReq );
 } );
 
-server.listen( 3129, () => {
+server.listen( 3129, 'localhost', () => {
 	const addr = server.address();
 	console.log( `Server listening on ${ addr.address }:${ addr.port }` );
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
And add a comment to try to ward off security "researchers" who find the proxy via some script.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1741996938604579-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure Build or Test runs to exercise the proxy, and is happy.