### PR TITLE
Update the documentation to include the `$wp_cache_mfunc_enabled` global variable.

### DIFF
--- a/projects/plugins/super-cache/changelog/update-super-cache-docs-to-mention-wp-cache-mfunc-enabled-variable
+++ b/projects/plugins/super-cache/changelog/update-super-cache-docs-to-mention-wp-cache-mfunc-enabled-variable
@@ -1,0 +1,3 @@
+Significance: patch
+Type: added
+Comment: Documentation: update the documentation to include the `$wp_cache_mfunc_enabled` global variable, ensuring users know it can help prevent the secret template tag from being revealed.

--- a/projects/plugins/super-cache/plugins/dynamic-cache-test.php
+++ b/projects/plugins/super-cache/plugins/dynamic-cache-test.php
@@ -47,6 +47,9 @@
  * dynamic_cache_test_template_tag()
  * This function hooks on to wp_footer and displays the secret template
  * tag that will be replaced by our dynamic content on each page view.
+ * It may be helpful to check the $wp_cache_mfunc_enabled global variable
+ * before outputting the template tag, to ensure it is not revealed when
+ * the dynamic cache is disabled.
  *
  *
  * dynamic_cache_test_filter()

--- a/projects/plugins/super-cache/plugins/dynamic-cache-test.php
+++ b/projects/plugins/super-cache/plugins/dynamic-cache-test.php
@@ -48,7 +48,7 @@
  * This function hooks on to wp_footer and displays the secret template
  * tag that will be replaced by our dynamic content on each page view.
  * It may be helpful to check the $wp_cache_mfunc_enabled global variable
- * before outputting the template tag, to ensure it is not revealed when
+ * before outputting the template tag, to ensure the tag is not revealed when
  * the dynamic cache is disabled.
  *
  *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/wp-super-cache#1004

## Proposed changes:
Updates the documentation to include the `$wp_cache_mfunc_enabled` global variable, ensuring users know it can help prevent the secret template tag from being revealed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Reviewed the proposed documentation change for correcteness.

