### PR TITLE
Social: Fix Editor CSS Warning

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-editor-css-warning-
+++ b/projects/packages/publicize/changelog/fix-social-editor-css-warning-
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fix Editor CSS Warning

--- a/projects/packages/publicize/src/class-publicize-assets.php
+++ b/projects/packages/publicize/src/class-publicize-assets.php
@@ -20,7 +20,7 @@ class Publicize_Assets {
 	public static function configure() {
 		Publicize_Script_Data::configure();
 
-		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_scripts' ), 15 );
+		add_action( 'enqueue_block_assets', array( __CLASS__, 'enqueue_block_editor_scripts' ), 15 );
 	}
 
 	/**
@@ -47,6 +47,11 @@ class Publicize_Assets {
 	 */
 	public static function enqueue_block_editor_scripts() {
 		if ( ! self::should_enqueue_block_editor_scripts() ) {
+			return;
+		}
+
+		// We need the assets only in the editor, not on the frontend.
+		if ( ! is_admin() ) {
 			return;
 		}
 


### PR DESCRIPTION
Currently, we use `enqueue_block_editor_assets` hook to enqueue the assets needed for block editor. In #42289, we had changed from `enqueue_block_assets` to the above hook to avoid loading styles on the front-end. But, that caused another issue - a warning in the editor

```
jetpack-social-editor-css was added to the iframe incorrectly.
Please use block.json or enqueue_block_assets to add styles to the iframe.
```

So, we need something good for both worlds, i.e. load the styles only in the editor but also in the iframed editor.

The [Block Editor Handbook about `enqueue_block_assets`](https://developer.wordpress.org/block-editor/how-to-guides/enqueueing-assets-in-the-editor/#editor-content-scripts-and-styles) mentions:

> There are instances where you may only want to add assets in the Editor and not on the front end. You can achieve this by using an [`is_admin()`](https://developer.wordpress.org/reference/functions/is_admin/) check.

That is exactly what this PR does.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Switch from `enqueue_block_editor_assets` to `enqueue_block_assets` for loading publicize editor assets.
* Add an `is_admin()` check to ensure we load the assets only in the editor

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the instructions given in #42289 to ensure the assets are not loaded on the front-end. [Query Monitor](https://wordpress.org/plugins/query-monitor/) plugin should help.
* Goto the editor
* Confirm that there is no warning about `jetpack-social-editor-css was added to the iframe incorrectly`