### PR TITLE
Newsletter Widget: add Tracks events

### DIFF
--- a/projects/plugins/jetpack/changelog/add-tracks-newsletter-widget
+++ b/projects/plugins/jetpack/changelog/add-tracks-newsletter-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Newsletter Widget: add Tracks events

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/components/newsletter-widget.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/components/newsletter-widget.tsx
@@ -1,10 +1,17 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import '../style.scss';
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { ExternalLink, Icon } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useEffect } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { envelope, payment } from '@wordpress/icons';
-import { buildJPRedirectSource, formatNumber, getSubscriberStatsUrl } from '../helpers';
+import { TRACKS_EVENT_NAME_PREFIX } from '../constants';
+import {
+	buildJPRedirectSource,
+	createTracksEventHandler,
+	formatNumber,
+	getSubscriberStatsUrl,
+} from '../helpers';
 import { SubscribersChart } from './subscribers-chart';
 import type { SubscriberTotalsByDate } from '../types';
 
@@ -32,6 +39,12 @@ export const NewsletterWidget = ( {
 		day => day?.all >= 5 || day?.paid > 0
 	);
 
+	const { tracks } = useAnalytics();
+
+	useEffect( () => {
+		tracks.recordEvent( `${ TRACKS_EVENT_NAME_PREFIX }_view` );
+	}, [ tracks ] );
+
 	return (
 		<div className="newsletter-widget">
 			{ showHeader && (
@@ -43,7 +56,10 @@ export const NewsletterWidget = ( {
 							</span>
 							<span className="newsletter-widget__stat-content">
 								<span className="newsletter-widget__stat-label">
-									<a href={ getSubscriberStatsUrl( site, isWpcomSite, adminUrl ) }>
+									<a
+										href={ getSubscriberStatsUrl( site, isWpcomSite, adminUrl ) }
+										onClick={ createTracksEventHandler( tracks, 'all_subscribers_click' ) }
+									>
 										{ sprintf(
 											//translators: %1$s is the total number of subscribers, %2$s is the number of email subscribers
 											_n(
@@ -65,7 +81,10 @@ export const NewsletterWidget = ( {
 							</span>
 							<span className="newsletter-widget__stat-content">
 								<span className="newsletter-widget__stat-label">
-									<a href={ getSubscriberStatsUrl( site, isWpcomSite, adminUrl ) }>
+									<a
+										href={ getSubscriberStatsUrl( site, isWpcomSite, adminUrl ) }
+										onClick={ createTracksEventHandler( tracks, 'paid_subscribers_click' ) }
+									>
 										{ sprintf(
 											//translators: %s is the number of paid subscribers
 											_n( '%s paid subscriber', '%s paid subscribers', paidSubscribers, 'jetpack' ),
@@ -94,6 +113,7 @@ export const NewsletterWidget = ( {
 						{
 							link: (
 								<ExternalLink
+									onClick={ createTracksEventHandler( tracks, 'learn_more_click' ) }
 									href={ getRedirectUrl(
 										buildJPRedirectSource(
 											'learn/courses/newsletters-101/wordpress-com-newsletter'
@@ -108,12 +128,18 @@ export const NewsletterWidget = ( {
 					<h3 className="newsletter-widget__heading">{ __( 'Quick Links', 'jetpack' ) }</h3>
 					<ul className="newsletter-widget__footer-list">
 						<li>
-							<a href={ `${ adminUrl }post-new.php` }>
+							<a
+								href={ `${ adminUrl }post-new.php` }
+								onClick={ createTracksEventHandler( tracks, 'publish_post_click' ) }
+							>
 								{ __( 'Publish your next post', 'jetpack' ) }
 							</a>
 						</li>
 						<li>
-							<ExternalLink href={ getSubscriberStatsUrl( site, isWpcomSite, adminUrl ) }>
+							<ExternalLink
+								href={ getSubscriberStatsUrl( site, isWpcomSite, adminUrl ) }
+								onClick={ createTracksEventHandler( tracks, 'view_stats_click' ) }
+							>
 								{ __( 'View subscriber stats', 'jetpack' ) }
 							</ExternalLink>
 						</li>
@@ -123,6 +149,7 @@ export const NewsletterWidget = ( {
 									buildJPRedirectSource( `subscribers/${ site }`, isWpcomSite ),
 									{ anchor: 'add-subscribers' }
 								) }
+								onClick={ createTracksEventHandler( tracks, 'import_subscribers_click' ) }
 							>
 								{ __( 'Import subscribers', 'jetpack' ) }
 							</ExternalLink>
@@ -132,6 +159,7 @@ export const NewsletterWidget = ( {
 								href={ getRedirectUrl(
 									buildJPRedirectSource( `subscribers/${ site }`, isWpcomSite )
 								) }
+								onClick={ createTracksEventHandler( tracks, 'manage_subscribers_click' ) }
 							>
 								{ __( 'Manage subscribers', 'jetpack' ) }
 							</ExternalLink>
@@ -144,6 +172,7 @@ export const NewsletterWidget = ( {
 										isWpcomSite
 									)
 								) }
+								onClick={ createTracksEventHandler( tracks, 'monetize_click' ) }
 							>
 								{ __( 'Monetize', 'jetpack' ) }
 							</ExternalLink>
@@ -154,11 +183,15 @@ export const NewsletterWidget = ( {
 									href={ getRedirectUrl(
 										buildJPRedirectSource( `settings/newsletter/${ site }` )
 									) }
+									onClick={ createTracksEventHandler( tracks, 'newsletter_settings_click' ) }
 								>
 									{ __( 'Newsletter settings', 'jetpack' ) }
 								</ExternalLink>
 							) : (
-								<a href={ `${ adminUrl }admin.php?page=jetpack#newsletter` }>
+								<a
+									href={ `${ adminUrl }admin.php?page=jetpack#newsletter` }
+									onClick={ createTracksEventHandler( tracks, 'newsletter_settings_click' ) }
+								>
 									{ __( 'Newsletter settings', 'jetpack' ) }
 								</a>
 							) }

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/components/subscribers-chart.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/components/subscribers-chart.tsx
@@ -1,10 +1,12 @@
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { curveMonotoneX } from '@visx/curve';
 import { LegendOrdinal } from '@visx/legend';
 import { ParentSize } from '@visx/responsive';
 import { scaleOrdinal } from '@visx/scale';
 import { Axis, Grid, LineSeries, Tooltip, XYChart, buildChartTheme } from '@visx/xychart';
+import { useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { SERIES_COLORS, SERIES_LABELS } from '../constants';
+import { SERIES_COLORS, SERIES_LABELS, TRACKS_EVENT_NAME_PREFIX } from '../constants';
 import {
 	calcLeftAxisMargin,
 	formatAxisTickDate,
@@ -117,6 +119,12 @@ interface SubscribersChartProps {
 }
 
 export const SubscribersChart = ( { subscriberTotalsByDate }: SubscribersChartProps ) => {
+	const { tracks } = useAnalytics();
+
+	useEffect( () => {
+		tracks.recordEvent( `${ TRACKS_EVENT_NAME_PREFIX }chart_view` );
+	}, [ tracks ] );
+
 	if ( Object.keys( subscriberTotalsByDate ).length === 0 ) {
 		return <div>{ __( 'No data available', 'jetpack' ) }</div>;
 	}

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/constants.ts
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/constants.ts
@@ -9,3 +9,5 @@ export const SERIES_LABELS = {
 	all: __( 'All', 'jetpack' ),
 	paid: __( 'Paid', 'jetpack' ),
 };
+
+export const TRACKS_EVENT_NAME_PREFIX = 'jetpack_newsletter_widget_';

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/helpers.ts
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/helpers.ts
@@ -1,3 +1,4 @@
+import analytics from '@automattic/jetpack-analytics';
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { dateI18n } from '@wordpress/date';
 import { SubscriberTotalsByDate, ChartSubscriptionDataPoint } from './types';
@@ -140,4 +141,25 @@ export const calcLeftAxisMargin = ( subs: ChartSubscriptionDataPoint[] ): number
 	// Each digit is roughly 8px, plus add some padding
 	const digitCount = maxValue.toString().length;
 	return Math.max( DEFAULT_MARGIN, digitCount * CHAR_PX_WIDTH + PADDING );
+};
+
+/**
+ * Creates an event handler function for tracking user interactions
+ *
+ * @param tracks          - The tracks analytics object
+ * @param eventName       - The "action" part of the event name. Will be appended to "jetpack_newsletter_widget_"
+ * @param eventProperties - Additional properties to include in the event
+ * @returns A callback function that records the event when triggered. To primarily be used as an onClick prop.
+ *
+ * @example
+ * const handleClick = createTracksEventHandler( tracks, 'learn_more_click', { locale: 'en' } );
+ */
+export const createTracksEventHandler = (
+	tracks: typeof analytics.tracks,
+	eventAction: string,
+	eventProperties: Record< string, unknown > = {}
+) => {
+	return () => {
+		tracks.recordEvent( `jetpack_newsletter_widget_${ eventAction }`, eventProperties );
+	};
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes Automattic/loop#575

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds Tracks events for link clicks and when the widget and chart loads so we can better understand how the widget is being used.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

We are adding simple Tracks events for each link in the widget, as well as when it loads.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to wp-admin
* Interact with the Newsletter Widget by clicking each link
* Verify you see each corresponding `jetpack_newsletter_widget_{action}` event in Tracks:

- jetpack_newsletter_widget_view
- jetpack_newsletter_widget_all_subscribers_click
- jetpack_newsletter_widget_paid_subscribers_click
- jetpack_newsletter_widget_learn_more_click
- jetpack_newsletter_widget_publish_post_click
- jetpack_newsletter_widget_view_stats_click
- jetpack_newsletter_widget_import_subscribers_click
- jetpack_newsletter_widget_manage_subscribers_click
- jetpack_newsletter_widget_monetize_click
- jetpack_newsletter_widget_newsletter_settings_click
- jetpack_newsletter_widget_chart_view (from the SubscribersChart component)

