### PR TITLE
Change the screen after logout on WoA sites

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcom-logout-sso
+++ b/projects/plugins/wpcomsh/changelog/update-wpcom-logout-sso
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+SSO: Use same login page after logging out as when already logged out

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -256,6 +256,21 @@ function wpcomsh_bypass_jetpack_sso_login() {
 add_filter( 'jetpack_sso_bypass_login_forward_wpcom', 'wpcomsh_bypass_jetpack_sso_login' );
 
 /**
+ * Add 'loggedout' to the list of actions that allow the wpcom login form to be used.
+ *
+ * This means that the login screen the user sees immediately after logging out is consistent
+ * with the login screen the user sees when they are not logged in: the wpcom login form.
+ *
+ * @param array $allowed_actions The allowed actions.
+ * @return array The modified allowed actions.
+ */
+function wpcomsh_modify_jetpack_sso_allowed_actions( $allowed_actions ) {
+	$allowed_actions[] = 'loggedout';
+	return $allowed_actions;
+}
+add_filter( 'jetpack_sso_allowed_actions', 'wpcomsh_modify_jetpack_sso_allowed_actions' );
+
+/**
  * Overwrite the default value of SSO "Match by Email" setting.
  * p9o2xV-2zY-p2
  */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/100437

## Proposed changes:
Visiting the log-in screen while logged out on a WoA site will go to the
WordPress.com login screen if you only have SSO-connected users and will
use the Jetpack SSO login screen if you have any non-SSO users.

This change brings the same behaviour to the logout button itself for
WordPress.com atomic sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to wp-admin an atomic site with only SSO connected users
2. Use the logout button behind your gravatar at the top right
3. Note you get sent to a screen that looks like this

<img width="534" alt="Screenshot 2025-03-19 at 16 09 57" src="https://github.com/user-attachments/assets/9cf4a87d-009e-4318-8916-b295801b5bd9" />

4. Apply these changes to your wpcom-dev-blog in the usual way
5. Repeat steps 1-3 from above.
6. Note you get sent to the Wordpress.com login screen
7. Log back in, you should find yourself back at the site in question
8. Add a new user to the site, taking care to untick "Invite user to WordPress.com"
9. Now logout as before
10. Note you get sent to the same login screen as pictured above.