### PR TITLE
[WordAds]: Add support for v2 configuration used by WATL

### DIFF
--- a/projects/plugins/jetpack/changelog/feat-wordads-client-for-watl-v2
+++ b/projects/plugins/jetpack/changelog/feat-wordads-client-for-watl-v2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+WordAds: update support for v2 configuration used by WATL

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -20,7 +20,6 @@ require_once WORDADS_ROOT . '/php/class-wordads-cron.php';
 require_once WORDADS_ROOT . '/php/class-wordads-california-privacy.php';
 require_once WORDADS_ROOT . '/php/class-wordads-ccpa-do-not-sell-link-widget.php';
 require_once WORDADS_ROOT . '/php/class-wordads-consent-management-provider.php';
-require_once WORDADS_ROOT . '/php/class-wordads-smart.php';
 require_once WORDADS_ROOT . '/php/class-wordads-shortcode.php';
 
 /**
@@ -220,7 +219,12 @@ class WordAds {
 		WordAds_Shortcode::init();
 
 		// Initialize Smart.
-		WordAds_Smart::instance()->init( $this->params );
+		// require_once WORDADS_ROOT . '/php/class-wordads-smart.php';
+		// WordAds_Smart::instance()->init( $this->params );
+
+		// Initialize WordAds client.
+		require_once WORDADS_ROOT . '/php/class-wordads-client.php';
+		WordAds_Client::instance()->init( $this->params );
 
 		if ( ( isset( $_SERVER['REQUEST_URI'] ) && '/ads.txt' === $_SERVER['REQUEST_URI'] )
 			|| ( site_url( 'ads.txt', 'relative' ) === $_SERVER['REQUEST_URI'] ) ) {

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-client-config.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-client-config.php
@@ -139,6 +139,8 @@ final class WordAds_Client_Config {
 	 * @return string The URL.
 	 */
 	public function get_server_config_url(): string {
+		// TODO: WPCOM needs to be updated to not rely on wordads-logging=true&aditude=true on the adflow endpoint as it's not going to be carried over from the browser and we don't want to include that here
+		// using the jetpack version `ver` included in the enqueued script or adding specific `api_version` query param is preferred.
 		return sprintf(
 			'https://public-api.wordpress.com/wpcom/v2/sites/%1$d/adflow/conf/?_jsonp=a8c_adflow_callback&api_version=2&wordads-logging=true&aditude=true',
 			$this->params->blog_id

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-client-config.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-client-config.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ *  Configuration for the WordAds client.
+ *
+ * @package automattic/jetpack
+ */
+
+// imports
+require_once WORDADS_ROOT . '/php/class-wordads-format.php';
+
+/**
+ * Configuration class for WordAds client.
+ */
+final class WordAds_Client_Config {
+	/**
+	 * Supported formats.
+	 * sidebar_widget formats represents the legacy Jetpack sidebar widget.
+	 *
+	 * @var array
+	 */
+	private $supported_formats = array(
+		WordAds_Format::TOP,
+		WordAds_Format::INLINE,
+		WordAds_Format::BELOWPOST,
+		WordAds_Format::BOTTOM_STICKY,
+		WordAds_Format::SIDEBAR_STICKY_RIGHT,
+		WordAds_Format::GUTENBERG_RECTANGLE,
+		WordAds_Format::GUTENBERG_LEADERBOARD,
+		WordAds_Format::GUTENBERG_MOBILE_LEADERBOARD,
+		WordAds_Format::GUTENBERG_SKYSCRAPER,
+		WordAds_Format::SIDEBAR_WIDGET_MEDIUMRECTANGLE,
+		WordAds_Format::SIDEBAR_WIDGET_LEADERBOARD,
+		WordAds_Format::SIDEBAR_WIDGET_WIDESKYCRAPER,
+		WordAds_Format::SHORTCODE,
+	);
+
+	/**
+	 * The parameters for WordAds.
+	 *
+	 * @var WordAds_Params
+	 */
+	private $params;
+
+	/**
+	 * List of enabled ad formats.
+	 *
+	 * @var array
+	 */
+	private $formats_enabled = array();
+
+	/**
+	 * Constructor.
+	 *
+	 * @param WordAds_Params $params Object containing WordAds settings.
+	 */
+	public function __construct( WordAds_Params $params ) {
+		$this->params = $params;
+		$this->enable_formats_from_options();
+		$this->override_enable_formats_from_query_string();
+	}
+
+	/**
+	 * Checks if a specific ad format is enabled.
+	 *
+	 * @param string $format The ad format to check.
+	 * @return bool True if the format is enabled, false otherwise.
+	 */
+	public function is_format_enabled( $format ) {
+		return in_array( $format, $this->formats_enabled, true );
+	}
+
+	/**
+	 * Enables a specific ad format if it is not already enabled.
+	 *
+	 * @param string $format The ad format to enable.
+	 */
+	public function enable_format( $format ): void {
+		if ( ! $this->is_format_enabled( $format ) ) {
+			$this->formats_enabled[] = $format;
+		}
+	}
+
+	/**
+	 * Returns the WordAds configuration as an array.
+	 *
+	 * @return array The WordAds configuration settings.
+	 */
+	public function get_config(): array {
+		return array(
+			'blog_id'       => $this->params->blog_id,
+			'blog_language' => explode( '-', get_locale() )[0],
+			'hosting_type'  => 1, // 0 = Automattic hosted, 1 = Self hosted
+			'theme'         => get_stylesheet(),
+			'formats'       => $this->formats_enabled,
+		);
+	}
+
+	/**
+	 * Enables ad formats based on the display options
+	 *
+	 * @return void
+	 */
+	private function enable_formats_from_options(): void {
+		$this->params->options['enable_header_ad'] && $this->enable_format( WordAds_Format::TOP );
+		is_singular( 'post' ) && $this->params->options['wordads_inline_enabled'] && $this->enable_format( WordAds_Format::INLINE );
+		$this->params->should_show() && $this->enable_format( WordAds_Format::BELOWPOST );
+		$this->params->options['wordads_bottom_sticky_enabled'] && $this->enable_format( WordAds_Format::BOTTOM_STICKY );
+		$this->params->options['wordads_sidebar_sticky_right_enabled'] && $this->enable_format( WordAds_Format::SIDEBAR_STICKY_RIGHT );
+	}
+
+	/**
+	 * Enables ad formats based on query string parameters, eg. ?inline=true.
+	 */
+	private function override_enable_formats_from_query_string(): void {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET['wordads-logging'] ) ) {
+			return;
+		}
+
+		foreach ( $this->supported_formats as $format ) {
+			if ( isset( $_GET[ $format ] ) && 'true' === $_GET[ $format ] ) {
+				$this->enable_format( $format );
+			}
+		}
+	}
+
+	/**
+	 * Check if has any format enabled.
+	 *
+	 * @return bool True if enabled, false otherwise.
+	 */
+	public function has_any_format_enabled(): bool {
+		return count( $this->formats_enabled ) > 0;
+	}
+
+	/**
+	 * Gets the URL to a JSONP endpoint with configuration data.
+	 *
+	 * @return string The URL.
+	 */
+	public function get_server_config_url(): string {
+		return sprintf(
+			'https://public-api.wordpress.com/wpcom/v2/sites/%1$d/adflow/conf/?_jsonp=a8c_adflow_callback&api_version=2&wordads-logging=true&aditude=true',
+			$this->params->blog_id
+		);
+	}
+}

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-client.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-client.php
@@ -1,0 +1,344 @@
+<?php
+/**
+ *  An implementation for ads served through WATL.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Assets;
+
+// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+
+require_once WORDADS_ROOT . '/php/class-wordads-array-utils.php';
+
+/**
+ * Contains all the implementation details for WATL ads
+ */
+class WordAds_Client {
+
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var WordAds_Client
+	 */
+	protected static $instance = null;
+
+	/**
+	 * The parameters for WordAds.
+	 *
+	 * @var WordAds_Params
+	 */
+	private $params;
+
+	/**
+	 * Has asset been enqueued?
+	 *
+	 * @var bool True if asset has been enqueued.
+	 */
+	private $is_asset_enqueued = false;
+
+	/**
+	 * Supported formats.
+	 * sidebar_widget formats represents the legacy Jetpack sidebar widget.
+	 *
+	 * @var array
+	 */
+	private $formats = array(
+		'top'                            => array(
+			'enabled' => false,
+		),
+		'inline'                         => array(
+			'enabled' => false,
+		),
+		'belowpost'                      => array(
+			'enabled' => false,
+		),
+		'bottom_sticky'                  => array(
+			'enabled' => false,
+		),
+		'sidebar_sticky_right'           => array(
+			'enabled' => false,
+		),
+		'gutenberg_rectangle'            => array(
+			'enabled' => false,
+		),
+		'gutenberg_leaderboard'          => array(
+			'enabled' => false,
+		),
+		'gutenberg_mobile_leaderboard'   => array(
+			'enabled' => false,
+		),
+		'gutenberg_skyscraper'           => array(
+			'enabled' => false,
+		),
+		'sidebar_widget_mediumrectangle' => array(
+			'enabled' => false,
+		),
+		'sidebar_widget_leaderboard'     => array(
+			'enabled' => false,
+		),
+		'sidebar_widget_wideskyscraper'  => array(
+			'enabled' => false,
+		),
+		'shortcode'                      => array(
+			'enabled' => false,
+		),
+	);
+
+	/**
+	 * Private constructor.
+	 */
+	private function __construct() {
+	}
+
+	/**
+	 * Main Class Instance.
+	 *
+	 * Ensures only one instance of WordAds_Client is loaded or can be loaded.
+	 *
+	 * @return WordAds_Client
+	 */
+	public static function instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Initialize the ads.
+	 *
+	 * @param WordAds_Params $params Object containing WordAds settings.
+	 *
+	 * @return void
+	 */
+	public function init( WordAds_Params $params ) {
+		$this->params = $params;
+
+		$this->enable_formats();
+		$this->override_formats_from_query_string();
+
+		if ( $this->has_any_format_enabled() ) {
+			$this->insert_ads();
+		}
+	}
+
+	/**
+	 * Enqueue any front-end CSS and JS.
+	 *
+	 * @return void
+	 */
+	public function enqueue_assets() {
+
+		if ( $this->is_asset_enqueued ) {
+			return;
+		}
+
+		add_action( 'wp_head', array( $this, 'insert_config' ) );
+
+		Assets::register_script(
+			'adflow_script_loader',
+			'_inc/build/wordads/js/adflow-loader.min.js',
+			JETPACK__PLUGIN_FILE,
+			array(
+				'nonmin_path'  => 'modules/wordads/js/adflow-loader.js',
+				'dependencies' => array(),
+				'enqueue'      => true,
+				'version'      => JETPACK__VERSION,
+			)
+		);
+
+		wp_enqueue_script(
+			'adflow_config',
+			esc_url( $this->get_config_url() ),
+			array( 'adflow_script_loader' ),
+			JETPACK__VERSION,
+			false
+		);
+
+		$this->is_asset_enqueued = true;
+	}
+
+	/**
+	 * Inserts ad tags on the page.
+	 *
+	 * @return void
+	 */
+	private function insert_ads() {
+		if ( $this->params->is_amp ) {
+			return;
+		}
+
+		// Don't run on not found pages.
+		if ( is_404() ) {
+			return;
+		}
+
+		// Add the resource hints.
+		add_filter( 'wp_resource_hints', array( $this, 'resource_hints' ), 10, 2 );
+
+		// Enqueue JS assets.
+		$this->enqueue_assets();
+
+		$is_static_front_page = is_front_page() && 'page' === get_option( 'show_on_front' );
+
+		if ( ! ( $is_static_front_page || is_home() ) ) {
+			if ( $this->formats['inline']['enabled'] ) {
+				add_filter(
+					'the_content',
+					array( $this, 'insert_inline_marker' ),
+					10
+				);
+			}
+		}
+
+		if ( $this->formats['bottom_sticky']['enabled'] ) {
+			// Disable IPW slot.
+			add_filter( 'wordads_iponweb_bottom_sticky_ad_disable', '__return_true', 10 );
+		}
+
+		if ( $this->formats['sidebar_sticky_right']['enabled'] ) {
+			// Disable IPW slot.
+			add_filter( 'wordads_iponweb_sidebar_sticky_right_ad_disable', '__return_true', 10 );
+		}
+	}
+
+	/**
+	 * Inserts JS configuration used by watl.js.
+	 *
+	 * @return void
+	 */
+	public function insert_config() {
+		global $post;
+
+		$config = array(
+			'post_id' => ( $post instanceof WP_Post ) && is_singular( 'post' ) ? $post->ID : null,
+			'origin'  => 'jetpack',
+			'theme'   => get_stylesheet(),
+			'target'  => $this->target_keywords(),
+		) + $this->formats;
+
+		// Do conversion.
+		$js_config = WordAds_Array_Utils::array_to_js_object( $config );
+
+		// Output script.
+		wp_print_inline_script_tag( "var wa_smart = $js_config; wa_smart.cmd = [];" );
+	}
+
+	/**
+	 * Add the resource hints.
+	 *
+	 * @param array  $hints Domains for hinting.
+	 * @param string $relation_type Resource type.
+	 *
+	 * @return array Domains for hinting.
+	 */
+	public function resource_hints( $hints, $relation_type ) {
+		if ( 'dns-prefetch' === $relation_type ) {
+			$hints[] = '//af.pubmine.com';
+		}
+
+		return $hints;
+	}
+
+	/**
+	 * Gets the URL to a JSONP endpoint with configuration data.
+	 *
+	 * @return string The URL.
+	 */
+	private function get_config_url(): string {
+		return sprintf(
+			'https://public-api.wordpress.com/wpcom/v2/sites/%1$d/adflow/conf/?_jsonp=a8c_adflow_callback',
+			$this->params->blog_id
+		);
+	}
+
+	/**
+	 * Places marker at the end of the content so inline can identify the post content container.
+	 *
+	 * @param string|null $content The post content.
+	 * @return string|null The post content with the marker appended.
+	 */
+	public function insert_inline_marker( ?string $content ): ?string {
+		if ( null === $content ) {
+			return null;
+		}
+		$inline_ad_marker = '<span id="wordads-inline-marker" style="display: none;"></span>';
+
+		// Append the ad to the post content.
+		return $content . $inline_ad_marker;
+	}
+
+	/**
+	 * Gets a formatted list of target keywords.
+	 *
+	 * @return string Formatted list of target keywords.
+	 */
+	private function target_keywords(): string {
+		$target_keywords = array_merge(
+			$this->get_blog_keywords(),
+			$this->get_language_keywords()
+		);
+
+		return implode( ';', $target_keywords );
+	}
+
+	/**
+	 * Gets a formatted list of blog keywords.
+	 *
+	 * @return array The list of blog keywords.
+	 */
+	private function get_blog_keywords(): array {
+		return array( 'wp_blog_id=' . $this->params->blog_id );
+	}
+
+	/**
+	 * Gets the site language formatted as a keyword.
+	 *
+	 * @return array The language as a keyword.
+	 */
+	private function get_language_keywords(): array {
+		return array( 'language=' . explode( '-', get_locale() )[0] );
+	}
+
+	/**
+	 * Enable formats by post types and the display options.
+	 *
+	 * @return void
+	 */
+	private function enable_formats(): void {
+		$this->formats['top']['enabled']                  = $this->params->options['enable_header_ad'];
+		$this->formats['inline']['enabled']               = is_singular( 'post' ) && $this->params->options['wordads_inline_enabled'];
+		$this->formats['belowpost']['enabled']            = $this->params->should_show();
+		$this->formats['bottom_sticky']['enabled']        = $this->params->options['wordads_bottom_sticky_enabled'];
+		$this->formats['sidebar_sticky_right']['enabled'] = $this->params->options['wordads_sidebar_sticky_right_enabled'];
+	}
+
+	/**
+	 * Allow format enabled override from query string, eg. ?inline=true.
+	 *
+	 * @return void
+	 */
+	private function override_formats_from_query_string(): void {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET['wordads-logging'] ) ) {
+			return;
+		}
+
+		foreach ( $this->formats as $format_type => $_ ) {
+			// phpcs:disable WordPress.Security.NonceVerification.Recommended
+			if ( isset( $_GET[ $format_type ] ) && 'true' === $_GET[ $format_type ] ) {
+				$this->formats[ $format_type ]['enabled'] = true;
+			}
+		}
+	}
+
+	/**
+	 * Check if has any format enabled.
+	 *
+	 * @return bool True if enabled, false otherwise.
+	 */
+	private function has_any_format_enabled(): bool {
+		return in_array( true, array_column( $this->formats, 'enabled' ), true );
+	}
+}

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-client.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-client.php
@@ -10,11 +10,19 @@ use Automattic\Jetpack\Assets;
 // phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 
 require_once WORDADS_ROOT . '/php/class-wordads-array-utils.php';
