### PR TITLE
JPMT-33 Add legacy fields back to get_info()

### DIFF
--- a/projects/packages/my-jetpack/changelog/hotfix-ensure-get-info-legacy-dependencies
+++ b/projects/packages/my-jetpack/changelog/hotfix-ensure-get-info-legacy-dependencies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Add back legacy properties to get_info() function

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -216,6 +216,13 @@ abstract class Product {
 			'name'                            => static::get_name(),
 			'title'                           => static::get_title(),
 			'category'                        => static::$category,
+			/* Maintain legacy compatibility with the old product info structure. See: #42271 */
+			'description'                     => static::get_description(),
+			'long_description'                => static::get_long_description(),
+			'tiers'                           => static::get_tiers(),
+			'features'                        => static::get_features(),
+			'features_by_tier'                => static::get_features_by_tier(),
+			/* End of legacy compatibility fields. */
 			'disclaimers'                     => static::get_disclaimers(),
 			'is_bundle'                       => static::is_bundle_product(),
 			'is_plugin_active'                => static::is_plugin_active(),


### PR DESCRIPTION
## Proposed changes:
A recent PR ([Automattic/jetpack#42271](https://linear.app/a8c/review/removered-bubble-data-from-window-state-d94dd7ef90be)) moved the product “features” data from get_info() to get_wpcom_info(), causing the VideoPress dashboard to break for non-connected users. This results in JS errors, preventing the dashboard from functioning correctly.
We add back the legacy  necessary “features” data to get_info() - and will plan improving VideoPress future versions not to depend on this data.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Have JN with Jetpack as a non-connected user.
* Access the VideoPress dashboard as a non-connected user.
* Observe that the UI loads and there are no JS errors.