### PR TITLE
Forms: Fix `source` filtering in classic view for responses management

### DIFF
--- a/projects/packages/forms/changelog/forms-fix-admin-source-filter
+++ b/projects/packages/forms/changelog/forms-fix-admin-source-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix `source` filtering in classic view for responses management

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -862,8 +862,13 @@ class Admin {
 			return;
 		}
 
-		// Don't apply to the filter dropdown query
-		if ( $query->query_vars['fields'] === 'id=>parent' ) {
+		/**
+		 * In the wp-admin list we perform two queries that trigger the `pre_get_posts` hook.
+		 * One is for the main list and the other is for the `source` dropdown filter.
+		 * We need to explicitly check one unique parameter between the two queries to avoid
+		 * filtering the dropdown query. The dropdown query is in `get_all_parent_post_ids`.
+		 */
+		if ( $query->query_vars['posts_per_page'] === 100000 ) {
 			return;
 		}
 


### PR DESCRIPTION


Fixes https://github.com/Automattic/jetpack/issues/42599

>Within simple and atomic sites, filtering form responses by the "All sources" dropdown menu does not filter correctly. There is no change to the results. This affects the classic wp-admin list.

### Proposed changes:

In the `wp-admin` list we perform two queries that trigger the `pre_get_posts` hook. One is for the main list and the other is for the `source` dropdown filter. We need to explicitly check one unique parameter between the two queries to avoid  filtering the dropdown query. The dropdown query is in `get_all_parent_post_ids`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
1. Visit the forms responses management (`/wp-admin/edit.php?post_type=feedback`) and make sure you're in the `classic` view
2. Update a `source` filter
3. Observe the results and the `source` filter options are displayed as expected.

