### PR TITLE
Admin Color Scheme: Fix the color of the Aquatic color scheme

### DIFF
--- a/projects/packages/masterbar/changelog/fix-aquatic-color-scheme
+++ b/projects/packages/masterbar/changelog/fix-aquatic-color-scheme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin Color Scheme: Fix the color of the Aquatic color scheme

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/_deprecated-color-variables.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/_deprecated-color-variables.scss
@@ -1,0 +1,14 @@
+// Legacy blue values were taken from https://github.com/Automattic/color-studio/pull/764/.
+$deprecated-studio-blue-0: #e9f0f5;
+$deprecated-studio-blue-5: #bbe0fa;
+$deprecated-studio-blue-10: #91caf2;
+$deprecated-studio-blue-20: #68b3e8;
+$deprecated-studio-blue-30: #399ce3;
+$deprecated-studio-blue-40: #1689db;
+$deprecated-studio-blue-50: #0675c4;
+$deprecated-studio-blue-60: #055d9c;
+$deprecated-studio-blue-70: #044b7a;
+$deprecated-studio-blue-80: #02395c;
+$deprecated-studio-blue-90: #01283d;
+$deprecated-studio-blue-100: #001621;
+$deprecated-studio-blue: $deprecated-studio-blue-50;

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/aquatic/_variables.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/aquatic/_variables.scss
@@ -1,10 +1,11 @@
 // make use of color studio variables for consistency across products
 @import 'node_modules/@automattic/color-studio/dist/color-variables.scss';
 @import 'node_modules/@automattic/color-studio/dist/color-variables-rgb.scss';
+@import '../deprecated-color-variables.scss';
 
 // core variables (core _variables.scss)
-$base-color: $studio-blue-80; // Calypso --color-masterbar-background
-$icon-color: $studio-blue-5; // Calypso --color-sidebar-gridicon-fill
+$base-color: $deprecated-studio-blue-80; // Calypso --color-masterbar-background
+$icon-color: $deprecated-studio-blue-5; // Calypso --color-sidebar-gridicon-fill
 $highlight-color: $studio-celadon-50; // Calypso --color-accent
 $notification-color: $studio-celadon-30; // Calypso --color-masterbar-unread-dot-background
 
@@ -13,32 +14,32 @@ $body-background: $studio-gray-0; // Calypso --color-surface-backdrop
 
 // admin menu & admin-bar (core _variables.scss)
 $menu-text: $studio-white; // Calypso --color-sidebar-text
-$menu-background: $studio-blue-60; // Calypso --color-sidebar-background
+$menu-background: $deprecated-studio-blue-60; // Calypso --color-sidebar-background
 $menu-highlight-text: $studio-white; // Calypso --color-sidebar-menu-hover-text
 $menu-highlight-icon: $studio-white;
-$menu-highlight-background: $studio-blue-50; // Calypso --color-sidebar-menu-hover-background
-$menu-current-text: $studio-blue-90; // Calypso --color-sidebar-menu-selected-text
+$menu-highlight-background: $deprecated-studio-blue-50; // Calypso --color-sidebar-menu-hover-background
+$menu-current-text: $deprecated-studio-blue-90; // Calypso --color-sidebar-menu-selected-text
 $menu-current-icon: $menu-current-text;
 $menu-current-background: $studio-yellow-20; // Calypso --color-sidebar-menu-selected-background
 $menu-submenu-text: $studio-gray-10; // Calypso --color-sidebar-submenu-text
-$menu-submenu-background: $studio-blue-90; // Calypso --color-sidebar-submenu-background
+$menu-submenu-background: $deprecated-studio-blue-90; // Calypso --color-sidebar-submenu-background
 $menu-submenu-focus-text: $studio-yellow-20; // Calypso --color-sidebar-submenu-hover-text
 $menu-submenu-current-text: $studio-white; // Calypso --color-sidebar-submenu-text
-$adminbar-avatar-frame: $studio-blue-80;
+$adminbar-avatar-frame: $deprecated-studio-blue-80;
 
 // masterbar overrides
