### PR TITLE
Star Rating: Fix color control padding and copy

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-star-rating-color-control-padding-and-copy
+++ b/projects/plugins/jetpack/changelog/fix-star-rating-color-control-padding-and-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Star Rating: Fix padding and improve panel copy.

--- a/projects/plugins/jetpack/extensions/blocks/rating-star/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/rating-star/edit.js
@@ -87,18 +87,18 @@ export default Symbol =>
 							max={ 10 }
 							__nextHasNoMarginBottom={ true }
 						/>
-						<PanelColorSettings
-							title={ __( 'Color Settings', 'jetpack' ) }
-							initialOpen
-							colorSettings={ [
-								{
-									value: color,
-									onChange: setNewColor,
-									label: __( 'Color', 'jetpack' ),
-								},
-							] }
-						/>
 					</PanelBody>
+					<PanelColorSettings
+						title={ __( 'Color', 'jetpack' ) }
+						initialOpen
+						colorSettings={ [
+							{
+								value: color,
+								onChange: setNewColor,
+								label: __( 'Color', 'jetpack' ),
+							},
+						] }
+					/>
 				</InspectorControls>
 			</div>
 		);


### PR DESCRIPTION
## Proposed changes:
Fixes a small issue I noticed in passing.

The Star Rating color control has unusual padding. This is because it's nested in a `PanelBody`, and that isn't necessary, the `PanelColorSettings` component implements its own Panel.

The PR also changes the copy of the panel to just 'Color'. The previous text of 'Color Settings' led to the options menu having the awkward tooltip 'Color Settings options':
<img width="271" alt="Screenshot 2025-03-20 at 10 35 27 am" src="https://github.com/user-attachments/assets/086d33b1-8c1e-414d-a0be-70db3c1bc656" />

Note: While there's an open issue for updating the color controls (#40238), I'm not planning on addressing that right now. This PR is just a v. small change to fix something I noticed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Add a Star Rating block to a post
2. Open the block inspector
3. Check that the Color Panel doesn't have incorrect padding around it
4. Hover over the tooltip

## Screenshots

#### Before
<img width="284" alt="Screenshot 2025-03-20 at 10 39 23 am" src="https://github.com/user-attachments/assets/b5911953-59f4-4d3a-abd5-39535d9c67af" />

#### After
<img width="283" alt="Screenshot 2025-03-20 at 10 40 05 am" src="https://github.com/user-attachments/assets/45fa7ba9-0d96-4ba8-a272-4a9d7ec4254f" />

