### PR TITLE
Social: Fix Twitter unsupported notice shown in the editor

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-twitter-unsupported-notice
+++ b/projects/js-packages/publicize-components/changelog/fix-social-twitter-unsupported-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fix Twitter unsupported notice shown in the editor

--- a/projects/js-packages/publicize-components/src/components/form/unsupported-connections-notice.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/unsupported-connections-notice.tsx
@@ -8,7 +8,11 @@ import styles from './styles.module.scss';
 
 export const UnsupportedConnectionsNotice: React.FC = () => {
 	const unsupportedServices = useSelect( select => {
-		return select( socialStore ).getServicesBy( 'status', 'unsupported' );
+		const { getServicesBy, getConnectionsByService } = select( socialStore );
+
+		return getServicesBy( 'status', 'unsupported' ).filter(
+			service => getConnectionsByService( service.id ).length
+		);
 	}, [] );
 
 	if ( ! unsupportedServices.length ) {


### PR DESCRIPTION
#42418 caused a slight regression which resulted in notice shown in the editor that Twitter is no longer supported even if there was no Twitter connection.

The reason for the regression was that the check for the connections with unsupported service got removed.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add the connections check for unsupported services.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this branch
* Goto editor for a site which does not have a Twitter connection
* Confirm that you don't see the notice in the Jetpack sidebar in the editor
* Now do the same for a site with a Twitter connection
* Confirm that you see the notice of unsupported connection