-$masterbar-background: $studio-blue-80; // Calypso --color-masterbar-background
-$masterbar-highlight-background: $studio-blue-90; // Calypso --color-masterbar-item-hover-background
-$masterbar-active-background: $studio-blue-100; // Calypso --color-masterbar-item-active-background
+$masterbar-background: $deprecated-studio-blue-80; // Calypso --color-masterbar-background
+$masterbar-highlight-background: $deprecated-studio-blue-90; // Calypso --color-masterbar-item-hover-background
+$masterbar-active-background: $deprecated-studio-blue-100; // Calypso --color-masterbar-item-active-background
 
 // nav unification overrides
-$nav-unification-sidebar-border: $studio-blue-70; // Calypso --color-sidebar-border
-$nav-unification-sidebar-text-alternative: $studio-blue-5; // Calypso --color-sidebar-text-alternative
+$nav-unification-sidebar-border: $deprecated-studio-blue-70; // Calypso --color-sidebar-border
+$nav-unification-sidebar-text-alternative: $deprecated-studio-blue-5; // Calypso --color-sidebar-text-alternative
 
 // Calypso color variables used in e.g. inline help
-$color-primary: $studio-blue-50; // Calypso --color-primary
-$color-primary-dark: $studio-blue-70; // Calypso --color-primary-dark
-$color-primary-light: $studio-blue-30; // Calypso --color-primary-light
+$color-primary: $deprecated-studio-blue-50; // Calypso --color-primary
+$color-primary-dark: $deprecated-studio-blue-70; // Calypso --color-primary-dark
+$color-primary-light: $deprecated-studio-blue-30; // Calypso --color-primary-light
 $color-surface: $studio-white; // Calypso --color-surface
 $color-neutral-100-rgb: $studio-gray-100-rgb; // Calypso --color-neutral-100-rgb
 

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/classic-blue/_variables.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/classic-blue/_variables.scss
@@ -1,9 +1,10 @@
 // make use of color studio variables for consistency across products
 @import 'node_modules/@automattic/color-studio/dist/color-variables.scss';
 @import 'node_modules/@automattic/color-studio/dist/color-variables-rgb.scss';
+@import '../deprecated-color-variables.scss';
 
 // core variables (core _variables.scss)
-$base-color: $studio-blue-60; // Calypso --color-masterbar-background
+$base-color: $deprecated-studio-blue-60; // Calypso --color-masterbar-background
 $icon-color: $studio-gray-50; // Calypso --color-sidebar-gridicon-fill
 $highlight-color: $studio-orange-50; // Calypso --color-accent
 $notification-color: $studio-orange-30; // Calypso --color-masterbar-unread-dot-background
@@ -14,33 +15,33 @@ $body-background: $studio-gray-0; // Calypso --color-surface-backdrop
 // admin menu & admin-bar (core _variables.scss)
 $menu-text: $studio-gray-80; // Calypso --color-sidebar-text
 $menu-background: $studio-gray-5; // Calypso --color-sidebar-background
-$menu-highlight-text: $studio-blue-50; // Calypso --color-sidebar-menu-hover-text
-$menu-highlight-icon: $studio-blue-50;
+$menu-highlight-text: $deprecated-studio-blue-50; // Calypso --color-sidebar-menu-hover-text
+$menu-highlight-icon: $deprecated-studio-blue-50;
 $menu-highlight-background: $studio-white; // Calypso --color-sidebar-menu-hover-background
 $menu-current-text: $studio-white; // Calypso --color-sidebar-menu-selected-text
 $menu-current-icon: $menu-current-text;
 $menu-current-background: $studio-gray-60; // Calypso --color-sidebar-menu-selected-background
 $menu-submenu-text: $studio-white; // Calypso --color-sidebar-submenu-text
