### PR TITLE
Forms: Fix icon url for file field block

### DIFF
--- a/projects/packages/forms/assets/images/upload-icon.svg
+++ b/projects/packages/forms/assets/images/upload-icon.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14.5 12V15.5H9V3.70002L13.5 7.80002L14.5 6.70002L8.3 0.900024L2.5 6.70002L3.5 7.80002L7.5 3.80002V15.5H1.5V12H0V17H16V12H14.5Z" fill="#1E1E1E"/>
+</svg> 

--- a/projects/packages/forms/changelog/fix-file-block-icon-url
+++ b/projects/packages/forms/changelog/fix-file-block-icon-url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Change will be included in new file filed changelog entry.
+
+

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -12,6 +12,7 @@ use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Forms\ContactForm\Contact_Form;
 use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
+use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Jetpack;
 
 /**
@@ -247,6 +248,7 @@ class Contact_Form_Block {
 				'formsAdminUrl'        => $admin_url,
 				'akismetActiveWithKey' => $akismet_active_with_key,
 				'akismetUrl'           => $akismet_key_url,
+				'assetsUrl'            => Jetpack_Forms::assets_url(),
 			),
 		);
 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-file/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-file/index.js
@@ -8,9 +8,7 @@ import JetpackFieldLabel from '../jetpack-field-label';
 import { useJetpackFieldStyles } from '../use-jetpack-field-styles';
 import './editor.css';
 
-// Base64 encoded version of our upload icon SVG
-const DEFAULT_ICON =
-	'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTciIHZpZXdCb3g9IjAgMCAxNiAxNyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMTQuNSAxMlYxNS41SDlWMy43MDAwMkwxMy41IDcuODAwMDJMMTQuNSA2LjcwMDAyTDguMyAwLjkwMDAyNEwyLjUgNi43MDAwMkwzLjUgNy44MDAwMkw3LjUgMy44MDAwMlYxNS41SDEuNVYxMkgwVjE3SDE2VjEySDE0LjVaIiBmaWxsPSIjMUUxRTFFIi8+PC9zdmc+';
+const DEFAULT_ICON = `${ window?.jpFormsBlocks?.defaults?.assetsUrl }/images/upload-icon.svg`;
 
 const BLOCKS_TEMPLATE = [
 	[


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Ensures we provide a proper image url to the image child block in our file field block by use Jetpack_Forms::asset_url() method. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form block with a file upload field to a page
* Confirm the upload icons shows correctly on both front and backends. 

