### PR TITLE
General: indicate compatibility with upcoming WP 6.8

### DIFF
--- a/projects/plugins/automattic-for-agencies-client/changelog/update-tested-to-6-8
+++ b/projects/plugins/automattic-for-agencies-client/changelog/update-tested-to-6-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: indicate compatibility with the upcoming version of WordPress - 6.8.

--- a/projects/plugins/automattic-for-agencies-client/readme.txt
+++ b/projects/plugins/automattic-for-agencies-client/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, jeherve, njweller, rcanepa
 Tags: agency, dashboard, management, sites, monitoring
 Requires at least: 6.6
 Requires PHP: 7.2
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag: 0.2.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/projects/plugins/backup/changelog/update-tested-to-6-8
+++ b/projects/plugins/backup/changelog/update-tested-to-6-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: indicate compatibility with the upcoming version of WordPress - 6.8.

--- a/projects/plugins/backup/readme.txt
+++ b/projects/plugins/backup/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, bjorsch, fgiannar, initsogar, jeherve, jwebbdev, kraft
 Tags: jetpack, backup, restore
 Requires at least: 6.6
 Requires PHP: 7.2
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag: 2.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/projects/plugins/boost/changelog/update-tested-to-6-8
+++ b/projects/plugins/boost/changelog/update-tested-to-6-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: indicate compatibility with the upcoming version of WordPress - 6.8.

--- a/projects/plugins/boost/readme.txt
+++ b/projects/plugins/boost/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, xwp, adnan007, bjorsch, danwalmsley, davidlonjon, dili
 Donate link: https://automattic.com
 Tags: performance, speed, web vitals, critical css, cache
 Requires at least: 6.6
-Tested up to: 6.7
+Tested up to: 6.8
 Requires PHP: 7.2
 Stable tag: 3.11.0
 License: GPLv2 or later

--- a/projects/plugins/classic-theme-helper-plugin/changelog/update-tested-to-6-8
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/update-tested-to-6-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: indicate compatibility with the upcoming version of WordPress - 6.8.

--- a/projects/plugins/classic-theme-helper-plugin/readme.txt
+++ b/projects/plugins/classic-theme-helper-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic,
 Tags: jetpack, stuff
 Requires at least: 6.6
 Requires PHP: 7.2
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag: 0.1.0-alpha
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/projects/plugins/crm/changelog/update-tested-to-6-8
+++ b/projects/plugins/crm/changelog/update-tested-to-6-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: indicate compatibility with the upcoming version of WordPress - 6.8.

--- a/projects/plugins/crm/readme.txt
+++ b/projects/plugins/crm/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack CRM - Clients, Leads, Invoices, Billing, Email Marketing, & Automation ===
 Contributors: automattic, kallehauge, cleacos, diegogarciarodrigues, bradshawtm, wpkaren, robertf4, woodyhayday, mikemayhem3030
 Tags: CRM, Invoice, Woocommerce CRM, Clients, Lead Generation, contacts, customers, billing, email marketing, Marketing Automation, contact form, automations
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag: 6.4.2
 Requires at least: 6.0
 Requires PHP: 7.4

--- a/projects/plugins/inspect/changelog/update-tested-to-6-8
+++ b/projects/plugins/inspect/changelog/update-tested-to-6-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: indicate compatibility with the upcoming version of WordPress - 6.8.

--- a/projects/plugins/inspect/readme.txt
+++ b/projects/plugins/inspect/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic,
 Tags: jetpack, stuff
 Requires at least: 6.6
 Requires PHP: 7.2
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag: 1.0.0-alpha
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/projects/plugins/jetpack/changelog/update-tested-to-6-8
+++ b/projects/plugins/jetpack/changelog/update-tested-to-6-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+General: indicate compatibility with the upcoming version of WordPress - 6.8.

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -4,7 +4,7 @@ Tags: Security, backup, malware, scan, performance
 Stable tag: 14.4
 Requires at least: 6.6
 Requires PHP: 7.2
-Tested up to: 6.7
+Tested up to: 6.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/projects/plugins/protect/changelog/update-tested-to-6-8
+++ b/projects/plugins/protect/changelog/update-tested-to-6-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: indicate compatibility with the upcoming version of WordPress - 6.8.

--- a/projects/plugins/protect/readme.txt
+++ b/projects/plugins/protect/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, retrofox, leogermani, renatoagds, bjorsch, ebinnion, f
 Tags: jetpack, protect, security, malware, scan
 Requires at least: 6.6
 Requires PHP: 7.2
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag: 1.4.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/projects/plugins/search/changelog/update-tested-to-6-8
+++ b/projects/plugins/search/changelog/update-tested-to-6-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: indicate compatibility with the upcoming version of WordPress - 6.8.

