### PR TITLE
Remove the launchpad's updated_write_tasklist param

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-launchpad-updated-write-task-flag
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-launchpad-updated-write-task-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Launchpad: updated_write_tasklist param no longer needed

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -375,11 +375,10 @@ class Launchpad_Task_Lists {
 	 *
 	 * @param string      $id Task list id.
 	 * @param string|null $launchpad_context Optional. Screen in which launchpad is loading.
-	 * @param bool        $updated_write_tasklist Optional. Whether we're using the updated `write` task list.
 	 *
 	 * @return Task[] Collection of tasks associated with a task list.
 	 */
-	public function build( $id, $launchpad_context = null, $updated_write_tasklist = false ) {
+	public function build( $id, $launchpad_context = null ) {
 		$task_list           = $this->get_task_list( $id );
 		$tasks_for_task_list = array();
 
@@ -396,7 +395,7 @@ class Launchpad_Task_Lists {
 			$task_definition = $this->get_task( $task_id );
 
 			// if task can't be found don't add anything
-			if ( $this->is_visible( $task_definition, $launchpad_context, $updated_write_tasklist ) ) {
+			if ( $this->is_visible( $task_definition, $launchpad_context ) ) {
 				$tasks_for_task_list[] = $this->build_task( $task_definition, $launchpad_context );
 			}
 		}
@@ -410,17 +409,15 @@ class Launchpad_Task_Lists {
 	 *
 	 * @param Task        $task_definition A task definition.
 	 * @param string|null $launchpad_context Optional. Screen in which launchpad is loading.
-	 * @param bool        $updated_write_tasklist Optional. Whether we're using the updated `write` task list.
 	 * @return boolean True if task is visible, false if not.
 	 */
-	protected function is_visible( $task_definition, $launchpad_context = null, $updated_write_tasklist = false ) {
+	protected function is_visible( $task_definition, $launchpad_context = null ) {
 		if ( empty( $task_definition ) ) {
 			return false;
 		}
 
 		$data = array(
-			'launchpad_context'      => $launchpad_context,
-			'updated_write_tasklist' => $updated_write_tasklist,
+			'launchpad_context' => $launchpad_context,
 		);
 
 		return $this->load_value_from_callback( $task_definition, 'is_visible_callback', true, $data );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -380,15 +380,6 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 		),
 
-		// Write tasks.
-		'setup_write'                     => array(
-			'get_title'            => function () {
-				return __( 'Set up your site', 'jetpack-mu-wpcom' );
-			},
-			'is_complete_callback' => '__return_true',
-			'is_disabled_callback' => '__return_true',
-		),
-
 		// Publish a Blog tasks.
 		'complete_profile'                => array(
 			'get_title'            => function () {
@@ -675,18 +666,6 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'id_map'               => 'subscribers_added',
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
-			'is_visible_callback'  => '__return_true',
-			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/subscribers/' . $data['site_slug_encoded'] . '#add-subscribers';
-			},
-		),
-		'add_first_subscribers'           => array(
-			// We do not want this mapped to the 'subscribers_added' task, since this task supports
-			// being marked as complete in situations where subscribers are not added.
-			'get_title'            => function () {
-				return __( 'Add subscribers', 'jetpack-mu-wpcom' );
-			},
-			'is_complete_callback' => 'wpcom_launchpad_is_add_first_subscribers_completed',
 			'is_visible_callback'  => '__return_true',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/subscribers/' . $data['site_slug_encoded'] . '#add-subscribers';
@@ -2414,16 +2393,12 @@ function wpcom_launchpad_is_front_page_updated_visible() {
 /**
  * Determine `site_title` task visibility. The task is not visible if the name was already set.
  *
- * @param Task  $task The task data.
- * @param bool  $is_visible Whether the task is currently visible.
- * @param array $data Metadata about the launchpad.
- *
  * @return bool True if we should show the task, false otherwise.
  */
-function wpcom_launchpad_is_site_title_task_visible( $task, $is_visible, $data ) {
+function wpcom_launchpad_is_site_title_task_visible() {
 	// Hide the task if it's already completed on write intent
 	if (
-		( 'launched' === get_option( 'launch-status' ) || ! $data['updated_write_tasklist'] ) &&
+		( 'launched' === get_option( 'launch-status' ) ) &&
 		get_option( 'site_intent' ) === 'write' &&
 		wpcom_launchpad_is_task_option_completed( array( 'id' => 'site_title' ) )
 	) {
@@ -2798,25 +2773,6 @@ function wpcom_launchpad_is_domain_customize_completed( $task, $default ) {
 
 	// For everyone else, show the task as incomplete.
 	return $default;
-}
-
-/**
- * Determines whether the add_first_subscribers task is complete by checking both the task option
- * and related tasks like subscribers_added and import_subscribers.
- *
- * This exists because we need a 1-way relationship between these tasks: completion of other
- * subscriber tasks implies add_first_subscribers is completed, but completion of
- * add_first_subscribers does not imply completion of other subscriber tasks. This is because
- * add_first_subscribers is allowed to be marked complete at times when no subscribers are actually
- * added, and why using id_map here will not work since it creates a 2-way relationship.
- *
- * @param Task $task    The Task object.
- * @return bool True if either condition is met.
- */
-function wpcom_launchpad_is_add_first_subscribers_completed( $task ) {
-	return wpcom_launchpad_is_task_option_completed( $task )
-		|| wpcom_is_checklist_task_complete( 'subscribers_added' )
-		|| wpcom_is_checklist_task_complete( 'import_subscribers' );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -143,21 +143,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
 			'task_ids'            => array(
-				'setup_write',
-				'design_completed',
-				'plan_selected',
-				'verify_email',
-				'add_first_subscribers',
-				'first_post_published',
-				'site_launched',
-			),
-			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
-		),
-		'updated-write-tasklist'  => array(
-			'get_title'           => function () {
-				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
-			},
-			'task_ids'            => array(
 				'verify_email',
 				'site_title',
 				'start_building_your_audience',
@@ -504,16 +489,15 @@ function wpcom_is_checklist_task_complete( $task_id ) {
  *
  * @param string      $checklist_slug Checklist slug.
  * @param string|null $launchpad_context Optional. Screen where Launchpad is loading.
- * @param bool        $updated_write_tasklist Optional. Whether we're using the updated `write` task list.
  *
  * @return Task[] Collection of tasks for a given checklist
  */
-function wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug, $launchpad_context = null, $updated_write_tasklist = false ) {
+function wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug, $launchpad_context = null ) {
 	if ( ! $checklist_slug ) {
 		return array();
 	}
 
-	return wpcom_launchpad_checklists()->build( $checklist_slug, $launchpad_context, $updated_write_tasklist );
+	return wpcom_launchpad_checklists()->build( $checklist_slug, $launchpad_context );
 }
 
 // TODO: Write code p2 post or dotcom post

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -62,12 +62,6 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 							'required'    => false,
 							'default'     => array(),
 						),
-						'updated_write_tasklist'     => array(
-							'description' => 'Enable the updated write tasklist, for testing purposes',
-							'type'        => 'boolean',
-							'required'    => false,
-							'default'     => false,
-						),
 					),
 				),
 				array(
@@ -179,20 +173,12 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 			$switched_locale = switch_to_locale( $locale );
 		}
 
-		$checklist_slug         = isset( $request['checklist_slug'] ) ? $request['checklist_slug'] : get_option( 'site_intent' );
-		$use_goals              = isset( $request['use_goals'] ) ? $request['use_goals'] : false;
-		$updated_write_tasklist = isset( $request['updated_write_tasklist'] ) ? $request['updated_write_tasklist'] : false;
+		$checklist_slug = isset( $request['checklist_slug'] ) ? $request['checklist_slug'] : get_option( 'site_intent' );
+		$use_goals      = isset( $request['use_goals'] ) ? $request['use_goals'] : false;
 
 		$launchpad_context = isset( $request['launchpad_context'] )
 			? $request['launchpad_context']
 			: null;
-
-		if ( $updated_write_tasklist && $checklist_slug === 'write' ) {
-			// The updated_write_tasklist param facilitates a call-for-testing where we want
-			// to try out changes to the write tasks. The intention is that `updated-write-tasklist`
-			// will replace `write`, at which point updated_write_tasklist should be removed.
-			$checklist_slug = 'updated-write-tasklist';
-		}
 
 		if ( $use_goals ) {
 			// The user must be part of a cohort which should deterine which checklist to show soley on
@@ -205,7 +191,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 			'site_intent'        => get_option( 'site_intent' ),
 			'launchpad_screen'   => get_option( 'launchpad_screen' ),
 			'checklist_statuses' => get_option( 'launchpad_checklist_tasks_statuses', array() ),
-			'checklist'          => wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug, $launchpad_context, $updated_write_tasklist ),
+			'checklist'          => wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug, $launchpad_context ),
 			'is_enabled'         => wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ),
 			'is_dismissed'       => wpcom_launchpad_is_task_list_dismissed( $checklist_slug ),
 			'is_dismissible'     => wpcom_launchpad_is_task_list_dismissible( $checklist_slug ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The publish a blog project (pet6gk-24g-p2) has deployed in Calypso, and the `updated_write_tasklist` param is now always set to true (https://github.com/Automattic/wp-calypso/pull/101552). This means we can clean up this temporary flag from Jetpack.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the `updated_write_tasklist` launchpad query param now that it is no longer needed
* Delete two launchpad tasks which are now never used by any checklist

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

The publish a blog project was deployed in https://github.com/Automattic/wp-calypso/pull/101552. Now that Calypso always wants the updated write tasklist we can clean up the code to remove the old write tasklist.

Once this PR has deployed then Calypso can stop sending the param:
https://github.com/Automattic/wp-calypso/pull/101627

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply Jetpack diff to sandbox
* Test using a site that was created with the "publish a blog" goal
* There should be no change to the launchpad tasks.