### PR TITLE
Social: Add fallback for deprecated components from edit-post package

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-crash-on-p2
+++ b/projects/js-packages/publicize-components/changelog/fix-social-crash-on-p2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fix editor crash on p2 for old package versions

--- a/projects/js-packages/publicize-components/src/components/block-editor/components/pre-publish-panels.tsx
+++ b/projects/js-packages/publicize-components/src/components/block-editor/components/pre-publish-panels.tsx
@@ -1,5 +1,6 @@
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils/components';
-import { PluginPrePublishPanel } from '@wordpress/editor';
+import { PluginPrePublishPanel as DeprecatedPluginPrePublishPanel } from '@wordpress/edit-post';
+import { PluginPrePublishPanel as EditorPluginPrePublishPanel } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { usePostCanUseSig } from '../../../hooks/use-post-can-use-sig';
 import useSocialMediaConnections from '../../../hooks/use-social-media-connections';
@@ -7,6 +8,8 @@ import { useSyncPostDataToStore } from '../../../hooks/use-sync-post-data-to-sto
 import PublicizePanel from '../../panel';
 import SocialImageGeneratorPanel from '../../social-image-generator/panel';
 import { UpsellNotice } from './upsell';
+
+const PluginPrePublishPanel = EditorPluginPrePublishPanel || DeprecatedPluginPrePublishPanel;
 
 const PrePublishPanels = () => {
 	useSyncPostDataToStore();

--- a/projects/js-packages/publicize-components/src/components/post-publish-manual-sharing/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-manual-sharing/index.tsx
@@ -1,10 +1,17 @@
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils/components';
 import { useSelect } from '@wordpress/data';
-import { PluginPostPublishPanel, store as editorStore } from '@wordpress/editor';
+import { PluginPostPublishPanel as DeprecatedPluginPostPublishPanel } from '@wordpress/edit-post';
+import {
+	PluginPostPublishPanel as EditorPluginPostPublishPanel,
+	store as editorStore,
+} from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { ManualSharingInfo } from '../manual-sharing/info';
 import { ShareButtons } from '../share-buttons/share-buttons';
 import styles from './styles.module.scss';
+
+const PluginPostPublishPanel = EditorPluginPostPublishPanel || DeprecatedPluginPostPublishPanel;
+
 /**
  * Post Publish Manual Sharing component.
  *

--- a/projects/js-packages/publicize-components/src/components/post-publish-review-prompt/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-review-prompt/index.tsx
@@ -1,12 +1,15 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import apiFetch from '@wordpress/api-fetch';
-import { PluginPostPublishPanel } from '@wordpress/editor';
+import { PluginPostPublishPanel as DeprecatedPluginPostPublishPanel } from '@wordpress/edit-post';
+import { PluginPostPublishPanel as EditorPluginPostPublishPanel } from '@wordpress/editor';
 import { useCallback, useState } from '@wordpress/element';
 import usePublicizeConfig from '../../hooks/use-publicize-config';
 import { usePostStartedPublishing } from '../../hooks/use-saving-post';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import { getSocialScriptData } from '../../utils';
 import ReviewPrompt from '../review-prompt';
+
+const PluginPostPublishPanel = EditorPluginPostPublishPanel || DeprecatedPluginPostPublishPanel;
 
 const PostPublishReviewPrompt = () => {
 	const { review } = getSocialScriptData();

--- a/projects/js-packages/publicize-components/src/components/post-publish-share-status/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-share-status/index.tsx
@@ -1,5 +1,9 @@
 import { useDispatch, useSelect } from '@wordpress/data';
-import { PluginPostPublishPanel, store as editorStore } from '@wordpress/editor';
+import { PluginPostPublishPanel as DeprecatedPluginPostPublishPanel } from '@wordpress/edit-post';
+import {
+	store as editorStore,
+	PluginPostPublishPanel as EditorPluginPostPublishPanel,
+} from '@wordpress/editor';
 import { useIsSharingPossible } from '../../hooks/use-is-sharing-possible';
 import { usePostMeta } from '../../hooks/use-post-meta';
 import { usePostPrePublishValue } from '../../hooks/use-post-pre-publish-value';
@@ -7,6 +11,8 @@ import { usePostJustPublished } from '../../hooks/use-saving-post';
 import { store as socialStore } from '../../social-store';
 import { getSocialScriptData } from '../../utils/script-data';
 import { ShareStatus } from './share-status';
+
+const PluginPostPublishPanel = EditorPluginPostPublishPanel || DeprecatedPluginPostPublishPanel;
 
 /**
  * Post publish share status component.


### PR DESCRIPTION
Following #42634, p2 editor crashes with Social warning. It seems like p2 loads older versions of Gutenberg packages where the package is not available yet.

Slack: p1742902170192989-slack-C0299DMPG

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add fallback for deprecated components from edit-post package

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to you sandbox
* Point a p2 and the public API to your sandbox
* Create a p2 post
* Confirm that there is no error related to Social crash