### PR TITLE
Offline Mode: activate using DB option

### DIFF
--- a/projects/packages/connection/changelog/add-offline-mode-db-option
+++ b/projects/packages/connection/changelog/add-offline-mode-db-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Indicate when Offline Mode is enabled via DB option.

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -476,6 +476,7 @@ class REST_Connector {
 				/** This filter is documented in packages/status/src/class-status.php */
 				'filter'          => ( apply_filters( 'jetpack_development_mode', false ) || apply_filters( 'jetpack_offline_mode', false ) ), // jetpack_development_mode is deprecated.
 				'wpLocalConstant' => defined( 'WP_LOCAL_DEV' ) && WP_LOCAL_DEV,
+				'option'          => get_option( 'jetpack_offline_mode' ),
 			),
 			'isPublic'          => '1' == get_option( 'blog_public' ), // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 		);

--- a/projects/packages/jitm/changelog/add-offline-mode-db-option
+++ b/projects/packages/jitm/changelog/add-offline-mode-db-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Adjust unit tests for the new Offline Mode DB option.

--- a/projects/packages/jitm/tests/php/Jetpack_JITM_Test.php
+++ b/projects/packages/jitm/tests/php/Jetpack_JITM_Test.php
@@ -38,6 +38,8 @@ class Jetpack_JITM_Test extends TestCase {
 	}
 
 	public function test_jitm_enabled_by_default() {
+		Functions\when( 'get_option' )->justReturn( false );
+
 		Functions\expect( 'apply_filters' )
 			->once()
 			->with( 'jetpack_just_in_time_msgs', true )
@@ -119,6 +121,8 @@ class Jetpack_JITM_Test extends TestCase {
 	 * method is called.
 	 */
 	public function test_register_jitm_action_fires_once() {
+		Functions\expect( 'get_option' )->with( 'jetpack_offline_mode' )->andReturn( false );
+
 		Functions\expect( 'get_option' )
 			->with( 'id' )
 			->andReturn( 123 );

--- a/projects/packages/status/changelog/add-offline-mode-db-option
+++ b/projects/packages/status/changelog/add-offline-mode-db-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add database option to enable Offline Mode.

--- a/projects/packages/status/src/class-status.php
+++ b/projects/packages/status/src/class-status.php
@@ -53,6 +53,10 @@ class Status {
 		 */
 		$offline_mode = (bool) apply_filters( 'jetpack_offline_mode', $offline_mode );
 
+		if ( ! $offline_mode ) {
+			$offline_mode = (bool) get_option( 'jetpack_offline_mode' );
+		}
+
 		Cache::set( 'is_offline_mode', $offline_mode );
 		return $offline_mode;
 	}

--- a/projects/packages/status/tests/php/Status_Test.php
+++ b/projects/packages/status/tests/php/Status_Test.php
@@ -99,6 +99,7 @@ class Status_Test extends TestCase {
 	 * @covers Automattic\Jetpack\Status::is_offline_mode
 	 */
 	public function test_is_offline_mode_default() {
+		Functions\expect( 'get_option' )->once()->with( 'jetpack_offline_mode' )->andReturn( false );
 		Filters\expectApplied( 'jetpack_offline_mode' )->once()->with( false )->andReturn( false );
 
 		$this->assertFalse( $this->status_obj->is_offline_mode() );
@@ -110,6 +111,7 @@ class Status_Test extends TestCase {
 	 * @covers Automattic\Jetpack\Status::is_offline_mode
 	 */
 	public function test_is_offline_mode_filter_true() {
+		Functions\expect( 'get_option' )->never();
 		Filters\expectApplied( 'jetpack_offline_mode' )->once()->with( false )->andReturn( true );
 
 		$this->assertTrue( $this->status_obj->is_offline_mode() );
@@ -121,6 +123,7 @@ class Status_Test extends TestCase {
 	 * @covers Automattic\Jetpack\Status::is_offline_mode
 	 */
 	public function test_is_offline_mode_filter_bool() {
+		Functions\expect( 'get_option' )->once()->with( 'jetpack_offline_mode' )->andReturn( false );
 		Filters\expectApplied( 'jetpack_offline_mode' )->once()->with( false )->andReturn( 0 );
 
 		$this->assertFalse( $this->status_obj->is_offline_mode() );
@@ -134,6 +137,7 @@ class Status_Test extends TestCase {
 	public function test_is_offline_mode_localhost() {
 		$this->site_url = 'localhost';
 
+		Functions\expect( 'get_option' )->never();
 		Filters\expectApplied( 'jetpack_offline_mode' )->once()->with( true )->andReturn( true );
 
 		$this->assertTrue( $this->status_obj->is_offline_mode() );
@@ -212,10 +216,33 @@ class Status_Test extends TestCase {
 	 * @runInSeparateProcess
 	 */
 	public function test_is_offline_mode_constant() {
+		Functions\expect( 'get_option' )->never();
 		Filters\expectApplied( 'jetpack_offline_mode' )->once()->with( true )->andReturn( true );
 		$this->mocked_constants['\\JETPACK_DEV_DEBUG'] = true;
 
 		$this->assertTrue( $this->status_obj->is_offline_mode() );
+	}
+
+	/**
+	 * Test that `is_offline_mode()` returns true when the `jetpack_offline_mode` option is set.
+	 *
+	 * @covers Automattic\Jetpack\Status::is_offline_mode
+	 */
+	public function test_is_offline_mode_option() {
+		Functions\expect( 'get_option' )->once()->with( 'jetpack_offline_mode' )->andReturn( '1' );
+
+		$this->assertTrue( $this->status_obj->is_offline_mode() );
+	}
+
+	/**
+	 * Test that `is_offline_mode()` returns false when the `jetpack_offline_mode` option exists, but set to '0'.
+	 *
+	 * @covers Automattic\Jetpack\Status::is_offline_mode
+	 */
+	public function test_is_offline_mode_option_inactive() {
+		Functions\expect( 'get_option' )->once()->with( 'jetpack_offline_mode' )->andReturn( '0' );
+
+		$this->assertFalse( $this->status_obj->is_offline_mode() );
 	}
 
 	/**
@@ -473,7 +500,7 @@ class Status_Test extends TestCase {
 	/** Data provider for test_cached */
 	public static function provide_cached() {
 		return array(
-			array( 'is_offline_mode', null, 'jetpack_offline_mode' ),
+			array( 'is_offline_mode', 'get_option', 'jetpack_offline_mode' ),
 			array( 'is_multi_network', 'is_multisite', null ),
 			array( 'is_single_user_site', 'get_transient', null ),
 			array( 'is_local_site', null, 'jetpack_is_local_site' ),

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/index.jsx
@@ -97,6 +97,9 @@ export class OfflineModeNotice extends React.Component {
 					__( 'Your site URL is a known local development environment URL', 'jetpack' )
 				);
 			}
+			if ( offlineMode.option ) {
+				reasons.push( __( 'The jetpack_offline_mode option is active', 'jetpack' ) );
+			}
 
 			const text = createInterpolateElement(
 				/* translators: reasons is an unordered list of reasons why a site may be in Offline mode. */

--- a/projects/plugins/jetpack/changelog/add-offline-mode-db-option
+++ b/projects/plugins/jetpack/changelog/add-offline-mode-db-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Display proper Offline Mode notices if enabled via DB option.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -1505,6 +1505,8 @@ class Jetpack {
 			/** This filter is documented in packages/status/src/class-status.php */
 		} elseif ( has_filter( 'jetpack_development_mode' ) && apply_filters( 'jetpack_development_mode', false ) ) { // This is a deprecated filter name.
 			$notice = __( 'The jetpack_development_mode filter is set to true.', 'jetpack' );
+		} elseif ( get_option( 'jetpack_offline_mode' ) ) {
+			$notice = __( 'The jetpack_offline_mode option is set to true.', 'jetpack' );
 		} else {
 			$notice = __( 'The jetpack_offline_mode filter is set to true.', 'jetpack' );
 		}

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_endpoints_Test.php
@@ -416,6 +416,7 @@ class Jetpack_REST_API_endpoints_Test extends WP_UnitTestCase {
 					'url'             => false,
 					'filter'          => false,
 					'wpLocalConstant' => false,
+					'option'          => false,
 				),
 			),
 			$response
@@ -451,6 +452,7 @@ class Jetpack_REST_API_endpoints_Test extends WP_UnitTestCase {
 					'url'             => false,
 					'filter'          => true,
 					'wpLocalConstant' => false,
+					'option'          => false,
 				),
 			),
 			$response


### PR DESCRIPTION
## Proposed changes:
* Utilize the `jetpack_offline_mode` DB option to activate Offline Mode.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
757-gh-Automattic/vulcan
p1741107156488199-slack-C0299DMPG

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect Jetpack. Confirm you don't see "Offline Mode" notice on the Jetpack Dashboard.
2. Set the option: `wp option set jetpack_offline_mode 1`
3. Visit Jetpack Dashboard, confirm you see the "Offline Mode" notice:
<img width="665" alt="Screenshot 2025-03-20 at 17 32 45" src="https://github.com/user-attachments/assets/949046b0-1b3f-4647-9f91-9484d8e2bfc1" />

4. Set the option to "0", confirm Offline Mode is turned off: `wp option set jetpack_offline_mode 0`
5. Remove the option, confirm it's still off.
6. Check the error log, confirm no errors were logged.