### PR TITLE
Forms: Add endpoint to check Akismet status

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-askismet-activation-check
+++ b/projects/packages/forms/changelog/fix-forms-askismet-activation-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add third party integration endpoint.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-akismet-panel.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-akismet-panel.js
@@ -3,7 +3,6 @@ import apiFetch from '@wordpress/api-fetch';
 import {
 	Button,
 	ExternalLink,
-	Spinner,
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { createInterpolateElement, useState, useCallback, useEffect } from '@wordpress/element';
@@ -20,34 +19,24 @@ const AkismetPanel = () => {
 	const [ akismetUrl, setAkismetUrl ] = useState(
 		window?.jpFormsBlocks?.defaults?.akismetUrl || ''
 	);
-	const [ isChecking, setIsChecking ] = useState( false );
 
 	// Method to check Akismet status from API
 	const checkAkismetStatus = useCallback( async () => {
-		setIsChecking( true );
 		try {
 			const response = await apiFetch( {
 				path: '/wp/v2/feedback/integration-status?slug=akismet',
 			} );
 			setAkismetActiveWithKey( response.isConnected );
-			// Update the URL from the endpoint response
 			if ( response.configurationUrl ) {
 				setAkismetUrl( response.configurationUrl );
 			}
-			setIsChecking( false );
 		} catch {
-			// Silent error - don't log to avoid linting issues
-			setIsChecking( false );
+			setAkismetActiveWithKey( false );
 		}
 	}, [] );
 
-	// Check status on component mount if plugin is active
 	useEffect( () => {
-		// Check Akismet status on mount if the plugin is installed and active
-		const isAkismetActive = window?.jpFormsBlocks?.defaults?.akismetActiveWithKey;
-		if ( isAkismetActive ) {
-			checkAkismetStatus();
-		}
+		checkAkismetStatus();
 	}, [ checkAkismetStatus ] );
 
 	return (
@@ -71,14 +60,7 @@ const AkismetPanel = () => {
 			initialOpen={ false }
 			onPluginActivated={ checkAkismetStatus }
 		>
-			{ /* Use individual if blocks to avoid nested ternary */ }
-			{ isChecking && (
-				<HStack justify="flex-start" spacing={ 2 }>
-					<Spinner />
-					<span>{ __( 'Checking Akismet status…', 'jetpack-forms' ) }</span>
-				</HStack>
-			) }
-			{ ! isChecking && akismetActiveWithKey && (
+			{ akismetActiveWithKey ? (
 				<>
 					<p>
 						{ createInterpolateElement(
@@ -109,8 +91,7 @@ const AkismetPanel = () => {
 						</Button>
 					</HStack>
 				</>
-			) }
-			{ ! isChecking && ! akismetActiveWithKey && (
+			) : (
 				<>
 					<p>
 						{ createInterpolateElement(

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-akismet-panel.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-akismet-panel.js
@@ -23,7 +23,7 @@ const AkismetPanel = () => {
 	const checkAkismetStatus = useCallback( async () => {
 		try {
 			const response = await apiFetch( {
-				path: '/wp/v2/feedback/integration-status?slug=akismet',
+				path: '/wp/v2/feedback/integration-status/akismet',
 			} );
 			setAkismetActiveWithKey( response.isConnected );
 			if ( response.configurationUrl ) {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-akismet-panel.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-akismet-panel.js
@@ -1,13 +1,54 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { Button, ExternalLink, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
-import { createInterpolateElement } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	Button,
+	ExternalLink,
+	Spinner,
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
+import { createInterpolateElement, useState, useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import PluginIntegrationPanel from './shared/plugin-integration-panel';
 
 const AkismetPanel = () => {
 	const adminUrl = window?.jpFormsBlocks?.defaults?.formsAdminUrl || '';
-	const akismetActiveWithKey = window?.jpFormsBlocks?.defaults?.akismetActiveWithKey || false;
-	const akismetUrl = window?.jpFormsBlocks?.defaults?.akismetUrl || '';
+
+	// Initialize from global defaults, but will be updated from API
+	const [ akismetActiveWithKey, setAkismetActiveWithKey ] = useState(
+		window?.jpFormsBlocks?.defaults?.akismetActiveWithKey || false
+	);
+	const [ akismetUrl, setAkismetUrl ] = useState(
+		window?.jpFormsBlocks?.defaults?.akismetUrl || ''
+	);
+	const [ isChecking, setIsChecking ] = useState( false );
+
+	// Method to check Akismet status from API
+	const checkAkismetStatus = useCallback( async () => {
+		setIsChecking( true );
+		try {
+			const response = await apiFetch( {
+				path: '/wp/v2/feedback/integration-status?slug=akismet',
+			} );
+			setAkismetActiveWithKey( response.isConnected );
+			// Update the URL from the endpoint response
+			if ( response.configurationUrl ) {
+				setAkismetUrl( response.configurationUrl );
+			}
+			setIsChecking( false );
+		} catch {
+			// Silent error - don't log to avoid linting issues
+			setIsChecking( false );
+		}
+	}, [] );
+
+	// Check status on component mount if plugin is active
+	useEffect( () => {
+		// Check Akismet status on mount if the plugin is installed and active
+		const isAkismetActive = window?.jpFormsBlocks?.defaults?.akismetActiveWithKey;
+		if ( isAkismetActive ) {
+			checkAkismetStatus();
+		}
+	}, [ checkAkismetStatus ] );
 
 	return (
 		<PluginIntegrationPanel
@@ -28,8 +69,16 @@ const AkismetPanel = () => {
 			) }
 			tracksEventName="jetpack_forms_upsell_akismet_click"
 			initialOpen={ false }
+			onPluginActivated={ checkAkismetStatus }
 		>
-			{ akismetActiveWithKey ? (
+			{ /* Use individual if blocks to avoid nested ternary */ }
+			{ isChecking && (
+				<HStack justify="flex-start" spacing={ 2 }>
+					<Spinner />
+					<span>{ __( 'Checking Akismet status…', 'jetpack-forms' ) }</span>
+				</HStack>
+			) }
+			{ ! isChecking && akismetActiveWithKey && (
 				<>
 					<p>
 						{ createInterpolateElement(
@@ -60,7 +109,8 @@ const AkismetPanel = () => {
 						</Button>
 					</HStack>
 				</>
-			) : (
+			) }
+			{ ! isChecking && ! akismetActiveWithKey && (
 				<>
 					<p>
 						{ createInterpolateElement(

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-akismet-panel.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-akismet-panel.js
@@ -20,7 +20,6 @@ const AkismetPanel = () => {
 		window?.jpFormsBlocks?.defaults?.akismetUrl || ''
 	);
 
-	// Method to check Akismet status from API
 	const checkAkismetStatus = useCallback( async () => {
 		try {
 			const response = await apiFetch( {

--- a/projects/packages/forms/src/blocks/contact-form/components/shared/plugin-integration-panel/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/shared/plugin-integration-panel/index.js
@@ -58,7 +58,6 @@ const PluginIntegrationPanel = ( {
 			setIsInstalling( false );
 			setIsActivating( false );
 
-			// Call onPluginActivated callback after plugin is activated
 			if ( isActivationCall && onPluginActivated ) {
 				onPluginActivated();
 			}

--- a/projects/packages/forms/src/blocks/contact-form/components/shared/plugin-integration-panel/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/shared/plugin-integration-panel/index.js
@@ -19,6 +19,7 @@ const PluginIntegrationPanel = ( {
 	tracksEventName,
 	children,
 	initialOpen = false,
+	onPluginActivated,
 } ) => {
 	const [ isInstalling, setIsInstalling ] = useState( false );
 	const [ isActivating, setIsActivating ] = useState( false );
@@ -56,6 +57,11 @@ const PluginIntegrationPanel = ( {
 			invalidateResolution( 'getPlugins' );
 			setIsInstalling( false );
 			setIsActivating( false );
+
+			// Call onPluginActivated callback after plugin is activated
+			if ( isActivationCall && onPluginActivated ) {
+				onPluginActivated();
+			}
 		} );
 	}, [
 		isInstalled,
@@ -66,6 +72,7 @@ const PluginIntegrationPanel = ( {
 		setIsActivating,
 		invalidateResolution,
 		tracks,
+		onPluginActivated,
 	] );
 
 	return (

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -528,7 +528,6 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 
 			case 'creative-mail':
 			case 'jetpack-crm':
-				// These just need basic plugin status
 				return $this->get_plugin_status( $slug );
 
 			default:
@@ -543,7 +542,6 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	/**
 	 * Get basic plugin status (installed/active).
 	 *
-	 * @since $$next-version$$
 	 * @param string $plugin_slug The plugin slug (e.g. 'akismet' or 'creative-mail').
 	 * @return array Plugin status data.
 	 */
@@ -586,7 +584,6 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	/**
 	 * Get Akismet plugin status including key configuration.
 	 *
-	 * @since $$next-version$$
 	 * @return WP_REST_Response Response object.
 	 */
 	public function get_akismet_status() {

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -547,30 +547,29 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * Get basic plugin status (installed/active).
 	 *
 	 * @param string $plugin_slug The plugin slug (e.g. 'akismet' or 'creative-mail').
-	 * @return array Plugin status data.
+	 * @return WP_REST_Response Plugin status data.
 	 */
 	private function get_plugin_status( $plugin_slug ) {
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		// WordPress core functions like get_plugins() and is_plugin_active() require the full plugin path
-		// (e.g. 'akismet/akismet.php'). Since we expose simpler slugs in our API, we maintain a mapping
-		// of slugs to their full plugin paths. You'll need to update this mapping as you add new integrations.
 		$plugin_files = array(
 			'akismet'       => 'akismet/akismet.php',
 			'creative-mail' => 'creative-mail-by-constant-contact/creative-mail-by-constant-contact.php',
 			'jetpack-crm'   => 'zero-bs-crm/ZeroBSCRM.php',
 		);
 
-		$plugin_file = isset( $plugin_files[ $plugin_slug ] ) ? $plugin_files[ $plugin_slug ] : '';
+		$plugin_file = $plugin_files[ $plugin_slug ] ?? '';
 		if ( empty( $plugin_file ) ) {
-			return array(
-				'type'        => 'plugin',
-				'isInstalled' => false,
-				'isActive'    => false,
-				/* translators: %s: plugin slug */
-				'error'       => sprintf( __( 'Unknown plugin: %s', 'jetpack-forms' ), $plugin_slug ),
+			return rest_ensure_response(
+				array(
+					'type'        => 'plugin',
+					'isInstalled' => false,
+					'isActive'    => false,
+					/* translators: %s: plugin slug */
+					'error'       => sprintf( __( 'Unknown plugin: %s', 'jetpack-forms' ), $plugin_slug ),
+				)
 			);
 		}
 
@@ -594,10 +593,11 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 */
 	public function get_akismet_status() {
 		$plugin_status = $this->get_plugin_status( 'akismet' );
+		$status_data   = $plugin_status->get_data();
 
 		return rest_ensure_response(
 			array_merge(
-				$plugin_status->get_data(),
+				$status_data,
 				array(
 					'isConnected'      => class_exists( 'Jetpack' ) && \Jetpack::is_akismet_active(),
 					'configurationUrl' => admin_url( 'admin.php?page=akismet-key-config' ),

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -36,15 +36,19 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/integration-status',
+			$this->rest_base . '/integration-status/(?P<slug>[\w-]+)',
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_integration_status' ),
 				'permission_callback' => array( $this, 'get_items_permissions_check' ),
 				'args'                => array(
 					'slug' => array(
-						'type'     => 'string',
-						'required' => true,
+						'type'              => 'string',
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_text_field',
+						'validate_callback' => function ( $param ) {
+							return preg_match( '/^[\w-]+$/', $param );
+						},
 					),
 				),
 			)
@@ -574,10 +578,12 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		$is_installed      = isset( $installed_plugins[ $plugin_file ] );
 		$is_active         = is_plugin_active( $plugin_file );
 
-		return array(
-			'type'        => 'plugin',
-			'isInstalled' => $is_installed,
-			'isActive'    => $is_active,
+		return rest_ensure_response(
+			array(
+				'type'        => 'plugin',
+				'isInstalled' => $is_installed,
+				'isActive'    => $is_active,
+			)
 		);
 	}
 
@@ -591,7 +597,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 
 		return rest_ensure_response(
 			array_merge(
-				$plugin_status,
+				$plugin_status->get_data(),
 				array(
 					'isConnected'      => class_exists( 'Jetpack' ) && \Jetpack::is_akismet_active(),
 					'configurationUrl' => admin_url( 'admin.php?page=akismet-key-config' ),

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -36,6 +36,22 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 
 		register_rest_route(
 			$this->namespace,
+			$this->rest_base . '/integration-status',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_integration_status' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				'args'                => array(
+					'slug' => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
 			$this->rest_base . '/bulk_actions',
 			array(
 				'methods'             => \WP_REST_Server::CREATABLE,
@@ -493,6 +509,96 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				'Content-Transfer-Encoding' => 'binary',
 				'X-Robots-Tag'              => 'noindex',
 				'Cache-Control'             => 'no-cache, must-revalidate, max-age=0',
+			)
+		);
+	}
+
+	/**
+	 * Get the status of a forms integration.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_integration_status( WP_REST_Request $request ) {
+		$slug = $request->get_param( 'slug' );
+
+		switch ( $slug ) {
+			case 'akismet':
+				return $this->get_akismet_status();
+
+			case 'creative-mail':
+			case 'jetpack-crm':
+				// These just need basic plugin status
+				return $this->get_plugin_status( $slug );
+
+			default:
+				return new WP_Error(
+					'invalid_integration',
+					/* translators: %s: integration slug */
+					sprintf( __( 'Unknown integration: %s', 'jetpack-forms' ), $slug )
+				);
+		}
+	}
+
+	/**
+	 * Get basic plugin status (installed/active).
+	 *
+	 * @since $$next-version$$
+	 * @param string $plugin_slug The plugin slug (e.g. 'akismet' or 'creative-mail').
+	 * @return array Plugin status data.
+	 */
+	private function get_plugin_status( $plugin_slug ) {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		// WordPress core functions like get_plugins() and is_plugin_active() require the full plugin path
+		// (e.g. 'akismet/akismet.php'). Since we expose simpler slugs in our API, we maintain a mapping
+		// of slugs to their full plugin paths. You'll need to update this mapping as you add new integrations.
+		$plugin_files = array(
+			'akismet'       => 'akismet/akismet.php',
+			'creative-mail' => 'creative-mail-by-constant-contact/creative-mail-by-constant-contact.php',
+			'jetpack-crm'   => 'zero-bs-crm/ZeroBSCRM.php',
+		);
+
+		$plugin_file = isset( $plugin_files[ $plugin_slug ] ) ? $plugin_files[ $plugin_slug ] : '';
+		if ( empty( $plugin_file ) ) {
+			return array(
+				'type'        => 'plugin',
+				'isInstalled' => false,
+				'isActive'    => false,
+				/* translators: %s: plugin slug */
+				'error'       => sprintf( __( 'Unknown plugin: %s', 'jetpack-forms' ), $plugin_slug ),
+			);
+		}
+
+		$installed_plugins = get_plugins();
+		$is_installed      = isset( $installed_plugins[ $plugin_file ] );
+		$is_active         = is_plugin_active( $plugin_file );
+
+		return array(
+			'type'        => 'plugin',
+			'isInstalled' => $is_installed,
+			'isActive'    => $is_active,
+		);
+	}
+
+	/**
+	 * Get Akismet plugin status including key configuration.
+	 *
+	 * @since $$next-version$$
+	 * @return WP_REST_Response Response object.
+	 */
+	public function get_akismet_status() {
+		$plugin_status = $this->get_plugin_status( 'akismet' );
+
+		return rest_ensure_response(
+			array_merge(
+				$plugin_status,
+				array(
+					'isConnected'      => class_exists( 'Jetpack' ) && \Jetpack::is_akismet_active(),
+					'configurationUrl' => admin_url( 'admin.php?page=akismet-key-config' ),
+				)
 			)
 		);
 	}

--- a/projects/plugins/jetpack/changelog/fix-forms-askismet-activation-check
+++ b/projects/plugins/jetpack/changelog/fix-forms-askismet-activation-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Added third party integration endpoint.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #42729

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
**Issue:** In the form block sidebar, we prompt users to install, activate, and add a key for Akismet. If a key is already present when Akismet is activated, we fail to detect that and still prompt the user to add a key. That's because we do not check key status dynamically. We check the key status in PHP, and pass via a global variable to the editor, so there is no way to check or updated it dynamically.

**Broader relevance for third party integrations:** 
- We are starting work on a third party integrations modal for forms. This modal will need to be able to fetch up-to-date state for Akismet, Jetpack CRM, Google, Zapier, etc. This issue with Akismet is just one example of broader needs. So I'm trying to think how to solve this not just for Akismet but for all integrations. 
- I'm updating the AkismetPanel and PluginIntegrationPanel. While we'll be removing these components when we move integrations to the modal, we'll need most of the same logic. So we should be able to re-use the same logic. 
- Right now, we fetching plugin status via useSelect with const installedPlugins = select( coreStore ).getPlugins(). This works. But as the Akismet example shows, that check doesn't give us all the status we want, and I think as we move toward many integrations, we should consolidate everything on a single endpoint. I'll plan to replace the select( coreStore ).getPlugins() calls with this endpoint as we build out the modal and consolidate logic for integrations.

**Changes**
- Adds an 'integration-status' endpoint that takes as slug like 'akismet', 'jetpack-crm', 'google'. Right now, the endpoint really just handles the 'akismet' case. I added logic for generic plugins, which we can use for Jetpack CRM, Creative Mail, and others. I plan to update those in subsequent PR. We can then later update the endpoint for other integraitons.
- Adds a method to the AkismetPanel to fetch status from this endpoint and calls this method when Akismet is activated.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. It does check for the status of another plugin (Akismet), but we were already doing that via other mean.s 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install Akismet and add a valid key
* Deactivate Akismet from the plugin dashboard
* Create a page and add a form block
* Go to the block sidebar and Spam Protection tab. Click the button to activate Akismet.
* Confirm that the plugin activates, but also that it detects your active key. It should not prompt you to add a key, and you should just see buttons to view spam or stats if successful. 

<img width="1265" alt="akismet-status" src="https://github.com/user-attachments/assets/997ec636-3670-4fd4-b045-2a2e5ff440b2" />


