### PR TITLE
Site verification: Fix Auto verify with Google when Social is OFF

### DIFF
--- a/projects/packages/publicize/changelog/fix-google-site-auto-verification
+++ b/projects/packages/publicize/changelog/fix-google-site-auto-verification
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Keyring Helper: Moved the initialization to pre_initialization to let it work even when Publicize is off.

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -58,6 +58,11 @@ class Publicize_Setup {
 		}
 
 		Social_Admin_Page::init();
+
+		// We need this only on Jetpack sites for Google Site auto-verification.
+		if ( ! ( new Host() )->is_wpcom_simple() ) {
+			add_action( 'init', array( Keyring_Helper::class, 'init' ), 9 );
+		}
 	}
 
 	/**
@@ -88,8 +93,6 @@ class Publicize_Setup {
 			// Load the settings page.
 			new Jetpack_Social_Settings\Settings();
 		}
-
-		add_action( 'init', array( Keyring_Helper::class, 'init' ), 9, 0 );
 
 		( new Social_Image_Generator\Setup() )->init();
 	}

--- a/projects/plugins/jetpack/changelog/fix-google-site-auto-verification
+++ b/projects/plugins/jetpack/changelog/fix-google-site-auto-verification
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Site verification: Fix Auto verify with Google when Social is OFF


### PR DESCRIPTION
Fixes #42592

In #41460, we removed the duplicate Keyring_Helper class and moved its [initialization logic](https://github.com/Automattic/jetpack/pull/41460/files#diff-3cddf08e0504d848dd6a4de6309dd100db0a463140146cbf54f5a68bacfb5123) to `on_jetpack_feature_publicize_enabled` which gets called only if Social is active, thus the site auto-verification request wasn't handled and it resulted in the URL landed at the site admin.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Publicize Keyring Helper: Moved the initialization to `pre_initialization` to let it work even when Publicize is off.
* It will allow Auto verify with Google work even when Social is OFF


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the instructions given in #42592 
* Confirm that the site verification works fine

