### PR TITLE
Donation/fix modal links

### DIFF
--- a/projects/plugins/jetpack/changelog/donation-fix-modal-links
+++ b/projects/plugins/jetpack/changelog/donation-fix-modal-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Moved donation modal links to jetpack redirect service.

--- a/projects/plugins/jetpack/extensions/blocks/donations/first-time-modal.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/first-time-modal.js
@@ -1,7 +1,15 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { Modal, Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 const FirstTimeModal = ( { onClose } ) => {
+	// Configure the redirect URLs in the Jetpack Redirects service (see the README in jetpack-redirects).
+	const supportLinkSource =
+		isSimpleSite() || isAtomicSite()
+			? 'wpcom-support-donation-block'
+			: 'jetpack-support-donation-block';
 	return (
 		<Modal
 			className="jetpack-donations-first-time-modal"
@@ -10,17 +18,21 @@ const FirstTimeModal = ( { onClose } ) => {
 		>
 			<div className="jetpack-donations-first-time-modal__content">
 				<p>
-					{ __(
-						"To accept donations on your site, you'll need to connect your Stripe account. Here's what you need to do:",
-						'jetpack'
-					) }{ ' ' }
-					<a
-						href="https://wordpress.com/support/wordpress-editor/blocks/donations/#about-donations"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						{ __( 'Learn more about donations.', 'jetpack' ) }
-					</a>
+					{ createInterpolateElement(
+						__(
+							"To accept donations on your site, you'll need to connect your Stripe account. Here's what you need to do: <docLink>Learn more about donations</docLink>.",
+							'jetpack'
+						),
+						{
+							docLink: (
+								<a
+									href={ getRedirectUrl( supportLinkSource ) }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						}
+					) }
 				</p>
 				<ol>
 					<li>{ __( 'Connect your Stripe account to your WordPress.com account', 'jetpack' ) }</li>
@@ -34,19 +46,21 @@ const FirstTimeModal = ( { onClose } ) => {
 					) }
 				</p>
 				<p>
-					{ __(
-						'Please note that accepting donations has additional requirements from Stripe. Learn more about',
-						'jetpack'
+					{ createInterpolateElement(
+						__(
+							'Please note that accepting donations has additional requirements from Stripe. Learn more about <requirementsLink>requirements for accepting donations</requirementsLink>.',
+							'jetpack'
+						),
+						{
+							requirementsLink: (
+								<a
+									href={ getRedirectUrl( 'jetpack-support-donation-block-stripe-reqs' ) }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						}
 					) }
-					&nbsp;
-					<a
-						href="https://support.stripe.com/questions/requirements-for-accepting-tips-or-donations"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						{ __( 'requirements for accepting donations', 'jetpack' ) }
-					</a>
-					.
 				</p>
 
 				<div className="jetpack-donations-first-time-modal__actions">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes issues highlighted in review of https://github.com/Automattic/jetpack/pull/42214.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Uses `createInterpolatedElement()` for adding links to translated strings.
* Uses jetpack redirect service for managing the URLs.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Visually there should be no changes from existing implementation:

<img width="927" alt="image" src="https://github.com/user-attachments/assets/7cc3c828-e7e8-4fac-88fb-100767d5036a" />

### Setup
#### Jurassic Ninja

* Create a JN site with the jetpack beta plugin and apply the `donation/fix-modal-links` branch.
* Make sure jetpack is connected and you are using a paid jetpack plan (required for donations block)

#### WPCOM simple

* Run `~/public_html/bin/jetpack-downloader test jetpack donation/fix-modal-links`.
* Sandbox both your site _and_ public-api.wordpress.com.
* Enable writes (e.g. `~/public_html/bin/allow-sandbox-production-writes '1 hour'`)

### Test
1. Create a post and add the donations block.
2. The first time should display the modal above. Check that it looks correct.
3. Make sure the links resolve correctly (e.g. jetpack sites use jetpack support page, wpcom sites use the wpcom support page, and the stripe link works)
4. Subsequent refreshes should not show the modal.

If you want to reset it you'll need to remove the `jetpack_donation_warning_dismissed` user meta from your user. (e.g. `wp user meta delete <user-id> jetpack_donation_warning_dismissed`.)