-$menu-submenu-background: $studio-blue-60; // Calypso --color-sidebar-submenu-background
+$menu-submenu-background: $deprecated-studio-blue-60; // Calypso --color-sidebar-submenu-background
 $menu-submenu-focus-text: $studio-orange-30; // Calypso --color-sidebar-submenu-hover-text
 $menu-submenu-current-text: $studio-white; // Calypso --color-sidebar-submenu-text
-$adminbar-avatar-frame: $studio-blue-70;
+$adminbar-avatar-frame: $deprecated-studio-blue-70;
 
 // masterbar overrides
-$masterbar-background: $studio-blue-60; // Calypso --color-masterbar-background
-$masterbar-highlight-background: $studio-blue-70; // Calypso --color-masterbar-item-hover-background
-$masterbar-active-background: $studio-blue-90; // Calypso --color-masterbar-item-active-background
-$masterbar-submenu-background: $studio-blue-70;
-$masterbar-submenu-background-alt: $studio-blue-80;
+$masterbar-background: $deprecated-studio-blue-60; // Calypso --color-masterbar-background
+$masterbar-highlight-background: $deprecated-studio-blue-70; // Calypso --color-masterbar-item-hover-background
+$masterbar-active-background: $deprecated-studio-blue-90; // Calypso --color-masterbar-item-active-background
+$masterbar-submenu-background: $deprecated-studio-blue-70;
+$masterbar-submenu-background-alt: $deprecated-studio-blue-80;
 
 // nav unification overrides
 $nav-unification-sidebar-border: $studio-gray-10; // Calypso --color-sidebar-border
 $nav-unification-sidebar-text-alternative: $studio-gray-50; // Calypso --color-sidebar-text-alternative
 
 // Calypso color variables used in e.g. inline help
-$color-primary: $studio-blue-50; // Calypso --color-primary
-$color-primary-dark: $studio-blue-70; // Calypso --color-primary-dark
-$color-primary-light: $studio-blue-30; // Calypso --color-primary-light
+$color-primary: $deprecated-studio-blue-50; // Calypso --color-primary
+$color-primary-dark: $deprecated-studio-blue-70; // Calypso --color-primary-dark
+$color-primary-light: $deprecated-studio-blue-30; // Calypso --color-primary-light
 $color-surface: $studio-white; // Calypso --color-surface
 $color-neutral-100-rgb: $studio-gray-100-rgb; // Calypso --color-neutral-100-rgb
 

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/classic-bright/_variables.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/classic-bright/_variables.scss
@@ -1,9 +1,10 @@
 // make use of color studio variables for consistency across products
 @import 'node_modules/@automattic/color-studio/dist/color-variables.scss';
 @import 'node_modules/@automattic/color-studio/dist/color-variables-rgb.scss';
+@import '../deprecated-color-variables.scss';
 
 // core variables (core _variables.scss)
-$base-color: $studio-blue-60; // Calypso --color-masterbar-background
+$base-color: $deprecated-studio-blue-60; // Calypso --color-masterbar-background
 $icon-color: $studio-gray-50; // Calypso --color-sidebar-gridicon-fill
 $highlight-color: $studio-pink-50; // Calypso --color-accent
 $notification-color: $studio-pink-20; // Calypso --color-masterbar-unread-dot-background
@@ -17,30 +18,30 @@ $menu-background: $studio-white; // Calypso --color-sidebar-background
 $menu-highlight-text: $studio-gray-90; // Calypso --color-sidebar-menu-hover-text
 $menu-highlight-icon: $studio-gray-90;
 $menu-highlight-background: $studio-gray-5; // Calypso --color-sidebar-menu-hover-background
-$menu-current-text: $studio-blue-70; // Calypso --color-sidebar-menu-selected-text
+$menu-current-text: $deprecated-studio-blue-70; // Calypso --color-sidebar-menu-selected-text
 $menu-current-icon: $menu-current-text;
