### PR TITLE
SEO Enhancer: Do not request Jetpack modules data on Simple sites

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-seo-enhancer-simple-request
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-seo-enhancer-simple-request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+SEO Enhancer: Do not request Jetpack modules data on Simple sites


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #42648 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a check for `isSimpleSite()` before getting the module settings

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox a simple site with this PR
* Go to the block editor with the network tab open
* Filter for `all?` and see that there are no requests where previously there was a request with a `404` response
* Enable the feature on your sandbox with `add_filter( 'ai_seo_enhancer_enabled', '__return_true' );`
* Reload the editor
* Check that the request is still not made
* Check that you can still use the SEO generation manually in the SEO section of the Jetpack sidebar
