### PR TITLE
phpunit: Remove unnecessary uses of `@before` etc with Yoast TestCase polyfill

### DIFF
--- a/projects/packages/boost-speed-score/changelog/remove-unnecessary-phpunit-before-after-with-polyfill
+++ b/projects/packages/boost-speed-score/changelog/remove-unnecessary-phpunit-before-after-with-polyfill
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: PHPUnit: Remove unnecessary `@before` and `@after` annotations from tests based on `Yoast\PHPUnitPolyfills\TestCases\TestCase`.
+
+

--- a/projects/packages/boost-speed-score/tests/php/class-base-testcase.php
+++ b/projects/packages/boost-speed-score/tests/php/class-base-testcase.php
@@ -17,9 +17,6 @@ if ( ! defined( 'JETPACK_BOOST_SPEED_SCORE_DIR_PATH' ) ) {
  * @package Automattic\Jetpack\Boost_Speed_Score\Tests
  */
 abstract class Base_TestCase extends TestCase {
-	/**
-	 * @before
-	 */
 	protected function set_up() {
 		Monkey\setUp();
 		Monkey\Functions\stubEscapeFunctions();
@@ -38,9 +35,6 @@ abstract class Base_TestCase extends TestCase {
 		);
 	}
 
-	/**
-	 * @after
-	 */
 	protected function tear_down() {
 		Monkey\tearDown();
 	}

--- a/projects/packages/connection/changelog/remove-unnecessary-phpunit-before-after-with-polyfill
+++ b/projects/packages/connection/changelog/remove-unnecessary-phpunit-before-after-with-polyfill
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: PHPUnit: Remove unnecessary `@before` and `@after` annotations from tests based on `Yoast\PHPUnitPolyfills\TestCases\TestCase`.
+
+

--- a/projects/packages/connection/tests/php/Jetpack_IXR_ClientMulticall_Test.php
+++ b/projects/packages/connection/tests/php/Jetpack_IXR_ClientMulticall_Test.php
@@ -30,8 +30,6 @@ class Jetpack_IXR_ClientMulticall_Test extends BaseTestCase {
 
 	/**
 	 * Clean up the testing environment.
-	 *
-	 * @after
 	 */
 	public function tear_down() {
 		Constants::clear_constants();

--- a/projects/packages/connection/tests/php/Jetpack_XMLRPC_Server_Test.php
+++ b/projects/packages/connection/tests/php/Jetpack_XMLRPC_Server_Test.php
@@ -40,8 +40,6 @@ class Jetpack_XMLRPC_Server_Test extends BaseTestCase {
 
 	/**
 	 * Clean up the testing environment.
-	 *
-	 * @after
 	 */
 	public function tear_down() {
 		Constants::clear_constants();

--- a/projects/packages/connection/tests/php/ManagerIntegrationTest.php
+++ b/projects/packages/connection/tests/php/ManagerIntegrationTest.php
@@ -32,8 +32,6 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 
 	/**
 	 * Clean up the testing environment.
-	 *
-	 * @after
 	 */
 	public function tear_down() {
 		Constants::clear_constants();

--- a/projects/packages/connection/tests/php/XMLRPC_Async_Call_Test.php
+++ b/projects/packages/connection/tests/php/XMLRPC_Async_Call_Test.php
@@ -24,8 +24,6 @@ class XMLRPC_Async_Call_Test extends BaseTestCase {
 
 	/**
 	 * Clean up the testing environment.
-	 *
-	 * @after
 	 */
 	public function tear_down() {
 		Constants::clear_constants();

--- a/projects/packages/connection/tests/php/sso/Helpers_Test.php
+++ b/projects/packages/connection/tests/php/sso/Helpers_Test.php
@@ -37,8 +37,6 @@ class Helpers_Test extends BaseTestCase {
 
 	/**
 	 * Clean up the testing environment.
-	 *
-	 * @after
 	 */
 	public function tear_down() {
 		Constants::clear_constants();

--- a/projects/packages/masterbar/changelog/remove-unnecessary-phpunit-before-after-with-polyfill
+++ b/projects/packages/masterbar/changelog/remove-unnecessary-phpunit-before-after-with-polyfill
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: PHPUnit: Remove unnecessary `@before` and `@after` annotations from tests based on `Yoast\PHPUnitPolyfills\TestCases\TestCase`.
+
+

--- a/projects/packages/masterbar/tests/php/Main_Test.php
+++ b/projects/packages/masterbar/tests/php/Main_Test.php
@@ -18,8 +18,6 @@ use WorDBless\BaseTestCase;
 class Main_Test extends BaseTestCase {
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
 	public function tear_down() {
 		Cache::clear();

--- a/projects/packages/publicize/changelog/remove-unnecessary-phpunit-before-after-with-polyfill
+++ b/projects/packages/publicize/changelog/remove-unnecessary-phpunit-before-after-with-polyfill
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: PHPUnit: Remove unnecessary `@before` and `@after` annotations from tests based on `Yoast\PHPUnitPolyfills\TestCases\TestCase`.
+
+

--- a/projects/packages/publicize/tests/php/jetpack-social-settings/Dismissed_Notices_Test.php
+++ b/projects/packages/publicize/tests/php/jetpack-social-settings/Dismissed_Notices_Test.php
@@ -26,8 +26,6 @@ class Dismissed_Notices_Test extends BaseTestCase {
 	protected $notices;
 	/**
 	 * Initialize tests
-	 *
-	 * @before
 	 */
 	public function set_up() {
 		add_filter( 'jetpack_active_modules', array( $this, 'mock_publicize_being_active' ) );
@@ -37,8 +35,6 @@ class Dismissed_Notices_Test extends BaseTestCase {
 
 	/**
 	 * Tear down
-	 *
-	 * @after
 	 */
 	public function tear_down() {
 		wp_set_current_user( 0 );

--- a/projects/packages/publicize/tests/php/jetpack-social-settings/Jetpack_Social_Settings_Test.php
+++ b/projects/packages/publicize/tests/php/jetpack-social-settings/Jetpack_Social_Settings_Test.php
@@ -27,8 +27,6 @@ class Jetpack_Social_Settings_Test extends BaseTestCase {
 
 	/**
 	 * Initialize tests
-	 *
-	 * @before
 	 */
 	public function set_up() {
 		add_filter( 'jetpack_active_modules', array( $this, 'mock_publicize_being_active' ) );
@@ -43,8 +41,6 @@ class Jetpack_Social_Settings_Test extends BaseTestCase {
 
 	/**
 	 * Tear down
-	 *
-	 * @after
 	 */
 	public function tear_down() {
 		wp_set_current_user( 0 );

--- a/projects/packages/publicize/tests/php/jetpack-social-settings/Social_Image_Generator_Settings_Test.php
+++ b/projects/packages/publicize/tests/php/jetpack-social-settings/Social_Image_Generator_Settings_Test.php
@@ -28,8 +28,6 @@ class Social_Image_Generator_Settings_Test extends BaseTestCase {
 
 	/**
 	 * Initialize tests
-	 *
-	 * @before
 	 */
 	public function set_up() {
 		add_filter( 'jetpack_active_modules', array( $this, 'mock_publicize_being_active' ) );
@@ -47,8 +45,6 @@ class Social_Image_Generator_Settings_Test extends BaseTestCase {
 
 	/**
 	 * Tear down
-	 *
-	 * @after
 	 */
 	public function tear_down() {
 		remove_filter( 'jetpack_active_modules', array( $this, 'mock_publicize_being_active' ) );

--- a/projects/packages/scheduled-updates/changelog/remove-unnecessary-phpunit-before-after-with-polyfill
+++ b/projects/packages/scheduled-updates/changelog/remove-unnecessary-phpunit-before-after-with-polyfill
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: PHPUnit: Remove unnecessary `@before` and `@after` annotations from tests based on `Yoast\PHPUnitPolyfills\TestCases\TestCase`.
+
+

--- a/projects/packages/scheduled-updates/tests/php/Pre_Rest_Api_Test.php
+++ b/projects/packages/scheduled-updates/tests/php/Pre_Rest_Api_Test.php
@@ -16,8 +16,6 @@ class Pre_Rest_Api_Test extends \WorDBless\BaseTestCase {
 
 	/**
 	 * Set up.
-	 *
-	 * @before
 	 */
 	protected function set_up() {
 		parent::set_up_wordbless();

--- a/projects/packages/scheduled-updates/tests/php/Scheduled_Updates_Health_Paths_Test.php
+++ b/projects/packages/scheduled-updates/tests/php/Scheduled_Updates_Health_Paths_Test.php
@@ -31,8 +31,6 @@ class Scheduled_Updates_Health_Paths_Test extends \WorDBless\BaseTestCase {
 
 	/**
 	 * Set up.
-	 *
-	 * @before
 	 */
 	public function set_up() {
 		parent::set_up_wordbless();
@@ -56,8 +54,6 @@ class Scheduled_Updates_Health_Paths_Test extends \WorDBless\BaseTestCase {
 
 	/**
 	 * Clean up after test
-	 *
-	 * @after
 	 */
 	public function tear_down() {
 		wp_delete_user( $this->admin_id );

--- a/projects/packages/scheduled-updates/tests/php/Scheduled_Updates_Logs_Test.php
+++ b/projects/packages/scheduled-updates/tests/php/Scheduled_Updates_Logs_Test.php
@@ -32,7 +32,6 @@ class Scheduled_Updates_Logs_Test extends \WorDBless\BaseTestCase {
 	 * Set up before class.
 	 *
 	 * @see Restrictions here: https://github.com/php-mock/php-mock-phpunit?tab=readme-ov-file#restrictions
-	 * @beforeClass
 	 */
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
@@ -42,8 +41,6 @@ class Scheduled_Updates_Logs_Test extends \WorDBless\BaseTestCase {
 
 	/**
 	 * Set up.
-	 *
-	 * @before
 	 */
 	protected function set_up() {
 		parent::set_up_wordbless();
@@ -67,8 +64,6 @@ class Scheduled_Updates_Logs_Test extends \WorDBless\BaseTestCase {
 
 	/**
 	 * Clean up after test
-	 *
-	 * @after
 	 */
 	protected function tear_down() {
 		delete_option( Scheduled_Updates_Logs::OPTION_NAME );

--- a/projects/packages/scheduled-updates/tests/php/Scheduled_Updates_Test.php
+++ b/projects/packages/scheduled-updates/tests/php/Scheduled_Updates_Test.php
@@ -39,7 +39,6 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	 * Set up before class.
 	 *
 	 * @see Restrictions here: https://github.com/php-mock/php-mock-phpunit?tab=readme-ov-file#restrictions
-	 * @beforeClass
 	 */
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
@@ -48,8 +47,6 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 
 	/**
 	 * Set up.
-	 *
-	 * @before
 	 */
 	protected function set_up() {
 		parent::set_up_wordbless();
@@ -74,8 +71,6 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 
 	/**
 	 * Clean up after test
-	 *
-	 * @after
 	 */
 	protected function tear_down() {
 		$this->wp_filesystem->delete( WP_PLUGIN_DIR . '/deleted-plugin-0', true );

--- a/projects/packages/scheduled-updates/tests/php/WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test.php
+++ b/projects/packages/scheduled-updates/tests/php/WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test.php
@@ -41,7 +41,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test extends \WorDBless
 	 * Set up before class.
 	 *
 	 * @see Restrictions here: https://github.com/php-mock/php-mock-phpunit?tab=readme-ov-file#restrictions
-	 * @beforeClass
 	 */
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
@@ -51,8 +50,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test extends \WorDBless
 
 	/**
 	 * Set up.
-	 *
-	 * @before
 	 */
 	public function set_up() {
 		parent::set_up_wordbless();
@@ -77,8 +74,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test extends \WorDBless
 
 	/**
 	 * Clean up after test
-	 *
-	 * @after
 	 */
 	public function tear_down() {
 		wp_delete_user( $this->admin_id );

--- a/projects/packages/scheduled-updates/tests/php/WPCOM_REST_API_V2_Endpoint_Update_Schedules_Logs_Test.php
+++ b/projects/packages/scheduled-updates/tests/php/WPCOM_REST_API_V2_Endpoint_Update_Schedules_Logs_Test.php
@@ -46,8 +46,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Logs_Test extends \WorDBless\B
 
 	/**
 	 * Clean up after test
-	 *
-	 * @after
 	 */
 	public function tear_down() {
 		wp_delete_user( $this->admin_id );

--- a/projects/packages/stats/changelog/remove-unnecessary-phpunit-before-after-with-polyfill
+++ b/projects/packages/stats/changelog/remove-unnecessary-phpunit-before-after-with-polyfill
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: PHPUnit: Remove unnecessary `@before` and `@after` annotations from tests based on `Yoast\PHPUnitPolyfills\TestCases\TestCase`.
+
+

--- a/projects/packages/stats/tests/php/Options_Test.php
+++ b/projects/packages/stats/tests/php/Options_Test.php
@@ -15,8 +15,6 @@ namespace Automattic\Jetpack\Stats;
 class Options_Test extends StatsBaseTestCase {
 	/**
 	 * Clean up the testing environment.
-	 *
-	 * @after
 	 */
 	public function tear_down() {
 		$reflected_class    = new \ReflectionClass( 'Automattic\Jetpack\Stats\Options' );

--- a/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
+++ b/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
@@ -26,8 +26,6 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 
 	/**
 	 * Clean up the testing environment.
-	 *
-	 * @after
 	 */
 	public function tear_down() {
 		parent::tear_down();

--- a/projects/packages/stats/tests/php/WPCOM_Stats_Test.php
+++ b/projects/packages/stats/tests/php/WPCOM_Stats_Test.php
@@ -24,8 +24,6 @@ class WPCOM_Stats_Test extends StatsBaseTestCase {
 
 	/**
 	 * Set up before each test
-	 *
-	 * @before
 	 */
 	protected function set_up() {
 		parent::set_up();

--- a/projects/packages/stats/tests/php/XMLRPC_Provider_Test.php
+++ b/projects/packages/stats/tests/php/XMLRPC_Provider_Test.php
@@ -24,8 +24,6 @@ class XMLRPC_Provider_Test extends StatsBaseTestCase {
 
 	/**
 	 * Set up before each test
-	 *
-	 * @before
 	 */
 	protected function set_up() {
 		parent::set_up();
@@ -35,8 +33,6 @@ class XMLRPC_Provider_Test extends StatsBaseTestCase {
 
 	/**
 	 * Clean up the testing environment.
-	 *
-	 * @after
 	 */
 	public function tear_down() {
 		parent::tear_down();

--- a/projects/plugins/boost/changelog/remove-unnecessary-phpunit-before-after-with-polyfill
+++ b/projects/plugins/boost/changelog/remove-unnecessary-phpunit-before-after-with-polyfill
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: PHPUnit: Remove unnecessary `@before` and `@after` annotations from tests based on `Yoast\PHPUnitPolyfills\TestCases\TestCase`.
+
+

--- a/projects/plugins/boost/tests/php/Base_TestCase.php
+++ b/projects/plugins/boost/tests/php/Base_TestCase.php
@@ -17,9 +17,6 @@ if ( ! defined( 'JETPACK_BOOST_DIR_PATH' ) ) {
  * @package Automattic\Jetpack_Boost\Tests
  */
 abstract class Base_TestCase extends TestCase {
-	/**
-	 * @before
-	 */
 	protected function set_up() {
 		Monkey\setUp();
 		Monkey\Functions\stubEscapeFunctions();
@@ -38,9 +35,6 @@ abstract class Base_TestCase extends TestCase {
 		);
 	}
 
-	/**
-	 * @after
-	 */
 	protected function tear_down() {
 		Monkey\tearDown();
 	}

--- a/projects/plugins/jetpack/changelog/remove-unnecessary-phpunit-before-after-with-polyfill
+++ b/projects/plugins/jetpack/changelog/remove-unnecessary-phpunit-before-after-with-polyfill
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: PHPUnit: Remove unnecessary `@before` and `@after` annotations from tests based on `Yoast\PHPUnitPolyfills\TestCases\TestCase`.
+
+

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Business_Hours_Block_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Business_Hours_Block_Test.php
@@ -44,8 +44,6 @@ class Business_Hours_Block_Test extends \Jetpack_Block_Fixture_TestCase {
 
 	/**
 	 * Setup and ensure the block is registered before running the tests.
-	 *
-	 * @before
 	 */
 	public function set_up() {
 		parent::set_up();
@@ -55,8 +53,6 @@ class Business_Hours_Block_Test extends \Jetpack_Block_Fixture_TestCase {
 
 	/**
 	 * Teardown and unregister the block if it wasn't registered before running these tests.
-	 *
-	 * @after
 	 */
 	public function tear_down() {
 		if ( ! $this->was_registered ) {

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Repeat_Visitor_Block_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Repeat_Visitor_Block_Test.php
@@ -58,8 +58,6 @@ class Repeat_Visitor_Block_Test extends \Jetpack_Block_Fixture_TestCase {
 
 	/**
 	 * Setup and ensure the block is registered before running the tests.
-	 *
-	 * @before
 	 */
 	public function set_up() {
 		parent::set_up();
@@ -73,8 +71,6 @@ class Repeat_Visitor_Block_Test extends \Jetpack_Block_Fixture_TestCase {
 
 	/**
 	 * Teardown and unregister the block if it wasn't registered before running these tests.
-	 *
-	 * @after
 	 */
 	public function tear_down() {
 		if ( ! $this->was_registered ) {

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Story_Block_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Story_Block_Test.php
@@ -32,8 +32,6 @@ class Story_Block_Test extends \WP_UnitTestCase {
 
 	/**
 	 * Setup and ensure the block is registered before running the tests.
-	 *
-	 * @before
 	 */
 	public function set_up() {
 		parent::set_up();
@@ -44,8 +42,6 @@ class Story_Block_Test extends \WP_UnitTestCase {
 
 	/**
 	 * Teardown and unregister the block if it wasn't registered before running these tests.
-	 *
-	 * @after
 	 */
 	public function tear_down() {
 		if ( ! $this->was_registered ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PHPUnit 8 started declaring a `void` return type on `setUp()`, `tearDown()`, and so on, which 7.1 and earler don't support.

The `Yoast\PHPUnitPolyfills\TestCases\TestCase` polyfill class, which is used by `WorDBless\BaseTestCase` and `WP_UnitTestCase`, provides replacement snake-case-named methods (e.g. `set_up()`, `tear_down()`) to use instead. These don't need annotations like `@before` and `@after`, but in some places we used them anyway.

Now that PHPUnit 11 is deprecating annotations in favor of attributes, remove these unnecessary annotations so it doesn't have to complain about them.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
PT: pf4qpu-Fo-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?