### PR TITLE
Likes: fix compatibility with WP.com locales

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-likes-wpcom-locale
+++ b/projects/plugins/jetpack/changelog/fix-likes-wpcom-locale
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Likes: fix compatibility with WP.com locales

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
@@ -20,7 +20,10 @@ function jetpack_likes_master_iframe() {
 	require_once JETPACK__GLOTPRESS_LOCALES_PATH;
 
 	$gp_locale = GP_Locales::by_field( 'wp_locale', $_locale );
-	$_locale   = isset( $gp_locale->slug ) ? $gp_locale->slug : '';
+	if ( ! $gp_locale ) {
+		$gp_locale = GP_Locales::by_slug( $_locale );
+	}
+	$_locale = isset( $gp_locale->slug ) ? $gp_locale->slug : '';
 
 	$likes_locale = ( '' === $_locale || 'en' === $_locale ) ? '' : '&amp;lang=' . strtolower( $_locale );
 


### PR DESCRIPTION
Fixes a localization bug when the Likes module runs in defusioned mode on WP.com. See also wpcom-177762-gh where this patch can be run in WP.com environment.

1. Apply the defusion patch wpcom-177762-gh so that the Jetpack Likes module runs on WP.com Simple sites.
2. Switch a Simple site's (sandboxed) language to `he` (Hebrew)
3. Load the Simple site's frontend. You'll see that the `he` localization is not applied, the `likes-master` iframe doesn't have `lang=he` in the `src` URL. The Like button UI remains in English.
4. After this patch, the localization is fixed.

The reason is that the name of the WP Core locale is `he_IL`, but the WP.com locale is just `he`. `GP_Locales::by_field( 'wp_locale', 'he' )` won't find the locale because the `wp_locale` field is `he`.

To fix this, I'm applying a patch identical to what @david-binda did in 2018 in `wpcom`: code-D10955. As a fallback, find the locale with `GP_Locales::by_slug`.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Without this patch, the Like button is not localized:
<img width="318" alt="Screenshot 2025-03-24 at 11 01 13" src="https://github.com/user-attachments/assets/af78856f-04db-4394-8f08-9cac27ee589e" />

With this patch, the localization is there:
<img width="426" alt="Screenshot 2025-03-24 at 11 11 44" src="https://github.com/user-attachments/assets/bb8e9922-39f9-49a3-a63a-bf27d824b88c" />

You only need to sandbox the Simple site's domain (`example.wordpress.com`) to test this patch.