-$menu-current-background: $studio-blue-5; // Calypso --color-sidebar-menu-selected-background
-$menu-submenu-text: $studio-blue-70; // Calypso --color-sidebar-submenu-text
-$menu-submenu-background: $studio-blue-0; // Calypso --color-sidebar-submenu-background
+$menu-current-background: $deprecated-studio-blue-5; // Calypso --color-sidebar-menu-selected-background
+$menu-submenu-text: $deprecated-studio-blue-70; // Calypso --color-sidebar-submenu-text
+$menu-submenu-background: $deprecated-studio-blue-0; // Calypso --color-sidebar-submenu-background
 $menu-submenu-focus-text: $studio-gray-90; // Calypso --color-sidebar-submenu-hover-text
 $menu-submenu-current-text: $studio-pink-50; // Calypso --color-sidebar-submenu-selected-text
-$adminbar-avatar-frame: $studio-blue-70;
+$adminbar-avatar-frame: $deprecated-studio-blue-70;
 
 // masterbar overrides
-$masterbar-background: $studio-blue-60; // Calypso --color-masterbar-background
-$masterbar-highlight-background: $studio-blue-70; // Calypso --color-masterbar-item-hover-background
-$masterbar-active-background: $studio-blue-90; // Calypso --color-masterbar-item-active-background
-$masterbar-submenu-background: $studio-blue-70;
-$masterbar-submenu-background-alt: $studio-blue-80;
+$masterbar-background: $deprecated-studio-blue-60; // Calypso --color-masterbar-background
+$masterbar-highlight-background: $deprecated-studio-blue-70; // Calypso --color-masterbar-item-hover-background
+$masterbar-active-background: $deprecated-studio-blue-90; // Calypso --color-masterbar-item-active-background
+$masterbar-submenu-background: $deprecated-studio-blue-70;
+$masterbar-submenu-background-alt: $deprecated-studio-blue-80;
 
 // nav unification overrides
 $nav-unification-sidebar-border: $studio-gray-5; // Calypso --color-sidebar-border
 $nav-unification-sidebar-text-alternative: $studio-gray-50; // Calypso --color-sidebar-text-alternative
 
 // Calypso color variables used in e.g. inline help
-$color-primary: $studio-blue-50; // Calypso --color-primary
-$color-primary-dark: $studio-blue-70; // Calypso --color-primary-dark
-$color-primary-light: $studio-blue-30; // Calypso --color-primary-light
+$color-primary: $deprecated-studio-blue-50; // Calypso --color-primary
+$color-primary-dark: $deprecated-studio-blue-70; // Calypso --color-primary-dark
+$color-primary-light: $deprecated-studio-blue-30; // Calypso --color-primary-light
 $color-surface: $studio-white; // Calypso --color-surface
 $color-neutral-100-rgb: $studio-gray-100-rgb; // Calypso --color-neutral-100-rgb
 

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/contrast/_variables.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/contrast/_variables.scss
@@ -1,11 +1,12 @@
 // make use of color studio variables for consistency across products
 @import 'node_modules/@automattic/color-studio/dist/color-variables.scss';
 @import 'node_modules/@automattic/color-studio/dist/color-variables-rgb.scss';
+@import '../deprecated-color-variables.scss';
 
 // core variables (core _variables.scss)
 $base-color: $studio-gray-100; // Calypso --color-masterbar-background
 $icon-color: $studio-gray-90; // Calypso --color-sidebar-gridicon-fill
-$highlight-color: $studio-blue-70;// Calypso --color-accent
+$highlight-color: $deprecated-studio-blue-70;// Calypso --color-accent
 $notification-color: $studio-yellow-20; // Calypso --color-masterbar-unread-dot-background
 
 // global (core _variables.scss)
@@ -47,4 +48,4 @@ $menu-nudge-background: $studio-gray-80;
 $menu-nudge-text-color: $studio-white;
 $menu-nudge-cta-background: $highlight-color;
 $menu-nudge-cta-color: $studio-white;
