### PR TITLE
Jetpack SEO Enhancer: add settings events

### DIFF
--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -17,6 +17,7 @@ import { ModuleToggle } from 'components/module-toggle';
 import SimpleNotice from 'components/notice';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
+import analytics from 'lib/analytics';
 import { isSeoEnhancerAvailable } from 'state/initial-state';
 import { isFetchingPluginsData, isPluginActive } from 'state/site/plugins';
 import CustomSeoTitles from './seo/custom-seo-titles.jsx';
@@ -74,8 +75,16 @@ export const SEO = withModuleSettingsFormHelpers(
 		};
 
 		toggleSeoEnhancer = () => {
+			const isEnabled = this.props.getOptionValue( 'ai_seo_enhancer_enabled' );
+
+			analytics.tracks.recordEvent( 'jetpack_wpa_settings_toggle', {
+				module: 'seo-tools',
+				setting: 'ai_seo_enhancer_enabled',
+				toggled: ! isEnabled ? 'on' : 'off',
+			} );
+
 			this.props.updateOptions( {
-				ai_seo_enhancer_enabled: ! this.props.getOptionValue( 'ai_seo_enhancer_enabled' ),
+				ai_seo_enhancer_enabled: ! isEnabled,
 			} );
 		};
 

--- a/projects/plugins/jetpack/changelog/add-jetpack-seo-enhancer-settings-tracks
+++ b/projects/plugins/jetpack/changelog/add-jetpack-seo-enhancer-settings-tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack SEO Enhancer: track settings change and triggers

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import {
 	BaseControl,
 	ToggleControl,
@@ -26,6 +27,7 @@ import './style.scss';
 const debug = debugFactory( 'seo-enhancer:index' );
 
 export function SeoEnhancer( { disableAutoEnhance = false }: { disableAutoEnhance?: boolean } ) {
+	const { tracks } = useAnalytics();
 	const { isEnabled, toggleEnhancer, isToggling } = useSeoModuleSettings();
 	const isLoading = useSelect( select => {
 		const isBusy = select( store ).isBusy();
@@ -44,9 +46,14 @@ export function SeoEnhancer( { disableAutoEnhance = false }: { disableAutoEnhanc
 
 	const toggleFeature = useCallback(
 		name => {
-			setFeatureEnabled( name, ! enabledFeatures.includes( name ) );
+			const isFeatureEnabled = enabledFeatures.includes( name );
+			tracks.recordEvent( 'jetpack_seo_enhancer_feature_toggle', {
+				feature: name,
+				toggled: ! isFeatureEnabled ? 'on' : 'off',
+			} );
+			setFeatureEnabled( name, ! isFeatureEnabled );
 		},
-		[ enabledFeatures, setFeatureEnabled ]
+		[ enabledFeatures, setFeatureEnabled, tracks ]
 	);
 
 	const generateHandler = async () => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
@@ -38,7 +38,7 @@ export function SeoEnhancer( { disableAutoEnhance = false }: { disableAutoEnhanc
 	const enabledFeatures = useSelect( select => select( store ).getEnabledFeatures(), [] );
 	const { setFeatureEnabled } = useDispatch( store );
 
-	const { updateSeoData } = useSeoRequests( enabledFeatures );
+	const { updateSeoData } = useSeoRequests();
 
 	const toggleSeoEnhancer = useCallback( async () => {
 		await toggleEnhancer();

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-module-settings.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-module-settings.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
@@ -15,6 +16,7 @@ import { store } from './store';
 const debug = debugFactory( 'seo-enhancer:use-seo-module-settings' );
 
 export const useSeoModuleSettings = () => {
+	const { tracks } = useAnalytics();
 	const isEnabled = useSelect( select => select( store ).isAutoEnhanceEnabled(), [] );
 	const isToggling = useSelect( select => select( store ).isTogglingAutoEnhance(), [] );
 	const setIsToggling = useDispatch( store ).setIsTogglingAutoEnhance;
@@ -28,14 +30,20 @@ export const useSeoModuleSettings = () => {
 				method: 'post',
 				data: { ai_seo_enhancer_enabled: ! isEnabled },
 			} );
-
+			tracks.recordEvent( 'jetpack_seo_enhancer_toggle', {
+				toggled: ! isEnabled ? 'on' : 'off',
+			} );
 			setIsEnabled( ! isEnabled );
 		} catch ( error ) {
 			debug( 'Error toggling SEO enhancer', error );
+			tracks.recordEvent( 'jetpack_seo_enhancer_toggle_error', {
+				toggled: ! isEnabled ? 'on' : 'off',
+				error: error?.message,
+			} );
 		} finally {
 			setIsToggling( false );
 		}
-	}, [ isEnabled, setIsEnabled, setIsToggling ] );
+	}, [ isEnabled, setIsEnabled, setIsToggling, tracks ] );
 
 	return {
 		isEnabled,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-requests.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-requests.ts
@@ -40,15 +40,18 @@ const parseResponse = ( response: string ) => {
 	return parsedResponse;
 };
 
-export const useSeoRequests = (
-	features: PromptType[] = [ 'seo-title', 'seo-meta-description', 'images-alt-text' ]
-) => {
+export const useSeoRequests = () => {
 	const { tracks } = useAnalytics();
 	const { editPost } = useDispatch( editorStore );
 	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
 	const postId = useSelect( select => select( editorStore ).getCurrentPostId(), [] );
 	const { getPostContent } = usePostContent();
-	const isBusy = useSelect( select => select( store ).isBusy(), [] );
+	const { isBusy, enabledFeatures } = useSelect( select => {
+		const busy = select( store ).isBusy();
+		const features = select( store ).getEnabledFeatures();
+
+		return { isBusy: busy, enabledFeatures: features };
+	}, [] );
 	const { setBusy, setTitleBusy, setDescriptionBusy } = useDispatch( store );
 	const { isImageBusy, hasImageFailed } = useSelect( select => select( store ), [] );
 	const { setImageBusy, setImageFailed } = useDispatch( store );
@@ -248,7 +251,7 @@ export const useSeoRequests = (
 				images_alt_text: false,
 			};
 
-			features.forEach( feature => {
+			enabledFeatures.forEach( feature => {
 				if ( feature === 'seo-title' ) {
 					promises.push( updateTitle() );
 					trackData.seo_title = true;
@@ -273,7 +276,15 @@ export const useSeoRequests = (
 				createInfoNotice( __( 'SEO metadata added', 'jetpack' ), { type: 'snackbar' } );
 			}
 		},
-		[ setBusy, features, createInfoNotice, updateTitle, updateDescription, updateAltTexts, tracks ]
+		[
+			setBusy,
+			enabledFeatures,
+			createInfoNotice,
+			updateTitle,
+			updateDescription,
+			updateAltTexts,
+			tracks,
+		]
 	);
 
 	return { updateSeoData, updateAltText, isBusy };

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-requests.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-requests.ts
@@ -8,6 +8,7 @@ import {
 	useAiFeature,
 	usePostContent,
 } from '@automattic/jetpack-ai-client';
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { select as globalSelect, useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useCallback } from '@wordpress/element';
@@ -42,6 +43,7 @@ const parseResponse = ( response: string ) => {
 export const useSeoRequests = (
 	features: PromptType[] = [ 'seo-title', 'seo-meta-description', 'images-alt-text' ]
 ) => {
+	const { tracks } = useAnalytics();
 	const { editPost } = useDispatch( editorStore );
 	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
 	const postId = useSelect( select => select( editorStore ).getCurrentPostId(), [] );
@@ -234,30 +236,45 @@ export const useSeoRequests = (
 		[ updateAltText ]
 	);
 
-	const updateSeoData = useCallback( async () => {
-		const promises = [];
-		setBusy( true );
+	const updateSeoData = useCallback(
+		async ( { trigger = 'manual' }: { trigger?: 'manual' | 'auto' } = {} ) => {
+			const promises = [];
+			setBusy( true );
 
-		features.forEach( feature => {
-			if ( feature === 'seo-title' ) {
-				promises.push( updateTitle() );
-			}
-			if ( feature === 'seo-meta-description' ) {
-				promises.push( updateDescription() );
-			}
-			if ( feature === 'images-alt-text' ) {
-				promises.push( updateAltTexts() );
-			}
-		} );
+			const trackData = {
+				trigger,
+				seo_title: false,
+				seo_meta_description: false,
+				images_alt_text: false,
+			};
 
-		const result = ( await Promise.all( promises ) ).flat();
-		setBusy( false );
+			features.forEach( feature => {
+				if ( feature === 'seo-title' ) {
+					promises.push( updateTitle() );
+					trackData.seo_title = true;
+				}
+				if ( feature === 'seo-meta-description' ) {
+					promises.push( updateDescription() );
+					trackData.seo_meta_description = true;
+				}
+				if ( feature === 'images-alt-text' ) {
+					promises.push( updateAltTexts() );
+					trackData.images_alt_text = true;
+				}
+			} );
 
-		// The notice is only shown if at least one value was updated
-		if ( result.some( value => value === true ) ) {
-			createInfoNotice( __( 'SEO metadata added', 'jetpack' ), { type: 'snackbar' } );
-		}
-	}, [ setBusy, features, createInfoNotice, updateTitle, updateDescription, updateAltTexts ] );
+			tracks.recordEvent( 'jetpack_seo_enhancer_trigger', trackData );
+
+			const result = ( await Promise.all( promises ) ).flat();
+			setBusy( false );
+
+			// The notice is only shown if at least one value was updated
+			if ( result.some( value => value === true ) ) {
+				createInfoNotice( __( 'SEO metadata added', 'jetpack' ), { type: 'snackbar' } );
+			}
+		},
+		[ setBusy, features, createInfoNotice, updateTitle, updateDescription, updateAltTexts, tracks ]
+	);
 
 	return { updateSeoData, updateAltText, isBusy };
 };

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -85,7 +85,7 @@ const Seo = () => {
 			canHaveAutoEnhance &&
 			supportsPublishSidebar
 		) {
-			updateSeoData();
+			updateSeoData( { trigger: 'auto' } );
 		}
 
 		previousIsOpenRef.current = isPrePublishPanelOpen;


### PR DESCRIPTION
Fixes #41104 

## Proposed changes:
This PR adds tracking events on SEO enhancer to measure/understand usage/engagement.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pe4Cmx-2ZI-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add filter to enable the new toggle `add_filter( 'ai_seo_enhancer_enabled', '__return_true' );`. Switch to Beta blocks variation.

Set localStorage to show debug information: `localStorage.setItem( 'debug', '*' )` and filter for `dops`

Check on the Jetpack Settings:
- [ ] On Jetpack settings -> Traffic you can toggle SEO automatic generation and the generic wpa settings change event triggers with `setting: ai_seo_enhancer_enabled` and toggle value

Check on the block editor panel:
- [ ] The toggle switch triggers `jetpack_seo_enhancer_toggle` with the toggle value
- [ ] Enabling/disabling individual features (checkboxes) triggers `jetpack_seo_enhancer_feature_toggle` with feature name and toggle value
- [ ] Generation CTA triggers `jetpack_seo_enhancer_trigger` with `trigger: manual` and individual features on/off (as booleans)
- [ ] Leave auto-generate on and hit Publish. See PrePublish Sidebar triggers `jetpack_seo_enhancer_trigger` with `trigger: auto` and individual features on/off (as booleans). See that the individual features match the checkboxes you enabled 