### PR TITLE
phpunit: Use standard setup/teardown methods instead of snake-cased names with annotations

### DIFF
--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -265,7 +265,6 @@ For all project types other than WordPress plugins, the necessary version of PHP
 We currently make use of the following packages in testing; it's encouraged to use these rather than introducing other tools that serve the same purpose.
 
 * [yoast/phpunit-polyfills](https://packagist.org/packages/yoast/phpunit-polyfills) supplies polyfills for compatibility with PHPUnit 8.5 to 9.6, to support PHP 7.2 to 8.4.
-  * Do not use `Yoast\PHPUnitPolyfills\TestCases\TestCase` or `Yoast\PHPUnitPolyfills\TestCases\XTestCase`. Just use the `@before`, `@after`, `@beforeClass`, and `@afterClass` annotations directly.
 * [automattic/phpunit-select-config](https://packagist.org/packages/automattic/phpunit-select-config) allows for selecting a configuration file based on the version of PHPUnit in use, since configs are often not compatible across major versions since PHPUnit 9.
 * PHPUnit's built-in mocking is used for class mocks.
 * [brain/monkey](https://packagist.org/packages/brain/monkey) is used for mocking functions, and can also provide some functions for minimal WordPress compatibility.

--- a/projects/packages/assets/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/assets/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/assets/tests/php/AssetsTest.php
+++ b/projects/packages/assets/tests/php/AssetsTest.php
@@ -36,10 +36,10 @@ class AssetsTest extends TestCase {
 
 	/**
 	 * Test setup.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
+
 		Monkey\setUp();
 		$plugin_dir = dirname( __DIR__, 4 ) . '/';
 		Jetpack_Constants::set_constant( 'JETPACK__PLUGIN_FILE', $plugin_dir . 'jetpack.php' );
@@ -71,10 +71,10 @@ class AssetsTest extends TestCase {
 
 	/**
 	 * Run after every test.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
+
 		Monkey\tearDown();
 		Jetpack_Constants::clear_constants();
 

--- a/projects/packages/autoloader/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/autoloader/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/autoloader/tests/php/lib/class-acceptance-testcase.php
+++ b/projects/packages/autoloader/tests/php/lib/class-acceptance-testcase.php
@@ -35,10 +35,10 @@ abstract class Acceptance_TestCase extends TestCase {
 
 	/**
 	 * Setup runs before each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
+
 		// Ensure that the current autoloader is always installed.
 		$this->installed_autoloaders = array( Test_Plugin_Factory::CURRENT => TEST_PLUGIN_DIR );
 		$this->symlinked_autoloaders = array();
@@ -49,13 +49,13 @@ abstract class Acceptance_TestCase extends TestCase {
 
 	/**
 	 * Teardown runs after each test.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
+
 		// Erase all of the directory symlinks since we're done with them.
 		foreach ( $this->symlinked_autoloaders as $dir ) {
-            // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			@unlink( $dir );
 		}
 	}

--- a/projects/packages/autoloader/tests/php/tests/integration/LoadingGeneratedManifestsTest.php
+++ b/projects/packages/autoloader/tests/php/tests/integration/LoadingGeneratedManifestsTest.php
@@ -30,19 +30,17 @@ class LoadingGeneratedManifestsTest extends TestCase {
 
 	/**
 	 * Setup runs before each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->manifest_handler = new Manifest_Reader( new Version_Selector() );
 	}
 
 	/**
 	 * Teardown runs after each test.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		unlink( TEST_PLUGIN_DIR . '/' . self::TEST_MANIFEST_PATH );
 	}
 

--- a/projects/packages/autoloader/tests/php/tests/integration/VersionLoadingFromManifestTest.php
+++ b/projects/packages/autoloader/tests/php/tests/integration/VersionLoadingFromManifestTest.php
@@ -27,10 +27,9 @@ class VersionLoadingFromManifestTest extends TestCase {
 
 	/**
 	 * Setup runs before each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->manifest_handler = new Manifest_Reader( new Version_Selector() );
 	}
 

--- a/projects/packages/autoloader/tests/php/tests/unit/AutoloaderHandlerTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/AutoloaderHandlerTest.php
@@ -48,10 +48,10 @@ class AutoloaderHandlerTest extends TestCase {
 
 	/**
 	 * Setup runs before each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
+
 		$this->php_autoloader     = $this->getMockBuilder( PHP_Autoloader::class )
 			->disableOriginalConstructor()
 			->getMock();

--- a/projects/packages/autoloader/tests/php/tests/unit/AutoloaderLocatorTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/AutoloaderLocatorTest.php
@@ -38,19 +38,17 @@ class AutoloaderLocatorTest extends TestCase {
 
 	/**
 	 * Setup before class runs before the class.
-	 *
-	 * @beforeClass
 	 */
-	public static function set_up_before_class() {
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
 		self::$older_plugin_dir = Test_Plugin_Factory::create_test_plugin( false, self::OLDER_VERSION )->make();
 	}
 
 	/**
 	 * Setup executes before each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->autoloader_locator = new Autoloader_Locator( new Version_Selector() );
 	}
 

--- a/projects/packages/autoloader/tests/php/tests/unit/AutoloaderTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/AutoloaderTest.php
@@ -34,10 +34,9 @@ class AutoloaderTest extends TestCase {
 
 	/**
 	 * Setup before class runs before the class.
-	 *
-	 * @beforeClass
 	 */
-	public static function set_up_before_class() {
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
 		self::$older_plugin_dir = Test_Plugin_Factory::create_test_plugin( false, self::OLDER_VERSION )->make();
 	}
 

--- a/projects/packages/autoloader/tests/php/tests/unit/HookManagerTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/HookManagerTest.php
@@ -24,19 +24,17 @@ class HookManagerTest extends TestCase {
 
 	/**
 	 * Setup runs before each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->hook_manager = new Hook_Manager();
 	}
 
 	/**
 	 * Teardown runs after each test.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		cleanup_test_wordpress_data();
 	}
 

--- a/projects/packages/autoloader/tests/php/tests/unit/LatestAutoloaderGuardTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/LatestAutoloaderGuardTest.php
@@ -46,10 +46,9 @@ class LatestAutoloaderGuardTest extends TestCase {
 
 	/**
 	 * Setup runs before each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->plugins_handler    = $this->getMockBuilder( Plugins_Handler::class )
 			->disableOriginalConstructor()
 			->getMock();

--- a/projects/packages/autoloader/tests/php/tests/unit/ManifestReaderTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/ManifestReaderTest.php
@@ -39,19 +39,17 @@ class ManifestReaderTest extends TestCase {
 
 	/**
 	 * Setup before class runs before the class.
-	 *
-	 * @beforeClass
 	 */
-	public static function set_up_before_class() {
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
 		self::$older_plugin_dir = Test_Plugin_Factory::create_test_plugin( false, self::OLDER_VERSION )->make();
 	}
 
 	/**
 	 * Setup runs before each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->reader = new Manifest_Reader( new Version_Selector() );
 	}
 

--- a/projects/packages/autoloader/tests/php/tests/unit/PathProcessorTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/PathProcessorTest.php
@@ -24,10 +24,9 @@ class PathProcessorTest extends TestCase {
 
 	/**
 	 * Setup runs before each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->processor = new Path_Processor();
 
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
@@ -36,10 +35,9 @@ class PathProcessorTest extends TestCase {
 
 	/**
 	 * Teardown runs after each test.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		@unlink( WP_PLUGIN_DIR . '/current_symlink' );
 	}

--- a/projects/packages/autoloader/tests/php/tests/unit/PluginLocatorTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/PluginLocatorTest.php
@@ -34,20 +34,18 @@ class PluginLocatorTest extends TestCase {
 
 	/**
 	 * Setup runs before each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->path_processor = $this->getMockBuilder( Path_Processor::class )->getMock();
 		$this->locator        = new Plugin_Locator( $this->path_processor );
 	}
 
 	/**
 	 * Teardown runs after each test.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		// Make sure all of the test data we made use of is cleaned up after each test.
 		cleanup_test_wordpress_data();
 	}

--- a/projects/packages/autoloader/tests/php/tests/unit/PluginsHandlerTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/PluginsHandlerTest.php
@@ -41,10 +41,9 @@ class PluginsHandlerTest extends TestCase {
 
 	/**
 	 * Setup runs before each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->plugin_locator  = $this->getMockBuilder( Plugin_Locator::class )
 			->disableOriginalConstructor()
 			->getMock();
@@ -56,10 +55,9 @@ class PluginsHandlerTest extends TestCase {
 
 	/**
 	 * Teardown runs after each test.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		cleanup_test_wordpress_data();
 	}
 

--- a/projects/packages/autoloader/tests/php/tests/unit/ShutdownHandlerTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/ShutdownHandlerTest.php
@@ -24,10 +24,9 @@ class ShutdownHandlerTest extends TestCase {
 
 	/**
 	 * Setup runs before each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->plugins_handler = $this->getMockBuilder( Plugins_Handler::class )
 			->disableOriginalConstructor()
 			->getMock();

--- a/projects/packages/autoloader/tests/php/tests/unit/VersionLoaderTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/VersionLoaderTest.php
@@ -33,10 +33,9 @@ class VersionLoaderTest extends TestCase {
 
 	/**
 	 * Setup before class runs before the class.
-	 *
-	 * @beforeClass
 	 */
-	public static function set_up_before_class() {
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
 		self::$older_plugin_dir = Test_Plugin_Factory::create_test_plugin( false, self::OLDER_VERSION )->make();
 	}
 

--- a/projects/packages/autoloader/tests/php/tests/unit/VersionSelectorTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/VersionSelectorTest.php
@@ -24,10 +24,9 @@ class VersionSelectorTest extends TestCase {
 
 	/**
 	 * This is called before each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->version_selector = new Version_Selector();
 	}
 

--- a/projects/packages/backup/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/backup/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/backup/tests/php/REST_Controller_Test.php
+++ b/projects/packages/backup/tests/php/REST_Controller_Test.php
@@ -47,10 +47,9 @@ class REST_Controller_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		global $wp_rest_server;
 
 		$wp_rest_server = new WP_REST_Server();
@@ -72,10 +71,9 @@ class REST_Controller_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		wp_set_current_user( 0 );
 
 		unset(

--- a/projects/packages/blocks/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/blocks/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/blocks/tests/php/Blocks_Test.php
+++ b/projects/packages/blocks/tests/php/Blocks_Test.php
@@ -27,10 +27,9 @@ class Blocks_Test extends TestCase {
 
 	/**
 	 * Setup runs before each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		Monkey\setUp();
 		Jetpack_Constants::set_constant( 'JETPACK__PLUGIN_FILE', __DIR__ . '/fixtures/jetpack.php' );
 		// Register a test block.
@@ -39,10 +38,9 @@ class Blocks_Test extends TestCase {
 
 	/**
 	 * Teardown runs after each test.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		Monkey\tearDown();
 		Jetpack_Constants::clear_constants();
 		// Unregister the test Jetpack block we may have created for our tests.

--- a/projects/packages/changelogger/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/changelogger/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/changelogger/tests/php/includes/src/TestCase.php
+++ b/projects/packages/changelogger/tests/php/includes/src/TestCase.php
@@ -39,20 +39,18 @@ abstract class TestCase extends PHPUnit_TestCase {
 
 	/**
 	 * Setup test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->oldenv = getenv( 'COMPOSER' );
 		$this->resetConfigCache();
 	}
 
 	/**
 	 * Teardown test.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		$this->cleanupTempDir();
 		$this->resetConfigCache();
 		putenv( false === $this->oldenv ? 'COMPOSER' : "COMPOSER=$this->oldenv" );

--- a/projects/packages/changelogger/tests/php/tests/src/AddCommandTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/AddCommandTest.php
@@ -23,11 +23,9 @@ class AddCommandTest extends CommandTestCase {
 
 	/**
 	 * Set up.
-	 *
-	 * @before
 	 */
-	public function set_up() {
-		parent::set_up();
+	public function setUp(): void {
+		parent::setUp();
 		$this->useTempDir();
 	}
 

--- a/projects/packages/changelogger/tests/php/tests/src/ApplicationTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/ApplicationTest.php
@@ -25,10 +25,9 @@ class ApplicationTest extends TestCase {
 
 	/**
 	 * Set up.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->useTempDir();
 		file_put_contents( 'composer.json', "{}\n" );
 	}

--- a/projects/packages/changelogger/tests/php/tests/src/ConfigTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/ConfigTest.php
@@ -21,10 +21,9 @@ class ConfigTest extends TestCase {
 
 	/**
 	 * Set up.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->useTempDir();
 
 		file_put_contents( 'bogus.json', "bogus\n" );

--- a/projects/packages/changelogger/tests/php/tests/src/SquashCommandTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/SquashCommandTest.php
@@ -27,11 +27,9 @@ class SquashCommandTest extends CommandTestCase {
 
 	/**
 	 * Set up.
-	 *
-	 * @before
 	 */
-	public function set_up() {
-		parent::set_up();
+	public function setUp(): void {
+		parent::setUp();
 		$this->useTempDir();
 	}
 

--- a/projects/packages/changelogger/tests/php/tests/src/ValidateCommandTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/ValidateCommandTest.php
@@ -19,11 +19,9 @@ class ValidateCommandTest extends CommandTestCase {
 
 	/**
 	 * Set up.
-	 *
-	 * @before
 	 */
-	public function set_up() {
-		parent::set_up();
+	public function setUp(): void {
+		parent::setUp();
 		$this->useTempDir();
 
 		mkdir( 'changelog' );

--- a/projects/packages/changelogger/tests/php/tests/src/VersionCommandTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/VersionCommandTest.php
@@ -19,11 +19,9 @@ class VersionCommandTest extends CommandTestCase {
 
 	/**
 	 * Set up.
-	 *
-	 * @before
 	 */
-	public function set_up() {
-		parent::set_up();
+	public function setUp(): void {
+		parent::setUp();
 		$this->useTempDir();
 
 		mkdir( 'changelog' );

--- a/projects/packages/changelogger/tests/php/tests/src/WriteCommandTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/WriteCommandTest.php
@@ -27,11 +27,9 @@ class WriteCommandTest extends CommandTestCase {
 
 	/**
 	 * Set up.
-	 *
-	 * @before
 	 */
-	public function set_up() {
-		parent::set_up();
+	public function setUp(): void {
+		parent::setUp();
 		$this->useTempDir();
 		mkdir( 'changelog' );
 		file_put_contents( 'changelog/.gitkeep', '' );

--- a/projects/packages/connection/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/connection/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/connection/tests/php/Connection_Notice_Test.php
+++ b/projects/packages/connection/tests/php/Connection_Notice_Test.php
@@ -61,12 +61,10 @@ class Connection_Notice_Test extends TestCase {
 
 	/**
 	 * Set up the environment.
-	 *
-	 * @before
-	 *
-	 * @return void
 	 */
-	protected function set_up() {
+	protected function setUp(): void {
+		parent::setUp();
+
 		global $current_screen;
 
 		\Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
@@ -134,12 +132,10 @@ class Connection_Notice_Test extends TestCase {
 
 	/**
 	 * Clean up.
-	 *
-	 * @after
-	 *
-	 * @return void
 	 */
-	protected function tear_down() {
+	protected function tearDown(): void {
+		parent::tearDown();
+
 		global $current_screen;
 
 		delete_transient( 'jetpack_connected_user_data_' . get_current_user_id() );

--- a/projects/packages/connection/tests/php/ManagerTest.php
+++ b/projects/packages/connection/tests/php/ManagerTest.php
@@ -51,10 +51,9 @@ class ManagerTest extends TestCase {
 
 	/**
 	 * Initialize the object before running the test method.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->manager = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Manager' )
 			->onlyMethods( array( 'get_tokens', 'get_connection_owner_id', 'unlink_user_from_wpcom', 'update_connection_owner_wpcom', 'disconnect_site_wpcom' ) )
 			->getMock();
@@ -76,10 +75,9 @@ class ManagerTest extends TestCase {
 
 	/**
 	 * Clean up the testing environment.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		wp_set_current_user( 0 );
 		WorDBless_Users::init()->clear_all_users();
 		WorDBless_Options::init()->clear_options();

--- a/projects/packages/connection/tests/php/Nonce_Handler_Test.php
+++ b/projects/packages/connection/tests/php/Nonce_Handler_Test.php
@@ -26,10 +26,9 @@ class Nonce_Handler_Test extends TestCase {
 
 	/**
 	 * Reset the environment after each test.
-	 *
-	 * @after
 	 */
-	protected function tear_down() {
+	protected function tearDown(): void {
+		parent::tearDown();
 		Nonce_Handler::invalidate_request_nonces();
 	}
 

--- a/projects/packages/connection/tests/php/Package_Version_Tracker_Test.php
+++ b/projects/packages/connection/tests/php/Package_Version_Tracker_Test.php
@@ -42,10 +42,9 @@ class Package_Version_Tracker_Test extends TestCase {
 
 	/**
 	 * Setting up the testing environment.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
 		Sync_Settings::update_settings( array( 'disable' => true ) );
 		$this->reset_connection_status();
@@ -53,10 +52,9 @@ class Package_Version_Tracker_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		global $wp_actions;
 		// Restore `init` in global $wp_actions.
 		$wp_actions['init'] = true;

--- a/projects/packages/connection/tests/php/Partner_Test.php
+++ b/projects/packages/connection/tests/php/Partner_Test.php
@@ -21,10 +21,9 @@ class Partner_Test extends TestCase {
 
 	/**
 	 * Reset the environment after each test.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		Partner::reset();
 	}
 

--- a/projects/packages/connection/tests/php/Plugin_Storage_Test.php
+++ b/projects/packages/connection/tests/php/Plugin_Storage_Test.php
@@ -29,10 +29,9 @@ class Plugin_Storage_Test extends TestCase {
 
 	/**
 	 * Setting up the testing environment.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
 		Sync_Settings::update_settings( array( 'disable' => true ) );
 		$this->reset_connection_status();
@@ -40,10 +39,9 @@ class Plugin_Storage_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		unset( $_SERVER['REQUEST_METHOD'] );
 		$this->http_request_attempted = false;
 		Constants::clear_constants();

--- a/projects/packages/connection/tests/php/Plugin_Test.php
+++ b/projects/packages/connection/tests/php/Plugin_Test.php
@@ -32,10 +32,9 @@ class Plugin_Test extends TestCase {
 
 	/**
 	 * Initialization of the test class
-	 *
-	 * @before
 	 */
-	protected function set_up() {
+	protected function setUp(): void {
+		parent::setUp();
 		Plugin_Storage::configure();
 	}
 

--- a/projects/packages/connection/tests/php/Provider_Auth_Endpoints_Test.php
+++ b/projects/packages/connection/tests/php/Provider_Auth_Endpoints_Test.php
@@ -41,10 +41,9 @@ class Provider_Auth_Endpoints_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		global $wp_rest_server;
 
 		// Suppress deprecation warning for urlencode(null)
@@ -72,10 +71,9 @@ class Provider_Auth_Endpoints_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		delete_transient( 'jetpack_assumed_site_creation_date' );
 	}
 

--- a/projects/packages/connection/tests/php/REST_Authentication_Test.php
+++ b/projects/packages/connection/tests/php/REST_Authentication_Test.php
@@ -40,10 +40,9 @@ class REST_Authentication_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		self::clear_auth_singleton();
 		$this->rest_authentication = Rest_Authentication::init();
 
@@ -59,10 +58,9 @@ class REST_Authentication_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		$_GET = null;
 		unset( $_SERVER['REQUEST_METHOD'] );
 		$this->rest_authentication->reset_saved_auth_state();

--- a/projects/packages/connection/tests/php/REST_Endpoints_Test.php
+++ b/projects/packages/connection/tests/php/REST_Endpoints_Test.php
@@ -67,10 +67,9 @@ class REST_Endpoints_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		global $wp_rest_server;
 
 		$wp_rest_server = new WP_REST_Server();
@@ -134,10 +133,9 @@ class REST_Endpoints_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		remove_action( 'jetpack_disabled_raw_options', array( $this, 'bypass_raw_options' ) );
 
 		$user = wp_get_current_user();

--- a/projects/packages/connection/tests/php/Terms_Of_Service_Test.php
+++ b/projects/packages/connection/tests/php/Terms_Of_Service_Test.php
@@ -29,10 +29,9 @@ class Terms_Of_Service_Test extends TestCase {
 
 	/**
 	 * Test setup.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		Monkey\setUp();
 		$this->terms_of_service = $this->createPartialMock(
 			__NAMESPACE__ . '\\Terms_Of_Service',
@@ -42,10 +41,9 @@ class Terms_Of_Service_Test extends TestCase {
 
 	/**
 	 * Test teardown.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		Monkey\tearDown();
 	}
 

--- a/projects/packages/connection/tests/php/TokensTest.php
+++ b/projects/packages/connection/tests/php/TokensTest.php
@@ -35,10 +35,9 @@ class TokensTest extends TestCase {
 
 	/**
 	 * Initialize the object before running the test method.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->tokens = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Tokens' )
 			->onlyMethods( array( 'get_access_token' ) )
 			->getMock();
@@ -46,10 +45,9 @@ class TokensTest extends TestCase {
 
 	/**
 	 * Clean up the testing environment.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		remove_all_filters( 'jetpack_options' );
 		unset( $this->tokens );
 		Constants::clear_constants();

--- a/projects/packages/connection/tests/php/Tracking_Test.php
+++ b/projects/packages/connection/tests/php/Tracking_Test.php
@@ -31,10 +31,9 @@ class Tracking_Test extends TestCase {
 
 	/**
 	 * Test setup.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		Monkey\setUp();
 
 		$this->connection = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Manager' )
@@ -45,10 +44,9 @@ class Tracking_Test extends TestCase {
 
 	/**
 	 * Test teardown.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		Monkey\tearDown();
 	}
 

--- a/projects/packages/connection/tests/php/UtilsTest.php
+++ b/projects/packages/connection/tests/php/UtilsTest.php
@@ -17,10 +17,9 @@ class UtilsTest extends TestCase {
 
 	/**
 	 * This method is called after each test.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		Constants::clear_constants();
 	}
 

--- a/projects/packages/connection/tests/php/Webhooks_Test.php
+++ b/projects/packages/connection/tests/php/Webhooks_Test.php
@@ -30,10 +30,9 @@ class Webhooks_Test extends TestCase {
 
 	/**
 	 * Setting up the testing environment.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		Monkey\Functions\when( 'check_admin_referer' )->justReturn( true );
 		Monkey\Functions\when( 'wp_safe_redirect' )->alias(
 			function ( $redirect ) {
@@ -45,10 +44,9 @@ class Webhooks_Test extends TestCase {
 
 	/**
 	 * Reverting the testing environment to its original state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		Monkey\tearDown();
 		$this->redirect_stack = array();
 		unset( $_GET['handler'], $_GET['action'] );

--- a/projects/packages/connection/tests/php/XMLRPC_Connector_Test.php
+++ b/projects/packages/connection/tests/php/XMLRPC_Connector_Test.php
@@ -37,10 +37,9 @@ class XMLRPC_Connector_Test extends TestCase {
 
 	/**
 	 * Initialize tests
-	 *
-	 * @beforeClass
 	 */
-	public static function set_up_before_class() {
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
 		$keys = openssl_pkey_new();
 		openssl_pkey_export( $keys, $private_key );
 		$public_key       = openssl_pkey_get_details( $keys );

--- a/projects/packages/connection/tests/php/identity-crisis/REST_Endpoints_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/REST_Endpoints_Test.php
@@ -51,9 +51,10 @@ class REST_Endpoints_Test extends TestCase {
 	 * Setting up the test.
 	 *
 	 * @suppress PhanNoopNew
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
+
 		global $wp_rest_server;
 
 		$wp_rest_server = new WP_REST_Server();
@@ -75,10 +76,9 @@ class REST_Endpoints_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	protected function tearDown(): void {
+		parent::tearDown();
 
 		Constants::$set_constants['JETPACK__WPCOM_JSON_API_BASE'] = $this->api_host_original;
 

--- a/projects/packages/connection/tests/php/identity-crisis/URL_Secret_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/URL_Secret_Test.php
@@ -20,10 +20,9 @@ class URL_Secret_Test extends TestCase {
 
 	/**
 	 * Cleanup after each test.
-	 *
-	 * @after
 	 */
-	public static function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		Jetpack_Options::delete_option( URL_Secret::OPTION_KEY );
 	}
 

--- a/projects/packages/constants/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/constants/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/constants/tests/php/Constants_Test.php
+++ b/projects/packages/constants/tests/php/Constants_Test.php
@@ -16,10 +16,9 @@ use PHPUnit\Framework\TestCase;
 class Constants_Test extends TestCase {
 	/**
 	 * Sets up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		if ( ! defined( 'JETPACK__VERSION' ) ) {
 			define( 'JETPACK__VERSION', '7.5' );
 		}
@@ -28,10 +27,9 @@ class Constants_Test extends TestCase {
 
 	/**
 	 * Tears down the test.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		Monkey\tearDown();
 		Constants::$set_constants = array();
 	}

--- a/projects/packages/forms/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/forms/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -40,10 +40,9 @@ class Contact_Form_Endpoint_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		global $wp_rest_server;
 
 		$this->plugin = Contact_Form_Plugin::init();
@@ -65,10 +64,9 @@ class Contact_Form_Endpoint_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
 

--- a/projects/packages/google-analytics/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/google-analytics/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/google-analytics/tests/php/Jetpack_Google_Analytics_Test.php
+++ b/projects/packages/google-analytics/tests/php/Jetpack_Google_Analytics_Test.php
@@ -31,12 +31,8 @@ class Jetpack_Google_Analytics_Test extends TestCase {
 
 	/**
 	 * Runs the routine before each test is executed.
-	 *
-	 * @before
-	 *
-	 * @return void
 	 */
-	public function set_up() {
+	public function setUp(): void {
 		parent::setUp();
 
 		// Hijack the option for Jetpack_Google_Analytics_Options::get_tracking_code().

--- a/projects/packages/ip/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/ip/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/ip/tests/php/UtilsTest.php
+++ b/projects/packages/ip/tests/php/UtilsTest.php
@@ -15,10 +15,9 @@ use Brain\Monkey\Functions;
 final class UtilsTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * Set up.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		Monkey\setUp();
 
 		Functions\when( 'wp_unslash' )->returnArg();
@@ -26,10 +25,9 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * Tear down.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		Monkey\tearDown();
 	}
 

--- a/projects/packages/jitm/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/jitm/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/jitm/tests/php/Jetpack_JITM_Test.php
+++ b/projects/packages/jitm/tests/php/Jetpack_JITM_Test.php
@@ -15,10 +15,9 @@ class Jetpack_JITM_Test extends TestCase {
 
 	/**
 	 * Set up.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		Monkey\setUp();
 
 		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
@@ -30,10 +29,9 @@ class Jetpack_JITM_Test extends TestCase {
 
 	/**
 	 * Tear down.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		Monkey\tearDown();
 	}
 

--- a/projects/packages/jitm/tests/php/Pre_Connection_JITM_Test.php
+++ b/projects/packages/jitm/tests/php/Pre_Connection_JITM_Test.php
@@ -28,10 +28,9 @@ class Pre_Connection_JITM_Test extends TestCase {
 
 	/**
 	 * Set up.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		Monkey\setUp();
 
 		Functions\when( 'get_current_screen' )->justReturn( new \stdClass() );
@@ -57,10 +56,9 @@ class Pre_Connection_JITM_Test extends TestCase {
 
 	/**
 	 * Tear down.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		Monkey\tearDown();
 	}
 

--- a/projects/packages/masterbar/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/masterbar/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/masterbar/tests/php/Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/Admin_Menu_Test.php
@@ -59,10 +59,9 @@ class Admin_Menu_Test extends TestCase {
 
 	/**
 	 * Set up each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		global $menu, $submenu;
 
 		static::$domain       = ( new Status() )->get_site_suffix();
@@ -87,10 +86,9 @@ class Admin_Menu_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
 	}

--- a/projects/packages/masterbar/tests/php/Atomic_Additional_CSS_Manager_Test.php
+++ b/projects/packages/masterbar/tests/php/Atomic_Additional_CSS_Manager_Test.php
@@ -28,19 +28,17 @@ class Atomic_Additional_CSS_Manager_Test extends TestCase {
 
 	/**
 	 * Set up each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->wp_customize = new \WP_Customize_Manager();
 	}
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
 	}

--- a/projects/packages/masterbar/tests/php/Atomic_Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/Atomic_Admin_Menu_Test.php
@@ -66,10 +66,9 @@ class Atomic_Admin_Menu_Test extends TestCase {
 
 	/**
 	 * Set up each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		global $menu, $submenu;
 
 		static::$domain       = ( new Status() )->get_site_suffix();
@@ -94,10 +93,9 @@ class Atomic_Admin_Menu_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
 	}

--- a/projects/packages/masterbar/tests/php/Base_Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/Base_Admin_Menu_Test.php
@@ -50,10 +50,9 @@ class Base_Admin_Menu_Test extends TestCase {
 
 	/**
 	 * Set up each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		global $menu, $submenu;
 
 		static::$menu_data    = get_menu_fixture();
@@ -79,10 +78,9 @@ class Base_Admin_Menu_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		wp_deregister_script( 'jetpack-admin-menu' );
 		wp_deregister_style( 'jetpack-admin-menu' );
 		WorDBless_Options::init()->clear_options();

--- a/projects/packages/masterbar/tests/php/CSS_Customizer_Nudge_Test.php
+++ b/projects/packages/masterbar/tests/php/CSS_Customizer_Nudge_Test.php
@@ -27,10 +27,9 @@ class CSS_Customizer_Nudge_Test extends TestCase {
 
 	/**
 	 * Set up each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->wp_customize = new \WP_Customize_Manager();
 		register_css_nudge_control( $this->wp_customize );
 	}

--- a/projects/packages/masterbar/tests/php/Dashboard_Switcher_Tracking_Test.php
+++ b/projects/packages/masterbar/tests/php/Dashboard_Switcher_Tracking_Test.php
@@ -34,10 +34,9 @@ class Dashboard_Switcher_Tracking_Test extends TestCase {
 
 	/**
 	 * Set up each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		static::$user_id = wp_insert_user(
 			array(
 				'user_login' => 'test_admin',
@@ -51,10 +50,9 @@ class Dashboard_Switcher_Tracking_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
 	}

--- a/projects/packages/masterbar/tests/php/Domain_Only_Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/Domain_Only_Admin_Menu_Test.php
@@ -58,10 +58,9 @@ class Domain_Only_Admin_Menu_Test extends TestCase {
 
 	/**
 	 * Set up each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		global $menu, $submenu;
 
 		static::$domain       = ( new Status() )->get_site_suffix();
@@ -86,10 +85,9 @@ class Domain_Only_Admin_Menu_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
 	}

--- a/projects/packages/masterbar/tests/php/Jetpack_Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/Jetpack_Admin_Menu_Test.php
@@ -65,10 +65,9 @@ class Jetpack_Admin_Menu_Test extends TestCase {
 
 	/**
 	 * Set up each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		global $menu, $submenu;
 
 		static::$domain       = ( new Status() )->get_site_suffix();
@@ -93,10 +92,9 @@ class Jetpack_Admin_Menu_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
 	}

--- a/projects/packages/masterbar/tests/php/WPCOM_Additional_Css_Manager_Test.php
+++ b/projects/packages/masterbar/tests/php/WPCOM_Additional_Css_Manager_Test.php
@@ -29,10 +29,9 @@ class WPCOM_Additional_Css_Manager_Test extends TestCase {
 
 	/**
 	 * Register a customizer manager.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->wp_customize = new \WP_Customize_Manager();
 	}
 

--- a/projects/packages/masterbar/tests/php/WPCOM_User_Profile_Fields_Revert_Test.php
+++ b/projects/packages/masterbar/tests/php/WPCOM_User_Profile_Fields_Revert_Test.php
@@ -35,10 +35,9 @@ class WPCOM_User_Profile_Fields_Revert_Test extends TestCase {
 
 	/**
 	 * Set up each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		global $l10n;
 		$this->l10n_backup = $l10n;
 
@@ -59,10 +58,9 @@ class WPCOM_User_Profile_Fields_Revert_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		// Restore the original global.
 		global $l10n;
 		$l10n = $this->l10n_backup;

--- a/projects/packages/masterbar/tests/php/WPcom_Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/WPcom_Admin_Menu_Test.php
@@ -65,10 +65,9 @@ class WPcom_Admin_Menu_Test extends TestCase {
 
 	/**
 	 * Set up each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		global $menu, $submenu;
 
 		static::$domain       = ( new Status() )->get_site_suffix();
@@ -105,10 +104,9 @@ class WPcom_Admin_Menu_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
 	}

--- a/projects/packages/my-jetpack/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/my-jetpack/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/my-jetpack/tests/php/Backup_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Backup_Product_Test.php
@@ -27,10 +27,9 @@ class Backup_Product_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->install_mock_plugins();
 		wp_cache_delete( 'plugins', 'plugins' );
 
@@ -63,10 +62,9 @@ class Backup_Product_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();

--- a/projects/packages/my-jetpack/tests/php/Hybrid_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Hybrid_Product_Test.php
@@ -26,10 +26,9 @@ class Hybrid_Product_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->install_mock_plugins();
 		wp_cache_delete( 'plugins', 'plugins' );
 
@@ -62,10 +61,9 @@ class Hybrid_Product_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();

--- a/projects/packages/my-jetpack/tests/php/Module_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Module_Product_Test.php
@@ -34,10 +34,9 @@ class Module_Product_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->install_mock_plugins();
 		wp_cache_delete( 'plugins', 'plugins' );
 
@@ -73,10 +72,9 @@ class Module_Product_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();

--- a/projects/packages/my-jetpack/tests/php/Product_Multiple_Filenames_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Product_Multiple_Filenames_Test.php
@@ -41,10 +41,9 @@ class Product_Multiple_Filenames_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		if ( file_exists( WP_PLUGIN_DIR . '/jetpack/jetpack.php' ) ) {
 			unlink( WP_PLUGIN_DIR . '/jetpack/jetpack.php' );
 			rmdir( WP_PLUGIN_DIR . '/jetpack' );
@@ -83,10 +82,9 @@ class Product_Multiple_Filenames_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		WorDBless_Options::init()->clear_options();
 	}
 

--- a/projects/packages/my-jetpack/tests/php/Products_Rest_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Products_Rest_Test.php
@@ -48,10 +48,9 @@ class Products_Rest_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->install_mock_plugin();
 		wp_cache_delete( 'plugins', 'plugins' );
 
@@ -101,10 +100,9 @@ class Products_Rest_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();

--- a/projects/packages/my-jetpack/tests/php/Products_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Products_Test.php
@@ -15,10 +15,9 @@ require_once __DIR__ . '/assets/mock-classes.php';
 class Products_Test extends TestCase {
 	/**
 	 * Cleaning up after the test.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		// Make sure to clear the filters even after exceptions.
 		remove_filter( 'my_jetpack_products_classes', array( $this, 'return_valid_class' ) );
 		remove_filter( 'my_jetpack_products_classes', array( $this, 'return_non_existent_class' ) );

--- a/projects/packages/my-jetpack/tests/php/Search_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Search_Product_Test.php
@@ -26,10 +26,9 @@ class Search_Product_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->install_mock_plugins();
 		wp_cache_delete( 'plugins', 'plugins' );
 
@@ -62,10 +61,9 @@ class Search_Product_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
 	}

--- a/projects/packages/my-jetpack/tests/php/Social_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Social_Product_Test.php
@@ -26,10 +26,9 @@ class Social_Product_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->install_mock_plugins();
 		wp_cache_delete( 'plugins', 'plugins' );
 
@@ -62,10 +61,9 @@ class Social_Product_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();

--- a/projects/packages/my-jetpack/tests/php/Videopress_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Videopress_Product_Test.php
@@ -26,10 +26,9 @@ class Videopress_Product_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->install_mock_plugins();
 		wp_cache_delete( 'plugins', 'plugins' );
 
@@ -62,10 +61,9 @@ class Videopress_Product_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
 	}

--- a/projects/packages/my-jetpack/tests/php/Wpcom_Products_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Wpcom_Products_Test.php
@@ -26,10 +26,9 @@ class Wpcom_Products_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		// Mock site connection.
 		( new Tokens() )->update_blog_token( 'test.test' );
 		Jetpack_Options::update_option( 'id', 123 );
@@ -119,10 +118,9 @@ class Wpcom_Products_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();

--- a/projects/packages/patchwork-redefine-exit/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/patchwork-redefine-exit/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/patchwork-redefine-exit/tests/php/fixtures/RedefinitionTestChild.php
+++ b/projects/packages/patchwork-redefine-exit/tests/php/fixtures/RedefinitionTestChild.php
@@ -17,10 +17,8 @@ use PHPUnit\Framework\TestCase;
 // phpcs:ignore Jetpack.PHPUnit.TestClassName.DoesNotEndWithTest
 class RedefinitionTestChild extends TestCase {
 
-	/**
-	 * @after
-	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		\Patchwork\restoreAll();
 	}
 

--- a/projects/packages/phan-plugins/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/phan-plugins/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/phan-plugins/tests/php/IntegrationTest.php
+++ b/projects/packages/phan-plugins/tests/php/IntegrationTest.php
@@ -19,10 +19,8 @@ class IntegrationTest extends TestCase {
 	/** @var CodeBase|null */
 	private $codeBase = null;
 
-	/**
-	 * @before
-	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		// Do what Phan does in its own CodeBaseAwareTest class.
 		// They say it's slow to create. Also I find reconstructing it seems to raise PHP constant deprecations on subsequent runs.
 		static $codeBase = null;
@@ -37,10 +35,8 @@ class IntegrationTest extends TestCase {
 		$this->codeBase = $codeBase->shallowClone();
 	}
 
-	/**
-	 * @after
-	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		$this->codeBase = null;
 	}
 

--- a/projects/packages/phpcs-filter/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/phpcs-filter/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/phpcs-filter/tests/php/PhpcsFilterTest.php
+++ b/projects/packages/phpcs-filter/tests/php/PhpcsFilterTest.php
@@ -30,20 +30,18 @@ class PhpcsFilterTest extends TestCase {
 
 	/**
 	 * Set up.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->oldcwd = getcwd();
 		Config::setConfigData( 'jetpack-filter-basedir', null, true );
 	}
 
 	/**
 	 * Tear down.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		chdir( $this->oldcwd );
 	}
 

--- a/projects/packages/phpunit-select-config/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/phpunit-select-config/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/phpunit-select-config/tests/BinTest.php
+++ b/projects/packages/phpunit-select-config/tests/BinTest.php
@@ -14,10 +14,9 @@ require_once __DIR__ . '/ExitException.php';
  */
 class BinTest extends TestCase {
 
-	/**
-	 * @before
-	 */
-	public function set_up() {
+	public function setUp(): void {
+		// @phan-suppress-previous-line PhanCompatibleAnyReturnTypePHP56, PhanCompatibleVoidTypePHP70 -- While the package claims earlier versions, we only run tests with 7.2+.
+		parent::setUp();
 		unset( $_SERVER['argv'] );
 		foreach ( array( 'exit', 'die', 'pcntl_exec', 'ini_get_all', 'fprintf' ) as $func ) {
 			\Patchwork\redefine(
@@ -31,10 +30,9 @@ class BinTest extends TestCase {
 		\Patchwork\redefine( 'extension_loaded', \Patchwork\always( false ) );
 	}
 
-	/**
-	 * @after
-	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		// @phan-suppress-previous-line PhanCompatibleAnyReturnTypePHP56, PhanCompatibleVoidTypePHP70 -- While the package claims earlier versions, we only run tests with 7.2+.
+		parent::tearDown();
 		\Patchwork\restoreAll();
 	}
 

--- a/projects/packages/plans/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/plans/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/plans/tests/php/Jetpack_Plan_Test.php
+++ b/projects/packages/plans/tests/php/Jetpack_Plan_Test.php
@@ -17,10 +17,9 @@ class Jetpack_Plan_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		delete_option( 'jetpack_active_plan' );
 	}
 

--- a/projects/packages/publicize/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/publicize/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/publicize/tests/php/Connections_Post_Field_Test.php
+++ b/projects/packages/publicize/tests/php/Connections_Post_Field_Test.php
@@ -81,10 +81,9 @@ class Connections_Post_Field_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		global $publicize;
 		$this->publicize = $this->getMockBuilder( Publicize::class )->onlyMethods( array( 'refresh_connections', 'test_connection' ) )->getMock();
 
@@ -168,10 +167,9 @@ class Connections_Post_Field_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		unregister_post_type( 'example-with' );
 		unregister_post_type( 'example-without' );
 		$publicizeable_post_types = array();

--- a/projects/packages/publicize/tests/php/REST_Controller_Test.php
+++ b/projects/packages/publicize/tests/php/REST_Controller_Test.php
@@ -34,10 +34,9 @@ class REST_Controller_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		global $wp_rest_server;
 
 		$wp_rest_server = new WP_REST_Server();
@@ -60,10 +59,9 @@ class REST_Controller_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		wp_set_current_user( 0 );
 
 		unset(

--- a/projects/packages/publicize/tests/php/Scheduled_Actions_Controller_Test.php
+++ b/projects/packages/publicize/tests/php/Scheduled_Actions_Controller_Test.php
@@ -59,10 +59,9 @@ class Scheduled_Actions_Controller_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		global $publicize;
 
 		$this->publicize = $this->getMockBuilder( Publicize::class )->onlyMethods( array( 'save_meta' ) )->getMock();
@@ -139,10 +138,9 @@ class Scheduled_Actions_Controller_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		wp_set_current_user( 0 );
 
 		WorDBless_Options::init()->clear_options();

--- a/projects/packages/publicize/tests/php/Share_Post_Controller_Test.php
+++ b/projects/packages/publicize/tests/php/Share_Post_Controller_Test.php
@@ -51,10 +51,9 @@ class Share_Post_Controller_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		global $wp_rest_server;
 
 		$wp_rest_server = new WP_REST_Server();
@@ -100,10 +99,9 @@ class Share_Post_Controller_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		wp_set_current_user( 0 );
 
 		WorDBless_Options::init()->clear_options();

--- a/projects/packages/publicize/tests/php/Social_Image_Generator_Controller_Test.php
+++ b/projects/packages/publicize/tests/php/Social_Image_Generator_Controller_Test.php
@@ -35,10 +35,9 @@ class Social_Image_Generator_Controller_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		global $wp_rest_server;
 
 		$wp_rest_server = new WP_REST_Server();
@@ -65,10 +64,9 @@ class Social_Image_Generator_Controller_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		wp_set_current_user( 0 );
 
 		unset( $_SERVER['REQUEST_METHOD'] );

--- a/projects/packages/redirect/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/redirect/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/redirect/tests/php/RedirectTest.php
+++ b/projects/packages/redirect/tests/php/RedirectTest.php
@@ -18,19 +18,17 @@ class RedirectTest extends TestCase {
 
 	/**
 	 * Test setup.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		Monkey\setUp();
 	}
 
 	/**
 	 * Test teardown.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		Monkey\tearDown();
 	}
 

--- a/projects/packages/roles/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/roles/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/roles/tests/php/Roles_Test.php
+++ b/projects/packages/roles/tests/php/Roles_Test.php
@@ -29,20 +29,18 @@ class Roles_Test extends TestCase {
 
 	/**
 	 * Test setup.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		Monkey\setUp();
 		$this->roles = new Roles();
 	}
 
 	/**
 	 * Test teardown.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		Monkey\tearDown();
 	}
 

--- a/projects/packages/search/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/search/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/search/tests/php/Helpers_Test.php
+++ b/projects/packages/search/tests/php/Helpers_Test.php
@@ -64,10 +64,9 @@ class Helpers_Test extends TestCase {
 
 	/**
 	 * Setup test instance
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$GLOBALS['wp_customize']  = new Test_Helpers_Customize();
 		$this->request_uri        = isset( $_SERVER['REQUEST_URI'] ) ? filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : null;
 		$this->get                = $_GET;
@@ -81,10 +80,9 @@ class Helpers_Test extends TestCase {
 
 	/**
 	 * Cleanup test instance.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		$_SERVER['REQUEST_URI'] = $this->request_uri;
 		$_GET                   = $this->get;
 		$_POST                  = $this->post;

--- a/projects/packages/search/tests/php/Instant_Search_Auto_Config_JP_Search_Widget_Test.php
+++ b/projects/packages/search/tests/php/Instant_Search_Auto_Config_JP_Search_Widget_Test.php
@@ -15,10 +15,9 @@ use PHPUnit\Framework\TestCase;
 class Instant_Search_Auto_Config_JP_Search_Widget_Test extends TestCase {
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		Instant_Search::initialize( -1 );
 	}
 

--- a/projects/packages/search/tests/php/Module_Control_Test.php
+++ b/projects/packages/search/tests/php/Module_Control_Test.php
@@ -27,11 +27,9 @@ class Module_Control_Test extends Search_TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
-		parent::set_up();
+	public function setUp(): void {
+		parent::setUp();
 
 		$plan = $this->createMock( Plan::class );
 		$plan->method( 'supports_search' )->willReturn( true );

--- a/projects/packages/search/tests/php/Plan_Test.php
+++ b/projects/packages/search/tests/php/Plan_Test.php
@@ -20,10 +20,9 @@ class Plan_Test extends Search_TestCase {
 
 	/**
 	 * Initialize static member `$plan`
-	 *
-	 * @beforeClass
 	 */
-	public static function set_up_before_class() {
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
 		static::$plan = new Plan();
 		static::$plan->init_hooks();
 	}

--- a/projects/packages/search/tests/php/REST_Controller_Test.php
+++ b/projects/packages/search/tests/php/REST_Controller_Test.php
@@ -31,11 +31,9 @@ class REST_Controller_Test extends Search_TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
-		parent::set_up();
+	public function setUp(): void {
+		parent::setUp();
 		global $wp_rest_server;
 
 		$wp_rest_server = new WP_REST_Server();
@@ -57,12 +55,10 @@ class REST_Controller_Test extends Search_TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
 		remove_action( 'rest_api_init', array( $this->rest_controller, 'register_rest_routes' ) );
-		parent::tear_down();
+		parent::tearDown();
 	}
 
 	/**

--- a/projects/packages/search/tests/php/class-testcase.php
+++ b/projects/packages/search/tests/php/class-testcase.php
@@ -36,10 +36,9 @@ abstract class TestCase extends PHPUnit_TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		// Clear any existing data.
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Posts::init()->clear_all_posts();
@@ -68,10 +67,9 @@ abstract class TestCase extends PHPUnit_TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		wp_set_current_user( 0 );
 
 		WorDBless_Options::init()->clear_options();

--- a/projects/packages/stats-admin/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/stats-admin/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/stats-admin/tests/php/Notices_Test.php
+++ b/projects/packages/stats-admin/tests/php/Notices_Test.php
@@ -20,11 +20,9 @@ class Notices_Test extends Stats_TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
-		parent::set_up();
+	public function setUp(): void {
+		parent::setUp();
 		Stats_Options::set_option( 'enable_odyssey_stats', true );
 		Stats_Options::set_option( 'notices', array() );
 		Stats_Options::set_option( 'views', 0 );

--- a/projects/packages/stats-admin/tests/php/REST_Controller_Test.php
+++ b/projects/packages/stats-admin/tests/php/REST_Controller_Test.php
@@ -68,11 +68,9 @@ class REST_Controller_Test extends Stats_TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
-		parent::set_up();
+	public function setUp(): void {
+		parent::setUp();
 		global $wp_rest_server;
 
 		$wp_rest_server = new WP_REST_Server();
@@ -89,12 +87,10 @@ class REST_Controller_Test extends Stats_TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
 		remove_action( 'rest_api_init', array( $this->rest_controller, 'register_rest_routes' ) );
-		parent::tear_down();
+		parent::tearDown();
 	}
 
 	/**

--- a/projects/packages/stats-admin/tests/php/class-testcase.php
+++ b/projects/packages/stats-admin/tests/php/class-testcase.php
@@ -32,10 +32,9 @@ abstract class TestCase extends PHPUnit_TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		// Clear any existing data.
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Posts::init()->clear_all_posts();
@@ -65,10 +64,9 @@ abstract class TestCase extends PHPUnit_TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		wp_set_current_user( 0 );
 
 		WorDBless_Options::init()->clear_options();

--- a/projects/packages/stats/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/stats/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/stats/tests/php/REST_Provider_Test.php
+++ b/projects/packages/stats/tests/php/REST_Provider_Test.php
@@ -26,10 +26,9 @@ class REST_Provider_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		global $wp_rest_server;
 
 		$wp_rest_server = new WP_REST_Server();
@@ -41,10 +40,9 @@ class REST_Provider_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		unset( $_SERVER['REQUEST_METHOD'] );
 		$_GET = array();
 

--- a/projects/packages/status/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/status/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/status/tests/php/Cache_Test.php
+++ b/projects/packages/status/tests/php/Cache_Test.php
@@ -17,20 +17,18 @@ use PHPUnit\Framework\TestCase;
 class Cache_Test extends TestCase {
 	/**
 	 * Test setup.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		Monkey\setUp();
 		Cache::clear();
 	}
 
 	/**
 	 * Test teardown.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		Monkey\tearDown();
 		Cache::clear();
 	}

--- a/projects/packages/status/tests/php/Host_Test.php
+++ b/projects/packages/status/tests/php/Host_Test.php
@@ -25,10 +25,9 @@ class Host_Test extends TestCase {
 
 	/**
 	 * Test setup.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		Monkey\setUp();
 
 		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
@@ -39,10 +38,9 @@ class Host_Test extends TestCase {
 
 	/**
 	 * Test teardown.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		Monkey\tearDown();
 		Constants::clear_constants();
 		Cache::clear();

--- a/projects/packages/status/tests/php/Status_Test.php
+++ b/projects/packages/status/tests/php/Status_Test.php
@@ -39,10 +39,9 @@ class Status_Test extends TestCase {
 
 	/**
 	 * Setup before running any of the tests.
-	 *
-	 * @beforeClass
 	 */
-	public static function set_up_before_class() {
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
 		if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
 			define( 'HOUR_IN_SECONDS', 60 * 60 );
 		}
@@ -50,10 +49,9 @@ class Status_Test extends TestCase {
 
 	/**
 	 * Test setup.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		Monkey\setUp();
 
 		// Set defaults for Core functionality.
@@ -85,10 +83,9 @@ class Status_Test extends TestCase {
 
 	/**
 	 * Test teardown.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		Monkey\tearDown();
 		Status\Cache::clear();
 	}

--- a/projects/packages/status/tests/php/Visitor_Test.php
+++ b/projects/packages/status/tests/php/Visitor_Test.php
@@ -24,19 +24,17 @@ class Visitor_Test extends TestCase {
 
 	/**
 	 * Test setup.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		$this->visitor_obj = new Visitor();
 	}
 
 	/**
 	 * Test teardown.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		unset( $_SERVER['REMOTE_ADDR'] );
 		unset( $_SERVER['HTTP_CF_CONNECTING_IP'] );
 		unset( $_SERVER['HTTP_CLIENT_IP'] );

--- a/projects/packages/subscribers-dashboard/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/subscribers-dashboard/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/subscribers-dashboard/tests/php/Subscribers_Dashboard_Test.php
+++ b/projects/packages/subscribers-dashboard/tests/php/Subscribers_Dashboard_Test.php
@@ -19,19 +19,17 @@ class Subscribers_Dashboard_Test extends TestCase {
 
 	/**
 	 * Setup runs before each test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		add_filter( 'jetpack_wp_admin_subscriber_management_enabled', '__return_true' );
 	}
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		remove_filter( 'jetpack_wp_admin_subscriber_management_enabled', '__return_true' );
 		Cache::clear();
 	}

--- a/projects/packages/sync/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/sync/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/sync/tests/php/REST_Endpoints_Test.php
+++ b/projects/packages/sync/tests/php/REST_Endpoints_Test.php
@@ -34,10 +34,9 @@ class REST_Endpoints_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		global $wp_rest_server;
 
 		$wp_rest_server = new WP_REST_Server();
@@ -58,10 +57,9 @@ class REST_Endpoints_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 
 		Constants::$set_constants['JETPACK__WPCOM_JSON_API_BASE'] = $this->api_host_original;
 

--- a/projects/packages/transport-helper/changelog/remove-unnecessary-phpunit-before-after
+++ b/projects/packages/transport-helper/changelog/remove-unnecessary-phpunit-before-after
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHPUnit: Use standard setup/teardown methods rather than snake-cased methods with annotations, now that we've dropped PHP 7.1 support and PHPUnit 11 is deprecating the annotations.
+
+

--- a/projects/packages/transport-helper/tests/php/REST_Controller_Test.php
+++ b/projects/packages/transport-helper/tests/php/REST_Controller_Test.php
@@ -45,10 +45,9 @@ class REST_Controller_Test extends TestCase {
 
 	/**
 	 * Setting up the test.
-	 *
-	 * @before
 	 */
-	public function set_up() {
+	public function setUp(): void {
+		parent::setUp();
 		global $wp_rest_server;
 
 		$wp_rest_server = new WP_REST_Server();
@@ -70,10 +69,9 @@ class REST_Controller_Test extends TestCase {
 
 	/**
 	 * Returning the environment into its initial state.
-	 *
-	 * @after
 	 */
-	public function tear_down() {
+	public function tearDown(): void {
+		parent::tearDown();
 		wp_set_current_user( 0 );
 
 		unset(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Back when we still supported PHP <=7.1, we had to add these in a lot of places to work around the fact that PHPUnit 8 started declaring a `void` return type on `setUp()`, `tearDown()`, and so on, which 7.1 and earler don't support.

But we've since dropped support for PHP <7.2, so we can swtich back to the normal functions. It's more straightforward to do that than to start adding attributes (`#[Before]` and such) for PHPUnit 11+ where the annotations are deprecated.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
PT: pf4qpu-Fo-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?