-$menu-nudge-cta-background-hover: $studio-blue-60;
+$menu-nudge-cta-background-hover: $deprecated-studio-blue-60;

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/nightfall/_variables.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/nightfall/_variables.scss
@@ -1,39 +1,40 @@
 // make use of color studio variables for consistency across products
 @import 'node_modules/@automattic/color-studio/dist/color-variables.scss';
 @import 'node_modules/@automattic/color-studio/dist/color-variables-rgb.scss';
+@import '../deprecated-color-variables.scss';
 
 // core variables (core _variables.scss)
-$base-color: $studio-blue-100; // Calypso --color-masterbar-background
-$icon-color: $studio-blue-10; // Calypso --color-sidebar-gridicon-fill
-$highlight-color: $studio-blue-50;// Calypso --color-accent
-$notification-color: $studio-blue-30; // Calypso --color-masterbar-unread-dot-background
+$base-color: $deprecated-studio-blue-100; // Calypso --color-masterbar-background
+$icon-color: $deprecated-studio-blue-10; // Calypso --color-sidebar-gridicon-fill
+$highlight-color: $deprecated-studio-blue-50;// Calypso --color-accent
+$notification-color: $deprecated-studio-blue-30; // Calypso --color-masterbar-unread-dot-background
 
 // global (core _variables.scss)
 $body-background: $studio-gray-0; // Calypso --color-surface-backdrop
 
 // admin menu & admin-bar (core _variables.scss)
-$menu-text: $studio-blue-5; // Calypso --color-sidebar-text
-$menu-background: $studio-blue-80; // Calypso --color-sidebar-background
+$menu-text: $deprecated-studio-blue-5; // Calypso --color-sidebar-text
+$menu-background: $deprecated-studio-blue-80; // Calypso --color-sidebar-background
 $menu-highlight-text: $studio-white; // Calypso --color-sidebar-menu-hover-text
 $menu-highlight-icon: $studio-white;
-$menu-highlight-background: $studio-blue-70; // Calypso --color-sidebar-menu-hover-background
+$menu-highlight-background: $deprecated-studio-blue-70; // Calypso --color-sidebar-menu-hover-background
 $menu-current-text: $studio-white; // Calypso --color-sidebar-menu-selected-text
 $menu-current-icon: $menu-current-text;
-$menu-current-background: $studio-blue-100; // Calypso --color-sidebar-menu-selected-background
+$menu-current-background: $deprecated-studio-blue-100; // Calypso --color-sidebar-menu-selected-background
 $menu-submenu-text: $studio-gray-10; // Calypso --color-sidebar-submenu-text
-$menu-submenu-background: $studio-blue-90; // Calypso --color-sidebar-submenu-background
-$menu-submenu-focus-text: $studio-blue-20; // Calypso --color-sidebar-submenu-hover-text
+$menu-submenu-background: $deprecated-studio-blue-90; // Calypso --color-sidebar-submenu-background
+$menu-submenu-focus-text: $deprecated-studio-blue-20; // Calypso --color-sidebar-submenu-hover-text
 $menu-submenu-current-text: $studio-white; // Calypso --color-sidebar-submenu-text
-$adminbar-avatar-frame: $studio-blue-100;
+$adminbar-avatar-frame: $deprecated-studio-blue-100;
 
 // masterbar overrides
-$masterbar-background: $studio-blue-100; // Calypso --color-masterbar-background
-$masterbar-highlight-background: $studio-blue-90; // Calypso --color-masterbar-item-hover-background
-$masterbar-active-background: $studio-blue-80; // Calypso --color-masterbar-item-active-background
+$masterbar-background: $deprecated-studio-blue-100; // Calypso --color-masterbar-background
+$masterbar-highlight-background: $deprecated-studio-blue-90; // Calypso --color-masterbar-item-hover-background
+$masterbar-active-background: $deprecated-studio-blue-80; // Calypso --color-masterbar-item-active-background
 
 // nav unification overrides
