### PR TITLE
In Media & Text block, replace video with a VideoPress block on the frontend

### DIFF
--- a/projects/packages/videopress/changelog/add-replace-video-for-media-text
+++ b/projects/packages/videopress/changelog/add-replace-video-for-media-text
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+For Media & Text block, replace video with VideoPress block

--- a/projects/packages/videopress/src/class-block-replacement.php
+++ b/projects/packages/videopress/src/class-block-replacement.php
@@ -12,9 +12,19 @@ namespace Automattic\Jetpack\VideoPress;
  **/
 class Block_Replacement {
 	/**
+	 * Whether the class has been initiated.
+	 *
+	 * @var bool
+	 */
+	private static $initiated = false;
+
+	/**
 	 * Initialize replacement.
 	 */
 	public static function init() {
+		if ( self::$initiated ) {
+			return;
+		}
 		add_filter( 'render_block', array( self::class, 'replace_media_text_with_videopress' ), 10, 2 );
 	}
 

--- a/projects/packages/videopress/src/class-block-replacement.php
+++ b/projects/packages/videopress/src/class-block-replacement.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Media block replacement class.
+ *
+ * @package automattic/jetpack-videopress
+ **/
+
+namespace Automattic\Jetpack\VideoPress;
+
+/**
+ * Class Block_Replacement
+ **/
+class Block_Replacement {
+	/**
+	 * Initialize replacement.
+	 */
+	public static function init() {
+		add_filter( 'render_block', array( self::class, 'replace_media_text_with_videopress' ), 10, 2 );
+	}
+
+	/**
+	 * Replace video in Media & Text block with Videopress shortcode.
+	 *
+	 * @param string $block_content The block content.
+	 * @param array  $block         The block.
+	 * @return string
+	 */
+	public static function replace_media_text_with_videopress( $block_content, $block ) {
+		if ( $block['blockName'] === 'core/media-text' ) {
+			$video_info = video_get_info_by_blogpostid( get_current_blog_id(), $block['attrs']['mediaId'] ?? 0 );
+			if ( $video_info && $video_info->guid ) {
+				$videopress_shortcode = sprintf( '[videopress %s]', esc_attr( $video_info->guid ) );
+				$block_content        = preg_replace( '/<video.*?<\/video>/is', do_shortcode( $videopress_shortcode ), $block_content );
+			}
+		}
+		return $block_content;
+	}
+}

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -95,6 +95,10 @@ class Initializer {
 		if ( is_admin() ) {
 			AJAX::init();
 		}
+
+		if ( ! is_admin() ) {
+			Block_Replacement::init();
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-replace-video-for-media-text
+++ b/projects/plugins/jetpack/changelog/add-replace-video-for-media-text
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+For Media & Text block, replace video with VideoPress block

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -2,6 +2,7 @@
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\VideoPress\Attachment_Handler;
+use Automattic\Jetpack\VideoPress\Block_Replacement;
 use Automattic\Jetpack\VideoPress\Jwt_Token_Bridge;
 use Automattic\Jetpack\VideoPress\Options as VideoPress_Options;
 /**
@@ -52,6 +53,8 @@ class Jetpack_VideoPress {
 
 		if ( $this->is_videopress_enabled() ) {
 			add_action( 'admin_notices', array( $this, 'media_new_page_admin_notice' ) );
+
+			Block_Replacement::init();
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -2,7 +2,6 @@
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\VideoPress\Attachment_Handler;
-use Automattic\Jetpack\VideoPress\Block_Replacement;
 use Automattic\Jetpack\VideoPress\Jwt_Token_Bridge;
 use Automattic\Jetpack\VideoPress\Options as VideoPress_Options;
 /**
@@ -53,8 +52,6 @@ class Jetpack_VideoPress {
 
 		if ( $this->is_videopress_enabled() ) {
 			add_action( 'admin_notices', array( $this, 'media_new_page_admin_notice' ) );
-
-			Block_Replacement::init();
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-gutenberg.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-gutenberg.php
@@ -8,6 +8,7 @@
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
+use Automattic\Jetpack\VideoPress\Block_Replacement;
 
 /**
  * Register a VideoPress extension to replace the default Core Video block.
@@ -37,6 +38,7 @@ class VideoPress_Gutenberg {
 		add_action( 'jetpack_register_gutenberg_extensions', array( $this, 'set_extension_availability' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'override_video_upload' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'add_resumable_upload_support' ) );
+		Block_Replacement::init();
 	}
 
 	/**

--- a/projects/plugins/videopress/changelog/add-replace-video-for-media-text
+++ b/projects/plugins/videopress/changelog/add-replace-video-for-media-text
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+For Media & Text block, replace video with VideoPress block


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/13239

When Media & Text block is used, it uses an HTML5 video player on the frontend, which leads to some unexpected behavior that is especially well noticeable on mobile (there is no thumbnail/preview for the video).

In this PR, we replace the video tag with a VideoPress player **only on the frontend**. The block remains untouched in the editor and keeps its standard behavior.

The Media & Text block doesn't use internally a video block of any kind, so we can't substitute only part of it in the editor.

One alternative I considered was to replace the whole block with a two column structure, with a VideoPress block on the left and a Paragraph block on the right. However, this feels like a dramatic change that might lead to unexpected effects. So I discarded it for this issue.

## Proposed changes:

* On the frontend, replace the video tag with the VideoPress block if the video is available as a VideoPress video.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox your test site if you test on WP.com.
* Insert a Text & Media block inside a page or post.
* Upload a video inside the Text & Media block.
  * Make sure it was uploaded to VideoPress and processed. You can check it in Jetpack -> VideoPress, for example.
* Open the post on the frontend and make sure it uses the VideoPress player.
* Open the post on your mobile and make sure it uses the VideoPress player (you should see a preview image).
  * Don't open it in the desktop browser with the responsive/mobile view: it behaves differently for a standard video tag.
* Make sure you can see a thumbnail/preview image for the video.
* Please test it in different environments, for example, on a Simple site.
