### PR TITLE
Jetpack SEO Enhancer: add business restriction

### DIFF
--- a/projects/packages/plans/changelog/add-jetpack-seo-enhancer-business-restriction
+++ b/projects/packages/plans/changelog/add-jetpack-seo-enhancer-business-restriction
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add ai-seo-enhancer as Business plan supported feature

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -135,7 +135,9 @@ class Current_Plan {
 				'wooexpress-medium-bundle-monthly',
 				'wp_com_hundred_year_bundle_centennially',
 			),
-			'supports' => array(),
+			'supports' => array(
+				'ai-seo-enhancer',
+			),
 		),
 
 		'complete' => array(

--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -19,6 +19,7 @@ import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import analytics from 'lib/analytics';
 import { isSeoEnhancerAvailable } from 'state/initial-state';
+import { siteHasFeature } from 'state/site';
 import { isFetchingPluginsData, isPluginActive } from 'state/site/plugins';
 import CustomSeoTitles from './seo/custom-seo-titles.jsx';
 
@@ -227,9 +228,14 @@ export const SEO = withModuleSettingsFormHelpers(
 							<FormFieldset>
 								<ToggleControl
 									id="seo-enhancer"
-									disabled={ ! this.props.getOptionValue( 'seo-tools' ) }
+									disabled={
+										! this.props.getOptionValue( 'seo-tools' ) || ! this.props.hasSeoEnhancer
+									}
 									toggling={ this.props.isSavingAnyOption( 'ai_seo_enhancer_enabled' ) }
-									checked={ this.props.getOptionValue( 'ai_seo_enhancer_enabled' ) }
+									checked={
+										this.props.hasSeoEnhancer &&
+										this.props.getOptionValue( 'ai_seo_enhancer_enabled' )
+									}
 									onChange={ this.toggleSeoEnhancer }
 									label={
 										<span className="jp-form-toggle-explanation">
@@ -368,5 +374,6 @@ export default connect( state => {
 		siteData: state.jetpack.siteData.data,
 		seoEnhancerAvailable: isSeoEnhancerAvailable( state ),
 		state,
+		hasSeoEnhancer: siteHasFeature( state, 'ai-seo-enhancer' ),
 	};
 } )( SEO );

--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -224,7 +224,7 @@ export const SEO = withModuleSettingsFormHelpers(
 								{ __( 'Customize your SEO settings', 'jetpack' ) }
 							</span>
 						</ModuleToggle>
-						{ this.props.seoEnhancerAvailable && (
+						{ this.props.seoEnhancerAvailable && this.props.hasSeoEnhancer && (
 							<FormFieldset>
 								<ToggleControl
 									id="seo-enhancer"

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -3097,7 +3097,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		// SEO Tools - SEO Enhancer. Only available to Automatticians.
 		// TODO: either remove this or make it available to all users by moving it to the main options array.
-		if ( apply_filters( 'ai_seo_enhancer_enabled', false ) ) {
+		if ( apply_filters( 'ai_seo_enhancer_enabled', false ) || apply_filters( 'ai_seo_enhancer_enabled_unrestricted', false ) ) {
 			$options['ai_seo_enhancer_enabled'] = array(
 				'description'       => esc_html__( 'Automatically generate SEO title, SEO description, and image alt text for new posts.', 'jetpack' ),
 				'type'              => 'boolean',

--- a/projects/plugins/jetpack/changelog/add-jetpack-seo-enhancer-business-restriction
+++ b/projects/plugins/jetpack/changelog/add-jetpack-seo-enhancer-business-restriction
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack SEO Enhancer: add Business plan restriction

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -131,7 +131,7 @@ add_action(
 			}
 
 			if ( apply_filters( 'ai_seo_enhancer_enabled', false ) ) {
-				Jetpack_Gutenberg::set_extension_available( 'ai-seo-enhancer' );
+				Jetpack_Gutenberg::set_availability_for_plan( 'ai-seo-enhancer' );
 			}
 		}
 	}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -130,7 +130,10 @@ add_action(
 				Jetpack_Gutenberg::set_extension_available( 'ai-proofread-breve' );
 			}
 
-			if ( apply_filters( 'ai_seo_enhancer_enabled', false ) ) {
+			if ( apply_filters( 'ai_seo_enhancer_enabled_unrestricted', false ) ) {
+				Jetpack_Gutenberg::set_extension_available( 'ai-seo-enhancer-enabled-unrestricted' );
+				Jetpack_Gutenberg::set_extension_available( 'ai-seo-enhancer' );
+			} elseif ( apply_filters( 'ai_seo_enhancer_enabled', false ) ) {
 				Jetpack_Gutenberg::set_availability_for_plan( 'ai-seo-enhancer' );
 			}
 		}

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -82,7 +82,8 @@
 		"ai-list-to-table-transform",
 		"ai-seo-assistant",
 		"ai-use-chrome-ai-sometimes",
-		"ai-seo-enhancer"
+		"ai-seo-enhancer",
+		"ai-seo-enhancer-enabled-unrestricted"
 	],
 	"experimental": [],
 	"no-post-editor": [

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -59,6 +59,9 @@ const supportsPublishSidebar =
 const isSeoAssistantEnabled =
 	getJetpackExtensionAvailability( 'ai-seo-assistant' )?.available === true;
 
+const isSeoEnhancerEnabledUnrestricted =
+	getJetpackExtensionAvailability( 'ai-seo-enhancer-enabled-unrestricted' )?.available === true;
+
 const isSeoEnhancerEnabled =
 	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true &&
 	supportsPublishSidebar;
@@ -113,7 +116,8 @@ const Seo = () => {
 
 	const requiredPlan = getRequiredPlan( 'advanced-seo' );
 	const canShowUpsell = isAtomicSite() || isSimpleSite();
-	const hasRequiredPlanForEnhancer = ! getRequiredPlan( 'ai-seo-enhancer' );
+	const hasRequiredPlanForEnhancer =
+		isSeoEnhancerEnabledUnrestricted || ! getRequiredPlan( 'ai-seo-enhancer' );
 
 	const jetpackSeoPanelProps = {
 		title: __( 'SEO', 'jetpack' ),

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -113,6 +113,7 @@ const Seo = () => {
 
 	const requiredPlan = getRequiredPlan( 'advanced-seo' );
 	const canShowUpsell = isAtomicSite() || isSimpleSite();
+	const hasRequiredPlanForEnhancer = ! getRequiredPlan( 'ai-seo-enhancer' );
 
 	const jetpackSeoPanelProps = {
 		title: __( 'SEO', 'jetpack' ),
@@ -181,7 +182,9 @@ const Seo = () => {
 							<SeoAssistantSidebarEntrypoint disabled={ false } placement="jetpack-sidebar" />
 						</PanelRow>
 					) }
-					{ isSeoEnhancerEnabled && <SeoEnhancer disableAutoEnhance={ ! canHaveAutoEnhance } /> }
+					{ isSeoEnhancerEnabled && hasRequiredPlanForEnhancer && (
+						<SeoEnhancer disableAutoEnhance={ ! canHaveAutoEnhance } />
+					) }
 					<PanelRow
 						className={ clsx( {
 							'jetpack-seo-sidebar__feature-section': isSeoEnhancerEnabled,
@@ -208,7 +211,9 @@ const Seo = () => {
 
 			<PluginPrePublishPanel { ...jetpackSeoPublishPanelsProps }>
 				<div className="jetpack-seo-panel">
-					{ isSeoEnhancerEnabled && <SeoEnhancer disableAutoEnhance={ ! canHaveAutoEnhance } /> }
+					{ isSeoEnhancerEnabled && hasRequiredPlanForEnhancer && (
+						<SeoEnhancer disableAutoEnhance={ ! canHaveAutoEnhance } />
+					) }
 					<PanelRow>
 						<SeoTitlePanel />
 					</PanelRow>

--- a/projects/plugins/wpcomsh/changelog/add-jetpack-seo-enhancer-business-restriction
+++ b/projects/plugins/wpcomsh/changelog/add-jetpack-seo-enhancer-business-restriction
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add AI_SEO_ENHANCER feature for Business plans and above and JP complete plans

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -328,6 +328,7 @@ class WPCOM_Features {
 	 * Public const for every mapped feature, sorted alphabetically.
 	 */
 	public const AI_ASSISTANT                      = 'ai-assistant';
+	public const AI_SEO_ENHANCER                   = 'ai-seo-enhancer';
 	public const AD_CREDIT_VOUCHERS                = 'ad-credit';
 	public const ADVANCED_SEO                      = 'advanced-seo';
 	public const AKISMET                           = 'akismet';
@@ -477,6 +478,10 @@ class WPCOM_Features {
 		self::AI_ASSISTANT                      => array(
 			self::JETPACK_AI_PLANS,
 			self::WPCOM_PERSONAL_AND_HIGHER_PLANS,
+			self::JETPACK_COMPLETE_PLANS,
+		),
+		self::AI_SEO_ENHANCER                   => array(
+			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
 			self::JETPACK_COMPLETE_PLANS,
 		),
 		self::AD_CREDIT_VOUCHERS                => array(


### PR DESCRIPTION
Fixes #42722 

## Proposed changes:
This PR adds a feature `ai-seo-enhancer` as a Business plan supports entry and sets the availability on the editor.

As required, a syncing change is proposed for wpcom: 178565-ghe-Automattic/wpcom

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pe4Cmx-37z-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Sandbox public API and patch with 178565-ghe-Automattic/wpcom

Add the SEO Enhancer filter `add_filter( 'ai_seo_enhancer_enabled', '__return_true' );` and switch to Beta blocks variation.

On a site with Business plan and above:
- Jetpack Settings -> Traffic should show a toggle for automatic SEO generation
- Block editor should show the SEO Enhancer on Jetpack sidebar, SEO panel

On a site with a lesser plan:
- Jetpack Settings -> Traffic should not show the toggle
- Block editor should not show the SEO Enhancer on Jetpack sidebar