-$nav-unification-sidebar-border: $studio-blue-90; // Calypso --color-sidebar-border
-$nav-unification-sidebar-text-alternative: $studio-blue-20; // Calypso --color-sidebar-text-alternative
+$nav-unification-sidebar-border: $deprecated-studio-blue-90; // Calypso --color-sidebar-border
+$nav-unification-sidebar-text-alternative: $deprecated-studio-blue-20; // Calypso --color-sidebar-text-alternative
 
 // Calypso color variables used in e.g. inline help
 $color-primary: $studio-gray-90; // Calypso --color-primary
@@ -47,4 +48,4 @@ $menu-nudge-background: $studio-white;
 $menu-nudge-text-color: $studio-black;
 $menu-nudge-cta-background: $highlight-color;
 $menu-nudge-cta-color: $studio-white;
-$menu-nudge-cta-background-hover: $studio-blue-60;
+$menu-nudge-cta-background-hover: $deprecated-studio-blue-60;

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/powder-snow/_variables.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/powder-snow/_variables.scss
@@ -1,12 +1,13 @@
 // make use of color studio variables for consistency across products
 @import 'node_modules/@automattic/color-studio/dist/color-variables.scss';
 @import 'node_modules/@automattic/color-studio/dist/color-variables-rgb.scss';
+@import '../deprecated-color-variables.scss';
 
 // core variables (core _variables.scss)
 $base-color: $studio-gray-100; // Calypso --color-masterbar-background
 $icon-color: $studio-gray-50; // Calypso --color-sidebar-gridicon-fill
-$highlight-color: $studio-blue-50; // Calypso --color-accent
-$notification-color: $studio-blue-30; // Calypso --color-masterbar-unread-dot-background
+$highlight-color: $deprecated-studio-blue-50; // Calypso --color-accent
+$notification-color: $deprecated-studio-blue-30; // Calypso --color-masterbar-unread-dot-background
 
 // global (core _variables.scss)
 $body-background: $studio-gray-0; // Calypso --color-surface-backdrop
@@ -14,15 +15,15 @@ $body-background: $studio-gray-0; // Calypso --color-surface-backdrop
 // admin menu & admin-bar (core _variables.scss)
 $menu-text: $studio-gray-80; // Calypso --color-sidebar-text
 $menu-background: $studio-gray-5; // Calypso --color-sidebar-background
-$menu-highlight-text: $studio-blue-60; // Calypso --color-sidebar-menu-hover-text
-$menu-highlight-icon: $studio-blue-60;
+$menu-highlight-text: $deprecated-studio-blue-60; // Calypso --color-sidebar-menu-hover-text
+$menu-highlight-icon: $deprecated-studio-blue-60;
 $menu-highlight-background: $studio-white; // Calypso --color-sidebar-menu-hover-background
 $menu-current-text: $studio-white; // Calypso --color-sidebar-menu-selected-text
 $menu-current-icon: $menu-current-text;
 $menu-current-background: $studio-gray-60; // Calypso --color-sidebar-menu-selected-background
 $menu-submenu-text: $studio-gray-80; // Calypso --color-sidebar-submenu-text
 $menu-submenu-background: $studio-gray-10; // Calypso --color-sidebar-submenu-background
-$menu-submenu-focus-text: $studio-blue-60; // Calypso --color-sidebar-submenu-hover-text
+$menu-submenu-focus-text: $deprecated-studio-blue-60; // Calypso --color-sidebar-submenu-hover-text
 $menu-submenu-current-text: $studio-gray-80; // Calypso --color-sidebar-submenu-selected-text
 $adminbar-avatar-frame: $studio-gray-90;
 
@@ -49,4 +50,4 @@ $menu-nudge-background: $studio-white;
 $menu-nudge-text-color: $studio-black;
 $menu-nudge-cta-background: $highlight-color;
 $menu-nudge-cta-color: $studio-white;
-$menu-nudge-cta-background-hover: $studio-blue-60;
+$menu-nudge-cta-background-hover: $deprecated-studio-blue-60;

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/powder-snow/colors.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/powder-snow/colors.scss
@@ -34,7 +34,7 @@
 	#wpadminbar li.hover .ab-item:before,
 	#wpadminbar li:hover #adminbarsearch:before,
 	#wpadminbar li #adminbarsearch.adminbar-focused:before {
