### PR TITLE
Full sync: Use term id for terms range

### DIFF
--- a/projects/packages/sync/changelog/update-full-sync-term-id-for-terms-range
+++ b/projects/packages/sync/changelog/update-full-sync-term-id-for-terms-range
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Full Sync: Use term_id to determine ranges in terms module

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -316,8 +316,11 @@ class Full_Sync_Immediately extends Module {
 			return array();
 		}
 
-		$table     = $module->table();
-		$id        = $module->id_field();
+		$table = $module->table();
+		$id    = $module->id_field();
+		if ( 'terms' === $module ) { // Terms module relies on the term_taxonomy and term_taxonomy_id for the where sql, let's use term_id instead.
+			$id = 'term_id';
+		}
 		$where_sql = $module->get_where_sql( array() );
 
 		// TODO: Call $wpdb->prepare on the following query.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Fallback from https://github.com/Automattic/jetpack/pull/42692

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use `term_id` for terms module when calculating ranges. Terms module is a bit messed up and the `where_sql` relies on `wp_term_taxonomy` and `term_taxonomy_id` to get the initial items when chunking for Full Sync, later down the road it calls [get_terms](https://github.com/Automattic/jetpack/blob/e424835/projects/packages/sync/src/modules/class-terms.php#L342) to expand the `term_taxonomy_ids` into terms. Let's send the ranges based on `term_id` to be a bit more consistent. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Repeat the instructions in https://github.com/Automattic/jetpack/pull/42692 for the Terms module.

