### PR TITLE
WordPress 6.8 Compatibility: Replace ButtonGroup usage in AI Client package

### DIFF
--- a/projects/js-packages/ai-client/changelog/replace-buttongroup-usage-ai-client
+++ b/projects/js-packages/ai-client/changelog/replace-buttongroup-usage-ai-client
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Controls: Increase compatibility of buttons, preventing console warnings.

--- a/projects/js-packages/ai-client/src/components/ai-control/block-ai-control.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/block-ai-control.tsx
@@ -224,7 +224,7 @@ export function BlockAIControl(
 			{ showAccept && ! editRequest && (
 				<div className="jetpack-components-ai-control__controls-prompt_button_wrapper">
 					{ ( value?.length > 0 || lastValue === null ) && (
-						<Flex gap={ 1 } className="jetpack-components-ai-control__button-group">
+						<Flex gap={ 1 } role="group" className="jetpack-components-ai-control__button-group">
 							<Button
 								className="jetpack-components-ai-control__controls-prompt_button"
 								label={ __( 'Discard', 'jetpack-ai-client' ) }

--- a/projects/js-packages/ai-client/src/components/ai-control/block-ai-control.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/block-ai-control.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Button, ButtonGroup } from '@wordpress/components';
+import { Button, Flex } from '@wordpress/components';
 import { useKeyboardShortcut } from '@wordpress/compose';
 import { useImperativeHandle, useRef, useEffect, useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -224,7 +224,7 @@ export function BlockAIControl(
 			{ showAccept && ! editRequest && (
 				<div className="jetpack-components-ai-control__controls-prompt_button_wrapper">
 					{ ( value?.length > 0 || lastValue === null ) && (
-						<ButtonGroup>
+						<Flex gap={ 1 } className="jetpack-components-ai-control__button-group">
 							<Button
 								className="jetpack-components-ai-control__controls-prompt_button"
 								label={ __( 'Discard', 'jetpack-ai-client' ) }
@@ -242,7 +242,7 @@ export function BlockAIControl(
 							>
 								<Icon icon={ regenerate } />
 							</Button>
-						</ButtonGroup>
+						</Flex>
 					) }
 					<Button
 						className="jetpack-components-ai-control__controls-prompt_button"

--- a/projects/js-packages/ai-client/src/components/ai-control/extension-ai-control.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/extension-ai-control.tsx
@@ -190,7 +190,7 @@ export function ExtensionAIControl(
 					) }
 					{ isDone && (
 						<div className="jetpack-components-ai-control__controls-prompt_button_wrapper">
-							<Flex gap={ 1 } className="jetpack-components-ai-control__button-group">
+							<Flex gap={ 1 } role="group" className="jetpack-components-ai-control__button-group">
 								<Button
 									className="jetpack-components-ai-control__controls-prompt_button"
 									label={ __( 'Undo', 'jetpack-ai-client' ) }

--- a/projects/js-packages/ai-client/src/components/ai-control/extension-ai-control.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/extension-ai-control.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Button, ButtonGroup } from '@wordpress/components';
+import { Button, Flex } from '@wordpress/components';
 import { useKeyboardShortcut } from '@wordpress/compose';
 import { useImperativeHandle, useRef, useEffect, useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -190,7 +190,7 @@ export function ExtensionAIControl(
 					) }
 					{ isDone && (
 						<div className="jetpack-components-ai-control__controls-prompt_button_wrapper">
-							<ButtonGroup>
+							<Flex gap={ 1 } className="jetpack-components-ai-control__button-group">
 								<Button
 									className="jetpack-components-ai-control__controls-prompt_button"
 									label={ __( 'Undo', 'jetpack-ai-client' ) }
@@ -207,7 +207,7 @@ export function ExtensionAIControl(
 								>
 									{ __( 'Close', 'jetpack-ai-client' ) }
 								</Button>
-							</ButtonGroup>
+							</Flex>
 						</div>
 					) }
 				</>

--- a/projects/plugins/jetpack/changelog/replace-buttongroup-usage-ai-client
+++ b/projects/plugins/jetpack/changelog/replace-buttongroup-usage-ai-client
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Controls: Increase compatibility of buttons, preventing console warnings.


### PR DESCRIPTION
Part of https://github.com/Automattic/jetpack/issues/42579

## Proposed changes:

* This PR replaces the `ButtonGroup` component in the AI Client package `BlockAiControl` and `ExtensionAIControl`, with `Flex` components. This was chosen as there is no impact on styling with the switch.
* This should also prevent console warnings when testing with WordPress 6.8 - `wp.components.ButtonGroup is deprecated since version 6.8. Please use wp.components.__experimentalToggleGroupControl instead`


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Checked in on Slack: p1742546688814569-slack-C02TQF5VAJD


## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

On trunk, in a local development environment:
* To test these components, I found the best way was via Story Book (I was unable to test directly on a site). To view the components, run `cd projects/js-packages/storybook && pnpm run storybook:dev`. Story book should open in a new tab in your current browser.
* Navigate to `AI client` > `AI control` > `Block AI control` > `Default`. Make note of how it looks and behaves.
* Do the same for `AI client` > `AI control` > Extension AI control` > `Default`.
* In doing this I don't believe you can replicate the console warnings, but we can focus on the component itself.

Then apply this PR in the local development environment. Follow the same steps as above - the components should look and behave as before.