### PR TITLE
Importer: Fix guided import banner link

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-importer-banner
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-importer-banner
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Importer: Fix guided importer banner URL to use site-migration flow

--- a/projects/packages/jetpack-mu-wpcom/changelog/show-importer-banner-free-sites
+++ b/projects/packages/jetpack-mu-wpcom/changelog/show-importer-banner-free-sites
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Importer: Show importer banner when the site is simple

--- a/projects/packages/jetpack-mu-wpcom/changelog/show-importer-banner-free-sites
+++ b/projects/packages/jetpack-mu-wpcom/changelog/show-importer-banner-free-sites
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Importer: Show importer banner when the site is simple

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -35,7 +35,7 @@ function import_admin_banner() {
 		return;
 	}
 
-	$import_url = esc_url( "https://wordpress.com/setup/site-migration/?siteId={$blog_id}&ref=wp-admin-importers-list" );
+	$import_url = esc_url( "https://wordpress.com/setup/site-setup/importList?siteId={$blog_id}&ref=wp-admin-importers-list" );
 
 	$banner_content = sprintf(
 		'<p>%s</p><a href="%s" class="button button-primary">%s</a>',

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -35,7 +35,7 @@ function import_admin_banner() {
 		return;
 	}
 
-	$import_url = esc_url( "https://wordpress.com/setup/site-setup/importList?siteId={$blog_id}&canMigrate=1&ref=wp-admin-importers-list" );
+	$import_url = esc_url( "https://wordpress.com/setup/site-setup/importList?siteId={$blog_id}&ref=wp-admin-importers-list" );
 
 	$banner_content = sprintf(
 		'<p>%s</p><a href="%s" class="button button-primary">%s</a>',

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -35,7 +35,7 @@ function import_admin_banner() {
 		return;
 	}
 
-	$import_url = esc_url( "https://wordpress.com/setup/hosted-site-migration/?siteId={$blog_id}&ref=wp-admin}" );
+	$import_url = esc_url( "https://wordpress.com/setup/site-migration/?siteId={$blog_id}&ref=wp-admin-importers-list" );
 
 	$banner_content = sprintf(
 		'<p>%s</p><a href="%s" class="button button-primary">%s</a>',

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -15,13 +15,11 @@ function import_page_customizations_init() {
 	$has_import_param = ! isset( $_GET['import'] );
 
 	if ( $screen && $screen->id === 'import' && $has_import_param ) {
-		// Only add the banner if the user is using the wp-admin interface.
-		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
 			add_action( 'admin_notices', 'import_admin_banner' );
 			add_action( 'admin_enqueue_scripts', 'import_admin_banner_css' );
-		}
 	}
 }
+
 add_action( 'current_screen', 'import_page_customizations_init' );
 
 /**
@@ -37,7 +35,7 @@ function import_admin_banner() {
 		return;
 	}
 
-	$import_url = esc_url( "https://wordpress.com/setup/hosted-site-migration/site-migration-import-or-migrate?siteId={$blog_id}&ref=wp-admin" );
+	$import_url = esc_url( "https://wordpress.com/setup/hosted-site-migration/?siteId={$blog_id}&ref=wp-admin}" );
 
 	$banner_content = sprintf(
 		'<p>%s</p><a href="%s" class="button button-primary">%s</a>',

--- a/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/import-customizations/import-customizations.php
@@ -35,7 +35,7 @@ function import_admin_banner() {
 		return;
 	}
 
-	$import_url = esc_url( "https://wordpress.com/setup/site-setup/importList?siteId={$blog_id}&ref=wp-admin-importers-list" );
+	$import_url = esc_url( "https://wordpress.com/setup/site-setup/importList?siteId={$blog_id}&canMigrate=1&ref=wp-admin-importers-list" );
 
 	$banner_content = sprintf(
 		'<p>%s</p><a href="%s" class="button button-primary">%s</a>',


### PR DESCRIPTION
Depends on https://github.com/Automattic/jetpack/pull/42693

## Proposed changes:
* Redirect the user to the site migration flow when they opt-in to use the guided version.

## Why are these changes being made?
Nowadays, we redirect the user to the import-or-migrate step, which assumes the user intends to migrate to a WordPress site when this is not necessarily true. 

> [!WARNING]
> The back button will only work after the https://github.com/Automattic/wp-calypso/pull/102224 is merged. 


### Other information

![image](https://github.com/user-attachments/assets/1a7d2adb-3298-4228-a83f-eba611ec017c)


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Apply this change in your sandbox
* Sandbox a site
* Navigate to {YOUR_SANDBOXED_SITE}/wp-admin/import.php
* Click on the banner get started button
* Could you verify whether you have been redirecting? The destination should be `https://wordpress.com/setup/site-setup/importList` and with the ref=`wp-admin-importers-list`




