### PR TITLE
Boost: Load my-jetpack script before Boost

### DIFF
--- a/projects/plugins/boost/app/admin/class-admin.php
+++ b/projects/plugins/boost/app/admin/class-admin.php
@@ -66,8 +66,8 @@ class Admin {
 		// Clear premium features cache when the plugin settings page is loaded.
 		Premium_Features::clear_cache();
 
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( My_Jetpack_Initializer::class, 'enqueue_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 	}
 
 	/**
@@ -88,6 +88,7 @@ class Admin {
 		$admin_js_dependencies = array(
 			'wp-i18n',
 			'wp-components',
+			'my_jetpack_main_app',
 		);
 
 		Assets::register_script(

--- a/projects/plugins/boost/changelog/fix-module-load-error
+++ b/projects/plugins/boost/changelog/fix-module-load-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+General: Fixed intermittent error during module loading.


### PR DESCRIPTION
## Proposed changes:
* Avoid `TypeError: Cannot destructure property 'topJetpackMenuItemUrl' of '(0 , a.A$)(...)' as it is undefined.` error.

The error started appearing intermittently recently after the upgrade CTAs was changed to interstitial instead of a dedicated page. After looking into it, the interstitials were reaching into my-jetpack, which tries to access `topJetpackMenuItemUrl` from `myJetpackInitialState`. The `my_jetpack_main_app` instantializes `myJetpackInitialState`. The error would only appear if Boost was trying to initialize the CTAs before My Jetpack was initialized. The change makes `my_jetpack_main_app` a dependency of Boost's JS, avoiding the sequence that causes the error.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1743074654523319-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Nothing much to test as the issue is intermittent. Just make sure Boost dashboard is loading without any errors.