### PR TITLE
VideoPress: Edit VideoPress details: Fix header layout

### DIFF
--- a/projects/js-packages/components/changelog/fix-videopress-page-layout
+++ b/projects/js-packages/components/changelog/fix-videopress-page-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixes admin panel header component layout

--- a/projects/js-packages/components/components/admin-page/index.tsx
+++ b/projects/js-packages/components/components/admin-page/index.tsx
@@ -63,7 +63,7 @@ const AdminPage: React.FC< AdminPageProps > = ( {
 		<div className={ rootClassName }>
 			{ showHeader && (
 				<Container horizontalSpacing={ 5 }>
-					<Col className={ styles[ 'admin-page-header' ] }>
+					<Col className={ clsx( styles[ 'admin-page-header' ], 'jp-admin-page-header' ) }>
 						{ header ? header : <JetpackLogo /> }
 						{ sandboxedDomain && (
 							<code

--- a/projects/packages/videopress/changelog/fix-videopress-page-layout
+++ b/projects/packages/videopress/changelog/fix-videopress-page-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixes admin panel header component layout

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/style.module.scss
@@ -138,6 +138,10 @@
 			display: none;
 		}
 	}
+
+	#jetpack-videopress-root .jp-admin-page-header {
+		display: block;
+	}
 }
 
 .jetpack-videopress-jitm-card {


### PR DESCRIPTION
Closes https://github.com/Automattic/videopress/issues/1219

## Proposed changes:

* Fixes admin panel's header layout

The piece of code which introduced the styling regression:
https://github.com/Automattic/jetpack/commit/9932919a4dba9bd05fd34252373331f8b3c32295#diff-08874fb3f92c22c0e98e6ff8c3168f957f6660799638875f1b19390d02bb6121R13-R15

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/videopress/issues/1219

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Nope

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `Jetpack/VideoPress` dashboard
* Select a video item
* Check the header style

**Before:**
<img width="1147" alt="Screenshot 2025-03-20 at 16 04 20" src="https://github.com/user-attachments/assets/39c16a11-d10d-4e2c-a9f5-ad35d5678569" />

**After:**
<img width="1150" alt="Screenshot 2025-03-20 at 16 04 01" src="https://github.com/user-attachments/assets/9b1b928c-7292-4765-9a6b-092120857eff" />

Following the screenshots of the UI on [the plugins's page](https://wordpress.org/plugins/jetpack-videopress/), I see the "Go back" link goes above the breadcrumbs, so I follow it.