-		color: $studio-blue-30;
+		color: $deprecated-studio-blue-30;
 	}
 
 	#wpadminbar .ab-submenu .ab-item,
@@ -47,6 +47,6 @@
 	}
 
 	#wpadminbar #wp-admin-bar-user-info a:hover .display-name {
-		color: $studio-blue-30;
+		color: $deprecated-studio-blue-30;
 	}
 }

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/sakura/_variables.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/sakura/_variables.scss
@@ -1,11 +1,12 @@
 // make use of color studio variables for consistency across products
 @import 'node_modules/@automattic/color-studio/dist/color-variables.scss';
 @import 'node_modules/@automattic/color-studio/dist/color-variables-rgb.scss';
+@import '../deprecated-color-variables.scss';
 
 // core variables (core _variables.scss)
 $base-color: $studio-celadon-70; // Calypso --color-masterbar-background
 $icon-color: $studio-pink-70; // Calypso --color-sidebar-gridicon-fill
-$highlight-color: $studio-blue-50; // Calypso --color-accent
+$highlight-color: $deprecated-studio-blue-50; // Calypso --color-accent
 $notification-color: $studio-pink-20; // Calypso Classic Bright (!) --color-masterbar-unread-dot-background
 
 // global (core _variables.scss)
@@ -19,11 +20,11 @@ $menu-highlight-icon: $studio-pink-90;
 $menu-highlight-background: $studio-pink-10; // Calypso --color-sidebar-menu-hover-background
 $menu-current-text: $studio-white; // Calypso --color-sidebar-menu-selected-text
 $menu-current-icon: $studio-white;
-$menu-current-background: $studio-blue-50; // Calypso --color-sidebar-menu-selected-background
+$menu-current-background: $deprecated-studio-blue-50; // Calypso --color-sidebar-menu-selected-background
 $menu-submenu-text: $studio-pink-0; // Calypso --color-sidebar-submenu-text
 $menu-submenu-background: $studio-pink-90; // Calypso --color-sidebar-submenu-background
 $menu-submenu-background-alt: $studio-pink-70; // Calypso --color-sidebar-submenu-background-alt
-$menu-submenu-focus-text: $studio-blue-20; // Calypso --color-sidebar-submenu-hover-text
+$menu-submenu-focus-text: $deprecated-studio-blue-20; // Calypso --color-sidebar-submenu-hover-text
 $menu-submenu-current-text: $studio-pink-0; // Calypso --color-sidebar-submenu-selected-text
 $adminbar-avatar-frame: $studio-celadon-80;
 
@@ -50,4 +51,4 @@ $menu-nudge-background: $studio-white;
 $menu-nudge-text-color: $studio-black;
 $menu-nudge-cta-background: $highlight-color;
 $menu-nudge-cta-color: $studio-white;
-$menu-nudge-cta-background-hover: $studio-blue-60;
+$menu-nudge-cta-background-hover: $deprecated-studio-blue-60;

--- a/projects/plugins/jetpack/changelog/fix-aquatic-color-scheme
+++ b/projects/plugins/jetpack/changelog/fix-aquatic-color-scheme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Admin Color Scheme: Fix the color of the Aquatic color scheme

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-aquatic-color-scheme
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-aquatic-color-scheme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin Color Scheme: Fix the color of the Aquatic color scheme

--- a/projects/plugins/wpcomsh/changelog/fix-aquatic-color-scheme
+++ b/projects/plugins/wpcomsh/changelog/fix-aquatic-color-scheme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin Color Scheme: Fix the color of the Aquatic color scheme


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1742529883291399/1742515891.497679-slack-CRWCHQGUB
Related to https://github.com/Automattic/jetpack/pull/42449

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix the color of the Aquatic color scheme because of the upgrade of the `@automattic/color-studio`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to /wp-admin with the Aquatic color scheme
* Go through each places and ensure the colors look good