### PR TITLE
MU WPCOM: Keep the launch site button always in blueberry (modern scheme) like in wp-admin

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-launch-site-button-style
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-launch-site-button-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+MU WPCOM: Keep the launch site button always in blueberry (modern scheme) like in wp-admin

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -60,7 +60,8 @@ function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
 			'title'  => '<span class="ab-icon">' . $icon . '</span><span class="ab-label">' . __( 'Launch site', 'jetpack-mu-wpcom' ) . '</span>',
 			'href'   => 'https://wordpress.com/start/launch-site?siteSlug=' . $blog_domain,
 			'meta'   => array(
-				'class' => 'launch-site',
+				// Use `admin-color-modern` to keep the button always in blueberry (modern scheme).
+				'class' => 'launch-site admin-color-modern',
 			),
 		)
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/style.css
@@ -5,7 +5,17 @@
 #wpadminbar #wp-toolbar .ab-top-menu li.launch-site .ab-item {
 	display: flex;
 	padding-inline: 8px;
+	color: #fff;
 }
+
+#wpadminbar #wp-toolbar .ab-top-menu li.launch-site span.ab-label {
+	color: currentColor;
+}
+
+#wpadminbar #wp-toolbar .ab-top-menu li.launch-site span.ab-icon {
+	color: currentColor;
+}
+
 
 #wpadminbar #wp-toolbar .ab-top-menu li.launch-site svg {
 	width: 15px;
@@ -18,7 +28,7 @@
 }
 
 #wpadminbar #wp-toolbar .ab-top-menu li.launch-site:hover .ab-item {
-	color: currentColor;
+	color: #fff;
 	background: transparent;
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/style.css
@@ -1,14 +1,31 @@
-#wpadminbar .launch-site {
+#wpadminbar #wp-toolbar .ab-top-menu li.launch-site {
 	background: var(--wp-admin-theme-color);
 }
 
-#wpadminbar .launch-site .ab-item {
+#wpadminbar #wp-toolbar .ab-top-menu li.launch-site .ab-item {
 	display: flex;
 	padding-inline: 8px;
 }
 
-#wpadminbar .launch-site svg {
+#wpadminbar #wp-toolbar .ab-top-menu li.launch-site svg {
 	width: 15px;
 	height: 15px;
 	fill: currentColor;
+}
+
+#wpadminbar #wp-toolbar .ab-top-menu li.launch-site:hover {
+	background: var(--wp-admin-theme-color-darker-10);
+}
+
+#wpadminbar #wp-toolbar .ab-top-menu li.launch-site:hover .ab-item {
+	color: currentColor;
+	background: transparent;
+}
+
+#wpadminbar #wp-toolbar .ab-top-menu li.launch-site:hover span.ab-label {
+	color: currentColor;
+}
+
+#wpadminbar #wp-toolbar .ab-top-menu li.launch-site:hover span.ab-icon {
+	color: currentColor;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -1,3 +1,14 @@
+@import '@wordpress/base-styles/mixins';
+
+/**
+ * Allow to apply the modern scheme to elements.
+ */
+#wpadminbar {
+	.admin-color-modern {
+		@include admin-scheme(#3858e9);
+	}
+}
+
 /**
  * Always shows WP logo (All Sites)
  */

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-launch-site-button-style
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-launch-site-button-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+MU WPCOM: Keep the launch site button always in blueberry (modern scheme) like in wp-admin

--- a/projects/plugins/wpcomsh/changelog/update-launch-site-button-style
+++ b/projects/plugins/wpcomsh/changelog/update-launch-site-button-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+MU WPCOM: Keep the launch site button always in blueberry (modern scheme) like in wp-admin


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/101284

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Keep the launch site button always in blueberry (modern scheme) like in wp-admin

| | Before | After |
| - | - | - |
| Default | <img width="362" alt="Image" src="https://github.com/user-attachments/assets/882baa48-9151-4716-aa2b-016e296e8228" /> | ![image](https://github.com/user-attachments/assets/117df56d-c7fd-44a2-8439-d6ad8583b836)  |
| Hover | <img width="365" alt="Image" src="https://github.com/user-attachments/assets/b7d17861-91bd-4e54-af9e-b3f1008c86e2" /> | ![image](https://github.com/user-attachments/assets/492a6e29-3486-4108-a4ba-1eb9d69d4c91) |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your site
* Go to `<your-site>/wp-admin` where the site has non-modern color scheme
* Ensure the style of the “Launch site” button is correct (default & hover)

