### PR TITLE
Boost: Add a notice for failed module

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/error-boundary/error-boundary.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/error-boundary/error-boundary.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 interface Props {
-	fallback: React.ReactNode;
+	fallback: ( error: Error ) => React.ReactNode;
 	children: React.ReactNode;
 }
 
@@ -26,8 +26,8 @@ class ErrorBoundary extends React.Component< Props, State > {
 	}
 
 	render(): React.ReactNode {
-		if ( this.state.hasError ) {
-			return this.props.fallback || null;
+		if ( this.state.hasError && this.state.error ) {
+			return this.props.fallback( this.state.error );
 		}
 		return this.props.children;
 	}

--- a/projects/plugins/boost/app/assets/src/js/features/module/module.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/module/module.module.scss
@@ -34,3 +34,9 @@
 .content {
 	width: 100%;
 }
+
+.failed-module-notice {
+	width: 100%;
+	margin-bottom: 2em;
+	margin-top: 1em;
+}

--- a/projects/plugins/boost/app/assets/src/js/features/module/module.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/module/module.tsx
@@ -112,7 +112,7 @@ export default ( props: ModuleProps ) => {
 		<ErrorBoundary
 			fallback={ error => (
 				<div>
-					<div className={ styles[ 'failed-module' ] }>
+					<div>
 						<h3>{ props.title }</h3>
 
 						<div className={ styles[ 'failed-module-notice' ] }>

--- a/projects/plugins/boost/app/assets/src/js/features/module/module.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/module/module.tsx
@@ -1,4 +1,4 @@
-import { ToggleControl } from '@automattic/jetpack-components';
+import { getRedirectUrl, Notice, ToggleControl } from '@automattic/jetpack-components';
 import { useEffect } from 'react';
 import { useSingleModuleState } from './lib/stores';
 import styles from './module.module.scss';
@@ -6,6 +6,7 @@ import ErrorBoundary from '$features/error-boundary/error-boundary';
 import { __ } from '@wordpress/i18n';
 import { isWoaHosting } from '$lib/utils/hosting';
 import { useNotices } from '$features/notice/context';
+import { createInterpolateElement } from '@wordpress/element';
 
 type ModuleProps = {
 	title: React.ReactNode;
@@ -111,11 +112,32 @@ export default ( props: ModuleProps ) => {
 		<ErrorBoundary
 			fallback={
 				<div>
-					<div className={ styles.content }>
+					<div className={ styles[ 'failed-module' ] }>
 						<h3>{ props.title }</h3>
 
-						<div className={ styles.description }>
-							{ __( `Failed to load module.`, 'jetpack-boost' ) }
+						<div className={ styles[ 'failed-module-notice' ] }>
+							<Notice
+								level="error"
+								hideCloseButton={ true }
+								title={ __( 'Failed to load module', 'jetpack-boost' ) }
+							>
+								{ createInterpolateElement(
+									__(
+										'We encountered a JavaScript error while loading this module. Please refresh the page and try again. If the issue persists, <link>click here</link> to get help.',
+										'jetpack-boost'
+									),
+									{
+										link: (
+											// eslint-disable-next-line jsx-a11y/anchor-has-content
+											<a
+												target="_blank"
+												rel="noopener noreferrer"
+												href={ getRedirectUrl( 'jetpack-boost-help-module-load-failed' ) }
+											/>
+										),
+									}
+								) }
+							</Notice>
 						</div>
 					</div>
 				</div>

--- a/projects/plugins/boost/app/assets/src/js/features/module/module.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/module/module.tsx
@@ -110,7 +110,7 @@ const Module = ( {
 export default ( props: ModuleProps ) => {
 	return (
 		<ErrorBoundary
-			fallback={
+			fallback={ error => (
 				<div>
 					<div className={ styles[ 'failed-module' ] }>
 						<h3>{ props.title }</h3>
@@ -121,27 +121,30 @@ export default ( props: ModuleProps ) => {
 								hideCloseButton={ true }
 								title={ __( 'Failed to load module', 'jetpack-boost' ) }
 							>
-								{ createInterpolateElement(
-									__(
-										'We encountered a JavaScript error while loading this module. Please refresh the page and try again. If the issue persists, <link>click here</link> to get help.',
-										'jetpack-boost'
-									),
-									{
-										link: (
-											// eslint-disable-next-line jsx-a11y/anchor-has-content
-											<a
-												target="_blank"
-												rel="noopener noreferrer"
-												href={ getRedirectUrl( 'jetpack-boost-help-module-load-failed' ) }
-											/>
+								<p>
+									{ createInterpolateElement(
+										__(
+											'We encountered an error while loading this module. Please refresh the page and try again. If the issue persists, <link>click here</link> to get help.',
+											'jetpack-boost'
 										),
-									}
-								) }
+										{
+											link: (
+												// eslint-disable-next-line jsx-a11y/anchor-has-content
+												<a
+													target="_blank"
+													rel="noopener noreferrer"
+													href={ getRedirectUrl( 'jetpack-boost-help-module-load-failed' ) }
+												/>
+											),
+										}
+									) }
+								</p>
+								<code>{ `${ error.constructor.name }: ${ error.message }` }</code>
 							</Notice>
 						</div>
 					</div>
 				</div>
-			}
+			) }
 		>
 			<Module { ...props } />
 		</ErrorBoundary>

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -305,12 +305,12 @@ const BypassPatternsExample = ( { children }: BypassPatternsExampleProps ) => {
 export default () => {
 	return (
 		<ErrorBoundary
-			fallback={
+			fallback={ _error => (
 				<ErrorNotice
 					title={ __( 'Error', 'jetpack-boost' ) }
 					error={ new Error( __( 'Unable to load Cache settings.', 'jetpack-boost' ) ) }
 				/>
-			}
+			) }
 		>
 			<Meta />
 		</ErrorBoundary>

--- a/projects/plugins/boost/app/assets/src/js/features/speed-score/speed-score.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/speed-score/speed-score.tsx
@@ -167,11 +167,11 @@ const SpeedScore = () => {
 export default () => {
 	return (
 		<ErrorBoundary
-			fallback={
+			fallback={ _error => (
 				<div className="jb-container">
 					<p>{ __( 'Failed to load Speed Score.', 'jetpack-boost' ) }</p>
 				</div>
-			}
+			) }
 		>
 			<SpeedScore />
 		</ErrorBoundary>

--- a/projects/plugins/boost/changelog/add-module-load-failed-notice
+++ b/projects/plugins/boost/changelog/add-module-load-failed-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+UI: Show module loading errors with details.


### PR DESCRIPTION
## Proposed changes:
We are seeing more people reaching out to support due to a module failing to load in the UI. However, it's hard to debug when that happens unless we have access to the site. This change updates the UI to show a notice about the module loading failure and include the error message to help us identify what's wrong.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
* It's hard to test without an exception happening in the UI so here is a screenshot:
<img width="1154" alt="Screenshot 2025-03-25 at 3 27 02 PM" src="https://github.com/user-attachments/assets/50cd51fa-68a9-44c2-80d0-65890e495ff9" />

Please test if modules are correctly loading and speed-scores, page cache meta, which utilize this error boundary are still working correctly.


