### PR TITLE
My Jetpack: Fix Protect product 'get_manage_url()' returning empty value.

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-protect-manage-url
+++ b/projects/packages/my-jetpack/changelog/fix-protect-manage-url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: My Jetpack: Fix 404 link on the Scan notice "Fix Threats" CTA.
+
+

--- a/projects/packages/my-jetpack/src/products/class-protect.php
+++ b/projects/packages/my-jetpack/src/products/class-protect.php
@@ -381,13 +381,12 @@ class Protect extends Hybrid_Product {
 	 * @return ?string
 	 */
 	public static function get_manage_url() {
-		// check standalone first
 		if ( static::is_standalone_plugin_active() ) {
+			// Protect admin dashboard
 			return admin_url( 'admin.php?page=jetpack-protect' );
-			// otherwise, check for the main Jetpack plugin
-		} elseif ( static::is_jetpack_plugin_active() ) {
-			return Redirect::get_url( 'my-jetpack-manage-scan' );
 		}
+		// Jetpack Cloud Scan dashboard.
+		return Redirect::get_url( 'my-jetpack-manage-scan' );
 	}
 
 	/**


### PR DESCRIPTION
When a site running only Jetpack (no Protect standalone plugin is installed/active), and when a threat is detected, the "Fix threats" CTA url points to `:site:/wp-admin/null` as reported by @oskosk in Slack here: p1742937416167659-slack-C02LK1W8T4Z

This PR is a fix attempt for this bug.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Explicitly returns a default value in `Protect::get_manage_url()`, leaving no chance of an empty or null return value.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
This bug was reported in Slack here: p1742937416167659-slack-C02LK1W8T4Z

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing notes
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I was not able to actually reproduce this bug.. But I can see in the code where the opportunity for this bug could possibly occur.

However here are the steps I took to attempt to reproduce the bug:

1. Created a Jurassic.Ninja site, with the Jetpack Debug Helper plugin.
2. Clicked the "Connect Jetpack in one click" button in the top of My Jetpack.
3. When redirected to the pricing page, I purchased Jetpack Scan.
4. Once back in wp-admin (my site now automatically user-connected during purchase), I opened the Debug Helper and selected the Scan Helper.
5. Opened the Scan Helper and selected to add "EICAR Threat" and selected to add "Create a fake vulnerable plugin".
6. I then went to Jetpack Cloud site settings and added my Jurassic Ninja SFTP server credentials.
7. I then opened the Jetpack Cloud Scan page and clicked "Scan now" to start scanning. Threats were detected.
8. Then went to wp-admin My Jetpack and reloaded the page.  The Scan notice was displaying at the top saying, "Scan found threats on your site"
9. The "Fix threats" button (this is where the bug was reported) was pointing to a Jetpack Redirect that points to the Jetpack Cloud scan dashboard.
10. I tried disconnecting my user account, but then the Scan notice disappears, and in it's place displays a "Connect user account" notice, so I was forced to reconnect the user account.
11. I tried installing the Protect plugin, but not activating it. But still the "Fix threats" button points correctly to Jetpack Cloud Scan dashboard.
12. Not sure what else to try at this point..

## Testing instructions:
As noted above, I was not able to reproduce the bug, however I can see in the code where possibly this error could have occurred.

- Therefore, the testing instructions basically consist of inspecting the code change in this PR, before and after, and verify that the change looks good, and that the possibility of returning a null or empty value from the `Protect::get_manage_url()` function has been eliminated.

