### PR TITLE
VideoPress Dashboard: Preserve search query when navigating back from video details page.

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-dashboard-navigation
+++ b/projects/packages/videopress/changelog/fix-videopress-dashboard-navigation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Preserve search query when navigating back from video details page.

--- a/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
@@ -33,7 +33,7 @@ const LibraryType = {
 
 type LibraryType = ( typeof LibraryType )[ keyof typeof LibraryType ];
 
-const VideoLibraryWrapper = ( {
+export const VideoLibraryWrapper = ( {
 	children,
 	totalVideos = 0,
 	libraryType = LibraryType.List,

--- a/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
@@ -6,7 +6,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { grid, formatListBullets } from '@wordpress/icons';
 import clsx from 'clsx';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 /**
  * Internal dependencies
@@ -50,12 +50,14 @@ const VideoLibraryWrapper = ( {
 	title?: string;
 	disabled?: boolean;
 } ) => {
-	const { isFetching } = useVideos();
+	const { isFetching, search } = useVideos();
 	const searchParams = useSearchParams();
 
-	const onSearchHandler = searchQuery => {
-		// clear the pagination, setting it back to page 1
-		searchParams.deleteParam( 'page' );
+	const onSearchHandler = ( searchQuery: string, clearPagination = true ) => {
+		if ( clearPagination ) {
+			// Clear the pagination, setting it back to page 1
+			searchParams.deleteParam( 'page' );
+		}
 
 		if ( searchQuery ) {
 			searchParams.setParam( 'q', searchQuery );
@@ -66,8 +68,15 @@ const VideoLibraryWrapper = ( {
 		searchParams.update();
 	};
 
-	const searchParamsSearchQuery = searchParams.getParam( 'q', '' );
-	const [ searchQuery, setSearchQuery ] = useState( searchParamsSearchQuery );
+	const [ searchQuery, setSearchQuery ] = useState( searchParams.getParam( 'q', '' ) );
+
+	// Sync search state with URL
+	useEffect( () => {
+		if ( search && search !== searchQuery ) {
+			onSearchHandler( search, false );
+			setSearchQuery( search );
+		}
+	}, [ search ] );
 
 	const [ isLg ] = useBreakpointMatch( 'lg' );
 

--- a/projects/packages/videopress/src/client/admin/components/admin-page/tests/libraries.test.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/tests/libraries.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { VideoLibraryWrapper } from '../libraries';
+
+jest.mock( '../../../hooks/use-videos', () => {
+	return jest.fn().mockImplementation( () => ( {
+		search: '',
+		isFetching: false,
+	} ) );
+} );
+
+jest.mock( '../../../hooks/use-search-params', () => ( {
+	useSearchParams: jest.fn().mockImplementation( () => ( {
+		deleteParam: jest.fn(),
+		setParam: jest.fn(),
+		getParam: jest.fn(),
+		update: jest.fn(),
+	} ) ),
+} ) );
+
+jest.mock( '@automattic/jetpack-connection', () => ( {
+	useConnection: jest.fn(),
+	useConnectionErrorNotice: jest.fn( () => ( { hasConnectionError: false } ) ),
+} ) );
+
+describe( 'VideoLibraryWrapper', () => {
+	it( 'renders', () => {
+		render( <VideoLibraryWrapper children={ <div>Content</div> } /> );
+
+		expect( screen.getByText( 'Content' ) ).toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/28260

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Preserve search query when navigating back from video details page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your env (instructions [here](https://github.com/Automattic/jetpack/pull/42612#issuecomment-2740720245)).
* Use a site with a VideoPress plan and the VideoPress plugin.
* Use a site with multiple videos uploaded (around 10 is enough to have better pagination tests).
* Go to Jetpack > VideoPress.
* Search for something that returns at least two pages.
* Go to the second page and click on **Edit video details** in one of the videos.
* Return to the list by clicking on **Go back** or using browser navigation.
* It should preserve the page state and URL parameters.
* Perform multiple combinations of filters, pagination, and search.
* All filters, pagination, and search should be preserved after returning to the list.
* Perform the same tests using the Grid and List views.