### PR TITLE
Legacy Music Player Widget: add hook to bump stats

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-music-player-widget-track
+++ b/projects/plugins/wpcomsh/changelog/update-music-player-widget-track
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Legacy Music Player Widget: add hook to bump stats on view

--- a/projects/plugins/wpcomsh/widgets/class-music-player-widget.php
+++ b/projects/plugins/wpcomsh/widgets/class-music-player-widget.php
@@ -48,6 +48,9 @@ class Music_Player_Widget extends WP_Widget {
 		$instance['shortcode'] = wp_kses( $instance['shortcode'], array() );
 		echo do_shortcode( $instance['shortcode'] );
 		echo $args['after_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+		/** This action is documented in jetpack/modules/widgets/gravatar-profile.php */
+		do_action( 'jetpack_stats_extra', 'widget_view', 'music-player' );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

In order to better judge of the impact of deprecating this widget, let's add some tracking to figure out if it is still used on sites today.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* See p1742309134934049-slack-CDLH4C1UZ
* Related: #42540

## Does this pull request change what data or activity we track or use?

* Yes, it adds tracking on widget views (see MC)

## Testing instructions:

* This will only be visible once deployed on production, at `/s/widget_view/music-player/` in MC.

