### PR TITLE
Publicize: Improve package initialization

### DIFF
--- a/projects/packages/publicize/changelog/fix-publicize-initialization
+++ b/projects/packages/publicize/changelog/fix-publicize-initialization
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Publicize: Improve package initialization

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -71,7 +71,7 @@ class Publicize_Setup {
 			 * Publicize is always enabled on WPCOM,
 			 * we can call the initialization method directly.
 			 */
-			self::on_jetpack_feature_publicize_enabled();
+			add_action( 'plugins_loaded', array( self::class, 'on_jetpack_feature_publicize_enabled' ) );
 		}
 	}
 
@@ -87,10 +87,6 @@ class Publicize_Setup {
 
 		global $publicize_ui;
 
-		if ( ! isset( $publicize_ui ) ) {
-			$publicize_ui = new Publicize_UI();
-		}
-
 		$is_wpcom_simple = ( new Host() )->is_wpcom_simple();
 
 		$rest_controllers = array(
@@ -102,6 +98,7 @@ class Publicize_Setup {
 			REST_API\Share_Status_Controller::class,
 			REST_API\Shares_Data_Controller::class,
 			REST_API\Social_Image_Generator_Controller::class,
+			Jetpack_Social_Settings\Settings::class,
 		);
 
 		// Load the REST controllers.
@@ -113,22 +110,20 @@ class Publicize_Setup {
 			}
 		}
 
-		add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
-		add_action( 'current_screen', array( static::class, 'init_sharing_limits' ) );
-
-		add_action( 'rest_api_init', array( static::class, 'register_core_options' ) );
-		add_action( 'admin_init', array( static::class, 'register_core_options' ) );
 		add_action( 'current_screen', array( self::class, 'add_filters_and_actions_for_screen' ), 5 );
 
-		if ( $is_wpcom_simple ) {
-
-			wpcom_rest_api_v2_load_plugin( Jetpack_Social_Settings\Settings::class );
-		} else {
-			// Load the settings page.
-			new Jetpack_Social_Settings\Settings();
-		}
-
 		( new Social_Image_Generator\Setup() )->init();
+
+		// Things that should not happen on WPCOM.
+		if ( ! $is_wpcom_simple ) {
+			add_action( 'rest_api_init', array( static::class, 'register_core_options' ) );
+			add_action( 'admin_init', array( static::class, 'register_core_options' ) );
+			add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
+			add_action( 'current_screen', array( static::class, 'init_sharing_limits' ) );
+			if ( ! isset( $publicize_ui ) ) {
+				$publicize_ui = new Publicize_UI();
+			}
+		}
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -95,11 +95,12 @@ class Publicize_Setup {
 
 		$rest_controllers = array(
 			REST_API\Connections_Controller::class,
+			REST_API\Connections_Post_Field::class,
 			REST_API\Scheduled_Actions_Controller::class,
 			REST_API\Services_Controller::class,
-			REST_API\Shares_Data_Controller::class,
 			REST_API\Share_Post_Controller::class,
 			REST_API\Share_Status_Controller::class,
+			REST_API\Shares_Data_Controller::class,
 			REST_API\Social_Image_Generator_Controller::class,
 		);
 
@@ -112,11 +113,6 @@ class Publicize_Setup {
 			}
 		}
 
-		if ( ! $is_wpcom_simple ) {
-			// Adding on a higher priority to make sure we're the first field registered.
-			// The priority parameter can be removed once we deprecate WPCOM_REST_API_V2_Post_Publicize_Connections_Field.
-			add_action( 'rest_api_init', array( new REST_API\Connections_Post_Field(), 'register_fields' ), 5 );
-		}
 		add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
 		add_action( 'current_screen', array( static::class, 'init_sharing_limits' ) );
 

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -92,6 +92,12 @@ class Publicize_Setup {
 			return;
 		}
 
+		global $publicize_ui;
+
+		if ( ! isset( $publicize_ui ) ) {
+			$publicize_ui = new Publicize_UI();
+		}
+
 		$rest_controllers = array(
 			REST_API\Connections_Controller::class,
 			REST_API\Connections_Post_Field::class,
@@ -123,12 +129,6 @@ class Publicize_Setup {
 			add_action( 'admin_init', array( static::class, 'register_core_options' ) );
 			add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
 			add_action( 'current_screen', array( static::class, 'init_sharing_limits' ) );
-
-			global $publicize_ui;
-
-			if ( ! isset( $publicize_ui ) ) {
-				$publicize_ui = new Publicize_UI();
-			}
 		}
 	}
 

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -112,9 +112,11 @@ class Publicize_Setup {
 			}
 		}
 
