### PR TITLE
Social: Fix deprecation warnings for WP 6.6

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-deprecation-warnings-for-wp-6.6
+++ b/projects/js-packages/publicize-components/changelog/fix-social-deprecation-warnings-for-wp-6.6
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed deprecation warnings for edit-post package

--- a/projects/js-packages/publicize-components/src/components/block-editor/components/pre-publish-panels.tsx
+++ b/projects/js-packages/publicize-components/src/components/block-editor/components/pre-publish-panels.tsx
@@ -1,5 +1,5 @@
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils/components';
-import { PluginPrePublishPanel } from '@wordpress/edit-post';
+import { PluginPrePublishPanel } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { usePostCanUseSig } from '../../../hooks/use-post-can-use-sig';
 import useSocialMediaConnections from '../../../hooks/use-social-media-connections';
@@ -18,12 +18,7 @@ const PrePublishPanels = () => {
 		<>
 			<PluginPrePublishPanel
 				initialOpen={ hasEnabledConnections }
-				id="publicize-title"
-				title={
-					<span id="publicize-defaults" key="publicize-title-span">
-						{ __( 'Share this post', 'jetpack-publicize-components' ) }
-					</span>
-				}
+				title={ __( 'Share this post', 'jetpack-publicize-components' ) }
 				icon={ <JetpackEditorPanelLogo /> }
 			>
 				<PublicizePanel prePublish={ true }>

--- a/projects/js-packages/publicize-components/src/components/post-publish-manual-sharing/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-manual-sharing/index.tsx
@@ -1,7 +1,6 @@
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils/components';
 import { useSelect } from '@wordpress/data';
-import { PluginPostPublishPanel } from '@wordpress/edit-post';
-import { store as editorStore } from '@wordpress/editor';
+import { PluginPostPublishPanel, store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { ManualSharingInfo } from '../manual-sharing/info';
 import { ShareButtons } from '../share-buttons/share-buttons';
@@ -22,7 +21,6 @@ export default function PostPublishManualSharing() {
 		<PluginPostPublishPanel
 			initialOpen
 			title={ __( 'Manual sharing', 'jetpack-publicize-components' ) }
-			id="publicize-manual-sharing"
 			icon={ <JetpackEditorPanelLogo /> }
 		>
 			<ManualSharingInfo className={ styles.description } variant="body-small" />

--- a/projects/js-packages/publicize-components/src/components/post-publish-review-prompt/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-review-prompt/index.tsx
@@ -1,6 +1,6 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import apiFetch from '@wordpress/api-fetch';
-import { PluginPostPublishPanel } from '@wordpress/edit-post';
+import { PluginPostPublishPanel } from '@wordpress/editor';
 import { useCallback, useState } from '@wordpress/element';
 import usePublicizeConfig from '../../hooks/use-publicize-config';
 import { usePostStartedPublishing } from '../../hooks/use-saving-post';
@@ -44,7 +44,7 @@ const PostPublishReviewPrompt = () => {
 	}
 
 	return (
-		<PluginPostPublishPanel id="publicize-title">
+		<PluginPostPublishPanel>
 			<ReviewPrompt
 				href={ getRedirectUrl( 'jetpack-social-plugin-reviews' ) }
 				onClose={ handleReviewDismiss }

--- a/projects/js-packages/publicize-components/src/components/post-publish-share-status/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-share-status/index.tsx
@@ -1,6 +1,5 @@
 import { useDispatch, useSelect } from '@wordpress/data';
-import { PluginPostPublishPanel } from '@wordpress/edit-post';
-import { store as editorStore } from '@wordpress/editor';
+import { PluginPostPublishPanel, store as editorStore } from '@wordpress/editor';
 import { useIsSharingPossible } from '../../hooks/use-is-sharing-possible';
 import { usePostMeta } from '../../hooks/use-post-meta';
 import { usePostPrePublishValue } from '../../hooks/use-post-pre-publish-value';
@@ -52,7 +51,7 @@ export function PostPublishShareStatus() {
 	}
 
 	return (
-		<PluginPostPublishPanel id="publicize-share-status">
+		<PluginPostPublishPanel>
 			<ShareStatus />
 		</PluginPostPublishPanel>
 	);


### PR DESCRIPTION
Related to #37713

In the editor, we have some warnings like

```
wp.editPost.PluginPrePublishPanel is deprecated since version 6.6.
Please use wp.editor.PluginPrePublishPanel instead.
```

```
wp.editPost.PluginPostPublishPanel is deprecated since version 6.6.
Please use wp.editor.PluginPostPublishPanel instead.
```

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix deprecation warnings in publicize-components for edit-post package for WP 6.6

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Activate the Social plugin and deactivate Jetpack
- Create a new post using the block editor
- Open Social sidebar
- Confirm that all is well
- Click on Publish
- Notice the pre-publish panel
- Confirm that the Social UI looks fine
- Publish the post
- Notice the post-publish panel
- Confirm that it looks fine
- Confirm that there are no warnings mentioned above
