### PR TITLE
Jetpack SEO: hide enhancer trigger button when toggle is on

### DIFF
--- a/projects/plugins/jetpack/changelog/change-jetpack-seo-enhancer-hide-trigger-button
+++ b/projects/plugins/jetpack/changelog/change-jetpack-seo-enhancer-hide-trigger-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack SEO Enhancer: hide trigger button when auto-generate toggle is on

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
@@ -114,19 +114,21 @@ export function SeoEnhancer( { disableAutoEnhance = false }: { disableAutoEnhanc
 					) }
 				</BaseControl>
 			</PanelRow>
-			<PanelRow className="jetpack-seo-sidebar__feature-section">
-				<BaseControl __nextHasNoMarginBottom={ true } className="ai-seo-enhancer-toggle">
-					<Button
-						isBusy={ isLoading }
-						disabled={ isLoading }
-						onClick={ generateHandler }
-						variant="secondary"
-						__next40pxDefaultSize
-					>
-						{ __( 'Generate metadata', 'jetpack' ) }
-					</Button>
-				</BaseControl>
-			</PanelRow>
+			{ ! isEnabled && (
+				<PanelRow className="jetpack-seo-sidebar__feature-section">
+					<BaseControl __nextHasNoMarginBottom={ true } className="ai-seo-enhancer-toggle">
+						<Button
+							isBusy={ isLoading }
+							disabled={ isLoading }
+							onClick={ generateHandler }
+							variant="secondary"
+							__next40pxDefaultSize
+						>
+							{ __( 'Generate metadata', 'jetpack' ) }
+						</Button>
+					</BaseControl>
+				</PanelRow>
+			) }
 		</>
 	);
 }


### PR DESCRIPTION
## Proposed changes:
This PR addresses a design issue where the manual trigger button should not be shown when the auto-generate toggle is on

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-wgI-p2
p1HpG7-wgI-p2#comment-75941

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Enable the feature with the filter `add_filter( 'ai_seo_enhancer_enabled', '__return_true' );` and switch to Beta blocks variation.

Go to the editor and check that the trigger button is only shown when the toggle is off. This should happen both on Jetpack sidebar as well as on PrePublish sidebar.