### PR TITLE
Fix/disable email address change emails

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-disable-email-address-change-emails
+++ b/projects/plugins/wpcomsh/changelog/fix-disable-email-address-change-emails
@@ -1,5 +1,3 @@
 Significance: patch
 Type: fixed
-Comment: When a user's email address is changed from wordpress.com/me/account they receive email notifications from all atomic sites under their account.
-
-
+Comment: Previously, when a user changed their email address from WordPress.com Account Settings, they received email notifications from all Atomic sites linked to their account. This update prevents unnecessary notifications by disabling the send_email_change_email filter.

--- a/projects/plugins/wpcomsh/changelog/fix-disable-email-address-change-emails
+++ b/projects/plugins/wpcomsh/changelog/fix-disable-email-address-change-emails
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: When a user's email address is changed from wordpress.com/me/account they receive email notifications from all atomic sites under their account.
+
+

--- a/projects/plugins/wpcomsh/functions.php
+++ b/projects/plugins/wpcomsh/functions.php
@@ -427,3 +427,10 @@ add_filter( 'wpcom_newsletter_categories_location', 'wpcomsh_newsletter_categori
  * Enables new likes layout on Atomic.
  */
 add_filter( 'likes_new_layout', '__return_true' );
+
+/**
+ * Disable email notification when a user's email address is changed.
+ *
+ * @see https://github.com/Automattic/wp-calypso/issues/100279
+ */
+add_filter( 'send_email_change_email', '__return_false' );


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Prevents email change notifications from being sent to all Atomic sites when a user updates their email via WordPress.com.
Implements the send_email_change_email filter to disable these notifications.

## Fixes
Previously, when a user changed their email from [WordPress.com Account Settings](https://wordpress.com/me/account), they received unnecessary email notifications from all Atomic sites under their account. This update stops that behavior.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your WoA site(p9o2xV-1r2-p2)
* Go to [WordPress.com Account Settings](https://wordpress.com/me/account).
* Update your email address.
* Check your new email inbox for a verification email and confirm the change.
* Ensure that no email notifications with the subject "[Your Site Name] Email Changed" are sent to your old email address from the WoA testing site.

