### PR TITLE
Jetpack Social: fix sidebar panel styles

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-jetpack-social-sidebar-panel-styles
+++ b/projects/js-packages/publicize-components/changelog/fix-jetpack-social-sidebar-panel-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Social: fix sidebar panel toggle and connection button styles

--- a/projects/js-packages/publicize-components/src/components/form/connection-notice.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/connection-notice.tsx
@@ -30,7 +30,7 @@ export const ConnectionNotice: React.FC = () => {
 	if ( ! hasConnections ) {
 		return (
 			<PanelRow>
-				<p>
+				<div>
 					<span className={ styles[ 'no-connections-text' ] }>
 						{ __(
 							'Sharing is disabled because there are no social media accounts connected.',
@@ -38,7 +38,7 @@ export const ConnectionNotice: React.FC = () => {
 						) }
 					</span>
 					<SettingsButton label={ __( 'Connect an account', 'jetpack-publicize-components' ) } />
-				</p>
+				</div>
 			</PanelRow>
 		);
 	}

--- a/projects/js-packages/publicize-components/src/components/form/settings-button.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/settings-button.tsx
@@ -24,7 +24,7 @@ type SettingsButtonProps = {
  *
  * @return {import('react').ReactNode} The button/link component.
  */
-export function SettingsButton( { label, variant = 'primary' }: SettingsButtonProps ) {
+export function SettingsButton( { label, variant = 'secondary' }: SettingsButtonProps ) {
 	const { useAdminUiV1 } = getSocialScriptData().feature_flags;
 
 	const { connections } = useSelect( select => {
@@ -42,7 +42,6 @@ export function SettingsButton( { label, variant = 'primary' }: SettingsButtonPr
 		<Button
 			onClick={ openConnectionsModal }
 			variant={ hasConnections ? 'link' : variant }
-			size={ hasConnections ? 'default' : 'small' }
 			className={ styles[ 'settings-button' ] }
 		>
 			{ text }

--- a/projects/js-packages/publicize-components/src/components/panel/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/panel/index.tsx
@@ -3,7 +3,7 @@
  * Jetpack plugin implementation.
  */
 
-import { PanelBody, ToggleControl } from '@wordpress/components';
+import { PanelBody, PanelRow, ToggleControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { Fragment } from '@wordpress/element';
@@ -59,21 +59,23 @@ const PublicizePanel = ( { prePublish, children }: PublicizePanelProps ) => {
 			{ ! hidePublicizeFeature && (
 				<Fragment>
 					{ ! isPostPublished && (
-						<ToggleControl
-							label={
-								isPublicizeEnabled
-									? __( 'Share when publishing', 'jetpack-publicize-components' )
-									: _x(
-											'Sharing is disabled',
-											'Label for publicize toggle',
-											'jetpack-publicize-components'
-									  )
-							}
-							onChange={ togglePublicizeFeature }
-							checked={ isPublicizeEnabled && hasConnections }
-							disabled={ ! hasConnections }
-							__nextHasNoMarginBottom={ true }
-						/>
+						<PanelRow>
+							<ToggleControl
+								label={
+									isPublicizeEnabled
+										? __( 'Share when publishing', 'jetpack-publicize-components' )
+										: _x(
+												'Sharing is disabled',
+												'Label for publicize toggle',
+												'jetpack-publicize-components'
+										  )
+								}
+								onChange={ togglePublicizeFeature }
+								checked={ isPublicizeEnabled && hasConnections }
+								disabled={ ! hasConnections }
+								__nextHasNoMarginBottom={ true }
+							/>
+						</PanelRow>
 					) }
 
 					<PublicizeForm />


### PR DESCRIPTION

Fixes #42610 

## Proposed changes:
This PR addresses some small layout/component usage, aligning to the newest "standard" on sidebar panels. By doing so, it also fixes some spacing issues.

Also, the connection button is now set to default to `secondary`, same as the rest of the panels CTAs

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
If working locally, watch/build both:
```
jetpack watch packages/publicize
jetpack watch plugins/jetpack
```

Load your site and go to the block editor. Open Jetpack sidebar and look for the Social panel (enable if needed, only with https, start free if in doubt). Check the styling compared to the mentioned issue:

<img width="295" alt="Screenshot 2025-03-20 at 15 33 07" src="https://github.com/user-attachments/assets/6eb92f5b-46d2-4742-8816-ea1e0953cbc3" />

<img width="296" alt="Screenshot 2025-03-20 at 15 34 13" src="https://github.com/user-attachments/assets/424f9480-dfc1-4c7b-b18b-707cb7d1d36f" />

<img width="294" alt="Screenshot 2025-03-20 at 15 34 52" src="https://github.com/user-attachments/assets/9aa6768f-ec1f-45c9-9374-5f0b31256f1a" />

<img width="296" alt="Screenshot 2025-03-20 at 15 35 06" src="https://github.com/user-attachments/assets/88690574-acda-4f54-8d04-86ad92e3438d" />

Check that it looks good on Jetpack sidebar and on PrePublish sidebar, before and after publishing.


