### PR TITLE
Editor: Improve first post modal styling

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/improve-first-post-modal-styling
+++ b/projects/packages/jetpack-mu-wpcom/changelog/improve-first-post-modal-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix first post modal styling for mobile view.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/first-post-published-modal/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/first-post-published-modal/style.scss
@@ -1,8 +1,19 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .wpcom-block-editor-post-published-modal {
+	border-radius: $radius-large;
+	margin: auto 16px;
+
+	@include break-small {
+		margin: auto;
+	}
+
 	.components-modal__content {
+		text-align: center;
+		padding: 60px 30px;
+
 		@include break-small {
 			padding: 48px 90px;
 		}
@@ -13,6 +24,10 @@
 			width: 158px;
 			height: 85px;
 		}
+	}
+
+	.wpcom-block-editor-nux-modal__title {
+		font-size: $font-size-2x-large;
 	}
 
 	.wpcom-block-editor-nux-modal__buttons {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/101116

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Improve styling of first post modal on mobile view.

| Before | After |
| -------|------| 
| ![Screenshot 2025-03-27 at 3 40 40 AM](https://github.com/user-attachments/assets/03ffc061-d5d5-4631-9a71-16de35bc970b) | ![image](https://github.com/user-attachments/assets/113be345-4c7e-4965-a472-a209eede40c8) |
| ![Screenshot 2025-03-27 at 3 39 54 AM](https://github.com/user-attachments/assets/b3c512ce-a540-4e27-8e5e-b261587b851f) | ![Screenshot 2025-03-27 at 3 09 21 AM](https://github.com/user-attachments/assets/48493c2e-6dca-4ca3-9333-976baf7803a5) | ![image](https://github.com/user-attachments/assets/13fd659a-522a-444d-803b-cbdd69902ca1) |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this PR locally.
* Change [isOpen](https://github.com/Automattic/jetpack/blob/e4ddbd36aad1da53bb6d2528dd8f4dc6430ba1db/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/first-post-published-modal/index.tsx#L91) to `true`.
* Update `FirstPostPublishedModal` component to always return [FirstPostPublishedModalInner](https://github.com/Automattic/jetpack/blob/e4ddbd36aad1da53bb6d2528dd8f4dc6430ba1db/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/first-post-published-modal/index.tsx#L120).
* Run `jetpack build packages/jetpack-mu-wpcom` to build the package.
* Update sandbox `jetpack rsync mu-wpcom-plugin HOST:/PATH/TO/mu-plugins/jetpack-mu-wpcom-plugin/[sun/moon]`

Another approach is to apply this to sandbox via `jetpack-downloader`, create a new account, publish first post and verify the modal.
