### PR TITLE
Forms: Update field style controls to use tools panel with single block inspector tab

### DIFF
--- a/projects/packages/forms/changelog/update-field-style-controls-to-use-tools-panel-and-live-in-the-style-tab
+++ b/projects/packages/forms/changelog/update-field-style-controls-to-use-tools-panel-and-live-in-the-style-tab
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: move field style design tools to the style tab in the block inspector.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -34,6 +34,7 @@ class Contact_Form_Block {
 
 		add_filter( 'render_block_data', array( __CLASS__, 'find_nested_html_block' ), 10, 3 );
 		add_filter( 'render_block_core/html', array( __CLASS__, 'render_wrapped_html_block' ), 10, 2 );
+		add_filter( 'block_editor_settings_all', array( __CLASS__, 'disable_field_inspector_tabs' ) );
 	}
 
 	/**
@@ -69,6 +70,36 @@ class Contact_Form_Block {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Disable the field inspector tabs for the Contact Form block.
+	 *
+	 * See https://make.wordpress.org/core/2023/03/07/introduction-of-block-inspector-tabs/.
+	 *
+	 * @param array $settings The block editor settings.
+	 * @return array The modified block editor settings.
+	 */
+	public static function disable_field_inspector_tabs( $settings ) {
+		$settings['blockInspectorTabs'] = array_merge(
+			$settings['blockInspectorTabs'] ?? array(),
+			array(
+				'jetpack/field-text'              => false,
+				'jetpack/field-name'              => false,
+				'jetpack/field-email'             => false,
+				'jetpack/field-url'               => false,
+				'jetpack/field-date'              => false,
+				'jetpack/field-telephone'         => false,
+				'jetpack/field-textarea'          => false,
+				'jetpack/field-checkbox'          => false,
+				'jetpack/field-checkbox-multiple' => false,
+				'jetpack/field-radio'             => false,
+				'jetpack/field-select'            => false,
+				'jetpack/field-consent'           => false,
+				'jetpack/field-number'            => false,
+			)
+		);
+		return $settings;
 	}
 
 	/**

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -88,7 +88,7 @@ function JetpackFieldCheckbox( {
 						resetAll={ () => setAttributes( { labelColor: undefined } ) }
 						dropdownMenuProps={ toolsPanelDropdownMenuProps }
 					>
-						<div className="jetpack-field-controls__color-settings">
+						<div className="jetpack-field-controls__full-width-control">
 							<ColorGradientSettingsDropdown
 								__experimentalIsRenderedInSidebar
 								panelId={ clientId }
@@ -133,7 +133,7 @@ function JetpackFieldCheckbox( {
 						</ToolsPanelItem>
 					</ToolsPanel>
 					<ToolsPanel>
-						<div style={ { gridColumn: '1 / -1' } }>
+						<div className="jetpack-field-controls__full-width-control">
 							<ToggleControl
 								label={ __( 'Sync field styles', 'jetpack-forms' ) }
 								checked={ attributes.shareFieldAttributes }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -8,10 +8,12 @@ import {
 import {
 	PanelBody,
 	ToggleControl,
+	__experimentalToolsPanel as ToolsPanel, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToolsPanelItem as ToolsPanelItem, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
+import useToolsPanelResponsiveDropdownProps from '../util/use-tool-panel-responsive-dropdown-props';
 import { withSharedFieldAttributes } from '../util/with-shared-field-attributes';
 import ToolbarRequiredGroup from './block-controls/toolbar-required-group';
 import JetpackFieldDimensionControls from './jetpack-field-dimension-controls';
@@ -37,6 +39,7 @@ function JetpackFieldCheckbox( {
 		className: 'jetpack-field jetpack-field-checkbox',
 		style: blockStyle,
 	} );
+	const toolsPanelDropdownMenuProps = useToolsPanelResponsiveDropdownProps();
 
 	return (
 		<>
@@ -77,47 +80,56 @@ function JetpackFieldCheckbox( {
 					setAttributes={ setAttributes }
 					width={ width }
 				/>
-				<InspectorControls group="color">
-					<ColorGradientSettingsDropdown
-						__experimentalIsRenderedInSidebar
+				<InspectorControls group="styles">
+					<ToolsPanel
 						panelId={ clientId }
-						gradients={ [] }
-						disableCustomGradients
-						settings={ [
-							{
-								colorValue: attributes.labelColor,
-								onColorChange: value => setAttributes( { labelColor: value } ),
-								label: __( 'Label Text', 'jetpack-forms' ),
-								resetAllFilter: () => setAttributes( { labelColor: undefined } ),
-								clearable: true,
-							},
-						] }
-					/>
-				</InspectorControls>
-				<InspectorControls group="typography">
-					<ToolsPanelItem
-						panelId={ clientId }
-						hasValue={ () => !! attributes.labelFontSize }
-						label={ __( 'Size', 'jetpack-forms' ) }
-						onDeselect={ () =>
-							setAttributes( {
-								labelFontSize: undefined,
-							} )
-						}
-						resetAllFilter={ () => ( {
-							labelFontSize: undefined,
-						} ) }
-						isShownByDefault
+						label={ __( 'Color', 'jetpack-forms' ) }
+						resetAll={ () => setAttributes( { labelColor: undefined } ) }
+						dropdownMenuProps={ toolsPanelDropdownMenuProps }
 					>
-						<FontSizePicker
-							withSlider
-							withReset={ true }
-							size="__unstable-large"
-							__nextHasNoMarginBottom
-							onChange={ labelFontSize => setAttributes( { labelFontSize } ) }
-							value={ attributes.labelFontSize }
-						/>
-					</ToolsPanelItem>
+						<div className="jetpack-field-controls__color-settings">
+							<ColorGradientSettingsDropdown
+								__experimentalIsRenderedInSidebar
+								panelId={ clientId }
+								gradients={ [] }
+								disableCustomGradients
+								settings={ [
+									{
+										colorValue: attributes.labelColor,
+										onColorChange: value => setAttributes( { labelColor: value } ),
+										label: __( 'Label Text', 'jetpack-forms' ),
+										clearable: true,
+									},
+								] }
+							/>
+						</div>
+					</ToolsPanel>
+					<ToolsPanel
+						panelId={ clientId }
+						label={ __( 'Label Typography', 'jetpack-forms' ) }
+						resetAll={ () => setAttributes( { labelFontSize: undefined } ) }
+						dropdownMenuProps={ toolsPanelDropdownMenuProps }
+					>
+						<ToolsPanelItem
+							panelId={ clientId }
+							hasValue={ () => !! attributes.labelFontSize }
+							label={ __( 'Size', 'jetpack-forms' ) }
+							onDeselect={ () =>
+								setAttributes( {
+									labelFontSize: undefined,
+								} )
+							}
+						>
+							<FontSizePicker
+								withSlider
+								withReset={ true }
+								size="__unstable-large"
+								__nextHasNoMarginBottom
+								onChange={ labelFontSize => setAttributes( { labelFontSize } ) }
+								value={ attributes.labelFontSize }
+							/>
+						</ToolsPanelItem>
+					</ToolsPanel>
 				</InspectorControls>
 				<InspectorControls>
 					<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -130,6 +130,20 @@ function JetpackFieldCheckbox( {
 							/>
 						</ToolsPanelItem>
 					</ToolsPanel>
+					<ToolsPanel>
+						<div style={ { gridColumn: '1 / -1' } }>
+							<ToggleControl
+								label={ __( 'Sync field style', 'jetpack-forms' ) }
+								checked={ attributes.shareFieldAttributes }
+								onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
+								help={ __(
+									'Syncs all styles except for Width. Deactivate for individual styling of this block.',
+									'jetpack-forms'
+								) }
+								__nextHasNoMarginBottom={ true }
+							/>
+						</div>
+					</ToolsPanel>
 				</InspectorControls>
 				<InspectorControls>
 					<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
@@ -141,14 +155,6 @@ function JetpackFieldCheckbox( {
 							checked={ required }
 							onChange={ value => setAttributes( { required: value } ) }
 							help={ __( 'You can edit the "required" label in the editor', 'jetpack-forms' ) }
-							__nextHasNoMarginBottom={ true }
-						/>
-
-						<ToggleControl
-							label={ __( 'Sync fields style', 'jetpack-forms' ) }
-							checked={ attributes.shareFieldAttributes }
-							onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
-							help={ __( 'Deactivate for individual styling of this block', 'jetpack-forms' ) }
 							__nextHasNoMarginBottom={ true }
 						/>
 					</PanelBody>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -4,6 +4,7 @@ import {
 	BlockControls,
 	useBlockProps,
 	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -101,6 +102,7 @@ function JetpackFieldCheckbox( {
 										clearable: true,
 									},
 								] }
+								{ ...useMultipleOriginColorsAndGradients() }
 							/>
 						</div>
 					</ToolsPanel>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -82,6 +82,15 @@ function JetpackFieldCheckbox( {
 					width={ width }
 				/>
 				<InspectorControls group="styles">
+					<PanelBody>
+						<ToggleControl
+							label={ __( 'Apply styling to all fields', 'jetpack-forms' ) }
+							checked={ attributes.shareFieldAttributes }
+							onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
+							help={ __( 'Toggle off if you want to style this block only.', 'jetpack-forms' ) }
+							__nextHasNoMarginBottom={ true }
+						/>
+					</PanelBody>
 					<ToolsPanel
 						panelId={ clientId }
 						label={ __( 'Color', 'jetpack-forms' ) }
@@ -130,20 +139,6 @@ function JetpackFieldCheckbox( {
 								value={ attributes.labelFontSize }
 							/>
 						</ToolsPanelItem>
-					</ToolsPanel>
-					<ToolsPanel>
-						<div className="jetpack-field-controls__full-width-control">
-							<ToggleControl
-								label={ __( 'Sync field styles', 'jetpack-forms' ) }
-								checked={ attributes.shareFieldAttributes }
-								onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
-								help={ __(
-									'Syncs all styles except for Width. Deactivate for individual styling of this block.',
-									'jetpack-forms'
-								) }
-								__nextHasNoMarginBottom={ true }
-							/>
-						</div>
 					</ToolsPanel>
 				</InspectorControls>
 				<InspectorControls>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -15,19 +15,18 @@ import JetpackFieldWidth from './jetpack-field-width';
 import JetpackManageResponsesSettings from './jetpack-manage-responses-settings';
 import { useJetpackFieldStyles } from './use-jetpack-field-styles';
 
-function JetpackFieldCheckbox( props ) {
-	const {
-		instanceId,
-		required,
-		requiredText,
-		label,
-		setAttributes,
-		width,
-		defaultValue,
-		attributes,
-		insertBlocksAfter,
-	} = props;
-
+function JetpackFieldCheckbox( {
+	clientId,
+	instanceId,
+	required,
+	requiredText,
+	label,
+	setAttributes,
+	width,
+	defaultValue,
+	attributes,
+	insertBlocksAfter,
+} ) {
 	const { blockStyle } = useJetpackFieldStyles( attributes );
 	const blockProps = useBlockProps( {
 		id: `jetpack-field-checkbox-${ instanceId }`,
@@ -69,6 +68,7 @@ function JetpackFieldCheckbox( props ) {
 						/>
 					</PanelBody>
 				</InspectorControls>
+				<JetpackFieldWidth clientId={ clientId } setAttributes={ setAttributes } width={ width } />
 				<InspectorControls>
 					<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
 						<JetpackManageResponsesSettings isChildBlock />
@@ -81,7 +81,6 @@ function JetpackFieldCheckbox( props ) {
 							help={ __( 'You can edit the "required" label in the editor', 'jetpack-forms' ) }
 							__nextHasNoMarginBottom={ true }
 						/>
-						<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
 
 						<ToggleControl
 							label={ __( 'Sync fields style', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -108,7 +108,7 @@ function JetpackFieldCheckbox( {
 					</ToolsPanel>
 					<ToolsPanel
 						panelId={ clientId }
-						label={ __( 'Label Typography', 'jetpack-forms' ) }
+						label={ __( 'Option typography', 'jetpack-forms' ) }
 						resetAll={ () => setAttributes( { labelFontSize: undefined } ) }
 						dropdownMenuProps={ toolsPanelDropdownMenuProps }
 					>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -1,11 +1,15 @@
 import {
 	FontSizePicker,
 	InspectorControls,
-	PanelColorSettings,
 	BlockControls,
 	useBlockProps,
+	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/block-editor';
-import { PanelBody, ToggleControl } from '@wordpress/components';
+import {
+	PanelBody,
+	ToggleControl,
+	__experimentalToolsPanelItem as ToolsPanelItem, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { withSharedFieldAttributes } from '../util/with-shared-field-attributes';
@@ -73,6 +77,48 @@ function JetpackFieldCheckbox( {
 					setAttributes={ setAttributes }
 					width={ width }
 				/>
+				<InspectorControls group="color">
+					<ColorGradientSettingsDropdown
+						__experimentalIsRenderedInSidebar
+						panelId={ clientId }
+						gradients={ [] }
+						disableCustomGradients
+						settings={ [
+							{
+								colorValue: attributes.labelColor,
+								onColorChange: value => setAttributes( { labelColor: value } ),
+								label: __( 'Label Text', 'jetpack-forms' ),
+								resetAllFilter: () => setAttributes( { labelColor: undefined } ),
+								clearable: true,
+							},
+						] }
+					/>
+				</InspectorControls>
+				<InspectorControls group="typography">
+					<ToolsPanelItem
+						panelId={ clientId }
+						hasValue={ () => !! attributes.labelFontSize }
+						label={ __( 'Size', 'jetpack-forms' ) }
+						onDeselect={ () =>
+							setAttributes( {
+								labelFontSize: undefined,
+							} )
+						}
+						resetAllFilter={ () => ( {
+							labelFontSize: undefined,
+						} ) }
+						isShownByDefault
+					>
+						<FontSizePicker
+							withSlider
+							withReset={ true }
+							size="__unstable-large"
+							__nextHasNoMarginBottom
+							onChange={ labelFontSize => setAttributes( { labelFontSize } ) }
+							value={ attributes.labelFontSize }
+						/>
+					</ToolsPanelItem>
+				</InspectorControls>
 				<InspectorControls>
 					<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
 						<JetpackManageResponsesSettings isChildBlock />
@@ -92,30 +138,6 @@ function JetpackFieldCheckbox( {
 							onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
 							help={ __( 'Deactivate for individual styling of this block', 'jetpack-forms' ) }
 							__nextHasNoMarginBottom={ true }
-						/>
-					</PanelBody>
-					<PanelColorSettings
-						title={ __( 'Color', 'jetpack-forms' ) }
-						initialOpen={ false }
-						colorSettings={ [
-							{
-								value: attributes.labelColor,
-								onChange: value => setAttributes( { labelColor: value } ),
-								label: __( 'Label Text', 'jetpack-forms' ),
-							},
-						] }
-					/>
-					<PanelBody
-						title={ __( 'Label Styles', 'jetpack-forms' ) }
-						initialOpen={ attributes.labelFontSize }
-					>
-						<FontSizePicker
-							withSlider
-							withReset={ true }
-							size="__unstable-large"
-							__nextHasNoMarginBottom
-							onChange={ labelFontSize => setAttributes( { labelFontSize } ) }
-							value={ attributes.labelFontSize }
 						/>
 					</PanelBody>
 				</InspectorControls>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -135,7 +135,7 @@ function JetpackFieldCheckbox( {
 					<ToolsPanel>
 						<div style={ { gridColumn: '1 / -1' } }>
 							<ToggleControl
-								label={ __( 'Sync field style', 'jetpack-forms' ) }
+								label={ __( 'Sync field styles', 'jetpack-forms' ) }
 								checked={ attributes.shareFieldAttributes }
 								onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
 								help={ __(

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -10,8 +10,8 @@ import { compose, withInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { withSharedFieldAttributes } from '../util/with-shared-field-attributes';
 import ToolbarRequiredGroup from './block-controls/toolbar-required-group';
+import JetpackFieldDimensionControls from './jetpack-field-dimension-controls';
 import JetpackFieldLabel from './jetpack-field-label';
-import JetpackFieldWidth from './jetpack-field-width';
 import JetpackManageResponsesSettings from './jetpack-manage-responses-settings';
 import { useJetpackFieldStyles } from './use-jetpack-field-styles';
 
@@ -68,7 +68,11 @@ function JetpackFieldCheckbox( {
 						/>
 					</PanelBody>
 				</InspectorControls>
-				<JetpackFieldWidth clientId={ clientId } setAttributes={ setAttributes } width={ width } />
+				<JetpackFieldDimensionControls
+					clientId={ clientId }
+					setAttributes={ setAttributes }
+					width={ width }
+				/>
 				<InspectorControls>
 					<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
 						<JetpackManageResponsesSettings isChildBlock />

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -121,6 +121,7 @@ function JetpackFieldCheckbox( {
 									labelFontSize: undefined,
 								} )
 							}
+							isShownByDefault
 						>
 							<FontSizePicker
 								withSlider

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -85,7 +85,6 @@ function JetpackFieldCheckbox( {
 					<ToolsPanel
 						panelId={ clientId }
 						label={ __( 'Color', 'jetpack-forms' ) }
-						resetAll={ () => setAttributes( { labelColor: undefined } ) }
 						dropdownMenuProps={ toolsPanelDropdownMenuProps }
 					>
 						<div className="jetpack-field-controls__full-width-control">
@@ -109,7 +108,6 @@ function JetpackFieldCheckbox( {
 					<ToolsPanel
 						panelId={ clientId }
 						label={ __( 'Option typography', 'jetpack-forms' ) }
-						resetAll={ () => setAttributes( { labelFontSize: undefined } ) }
 						dropdownMenuProps={ toolsPanelDropdownMenuProps }
 					>
 						<ToolsPanelItem

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
@@ -2,6 +2,7 @@ import {
 	InspectorControls,
 	useBlockProps,
 	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/block-editor';
 import {
 	BaseControl,
@@ -84,6 +85,7 @@ const JetpackFieldConsent = ( {
 									clearable: true,
 								},
 							] }
+							{ ...useMultipleOriginColorsAndGradients() }
 						/>
 					</div>
 				</ToolsPanel>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
@@ -3,9 +3,16 @@ import {
 	useBlockProps,
 	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/block-editor';
-import { BaseControl, PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
+import {
+	BaseControl,
+	PanelBody,
+	SelectControl,
+	ToggleControl,
+	__experimentalToolsPanel as ToolsPanel, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
+import useToolsPanelResponsiveDropdownProps from '../util/use-tool-panel-responsive-dropdown-props';
 import { withSharedFieldAttributes } from '../util/with-shared-field-attributes';
 import JetpackFieldDimensionControls from './jetpack-field-dimension-controls';
 import JetpackFieldLabel from './jetpack-field-label';
@@ -26,6 +33,7 @@ const JetpackFieldConsent = ( {
 		id: `jetpack-field-consent-${ instanceId }`,
 		className: 'jetpack-field jetpack-field-consent',
 	} );
+	const toolsPanelDropdownMenuProps = useToolsPanelResponsiveDropdownProps();
 
 	return (
 		<div { ...blockProps }>
@@ -55,22 +63,31 @@ const JetpackFieldConsent = ( {
 				setAttributes={ setAttributes }
 				width={ width }
 			/>
-			<InspectorControls group="color">
-				<ColorGradientSettingsDropdown
-					__experimentalIsRenderedInSidebar
+			<InspectorControls group="styles">
+				<ToolsPanel
 					panelId={ clientId }
-					gradients={ [] }
-					disableCustomGradients
-					settings={ [
-						{
-							colorValue: attributes.labelColor,
-							onColorChange: value => setAttributes( { labelColor: value } ),
-							label: __( 'Label Text', 'jetpack-forms' ),
-							resetAllFilter: () => setAttributes( { labelColor: undefined } ),
-							clearable: true,
-						},
-					] }
-				/>
+					label={ __( 'Color', 'jetpack-forms' ) }
+					onDeselect={ () => setAttributes( { labelColor: undefined } ) }
+					resetAll={ () => setAttributes( { labelColor: undefined } ) }
+					dropdownMenuProps={ toolsPanelDropdownMenuProps }
+				>
+					<div className="jetpack-field-controls__color-settings">
+						<ColorGradientSettingsDropdown
+							__experimentalIsRenderedInSidebar
+							panelId={ clientId }
+							gradients={ [] }
+							disableCustomGradients
+							settings={ [
+								{
+									colorValue: attributes.labelColor,
+									onColorChange: value => setAttributes( { labelColor: value } ),
+									label: __( 'Label Text', 'jetpack-forms' ),
+									clearable: true,
+								},
+							] }
+						/>
+					</div>
+				</ToolsPanel>
 			</InspectorControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
@@ -9,6 +9,7 @@ import JetpackManageResponsesSettings from './jetpack-manage-responses-settings'
 
 const JetpackFieldConsent = ( {
 	instanceId,
+	clientId,
 	width,
 	consentType,
 	implicitConsentMessage,
@@ -45,12 +46,12 @@ const JetpackFieldConsent = ( {
 				) }
 				insertBlocksAfter={ insertBlocksAfter }
 			/>
+			<JetpackFieldWidth clientId={ clientId } setAttributes={ setAttributes } width={ width } />
 			<InspectorControls>
 				<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
 					<JetpackManageResponsesSettings isChildBlock />
 				</PanelBody>
 				<PanelBody title={ __( 'Field Settings', 'jetpack-forms' ) }>
-					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
 					<ToggleControl
 						label={ __( 'Sync fields style', 'jetpack-forms' ) }
 						checked={ attributes.shareFieldAttributes }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
@@ -1,4 +1,8 @@
-import { InspectorControls, PanelColorSettings, useBlockProps } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	useBlockProps,
+	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/block-editor';
 import { BaseControl, PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
@@ -51,6 +55,23 @@ const JetpackFieldConsent = ( {
 				setAttributes={ setAttributes }
 				width={ width }
 			/>
+			<InspectorControls group="color">
+				<ColorGradientSettingsDropdown
+					__experimentalIsRenderedInSidebar
+					panelId={ clientId }
+					gradients={ [] }
+					disableCustomGradients
+					settings={ [
+						{
+							colorValue: attributes.labelColor,
+							onColorChange: value => setAttributes( { labelColor: value } ),
+							label: __( 'Label Text', 'jetpack-forms' ),
+							resetAllFilter: () => setAttributes( { labelColor: undefined } ),
+							clearable: true,
+						},
+					] }
+				/>
+			</InspectorControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
 					<JetpackManageResponsesSettings isChildBlock />
@@ -64,17 +85,6 @@ const JetpackFieldConsent = ( {
 						__nextHasNoMarginBottom={ true }
 					/>
 				</PanelBody>
-				<PanelColorSettings
-					title={ __( 'Color', 'jetpack-forms' ) }
-					initialOpen={ false }
-					colorSettings={ [
-						{
-							value: attributes.labelColor,
-							onChange: value => setAttributes( { labelColor: value } ),
-							label: __( 'Label Text', 'jetpack-forms' ),
-						},
-					] }
-				/>
 				<PanelBody title={ __( 'Consent Settings', 'jetpack-forms' ) }>
 					<BaseControl __nextHasNoMarginBottom={ true }>
 						<SelectControl

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
@@ -3,8 +3,8 @@ import { BaseControl, PanelBody, SelectControl, ToggleControl } from '@wordpress
 import { compose, withInstanceId } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 import { withSharedFieldAttributes } from '../util/with-shared-field-attributes';
+import JetpackFieldDimensionControls from './jetpack-field-dimension-controls';
 import JetpackFieldLabel from './jetpack-field-label';
-import JetpackFieldWidth from './jetpack-field-width';
 import JetpackManageResponsesSettings from './jetpack-manage-responses-settings';
 
 const JetpackFieldConsent = ( {
@@ -46,7 +46,11 @@ const JetpackFieldConsent = ( {
 				) }
 				insertBlocksAfter={ insertBlocksAfter }
 			/>
-			<JetpackFieldWidth clientId={ clientId } setAttributes={ setAttributes } width={ width } />
+			<JetpackFieldDimensionControls
+				clientId={ clientId }
+				setAttributes={ setAttributes }
+				width={ width }
+			/>
 			<InspectorControls>
 				<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
 					<JetpackManageResponsesSettings isChildBlock />

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
@@ -71,7 +71,7 @@ const JetpackFieldConsent = ( {
 					resetAll={ () => setAttributes( { labelColor: undefined } ) }
 					dropdownMenuProps={ toolsPanelDropdownMenuProps }
 				>
-					<div className="jetpack-field-controls__color-settings">
+					<div className="jetpack-field-controls__full-width-control">
 						<ColorGradientSettingsDropdown
 							__experimentalIsRenderedInSidebar
 							panelId={ clientId }
@@ -90,7 +90,7 @@ const JetpackFieldConsent = ( {
 					</div>
 				</ToolsPanel>
 				<ToolsPanel>
-					<div style={ { gridColumn: '1 / -1' } }>
+					<div className="jetpack-field-controls__full-width-control">
 						<ToggleControl
 							label={ __( 'Sync field styles', 'jetpack-forms' ) }
 							checked={ attributes.shareFieldAttributes }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
@@ -92,7 +92,7 @@ const JetpackFieldConsent = ( {
 				<ToolsPanel>
 					<div style={ { gridColumn: '1 / -1' } }>
 						<ToggleControl
-							label={ __( 'Sync field style', 'jetpack-forms' ) }
+							label={ __( 'Sync field styles', 'jetpack-forms' ) }
 							checked={ attributes.shareFieldAttributes }
 							onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
 							help={ __(

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
@@ -68,7 +68,6 @@ const JetpackFieldConsent = ( {
 				<ToolsPanel
 					panelId={ clientId }
 					label={ __( 'Color', 'jetpack-forms' ) }
-					resetAll={ () => setAttributes( { labelColor: undefined } ) }
 					dropdownMenuProps={ toolsPanelDropdownMenuProps }
 				>
 					<div className="jetpack-field-controls__full-width-control">

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
@@ -67,7 +67,6 @@ const JetpackFieldConsent = ( {
 				<ToolsPanel
 					panelId={ clientId }
 					label={ __( 'Color', 'jetpack-forms' ) }
-					onDeselect={ () => setAttributes( { labelColor: undefined } ) }
 					resetAll={ () => setAttributes( { labelColor: undefined } ) }
 					dropdownMenuProps={ toolsPanelDropdownMenuProps }
 				>
@@ -88,19 +87,24 @@ const JetpackFieldConsent = ( {
 						/>
 					</div>
 				</ToolsPanel>
+				<ToolsPanel>
+					<div style={ { gridColumn: '1 / -1' } }>
+						<ToggleControl
+							label={ __( 'Sync field style', 'jetpack-forms' ) }
+							checked={ attributes.shareFieldAttributes }
+							onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
+							help={ __(
+								'Syncs all styles except for Width. Deactivate for individual styling of this block.',
+								'jetpack-forms'
+							) }
+							__nextHasNoMarginBottom={ true }
+						/>
+					</div>
+				</ToolsPanel>
 			</InspectorControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
 					<JetpackManageResponsesSettings isChildBlock />
-				</PanelBody>
-				<PanelBody title={ __( 'Field Settings', 'jetpack-forms' ) }>
-					<ToggleControl
-						label={ __( 'Sync fields style', 'jetpack-forms' ) }
-						checked={ attributes.shareFieldAttributes }
-						onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
-						help={ __( 'Deactivate for individual styling of this block', 'jetpack-forms' ) }
-						__nextHasNoMarginBottom={ true }
-					/>
 				</PanelBody>
 				<PanelBody title={ __( 'Consent Settings', 'jetpack-forms' ) }>
 					<BaseControl __nextHasNoMarginBottom={ true }>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
@@ -65,6 +65,15 @@ const JetpackFieldConsent = ( {
 				width={ width }
 			/>
 			<InspectorControls group="styles">
+				<PanelBody>
+					<ToggleControl
+						label={ __( 'Apply styling to all fields', 'jetpack-forms' ) }
+						checked={ attributes.shareFieldAttributes }
+						onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
+						help={ __( 'Toggle off if you want to style this block only.', 'jetpack-forms' ) }
+						__nextHasNoMarginBottom={ true }
+					/>
+				</PanelBody>
 				<ToolsPanel
 					panelId={ clientId }
 					label={ __( 'Color', 'jetpack-forms' ) }
@@ -85,20 +94,6 @@ const JetpackFieldConsent = ( {
 								},
 							] }
 							{ ...useMultipleOriginColorsAndGradients() }
-						/>
-					</div>
-				</ToolsPanel>
-				<ToolsPanel>
-					<div className="jetpack-field-controls__full-width-control">
-						<ToggleControl
-							label={ __( 'Sync field styles', 'jetpack-forms' ) }
-							checked={ attributes.shareFieldAttributes }
-							onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
-							help={ __(
-								'Syncs all styles except for Width. Deactivate for individual styling of this block.',
-								'jetpack-forms'
-							) }
-							__nextHasNoMarginBottom={ true }
 						/>
 					</div>
 				</ToolsPanel>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -195,6 +195,100 @@ const JetpackFieldControls = ( {
 					disableCustomGradients
 				/>
 			</InspectorControls>
+			<InspectorControls group="border">
+				{ ( isChoicesBlock || blockStyle === 'button' ) && (
+					<>
+						<ToolsPanelItem
+							panelId={ clientId }
+							hasValue={ () => !! attributes.buttonBorderWidth }
+							label={ __( 'Button Border Width', 'jetpack-forms' ) }
+							onDeselect={ () =>
+								setAttributes( {
+									buttonBorderWidth: undefined,
+								} )
+							}
+							isShownByDefault
+						>
+							<RangeControl
+								label={ __( 'Button Border Width', 'jetpack-forms' ) }
+								value={ attributes.buttonBorderWidth }
+								initialPosition={ 1 }
+								onChange={ setNumberAttribute( 'buttonBorderWidth' ) }
+								min={ 0 }
+								max={ 100 }
+								__nextHasNoMarginBottom={ true }
+							/>
+						</ToolsPanelItem>
+						<ToolsPanelItem
+							panelId={ clientId }
+							hasValue={ () => !! attributes.buttonBorderRadius }
+							label={ __( 'Button Border Radius', 'jetpack-forms' ) }
+							onDeselect={ () =>
+								setAttributes( {
+									buttonBorderRadius: undefined,
+								} )
+							}
+							isShownByDefault
+						>
+							<RangeControl
+								label={ __( 'Button Border Radius', 'jetpack-forms' ) }
+								value={ attributes.buttonBorderRadius }
+								initialPosition={ 0 }
+								onChange={ setNumberAttribute( 'buttonBorderRadius' ) }
+								min={ 0 }
+								max={ 100 }
+								__nextHasNoMarginBottom={ true }
+							/>
+						</ToolsPanelItem>
+					</>
+				) }
+				{ ( ! isChoicesBlock || formStyle === FORM_STYLE.OUTLINED ) && (
+					<>
+						<ToolsPanelItem
+							panelId={ clientId }
+							hasValue={ () => !! attributes.borderWidth }
+							label={ __( 'Border Width', 'jetpack-forms' ) }
+							onDeselect={ () =>
+								setAttributes( {
+									borderWidth: undefined,
+								} )
+							}
+							isShownByDefault
+						>
+							<RangeControl
+								label={ __( 'Border Width', 'jetpack-forms' ) }
+								value={ attributes.borderWidth }
+								initialPosition={ 1 }
+								onChange={ setNumberAttribute( 'borderWidth' ) }
+								min={ 0 }
+								max={ 100 }
+								__nextHasNoMarginBottom={ true }
+							/>
+						</ToolsPanelItem>
+						<ToolsPanelItem
+							panelId={ clientId }
+							hasValue={ () => !! attributes.borderRadius }
+							label={ __( 'Border Radius', 'jetpack-forms' ) }
+							onDeselect={ () =>
+								setAttributes( {
+									borderRadius: undefined,
+								} )
+							}
+							isShownByDefault
+						>
+							<RangeControl
+								label={ __( 'Border Radius', 'jetpack-forms' ) }
+								value={ attributes.borderRadius }
+								initialPosition={ 0 }
+								onChange={ setNumberAttribute( 'borderRadius' ) }
+								min={ 0 }
+								max={ 100 }
+								__nextHasNoMarginBottom={ true }
+							/>
+						</ToolsPanelItem>
+					</>
+				) }
+			</InspectorControls>
 			<InspectorControls group="styles">
 				<ToolsPanel
 					label={ stylesPanelTitle }
@@ -245,94 +339,6 @@ const JetpackFieldControls = ( {
 							size="__unstable-large"
 						/>
 					</ToolsPanelItem>
-					{ ( isChoicesBlock || blockStyle === 'button' ) && (
-						<>
-							<ToolsPanelItem
-								hasValue={ () => !! attributes.buttonBorderWidth }
-								label={ __( 'Button Border Width', 'jetpack-forms' ) }
-								onDeselect={ () =>
-									setAttributes( {
-										buttonBorderWidth: undefined,
-									} )
-								}
-								isShownByDefault
-							>
-								<RangeControl
-									label={ __( 'Button Border Width', 'jetpack-forms' ) }
-									value={ attributes.buttonBorderWidth }
-									initialPosition={ 1 }
-									onChange={ setNumberAttribute( 'buttonBorderWidth' ) }
-									min={ 0 }
-									max={ 100 }
-									__nextHasNoMarginBottom={ true }
-								/>
-							</ToolsPanelItem>
-							<ToolsPanelItem
-								hasValue={ () => !! attributes.buttonBorderRadius }
-								label={ __( 'Button Border Radius', 'jetpack-forms' ) }
-								onDeselect={ () =>
-									setAttributes( {
-										buttonBorderRadius: undefined,
-									} )
-								}
-								isShownByDefault
-							>
-								<RangeControl
-									label={ __( 'Button Border Radius', 'jetpack-forms' ) }
-									value={ attributes.buttonBorderRadius }
-									initialPosition={ 0 }
-									onChange={ setNumberAttribute( 'buttonBorderRadius' ) }
-									min={ 0 }
-									max={ 100 }
-									__nextHasNoMarginBottom={ true }
-								/>
-							</ToolsPanelItem>
-						</>
-					) }
-					{ ( ! isChoicesBlock || formStyle === FORM_STYLE.OUTLINED ) && (
-						<>
-							<ToolsPanelItem
-								hasValue={ () => !! attributes.borderWidth }
-								label={ __( 'Border Width', 'jetpack-forms' ) }
-								onDeselect={ () =>
-									setAttributes( {
-										borderWidth: undefined,
-									} )
-								}
-								isShownByDefault
-							>
-								<RangeControl
-									label={ __( 'Border Width', 'jetpack-forms' ) }
-									value={ attributes.borderWidth }
-									initialPosition={ 1 }
-									onChange={ setNumberAttribute( 'borderWidth' ) }
-									min={ 0 }
-									max={ 100 }
-									__nextHasNoMarginBottom={ true }
-								/>
-							</ToolsPanelItem>
-							<ToolsPanelItem
-								hasValue={ () => !! attributes.borderRadius }
-								label={ __( 'Border Radius', 'jetpack-forms' ) }
-								onDeselect={ () =>
-									setAttributes( {
-										borderRadius: undefined,
-									} )
-								}
-								isShownByDefault
-							>
-								<RangeControl
-									label={ __( 'Border Radius', 'jetpack-forms' ) }
-									value={ attributes.borderRadius }
-									initialPosition={ 0 }
-									onChange={ setNumberAttribute( 'borderRadius' ) }
-									min={ 0 }
-									max={ 100 }
-									__nextHasNoMarginBottom={ true }
-								/>
-							</ToolsPanelItem>
-						</>
-					) }
 				</ToolsPanel>
 				<ToolsPanel
 					label={ __( 'Label Styles', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -54,11 +54,13 @@ const JetpackFieldControls = ( {
 	const optionColorLabel =
 		blockStyle === 'button'
 			? __( 'Button Text', 'jetpack-forms' )
-			: __( 'Option Text', 'jetpack-forms' );
-	const inputColorLabel = isChoicesBlock ? optionColorLabel : __( 'Field Text', 'jetpack-forms' );
+			: __( 'Option Text', 'jetpack-forms', 0 );
+	const inputColorLabel = isChoicesBlock
+		? optionColorLabel
+		: __( 'Field Text', 'jetpack-forms', 0 );
 	const backgroundColorLabel = isChoicesBlock
 		? __( 'Background', 'jetpack-forms' )
-		: __( 'Field Background', 'jetpack-forms' );
+		: __( 'Field Background', 'jetpack-forms', 0 );
 
 	const colorSettings = [
 		{
@@ -196,7 +198,7 @@ const JetpackFieldControls = ( {
 					label={
 						isChoicesBlock
 							? __( 'Options Typography', 'jetpack-forms' )
-							: __( 'Input Typography', 'jetpack-forms' )
+							: __( 'Input Typography', 'jetpack-forms', 0 )
 					}
 					resetAll={ () => {
 						setAttributes( {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -183,7 +183,7 @@ const JetpackFieldControls = ( {
 							borderColor: undefined,
 						} );
 					} }
-					toolsPanelDropdownMenuProps={ toolsPanelDropdownMenuProps }
+					dropdownMenuProps={ toolsPanelDropdownMenuProps }
 				>
 					<div className="jetpack-field-controls__color-settings">
 						<ColorGradientSettingsDropdown
@@ -212,7 +212,7 @@ const JetpackFieldControls = ( {
 							borderRadius: undefined,
 						} );
 					} }
-					toolsPanelDropdownMenuProps={ toolsPanelDropdownMenuProps }
+					dropdownMenuProps={ toolsPanelDropdownMenuProps }
 				>
 					<ToolsPanelItem
 						hasValue={ () => !! attributes.fieldFontSize }
@@ -257,7 +257,7 @@ const JetpackFieldControls = ( {
 							labelLineHeight: undefined,
 						} );
 					} }
-					toolsPanelDropdownMenuProps={ toolsPanelDropdownMenuProps }
+					dropdownMenuProps={ toolsPanelDropdownMenuProps }
 				>
 					<ToolsPanelItem
 						hasValue={ () => !! attributes.labelFontSize }
@@ -305,7 +305,7 @@ const JetpackFieldControls = ( {
 							borderRadius: undefined,
 						} );
 					} }
-					toolsPanelDropdownMenuProps={ toolsPanelDropdownMenuProps }
+					dropdownMenuProps={ toolsPanelDropdownMenuProps }
 				>
 					{ ( isChoicesBlock || blockStyle === 'button' ) && (
 						<>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -78,14 +78,12 @@ const JetpackFieldControls = ( {
 			colorValue: attributes.labelColor,
 			onColorChange: value => setAttributes( { labelColor: value } ),
 			label: __( 'Label Text', 'jetpack-forms' ),
-			resetAllFilter: () => setAttributes( { labelColor: undefined } ),
 			clearable: true,
 		},
 		{
 			colorValue: attributes.inputColor,
 			onColorChange: value => setAttributes( { inputColor: value } ),
 			label: inputColorLabel,
-			resetAllFilter: () => setAttributes( { inputColor: undefined } ),
 			clearable: true,
 		},
 	];
@@ -95,7 +93,6 @@ const JetpackFieldControls = ( {
 			colorValue: attributes.buttonBackgroundColor,
 			onColorChange: value => setAttributes( { buttonBackgroundColor: value } ),
 			label: __( 'Button Background', 'jetpack-forms' ),
-			resetAllFilter: () => setAttributes( { buttonBackgroundColor: undefined } ),
 			clearable: true,
 		} );
 	}
@@ -105,7 +102,6 @@ const JetpackFieldControls = ( {
 			colorValue: attributes.fieldBackgroundColor,
 			onColorChange: value => setAttributes( { fieldBackgroundColor: value } ),
 			label: backgroundColorLabel,
-			resetAllFilter: () => setAttributes( { fieldBackgroundColor: undefined } ),
 			clearable: true,
 		} );
 
@@ -113,7 +109,6 @@ const JetpackFieldControls = ( {
 			colorValue: attributes.borderColor,
 			onColorChange: value => setAttributes( { borderColor: value } ),
 			label: __( 'Border', 'jetpack-forms' ),
-			resetAllFilter: () => setAttributes( { borderColor: undefined } ),
 			clearable: true,
 		} );
 	}
@@ -193,106 +188,133 @@ const JetpackFieldControls = ( {
 				setAttributes={ setAttributes }
 				width={ width }
 			/>
-			<InspectorControls group="color">
-				<ColorGradientSettingsDropdown
-					__experimentalIsRenderedInSidebar
-					settings={ colorSettings }
-					panelId={ clientId }
-					gradients={ [] }
-					disableCustomGradients
-				/>
-			</InspectorControls>
-			<InspectorControls group="border">
-				{ ( isChoicesBlock || blockStyle === 'button' ) && (
-					<>
-						<ToolsPanelItem
-							panelId={ clientId }
-							hasValue={ () => !! attributes.buttonBorderWidth }
-							label={ __( 'Button Border Width', 'jetpack-forms' ) }
-							onDeselect={ () =>
-								setAttributes( {
-									buttonBorderWidth: undefined,
-								} )
-							}
-						>
-							<RangeControl
-								label={ __( 'Button Border Width', 'jetpack-forms' ) }
-								value={ attributes.buttonBorderWidth }
-								initialPosition={ 1 }
-								onChange={ setNumberAttribute( 'buttonBorderWidth' ) }
-								min={ 0 }
-								max={ 100 }
-								__nextHasNoMarginBottom={ true }
-							/>
-						</ToolsPanelItem>
-						<ToolsPanelItem
-							panelId={ clientId }
-							hasValue={ () => !! attributes.buttonBorderRadius }
-							label={ __( 'Button Border Radius', 'jetpack-forms' ) }
-							onDeselect={ () =>
-								setAttributes( {
-									buttonBorderRadius: undefined,
-								} )
-							}
-						>
-							<RangeControl
-								label={ __( 'Button Border Radius', 'jetpack-forms' ) }
-								value={ attributes.buttonBorderRadius }
-								initialPosition={ 0 }
-								onChange={ setNumberAttribute( 'buttonBorderRadius' ) }
-								min={ 0 }
-								max={ 100 }
-								__nextHasNoMarginBottom={ true }
-							/>
-						</ToolsPanelItem>
-					</>
-				) }
-				{ ( ! isChoicesBlock || formStyle === FORM_STYLE.OUTLINED ) && (
-					<>
-						<ToolsPanelItem
-							panelId={ clientId }
-							hasValue={ () => !! attributes.borderWidth }
-							label={ __( 'Border Width', 'jetpack-forms' ) }
-							onDeselect={ () =>
-								setAttributes( {
-									borderWidth: undefined,
-								} )
-							}
-						>
-							<RangeControl
-								label={ __( 'Border Width', 'jetpack-forms' ) }
-								value={ attributes.borderWidth }
-								initialPosition={ 1 }
-								onChange={ setNumberAttribute( 'borderWidth' ) }
-								min={ 0 }
-								max={ 100 }
-								__nextHasNoMarginBottom={ true }
-							/>
-						</ToolsPanelItem>
-						<ToolsPanelItem
-							panelId={ clientId }
-							hasValue={ () => !! attributes.borderRadius }
-							label={ __( 'Border Radius', 'jetpack-forms' ) }
-							onDeselect={ () =>
-								setAttributes( {
-									borderRadius: undefined,
-								} )
-							}
-						>
-							<RangeControl
-								label={ __( 'Border Radius', 'jetpack-forms' ) }
-								value={ attributes.borderRadius }
-								initialPosition={ 0 }
-								onChange={ setNumberAttribute( 'borderRadius' ) }
-								min={ 0 }
-								max={ 100 }
-								__nextHasNoMarginBottom={ true }
-							/>
-						</ToolsPanelItem>
-					</>
-				) }
-			</InspectorControls>
 			<InspectorControls group="styles">
+				<ToolsPanel
+					label={ __( 'Color', 'jetpack-forms' ) }
+					panelId={ clientId }
+					resetAll={ () => {
+						setAttributes( {
+							labelColor: undefined,
+							inputColor: undefined,
+							buttonBackgroundColor: undefined,
+							fieldBackgroundColor: undefined,
+							borderColor: undefined,
+						} );
+					} }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
+					<div className="jetpack-field-controls__color-settings">
+						<ColorGradientSettingsDropdown
+							__experimentalIsRenderedInSidebar
+							settings={ colorSettings }
+							panelId={ clientId }
+							gradients={ [] }
+							disableCustomGradients
+						/>
+					</div>
+				</ToolsPanel>
+				<ToolsPanel
+					label={ __( 'Border', 'jetpack-forms' ) }
+					panelId={ clientId }
+					resetAll={ () => {
+						setAttributes( {
+							buttonBorderWidth: undefined,
+							buttonBorderRadius: undefined,
+							borderWidth: undefined,
+							borderRadius: undefined,
+						} );
+					} }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
+					{ ( isChoicesBlock || blockStyle === 'button' ) && (
+						<>
+							<ToolsPanelItem
+								panelId={ clientId }
+								hasValue={ () => !! attributes.buttonBorderWidth }
+								label={ __( 'Button Border Width', 'jetpack-forms' ) }
+								onDeselect={ () =>
+									setAttributes( {
+										buttonBorderWidth: undefined,
+									} )
+								}
+							>
+								<RangeControl
+									label={ __( 'Button Border Width', 'jetpack-forms' ) }
+									value={ attributes.buttonBorderWidth }
+									initialPosition={ 1 }
+									onChange={ setNumberAttribute( 'buttonBorderWidth' ) }
+									min={ 0 }
+									max={ 100 }
+									__nextHasNoMarginBottom={ true }
+								/>
+							</ToolsPanelItem>
+							<ToolsPanelItem
+								panelId={ clientId }
+								hasValue={ () => !! attributes.buttonBorderRadius }
+								label={ __( 'Button Border Radius', 'jetpack-forms' ) }
+								onDeselect={ () =>
+									setAttributes( {
+										buttonBorderRadius: undefined,
+									} )
+								}
+							>
+								<RangeControl
+									label={ __( 'Button Border Radius', 'jetpack-forms' ) }
+									value={ attributes.buttonBorderRadius }
+									initialPosition={ 0 }
+									onChange={ setNumberAttribute( 'buttonBorderRadius' ) }
+									min={ 0 }
+									max={ 100 }
+									__nextHasNoMarginBottom={ true }
+								/>
+							</ToolsPanelItem>
+						</>
+					) }
+					{ ( ! isChoicesBlock || formStyle === FORM_STYLE.OUTLINED ) && (
+						<>
+							<ToolsPanelItem
+								panelId={ clientId }
+								hasValue={ () => !! attributes.borderWidth }
+								label={ __( 'Border Width', 'jetpack-forms' ) }
+								onDeselect={ () =>
+									setAttributes( {
+										borderWidth: undefined,
+									} )
+								}
+							>
+								<RangeControl
+									label={ __( 'Border Width', 'jetpack-forms' ) }
+									value={ attributes.borderWidth }
+									initialPosition={ 1 }
+									onChange={ setNumberAttribute( 'borderWidth' ) }
+									min={ 0 }
+									max={ 100 }
+									__nextHasNoMarginBottom={ true }
+								/>
+							</ToolsPanelItem>
+							<ToolsPanelItem
+								panelId={ clientId }
+								hasValue={ () => !! attributes.borderRadius }
+								label={ __( 'Border Radius', 'jetpack-forms' ) }
+								onDeselect={ () =>
+									setAttributes( {
+										borderRadius: undefined,
+									} )
+								}
+							>
+								<RangeControl
+									label={ __( 'Border Radius', 'jetpack-forms' ) }
+									value={ attributes.borderRadius }
+									initialPosition={ 0 }
+									onChange={ setNumberAttribute( 'borderRadius' ) }
+									min={ 0 }
+									max={ 100 }
+									__nextHasNoMarginBottom={ true }
+								/>
+							</ToolsPanelItem>
+						</>
+					) }
+				</ToolsPanel>
 				<ToolsPanel
 					label={
 						isChoicesBlock

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -185,7 +185,7 @@ const JetpackFieldControls = ( {
 					} }
 					dropdownMenuProps={ toolsPanelDropdownMenuProps }
 				>
-					<div className="jetpack-field-controls__color-settings">
+					<div className="jetpack-field-controls__full-width-control">
 						<ColorGradientSettingsDropdown
 							__experimentalIsRenderedInSidebar
 							settings={ colorSettings }
@@ -397,7 +397,7 @@ const JetpackFieldControls = ( {
 					) }
 				</ToolsPanel>
 				<ToolsPanel>
-					<div style={ { gridColumn: '1 / -1' } }>
+					<div className="jetpack-field-controls__full-width-control">
 						<ToggleControl
 							label={ __( 'Sync field styles', 'jetpack-forms' ) }
 							checked={ attributes.shareFieldAttributes }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -171,17 +171,15 @@ const JetpackFieldControls = ( {
 				width={ width }
 			/>
 			<InspectorControls group="styles">
-				<ToolsPanel>
-					<div className="jetpack-field-controls__full-width-control">
-						<ToggleControl
-							label={ __( 'Apply styling to all fields', 'jetpack-forms' ) }
-							checked={ attributes.shareFieldAttributes }
-							onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
-							help={ __( 'Toggle off if you want to style this block only.', 'jetpack-forms' ) }
-							__nextHasNoMarginBottom={ true }
-						/>
-					</div>
-				</ToolsPanel>
+				<PanelBody>
+					<ToggleControl
+						label={ __( 'Apply styling to all fields', 'jetpack-forms' ) }
+						checked={ attributes.shareFieldAttributes }
+						onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
+						help={ __( 'Toggle off if you want to style this block only.', 'jetpack-forms' ) }
+						__nextHasNoMarginBottom={ true }
+					/>
+				</PanelBody>
 				<ToolsPanel
 					label={ __( 'Color', 'jetpack-forms' ) }
 					panelId={ clientId }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -18,7 +18,7 @@ import { isValidElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useFormStyle, FORM_STYLE, getBlockStyle } from '../util/form';
 import ToolbarRequiredGroup from './block-controls/toolbar-required-group';
-import JetpackFieldWidth from './jetpack-field-width';
+import JetpackFieldDimensionControls from './jetpack-field-dimension-controls';
 import JetpackManageResponsesSettings from './jetpack-manage-responses-settings';
 
 const JetpackFieldControls = ( {
@@ -181,7 +181,11 @@ const JetpackFieldControls = ( {
 					<>{ fieldSettings }</>
 				</PanelBody>
 			</InspectorControls>
-			<JetpackFieldWidth clientId={ clientId } setAttributes={ setAttributes } width={ width } />
+			<JetpackFieldDimensionControls
+				clientId={ clientId }
+				setAttributes={ setAttributes }
+				width={ width }
+			/>
 			<InspectorControls group="color">
 				<ColorGradientSettingsDropdown
 					__experimentalIsRenderedInSidebar

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -7,11 +7,12 @@ import {
 	PanelColorSettings,
 } from '@wordpress/block-editor';
 import {
-	BaseControl,
 	PanelBody,
 	TextControl,
 	ToggleControl,
 	RangeControl,
+	__experimentalToolsPanel as ToolsPanel, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { isValidElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -171,22 +172,56 @@ const JetpackFieldControls = ( {
 				<PanelBody title={ __( 'Field Settings', 'jetpack-forms' ) }>
 					<>{ fieldSettings }</>
 				</PanelBody>
+			</InspectorControls>
+			<InspectorControls>
 				<PanelColorSettings
 					title={ __( 'Color', 'jetpack-forms' ) }
 					initialOpen={ false }
 					colorSettings={ colorSettings }
 				/>
-				<PanelBody title={ stylesPanelTitle } initialOpen={ false }>
-					<BaseControl>
+			</InspectorControls>
+			<InspectorControls group="styles">
+				<ToolsPanel
+					label={ stylesPanelTitle }
+					resetAll={ () => {
+						setAttributes( {
+							fieldFontSize: undefined,
+							lineHeight: undefined,
+							buttonBorderWidth: undefined,
+							buttonBorderRadius: undefined,
+							borderWidth: undefined,
+							borderRadius: undefined,
+						} );
+					} }
+				>
+					<ToolsPanelItem
+						hasValue={ () => !! attributes.fieldFontSize }
+						label={ __( 'Font size', 'jetpack-forms' ) }
+						onDeselect={ () =>
+							setAttributes( {
+								fieldFontSize: undefined,
+							} )
+						}
+						isShownByDefault
+					>
 						<FontSizePicker
-							withReset={ true }
-							size="__unstable-large"
-							__nextHasNoMarginBottom
+							withReset={ false }
 							onChange={ fieldFontSize => setAttributes( { fieldFontSize } ) }
 							value={ attributes.fieldFontSize }
+							size="__unstable-large"
+							__nextHasNoMarginBottom
 						/>
-					</BaseControl>
-					<BaseControl>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						hasValue={ () => !! attributes.lineHeight }
+						label={ __( 'Line height', 'jetpack-forms' ) }
+						onDeselect={ () =>
+							setAttributes( {
+								lineHeight: undefined,
+							} )
+						}
+						isShownByDefault
+					>
 						<LineHeightControl
 							__nextHasNoMarginBottom={ true }
 							__unstableInputWidth="100%"
@@ -194,54 +229,115 @@ const JetpackFieldControls = ( {
 							onChange={ setNumberAttribute( 'lineHeight', parseFloat ) }
 							size="__unstable-large"
 						/>
-					</BaseControl>
+					</ToolsPanelItem>
 					{ ( isChoicesBlock || blockStyle === 'button' ) && (
 						<>
-							<RangeControl
+							<ToolsPanelItem
+								hasValue={ () => !! attributes.buttonBorderWidth }
 								label={ __( 'Button Border Width', 'jetpack-forms' ) }
-								value={ attributes.buttonBorderWidth }
-								initialPosition={ 1 }
-								onChange={ setNumberAttribute( 'buttonBorderWidth' ) }
-								min={ 0 }
-								max={ 100 }
-								__nextHasNoMarginBottom={ true }
-							/>
-							<RangeControl
+								onDeselect={ () =>
+									setAttributes( {
+										buttonBorderWidth: undefined,
+									} )
+								}
+								isShownByDefault
+							>
+								<RangeControl
+									label={ __( 'Button Border Width', 'jetpack-forms' ) }
+									value={ attributes.buttonBorderWidth }
+									initialPosition={ 1 }
+									onChange={ setNumberAttribute( 'buttonBorderWidth' ) }
+									min={ 0 }
+									max={ 100 }
+									__nextHasNoMarginBottom={ true }
+								/>
+							</ToolsPanelItem>
+							<ToolsPanelItem
+								hasValue={ () => !! attributes.buttonBorderRadius }
 								label={ __( 'Button Border Radius', 'jetpack-forms' ) }
-								value={ attributes.buttonBorderRadius }
-								initialPosition={ 0 }
-								onChange={ setNumberAttribute( 'buttonBorderRadius' ) }
-								min={ 0 }
-								max={ 100 }
-								__nextHasNoMarginBottom={ true }
-							/>
+								onDeselect={ () =>
+									setAttributes( {
+										buttonBorderRadius: undefined,
+									} )
+								}
+								isShownByDefault
+							>
+								<RangeControl
+									label={ __( 'Button Border Radius', 'jetpack-forms' ) }
+									value={ attributes.buttonBorderRadius }
+									initialPosition={ 0 }
+									onChange={ setNumberAttribute( 'buttonBorderRadius' ) }
+									min={ 0 }
+									max={ 100 }
+									__nextHasNoMarginBottom={ true }
+								/>
+							</ToolsPanelItem>
 						</>
 					) }
 					{ ( ! isChoicesBlock || formStyle === FORM_STYLE.OUTLINED ) && (
 						<>
-							<RangeControl
+							<ToolsPanelItem
+								hasValue={ () => !! attributes.borderWidth }
 								label={ __( 'Border Width', 'jetpack-forms' ) }
-								value={ attributes.borderWidth }
-								initialPosition={ 1 }
-								onChange={ setNumberAttribute( 'borderWidth' ) }
-								min={ 0 }
-								max={ 100 }
-								__nextHasNoMarginBottom={ true }
-							/>
-							<RangeControl
+								onDeselect={ () =>
+									setAttributes( {
+										borderWidth: undefined,
+									} )
+								}
+								isShownByDefault
+							>
+								<RangeControl
+									label={ __( 'Border Width', 'jetpack-forms' ) }
+									value={ attributes.borderWidth }
+									initialPosition={ 1 }
+									onChange={ setNumberAttribute( 'borderWidth' ) }
+									min={ 0 }
+									max={ 100 }
+									__nextHasNoMarginBottom={ true }
+								/>
+							</ToolsPanelItem>
+							<ToolsPanelItem
+								hasValue={ () => !! attributes.borderRadius }
 								label={ __( 'Border Radius', 'jetpack-forms' ) }
-								value={ attributes.borderRadius }
-								initialPosition={ 0 }
-								onChange={ setNumberAttribute( 'borderRadius' ) }
-								min={ 0 }
-								max={ 100 }
-								__nextHasNoMarginBottom={ true }
-							/>
+								onDeselect={ () =>
+									setAttributes( {
+										borderRadius: undefined,
+									} )
+								}
+								isShownByDefault
+							>
+								<RangeControl
+									label={ __( 'Border Radius', 'jetpack-forms' ) }
+									value={ attributes.borderRadius }
+									initialPosition={ 0 }
+									onChange={ setNumberAttribute( 'borderRadius' ) }
+									min={ 0 }
+									max={ 100 }
+									__nextHasNoMarginBottom={ true }
+								/>
+							</ToolsPanelItem>
 						</>
 					) }
-				</PanelBody>
-				<PanelBody title={ __( 'Label Styles', 'jetpack-forms' ) } initialOpen={ false }>
-					<BaseControl>
+				</ToolsPanel>
+				<ToolsPanel
+					label={ __( 'Label Styles', 'jetpack-forms' ) }
+					resetAll={ () => {
+						setAttributes( {
+							labelFontSize: undefined,
+							labelLineHeight: undefined,
+						} );
+					} }
+				>
+					<ToolsPanelItem
+						hasValue={ () => !! attributes.labelFontSize }
+						label={ __( 'Font size', 'jetpack-forms' ) }
+						onDeselect={ () =>
+							setAttributes( {
+								labelFontSize: undefined,
+							} )
+						}
+						isShownByDefault
+					>
 						<FontSizePicker
 							withReset={ true }
 							size="__unstable-large"
@@ -249,8 +345,17 @@ const JetpackFieldControls = ( {
 							onChange={ labelFontSize => setAttributes( { labelFontSize } ) }
 							value={ attributes.labelFontSize }
 						/>
-					</BaseControl>
-					<BaseControl>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						hasValue={ () => !! attributes.labelLineHeight }
+						label={ __( 'Line height', 'jetpack-forms' ) }
+						onDeselect={ () =>
+							setAttributes( {
+								labelLineHeight: undefined,
+							} )
+						}
+						isShownByDefault
+					>
 						<LineHeightControl
 							__unstableInputWidth="100%"
 							__nextHasNoMarginBottom={ true }
@@ -258,8 +363,8 @@ const JetpackFieldControls = ( {
 							onChange={ setNumberAttribute( 'labelLineHeight', parseFloat ) }
 							size="__unstable-large"
 						/>
-					</BaseControl>
-				</PanelBody>
+					</ToolsPanelItem>
+				</ToolsPanel>
 			</InspectorControls>
 
 			<InspectorAdvancedControls>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -222,6 +222,7 @@ const JetpackFieldControls = ( {
 								fieldFontSize: undefined,
 							} )
 						}
+						isShownByDefault
 					>
 						<FontSizePicker
 							withReset={ false }
@@ -267,6 +268,7 @@ const JetpackFieldControls = ( {
 								labelFontSize: undefined,
 							} )
 						}
+						isShownByDefault
 					>
 						<FontSizePicker
 							withReset={ true }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -171,6 +171,17 @@ const JetpackFieldControls = ( {
 				width={ width }
 			/>
 			<InspectorControls group="styles">
+				<ToolsPanel>
+					<div className="jetpack-field-controls__full-width-control">
+						<ToggleControl
+							label={ __( 'Apply styling to all fields', 'jetpack-forms' ) }
+							checked={ attributes.shareFieldAttributes }
+							onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
+							help={ __( 'Toggle off if you want to style this block only.', 'jetpack-forms' ) }
+							__nextHasNoMarginBottom={ true }
+						/>
+					</div>
+				</ToolsPanel>
 				<ToolsPanel
 					label={ __( 'Color', 'jetpack-forms' ) }
 					panelId={ clientId }
@@ -397,20 +408,6 @@ const JetpackFieldControls = ( {
 							</ToolsPanelItem>
 						</>
 					) }
-				</ToolsPanel>
-				<ToolsPanel>
-					<div className="jetpack-field-controls__full-width-control">
-						<ToggleControl
-							label={ __( 'Sync field styles', 'jetpack-forms' ) }
-							checked={ attributes.shareFieldAttributes }
-							onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
-							help={ __(
-								'Syncs all styles except for Width. Deactivate for individual styling of this block.',
-								'jetpack-forms'
-							) }
-							__nextHasNoMarginBottom={ true }
-						/>
-					</div>
 				</ToolsPanel>
 			</InspectorControls>
 			<InspectorAdvancedControls>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -307,7 +307,7 @@ const JetpackFieldControls = ( {
 						<>
 							<ToolsPanelItem
 								panelId={ clientId }
-								hasValue={ () => !! attributes.buttonBorderWidth }
+								hasValue={ () => typeof attributes.buttonBorderWidth === 'number' }
 								label={ __( 'Button Border Width', 'jetpack-forms' ) }
 								onDeselect={ () =>
 									setAttributes( {
@@ -327,7 +327,7 @@ const JetpackFieldControls = ( {
 							</ToolsPanelItem>
 							<ToolsPanelItem
 								panelId={ clientId }
-								hasValue={ () => !! attributes.buttonBorderRadius }
+								hasValue={ () => typeof attributes.buttonBorderRadius === 'number' }
 								label={ __( 'Button Border Radius', 'jetpack-forms' ) }
 								onDeselect={ () =>
 									setAttributes( {
@@ -351,7 +351,7 @@ const JetpackFieldControls = ( {
 						<>
 							<ToolsPanelItem
 								panelId={ clientId }
-								hasValue={ () => !! attributes.borderWidth }
+								hasValue={ () => typeof attributes.borderWidth === 'number' }
 								label={ __( 'Border Width', 'jetpack-forms' ) }
 								onDeselect={ () =>
 									setAttributes( {
@@ -371,7 +371,7 @@ const JetpackFieldControls = ( {
 							</ToolsPanelItem>
 							<ToolsPanelItem
 								panelId={ clientId }
-								hasValue={ () => !! attributes.borderRadius }
+								hasValue={ () => typeof attributes.borderRadius === 'number' }
 								label={ __( 'Border Radius', 'jetpack-forms' ) }
 								onDeselect={ () =>
 									setAttributes( {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -214,6 +214,104 @@ const JetpackFieldControls = ( {
 					</div>
 				</ToolsPanel>
 				<ToolsPanel
+					label={
+						isChoicesBlock
+							? __( 'Options Typography', 'jetpack-forms' )
+							: __( 'Input Typography', 'jetpack-forms' )
+					}
+					resetAll={ () => {
+						setAttributes( {
+							fieldFontSize: undefined,
+							lineHeight: undefined,
+							buttonBorderWidth: undefined,
+							buttonBorderRadius: undefined,
+							borderWidth: undefined,
+							borderRadius: undefined,
+						} );
+					} }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
+					<ToolsPanelItem
+						hasValue={ () => !! attributes.fieldFontSize }
+						label={ __( 'Size', 'jetpack-forms' ) }
+						onDeselect={ () =>
+							setAttributes( {
+								fieldFontSize: undefined,
+							} )
+						}
+					>
+						<FontSizePicker
+							withReset={ false }
+							onChange={ fieldFontSize => setAttributes( { fieldFontSize } ) }
+							value={ attributes.fieldFontSize }
+							size="__unstable-large"
+							__nextHasNoMarginBottom
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						hasValue={ () => !! attributes.lineHeight }
+						label={ __( 'Line height', 'jetpack-forms' ) }
+						onDeselect={ () =>
+							setAttributes( {
+								lineHeight: undefined,
+							} )
+						}
+					>
+						<LineHeightControl
+							__nextHasNoMarginBottom={ true }
+							__unstableInputWidth="100%"
+							value={ attributes.lineHeight }
+							onChange={ setNumberAttribute( 'lineHeight', parseFloat ) }
+							size="__unstable-large"
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
+				<ToolsPanel
+					label={ __( 'Label Typography', 'jetpack-forms' ) }
+					resetAll={ () => {
+						setAttributes( {
+							labelFontSize: undefined,
+							labelLineHeight: undefined,
+						} );
+					} }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
+					<ToolsPanelItem
+						hasValue={ () => !! attributes.labelFontSize }
+						label={ __( 'Size', 'jetpack-forms' ) }
+						onDeselect={ () =>
+							setAttributes( {
+								labelFontSize: undefined,
+							} )
+						}
+					>
+						<FontSizePicker
+							withReset={ true }
+							size="__unstable-large"
+							__nextHasNoMarginBottom
+							onChange={ labelFontSize => setAttributes( { labelFontSize } ) }
+							value={ attributes.labelFontSize }
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						hasValue={ () => !! attributes.labelLineHeight }
+						label={ __( 'Line height', 'jetpack-forms' ) }
+						onDeselect={ () =>
+							setAttributes( {
+								labelLineHeight: undefined,
+							} )
+						}
+					>
+						<LineHeightControl
+							__unstableInputWidth="100%"
+							__nextHasNoMarginBottom={ true }
+							value={ attributes.labelLineHeight }
+							onChange={ setNumberAttribute( 'labelLineHeight', parseFloat ) }
+							size="__unstable-large"
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
+				<ToolsPanel
 					label={ __( 'Border', 'jetpack-forms' ) }
 					panelId={ clientId }
 					resetAll={ () => {
@@ -314,104 +412,6 @@ const JetpackFieldControls = ( {
 							</ToolsPanelItem>
 						</>
 					) }
-				</ToolsPanel>
-				<ToolsPanel
-					label={
-						isChoicesBlock
-							? __( 'Options Typography', 'jetpack-forms' )
-							: __( 'Input Typography', 'jetpack-forms' )
-					}
-					resetAll={ () => {
-						setAttributes( {
-							fieldFontSize: undefined,
-							lineHeight: undefined,
-							buttonBorderWidth: undefined,
-							buttonBorderRadius: undefined,
-							borderWidth: undefined,
-							borderRadius: undefined,
-						} );
-					} }
-					dropdownMenuProps={ dropdownMenuProps }
-				>
-					<ToolsPanelItem
-						hasValue={ () => !! attributes.fieldFontSize }
-						label={ __( 'Size', 'jetpack-forms' ) }
-						onDeselect={ () =>
-							setAttributes( {
-								fieldFontSize: undefined,
-							} )
-						}
-					>
-						<FontSizePicker
-							withReset={ false }
-							onChange={ fieldFontSize => setAttributes( { fieldFontSize } ) }
-							value={ attributes.fieldFontSize }
-							size="__unstable-large"
-							__nextHasNoMarginBottom
-						/>
-					</ToolsPanelItem>
-					<ToolsPanelItem
-						hasValue={ () => !! attributes.lineHeight }
-						label={ __( 'Line height', 'jetpack-forms' ) }
-						onDeselect={ () =>
-							setAttributes( {
-								lineHeight: undefined,
-							} )
-						}
-					>
-						<LineHeightControl
-							__nextHasNoMarginBottom={ true }
-							__unstableInputWidth="100%"
-							value={ attributes.lineHeight }
-							onChange={ setNumberAttribute( 'lineHeight', parseFloat ) }
-							size="__unstable-large"
-						/>
-					</ToolsPanelItem>
-				</ToolsPanel>
-				<ToolsPanel
-					label={ __( 'Label Typography', 'jetpack-forms' ) }
-					resetAll={ () => {
-						setAttributes( {
-							labelFontSize: undefined,
-							labelLineHeight: undefined,
-						} );
-					} }
-					dropdownMenuProps={ dropdownMenuProps }
-				>
-					<ToolsPanelItem
-						hasValue={ () => !! attributes.labelFontSize }
-						label={ __( 'Size', 'jetpack-forms' ) }
-						onDeselect={ () =>
-							setAttributes( {
-								labelFontSize: undefined,
-							} )
-						}
-					>
-						<FontSizePicker
-							withReset={ true }
-							size="__unstable-large"
-							__nextHasNoMarginBottom
-							onChange={ labelFontSize => setAttributes( { labelFontSize } ) }
-							value={ attributes.labelFontSize }
-						/>
-					</ToolsPanelItem>
-					<ToolsPanelItem
-						hasValue={ () => !! attributes.labelLineHeight }
-						label={ __( 'Line height', 'jetpack-forms' ) }
-						onDeselect={ () =>
-							setAttributes( {
-								labelLineHeight: undefined,
-							} )
-						}
-					>
-						<LineHeightControl
-							__unstableInputWidth="100%"
-							__nextHasNoMarginBottom={ true }
-							value={ attributes.labelLineHeight }
-							onChange={ setNumberAttribute( 'labelLineHeight', parseFloat ) }
-							size="__unstable-large"
-						/>
-					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>
 			<InspectorAdvancedControls>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -199,8 +199,8 @@ const JetpackFieldControls = ( {
 				<ToolsPanel
 					label={
 						isChoicesBlock
-							? __( 'Options Typography', 'jetpack-forms' )
-							: __( 'Input Typography', 'jetpack-forms', 0 )
+							? __( 'Options typography', 'jetpack-forms' )
+							: __( 'Input typography', 'jetpack-forms', 0 )
 					}
 					resetAll={ () => {
 						setAttributes( {
@@ -250,7 +250,7 @@ const JetpackFieldControls = ( {
 					</ToolsPanelItem>
 				</ToolsPanel>
 				<ToolsPanel
-					label={ __( 'Label Typography', 'jetpack-forms' ) }
+					label={ __( 'Label typography', 'jetpack-forms' ) }
 					resetAll={ () => {
 						setAttributes( {
 							labelFontSize: undefined,

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -4,7 +4,7 @@ import {
 	InspectorControls,
 	LineHeightControl,
 	BlockControls,
-	PanelColorSettings,
+	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -68,36 +68,46 @@ const JetpackFieldControls = ( {
 
 	const colorSettings = [
 		{
-			value: attributes.labelColor,
-			onChange: value => setAttributes( { labelColor: value } ),
+			colorValue: attributes.labelColor,
+			onColorChange: value => setAttributes( { labelColor: value } ),
 			label: __( 'Label Text', 'jetpack-forms' ),
+			resetAllFilter: () => setAttributes( { labelColor: undefined } ),
+			clearable: true,
 		},
 		{
-			value: attributes.inputColor,
-			onChange: value => setAttributes( { inputColor: value } ),
+			colorValue: attributes.inputColor,
+			onColorChange: value => setAttributes( { inputColor: value } ),
 			label: inputColorLabel,
+			resetAllFilter: () => setAttributes( { inputColor: undefined } ),
+			clearable: true,
 		},
 	];
 
 	if ( isChoicesBlock && blockStyle === 'button' ) {
 		colorSettings.push( {
-			value: attributes.buttonBackgroundColor,
-			onChange: value => setAttributes( { buttonBackgroundColor: value } ),
+			colorValue: attributes.buttonBackgroundColor,
+			onColorChange: value => setAttributes( { buttonBackgroundColor: value } ),
 			label: __( 'Button Background', 'jetpack-forms' ),
+			resetAllFilter: () => setAttributes( { buttonBackgroundColor: undefined } ),
+			clearable: true,
 		} );
 	}
 
 	if ( ! isChoicesBlock || formStyle === FORM_STYLE.OUTLINED ) {
 		colorSettings.push( {
-			value: attributes.fieldBackgroundColor,
-			onChange: value => setAttributes( { fieldBackgroundColor: value } ),
+			colorValue: attributes.fieldBackgroundColor,
+			onColorChange: value => setAttributes( { fieldBackgroundColor: value } ),
 			label: backgroundColorLabel,
+			resetAllFilter: () => setAttributes( { fieldBackgroundColor: undefined } ),
+			clearable: true,
 		} );
 
 		colorSettings.push( {
-			value: attributes.borderColor,
-			onChange: value => setAttributes( { borderColor: value } ),
+			colorValue: attributes.borderColor,
+			onColorChange: value => setAttributes( { borderColor: value } ),
 			label: __( 'Border', 'jetpack-forms' ),
+			resetAllFilter: () => setAttributes( { borderColor: undefined } ),
+			clearable: true,
 		} );
 	}
 
@@ -164,7 +174,6 @@ const JetpackFieldControls = ( {
 					onClick={ () => setAttributes( { required: ! required } ) }
 				/>
 			</BlockControls>
-
 			<InspectorControls>
 				<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
 					<JetpackManageResponsesSettings isChildBlock />
@@ -173,11 +182,13 @@ const JetpackFieldControls = ( {
 					<>{ fieldSettings }</>
 				</PanelBody>
 			</InspectorControls>
-			<InspectorControls>
-				<PanelColorSettings
-					title={ __( 'Color', 'jetpack-forms' ) }
-					initialOpen={ false }
-					colorSettings={ colorSettings }
+			<InspectorControls group="color">
+				<ColorGradientSettingsDropdown
+					__experimentalIsRenderedInSidebar
+					settings={ colorSettings }
+					panelId={ clientId }
+					gradients={ [] }
+					disableCustomGradients
 				/>
 			</InspectorControls>
 			<InspectorControls group="styles">
@@ -366,7 +377,6 @@ const JetpackFieldControls = ( {
 					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>
-
 			<InspectorAdvancedControls>
 				<TextControl
 					label={ __( 'Name/ID', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -399,7 +399,7 @@ const JetpackFieldControls = ( {
 				<ToolsPanel>
 					<div style={ { gridColumn: '1 / -1' } }>
 						<ToggleControl
-							label={ __( 'Sync field style', 'jetpack-forms' ) }
+							label={ __( 'Sync field styles', 'jetpack-forms' ) }
 							checked={ attributes.shareFieldAttributes }
 							onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
 							help={ __(

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -52,19 +52,11 @@ const JetpackFieldControls = ( {
 	const optionColorLabel =
 		blockStyle === 'button'
 			? __( 'Button Text', 'jetpack-forms' )
-			: __( 'Option Text', 'jetpack-forms', 0 );
-
-	const inputColorLabel = isChoicesBlock
-		? optionColorLabel
-		: __( 'Field Text', 'jetpack-forms', 0 );
-
+			: __( 'Option Text', 'jetpack-forms' );
+	const inputColorLabel = isChoicesBlock ? optionColorLabel : __( 'Field Text', 'jetpack-forms' );
 	const backgroundColorLabel = isChoicesBlock
 		? __( 'Background', 'jetpack-forms' )
-		: __( 'Field Background', 'jetpack-forms', 0 );
-
-	const stylesPanelTitle = isChoicesBlock
-		? __( 'Options Styles', 'jetpack-forms' )
-		: __( 'Input Field Styles', 'jetpack-forms', 0 );
+		: __( 'Field Background', 'jetpack-forms' );
 
 	const colorSettings = [
 		{
@@ -291,7 +283,11 @@ const JetpackFieldControls = ( {
 			</InspectorControls>
 			<InspectorControls group="styles">
 				<ToolsPanel
-					label={ stylesPanelTitle }
+					label={
+						isChoicesBlock
+							? __( 'Options Typography', 'jetpack-forms' )
+							: __( 'Input Typography', 'jetpack-forms' )
+					}
 					resetAll={ () => {
 						setAttributes( {
 							fieldFontSize: undefined,
@@ -305,7 +301,7 @@ const JetpackFieldControls = ( {
 				>
 					<ToolsPanelItem
 						hasValue={ () => !! attributes.fieldFontSize }
-						label={ __( 'Font size', 'jetpack-forms' ) }
+						label={ __( 'Size', 'jetpack-forms' ) }
 						onDeselect={ () =>
 							setAttributes( {
 								fieldFontSize: undefined,
@@ -341,7 +337,7 @@ const JetpackFieldControls = ( {
 					</ToolsPanelItem>
 				</ToolsPanel>
 				<ToolsPanel
-					label={ __( 'Label Styles', 'jetpack-forms' ) }
+					label={ __( 'Label Typography', 'jetpack-forms' ) }
 					resetAll={ () => {
 						setAttributes( {
 							labelFontSize: undefined,
@@ -351,7 +347,7 @@ const JetpackFieldControls = ( {
 				>
 					<ToolsPanelItem
 						hasValue={ () => !! attributes.labelFontSize }
-						label={ __( 'Font size', 'jetpack-forms' ) }
+						label={ __( 'Size', 'jetpack-forms' ) }
 						onDeselect={ () =>
 							setAttributes( {
 								labelFontSize: undefined,

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -14,26 +14,13 @@ import {
 	__experimentalToolsPanel as ToolsPanel, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToolsPanelItem as ToolsPanelItem, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
 import { isValidElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useFormStyle, FORM_STYLE, getBlockStyle } from '../util/form';
+import useToolsPanelResponsiveDropdownProps from '../util/use-tool-panel-responsive-dropdown-props';
 import ToolbarRequiredGroup from './block-controls/toolbar-required-group';
 import JetpackFieldDimensionControls from './jetpack-field-dimension-controls';
 import JetpackManageResponsesSettings from './jetpack-manage-responses-settings';
-
-export function useToolsPanelDropdownMenuProps() {
-	const isMobile = useViewportMatch( 'medium', '<' );
-	return ! isMobile
-		? {
-				popoverProps: {
-					placement: 'left-start',
-					// For non-mobile, inner sidebar width (248px) - button width (24px) - border (1px) + padding (16px) + spacing (20px)
-					offset: 259,
-				},
-		  }
-		: {};
-}
 
 const JetpackFieldControls = ( {
 	attributes,
@@ -52,7 +39,7 @@ const JetpackFieldControls = ( {
 	const formStyle = useFormStyle( clientId );
 	const blockStyle = getBlockStyle( blockClassNames );
 	const isChoicesBlock = [ 'radio', 'checkbox' ].includes( type );
-	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+	const toolsPanelDropdownMenuProps = useToolsPanelResponsiveDropdownProps();
 
 	const setNumberAttribute =
 		( key, parse = parseInt ) =>
@@ -201,7 +188,7 @@ const JetpackFieldControls = ( {
 							borderColor: undefined,
 						} );
 					} }
-					dropdownMenuProps={ dropdownMenuProps }
+					toolsPanelDropdownMenuProps={ toolsPanelDropdownMenuProps }
 				>
 					<div className="jetpack-field-controls__color-settings">
 						<ColorGradientSettingsDropdown
@@ -229,7 +216,7 @@ const JetpackFieldControls = ( {
 							borderRadius: undefined,
 						} );
 					} }
-					dropdownMenuProps={ dropdownMenuProps }
+					toolsPanelDropdownMenuProps={ toolsPanelDropdownMenuProps }
 				>
 					<ToolsPanelItem
 						hasValue={ () => !! attributes.fieldFontSize }
@@ -274,7 +261,7 @@ const JetpackFieldControls = ( {
 							labelLineHeight: undefined,
 						} );
 					} }
-					dropdownMenuProps={ dropdownMenuProps }
+					toolsPanelDropdownMenuProps={ toolsPanelDropdownMenuProps }
 				>
 					<ToolsPanelItem
 						hasValue={ () => !! attributes.labelFontSize }
@@ -322,7 +309,7 @@ const JetpackFieldControls = ( {
 							borderRadius: undefined,
 						} );
 					} }
-					dropdownMenuProps={ dropdownMenuProps }
+					toolsPanelDropdownMenuProps={ toolsPanelDropdownMenuProps }
 				>
 					{ ( isChoicesBlock || blockStyle === 'button' ) && (
 						<>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -128,14 +128,6 @@ const JetpackFieldControls = ( {
 				__next40pxDefaultSize={ true }
 			/>
 		),
-		<ToggleControl
-			key="shareFieldAttributes"
-			label={ __( 'Sync fields style', 'jetpack-forms' ) }
-			checked={ attributes.shareFieldAttributes }
-			onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
-			help={ __( 'Deactivate for individual styling of this block', 'jetpack-forms' ) }
-			__nextHasNoMarginBottom={ true }
-		/>,
 	];
 
 	extraFieldSettings.forEach( ( { element, index } ) => {
@@ -399,6 +391,20 @@ const JetpackFieldControls = ( {
 							</ToolsPanelItem>
 						</>
 					) }
+				</ToolsPanel>
+				<ToolsPanel>
+					<div style={ { gridColumn: '1 / -1' } }>
+						<ToggleControl
+							label={ __( 'Sync field style', 'jetpack-forms' ) }
+							checked={ attributes.shareFieldAttributes }
+							onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
+							help={ __(
+								'Syncs all styles except for Width. Deactivate for individual styling of this block.',
+								'jetpack-forms'
+							) }
+							__nextHasNoMarginBottom={ true }
+						/>
+					</div>
 				</ToolsPanel>
 			</InspectorControls>
 			<InspectorAdvancedControls>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -139,7 +139,6 @@ const JetpackFieldControls = ( {
 				__next40pxDefaultSize={ true }
 			/>
 		),
-		<JetpackFieldWidth key="width" setAttributes={ setAttributes } width={ width } />,
 		<ToggleControl
 			key="shareFieldAttributes"
 			label={ __( 'Sync fields style', 'jetpack-forms' ) }
@@ -182,6 +181,7 @@ const JetpackFieldControls = ( {
 					<>{ fieldSettings }</>
 				</PanelBody>
 			</InspectorControls>
+			<JetpackFieldWidth clientId={ clientId } setAttributes={ setAttributes } width={ width } />
 			<InspectorControls group="color">
 				<ColorGradientSettingsDropdown
 					__experimentalIsRenderedInSidebar

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -214,7 +214,6 @@ const JetpackFieldControls = ( {
 									buttonBorderWidth: undefined,
 								} )
 							}
-							isShownByDefault
 						>
 							<RangeControl
 								label={ __( 'Button Border Width', 'jetpack-forms' ) }
@@ -235,7 +234,6 @@ const JetpackFieldControls = ( {
 									buttonBorderRadius: undefined,
 								} )
 							}
-							isShownByDefault
 						>
 							<RangeControl
 								label={ __( 'Button Border Radius', 'jetpack-forms' ) }
@@ -260,7 +258,6 @@ const JetpackFieldControls = ( {
 									borderWidth: undefined,
 								} )
 							}
-							isShownByDefault
 						>
 							<RangeControl
 								label={ __( 'Border Width', 'jetpack-forms' ) }
@@ -281,7 +278,6 @@ const JetpackFieldControls = ( {
 									borderRadius: undefined,
 								} )
 							}
-							isShownByDefault
 						>
 							<RangeControl
 								label={ __( 'Border Radius', 'jetpack-forms' ) }
@@ -323,7 +319,6 @@ const JetpackFieldControls = ( {
 								fieldFontSize: undefined,
 							} )
 						}
-						isShownByDefault
 					>
 						<FontSizePicker
 							withReset={ false }
@@ -341,7 +336,6 @@ const JetpackFieldControls = ( {
 								lineHeight: undefined,
 							} )
 						}
-						isShownByDefault
 					>
 						<LineHeightControl
 							__nextHasNoMarginBottom={ true }
@@ -370,7 +364,6 @@ const JetpackFieldControls = ( {
 								labelFontSize: undefined,
 							} )
 						}
-						isShownByDefault
 					>
 						<FontSizePicker
 							withReset={ true }
@@ -388,7 +381,6 @@ const JetpackFieldControls = ( {
 								labelLineHeight: undefined,
 							} )
 						}
-						isShownByDefault
 					>
 						<LineHeightControl
 							__unstableInputWidth="100%"

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -4,8 +4,8 @@ import {
 	InspectorControls,
 	LineHeightControl,
 	BlockControls,
-	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/block-editor';
 import {
 	PanelBody,

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -14,12 +14,26 @@ import {
 	__experimentalToolsPanel as ToolsPanel, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToolsPanelItem as ToolsPanelItem, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { isValidElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useFormStyle, FORM_STYLE, getBlockStyle } from '../util/form';
 import ToolbarRequiredGroup from './block-controls/toolbar-required-group';
 import JetpackFieldDimensionControls from './jetpack-field-dimension-controls';
 import JetpackManageResponsesSettings from './jetpack-manage-responses-settings';
+
+export function useToolsPanelDropdownMenuProps() {
+	const isMobile = useViewportMatch( 'medium', '<' );
+	return ! isMobile
+		? {
+				popoverProps: {
+					placement: 'left-start',
+					// For non-mobile, inner sidebar width (248px) - button width (24px) - border (1px) + padding (16px) + spacing (20px)
+					offset: 259,
+				},
+		  }
+		: {};
+}
 
 const JetpackFieldControls = ( {
 	attributes,
@@ -38,6 +52,7 @@ const JetpackFieldControls = ( {
 	const formStyle = useFormStyle( clientId );
 	const blockStyle = getBlockStyle( blockClassNames );
 	const isChoicesBlock = [ 'radio', 'checkbox' ].includes( type );
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	const setNumberAttribute =
 		( key, parse = parseInt ) =>
@@ -298,6 +313,7 @@ const JetpackFieldControls = ( {
 							borderRadius: undefined,
 						} );
 					} }
+					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
 						hasValue={ () => !! attributes.fieldFontSize }
@@ -344,6 +360,7 @@ const JetpackFieldControls = ( {
 							labelLineHeight: undefined,
 						} );
 					} }
+					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
 						hasValue={ () => !! attributes.labelFontSize }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -4,6 +4,7 @@ import {
 	InspectorControls,
 	LineHeightControl,
 	BlockControls,
+	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/block-editor';
 import {
@@ -191,6 +192,7 @@ const JetpackFieldControls = ( {
 							panelId={ clientId }
 							gradients={ [] }
 							disableCustomGradients
+							{ ...useMultipleOriginColorsAndGradients() }
 						/>
 					</div>
 				</ToolsPanel>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -185,15 +185,6 @@ const JetpackFieldControls = ( {
 				<ToolsPanel
 					label={ __( 'Color', 'jetpack-forms' ) }
 					panelId={ clientId }
-					resetAll={ () => {
-						setAttributes( {
-							labelColor: undefined,
-							inputColor: undefined,
-							buttonBackgroundColor: undefined,
-							fieldBackgroundColor: undefined,
-							borderColor: undefined,
-						} );
-					} }
 					dropdownMenuProps={ toolsPanelDropdownMenuProps }
 				>
 					<div className="jetpack-field-controls__full-width-control">
@@ -213,16 +204,6 @@ const JetpackFieldControls = ( {
 							? __( 'Options typography', 'jetpack-forms' )
 							: __( 'Input typography', 'jetpack-forms', 0 )
 					}
-					resetAll={ () => {
-						setAttributes( {
-							fieldFontSize: undefined,
-							lineHeight: undefined,
-							buttonBorderWidth: undefined,
-							buttonBorderRadius: undefined,
-							borderWidth: undefined,
-							borderRadius: undefined,
-						} );
-					} }
 					dropdownMenuProps={ toolsPanelDropdownMenuProps }
 				>
 					<ToolsPanelItem
@@ -263,12 +244,6 @@ const JetpackFieldControls = ( {
 				</ToolsPanel>
 				<ToolsPanel
 					label={ __( 'Label typography', 'jetpack-forms' ) }
-					resetAll={ () => {
-						setAttributes( {
-							labelFontSize: undefined,
-							labelLineHeight: undefined,
-						} );
-					} }
 					dropdownMenuProps={ toolsPanelDropdownMenuProps }
 				>
 					<ToolsPanelItem
@@ -310,14 +285,6 @@ const JetpackFieldControls = ( {
 				<ToolsPanel
 					label={ __( 'Border', 'jetpack-forms' ) }
 					panelId={ clientId }
-					resetAll={ () => {
-						setAttributes( {
-							buttonBorderWidth: undefined,
-							buttonBorderRadius: undefined,
-							borderWidth: undefined,
-							borderRadius: undefined,
-						} );
-					} }
 					dropdownMenuProps={ toolsPanelDropdownMenuProps }
 				>
 					{ ( isChoicesBlock || blockStyle === 'button' ) && (

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
@@ -78,6 +78,7 @@ const JetpackDatePicker = props => {
 			</div>
 
 			<JetpackFieldControls
+				clientId={ clientId }
 				id={ id }
 				required={ required }
 				width={ width }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dimension-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dimension-controls.js
@@ -14,9 +14,10 @@ export default function JetpackFieldDimensionControls( { clientId, setAttributes
 		<InspectorControls group="dimensions">
 			<ToolsPanelItem
 				panelId={ clientId }
-				hasValue={ () => !! width }
+				hasValue={ () => width !== 100 }
 				label={ __( 'Width', 'jetpack-forms' ) }
-				onDeselect={ () => setAttributes( { width: undefined } ) }
+				onDeselect={ () => setAttributes( { width: 100 } ) }
+				resetAllFilter={ () => ( { width: 100 } ) }
 				isShownByDefault
 			>
 				<BaseControl

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dimension-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dimension-controls.js
@@ -1,6 +1,5 @@
 import { InspectorControls } from '@wordpress/block-editor';
 import {
-	BaseControl,
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToolsPanelItem as ToolsPanelItem, // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -20,33 +19,29 @@ export default function JetpackFieldDimensionControls( { clientId, setAttributes
 				resetAllFilter={ () => ( { width: 100 } ) }
 				isShownByDefault
 			>
-				<BaseControl
+				<ToggleGroupControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					aria-label={ __( 'Width', 'jetpack-forms' ) }
+					isBlock
+					label={ __( 'Width', 'jetpack-forms' ) }
 					help={ __(
 						'Adjust the width of the field to include multiple fields on a single line.',
 						'jetpack-forms'
 					) }
-					__nextHasNoMarginBottom={ true }
+					onChange={ value => setAttributes( { width: value } ) }
+					value={ width }
 				>
-					<ToggleGroupControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						aria-label={ __( 'Width', 'jetpack-forms' ) }
-						isBlock
-						label={ __( 'Width', 'jetpack-forms' ) }
-						onChange={ value => setAttributes( { width: value } ) }
-						value={ width }
-					>
-						{ PERCENTAGE_WIDTHS.map( widthValue => {
-							return (
-								<ToggleGroupControlOption
-									key={ widthValue }
-									label={ `${ widthValue }%` }
-									value={ widthValue }
-								/>
-							);
-						} ) }
-					</ToggleGroupControl>
-				</BaseControl>
+					{ PERCENTAGE_WIDTHS.map( widthValue => {
+						return (
+							<ToggleGroupControlOption
+								key={ widthValue }
+								label={ `${ widthValue }%` }
+								value={ widthValue }
+							/>
+						);
+					} ) }
+				</ToggleGroupControl>
 			</ToolsPanelItem>
 		</InspectorControls>
 	);

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dimension-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dimension-controls.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 
 const PERCENTAGE_WIDTHS = [ 25, 50, 75, 100 ];
 
-export default function JetpackFieldWidth( { clientId, setAttributes, width } ) {
+export default function JetpackFieldDimensionControls( { clientId, setAttributes, width } ) {
 	return (
 		<InspectorControls group="dimensions">
 			<ToolsPanelItem

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dropdown.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dropdown.js
@@ -157,6 +157,7 @@ const JetpackDropdown = ( { attributes, clientId, isSelected, name, setAttribute
 				</div>
 			) }
 			<JetpackFieldControls
+				clientId={ clientId }
 				id={ id }
 				required={ required }
 				attributes={ attributes }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-number.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-number.js
@@ -68,6 +68,7 @@ const JetpackNumberField = props => {
 			</div>
 
 			<JetpackFieldControls
+				clientId={ clientId }
 				id={ id }
 				required={ required }
 				width={ width }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-textarea.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-textarea.js
@@ -61,6 +61,7 @@ const JetpackFieldTextarea = props => {
 			</div>
 
 			<JetpackFieldControls
+				clientId={ clientId }
 				id={ id }
 				required={ required }
 				setAttributes={ setAttributes }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-width.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-width.js
@@ -1,40 +1,52 @@
+import { InspectorControls } from '@wordpress/block-editor';
 import {
 	BaseControl,
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 const PERCENTAGE_WIDTHS = [ 25, 50, 75, 100 ];
 
-export default function JetpackFieldWidth( { setAttributes, width } ) {
+export default function JetpackFieldWidth( { clientId, setAttributes, width } ) {
 	return (
-		<BaseControl
-			help={ __(
-				'Adjust the width of the field to include multiple fields on a single line.',
-				'jetpack-forms'
-			) }
-			__nextHasNoMarginBottom={ true }
-		>
-			<ToggleGroupControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				aria-label={ __( 'Width', 'jetpack-forms' ) }
-				isBlock
+		<InspectorControls group="dimensions">
+			<ToolsPanelItem
+				panelId={ clientId }
+				hasValue={ () => !! width }
 				label={ __( 'Width', 'jetpack-forms' ) }
-				onChange={ value => setAttributes( { width: value } ) }
-				value={ width }
+				onDeselect={ () => setAttributes( { width: undefined } ) }
+				isShownByDefault
 			>
-				{ PERCENTAGE_WIDTHS.map( widthValue => {
-					return (
-						<ToggleGroupControlOption
-							key={ widthValue }
-							label={ `${ widthValue }%` }
-							value={ widthValue }
-						/>
-					);
-				} ) }
-			</ToggleGroupControl>
-		</BaseControl>
+				<BaseControl
+					help={ __(
+						'Adjust the width of the field to include multiple fields on a single line.',
+						'jetpack-forms'
+					) }
+					__nextHasNoMarginBottom={ true }
+				>
+					<ToggleGroupControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						aria-label={ __( 'Width', 'jetpack-forms' ) }
+						isBlock
+						label={ __( 'Width', 'jetpack-forms' ) }
+						onChange={ value => setAttributes( { width: value } ) }
+						value={ width }
+					>
+						{ PERCENTAGE_WIDTHS.map( widthValue => {
+							return (
+								<ToggleGroupControlOption
+									key={ widthValue }
+									label={ `${ widthValue }%` }
+									value={ widthValue }
+								/>
+							);
+						} ) }
+					</ToggleGroupControl>
+				</BaseControl>
+			</ToolsPanelItem>
+		</InspectorControls>
 	);
 }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
@@ -64,6 +64,7 @@ const JetpackField = props => {
 			</div>
 
 			<JetpackFieldControls
+				clientId={ clientId }
 				id={ id }
 				required={ required }
 				width={ width }

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -536,6 +536,17 @@
 	font-size: inherit;
 }
 
+// Replicates `color-block-support-panel__inner-wrapper` in core, which
+// wraps the `ColorGradientSettingsDropdown` and sets the correct column
+// and margin.
+.jetpack-field-controls__color-settings {
+	grid-column: 1 / -1;
+
+	.components-tools-panel-item:first-child {
+		margin-top: 0;
+	}
+}
+
 // Duplicated to elevate specificity in order to overwrite calypso styles
 .jetpack-option__remove.jetpack-option__remove {
 	padding: 6px;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -536,9 +536,11 @@
 	font-size: inherit;
 }
 
-// Replicates `color-block-support-panel__inner-wrapper` in core, which
-// wraps the `ColorGradientSettingsDropdown` and sets the correct column
-// and margin.
+/*
+ * Replicates `color-block-support-panel__inner-wrapper` in core, which
+ * wraps the `ColorGradientSettingsDropdown` and sets the correct column
+ * and margin.
+ */
 .jetpack-field-controls__full-width-control {
 	grid-column: 1 / -1;
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -539,7 +539,7 @@
 // Replicates `color-block-support-panel__inner-wrapper` in core, which
 // wraps the `ColorGradientSettingsDropdown` and sets the correct column
 // and margin.
-.jetpack-field-controls__color-settings {
+.jetpack-field-controls__full-width-control {
 	grid-column: 1 / -1;
 
 	.components-tools-panel-item:first-child {

--- a/projects/packages/forms/src/blocks/contact-form/util/use-tool-panel-responsive-dropdown-props.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/use-tool-panel-responsive-dropdown-props.js
@@ -1,5 +1,14 @@
 import { useViewportMatch } from '@wordpress/compose';
 
+/**
+ * Returns responsive props for the tool panel dropdown.
+ *
+ * On desktop, makes the dropdown opened via the three dots button open
+ * to the left (in LTR) of the block inspector to ensure it doesn't
+ * obscure the controls in the inspector.
+ *
+ * @return {object} Props for the tool panel dropdown.
+ */
 export default function useToolsPanelResponsiveDropdownProps() {
 	const isMobile = useViewportMatch( 'medium', '<' );
 	return ! isMobile

--- a/projects/packages/forms/src/blocks/contact-form/util/use-tool-panel-responsive-dropdown-props.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/use-tool-panel-responsive-dropdown-props.js
@@ -1,0 +1,14 @@
+import { useViewportMatch } from '@wordpress/compose';
+
+export default function useToolsPanelResponsiveDropdownProps() {
+	const isMobile = useViewportMatch( 'medium', '<' );
+	return ! isMobile
+		? {
+				popoverProps: {
+					placement: 'left-start',
+					// For non-mobile, inner sidebar width (248px) - button width (24px) - border (1px) + padding (16px) + spacing (20px)
+					offset: 259,
+				},
+		  }
+		: {};
+}

--- a/projects/plugins/jetpack/changelog/update-field-style-controls-to-use-tools-panel-and-live-in-the-style-tab
+++ b/projects/plugins/jetpack/changelog/update-field-style-controls-to-use-tools-panel-and-live-in-the-style-tab
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: move field style design tools to the style tab in the block inspector.


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/41205
Related https://github.com/Automattic/jetpack/pull/41805

## Proposed changes:
Alternative to #42278, this PR is based on that one, but adds extra commit(s).

Instead of introducing the 'Styles' tab for form fields, this keeps all style settings in one (even any style settings that WordPress core adds) using the `blockInspectorTabs` editor setting. A dev note explains the setting more - https://make.wordpress.org/core/2023/03/07/introduction-of-block-inspector-tabs/

A reason for doing this would be that it results in less disruption for users, given there are also other proposals to change the design tools further in #41281, and the family of issues relating to that - #42358


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Add a form
2. Add form fields
3. Open the block Inspector
4. Observe that there's no styles tab, all the design tools are together with in the one block inspector panel

## Screenshots

| Trunk | #42278 | This PR |
|--------|--------|--------|
| <img width="263" alt="Screenshot 2025-03-07 at 10 17 22 am" src="https://github.com/user-attachments/assets/ba28138e-b071-4fab-ab13-29afb0c76ad3" /> | <img width="277" alt="Screenshot 2025-03-13 at 3 07 09 pm" src="https://github.com/user-attachments/assets/fe85176a-9f54-4c95-af5e-66d4abd471dd" /> | <img width="263" alt="Screenshot 2025-03-18 at 12 40 47 pm" src="https://github.com/user-attachments/assets/0efc880e-1dd3-46c9-9d14-268490a7b5e4" /> | 

