### PR TITLE
Subscriptions block: move inline css to stylesheets

### DIFF
--- a/projects/plugins/jetpack/changelog/try-remove-inline-css-subscription-block
+++ b/projects/plugins/jetpack/changelog/try-remove-inline-css-subscription-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Moves inline CSS to a stylesheet so themes can better override it

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -466,7 +466,6 @@ function get_element_styles_from_attributes( $attributes ) {
 		? get_attribute( $attributes, 'customButtonGradient' )
 		: get_attribute( $attributes, 'customButtonBackgroundColor' );
 
-	$email_field_styles           = '';
 	$submit_button_wrapper_styles = '';
 	$submit_button_styles         = '';
 
@@ -492,13 +491,10 @@ function get_element_styles_from_attributes( $attributes ) {
 	$style     = ( $font_size && $font_size !== DEFAULT_FONTSIZE_VALUE ) ? sprintf( 'font-size: %s%s;', $font_size, is_numeric( $font_size ) ? 'px' : '' ) : '';
 
 	$submit_button_styles .= $style;
-	$email_field_styles   .= $style;
 
-	$padding = get_attribute( $attributes, 'padding' );
-	$style   = ( $padding && $padding !== DEFAULT_PADDING_VALUE ) ? sprintf( 'padding: %1$dpx %2$dpx %1$dpx %2$dpx;', $padding, round( $padding * 1.5 ) ) : '';
-
+	$padding               = get_attribute( $attributes, 'padding' );
+	$style                 = ( $padding && $padding !== DEFAULT_PADDING_VALUE ) ? sprintf( 'padding: %1$dpx %2$dpx %1$dpx %2$dpx;', $padding, round( $padding * 1.5 ) ) : '';
 	$submit_button_styles .= $style;
-	$email_field_styles   .= $style;
 
 	if ( ! $is_button_only_style ) {
 		$button_spacing = get_attribute( $attributes, 'spacing', DEFAULT_SPACING_VALUE );
@@ -513,24 +509,19 @@ function get_element_styles_from_attributes( $attributes ) {
 	if ( has_attribute( $attributes, 'borderColor' ) ) {
 		$style                 = sprintf( 'border-color: %s;', get_attribute( $attributes, 'borderColor', '' ) );
 		$submit_button_styles .= $style;
-		$email_field_styles   .= $style;
 	}
 
 	$border_radius         = get_attribute( $attributes, 'borderRadius' );
 	$style                 = ( $border_radius && $border_radius !== DEFAULT_BORDER_RADIUS_VALUE ) ? sprintf( 'border-radius: %dpx;', $border_radius ) : '';
 	$submit_button_styles .= $style;
-	$email_field_styles   .= $style;
 
 	$border_width          = get_attribute( $attributes, 'borderWeight' );
 	$style                 = ( $border_width && $border_width !== DEFAULT_BORDER_WEIGHT_VALUE ) ? sprintf( 'border-width: %dpx;', $border_width ) : '';
 	$submit_button_styles .= $style;
-	$email_field_styles   .= $style;
 
 	if ( has_attribute( $attributes, 'customBorderColor' ) ) {
-		$style = sprintf( 'border-color: %s; border-style: solid;', get_attribute( $attributes, 'customBorderColor' ) );
-
+		$style                 = sprintf( 'border-color: %s; border-style: solid;', get_attribute( $attributes, 'customBorderColor' ) );
 		$submit_button_styles .= $style;
-		$email_field_styles   .= $style;
 	}
 
 	if ( ! jetpack_is_frontend() ) {
@@ -540,7 +531,6 @@ function get_element_styles_from_attributes( $attributes ) {
 	}
 
 	return array(
-		'email_field'           => $email_field_styles,
 		'submit_button'         => $submit_button_styles,
 		'submit_button_wrapper' => $submit_button_wrapper_styles,
 	);

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -488,14 +488,14 @@ function get_element_styles_from_attributes( $attributes ) {
 			: sprintf( 'width: calc(100%% - %dpx);', get_attribute( $attributes, 'spacing', DEFAULT_SPACING_VALUE ) );
 	}
 
-	$font_size = get_attribute( $attributes, 'customFontSize', DEFAULT_FONTSIZE_VALUE );
-	$style     = sprintf( 'font-size: %s%s;', $font_size, is_numeric( $font_size ) ? 'px' : '' );
+	$font_size = get_attribute( $attributes, 'customFontSize' );
+	$style     = ( $font_size && $font_size !== DEFAULT_FONTSIZE_VALUE ) ? sprintf( 'font-size: %s%s;', $font_size, is_numeric( $font_size ) ? 'px' : '' ) : '';
 
 	$submit_button_styles .= $style;
 	$email_field_styles   .= $style;
 
-	$padding = get_attribute( $attributes, 'padding', DEFAULT_PADDING_VALUE );
-	$style   = sprintf( 'padding: %1$dpx %2$dpx %1$dpx %2$dpx;', $padding, round( $padding * 1.5 ) );
+	$padding = get_attribute( $attributes, 'padding' );
+	$style   = ( $padding && $padding !== DEFAULT_PADDING_VALUE ) ? sprintf( 'padding: %1$dpx %2$dpx %1$dpx %2$dpx;', $padding, round( $padding * 1.5 ) ) : '';
 
 	$submit_button_styles .= $style;
 	$email_field_styles   .= $style;
@@ -516,11 +516,13 @@ function get_element_styles_from_attributes( $attributes ) {
 		$email_field_styles   .= $style;
 	}
 
-	$style                 = sprintf( 'border-radius: %dpx;', get_attribute( $attributes, 'borderRadius', DEFAULT_BORDER_RADIUS_VALUE ) );
+	$border_radius         = get_attribute( $attributes, 'borderRadius' );
+	$style                 = ( $border_radius && $border_radius !== DEFAULT_BORDER_RADIUS_VALUE ) ? sprintf( 'border-radius: %dpx;', $border_radius ) : '';
 	$submit_button_styles .= $style;
 	$email_field_styles   .= $style;
 
-	$style                 = sprintf( 'border-width: %dpx;', get_attribute( $attributes, 'borderWeight', DEFAULT_BORDER_WEIGHT_VALUE ) );
+	$border_width          = get_attribute( $attributes, 'borderWeight' );
+	$style                 = ( $border_width && $border_width !== DEFAULT_BORDER_WEIGHT_VALUE ) ? sprintf( 'border-width: %dpx;', $border_width ) : '';
 	$submit_button_styles .= $style;
 	$email_field_styles   .= $style;
 
@@ -811,19 +813,14 @@ function render_for_website( $data, $classes, $styles ) {
 									type="email"
 									name="email"
 									%1$s
-									style="%2$s"
-									placeholder="%3$s"
-									value="%4$s"
-									id="%5$s"
-									%6$s
+									placeholder="%2$s"
+									value="%3$s"
+									id="%4$s"
+									%5$s
 								/>',
 								( ! empty( $classes['email_field'] )
 									? 'class="' . esc_attr( $classes['email_field'] ) . '"'
 									: ''
-								),
-								( ! empty( $styles['email_field'] )
-									? esc_attr( $styles['email_field'] )
-									: 'width: 95%; padding: 1px 10px'
 								),
 								esc_attr( $data['subscribe_placeholder'] ),
 								esc_attr( $data['subscribe_email'] ),

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -487,12 +487,12 @@ function get_element_styles_from_attributes( $attributes ) {
 			: sprintf( 'width: calc(100%% - %dpx);', get_attribute( $attributes, 'spacing', DEFAULT_SPACING_VALUE ) );
 	}
 
-	$font_size = get_attribute( $attributes, 'customFontSize' );
+	$font_size = (string) get_attribute( $attributes, 'customFontSize' );
 	$style     = ( $font_size && $font_size !== DEFAULT_FONTSIZE_VALUE ) ? sprintf( 'font-size: %s%s;', $font_size, is_numeric( $font_size ) ? 'px' : '' ) : '';
 
 	$submit_button_styles .= $style;
 
-	$padding               = get_attribute( $attributes, 'padding' );
+	$padding               = (int) get_attribute( $attributes, 'padding' );
 	$style                 = ( $padding && $padding !== DEFAULT_PADDING_VALUE ) ? sprintf( 'padding: %1$dpx %2$dpx %1$dpx %2$dpx;', $padding, round( $padding * 1.5 ) ) : '';
 	$submit_button_styles .= $style;
 
@@ -511,11 +511,11 @@ function get_element_styles_from_attributes( $attributes ) {
 		$submit_button_styles .= $style;
 	}
 
-	$border_radius         = get_attribute( $attributes, 'borderRadius' );
+	$border_radius         = (int) get_attribute( $attributes, 'borderRadius' );
 	$style                 = ( $border_radius && $border_radius !== DEFAULT_BORDER_RADIUS_VALUE ) ? sprintf( 'border-radius: %dpx;', $border_radius ) : '';
 	$submit_button_styles .= $style;
 
-	$border_width          = get_attribute( $attributes, 'borderWeight' );
+	$border_width          = (int) get_attribute( $attributes, 'borderWeight' );
 	$style                 = ( $border_width && $border_width !== DEFAULT_BORDER_WEIGHT_VALUE ) ? sprintf( 'border-width: %dpx;', $border_width ) : '';
 	$submit_button_styles .= $style;
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -143,6 +143,8 @@
 :where(.wp-block-jetpack-subscriptions input[type="email"]) {
 	font-size: 16px;
 	padding: 15px 23px 15px 23px;
-	border-radius: 0px;
+	border-radius: 0;
 	border-width: 1px;
+	// This is needed because border width is no longer inline and html :where([style*="border-width"]) no longer applies
+	border-style: solid;
 }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -139,3 +139,10 @@
 		margin-top: 0 !important;
 	}
 }
+
+:where(.wp-block-jetpack-subscriptions input[type="email"]) {
+	font-size: 16px;
+	padding: 15px 23px 15px 23px;
+	border-radius: 0px;
+	border-width: 1px;
+}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -140,7 +140,8 @@
 	}
 }
 
-:where(.wp-block-jetpack-subscriptions input[type="email"]) {
+:where(.wp-block-jetpack-subscriptions) .wp-block-button__link,
+:where(.wp-block-jetpack-subscriptions) input[type="email"] {
 	font-size: 16px;
 	padding: 15px 23px 15px 23px;
 	border-radius: 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/big-sky-plugin/issues/2785

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR moves the inline CSS to the stylesheet so themes can override it, while maintaining the ability of users to customize the same styling.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Assembler has some opinionated CSS for inputs, before this PR that CSS could never apply because inline styles are always going to be applied first.

- Create a post with the subscription block
- Using assembler, I inserted a text input for reference to see if the styling applies
- Compare the two. Before this PR, the default styling for the block was applied. After, the Assembler CSS prevails
- Check on other themes that don't have CSS for inputs (like TT4 or TT5), it should look as it does on trunk.


List of [top themes on atomic](https://github.com/Automattic/jetpack/pull/42473#issuecomment-2810209394)

I have tested this on a bunch of the above themes and the results are inconsistent. In some cases this PR is an improvement, in some it isn't. At the same time the CSS is too specific or not specific enough, and classic themes and block themes require different approaches. We are using the core button link class for the button, when we probably should be using the button element one (I don't know if changing a class would be a big no in terms of backwards compatibility for Jetpack) and in general, the solution that would work better for classic themes should be different than the one for block themes in my opinion, for the defaults to be flexible enough to work out of the box.

I'm going to step out of this for a bit and maybe come back later with a more holistic solution. This kind of work is aligned with the work being done on Woo blocks, and trying to find what the best way to extend core blocks is. It's a pity we can't contribute to core because we definitely need an input element for this to be a little easier/consistent!
# Theme Compatibility Changes
This PR addresses button/input styling inconsistencies across themes by adjusting selector specificity.

| Theme Name                 | Before | After |
|:--------------------------|--------|-------|
| Assembler                 | <img width="600" alt="Assembler before" src="https://github.com/user-attachments/assets/7950bfb9-987a-4de3-900c-65f759887445" /> | <img width="600" alt="Assembler after" src="https://github.com/user-attachments/assets/12a5ab80-5bce-49e2-8c4a-61900748cedf" /> |
| Astra                     | <img width="600" alt="Astra before" src="https://github.com/user-attachments/assets/4a1417b1-60db-45f7-8038-577225aad4bf" /> | <img width="600" alt="Astra after" src="https://github.com/user-attachments/assets/cc3ec4fa-d8fe-4d33-80d5-7439f6565d98" /> |
| Dara                      | <img width="600" alt="Dara before" src="https://github.com/user-attachments/assets/6c15389a-972f-4fdd-b9d9-f1623c092872" /> | <img width="600" alt="Dara after" src="https://github.com/user-attachments/assets/6a3222f0-f7c2-495a-a9f3-2cb506dd5955" /> |
| Elementor                 | <img width="600" alt="Elementor before" src="https://github.com/user-attachments/assets/b419b6f8-ceed-42c8-95e8-44ae7483ada4" /> | <img width="600" alt="Elementor after" src="https://github.com/user-attachments/assets/f5c984b1-b9b3-431d-b5af-f74579cf7435" /> |
| Hever                     | <img width="600" alt="Hever before" src="https://github.com/user-attachments/assets/16e91c07-e4d1-4f88-880a-270f3cb96657" /> | <img width="600" alt="Hever after" src="https://github.com/user-attachments/assets/b7c260dc-1353-4462-b195-939ded6a4a6a" /> |
| OceanWP                   | <img width="600" alt="oceanwp before" src="https://github.com/user-attachments/assets/b5261fa8-2b9c-4db5-8f7d-19dd68058147" /> | <img width="600" alt="Oceanwp after" src="https://github.com/user-attachments/assets/a4aba248-c6d1-48c9-8591-ab7ebec4ca7e" /> |
| Storefront                | <img width="600" alt="Storefront before" src="https://github.com/user-attachments/assets/5ee81fc1-ec36-49d0-9cbf-3bc4da7afba3" /> | <img width="600" alt="Storefront after" src="https://github.com/user-attachments/assets/34de341f-b023-45d1-bf35-8043fd3fc35d" /> |
| Twenty Seventeen          | <img width="600" alt="T17 before" src="https://github.com/user-attachments/assets/bdb4daad-efa9-4560-90ba-0f1f3cc1895a" /> | <img width="600" alt="T17 after" src="https://github.com/user-attachments/assets/3544ab56-ea93-4838-8ec0-298ff79a3dc5" /> |
| Tsubaki                   | <img width="600" alt="Tsubaki before" src="https://github.com/user-attachments/assets/b458d675-1f37-4392-8ddd-882218ff4da0" /> | <img width="600" alt="Tsubaki after" src="https://github.com/user-attachments/assets/ac0c41dd-f375-4a0f-b58b-1d17a9484585" /> |
| Twenty Ten                | <img width="600" alt="TT before" src="https://github.com/user-attachments/assets/7e1d5aa2-1fa7-48c1-8b1f-d692eb25dae0" /> | <img width="600" alt="TT after" src="https://github.com/user-attachments/assets/5064e36b-f80e-44c1-9b5f-a460e187f3bf" /> |
| Twenty Twenty-Two         | <img width="600" alt="TT2 before" src="https://github.com/user-attachments/assets/c1d1209d-95a6-4699-b870-9d701e2833d7" /> | <img width="600" alt="TT2 after" src="https://github.com/user-attachments/assets/f6465e4b-26e5-44a9-9b51-c66e9beee3fd" /> |
| Twenty Twenty-Three       | <img width="600" alt="TT3 before" src="https://github.com/user-attachments/assets/c15217eb-a6e1-41a1-8126-76c4809f06e0" /> | <img width="600" alt="TT3 after" src="https://github.com/user-attachments/assets/f923dd7a-5e3a-4a5e-8974-c36abe501d49" /> |
| Twenty Twenty-Four        | <img width="600" alt="TT4 before" src="https://github.com/user-attachments/assets/79a5cae7-18ce-44c1-b83d-4f5e472badfd" /> | <img width="600" alt="TT4 after" src="https://github.com/user-attachments/assets/2e2e7466-1c11-43a9-8fe6-fda85b9685b0" /> |
| Twenty Twenty-Five        | <img width="600" alt="TT5 before" src="https://github.com/user-attachments/assets/82581e1b-29b0-46d5-9458-96efcfb1569e" /> | <img width="600" alt="TT5 after" src="https://github.com/user-attachments/assets/9a404d5c-2d25-4be3-9222-6c0f9b81ee1e" /> |




