### PR TITLE
Rename the variable used to check the main import page

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-var-name-import-screen
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-var-name-import-screen
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Simply rename a variable used on the import page for clarity.

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -12,11 +12,11 @@ function import_page_customizations_init() {
 	$screen = get_current_screen();
 
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no changes made to the site.
-	$has_import_param = ! isset( $_GET['import'] );
+	$is_main_import_page = ! isset( $_GET['import'] );
 
-	if ( $screen && $screen->id === 'import' && $has_import_param ) {
-			add_action( 'admin_notices', 'import_admin_banner' );
-			add_action( 'admin_enqueue_scripts', 'import_admin_banner_css' );
+	if ( $screen && $screen->id === 'import' && $is_main_import_page ) {
+		add_action( 'admin_notices', 'import_admin_banner' );
+		add_action( 'admin_enqueue_scripts', 'import_admin_banner_css' );
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/101628#issuecomment-2743433798

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Simply fixes a variable name that means the opposite of what it should. We need to check that the user is not in the main import page, and we achieve that by checking that the `import` URL parameter is not set.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Visual inspection should be enough.

