### PR TITLE
Boost: Run `jetpack_boost_critical_css_generated` action after saving state.

### DIFF
--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
@@ -33,6 +33,10 @@ class Critical_CSS_State {
 	public function save() {
 		$this->state['updated'] = microtime( true );
 		jetpack_boost_ds_set( 'critical_css_state', $this->state );
+
+		if ( $this->is_generated() ) {
+			do_action( 'jetpack_boost_critical_css_generated' );
+		}
 	}
 
 	public function set_error( $message ) {
@@ -151,7 +155,6 @@ class Critical_CSS_State {
 
 		if ( $is_done ) {
 			$this->state['status'] = self::GENERATION_STATES['generated'];
-			do_action( self::GENERATION_ACTION_NAME );
 		}
 	}
 

--- a/projects/plugins/boost/changelog/fix-critical-css-state-update
+++ b/projects/plugins/boost/changelog/fix-critical-css-state-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Critical CSS: Improve reliability of generation by running hooks after saving the state.


### PR DESCRIPTION
Related to Automattic/jpop-issues#9659
Fixes HOG-27

## Proposed changes:
* Save critical CSS state first and then run the action instead of vice-versa. This allows saving the state without action interference.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Make sure critical CSS generation still completes as expected.
* Make sure critical CSS generation still clears cache.

