### PR TITLE
Video block: Fix video upload reload issue

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-video-upload-reload
+++ b/projects/plugins/jetpack/changelog/fix-video-upload-reload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Video upload: fix video upload reload

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -94,7 +94,7 @@ const VideoPressEdit = CoreVideoEdit =>
 			if ( state.fileForUpload && ! state.isEditingWhileUploading ) {
 				const isResumableUploading =
 					null !== state.fileForUpload && state.fileForUpload instanceof File;
-				if ( isResumableUploading ) {
+				if ( isResumableUploading || state.pendingVideoAttributes ) {
 					newState.isEditingWhileUploading = true;
 				}
 			} else if (

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -90,12 +90,20 @@ const VideoPressEdit = CoreVideoEdit =>
 				newState.interactive = false;
 			}
 
+			// Ensure we preserve isEditingWhileUploading state during upload
 			if ( state.fileForUpload && ! state.isEditingWhileUploading ) {
 				const isResumableUploading =
 					null !== state.fileForUpload && state.fileForUpload instanceof File;
 				if ( isResumableUploading ) {
 					newState.isEditingWhileUploading = true;
 				}
+			} else if (
+				state.isEditingWhileUploading &&
+				! state.fileForUpload &&
+				state.pendingVideoAttributes
+			) {
+				// Keep editing state active if we have pending attributes
+				newState.isEditingWhileUploading = true;
 			}
 
 			return Object.keys( newState ).length ? newState : null;

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -74,6 +74,7 @@ const VideoPressEdit = CoreVideoEdit =>
 				isEditingWhileUploading: false,
 				isUploadComplete: false,
 				lastPosterValueSource: '',
+				pendingVideoAttributes: null,
 			};
 			this.posterImageButton = createRef();
 			this.previewCacheReloadTimer = null;
@@ -748,11 +749,12 @@ const VideoPressEdit = CoreVideoEdit =>
 					fileForUpload: null,
 					isUploadComplete: !! mediaId,
 					isEditingWhileUploading: mediaId ? this.state.isEditingWhileUploading : false,
+					// Store video attributes to apply them later when user clicks Done
+					pendingVideoAttributes:
+						mediaId && videoGuid && videoSrc
+							? { id: mediaId, guid: videoGuid, src: videoSrc }
+							: null,
 				} );
-
-				if ( mediaId && videoGuid && videoSrc ) {
-					setAttributes( { id: mediaId, guid: videoGuid, src: videoSrc } );
-				}
 			};
 
 			const onChangeTitle = newTitle => {
@@ -857,7 +859,15 @@ const VideoPressEdit = CoreVideoEdit =>
 			};
 
 			const dismissEditor = () => {
-				this.setState( { isEditingWhileUploading: false } );
+				// Apply any pending video attributes before dismissing
+				if ( this.state.pendingVideoAttributes ) {
+					setAttributes( this.state.pendingVideoAttributes );
+				}
+
+				this.setState( {
+					isEditingWhileUploading: false,
+					pendingVideoAttributes: null,
+				} );
 				saveEditorData();
 			};
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -94,14 +94,10 @@ const VideoPressEdit = CoreVideoEdit =>
 			if ( state.fileForUpload && ! state.isEditingWhileUploading ) {
 				const isResumableUploading =
 					null !== state.fileForUpload && state.fileForUpload instanceof File;
-				if ( isResumableUploading || state.pendingVideoAttributes ) {
+				if ( isResumableUploading ) {
 					newState.isEditingWhileUploading = true;
 				}
-			} else if (
-				state.isEditingWhileUploading &&
-				! state.fileForUpload &&
-				state.pendingVideoAttributes
-			) {
+			} else if ( state.pendingVideoAttributes ) {
 				// Keep editing state active if we have pending attributes
 				newState.isEditingWhileUploading = true;
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/26703

## Proposed changes:
* Fixes the issue with auto-reload/render core/video block when the upload is finished.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/jetpack/issues/26703

## Does this pull request change what data or activity we track or use?

Nope

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox; you can [follow instructions](https://github.com/Automattic/jetpack/pull/42655#issuecomment-2744069693)
* Open post/page editor
* Add core/video block
* Upload a video file
* Check if the "Done" button is appeared 
* Please test it on both `Simple` and `WoA` environments

For more details, check: https://github.com/Automattic/jetpack/issues/26703

<img width="722" alt="Screenshot 2025-03-23 at 20 32 52" src="https://github.com/user-attachments/assets/7fb2e59d-4976-4ad2-ab1d-e6af54a6efa3" />
