### PR TITLE
Publicize: Fix the Jetpack plugin version check

### DIFF
--- a/projects/packages/publicize/changelog/fix-publicize-jetpack-version-check
+++ b/projects/packages/publicize/changelog/fix-publicize-jetpack-version-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Publicize: Update the Jetpack plugin version check

--- a/projects/packages/publicize/src/class-publicize-assets.php
+++ b/projects/packages/publicize/src/class-publicize-assets.php
@@ -52,7 +52,7 @@ class Publicize_Assets {
 
 		// We don't want to render the Social UI in Jetpack sidebar
 		// if Jetpack is old, which has it bundled.
-		if ( defined( 'JETPACK__VERSION' ) && ( version_compare( (string) JETPACK__VERSION, '14.4-a.7', '<=' ) ) ) {
+		if ( defined( 'JETPACK__VERSION' ) && ( version_compare( (string) JETPACK__VERSION, '14.5-a.1', '<' ) ) ) {
 			return;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/jetpack-reach#892

## Proposed changes:
In order to know whether to load the new package versions of the editor sidebar code, we check the Jetpack version. Previously we were checking for less than or equal to 14.4-a.7, but it seems that the change didn't make the 14.4 cut at all, and there has been a point release 14.4.1, so it seems like that should contain the new code, when it doesn't.

This updates the version check to 14.5-a.1, which was the first release with the new Publicize package.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a test site running Jetpack 14.4.1 and the Jetpack Social Release Candidate
* Connect the site and a social account
* Create a new post and open the Jetpack sidebar. The editor will crash
* Swap to this branch for Jetpack Social, and the issue should be resolved, but the Social panel in the sidebar will be the old version bundled with Jetpack.



