### PR TITLE
Forms: add dashboard widget

### DIFF
--- a/projects/packages/forms/changelog/add-forms-dashboard-widget
+++ b/projects/packages/forms/changelog/add-forms-dashboard-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add dashboard widget for form responses.

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Forms;
 
+use Automattic\Jetpack\Forms\ContactForm\Dashboard_Widget;
 use Automattic\Jetpack\Forms\ContactForm\Util;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
@@ -35,6 +36,10 @@ class Jetpack_Forms {
 		}
 
 		add_action( 'init', '\Automattic\Jetpack\Forms\ContactForm\Util::register_pattern' );
+
+		if ( is_admin() ) {
+			Dashboard_Widget::init();
+		}
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-dashboard-widget.php
+++ b/projects/packages/forms/src/contact-form/class-dashboard-widget.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Dashboard_Widget class.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
+
+/**
+ * Class manages the dashboard widget for displaying the latest form entries in the admin dashboard.
+ */
+class Dashboard_Widget {
+	/**
+	 * Initialize the dashboard widget.
+	 */
+	public static function init() {
+		add_action( 'wp_dashboard_setup', array( __CLASS__, 'add_widget' ) );
+	}
+
+	/**
+	 * Register the dashboard widget.
+	 */
+	public static function add_widget() {
+		wp_add_dashboard_widget( 'jetpack_forms_responses_widget', __( 'Latest Form Responses', 'jetpack-forms' ), array( __CLASS__, 'display_widget' ) );
+	}
+
+	/**
+	 * Display the latest form responses in the dashboard widget.
+	 */
+	public static function display_widget() {
+
+		$args = array(
+			'post_type'      => 'feedback',
+			'posts_per_page' => 6,
+			'post_status'    => 'publish',
+			'orderby'        => 'date',
+			'order'          => 'DESC',
+		);
+
+		$entries   = get_posts( $args );
+		$admin_url = ( new Dashboard_View_Switch() )->get_forms_admin_url();
+		$has_more  = count( $entries ) > 5 ? true : false;
+
+		// only show 5 entries
+		$entries = array_slice( $entries, 0, 5 );
+		if ( $entries ) {
+			echo '<ul style="margin: 0 -12px;">';
+			foreach ( $entries as $entry ) {
+				echo '<li style="padding: 8px 12px; border-bottom: 1px solid #EEE; display: flex; gap: 4px;">';
+				echo '<a href="' . esc_url( $admin_url . '#/responses?status=inbox&r=' . $entry->ID ) . '">' . esc_html( self::get_from( $entry ) ) . '</a>';
+				echo '<span>&middot;</span> <time style="color: #646970;" datetime="' . esc_attr( $entry->post_date ) . '">' . esc_html( human_time_diff( strtotime( $entry->post_date_gmt ) ) ) . '</time>';
+				echo '</li>';
+			}
+			echo '</ul>';
+			echo ( $has_more ? '<a href="' . esc_url( $admin_url ) . '">' . esc_html__( 'View all responses', 'jetpack-forms' ) . '</a>' : '' );
+		} else {
+			echo '<p>' . esc_html__( 'No recent form responses found.', 'jetpack-forms' ) . '</p>';
+		}
+	}
+
+	/**
+	 * Returns the from strin for a form entry.
+	 *
+	 * @param \WP_Post $entry The form entry.
+	 * @return string The from string.
+	 */
+	private static function get_from( $entry ) {
+		$content_fields = Contact_Form_Plugin::parse_fields_from_content( $entry->ID );
+
+		if ( ! empty( $content_fields['_feedback_author'] ) ) {
+			return $content_fields['_feedback_author'];
+		}
+
+		if ( ! empty( $content_fields['_feedback_author_email'] ) ) {
+			return $content_fields['_feedback_author_email'];
+		}
+
+		if ( ! empty( $content_fields['_feedback_ip'] ) ) {
+			return $content_fields['_feedback_ip'];
+		}
+
+		return __( 'Unknown', 'jetpack-forms' );
+	}
+}

--- a/projects/plugins/jetpack/changelog/add-forms-dashboard-widget
+++ b/projects/plugins/jetpack/changelog/add-forms-dashboard-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Add dashboard widget for form responses


### PR DESCRIPTION
This Pr add a forms dashboard widget. In order to display forms latest forms entries. 

Forms with responses.
![Screenshot 2025-03-17 at 9 45 14 AM](https://github.com/user-attachments/assets/b884a817-7932-42f7-b239-eafdac92f3e0)

Widget without responses yet. 
![Screenshot 2025-03-17 at 11 00 36 AM](https://github.com/user-attachments/assets/ec5eaf02-7a95-4b2e-922d-455bb448474f)

^ The empty state could use more work. 

## Proposed changes:
* Adds a new dashboard widget that displays from recent from responses. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Go to the Dashboard. 
* Notice the new dashboard widget. 
* Do the links work as expected. (currently only they work for the new dashboard) 