### PR TITLE
Rename Instant search feature for non-business plans

### DIFF
--- a/projects/plugins/wpcomsh/changelog/Instant search feature rename
+++ b/projects/plugins/wpcomsh/changelog/Instant search feature rename
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Just renamed a feature so that it makes more sense now that the requirements have shifted and jetpack-search-29 no longer makes sense.

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -380,7 +380,7 @@ class WPCOM_Features {
 	public const INSTALL_THEMES                    = 'install-themes';
 	public const INSTALL_WOO_ONBOARDING_PLUGINS    = 'install-woo-onboarding-plugins';
 	public const INSTANT_SEARCH                    = 'instant-search';
-	public const INSTANT_SEARCH_29                 = 'instant-search_29'; // TEMP AND TO BE DELETED AFTER REBUILDING the jetpack-search index
+	public const INSTANT_SEARCH_NO_BUSINESS        = 'instant-search-no-business'; // TEMP AND TO BE DELETED AFTER REBUILDING the jetpack-search index
 	public const JETPACK_DASHBOARD                 = 'jetpack-dashboard';
 	public const LEGACY_CONTACT                    = 'legacy-contact';
 	public const LIST_INSTALLED_PLUGINS            = 'list-installed-plugins';
@@ -783,7 +783,7 @@ class WPCOM_Features {
 			self::JETPACK_SEARCH_PLANS,
 			self::JETPACK_COMPLETE_PLANS,
 		),
-		self::INSTANT_SEARCH_29                 => array(
+		self::INSTANT_SEARCH_NO_BUSINESS        => array(
 			self::WPCOM_SEARCH,
 			self::WPCOM_SEARCH_MONTHLY,
 			self::WP_P2_PLUS_MONTHLY,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Rename Instant search feature for non-business plans from `INSTANT_SEARCH_29` to `INSTANT_SEARCH_NO_BUSINESS`. This is so that the feature name makes more sense now. 

## Testing instructions:

No testing required.

## Does this pull request change what data or activity we track or use?

No.