### PR TITLE
The import banner should not be visible when running it

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/hide-banner-running-import
+++ b/projects/packages/jetpack-mu-wpcom/changelog/hide-banner-running-import
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Hides the Import banner when actually running the import tool.

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -11,7 +11,10 @@
 function import_page_customizations_init() {
 	$screen = get_current_screen();
 
-	if ( $screen && $screen->id === 'import' ) {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no changes made to the site.
+	$has_import_param = ! isset( $_GET['import'] );
+
+	if ( $screen && $screen->id === 'import' && $has_import_param ) {
 		// Only add the banner if the user is using the wp-admin interface.
 		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
 			add_action( 'admin_notices', 'import_admin_banner' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/101628

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure that the Import banner is not displayed when running the import tool. The banner should only be displayed on the Import page.

<img width="1512" alt="Captura de Tela 2025-03-20 às 15 33 32" src="https://github.com/user-attachments/assets/dab7b640-2c8a-45c4-b671-b13af1ed67ff" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/wp-calypso/issues/101628

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your WoA site(p9o2xV-1r2-p2)
* Navigate to `/wp-admin/import.php`
* Install one of the import tools and run it
* Once you reach the Run page, you should no longer see the banner.