### PR TITLE
SEO Enhancer: Disable auto-enhance and toggle on simple sites

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-seo-enhancer-disable-simple
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-seo-enhancer-disable-simple
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+SEO Enhancer: Disable auto-enhance and toggle on simple sites

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
@@ -25,7 +25,7 @@ import './style.scss';
  */
 const debug = debugFactory( 'seo-enhancer:index' );
 
-export function SeoEnhancer() {
+export function SeoEnhancer( { disableAutoEnhance = false }: { disableAutoEnhance?: boolean } ) {
 	const { isEnabled, toggleEnhancer, isToggling } = useSeoModuleSettings();
 	const isLoading = useSelect( select => {
 		const isBusy = select( store ).isBusy();
@@ -64,22 +64,24 @@ export function SeoEnhancer() {
 					<BaseControl.VisualLabel className="ai-seo-enhancer-label">
 						{ __( 'Metadata AI Generator', 'jetpack' ) }
 					</BaseControl.VisualLabel>
-					<ToggleControl
-						checked={ isEnabled }
-						disabled={ isToggling }
-						onChange={ toggleSeoEnhancer }
-						label={ __( 'Auto-generate metadata', 'jetpack' ) }
-						__nextHasNoMarginBottom={ true }
-						help={ __(
-							'When enabled, missing metadata will be automatically generated when you publish a post.',
-							'jetpack'
-						) }
-					/>
+					{ ! disableAutoEnhance && (
+						<ToggleControl
+							checked={ isEnabled }
+							disabled={ isToggling }
+							onChange={ toggleSeoEnhancer }
+							label={ __( 'Auto-generate metadata', 'jetpack' ) }
+							__nextHasNoMarginBottom={ true }
+							help={ __(
+								'When enabled, missing metadata will be automatically generated when you publish a post.',
+								'jetpack'
+							) }
+						/>
+					) }
 				</BaseControl>
 			</PanelRow>
 			<PanelRow className="jetpack-seo-sidebar__feature-section">
 				<BaseControl __nextHasNoMarginBottom={ true }>
-					{ ! isEnabled && (
+					{ ( ! isEnabled || disableAutoEnhance ) && (
 						<div className="feature-checkboxes-container">
 							{ FEATURES.map( feature => (
 								<CheckboxControl
@@ -94,7 +96,7 @@ export function SeoEnhancer() {
 							) ) }
 						</div>
 					) }
-					{ isEnabled && (
+					{ isEnabled && ! disableAutoEnhance && (
 						<div className="jetpack-seo-sidebar__feature-list-container">
 							{ enabledFeatures.length > 0 ? (
 								<>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/with-seo-auto-generation.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/with-seo-auto-generation.tsx
@@ -3,6 +3,7 @@
  */
 import {
 	getJetpackExtensionAvailability,
+	isSimpleSite,
 	useModuleStatus,
 } from '@automattic/jetpack-shared-extension-utils';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -21,7 +22,7 @@ import { useSeoRequests } from './use-seo-requests';
 import type { Block } from '@automattic/jetpack-ai-client';
 
 const isSeoEnhancerEnabled =
-	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true;
+	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true && ! isSimpleSite();
 
 function isPossibleToExtendImageBlock( blockName: string ): boolean {
 	return blockName === 'core/image' && isSeoEnhancerEnabled;

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -53,6 +53,8 @@ const isSeoEnhancerEnabled =
 	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true &&
 	supportsPublishSidebar;
 
+const canHaveAutoEnhance = ! isSimpleSite();
+
 const Seo = () => {
 	const { isLoadingModules, isChangingStatus, isModuleActive, changeStatus } =
 		useModuleStatus( 'seo-tools' );
@@ -79,6 +81,7 @@ const Seo = () => {
 			! isBusy &&
 			isAutoEnhanceEnabled &&
 			! isToggling &&
+			canHaveAutoEnhance &&
 			supportsPublishSidebar
 		) {
 			updateSeoData();
@@ -167,7 +170,7 @@ const Seo = () => {
 							<SeoAssistantSidebarEntrypoint disabled={ false } placement="jetpack-sidebar" />
 						</PanelRow>
 					) }
-					{ isSeoEnhancerEnabled && <SeoEnhancer /> }
+					{ isSeoEnhancerEnabled && <SeoEnhancer disableAutoEnhance={ ! canHaveAutoEnhance } /> }
 					<PanelRow
 						className={ clsx( {
 							'jetpack-seo-sidebar__feature-section': isSeoEnhancerEnabled,
@@ -194,7 +197,7 @@ const Seo = () => {
 
 			<PluginPrePublishPanel { ...jetpackSeoPublishPanelsProps }>
 				<>
-					{ isSeoEnhancerEnabled && <SeoEnhancer /> }
+					{ isSeoEnhancerEnabled && <SeoEnhancer disableAutoEnhance={ ! canHaveAutoEnhance } /> }
 					<PanelRow>
 						<SeoTitlePanel />
 					</PanelRow>
@@ -207,7 +210,7 @@ const Seo = () => {
 				</>
 			</PluginPrePublishPanel>
 
-			{ isSeoEnhancerEnabled && isAutoEnhanceEnabled && (
+			{ isSeoEnhancerEnabled && isAutoEnhanceEnabled && canHaveAutoEnhance && (
 				<PluginPostPublishPanel { ...jetpackSeoPublishPanelsProps }>
 					<SeoSummary onEdit={ handleSummaryEdit } />
 				</PluginPostPublishPanel>

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -76,6 +76,7 @@ const Seo = () => {
 
 	useEffect( () => {
 		if (
+			isSeoEnhancerEnabled &&
 			isPrePublishPanelOpen &&
 			! previousIsOpenRef.current &&
 			! isBusy &&


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #42596 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Hides the toggle without removing the capability of generating data manually

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a non-simple site:
* Enable the SEO Enhancer with a code snippet
* Check that there are no changes
* On a simple site:
* Enable the SEO Enhancer in your sandbox's 0-sandbox file
* Check that you can generate SEO data manually, but not automatically, and the toggle is gone
