### PR TITLE
Full sync: send ranges for all chunked modules

### DIFF
--- a/projects/packages/sync/.phan/baseline.php
+++ b/projects/packages/sync/.phan/baseline.php
@@ -15,10 +15,10 @@ return [
     // PhanTypeMismatchReturn : 20+ occurrences
     // PhanParamSignatureMismatch : 15+ occurrences
     // PhanTypeMismatchArgumentProbablyReal : 10+ occurrences
-    // PhanPluginSimplifyExpressionBool : 9 occurrences
-    // PhanPossiblyUndeclaredVariable : 8 occurrences
+    // PhanPluginSimplifyExpressionBool : 8 occurrences
     // PhanPluginDuplicateSwitchCaseLooseEquality : 6 occurrences
     // PhanNonClassMethodCall : 5 occurrences
+    // PhanPossiblyUndeclaredVariable : 5 occurrences
     // PhanRedundantCondition : 4 occurrences
     // PhanTypeExpectedObjectPropAccess : 4 occurrences
     // PhanTypeMismatchArgumentInternal : 4 occurrences
@@ -61,7 +61,7 @@ return [
         'src/modules/class-callables.php' => ['PhanParamSignatureMismatch', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
         'src/modules/class-comments.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'src/modules/class-constants.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchReturnProbablyReal'],
-        'src/modules/class-full-sync-immediately.php' => ['PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchReturn'],
+        'src/modules/class-full-sync-immediately.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchReturn'],
         'src/modules/class-full-sync.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanTypeComparisonFromArray'],
         'src/modules/class-import.php' => ['PhanTypeMismatchArgumentInternal'],
         'src/modules/class-module.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],

--- a/projects/packages/sync/changelog/update-full-sync-send-ranges-for-all-chunked-modules
+++ b/projects/packages/sync/changelog/update-full-sync-send-ranges-for-all-chunked-modules
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Full Sync: Calculate ranges for all chunked modules.

--- a/projects/packages/sync/src/modules/class-comments.php
+++ b/projects/packages/sync/src/modules/class-comments.php
@@ -378,7 +378,7 @@ class Comments extends Module {
 	 * @return string WHERE SQL clause, or `null` if no comments are specified in the module config.
 	 */
 	public function get_where_sql( $config ) {
-		if ( is_array( $config ) ) {
+		if ( is_array( $config ) && ! empty( $config ) ) {
 			return 'comment_ID IN (' . implode( ',', array_map( 'intval', $config ) ) . ')';
 		}
 

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -263,7 +263,7 @@ class Full_Sync_Immediately extends Module {
 			}
 			$status[ $name ] = array(
 				// If we have a range for the module, use the count from the range to avoid querying the database again.
-				'total'    => ( isset( $range[ $name ]->count ) ) ? $range[ $name ]->count : $module->total( $config ),
+				'total'    => $range[ $name ]->count ?? $module->total( $config ),
 				'sent'     => 0,
 				'finished' => false,
 			);
@@ -277,13 +277,13 @@ class Full_Sync_Immediately extends Module {
 	 *
 	 * @access private
 	 *
-	 * @param array $config Full sync configuration.
+	 * @param array $full_sync_config Full sync configuration.
 	 *
 	 * @return array Array of range (min ID, max ID, total items) for all content types.
 	 */
-	private function get_content_range( $config ) {
+	private function get_content_range( $full_sync_config ) {
 		$range = array();
-		foreach ( array_keys( $config ) as $module_name ) {
+		foreach ( $full_sync_config as $module_name => $config ) {
 			// Calculate ranges only for modules that get chunked.
 			if ( in_array( $module_name, array( 'constants', 'functions', 'network_options', 'options', 'themes', 'updates' ), true ) ) {
 				continue;
@@ -293,8 +293,8 @@ class Full_Sync_Immediately extends Module {
 				continue;
 			}
 			// Add range only when syncing all objects.
-			if ( true === isset( $config[ $module_name ] ) && $config[ $module_name ] ) {
-				$range[ $module_name ] = $this->get_range( $module_name );
+			if ( true === isset( $config ) && $config ) {
+				$range[ $module_name ] = $this->get_range( $module_name, $config );
 			}
 		}
 
@@ -307,10 +307,11 @@ class Full_Sync_Immediately extends Module {
 	 * @access public
 	 *
 	 * @param string $type Type of sync item to get the range for.
+	 * @param array  $config Configuration for the sync item.
 	 *
 	 * @return array Array of min ID, max ID and total items in the range.
 	 */
-	public function get_range( $type ) {
+	public function get_range( $type, $config ) {
 		global $wpdb;
 		$module = Modules::get_module( $type );
 		if ( ! $module ) {
@@ -319,7 +320,7 @@ class Full_Sync_Immediately extends Module {
 
 		$table     = $module->table();
 		$id        = $module->id_field();
-		$where_sql = $module->get_where_sql( null );
+		$where_sql = $module->get_where_sql( $config );
 
 		// TODO: Call $wpdb->prepare on the following query.
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -100,15 +100,15 @@ class Full_Sync_Immediately extends Module {
 			$full_sync_config['users'] = $users_module->get_initial_sync_user_config();
 		}
 
+		$range = $this->get_content_range();
+
 		$this->update_status(
 			array(
 				'started'  => time(),
 				'config'   => $full_sync_config,
-				'progress' => $this->get_initial_progress( $full_sync_config ),
+				'progress' => $this->get_initial_progress( $full_sync_config, $range ),
 			)
 		);
-
-		$range = $this->get_content_range();
 		/**
 		 * Fires when a full sync begins. This action is serialized
 		 * and sent to the server so that it knows a full sync is coming.
@@ -249,10 +249,11 @@ class Full_Sync_Immediately extends Module {
 	 * Given an initial Full Sync configuration get the initial status.
 	 *
 	 * @param array $full_sync_config Full sync configuration.
+	 * @param array $range Range of the sync items, containing min, max and count IDs for some item types.
 	 *
 	 * @return array Initial Sent status.
 	 */
-	public function get_initial_progress( $full_sync_config ) {
+	public function get_initial_progress( $full_sync_config, $range = null ) {
 		// Set default configuration, calculate totals, and save configuration if totals > 0.
 		$status = array();
 		foreach ( $full_sync_config as $name => $config ) {
@@ -261,7 +262,8 @@ class Full_Sync_Immediately extends Module {
 				continue;
 			}
 			$status[ $name ] = array(
-				'total'    => $module->total( $config ),
+				// If we have a range for the module, use the count from the range to avoid querying the database again.
+				'total'    => ( isset( $range[ $name ]['count'] ) ) ? $range[ $name ]['count'] : $module->total( $config ),
 				'sent'     => 0,
 				'finished' => false,
 			);

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -100,7 +100,7 @@ class Full_Sync_Immediately extends Module {
 			$full_sync_config['users'] = $users_module->get_initial_sync_user_config();
 		}
 
-		$range = $this->get_content_range();
+		$range = $this->get_content_range( $full_sync_config );
 
 		$this->update_status(
 			array(
@@ -263,7 +263,7 @@ class Full_Sync_Immediately extends Module {
 			}
 			$status[ $name ] = array(
 				// If we have a range for the module, use the count from the range to avoid querying the database again.
-				'total'    => ( isset( $range[ $name ]['count'] ) ) ? $range[ $name ]['count'] : $module->total( $config ),
+				'total'    => ( isset( $range[ $name ]->count ) ) ? $range[ $name ]->count : $module->total( $config ),
 				'sent'     => 0,
 				'finished' => false,
 			);
@@ -277,11 +277,12 @@ class Full_Sync_Immediately extends Module {
 	 *
 	 * @access private
 	 *
+	 * @param array $config Full sync configuration.
+	 *
 	 * @return array Array of range (min ID, max ID, total items) for all content types.
 	 */
-	private function get_content_range() {
-		$range  = array();
-		$config = $this->get_status()['config'];
+	private function get_content_range( $config ) {
+		$range = array();
 		foreach ( array_keys( $config ) as $module_name ) {
 			// Calculate ranges only for modules that get chunked.
 			if ( in_array( $module_name, array( 'constants', 'functions', 'network_options', 'options', 'themes', 'updates' ), true ) ) {
@@ -447,7 +448,7 @@ class Full_Sync_Immediately extends Module {
 	 * @access public
 	 */
 	public function send_full_sync_end() {
-		$range = $this->get_content_range();
+		$range = $this->get_content_range( $this->get_status()['config'] );
 
 		/**
 		 * Fires when a full sync ends. This action is serialized

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -292,9 +292,8 @@ class Full_Sync_Immediately extends Module {
 			if ( ! $module ) {
 				continue;
 			}
-			// Add range only when syncing all objects.
-			if ( true === isset( $config ) && $config && ! is_array( $config ) ) {
-				$range[ $module_name ] = $this->get_range( $module_name, $config );
+			if ( true === isset( $config ) && $config ) {
+				$range[ $module_name ] = $this->get_range( $module_name );
 			}
 		}
 
@@ -307,11 +306,10 @@ class Full_Sync_Immediately extends Module {
 	 * @access public
 	 *
 	 * @param string $type Type of sync item to get the range for.
-	 * @param array  $config Configuration for the sync item.
 	 *
 	 * @return array Array of min ID, max ID and total items in the range.
 	 */
-	public function get_range( $type, $config ) {
+	public function get_range( $type ) {
 		global $wpdb;
 		$module = Modules::get_module( $type );
 		if ( ! $module ) {
@@ -320,7 +318,7 @@ class Full_Sync_Immediately extends Module {
 
 		$table     = $module->table();
 		$id        = $module->id_field();
-		$where_sql = $module->get_where_sql( $config );
+		$where_sql = $module->get_where_sql( array() );
 
 		// TODO: Call $wpdb->prepare on the following query.
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -280,13 +280,19 @@ class Full_Sync_Immediately extends Module {
 	private function get_content_range() {
 		$range  = array();
 		$config = $this->get_status()['config'];
-		// Add range only when syncing all objects.
-		if ( true === isset( $config['posts'] ) && $config['posts'] ) {
-			$range['posts'] = $this->get_range( 'posts' );
-		}
-
-		if ( true === isset( $config['comments'] ) && $config['comments'] ) {
-			$range['comments'] = $this->get_range( 'comments' );
+		foreach ( array_keys( $config ) as $module_name ) {
+			// Calculate ranges only for modules that get chunked.
+			if ( in_array( $module_name, array( 'constants', 'functions', 'network_options', 'options', 'themes', 'updates' ), true ) ) {
+				continue;
+			}
+			$module = Modules::get_module( $module_name );
+			if ( ! $module ) {
+				continue;
+			}
+			// Add range only when syncing all objects.
+			if ( true === isset( $config[ $module_name ] ) && $config[ $module_name ] ) {
+				$range[ $module_name ] = $this->get_range( $module_name );
+			}
 		}
 
 		return $range;
@@ -303,23 +309,14 @@ class Full_Sync_Immediately extends Module {
 	 */
 	public function get_range( $type ) {
 		global $wpdb;
-		if ( ! in_array( $type, array( 'comments', 'posts' ), true ) ) {
+		$module = Modules::get_module( $type );
+		if ( ! $module ) {
 			return array();
 		}
 
-		switch ( $type ) {
-			case 'posts':
-				$table     = $wpdb->posts;
-				$id        = 'ID';
-				$where_sql = Settings::get_blacklisted_post_types_sql();
-
-				break;
-			case 'comments':
-				$table     = $wpdb->comments;
-				$id        = 'comment_ID';
-				$where_sql = Settings::get_comments_filter_sql();
-				break;
-		}
+		$table     = $module->table();
+		$id        = $module->id_field();
+		$where_sql = $module->get_where_sql( null );
 
 		// TODO: Call $wpdb->prepare on the following query.
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -293,7 +293,7 @@ class Full_Sync_Immediately extends Module {
 				continue;
 			}
 			// Add range only when syncing all objects.
-			if ( true === isset( $config ) && $config ) {
+			if ( true === isset( $config ) && $config && ! is_array( $config ) ) {
 				$range[ $module_name ] = $this->get_range( $module_name, $config );
 			}
 		}

--- a/projects/packages/sync/src/modules/class-posts.php
+++ b/projects/packages/sync/src/modules/class-posts.php
@@ -282,7 +282,7 @@ class Posts extends Module {
 		$where_sql = Settings::get_blacklisted_post_types_sql();
 
 		// Config is a list of post IDs to sync.
-		if ( is_array( $config ) ) {
+		if ( is_array( $config ) && ! empty( $config ) ) {
 			$where_sql .= ' AND ID IN (' . implode( ',', array_map( 'intval', $config ) ) . ')';
 		}
 

--- a/projects/packages/sync/src/modules/class-terms.php
+++ b/projects/packages/sync/src/modules/class-terms.php
@@ -204,7 +204,7 @@ class Terms extends Module {
 	public function get_where_sql( $config ) {
 		$where_sql = Settings::get_blacklisted_taxonomies_sql();
 
-		if ( is_array( $config ) ) {
+		if ( is_array( $config ) && ! empty( $config ) ) {
 			$where_sql .= ' AND term_taxonomy_id IN (' . implode( ',', array_map( 'intval', $config ) ) . ')';
 		}
 

--- a/projects/packages/sync/src/modules/class-users.php
+++ b/projects/packages/sync/src/modules/class-users.php
@@ -760,7 +760,7 @@ class Users extends Module {
 		$query = "meta_key = '{$wpdb->prefix}user_level' AND meta_value > 0";
 
 		// The $config variable is a list of user IDs to sync.
-		if ( is_array( $config ) ) {
+		if ( is_array( $config ) && ! empty( $config ) ) {
 			$query .= ' AND user_id IN (' . implode( ',', array_map( 'intval', $config ) ) . ')';
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of https://github.com/Automattic/vulcan/issues/735
> Full Sync logic in WPCOM has two functions to handle non-existing items in Remote but that existed in wpcom.
The first one is `cleanup_out_of_range` which is called during the jetpack_full_sync_start action. For this, we need to ensure we [send](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/modules/class-full-sync-immediately.php#L111-L126) the ranges from the package end for the corresponding module. At the moment this is only done for posts and comments.
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Send Ranges for all chunked modules leveraging `get_where_sql`. **Note:** This is not necessarily 100% precise with the actions sent later since some filtering can happen when getting the chunks. But it is a pretty good estimate and plenty useful for the  `cleanup_out_of_range` function.
* Avoid calculating totals for the modules that we calculated ranges since the same query is done

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
#### Test Complete Full Syncs via Debugger
* Go to Jetpack Debugger for your test site and trigger a Full Sync for everything.
* In the `jetpack_full_sync_start` action you should be seeing ranges being sent for all chunked modules active in the site 
* Try the same but for a specific chunked module. (e.g. Term relationships). You should only see the ranges for this module in the action.
* Try it for a non chunked module (e.g. options) You should not see ranges sent in the action.
#### Test partial Full Syncs via CLI
- In your local check for some post IDs and run the following in WP CLI (with your own POST IDS)
    `wp jetpack sync start --modules=posts --posts=555,559,562 --allow-root`
-  In the `jetpack_full_sync_start` action the ranges should still send the whole ranges without considering the ids specified in WP CLI.