### PR TITLE
Keep a single instant_search feature

### DIFF
--- a/projects/plugins/wpcomsh/changelog/Keep a single INSTANT_SEARCH feature
+++ b/projects/plugins/wpcomsh/changelog/Keep a single INSTANT_SEARCH feature
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Removed an extra instant search feature which included the business/commerce sites and we won't be using it for now.

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -380,7 +380,6 @@ class WPCOM_Features {
 	public const INSTALL_THEMES                    = 'install-themes';
 	public const INSTALL_WOO_ONBOARDING_PLUGINS    = 'install-woo-onboarding-plugins';
 	public const INSTANT_SEARCH                    = 'instant-search';
-	public const INSTANT_SEARCH_NO_BUSINESS        = 'instant-search-no-business'; // TEMP AND TO BE DELETED AFTER REBUILDING the jetpack-search index
 	public const JETPACK_DASHBOARD                 = 'jetpack-dashboard';
 	public const LEGACY_CONTACT                    = 'legacy-contact';
 	public const LIST_INSTALLED_PLUGINS            = 'list-installed-plugins';
@@ -774,16 +773,6 @@ class WPCOM_Features {
 			self::WPCOM_ECOMMERCE_TRIAL_PLANS,
 		),
 		self::INSTANT_SEARCH                    => array(
-			self::WPCOM_BUSINESS_PLANS,
-			self::WPCOM_ECOMMERCE_PLANS,
-			self::WPCOM_ECOMMERCE_TRIAL_PLANS,
-			self::WPCOM_SEARCH,
-			self::WPCOM_SEARCH_MONTHLY,
-			self::WP_P2_PLUS_MONTHLY,
-			self::JETPACK_SEARCH_PLANS,
-			self::JETPACK_COMPLETE_PLANS,
-		),
-		self::INSTANT_SEARCH_NO_BUSINESS        => array(
 			self::WPCOM_SEARCH,
 			self::WPCOM_SEARCH_MONTHLY,
 			self::WP_P2_PLUS_MONTHLY,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Keep a single INSTANT_SEARCH feature i.e. remove the one that included business/commerce sites.

We wanted to have this as we would like to index all business/commerce sites but now we are thinking of indexing all sites with the Search module enabled which should include the business/commerce sites. Then we want the existing indexing to resume as it is from instant search and hence we need to revert it to its initial situation.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
None needed.

