### PR TITLE
Jeptack SEO Enhancer: fix panel vertical spacing

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jeptack-seo-enhancer-panel-styles
+++ b/projects/plugins/jetpack/changelog/fix-jeptack-seo-enhancer-panel-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack SEO Enhancer: normalize vertical spacing throughout Jetpack sidebar, pre and post publish panels

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/style.scss
@@ -1,5 +1,5 @@
 .jetpack-seo-sidebar__feature-section--toggle {
-	min-height: unset;
+	// min-height: unset;
 
 	.ai-seo-enhancer-label {
 		margin-bottom: 24px;
@@ -7,6 +7,8 @@
 }
 
 .jetpack-seo-sidebar__feature-section {
+	margin-bottom: 2em;
+
 	.feature-checkboxes-container {
 		display: flex;
 		flex-direction: column;
@@ -32,9 +34,10 @@
 
 .jetpack-seo-enhancer-summary-feature {
 	display: flex;
+	margin-bottom: 12px;
 
-	+ .jetpack-seo-enhancer-summary-feature {
-		margin-top: 12px;
+	&:last-child {
+		margin-bottom: 2em;
 	}
 
 	.jetpack-seo-enhancer-summary-feature__control {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/style.scss
@@ -6,8 +6,15 @@
 	}
 }
 
+.jetpack-seo-panel {
+	.components-panel__row {
+		&:not(:last-child) {
+			margin-bottom: 2em;
+		}
+	}
+}
+
 .jetpack-seo-sidebar__feature-section {
-	margin-bottom: 2em;
 
 	.feature-checkboxes-container {
 		display: flex;

--- a/projects/plugins/jetpack/extensions/plugins/seo/editor.scss
+++ b/projects/plugins/jetpack/extensions/plugins/seo/editor.scss
@@ -17,6 +17,3 @@
 	}
 }
 
-.jetpack-seo-sidebar__feature-section + .jetpack-seo-sidebar__feature-section {
-	margin-top: 2em;
-}

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -197,7 +197,7 @@ const Seo = () => {
 			</JetpackPluginSidebar>
 
 			<PluginPrePublishPanel { ...jetpackSeoPublishPanelsProps }>
-				<>
+				<div className="jetpack-seo-panel">
 					{ isSeoEnhancerEnabled && <SeoEnhancer disableAutoEnhance={ ! canHaveAutoEnhance } /> }
 					<PanelRow>
 						<SeoTitlePanel />
@@ -208,12 +208,14 @@ const Seo = () => {
 					<PanelRow>
 						<SeoNoindexPanel />
 					</PanelRow>
-				</>
+				</div>
 			</PluginPrePublishPanel>
 
 			{ isSeoEnhancerEnabled && isAutoEnhanceEnabled && canHaveAutoEnhance && (
 				<PluginPostPublishPanel { ...jetpackSeoPublishPanelsProps }>
-					<SeoSummary onEdit={ handleSummaryEdit } />
+					<div className="jetpack-seo-panel">
+						<SeoSummary onEdit={ handleSummaryEdit } />
+					</div>
 				</PluginPostPublishPanel>
 			) }
 		</>


### PR DESCRIPTION
## Proposed changes:
This PR normalizes the spacing used on the panel to show consistently on Jetpack sidebar, PrePublish and PostPublish panels.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-wlg-p2#comment-75969

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add the filter `add_filter( 'ai_seo_enhancer_enabled', '__return_true' );` and switch to Beta blocks variation.

On the editor, open the Jetpack sidebar. See that the SEO panel looks like in the design previews on the P2 comment.
Make sure you have "Enable pre-publish checks" on the editor preferences and click on "Publish" to see the PrePublish sidebar. Confirm the vertical spacing is also as expected there.
Finally, publish the post and check the PostPublish panel where the SEO summary is and verify the vertical spacing there as well.