### PR TITLE
Add object-cache-pro and variation of wp-simple-firewall to incompatible plugins

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-object-cache-pro-to-incompatible-plugins
+++ b/projects/plugins/wpcomsh/changelog/add-object-cache-pro-to-incompatible-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Incompatible Plugins: added object-cache-pro and variation of wp-simple-firewall

--- a/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
+++ b/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
@@ -73,6 +73,7 @@ class Jetpack_Plugin_Compatibility {
 		'comet-cache/comet-cache.php'                      => '"comet-cache" has been deactivated, WordPress.com automatically handles caching for your site.',
 		'hyper-cache/plugin.php'                           => '"hyper-cache" has been deactivated, WordPress.com automatically handles caching for your site.',
 		'jch-optimize/jch-optimize.php'                    => '"jch-optimize" has been deactivated, WordPress.com automatically handles caching for your site.',
+		'object-cache-pro/object-cache-pro.php'            => '"object-cache-pro" has been deactivated, WordPress.com automatically handles caching for your site.',
 		'performance-lab/load.php'                         => '"performance-lab" has been deactivated, WordPress.com automatically handles caching and database optimization for your site.',
 		'powered-cache/powered-cache.php'                  => '"powered-cache" has been deactivated, WordPress.com automatically handles caching for your site.',
 		'quick-cache/quick-cache.php'                      => '"quick-cache" has been deactivated, WordPress.com automatically handles caching for your site.',
@@ -127,6 +128,7 @@ class Jetpack_Plugin_Compatibility {
 		'wp-hide-security-enhancer/wp-hide.php'            => '"wp-hide-security-enhancer" has been deactivated, "security" related plugins may break your site or cause performance issues for your site and are not supported on WordPress.com.',
 		'wp-security-hardening/wp-hardening.php'           => '"wp-security-hardening" has been deactivated. It breaks WordPress.com required plugins.', // p9F6qB-66o-p2
 		'wp-simple-firewall/wp-simple-firewall.php'        => '"wp-simple-firewall" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
+		'wp-simple-firewall/icwp-wpsf.php'                 => '"wp-simple-firewall" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 
 		// Spam.
 		'e-mail-broadcasting/e-mail-broadcasting.php'      => '"e-mail-broadcasting" has been deactivated, plugins that support sending e-mails in bulk are not supported on WordPress.com.',


### PR DESCRIPTION
## Proposed changes:
* Added object-cache-pro as it relies on Redis and causes fatals
* Added variation of wp-simple-firewall that use icwp-wpsf.php as the file name in latest version

## Testing instructions:
1. Create a new Business Plan site, mark it as a WoA Dev site, and take it Atomic.
2. Build wpcomsh plugin and synchronize to the WoA Dev site

```
git checkout BRANCH
composer install
WPCOMSH_DEVMODE=1 make clean build
rsync -avze ssh --delete build/wpcomsh USERNAME@sftp.wp.com:htdocs/wp-content/mu-plugins
```

3. SSH into the WoA dev site, and run: `wp plugin install wp-simple-firewall --activate`
4. Navigate to the WoA dev site's `/wp-admin/plugins.php` page and confirm that the Shield Security is disabled.

object-cache-pro is a paid plugin and can't be tested unless having a copy: https://objectcache.pro/

## Does this pull request change what data or activity we track or use?

No
