### PR TITLE
Remove dependency on `istanbul-merge`

### DIFF
--- a/.github/files/coverage-munger/package.json
+++ b/.github/files/coverage-munger/package.json
@@ -1,7 +1,6 @@
 {
 	"private": true,
 	"devDependencies": {
-		"istanbul-merge": "^2.0.0",
 		"nyc": "^17.1.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,9 +33,6 @@ importers:
 
   .github/files/coverage-munger:
     devDependencies:
-      istanbul-merge:
-        specifier: ^2.0.0
-        version: 2.0.0
       nyc:
         specifier: ^17.1.0
         version: 17.1.0
@@ -11812,11 +11809,6 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
 
-  istanbul-merge@2.0.0:
-    resolution: {integrity: sha512-Y812/uTdnF5Qc2qWxA7jQOTkqpFLEr7BHy8mzUQFRJstTjPigNS1Bh3q06AbOhBZ7tZqrI4MZdMgG34KVnUn6w==}
-    engines: {node: '>= 8'}
-    hasBin: true
-
   istanbul-reports@3.1.7:
     resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
     engines: {node: '>=8'}
@@ -12676,10 +12668,6 @@ packages:
 
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
-
-  mkdirp@0.5.6:
-    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
-    hasBin: true
 
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
@@ -26199,15 +26187,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  istanbul-merge@2.0.0:
-    dependencies:
-      array.prototype.flatmap: 1.3.3
-      for-each: 0.3.5
-      glob: 7.2.3
-      istanbul-lib-coverage: 3.2.2
-      mkdirp: 0.5.6
-      yargs: 15.4.1
-
   istanbul-reports@3.1.7:
     dependencies:
       html-escaper: 2.0.2
@@ -27553,10 +27532,6 @@ snapshots:
   mitt@2.1.0: {}
 
   mitt@3.0.1: {}
-
-  mkdirp@0.5.6:
-    dependencies:
-      minimist: 1.2.8
 
   mkdirp@1.0.4: {}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
It turns out that `nyc` has a `merge` subcommand, which will do what we need if we first copy all the to-be-merged files into a single directory for it to work from.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Coverage should be unchanged.
* Also check that the JS coverage report has all the same files.
* Run `jetpack test coverage <several-js-packages-with-tests>` and make sure the output shows an appropriate coverage report for all the specified packages.