### PR TITLE
Subscriber button: prefill logged in email

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscriber-button-default-email
+++ b/projects/plugins/jetpack/changelog/update-subscriber-button-default-email
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Autofill logged in email'

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -641,18 +641,16 @@ function render_block( $attributes ) {
 		return '';
 	}
 
+	// Prefill the email field with the current user's email if they are logged in via Memberships premium content token
 	$subscribe_email = Jetpack_Memberships::get_current_user_email();
-	error_log( print_r( compact( 'subscribe_email' ), true ) );
 
-	/** This filter is documented in \Automattic\Jetpack\Forms\ContactForm\Contact_Form */
-	if ( false !== apply_filters( 'jetpack_auto_fill_logged_in_user', false ) ) {
-		error_log( 'jetpack_auto_fill_logged_in_user' );
+	// If no email, then prefill the email field with the current user's email if they are logged in
+	if ( empty( $subscribe_email ) ) {
 		$current_user = wp_get_current_user();
 		if ( ! empty( $current_user->user_email ) ) {
 			$subscribe_email = $current_user->user_email;
 		}
 	}
-	error_log( print_r( compact( 'subscribe_email' ), true ) );
 
 	// The block is using the Jetpack_Subscriptions_Widget backend, hence the need to increase the instance count.
 	++Jetpack_Subscriptions_Widget::$instance_count;
@@ -697,8 +695,6 @@ function render_block( $attributes ) {
 		'selected_newsletter_categories'    => get_attribute( $attributes, 'selectedNewsletterCategoryIds', array() ),
 		'preselected_newsletter_categories' => get_attribute( $attributes, 'preselectNewsletterCategories', false ),
 	);
-
-	error_log( print_r( compact( 'data' ), true ) );
 
 	if ( ! jetpack_is_frontend() ) {
 		return render_for_email( $data, $styles );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -642,14 +642,17 @@ function render_block( $attributes ) {
 	}
 
 	$subscribe_email = Jetpack_Memberships::get_current_user_email();
+	error_log( print_r( compact( 'subscribe_email' ), true ) );
 
 	/** This filter is documented in \Automattic\Jetpack\Forms\ContactForm\Contact_Form */
-	if ( is_wpcom() || false !== apply_filters( 'jetpack_auto_fill_logged_in_user', false ) ) {
+	if ( false !== apply_filters( 'jetpack_auto_fill_logged_in_user', false ) ) {
+		error_log( 'jetpack_auto_fill_logged_in_user' );
 		$current_user = wp_get_current_user();
 		if ( ! empty( $current_user->user_email ) ) {
 			$subscribe_email = $current_user->user_email;
 		}
 	}
+	error_log( print_r( compact( 'subscribe_email' ), true ) );
 
 	// The block is using the Jetpack_Subscriptions_Widget backend, hence the need to increase the instance count.
 	++Jetpack_Subscriptions_Widget::$instance_count;

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -695,6 +695,8 @@ function render_block( $attributes ) {
 		'preselected_newsletter_categories' => get_attribute( $attributes, 'preselectNewsletterCategories', false ),
 	);
 
+	error_log( print_r( compact( 'data' ), true ) );
+
 	if ( ! jetpack_is_frontend() ) {
 		return render_for_email( $data, $styles );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/loop/issues/400

The expected behavior is that it prefills your WPCOM email if you are logged in.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This removes the check on `jetpack_auto_fill_logged_in_user` filter when prefilling the logged in users email address

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a JN site
* On the JN site, connect JP and enable Newsletter module (so the Subscriber block is available in editor).
* Create a post with the Subscribe block
* Open WordPress.com incognito and log in
* Go to the post URL and confirm the WP email is prefilled in the subscribe email field.

