### PR TITLE
AGORA-32 SEO Enhancer: Enable SEO summary when auto-enhance is disabled

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-seo-enhancer-summary-for-all
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-seo-enhancer-summary-for-all
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+SEO Enhancer: Enable SEO summary when auto-enhance is disabled

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-summary.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-summary.tsx
@@ -102,11 +102,18 @@ export function SeoSummary( { onEdit }: { onEdit: () => void } ) {
 
 	const helpTexts = useMemo( () => {
 		return {
-			'seo-title': seoTitleHelpText,
-			'seo-meta-description': seoDescriptionHelpText,
-			'images-alt-text': imageAltTextHelpText,
+			'seo-title': titleBusy ? null : seoTitleHelpText,
+			'seo-meta-description': descriptionBusy ? null : seoDescriptionHelpText,
+			'images-alt-text': imageBusy ? null : imageAltTextHelpText,
 		};
-	}, [ imageAltTextHelpText, seoDescriptionHelpText, seoTitleHelpText ] );
+	}, [
+		descriptionBusy,
+		imageAltTextHelpText,
+		imageBusy,
+		seoDescriptionHelpText,
+		seoTitleHelpText,
+		titleBusy,
+	] );
 
 	const getIcon = ( feature: PromptType ) => {
 		if ( feature === 'seo-title' ) {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-summary.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-summary.tsx
@@ -1,22 +1,24 @@
 /**
  * External dependencies
  */
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { PanelRow, Button, BaseControl, Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useMemo } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import { Icon, check } from '@wordpress/icons';
+import { useEffect, useMemo, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { Icon, check, closeSmall } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { FEATURE_LABELS } from './constants';
+import { FEATURE_LABELS, FEATURES } from './constants';
 import { store as seoEnhancerStore } from './store';
 import './style.scss';
 /**
  * Types
  */
-import { PromptType } from './types';
+import type { PromptType } from './types';
+import type { Block } from '@automattic/jetpack-ai-client';
 
 export function SeoSummary( { onEdit }: { onEdit: () => void } ) {
 	const { title, description } = useSelect( select => {
@@ -28,40 +30,116 @@ export function SeoSummary( { onEdit }: { onEdit: () => void } ) {
 		};
 	}, [] );
 
-	const { enabledFeatures, titleBusy, descriptionBusy, imageBusy } = useSelect( select => {
-		const { getEnabledFeatures, isTitleBusy, isDescriptionBusy, isAnyImageBusy } =
-			select( seoEnhancerStore );
+	const { titleBusy, descriptionBusy, imageBusy } = useSelect( select => {
+		const { isTitleBusy, isDescriptionBusy, isAnyImageBusy } = select( seoEnhancerStore );
 
 		return {
-			enabledFeatures: getEnabledFeatures(),
 			titleBusy: isTitleBusy(),
 			descriptionBusy: isDescriptionBusy(),
 			imageBusy: isAnyImageBusy(),
 		};
 	}, [] );
 
+	const { getBlocksByName, getBlock } = useSelect(
+		select =>
+			select( blockEditorStore ) as {
+				getBlocksByName: ( name: string ) => string[];
+				getBlock: ( id: string ) => Block;
+			},
+		[]
+	);
+
+	const [ allImagesHaveAltText, setAllImagesHaveAltText ] = useState( false );
+
+	const [ imageAltTextHelpText, setImageAltTextHelpText ] = useState( null );
+
+	const seoTitleHelpText = useMemo( () => {
+		return title
+			? title
+			: __( 'No title found. Add it for better search engine visibility.', 'jetpack' );
+	}, [ title ] );
+
+	const seoDescriptionHelpText = useMemo( () => {
+		return description
+			? description
+			: __( 'No description found. Add it for better search engine visibility.', 'jetpack' );
+	}, [ description ] );
+
+	useEffect( () => {
+		if ( ! imageBusy ) {
+			const imageBlockIds = getBlocksByName( 'core/image' );
+
+			if ( imageBlockIds.length === 0 ) {
+				setImageAltTextHelpText( __( 'No images in the post.', 'jetpack' ) );
+
+				setAllImagesHaveAltText( true );
+			} else {
+				const imageBlocks = imageBlockIds.map( blockId => getBlock( blockId ) );
+				const imageBlocksWithAltText = imageBlocks.filter( block => block.attributes.alt );
+
+				if ( imageBlocksWithAltText.length === imageBlockIds.length ) {
+					setImageAltTextHelpText(
+						// Translators: %d is the number of images.
+						sprintf( __( 'Alt text added to all %d images', 'jetpack' ), imageBlockIds.length )
+					);
+
+					setAllImagesHaveAltText( true );
+				} else {
+					setImageAltTextHelpText(
+						sprintf(
+							// Translators: %1$d is the number of images with alt text, %2$d is the total number of images.
+							__( 'Alt text added to %1$d of %2$d images', 'jetpack' ),
+							imageBlocksWithAltText.length,
+							imageBlockIds.length
+						)
+					);
+
+					setAllImagesHaveAltText( false );
+				}
+			}
+		}
+	}, [ getBlock, getBlocksByName, imageBusy ] );
+
 	const helpTexts = useMemo( () => {
 		return {
-			'seo-title': title,
-			'seo-meta-description': description,
-			'images-alt-text': __( 'Alt text added to images', 'jetpack' ),
+			'seo-title': seoTitleHelpText,
+			'seo-meta-description': seoDescriptionHelpText,
+			'images-alt-text': imageAltTextHelpText,
 		};
-	}, [ description, title ] );
+	}, [ imageAltTextHelpText, seoDescriptionHelpText, seoTitleHelpText ] );
 
 	const getIcon = ( feature: PromptType ) => {
 		if ( feature === 'seo-title' ) {
-			return titleBusy ? <Spinner /> : check;
+			if ( titleBusy ) {
+				return <Spinner />;
+			}
+
+			if ( title ) {
+				return check;
+			}
 		}
 
 		if ( feature === 'seo-meta-description' ) {
-			return descriptionBusy ? <Spinner /> : check;
+			if ( descriptionBusy ) {
+				return <Spinner />;
+			}
+
+			if ( description ) {
+				return check;
+			}
 		}
 
 		if ( feature === 'images-alt-text' ) {
-			return imageBusy ? <Spinner /> : check;
+			if ( imageBusy ) {
+				return <Spinner />;
+			}
+
+			if ( allImagesHaveAltText ) {
+				return check;
+			}
 		}
 
-		return null;
+		return closeSmall;
 	};
 
 	return (
@@ -71,10 +149,10 @@ export function SeoSummary( { onEdit }: { onEdit: () => void } ) {
 					__nextHasNoMarginBottom={ true }
 					className="ai-seo-enhancer-toggle"
 					help={ __( 'Want to fine-tune this metadata further?', 'jetpack' ) }
-					label={ __( 'Generated Metadata', 'jetpack' ) }
+					label={ __( 'Metadata', 'jetpack' ) }
 					id="jetpack-seo-enhancer-generated-metadata"
 				>
-					{ enabledFeatures.map( feature => (
+					{ FEATURES.map( feature => (
 						<div key={ feature } className="jetpack-seo-enhancer-summary-feature">
 							<div className="jetpack-seo-enhancer-summary-feature__icon-container">
 								<Icon

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -211,7 +211,7 @@ const Seo = () => {
 				</div>
 			</PluginPrePublishPanel>
 
-			{ isSeoEnhancerEnabled && isAutoEnhanceEnabled && canHaveAutoEnhance && (
+			{ isSeoEnhancerEnabled && (
 				<PluginPostPublishPanel { ...jetpackSeoPublishPanelsProps }>
 					<div className="jetpack-seo-panel">
 						<SeoSummary onEdit={ handleSummaryEdit } />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Enabled the SEO summary even if auto-enhance is disabled, with the actual values and numbers for images

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor with the SEO enhancer enabled
* Add some content and images, disable auto-enhance
* Publish the post
* Check that the summary is visible with correct data