-		// Adding on a higher priority to make sure we're the first field registered.
-		// The priority parameter can be removed once we deprecate WPCOM_REST_API_V2_Post_Publicize_Connections_Field.
-		add_action( 'rest_api_init', array( new REST_API\Connections_Post_Field(), 'register_fields' ), 5 );
+		if ( ! $is_wpcom_simple ) {
+			// Adding on a higher priority to make sure we're the first field registered.
+			// The priority parameter can be removed once we deprecate WPCOM_REST_API_V2_Post_Publicize_Connections_Field.
+			add_action( 'rest_api_init', array( new REST_API\Connections_Post_Field(), 'register_fields' ), 5 );
+		}
 		add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
 		add_action( 'current_screen', array( static::class, 'init_sharing_limits' ) );
 

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -88,6 +88,12 @@ class Publicize_Setup {
 		$is_wpcom_simple = ( new Host() )->is_wpcom_simple();
 
 		global $publicize;
+		/**
+		 * If publicize is not initialzed on WPCOM,
+		 * it means that we are either on a public facing page
+		 * or a page where Publicize is not needed.
+		 * So, we will skip the whole set up here.
+		 */
 		if ( $is_wpcom_simple && ! $publicize ) {
 			return;
 		}

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -85,8 +85,6 @@ class Publicize_Setup {
 
 		self::$initialized = true;
 
-		global $publicize_ui;
-
 		$is_wpcom_simple = ( new Host() )->is_wpcom_simple();
 
 		$rest_controllers = array(
@@ -120,6 +118,9 @@ class Publicize_Setup {
 			add_action( 'admin_init', array( static::class, 'register_core_options' ) );
 			add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
 			add_action( 'current_screen', array( static::class, 'init_sharing_limits' ) );
+
+			global $publicize_ui;
+
 			if ( ! isset( $publicize_ui ) ) {
 				$publicize_ui = new Publicize_UI();
 			}

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -23,6 +23,13 @@ class Publicize_Setup {
 	public static $refresh_plan_info = false;
 
 	/**
+	 * Whether the class has been initialized.
+	 *
+	 * @var bool
+	 */
+	public static $initialized = false;
+
+	/**
 	 * To configure the publicize package, when called via the Config package.
 	 */
 	public static function configure() {
@@ -30,14 +37,61 @@ class Publicize_Setup {
 	}
 
 	/**
-	 * Initialization of publicize logic that should always be loaded.
+	 * Initialization of publicize logic that should always be loaded,
+	 * regardless of whether Publicize is enabled or not.
+	 *
+	 * You should justify everyting that is done here, as it will be loaded on every pageload.
 	 */
 	public static function pre_initialization() {
 
-		$is_wpcom = ( new Host() )->is_wpcom_simple();
+		$is_wpcom_simple = ( new Host() )->is_wpcom_simple();
 
-		// Assets are to be loaded in all cases.
+		/**
+		 * Assets are to be loaded in all cases.
+		 *
+		 * To allow loading of admin page and
+		 * the editor placeholder when publicize is OFF.
+		 */
 		Publicize_Assets::configure();
+
+		/**
+		 * Social admin page is to be always registered.
+		 */
+		Social_Admin_Page::init();
+
+		if ( ! $is_wpcom_simple ) {
+			/**
+			 * We need this only on Jetpack sites for Google Site auto-verification.
+			 */
+			add_action( 'init', array( Keyring_Helper::class, 'init' ), 9 );
+		}
+
+		if ( $is_wpcom_simple ) {
+			/**
+			 * Publicize is always enabled on WPCOM,
+			 * we can call the initialization method directly.
+			 */
+			self::on_jetpack_feature_publicize_enabled();
+		}
+	}
+
+	/**
+	 * To configure the publicize package, when called via the Config package.
+	 */
+	public static function on_jetpack_feature_publicize_enabled() {
+		if ( self::$initialized ) {
+			return;
+		}
+
+		self::$initialized = true;
+
+		global $publicize_ui;
+
+		if ( ! isset( $publicize_ui ) ) {
+			$publicize_ui = new Publicize_UI();
+		}
+
+		$is_wpcom_simple = ( new Host() )->is_wpcom_simple();
 
 		$rest_controllers = array(
 			REST_API\Connections_Controller::class,
@@ -51,34 +105,15 @@ class Publicize_Setup {
 
 		// Load the REST controllers.
 		foreach ( $rest_controllers as $controller ) {
-			if ( $is_wpcom ) {
+			if ( $is_wpcom_simple ) {
 				wpcom_rest_api_v2_load_plugin( $controller );
 			} else {
 				new $controller();
 			}
 		}
 
-		Social_Admin_Page::init();
-
-		// We need this only on Jetpack sites for Google Site auto-verification.
-		if ( ! ( new Host() )->is_wpcom_simple() ) {
-			add_action( 'init', array( Keyring_Helper::class, 'init' ), 9 );
-		}
-	}
-
-	/**
-	 * To configure the publicize package, when called via the Config package.
-	 */
-	public static function on_jetpack_feature_publicize_enabled() {
-		global $publicize_ui;
-
-		if ( ! isset( $publicize_ui ) ) {
-			$publicize_ui = new Publicize_UI();
-
-		}
-
 		// Adding on a higher priority to make sure we're the first field registered.
-		// The priority parameter can be removed once we deprecate WPCOM_REST_API_V2_Post_Publicize_Connections_Field
+		// The priority parameter can be removed once we deprecate WPCOM_REST_API_V2_Post_Publicize_Connections_Field.
 		add_action( 'rest_api_init', array( new REST_API\Connections_Post_Field(), 'register_fields' ), 5 );
 		add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
 		add_action( 'current_screen', array( static::class, 'init_sharing_limits' ) );
@@ -87,7 +122,7 @@ class Publicize_Setup {
 		add_action( 'admin_init', array( static::class, 'register_core_options' ) );
 		add_action( 'current_screen', array( self::class, 'add_filters_and_actions_for_screen' ), 5 );
 
-		if ( ( new Host() )->is_wpcom_simple() ) {
+		if ( $is_wpcom_simple ) {
 
 			wpcom_rest_api_v2_load_plugin( Jetpack_Social_Settings\Settings::class );
 		} else {
@@ -135,7 +170,7 @@ class Publicize_Setup {
 	public static function init_sharing_limits() {
 		$current_screen = get_current_screen();
 
-		if ( empty( $current_screen ) || $current_screen->base !== 'post' ) {
+		if ( empty( $current_screen ) || 'post' !== $current_screen->base ) {
 			return;
 		}
 

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -87,6 +87,11 @@ class Publicize_Setup {
 
 		$is_wpcom_simple = ( new Host() )->is_wpcom_simple();
 
+		global $publicize;
+		if ( $is_wpcom_simple && ! $publicize ) {
+			return;
+		}
+
 		$rest_controllers = array(
 			REST_API\Connections_Controller::class,
 			REST_API\Connections_Post_Field::class,

--- a/projects/packages/publicize/src/rest-api/class-connections-post-field.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-post-field.php
@@ -34,6 +34,15 @@ class Connections_Post_Field {
 	public $memoized_updates = array();
 
 	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		// Adding on a higher priority to make sure we're the first field registered.
+		// The priority parameter can be removed once we deprecate WPCOM_REST_API_V2_Post_Publicize_Connections_Field.
+		add_action( 'rest_api_init', array( $this, 'register_fields' ), 5 );
+	}
+
+	/**
 	 * Registers the jetpack_publicize_connections field. Called
 	 * automatically on `rest_api_init()`.
 	 */

--- a/projects/packages/publicize/tests/php/REST_Controller_Test.php
+++ b/projects/packages/publicize/tests/php/REST_Controller_Test.php
@@ -85,8 +85,8 @@ class REST_Controller_Test extends TestCase {
 	public function test_get_publicize_connections_without_proper_permission() {
 		$request  = new WP_REST_Request( 'GET', '/wpcom/v2/publicize/connections' );
 		$response = $this->dispatch_request_signed_with_blog_token( $request );
-		$this->assertEquals( 401, $response->get_status() );
-		$this->assertEquals( 'Sorry, you are not allowed to access Jetpack Social data on this site.', $response->get_data()['message'] );
+		$this->assertEquals( 404, $response->get_status() );
+		$this->assertEquals( 'No route was found matching the URL and request method.', $response->get_data()['message'] );
 	}
 
 	/**


### PR DESCRIPTION
## Problem
We have been dealing with the initialization issues in Publicize package for a while now and due to the way Jetpack plugin works in different environments, the packages are initialized differently. For example, on Jetpack sites, when the `publicize` feature is enabled, [`Publicize_Setup::configure()`](https://github.com/Automattic/jetpack/blob/c0bef0a6952e2596e2c1e85197e99f163186c452/projects/packages/publicize/src/class-publicize-setup.php#L28) gets [called by the `Config` package](https://github.com/Automattic/jetpack/blob/c0bef0a6952e2596e2c1e85197e99f163186c452/projects/packages/config/src/class-config.php#L295-L296) but that doesn't happen on WPCOM.

Thus, we had to [create `Publicize_Setup::pre_initialization`](https://github.com/Automattic/jetpack/pull/40607/files#r1890692209) method to make things work on WPCOM. But, over the time, more things were added to `pre_initialization` method which resulted in almost all the endpoints being loaded even when publicize is OFF, on Jetpack sites.

Thus we need to fix this!

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move the logic that should run only when Publicize is ON to the `on_jetpack_feature_publicize_enabled` method.
* Keep the logic that should run regardless of whether Publicize is ON or not in the `pre_initialization` method
* Call the `on_jetpack_feature_publicize_enabled` method explicitly on WPCOM
* Add a safety check `if ( self::$initialized )` to the `on_jetpack_feature_publicize_enabled` method because it's now called from multiple places.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox
* Run this on your sandbox to enable SIG feature for testing
```bash
git checkout origin/update/enable-sig-on-wpcom wp-content/mu-plugins/wpcom-features/class-wpcom-features.php
```
* Point your site and the public API to your sandbox
* We need to smoke test almost every area of Publicize with both Social and Jetpack, together and individually
* On Atomic, you may need to have Wordpress.com Site Helper to be on the bleeding edge.
* On Jetpack, Simple and Atomic, we should ensure that
    * Social admin page and the editor loads fine both when Social is ON and OFF
    * Settings on the social admin page work fine, toggle some ON/OFF
    * Editor loads fine with Social UI as expected both when Social is ON and OFF
    * Connections management works fine for all the CRUD operations
    * Sharing and Social Post UI works fine
    * Resharing and scheduled resharing works fine
    * Share status works fine
    * Social image generator settings works fine on Social admin page and the editor
    * Classic editor works fine
