### PR TITLE
wpcomsh: Update wc-calypso-bridge to 2.9.2

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wc-calypso-bridge-2.9.2
+++ b/projects/plugins/wpcomsh/changelog/update-wc-calypso-bridge-2.9.2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update wc-calypso-bridge dependency to 2.9.2

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -9,7 +9,7 @@
 		"automattic/custom-fonts": "^3.0",
 		"automattic/custom-fonts-typekit": "^2.0",
 		"automattic/text-media-widget-styles": "^2.0",
-		"automattic/wc-calypso-bridge": "2.9.1",
+		"automattic/wc-calypso-bridge": "2.9.2",
 		"wordpress/classic-editor-plugin": "1.6.7",
 		"automattic/jetpack-composer-plugin": "@dev",
 		"automattic/jetpack-config": "@dev",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7d016152b5066c33148a7afe0c2a9fac",
+    "content-hash": "bba2f0c5c366144065179146d49f37fb",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
@@ -2044,16 +2044,16 @@
         },
         {
             "name": "automattic/wc-calypso-bridge",
-            "version": "v2.9.1",
+            "version": "v2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/wc-calypso-bridge.git",
-                "reference": "5e218260e09efaee778cbaeaa894084b8f8770b9"
+                "reference": "e740874c1149a1307a1da2ec73f2ffde6a260540"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/5e218260e09efaee778cbaeaa894084b8f8770b9",
-                "reference": "5e218260e09efaee778cbaeaa894084b8f8770b9",
+                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/e740874c1149a1307a1da2ec73f2ffde6a260540",
+                "reference": "e740874c1149a1307a1da2ec73f2ffde6a260540",
                 "shasum": ""
             },
             "require-dev": {
@@ -2092,7 +2092,7 @@
                     "phpcbf -p"
                 ]
             },
-            "time": "2025-03-20T10:13:16+00:00"
+            "time": "2025-03-26T12:26:04+00:00"
         },
         {
             "name": "scssphp/scssphp",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR bumps the version of `wc-calypso-bridge` to 2.9.2, which includes the following change:

- https://github.com/Automattic/wc-calypso-bridge/pull/1551

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The changes related to the `wc-calypso-bridge` were already tested in the linked PR. Testing instructions can be found on the linked PR above.
