### PR TITLE
Site Visibility: Prevent accidental changes to blog_public on the Settings > Reading page

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-site-launched-by-accident
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-site-launched-by-accident
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Site Visibility: Prevent accidental changes to blog_public on the Settings > Reading page

--- a/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
@@ -180,6 +180,22 @@ HTML;
 add_action( 'blog_privacy_selector', 'replace_site_visibility' );
 
 /**
+ * Filter out the settings related to the site visibility.
+ *
+ * @param array $allowed_options The allowed options list.
+ * @return array
+ */
+function allowed_options_remove_site_visibility( $allowed_options ) {
+	$del_options = array(
+		'reading' => array( 'blog_public' ),
+	);
+
+	$allowed_options = remove_allowed_options( $del_options, $allowed_options );
+
+	return $allowed_options;
+}
+
+/**
  * Update the site options that are related to the site visibility.
  */
 function load_options_update_site_visibility() {
@@ -207,6 +223,7 @@ function load_options_update_site_visibility() {
 	}
 
 	if ( empty( $data ) ) {
+		add_filter( 'allowed_options', 'allowed_options_remove_site_visibility' );
 		return;
 	}
 

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-site-launched-by-accident
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-site-launched-by-accident
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Site Visibility: Prevent accidental changes to blog_public on the Settings > Reading page

--- a/projects/plugins/wpcomsh/changelog/fix-site-launched-by-accident
+++ b/projects/plugins/wpcomsh/changelog/fix-site-launched-by-accident
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Site Visibility: Prevent accidental changes to blog_public on the Settings > Reading page


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/101882

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The `blog_public` setting was being updated to `null` when users navigated to Settings > Reading and saved changes on simple sites. This happened because `blog_public` was included in the `allowed_options` list by default. As a result, when users saved their settings, WordPress still called the `update_option` function, even if the value remained `null`. This ultimately led to an unintended call to `update_option('blog_public', 1)`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your sandbox and sandbox your site
* Go to /wp-admin/options-reading.php on your unlaunched site
* Save changes
* Ensure your site won't be launched

