### PR TITLE
Likes: when unloading, don't set display:block style on the placeholder

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-likes-unload-on-scroll
+++ b/projects/plugins/jetpack/changelog/fix-likes-unload-on-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Likes: when unloading, don't set display:block style on the placeholder

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -470,11 +470,6 @@ function jetpackUnloadScrolledOutWidgets() {
 			widgetWrapper.classList.remove( 'jetpack-likes-widget-loading' );
 			widgetWrapper.classList.add( 'jetpack-likes-widget-unloaded' );
 
-			// Bring back the loading placeholder into view.
-			widgetWrapper
-				.querySelectorAll( '.comment-likes-widget-placeholder' )
-				.forEach( item => ( item.style.display = 'block' ) );
-
 			// Remove it from the list of loaded widgets.
 			jetpackCommentLikesLoadedWidgets.splice( i, 1 );
 


### PR DESCRIPTION
Fixes a regression introduced in #42361. When a Like widget scrolls out of view, it is unloaded: the iframe is removed, placeholder displayed, the widget is back in fully unloaded state. That's supposedly to prevent having too many (hundreds) iframes on the page when there are many comments. (iframes are expensive).

Since #42361 we show and hide elements based on the presence of classes like `jetpack-likes-widget-loaded`. We no longer set explicit styles on the elements. Look at the diff and note how it removes code that sets `placeholder.style.display = 'none'` and how it adds CSS rules to `style.css` instead.

But the unload code (`jetpackUnloadScrolledOutWidgets`) keeps setting `placeholder.style.display` back to `block`. We don't want to do that, because there is no longer any code that would set it to `none` when the widget loads again. This PR fixes that.

## Testing instructions:
Reported by @kathrynwp in https://github.com/Automattic/jetpack/issues/42670#issuecomment-2755701409. Go to https://om.co/2025/03/20/has-search-become-just-a-feature/ and scroll down and up again. The page has a long-enough thread of comments and the unload-on-scroll behavior is triggered. The comment likes that were unloaded and then loaded again have a hanging placeholder displayed:

<img width="391" alt="Screenshot 2025-03-27 at 11 16 41" src="https://github.com/user-attachments/assets/e1fea2c5-bcfa-48fd-addf-0003a0986ab5" />

To test this, create your own Jetpack site with many comments and verify that the bug gets really fixed.

## Does this pull request change what data or activity we track or use?
No
