### PR TITLE
Update new JITM endpoint from v2 to v3

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-jitm.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-jitm.php
@@ -6,8 +6,8 @@
  * Replaces projects/packages/jitm/src/class-rest-api-endpoints.php.
  *
  * Available on:
- * - Simple - via Dotcom Public API (https://public-api.wordpress.com/wpcom/v2/sites/{site_id}/jitm-v2).
- * - WoA and Jetpack connected sites - via local site REST API (https://myjetpackconnectedsite.com/wp-json/wpcom/v2/jitm-v2)
+ * - Simple - via Dotcom Public API (https://public-api.wordpress.com/wpcom/v3/sites/{site_id}/jitm).
+ * - WoA and Jetpack connected sites - via local site REST API (https://myjetpackconnectedsite.com/wp-json/wpcom/v3/jitm)
  *
  * Utilises Jetpack classes to orchestrate the request and response handling.
  * All JITM configuration happens on the Dotcom Simple codebase.
@@ -18,33 +18,33 @@
 use Automattic\Jetpack\Connection\REST_Connector;
 
 /**
- * Class WPCOM_REST_API_V2_Endpoint_JITM_V2
+ * Class WPCOM_REST_API_V3_Endpoint_JITM
  */
-class WPCOM_REST_API_V2_Endpoint_JITM_V2 extends WP_REST_Controller {
+class WPCOM_REST_API_V3_Endpoint_JITM extends WP_REST_Controller {
 
 	/**
 	 * Namespace prefix.
 	 *
 	 * @var string
 	 */
-	public $namespace = 'wpcom/v2';
+	public $namespace = 'wpcom/v3';
 
 	/**
 	 * Endpoint base route.
 	 *
 	 * @var string
 	 */
-	public $rest_base = 'jitm-v2';
+	public $rest_base = 'jitm';
 
 	/**
-	 * WPCOM_REST_API_V2_Endpoint_JITM_V2 constructor.
+	 * WPCOM_REST_API_V3_Endpoint_JITM constructor.
 	 */
 	public function __construct() {
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 	}
 
 	/**
-	 * Register JITM V2 routes.
+	 * Register JITM routes.
 	 */
 	public function register_routes() {
 		register_rest_route(
@@ -112,7 +112,7 @@ class WPCOM_REST_API_V2_Endpoint_JITM_V2 extends WP_REST_Controller {
 		$query_param = $request['query'] ?? '';
 
 		// Disable the jetpack_user_auth_check filter on Dotcom Simple codebase.
-		// This allows the wpcom/v2/jitm endpoint to work for Simple sites.
+		// This allows the wpcom/v3/jitm endpoint to work for Simple sites.
 		// See fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Serfg%2Qncv%2Qcyhtvaf%2Sraqcbvagf%2Swrgcnpx.cuc%3Se%3Q4580oq59%2374-og.
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			add_filter( 'rest_api_jitm_jetpack_user_auth_check', '__return_true' );
@@ -183,7 +183,7 @@ class WPCOM_REST_API_V2_Endpoint_JITM_V2 extends WP_REST_Controller {
 		}
 
 		// Disable the jetpack_user_auth_check filter on Dotcom Simple codebase.
-		// This allows the wpcom/v2/jitm endpoint to work for Simple sites.
+		// This allows the wpcom/v3/jitm endpoint to work for Simple sites.
 		// See fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Serfg%2Qncv%2Qcyhtvaf%2Sraqcbvagf%2Swrgcnpx.cuc%3Se%3Q4580oq59%2374-og.
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			add_filter( 'rest_api_jitm_jetpack_user_auth_check', '__return_true' );
@@ -199,4 +199,5 @@ class WPCOM_REST_API_V2_Endpoint_JITM_V2 extends WP_REST_Controller {
 	}
 }
 
-wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_JITM_V2' );
+// This function is badly named since it works for all versions of the REST API.
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V3_Endpoint_JITM' );

--- a/projects/plugins/jetpack/changelog/update-jitm-version
+++ b/projects/plugins/jetpack/changelog/update-jitm-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Renaming the endpoint from v2, which already exists, to v3 which is new

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V3_Endpoint_JITM_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V3_Endpoint_JITM_Test.php
@@ -3,11 +3,11 @@
 require_once dirname( __DIR__, 2 ) . '/lib/Jetpack_REST_TestCase.php';
 
 /**
- * Tests for JITM V2 REST API Endpoints.
+ * Tests for JITM V3 REST API Endpoints.
  *
  * @package automattic/jetpack
  */
-class WPCOM_REST_API_V2_Endpoint_JITM_V2_Test extends Jetpack_REST_TestCase {
+class WPCOM_REST_API_V3_Endpoint_JITM_Test extends Jetpack_REST_TestCase {
 
 	/**
 	 * Mock user ID.
@@ -105,7 +105,7 @@ class WPCOM_REST_API_V2_Endpoint_JITM_V2_Test extends Jetpack_REST_TestCase {
 
 		$message_path = 'test_message_path';
 
-		$request = new WP_REST_Request( 'GET', '/wpcom/v2/jitm-v2' );
+		$request = new WP_REST_Request( 'GET', '/wpcom/v3/jitm' );
 		$request->set_query_params(
 			array(
 				'message_path'        => $message_path,
@@ -143,11 +143,11 @@ class WPCOM_REST_API_V2_Endpoint_JITM_V2_Test extends Jetpack_REST_TestCase {
 	public function test_schema_request() {
 		wp_set_current_user( 0 );
 
-		$request  = new WP_REST_Request( 'OPTIONS', '/wpcom/v2/jitm-v2' );
+		$request  = new WP_REST_Request( 'OPTIONS', '/wpcom/v3/jitm' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( 'wpcom/v2', $data['namespace'] );
+		$this->assertEquals( 'wpcom/v3', $data['namespace'] );
 		$this->assertEquals( array( 'GET', 'POST' ), $data['methods'] );
 	}
 
@@ -155,7 +155,7 @@ class WPCOM_REST_API_V2_Endpoint_JITM_V2_Test extends Jetpack_REST_TestCase {
 	 * Tests the permission check for GET requests.
 	 */
 	public function test_get_item_permissions_check() {
-		$request = new WP_REST_Request( 'GET', '/wpcom/v2/jitm-v2' );
+		$request = new WP_REST_Request( 'GET', '/wpcom/v3/jitm' );
 		$request->set_query_params(
 			array(
 				'message_path'        => '/test_message_path/',
@@ -184,7 +184,7 @@ class WPCOM_REST_API_V2_Endpoint_JITM_V2_Test extends Jetpack_REST_TestCase {
 	 * Tests the permission check for POST (dismiss) requests.
 	 */
 	public function test_dismiss_item_permissions_check() {
-		$request = new WP_REST_Request( 'POST', '/wpcom/v2/jitm-v2' );
+		$request = new WP_REST_Request( 'POST', '/wpcom/v3/jitm' );
 		$request->set_body_params(
 			array(
 				'id'            => 'test-jitm',
@@ -212,7 +212,7 @@ class WPCOM_REST_API_V2_Endpoint_JITM_V2_Test extends Jetpack_REST_TestCase {
 	 * Tests dismissing a JITM.
 	 */
 	public function test_dismiss_jitm() {
-		$request = new WP_REST_Request( 'POST', '/wpcom/v2/jitm-v2' );
+		$request = new WP_REST_Request( 'POST', '/wpcom/v3/jitm' );
 		$request->set_body_params(
 			array(
 				'id'            => 'test-jitm',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to
- 177578-ghe-Automattic/wpcom 
- #41993

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Rather than using versioning in the URL we should use the versioning system that is part of the REST API system,

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Same as https://github.com/Automattic/jetpack/pull/41993