--- a/projects/plugins/search/readme.txt
+++ b/projects/plugins/search/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, annamcphee, bluefuton, kangzj, jsnmoon, robfelty, gibr
 Tags: search, filter, woocommerce search, ajax search, product search, free cloud-based search
 Requires at least: 6.6
 Requires PHP: 7.2
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag: 1.4.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/projects/plugins/social/changelog/update-tested-to-6-8
+++ b/projects/plugins/social/changelog/update-tested-to-6-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: indicate compatibility with the upcoming version of WordPress - 6.8.

--- a/projects/plugins/social/readme.txt
+++ b/projects/plugins/social/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, pabline, siddarthan, gmjuhasz, manzoorwanijk
 Tags: social media automation, social media scheduling, auto share, social sharing, social media marketing
 Requires at least: 6.6
 Requires PHP: 7.2
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag: 4.5.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/projects/plugins/starter-plugin/changelog/update-tested-to-6-8
+++ b/projects/plugins/starter-plugin/changelog/update-tested-to-6-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: indicate compatibility with the upcoming version of WordPress - 6.8.

--- a/projects/plugins/starter-plugin/readme.txt
+++ b/projects/plugins/starter-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic,
 Tags: jetpack, stuff
 Requires at least: 6.6
 Requires PHP: 7.2
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag: 0.1.0-alpha
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/projects/plugins/vaultpress/changelog/update-tested-to-6-8
+++ b/projects/plugins/vaultpress/changelog/update-tested-to-6-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: indicate compatibility with the upcoming version of WordPress - 6.8.

--- a/projects/plugins/vaultpress/readme.txt
+++ b/projects/plugins/vaultpress/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, annezazu, apokalyptik, bjorsch, briancolinger, dsmart, georgestephanis, initsogar, jeherve, josephscott, miguelxavierpenha, rachelsquirrel, rdcoll, sdixon194, shaunandrews, thingalon, viper007bond, williamvianas, xknown
 Tags: security, malware, virus, archive, back up, back ups, backup, backups, scanning, restore, wordpress backup, site backup, website backup
 Requires at least: 5.2
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag: 3.0.0
 Requires PHP: 7.2
 License: GPLv2

--- a/projects/plugins/videopress/changelog/update-tested-to-6-8
+++ b/projects/plugins/videopress/changelog/update-tested-to-6-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: indicate compatibility with the upcoming version of WordPress - 6.8.

--- a/projects/plugins/videopress/readme.txt
+++ b/projects/plugins/videopress/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, retrofox, oskosk, thehenridev, renatoagds, lhkowalski,
 Tags: video, video-hosting, video-player, cdn, video-streaming
 
 Requires at least: 6.6
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag: 1.5
 Requires PHP: 7.2
 License: GPLv2 or later

--- a/projects/plugins/wpcomsh/changelog/update-tested-to-6-8
+++ b/projects/plugins/wpcomsh/changelog/update-tested-to-6-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: indicate compatibility with the upcoming version of WordPress - 6.8.

--- a/projects/plugins/wpcomsh/readme.txt
+++ b/projects/plugins/wpcomsh/readme.txt
@@ -3,7 +3,7 @@ Contributors: lamosty, obenland, automattic
 Tags: WP.com
 Requires at least: 6.6
 Requires PHP: 7.4
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -955,7 +955,7 @@ function createReadMeTxt( answers ) {
 		'Tags: jetpack, stuff\n' +
 		'Requires at least: 6.6\n' +
 		'Requires PHP: 7.2\n' +
-		'Tested up to: 6.7\n' +
+		'Tested up to: 6.8\n' +
 		`Stable tag: ${ answers.version }\n` +
 		'License: GPLv2 or later\n' +
 		'License URI: http://www.gnu.org/licenses/gpl-2.0.html\n' +


### PR DESCRIPTION

Fixes https://github.com/Automattic/vulcan/issues/745

## Proposed changes:

* This PR updates all plugin's 'tested to' version to indicate compatibility with WordPress 6.8. The 'required' version won't be changed until next month.
* This is just 'paperwork' at this stage - I'll deploy it as late as possible, with more testing happening in the meantime.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Epic: https://github.com/Automattic/jetpack/issues/39818

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Proof-read to check version update is correct, and that all plugins are included. I've left out WP Super Cache as it has been updating itself (not technically by itself but with developer support... 😁 )