+require_once WORDADS_ROOT . '/php/class-wordads-client-config.php';
+require_once WORDADS_ROOT . '/php/class-wordads-format.php';
 
 /**
  * Contains all the implementation details for WATL ads
  */
 class WordAds_Client {
+	/**
+	 * WordAds Client Configuration settings.
+	 *
+	 * @var WordAds_Client_Config
+	 */
+	private $config;
 
 	/**
 	 * The single instance of the class.
@@ -36,54 +44,6 @@ class WordAds_Client {
 	 * @var bool True if asset has been enqueued.
 	 */
 	private $is_asset_enqueued = false;
-
-	/**
-	 * Supported formats.
-	 * sidebar_widget formats represents the legacy Jetpack sidebar widget.
-	 *
-	 * @var array
-	 */
-	private $formats = array(
-		'top'                            => array(
-			'enabled' => false,
-		),
-		'inline'                         => array(
-			'enabled' => false,
-		),
-		'belowpost'                      => array(
-			'enabled' => false,
-		),
-		'bottom_sticky'                  => array(
-			'enabled' => false,
-		),
-		'sidebar_sticky_right'           => array(
-			'enabled' => false,
-		),
-		'gutenberg_rectangle'            => array(
-			'enabled' => false,
-		),
-		'gutenberg_leaderboard'          => array(
-			'enabled' => false,
-		),
-		'gutenberg_mobile_leaderboard'   => array(
-			'enabled' => false,
-		),
-		'gutenberg_skyscraper'           => array(
-			'enabled' => false,
-		),
-		'sidebar_widget_mediumrectangle' => array(
-			'enabled' => false,
-		),
-		'sidebar_widget_leaderboard'     => array(
-			'enabled' => false,
-		),
-		'sidebar_widget_wideskyscraper'  => array(
-			'enabled' => false,
-		),
-		'shortcode'                      => array(
-			'enabled' => false,
-		),
-	);
 
 	/**
 	 * Private constructor.
@@ -114,11 +74,9 @@ class WordAds_Client {
 	 */
 	public function init( WordAds_Params $params ) {
 		$this->params = $params;
+		$this->config = new WordAds_Client_Config( $this->params );
 
-		$this->enable_formats();
-		$this->override_formats_from_query_string();
-
-		if ( $this->has_any_format_enabled() ) {
+		if ( $this->config->has_any_format_enabled() ) {
 			$this->insert_ads();
 		}
 	}
@@ -150,7 +108,7 @@ class WordAds_Client {
 
 		wp_enqueue_script(
 			'adflow_config',
-			esc_url( $this->get_config_url() ),
+			$this->config->get_server_config_url(),
 			array( 'adflow_script_loader' ),
 			JETPACK__VERSION,
 			false
@@ -183,7 +141,7 @@ class WordAds_Client {
 		$is_static_front_page = is_front_page() && 'page' === get_option( 'show_on_front' );
 
 		if ( ! ( $is_static_front_page || is_home() ) ) {
-			if ( $this->formats['inline']['enabled'] ) {
+			if ( $this->config->is_format_enabled( WordAds_Format::INLINE ) ) {
 				add_filter(
 					'the_content',
 					array( $this, 'insert_inline_marker' ),
@@ -192,12 +150,12 @@ class WordAds_Client {
 			}
 		}
 
-		if ( $this->formats['bottom_sticky']['enabled'] ) {
+		if ( $this->config->is_format_enabled( WordAds_Format::BOTTOM_STICKY ) ) {
 			// Disable IPW slot.
 			add_filter( 'wordads_iponweb_bottom_sticky_ad_disable', '__return_true', 10 );
 		}
 
-		if ( $this->formats['sidebar_sticky_right']['enabled'] ) {
+		if ( $this->config->is_format_enabled( WordAds_Format::SIDEBAR_STICKY_RIGHT ) ) {
 			// Disable IPW slot.
 			add_filter( 'wordads_iponweb_sidebar_sticky_right_ad_disable', '__return_true', 10 );
 		}
@@ -209,20 +167,11 @@ class WordAds_Client {
 	 * @return void
 	 */
 	public function insert_config() {
-		global $post;
-
-		$config = array(
-			'post_id' => ( $post instanceof WP_Post ) && is_singular( 'post' ) ? $post->ID : null,
-			'origin'  => 'jetpack',
-			'theme'   => get_stylesheet(),
-			'target'  => $this->target_keywords(),
-		) + $this->formats;
-
 		// Do conversion.
-		$js_config = WordAds_Array_Utils::array_to_js_object( $config );
+		$js_config = WordAds_Array_Utils::array_to_js_object( $this->config->get_config() );
 
 		// Output script.
-		wp_print_inline_script_tag( "var wa_smart = $js_config; wa_smart.cmd = [];" );
+		wp_print_inline_script_tag( "var wa_client = {}; wa_client.cmd = []; wa_client.config = $js_config;" );
 	}
 
 	/**
@@ -242,18 +191,6 @@ class WordAds_Client {
 	}
 
 	/**
-	 * Gets the URL to a JSONP endpoint with configuration data.
-	 *
-	 * @return string The URL.
-	 */
-	private function get_config_url(): string {
-		return sprintf(
-			'https://public-api.wordpress.com/wpcom/v2/sites/%1$d/adflow/conf/?_jsonp=a8c_adflow_callback',
-			$this->params->blog_id
-		);
-	}
-
-	/**
 	 * Places marker at the end of the content so inline can identify the post content container.
 	 *
 	 * @param string|null $content The post content.
@@ -267,78 +204,5 @@ class WordAds_Client {
 
 		// Append the ad to the post content.
 		return $content . $inline_ad_marker;
-	}
-
-	/**
-	 * Gets a formatted list of target keywords.
-	 *
-	 * @return string Formatted list of target keywords.
-	 */
-	private function target_keywords(): string {
-		$target_keywords = array_merge(
-			$this->get_blog_keywords(),
-			$this->get_language_keywords()
-		);
-
-		return implode( ';', $target_keywords );
-	}
-
-	/**
-	 * Gets a formatted list of blog keywords.
-	 *
-	 * @return array The list of blog keywords.
-	 */
-	private function get_blog_keywords(): array {
-		return array( 'wp_blog_id=' . $this->params->blog_id );
-	}
-
-	/**
-	 * Gets the site language formatted as a keyword.
-	 *
-	 * @return array The language as a keyword.
-	 */
-	private function get_language_keywords(): array {
-		return array( 'language=' . explode( '-', get_locale() )[0] );
-	}
-
-	/**
-	 * Enable formats by post types and the display options.
-	 *
-	 * @return void
-	 */
-	private function enable_formats(): void {
-		$this->formats['top']['enabled']                  = $this->params->options['enable_header_ad'];
-		$this->formats['inline']['enabled']               = is_singular( 'post' ) && $this->params->options['wordads_inline_enabled'];
-		$this->formats['belowpost']['enabled']            = $this->params->should_show();
-		$this->formats['bottom_sticky']['enabled']        = $this->params->options['wordads_bottom_sticky_enabled'];
-		$this->formats['sidebar_sticky_right']['enabled'] = $this->params->options['wordads_sidebar_sticky_right_enabled'];
-	}
-
-	/**
-	 * Allow format enabled override from query string, eg. ?inline=true.
-	 *
-	 * @return void
-	 */
-	private function override_formats_from_query_string(): void {
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( ! isset( $_GET['wordads-logging'] ) ) {
-			return;
-		}
-
-		foreach ( $this->formats as $format_type => $_ ) {
-			// phpcs:disable WordPress.Security.NonceVerification.Recommended
-			if ( isset( $_GET[ $format_type ] ) && 'true' === $_GET[ $format_type ] ) {
-				$this->formats[ $format_type ]['enabled'] = true;
-			}
-		}
-	}
-
-	/**
-	 * Check if has any format enabled.
-	 *
-	 * @return bool True if enabled, false otherwise.
-	 */
-	private function has_any_format_enabled(): bool {
-		return in_array( true, array_column( $this->formats, 'enabled' ), true );
 	}
 }

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-format.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-format.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ *  WordAds Format definition.
+ *
+ * @package automattic/jetpack
+ */
+
+/**
+ * Contains definition of all the add formats
+ */
+class WordAds_Format {
+	public const TOP                            = 'top';
+	public const INLINE                         = 'inline';
+	public const BELOWPOST                      = 'belowpost';
+	public const BOTTOM_STICKY                  = 'bottom_sticky';
+	public const SIDEBAR_STICKY_RIGHT           = 'sidebar_sticky_right';
+	public const GUTENBERG_RECTANGLE            = 'gutenberg_rectangle';
+	public const GUTENBERG_LEADERBOARD          = 'gutenberg_leaderboard';
+	public const GUTENBERG_MOBILE_LEADERBOARD   = 'gutenberg_mobile_leaderboard';
+	public const GUTENBERG_SKYSCRAPER           = 'gutenberg_skyscraper';
+	public const SIDEBAR_WIDGET_MEDIUMRECTANGLE = 'sidebar_widget_mediumrectangle';  // Used by legacy Jetpack sidebar widget.
+	public const SIDEBAR_WIDGET_LEADERBOARD     = 'sidebar_widget_leaderboard';  // Used by legacy Jetpack sidebar widget.
+	public const SIDEBAR_WIDGET_WIDESKYCRAPER   = 'sidebar_widget_wideskyscraper';  // Used by legacy Jetpack sidebar widget.
+	public const SHORTCODE                      = 'shortcode';
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Following our integration with Aditude prebid, we have made changes to the adflow configuration endpoint and WordAds Tag Library WATL, and the changes in the PR are made to adapt to this new implementation.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Go to a post on your test WordAds site with query `?wordads-logging=true&aditude=true`
- View the browser console to confirm that the new configuration is being requested from the adflow config endpoint
- Check the logs to see that the prebid ads are being requested for each enabled slot and fallback ads are displayed where applicable.