### PR TITLE
Legacy Music Player widget: hide from block-based widget editor

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-music-player-widget-hide
+++ b/projects/plugins/wpcomsh/changelog/update-music-player-widget-hide
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Legacy Music Player Widget: hide from the block-based widget editor

--- a/projects/plugins/wpcomsh/widgets/class-music-player-widget.php
+++ b/projects/plugins/wpcomsh/widgets/class-music-player-widget.php
@@ -17,6 +17,18 @@ class Music_Player_Widget extends WP_Widget {
 		);
 		parent::__construct( 'music-player', __( 'Music Player', 'wpcomsh' ), $widget_ops );
 		add_action( 'admin_enqueue_scripts', array( $this, 'widget_scripts' ) );
+		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_widget_in_block_editor' ) );
+	}
+
+	/**
+	 * Remove the widget from the Legacy Widget block
+	 *
+	 * @param array $widget_types List of widgets that are currently removed from the Legacy Widget block.
+	 * @return array $widget_types New list of widgets that will be removed.
+	 */
+	public function hide_widget_in_block_editor( $widget_types ) {
+		$widget_types[] = 'music-player';
+		return $widget_types;
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

This is an old widget, and one can use an Audio block instead nowadays. Let's hide it from the block-based widget editor.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* See p1742309134934049-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

> [!NOTE]
> This can be tested on a WoA site

* On a WoA site using this branch's version of WPCOMSH,
* Go to Appearance > Themes and activate a legacy theme such as Twenty Twenty.
* Go to Appearance > Widgets
* In the block-based widget editor, insert a legacy widgets block
* In that block, you should not find the music player widget in the dropdown.

