### PR TITLE
Social: Update recommedation CTAs to point to social admin page

### DIFF
--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -1,8 +1,8 @@
 import formatCurrency from '@automattic/format-currency';
 import restApi from '@automattic/jetpack-api';
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { getSocialScriptData } from '@automattic/jetpack-publicize-components';
-import { sprintf, __, _x } from '@wordpress/i18n';
+import { getAdminUrl } from '@automattic/jetpack-script-data';
+import { sprintf, __ } from '@wordpress/i18n';
 import {
 	PLAN_JETPACK_SECURITY_T1_YEARLY,
 	PLAN_JETPACK_VIDEOPRESS,
@@ -79,16 +79,10 @@ export const mapStateToSummaryFeatureProps = ( state, featureSlug ) => {
 			};
 		case 'publicize':
 			return {
-				configureButtonLabel: getSocialScriptData().feature_flags.useAdminUiV1
-					? __( 'View Jetpack Social settings', 'jetpack' )
-					: _x( 'Manage connections', '', 'jetpack' ),
+				configureButtonLabel: __( 'View Jetpack Social settings', 'jetpack' ),
 				displayName: __( 'Social Media Sharing', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Enable', 'jetpack' ),
-				configLink: getSocialScriptData().feature_flags.useAdminUiV1
-					? '#/sharing'
-					: getRedirectUrl( 'calypso-marketing-connections', {
-							site: getSiteRawUrl( state ),
-					  } ),
+				configLink: getAdminUrl( 'admin.php?page=jetpack-social' ),
 			};
 		case 'videopress':
 			return {
@@ -163,13 +157,13 @@ export const getSummaryPrimaryProps = ( state, primarySlug ) => {
 			return {
 				displayName: __( 'Social Media Sharing', 'jetpack' ),
 				ctaLabel: __( 'Manage', 'jetpack' ),
-				ctaLink: getSiteAdminUrl( state ) + 'admin.php?page=jetpack#/sharing',
+				ctaLink: getAdminUrl( 'admin.php?page=jetpack-social' ),
 			};
 		case 'social-v1-activated':
 			return {
 				displayName: __( 'Advanced Sharing Features', 'jetpack' ),
 				ctaLabel: __( 'Manage', 'jetpack' ),
-				ctaLink: getSiteAdminUrl( state ) + 'admin.php?page=jetpack#/sharing',
+				ctaLink: getAdminUrl( 'admin.php?page=jetpack-social' ),
 			};
 		case 'antispam-activated':
 			return {
@@ -548,9 +542,7 @@ export const getStepContent = ( state, stepSlug ) => {
 					'jetpack'
 				),
 				ctaText: __( 'Manage Social Media Connections', 'jetpack' ),
-				ctaLink: getRedirectUrl( 'calypso-marketing-connections', {
-					site: getSiteRawUrl( state ),
-				} ),
+				ctaLink: getAdminUrl( 'admin.php?page=jetpack-social' ),
 				illustration: 'assistant-jetpack-social',
 				skipText: __( 'Next', 'jetpack' ),
 			};
@@ -562,11 +554,7 @@ export const getStepContent = ( state, stepSlug ) => {
 					'jetpack'
 				),
 				ctaText: __( 'Manage Social Media Connections', 'jetpack' ),
-				ctaLink: getSocialScriptData().feature_flags.useAdminUiV1
-					? getSiteAdminUrl( state ) + 'admin.php?page=jetpack#/sharing'
-					: getRedirectUrl( 'calypso-marketing-connections', {
-							site: getSiteRawUrl( state ),
-					  } ),
+				ctaLink: getAdminUrl( 'admin.php?page=jetpack-social' ),
 				ctaForceExternal: true,
 				illustration: 'assistant-jetpack-social',
 				skipText: __( 'Next', 'jetpack' ),
@@ -579,7 +567,7 @@ export const getStepContent = ( state, stepSlug ) => {
 					'jetpack'
 				),
 				ctaText: __( 'View Jetpack Social settings', 'jetpack' ),
-				ctaLink: getSiteAdminUrl( state ) + 'admin.php?page=jetpack#/sharing',
+				ctaLink: getAdminUrl( 'admin.php?page=jetpack-social' ),
 				ctaForceExternal: true,
 				illustration: 'assistant-social-image-post',
 				skipText: __( 'Next', 'jetpack' ),
@@ -631,7 +619,7 @@ export const getStepContent = ( state, stepSlug ) => {
 					'jetpack'
 				),
 				ctaText: __( 'View Jetpack Social settings', 'jetpack' ),
-				ctaLink: getSiteAdminUrl( state ) + 'admin.php?page=jetpack#/sharing',
+				ctaLink: getAdminUrl( 'admin.php?page=jetpack-social' ),
 				illustration: 'assistant-jetpack-social',
 				skipText: __( 'Next', 'jetpack' ),
 			};
@@ -643,7 +631,7 @@ export const getStepContent = ( state, stepSlug ) => {
 					'jetpack'
 				),
 				ctaText: __( 'View Jetpack Social settings', 'jetpack' ),
-				ctaLink: getSiteAdminUrl( state ) + 'admin.php?page=jetpack#/sharing',
+				ctaLink: getAdminUrl( 'admin.php?page=jetpack-social' ),
 				illustration: 'assistant-social-image-post',
 				skipText: __( 'Next', 'jetpack' ),
 			};

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -622,6 +622,7 @@ export const getStepContent = ( state, stepSlug ) => {
 				ctaLink: getAdminUrl( 'admin.php?page=jetpack-social' ),
 				illustration: 'assistant-jetpack-social',
 				skipText: __( 'Next', 'jetpack' ),
+				ctaForceExternal: true,
 			};
 		case 'social-v1-activated':
 			return {
@@ -634,6 +635,7 @@ export const getStepContent = ( state, stepSlug ) => {
 				ctaLink: getAdminUrl( 'admin.php?page=jetpack-social' ),
 				illustration: 'assistant-social-image-post',
 				skipText: __( 'Next', 'jetpack' ),
+				ctaForceExternal: true,
 			};
 		case 'antispam-activated':
 			return {

--- a/projects/plugins/jetpack/changelog/fix-social-recommendations
+++ b/projects/plugins/jetpack/changelog/fix-social-recommendations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Social: Update recommedation CTAs to point to social admin page


### PR DESCRIPTION
If you go to the following links, you will see the CTAs pointing to Sharing section.
- `/wp-admin/admin.php?page=jetpack#/recommendations/publicize`
- `/wp-admin/admin.php?page=jetpack#/recommendations/unlimited-sharing-activated`
- `/wp-admin/admin.php?page=jetpack#/recommendations/social-v1-activated`

<details>
<summary>We need to update them to point to the Social admin page</summary>

<img width="881" alt="Image" src="https://github.com/user-attachments/assets/46823757-c227-4b58-b81b-b22d17d8eac7" />

<img width="898" alt="Image" src="https://github.com/user-attachments/assets/7c4eb01c-0d27-465b-9f13-a8ceda739acb" />

</details>

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Social: Update recommedation CTAs to point to social admin page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the following links, and confirm that the CTAs point to the Social admin page
    - `/wp-admin/admin.php?page=jetpack#/recommendations/publicize`
    - `/wp-admin/admin.php?page=jetpack#/recommendations/unlimited-sharing-activated`
    - `/wp-admin/admin.php?page=jetpack#/recommendations/social-v1-activated`

<img width="597" alt="Screenshot 2025-03-25 at 1 18 02 PM" src="https://github.com/user-attachments/assets/557039e0-bbf8-49a3-82c8-1c629dace809" />
