### PR TITLE
Social: Fix the default value for Social Image Generator in the editor

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-defatul-sig-settings-for-editor
+++ b/projects/packages/publicize/changelog/fix-social-defatul-sig-settings-for-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fix the default value for Social Image Generator in the editor

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1133,14 +1133,18 @@ abstract class Publicize_Base {
 			'auth_callback' => array( $this, 'message_meta_auth_callback' ),
 		);
 
+		$social_settings = new Jetpack_Social_Settings\Settings();
+
+		$sig_settings = $social_settings->get_image_generator_settings();
+
 		$jetpack_social_options_args = array(
 			'type'          => 'object',
 			'description'   => __( 'Post options related to Jetpack Social.', 'jetpack-publicize-pkg' ),
 			'single'        => true,
 			'default'       => array(
 				'image_generator_settings' => array(
-					'template' => ( new Jetpack_Social_Settings\Settings() )->sig_get_default_template(),
-					'enabled'  => false,
+					'template' => $social_settings->sig_get_default_template(),
+					'enabled'  => ! empty( $sig_settings['enabled'] ),
 				),
 				'version'                  => 2,
 			),


### PR DESCRIPTION
Currently on WPCOM sites, if you enable Social Image Generator from the Social admin page and then create a new post, the SIG settings is not reflected in the editor, the SIG rather remains disabled. So, we need to change the default state to reflect what is on the settings page

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Set the default value for Social Image Generator in the editor to what is set on the settings page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply/rsync this PR to your sandbox
* Point your Simple site with SIG enabled to your sandbox along with the public API
* Go to Social admin page and turn ON SIG
* Create a new post
* Open Jetpack sidebar
* Confirm that SIG is open
* Turn the SIG off in the sidebar and save the post as draft
* Reload the page
* Confirm that the settings in the editor is now retained
* Now turn the SIG off on the settings page
* Reload the above draft to confirm it is still the same
* Now create a new post
* Confirm that SIG is OFF as on the settings page
* Turn it on in the sidebar and save as draft
* Reload the page to confirm that it is still ON

