### PR TITLE
Tools: Add "[Type] Janitorial" label to backport PRs

### DIFF
--- a/tools/changelogger-release.sh
+++ b/tools/changelogger-release.sh
@@ -293,10 +293,14 @@ pnpm install --silent
 
 cat <<-EOM
 
-	You can examine the changelogs with
+	You can examine the changelogs directly with the following:
 
 	  git diff '**/CHANGELOG.md'
 
-	Feel free to edit them as needed.
+	You can open them all in VS Code with the following:
+
+	  code $(git diff --name-only '**/CHANGELOG.md')
+
+	Feel free to edit and save them as needed.
 
 EOM

--- a/tools/changelogger-release.sh
+++ b/tools/changelogger-release.sh
@@ -297,9 +297,9 @@ cat <<-EOM
 
 	  git diff '**/CHANGELOG.md'
 
-	You can open them all in VS Code with the following:
+	To get a list of the files that changed, use the following:
 
-	  code $(git diff --name-only '**/CHANGELOG.md')
+	  git diff --name-only '**/CHANGELOG.md'
 
 	Feel free to edit and save them as needed.
 

--- a/tools/release-plugin.sh
+++ b/tools/release-plugin.sh
@@ -324,7 +324,7 @@ function do_create_prerelease_PR {
 	# Remove the trailing comma and space
 	PLUGINS_CHANGED=${PLUGINS_CHANGED%, }
 	sed "s/%RELEASED_PLUGINS%/$PLUGINS_CHANGED/g" .github/files/BACKPORT_RELEASE_CHANGES.md > .github/files/TEMP_BACKPORT_RELEASE_CHANGES.md
-	gh pr create --title "Backport $PLUGINS_CHANGED Changes" --body "$(cat .github/files/TEMP_BACKPORT_RELEASE_CHANGES.md)" --label "[Status] Needs Review" --repo "Automattic/jetpack" --head "$(git rev-parse --abbrev-ref HEAD)"
+	gh pr create --title "Backport $PLUGINS_CHANGED Changes" --body "$(cat .github/files/TEMP_BACKPORT_RELEASE_CHANGES.md)" --label "[Status] Needs Review" --label "[Type] Janitorial" --repo "Automattic/jetpack" --head "$(git rev-parse --abbrev-ref HEAD)"
 	rm .github/files/TEMP_BACKPORT_RELEASE_CHANGES.md
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This ensures backport PRs have a Type label for better reporting.

Original request: p1742230184905479-slack-C05Q5HSS013

Related to the release process, I also add a hint for opening changelogs in VS Code.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*