### PR TITLE
Forms: Fix WordPress 6.8 useSelect notice

### DIFF
--- a/projects/packages/forms/changelog/fix-plugin-integration-useselect
+++ b/projects/packages/forms/changelog/fix-plugin-integration-useselect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix WordPress useSelect warning.

--- a/projects/packages/forms/src/blocks/contact-form/components/shared/plugin-integration-panel/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/shared/plugin-integration-panel/index.js
@@ -25,26 +25,21 @@ const PluginIntegrationPanel = ( {
 	const { invalidateResolution } = useDispatch( coreStore );
 	const { tracks } = useAnalytics();
 
-	const { pluginStatus, isLoading } = useSelect(
-		select => {
-			const installedPlugins = select( coreStore ).getPlugins();
+	const { plugins, isLoading } = useSelect( select => {
+		const installedPlugins = select( coreStore ).getPlugins();
+		return {
+			isLoading: ! installedPlugins,
+			plugins: installedPlugins || [],
+		};
+	}, [] );
 
-			if ( ! installedPlugins ) {
-				return { isLoading: true };
-			}
-
-			const plugin = installedPlugins.find( p => p.plugin === pluginPath );
-
-			return {
-				isLoading: false,
-				pluginStatus: {
-					isInstalled: !! plugin,
-					isActive: plugin?.status === 'active',
-				},
-			};
-		},
-		[ pluginPath ]
-	);
+	const plugin = plugins.find( p => p.plugin === pluginPath );
+	const pluginStatus = plugin
+		? {
+				isInstalled: true,
+				isActive: plugin.status === 'active',
+		  }
+		: null;
 
 	const { isInstalled = false, isActive = false } = pluginStatus || {};
 

--- a/projects/packages/forms/src/blocks/contact-form/components/shared/plugin-integration-panel/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/shared/plugin-integration-panel/index.js
@@ -1,5 +1,5 @@
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { Icon, Spinner, PanelBody } from '@wordpress/components';
+import { Spinner, PanelBody } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useCallback } from '@wordpress/element';
@@ -25,23 +25,20 @@ const PluginIntegrationPanel = ( {
 	const { invalidateResolution } = useDispatch( coreStore );
 	const { tracks } = useAnalytics();
 
-	const { plugins, isLoading } = useSelect( select => {
-		const installedPlugins = select( coreStore ).getPlugins();
-		return {
-			isLoading: ! installedPlugins,
-			plugins: installedPlugins || [],
-		};
-	}, [] );
-
-	const plugin = plugins.find( p => p.plugin === pluginPath );
-	const pluginStatus = plugin
-		? {
-				isInstalled: true,
-				isActive: plugin.status === 'active',
-		  }
-		: null;
-
-	const { isInstalled = false, isActive = false } = pluginStatus || {};
+	const { isLoading, isInstalled, isActive } = useSelect(
+		select => {
+			const installedPlugins = select( coreStore ).getPlugins();
+			const plugin = installedPlugins
+				? installedPlugins.find( p => p.plugin === pluginPath )
+				: null;
+			return {
+				isLoading: ! installedPlugins,
+				isInstalled: !! plugin,
+				isActive: plugin && plugin.status === 'active',
+			};
+		},
+		[ pluginPath ]
+	);
 
 	const handleButtonClick = useCallback( () => {
 		const func = isInstalled ? activatePlugin : installAndActivatePlugin;
@@ -83,19 +80,7 @@ const PluginIntegrationPanel = ( {
 					</div>
 				) }
 
-				{ ! isLoading && ! pluginStatus && (
-					<div className="jetpack-plugin-integration__status">
-						<Icon icon="warning" />
-						<span>
-							{ __(
-								'Unable to determine plugin status. Please refresh the page.',
-								'jetpack-forms'
-							) }
-						</span>
-					</div>
-				) }
-
-				{ ! isLoading && pluginStatus && ! isInstalled && (
+				{ ! isLoading && ! isInstalled && (
 					<div className="jetpack-plugin-integration__panel">
 						<div className="jetpack-plugin-integration__panel-content">
 							<div>{ description }</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #42673

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
WordPress 6.8 will start returning a console warning if a useSelect call manipulates retrieved data to return a new object/array reference. The useSelect in the PluginIntegrationPanel is doing this, and should be fixed before WordPress 6.8 is released.

This PR fixes it by only returning the raw data from the useSelect call, and then handling filtering / manipulation outside of the useSelect.

For more context, see: 
- https://github.com/Automattic/jetpack/issues/42421
- https://make.wordpress.org/core/2025/03/12/data-a-helpful-performance-warning-for-developers-in-the-useselect-hook/

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Review issue and code to confirm underlying issue is resolved. 

Test that the panel still works as expected.
- Deactivate or delete Akismet on your site if needed.
- Add a form block to a page or post. 
- In the form block sidebar, open the Akismet panel and install or activate Akismet. Confirm state updates once plugin is installed or activated.
 

