### PR TITLE
Add atomic site ID to tracker data

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-woocommerce-tracker-data-atomic-site-id
+++ b/projects/plugins/wpcomsh/changelog/add-woocommerce-tracker-data-atomic-site-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add atomic site ID to WooCommerce tracker data

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -666,6 +666,20 @@ function wpcomsh_get_woo_rum_data( $rum_kv = array() ) {
 add_action( 'wp_footer', 'wpcomsh_footer_rum_js' );
 add_action( 'admin_footer', 'wpcomsh_footer_rum_js' );
 
+/**
+ * Adds Atomic site ID to WooCommerce tracker data.
+ *
+ * @param array $data The WooCommerce tracker data.
+ *
+ * @return array The WooCommerce tracker data with Atomic site ID added.
+ */
+function wpcomsh_woocommerce_tracker_data( $data ) {
+	$data['atomic_site_id'] = wpcomsh_get_atomic_site_id();
+	return $data;
+}
+
+add_filter( 'woocommerce_tracker_data', 'wpcomsh_woocommerce_tracker_data' );
+
 add_filter( 'amp_dev_tools_user_default_enabled', '__return_false' );
 
 /**


### PR DESCRIPTION
## Proposed changes:
This PR adds in the `atomic_site_id` to WooCommerce tracker data snapshots.  Having this ID allows us to better analyze segments on performance in WooCommerce based on request timing and performance.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
This PR makes the Atomic Site ID available in WooCommerce tracks data.

## Testing instructions:

1. Install and activate WooCommerce
2. Add the following constants to your `wp-config.php` file, noting the `ATOMIC_SITE_ID`
```php
define( 'IS_ATOMIC', true );
define( 'ATOMIC_SITE_ID', 123456789 );
define( 'ATOMIC_CLIENT_ID', true );
```
3. Install the wpcomsh plugin in this PR in your `mu-plugins/` folder
4. Add the following snippet to your site:
```php
add_action( 'admin_init', function() {
	$data = WC_Tracker::get_tracking_data();
	error_log( 'atomic_site_id: ' . $data['atomic_site_id'] ?? null );
} );
```
5. Inspect your debug log and check that the atomic ID from above was correctly logged

<img width="414" alt="Screenshot 2025-03-19 at 12 02 01 PM" src="https://github.com/user-attachments/assets/419c0f9c-245f-478a-9c62-1585ed849bdd" />



