### PR TITLE
WIP Forms: Add third party integration modal

### DIFF
--- a/projects/packages/forms/changelog/add-forms-modal
+++ b/projects/packages/forms/changelog/add-forms-modal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Move form block integrations to modal.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-akismet-panel.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-akismet-panel.js
@@ -1,6 +1,6 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { Button, ExternalLink, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import PluginIntegrationPanel from './shared/plugin-integration-panel';
 
@@ -8,6 +8,20 @@ const AkismetPanel = () => {
 	const adminUrl = window?.jpFormsBlocks?.defaults?.formsAdminUrl || '';
 	const akismetActiveWithKey = window?.jpFormsBlocks?.defaults?.akismetActiveWithKey || false;
 	const akismetUrl = window?.jpFormsBlocks?.defaults?.akismetUrl || '';
+
+	// Check if we need to refresh the page to get updated key status
+	useEffect( () => {
+		const needsRefresh = window?.sessionStorage?.getItem( 'akismet_activation_pending' );
+		if ( needsRefresh ) {
+			window.sessionStorage.removeItem( 'akismet_activation_pending' );
+			window.location.reload();
+		}
+	}, [] );
+
+	const onActivate = () => {
+		// Set a flag to check on next render if we need to refresh
+		window.sessionStorage.setItem( 'akismet_activation_pending', 'true' );
+	};
 
 	return (
 		<PluginIntegrationPanel
@@ -28,6 +42,7 @@ const AkismetPanel = () => {
 			) }
 			tracksEventName="jetpack_forms_upsell_akismet_click"
 			initialOpen={ false }
+			onActivate={ onActivate }
 		>
 			{ akismetActiveWithKey ? (
 				<>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal.js
@@ -1,0 +1,177 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import {
+	Modal,
+	Card,
+	CardHeader,
+	CardBody,
+	Button,
+	ExternalLink,
+	Icon,
+} from '@wordpress/components';
+import { createInterpolateElement, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import CRMIntegrationSettings from './jetpack-crm-integration/jetpack-crm-integration-settings';
+import NewsletterIntegrationSettings from './jetpack-newsletter-integration-settings';
+import PluginIntegrationPanel from './shared/plugin-integration-panel';
+
+const JetpackIntegrationsModal = ( { isOpen, onClose, attributes, setAttributes } ) => {
+	const [ expandedCards, setExpandedCards ] = useState( {
+		akismet: false,
+		crm: false,
+		creativemail: false,
+	} );
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	const toggleCard = cardId => {
+		setExpandedCards( prev => ( {
+			...prev,
+			[ cardId ]: ! prev[ cardId ],
+		} ) );
+	};
+
+	const adminUrl = window?.jpFormsBlocks?.defaults?.formsAdminUrl || '';
+	const akismetActiveWithKey = window?.jpFormsBlocks?.defaults?.akismetActiveWithKey || false;
+	const akismetUrl = window?.jpFormsBlocks?.defaults?.akismetUrl || '';
+
+	return (
+		<Modal
+			title={ __( 'Form Integrations', 'jetpack-forms' ) }
+			onRequestClose={ onClose }
+			style={ { width: '700px' } }
+		>
+			<div style={ { padding: '16px', display: 'flex', flexDirection: 'column', gap: '16px' } }>
+				<Card>
+					<CardHeader onClick={ () => toggleCard( 'akismet' ) } style={ { cursor: 'pointer' } }>
+						<div style={ { display: 'flex', alignItems: 'center', gap: '8px' } }>
+							<Icon icon={ expandedCards.akismet ? 'arrow-down-alt2' : 'arrow-right-alt2' } />
+							<strong>{ __( 'Akismet', 'jetpack-forms' ) }</strong>
+						</div>
+					</CardHeader>
+					{ expandedCards.akismet && (
+						<CardBody>
+							<PluginIntegrationPanel
+								title={ __( 'Spam protection', 'jetpack-forms' ) }
+								pluginSlug="akismet"
+								pluginPath="akismet/akismet"
+								pluginTitle="Akismet"
+								installText={ __( 'Install Akismet', 'jetpack-forms' ) }
+								activateText={ __( 'Activate Akismet', 'jetpack-forms' ) }
+								description={ createInterpolateElement(
+									__(
+										"Add one-click spam protection for your forms with <a>Akismet</a>. Simply install the plugin and you're set.",
+										'jetpack-forms'
+									),
+									{
+										a: <ExternalLink href={ getRedirectUrl( 'akismet-wordpress-org' ) } />,
+									}
+								) }
+								tracksEventName="jetpack_forms_upsell_akismet_click"
+								hideWrapper
+							>
+								{ akismetActiveWithKey ? (
+									<>
+										<p>
+											{ createInterpolateElement(
+												__(
+													'Your forms are protected from spam with <a>Akismet</a>!',
+													'jetpack-forms'
+												),
+												{
+													a: (
+														<ExternalLink href={ getRedirectUrl( 'akismet-jetpack-forms-docs' ) } />
+													),
+												}
+											) }
+										</p>
+										<div style={ { display: 'flex', gap: '8px', justifyContent: 'flex-start' } }>
+											<Button
+												variant="secondary"
+												href={ adminUrl }
+												target="_blank"
+												rel="noopener noreferrer"
+												__next40pxDefaultSize={ true }
+											>
+												{ __( 'View spam', 'jetpack-forms' ) }
+											</Button>
+											<Button
+												variant="secondary"
+												href={ akismetUrl }
+												target="_blank"
+												rel="noopener noreferrer"
+												__next40pxDefaultSize={ true }
+											>
+												{ __( 'View stats', 'jetpack-forms' ) }
+											</Button>
+										</div>
+									</>
+								) : (
+									<>
+										<p>
+											{ createInterpolateElement(
+												__(
+													'Akismet is active! There is one step left. Please add your <a>Akismet key</a>.',
+													'jetpack-forms'
+												),
+												{
+													a: <ExternalLink href={ akismetUrl } />,
+												}
+											) }
+										</p>
+										<Button
+											variant="secondary"
+											href={ akismetUrl }
+											target="_blank"
+											rel="noopener noreferrer"
+											__next40pxDefaultSize={ true }
+										>
+											{ __( 'Add Akismet key', 'jetpack-forms' ) }
+										</Button>
+									</>
+								) }
+							</PluginIntegrationPanel>
+						</CardBody>
+					) }
+				</Card>
+
+				<Card>
+					<CardHeader onClick={ () => toggleCard( 'crm' ) } style={ { cursor: 'pointer' } }>
+						<div style={ { display: 'flex', alignItems: 'center', gap: '8px' } }>
+							<Icon icon={ expandedCards.crm ? 'arrow-down-alt2' : 'arrow-right-alt2' } />
+							<strong>{ __( 'Jetpack CRM', 'jetpack-forms' ) }</strong>
+						</div>
+					</CardHeader>
+					{ expandedCards.crm && (
+						<CardBody>
+							<CRMIntegrationSettings
+								jetpackCRM={ attributes.jetpackCRM }
+								setAttributes={ setAttributes }
+							/>
+						</CardBody>
+					) }
+				</Card>
+
+				<Card>
+					<CardHeader
+						onClick={ () => toggleCard( 'creativemail' ) }
+						style={ { cursor: 'pointer' } }
+					>
+						<div style={ { display: 'flex', alignItems: 'center', gap: '8px' } }>
+							<Icon icon={ expandedCards.creativemail ? 'arrow-down-alt2' : 'arrow-right-alt2' } />
+							<strong>{ __( 'Creative Mail', 'jetpack-forms' ) }</strong>
+						</div>
+					</CardHeader>
+					{ expandedCards.creativemail && (
+						<CardBody>
+							<NewsletterIntegrationSettings />
+						</CardBody>
+					) }
+				</Card>
+			</div>
+		</Modal>
+	);
+};
+
+export default JetpackIntegrationsModal;

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-manage-responses-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-manage-responses-settings.js
@@ -1,12 +1,16 @@
 import { getJetpackData } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { get } from 'lodash';
 import InspectorHint from '../components/inspector-hint';
+import JetpackIntegrationsModal from './jetpack-integrations-modal';
 
 const RESPONSES_PATH = `${ get( getJetpackData(), 'adminUrl', false ) }edit.php?post_type=feedback`;
 
-const JetpackManageResponsesSettings = () => {
+const JetpackManageResponsesSettings = ( { setAttributes, attributes } ) => {
+	const [ isIntegrationsModalOpen, setIsIntegrationsModalOpen ] = useState( false );
+
 	return (
 		<>
 			<InspectorHint>
@@ -18,6 +22,20 @@ const JetpackManageResponsesSettings = () => {
 					{ __( '(opens in a new tab)', 'jetpack-forms' ) }
 				</span>
 			</Button>
+			<Button
+				variant="secondary"
+				onClick={ () => setIsIntegrationsModalOpen( true ) }
+				className="jetpack-forms-integrations-panel"
+				style={ { marginTop: '8px' } }
+			>
+				{ __( 'Manage Integrations', 'jetpack-forms' ) }
+			</Button>
+			<JetpackIntegrationsModal
+				isOpen={ isIntegrationsModalOpen }
+				onClose={ () => setIsIntegrationsModalOpen( false ) }
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+			/>
 		</>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/shared/plugin-integration-panel/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/shared/plugin-integration-panel/index.js
@@ -19,6 +19,8 @@ const PluginIntegrationPanel = ( {
 	tracksEventName,
 	children,
 	initialOpen = false,
+	hideWrapper = false,
+	onActivate,
 } ) => {
 	const [ isInstalling, setIsInstalling ] = useState( false );
 	const [ isActivating, setIsActivating ] = useState( false );
@@ -56,6 +58,9 @@ const PluginIntegrationPanel = ( {
 			invalidateResolution( 'getPlugins' );
 			setIsInstalling( false );
 			setIsActivating( false );
+			if ( isActivationCall && onActivate ) {
+				onActivate();
+			}
 		} );
 	}, [
 		isInstalled,
@@ -66,60 +71,69 @@ const PluginIntegrationPanel = ( {
 		setIsActivating,
 		invalidateResolution,
 		tracks,
+		onActivate,
 	] );
+
+	const content = (
+		<div className="jetpack-plugin-integration__content" aria-live="polite">
+			{ isLoading && (
+				<div className="jetpack-plugin-integration__status">
+					<div>
+						<Spinner />
+						<span>{ __( 'Checking plugin status…', 'jetpack-forms' ) }</span>
+					</div>
+				</div>
+			) }
+
+			{ ! isLoading && ! isInstalled && (
+				<div className="jetpack-plugin-integration__panel">
+					<div className="jetpack-plugin-integration__panel-content">
+						<div>{ description }</div>
+						<PluginActionButton
+							isInstalling={ isInstalling }
+							isActivating={ isActivating }
+							isInstalled={ isInstalled }
+							installText={ installText }
+							activateText={ activateText }
+							onClick={ handleButtonClick }
+						/>
+					</div>
+				</div>
+			) }
+
+			{ ! isLoading && isInstalled && ! isActive && (
+				<div className="jetpack-plugin-integration__panel">
+					<div className="jetpack-plugin-integration__panel-content">
+						<div>
+							{ sprintf(
+								/* translators: %s: plugin name */
+								__( "You already have %s installed, but it's not activated.", 'jetpack-forms' ),
+								pluginTitle || __( 'the plugin', 'jetpack-forms' )
+							) }
+						</div>
+						<PluginActionButton
+							isInstalling={ isInstalling }
+							isActivating={ isActivating }
+							isInstalled={ isInstalled }
+							installText={ installText }
+							activateText={ activateText }
+							onClick={ handleButtonClick }
+						/>
+					</div>
+				</div>
+			) }
+
+			{ ! isLoading && isInstalled && isActive && children }
+		</div>
+	);
+
+	if ( hideWrapper ) {
+		return content;
+	}
 
 	return (
 		<PanelBody title={ title } initialOpen={ initialOpen }>
-			<div className="jetpack-plugin-integration__content" aria-live="polite">
-				{ isLoading && (
-					<div className="jetpack-plugin-integration__status">
-						<div>
-							<Spinner />
-							<span>{ __( 'Checking plugin status…', 'jetpack-forms' ) }</span>
-						</div>
-					</div>
-				) }
-
-				{ ! isLoading && ! isInstalled && (
-					<div className="jetpack-plugin-integration__panel">
-						<div className="jetpack-plugin-integration__panel-content">
-							<div>{ description }</div>
-							<PluginActionButton
-								isInstalling={ isInstalling }
-								isActivating={ isActivating }
-								isInstalled={ isInstalled }
-								installText={ installText }
-								activateText={ activateText }
-								onClick={ handleButtonClick }
-							/>
-						</div>
-					</div>
-				) }
-
-				{ ! isLoading && isInstalled && ! isActive && (
-					<div className="jetpack-plugin-integration__panel">
-						<div className="jetpack-plugin-integration__panel-content">
-							<div>
-								{ sprintf(
-									/* translators: %s: plugin name */
-									__( "You already have %s installed, but it's not activated.", 'jetpack-forms' ),
-									pluginTitle || __( 'the plugin', 'jetpack-forms' )
-								) }
-							</div>
-							<PluginActionButton
-								isInstalling={ isInstalling }
-								isActivating={ isActivating }
-								isInstalled={ isInstalled }
-								installText={ installText }
-								activateText={ activateText }
-								onClick={ handleButtonClick }
-							/>
-						</div>
-					</div>
-				) }
-
-				{ ! isLoading && isInstalled && isActive && children }
-			</div>
+			{ content }
 		</PanelBody>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -25,10 +25,13 @@ import clsx from 'clsx';
 import { filter, isArray, map } from 'lodash';
 import { childBlocks } from './child-blocks';
 import InspectorHint from './components/inspector-hint';
+import AkismetPanel from './components/jetpack-akismet-panel';
 import { ContactFormPlaceholder } from './components/jetpack-contact-form-placeholder';
 import ContactFormSkeletonLoader from './components/jetpack-contact-form-skeleton-loader';
+import CRMIntegrationSettings from './components/jetpack-crm-integration/jetpack-crm-integration-settings';
 import JetpackEmailConnectionSettings from './components/jetpack-email-connection-settings';
 import JetpackManageResponsesSettings from './components/jetpack-manage-responses-settings';
+import NewsletterIntegrationSettings from './components/jetpack-newsletter-integration-settings';
 import SalesforceLeadFormSettings from './components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings';
 import VariationPicker from './variation-picker';
 import './util/form-styles.js';
@@ -69,6 +72,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		customThankyouMessage,
 		customThankyouRedirect,
 		salesforceData,
+		jetpackCRM,
 		formTitle,
 	} = attributes;
 	const instanceId = useInstanceId( JetpackContactFormEdit );
@@ -149,11 +153,8 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		elt = (
 			<>
 				<InspectorControls>
-					<PanelBody title={ __( 'Manage Form', 'jetpack-forms' ) }>
-						<JetpackManageResponsesSettings
-							setAttributes={ setAttributes }
-							attributes={ attributes }
-						/>
+					<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
+						<JetpackManageResponsesSettings setAttributes={ setAttributes } />
 					</PanelBody>
 					<PanelBody title={ __( 'Action after submit', 'jetpack-forms' ) } initialOpen={ false }>
 						<InspectorHint>
@@ -223,6 +224,27 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 							setAttributes={ setAttributes }
 							instanceId={ instanceId }
 						/>
+					) }
+					{ ! isSimpleSite() && (
+						<>
+							{ canUserInstallPlugins && (
+								<>
+									<AkismetPanel />
+									<PanelBody
+										title={ __( 'CRM Connection', 'jetpack-forms' ) }
+										initialOpen={ false }
+									>
+										<CRMIntegrationSettings
+											jetpackCRM={ jetpackCRM }
+											setAttributes={ setAttributes }
+										/>
+									</PanelBody>
+									<PanelBody title={ __( 'Creative Mail', 'jetpack-forms' ) } initialOpen={ false }>
+										<NewsletterIntegrationSettings />
+									</PanelBody>
+								</>
+							) }
+						</>
 					) }
 					{ ! isSimpleSite() && <>{ canUserInstallPlugins && <></> }</> }
 				</InspectorControls>

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -25,13 +25,10 @@ import clsx from 'clsx';
 import { filter, isArray, map } from 'lodash';
 import { childBlocks } from './child-blocks';
 import InspectorHint from './components/inspector-hint';
-import AkismetPanel from './components/jetpack-akismet-panel';
 import { ContactFormPlaceholder } from './components/jetpack-contact-form-placeholder';
 import ContactFormSkeletonLoader from './components/jetpack-contact-form-skeleton-loader';
-import CRMIntegrationSettings from './components/jetpack-crm-integration/jetpack-crm-integration-settings';
 import JetpackEmailConnectionSettings from './components/jetpack-email-connection-settings';
 import JetpackManageResponsesSettings from './components/jetpack-manage-responses-settings';
-import NewsletterIntegrationSettings from './components/jetpack-newsletter-integration-settings';
 import SalesforceLeadFormSettings from './components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings';
 import VariationPicker from './variation-picker';
 import './util/form-styles.js';
@@ -71,7 +68,6 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		customThankyouHeading,
 		customThankyouMessage,
 		customThankyouRedirect,
-		jetpackCRM,
 		salesforceData,
 		formTitle,
 	} = attributes;
@@ -153,8 +149,11 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		elt = (
 			<>
 				<InspectorControls>
-					<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
-						<JetpackManageResponsesSettings setAttributes={ setAttributes } />
+					<PanelBody title={ __( 'Manage Form', 'jetpack-forms' ) }>
+						<JetpackManageResponsesSettings
+							setAttributes={ setAttributes }
+							attributes={ attributes }
+						/>
 					</PanelBody>
 					<PanelBody title={ __( 'Action after submit', 'jetpack-forms' ) } initialOpen={ false }>
 						<InspectorHint>
@@ -225,27 +224,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 							instanceId={ instanceId }
 						/>
 					) }
-					{ ! isSimpleSite() && (
-						<>
-							{ canUserInstallPlugins && (
-								<>
-									<AkismetPanel />
-									<PanelBody
-										title={ __( 'CRM Connection', 'jetpack-forms' ) }
-										initialOpen={ false }
-									>
-										<CRMIntegrationSettings
-											jetpackCRM={ jetpackCRM }
-											setAttributes={ setAttributes }
-										/>
-									</PanelBody>
-									<PanelBody title={ __( 'Creative Mail', 'jetpack-forms' ) } initialOpen={ false }>
-										<NewsletterIntegrationSettings />
-									</PanelBody>
-								</>
-							) }
-						</>
-					) }
+					{ ! isSimpleSite() && <>{ canUserInstallPlugins && <></> }</> }
 				</InspectorControls>
 				<InspectorAdvancedControls>
 					<TextControl

--- a/projects/plugins/jetpack/changelog/add-forms-modal
+++ b/projects/plugins/jetpack/changelog/add-forms-modal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Move form block integrations to modal.


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR adds a new modal to the forms block to house third party integrations like Akismet, Jetpack CRM, Creative Mail, and others. It is experimental, and was developed quickly during Zap's team meetup. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I will add testing instructions when this is ready, if we decided to proceed with it.

