### PR TITLE
Forms: Add integrations modal scaffolding with feature flag

### DIFF
--- a/projects/packages/forms/changelog/add-forms-integration-modal-scaffolding
+++ b/projects/packages/forms/changelog/add-forms-integration-modal-scaffolding
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Added block integrations modal with feature flag.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -249,6 +249,7 @@ class Contact_Form_Block {
 				'akismetActiveWithKey' => $akismet_active_with_key,
 				'akismetUrl'           => $akismet_key_url,
 				'assetsUrl'            => Jetpack_Forms::assets_url(),
+				'enableModal'          => Contact_Form_Plugin::is_block_modal_enabled(),
 			),
 		);
 

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -249,7 +249,7 @@ class Contact_Form_Block {
 				'akismetActiveWithKey' => $akismet_active_with_key,
 				'akismetUrl'           => $akismet_key_url,
 				'assetsUrl'            => Jetpack_Forms::assets_url(),
-				'enableModal'          => Contact_Form_Plugin::is_block_modal_enabled(),
+				'isFormModalEnabled'   => Contact_Form_Plugin::is_form_modal_enabled(),
 			),
 		);
 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-panel.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-panel.js
@@ -1,0 +1,34 @@
+import { Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import JetpackIntegrationsModal from './jetpack-integrations-modal';
+
+/**
+ * Integration Panel component.
+ *
+ * @param {object}   props               - Component props.
+ * @param {object}   props.attributes    - Block attributes.
+ * @param {Function} props.setAttributes - Function to set block attributes.
+ * @return {object} The IntegrationPanel component.
+ */
+export default function IntegrationPanel( { attributes, setAttributes } ) {
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+
+	return (
+		<div className="jetpack-forms-integration-panel">
+			<Button
+				variant="secondary"
+				onClick={ () => setIsModalOpen( true ) }
+				__next40pxDefaultSize={ true }
+			>
+				{ __( 'Manage Integrations', 'jetpack-forms' ) }
+			</Button>
+			<JetpackIntegrationsModal
+				isOpen={ isModalOpen }
+				onClose={ () => setIsModalOpen( false ) }
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+			/>
+		</div>
+	);
+}

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal.js
@@ -1,0 +1,177 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import {
+	Modal,
+	Card,
+	CardHeader,
+	CardBody,
+	Button,
+	ExternalLink,
+	Icon,
+} from '@wordpress/components';
+import { createInterpolateElement, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import CRMIntegrationSettings from './jetpack-crm-integration/jetpack-crm-integration-settings';
+import NewsletterIntegrationSettings from './jetpack-newsletter-integration-settings';
+import PluginIntegrationPanel from './shared/plugin-integration-panel';
+
+const JetpackIntegrationsModal = ( { isOpen, onClose, attributes, setAttributes } ) => {
+	const [ expandedCards, setExpandedCards ] = useState( {
+		akismet: false,
+		crm: false,
+		creativemail: false,
+	} );
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	const toggleCard = cardId => {
+		setExpandedCards( prev => ( {
+			...prev,
+			[ cardId ]: ! prev[ cardId ],
+		} ) );
+	};
+
+	const adminUrl = window?.jpFormsBlocks?.defaults?.formsAdminUrl || '';
+	const akismetActiveWithKey = window?.jpFormsBlocks?.defaults?.akismetActiveWithKey || false;
+	const akismetUrl = window?.jpFormsBlocks?.defaults?.akismetUrl || '';
+
+	return (
+		<Modal
+			title={ __( 'Form Integrations', 'jetpack-forms' ) }
+			onRequestClose={ onClose }
+			style={ { width: '700px' } }
+		>
+			<div style={ { padding: '16px', display: 'flex', flexDirection: 'column', gap: '16px' } }>
+				<Card>
+					<CardHeader onClick={ () => toggleCard( 'akismet' ) } style={ { cursor: 'pointer' } }>
+						<div style={ { display: 'flex', alignItems: 'center', gap: '8px' } }>
+							<Icon icon={ expandedCards.akismet ? 'arrow-down-alt2' : 'arrow-right-alt2' } />
+							<strong>{ __( 'Akismet', 'jetpack-forms' ) }</strong>
+						</div>
+					</CardHeader>
+					{ expandedCards.akismet && (
+						<CardBody>
+							<PluginIntegrationPanel
+								title={ __( 'Spam protection', 'jetpack-forms' ) }
+								pluginSlug="akismet"
+								pluginPath="akismet/akismet"
+								pluginTitle="Akismet"
+								installText={ __( 'Install Akismet', 'jetpack-forms' ) }
+								activateText={ __( 'Activate Akismet', 'jetpack-forms' ) }
+								description={ createInterpolateElement(
+									__(
+										"Add one-click spam protection for your forms with <a>Akismet</a>. Simply install the plugin and you're set.",
+										'jetpack-forms'
+									),
+									{
+										a: <ExternalLink href={ getRedirectUrl( 'akismet-wordpress-org' ) } />,
+									}
+								) }
+								tracksEventName="jetpack_forms_upsell_akismet_click"
+								hideWrapper
+							>
+								{ akismetActiveWithKey ? (
+									<>
+										<p>
+											{ createInterpolateElement(
+												__(
+													'Your forms are protected from spam with <a>Akismet</a>!',
+													'jetpack-forms'
+												),
+												{
+													a: (
+														<ExternalLink href={ getRedirectUrl( 'akismet-jetpack-forms-docs' ) } />
+													),
+												}
+											) }
+										</p>
+										<div style={ { display: 'flex', gap: '8px', justifyContent: 'flex-start' } }>
+											<Button
+												variant="secondary"
+												href={ adminUrl }
+												target="_blank"
+												rel="noopener noreferrer"
+												__next40pxDefaultSize={ true }
+											>
+												{ __( 'View spam', 'jetpack-forms' ) }
+											</Button>
+											<Button
+												variant="secondary"
+												href={ akismetUrl }
+												target="_blank"
+												rel="noopener noreferrer"
+												__next40pxDefaultSize={ true }
+											>
+												{ __( 'View stats', 'jetpack-forms' ) }
+											</Button>
+										</div>
+									</>
+								) : (
+									<>
+										<p>
+											{ createInterpolateElement(
+												__(
+													'Akismet is active! There is one step left. Please add your <a>Akismet key</a>.',
+													'jetpack-forms'
+												),
+												{
+													a: <ExternalLink href={ akismetUrl } />,
+												}
+											) }
+										</p>
+										<Button
+											variant="secondary"
+											href={ akismetUrl }
+											target="_blank"
+											rel="noopener noreferrer"
+											__next40pxDefaultSize={ true }
+										>
+											{ __( 'Add Akismet key', 'jetpack-forms' ) }
+										</Button>
+									</>
+								) }
+							</PluginIntegrationPanel>
+						</CardBody>
+					) }
+				</Card>
+
+				<Card>
+					<CardHeader onClick={ () => toggleCard( 'crm' ) } style={ { cursor: 'pointer' } }>
+						<div style={ { display: 'flex', alignItems: 'center', gap: '8px' } }>
+							<Icon icon={ expandedCards.crm ? 'arrow-down-alt2' : 'arrow-right-alt2' } />
+							<strong>{ __( 'Jetpack CRM', 'jetpack-forms' ) }</strong>
+						</div>
+					</CardHeader>
+					{ expandedCards.crm && (
+						<CardBody>
+							<CRMIntegrationSettings
+								jetpackCRM={ attributes.jetpackCRM }
+								setAttributes={ setAttributes }
+							/>
+						</CardBody>
+					) }
+				</Card>
+
+				<Card>
+					<CardHeader
+						onClick={ () => toggleCard( 'creativemail' ) }
+						style={ { cursor: 'pointer' } }
+					>
+						<div style={ { display: 'flex', alignItems: 'center', gap: '8px' } }>
+							<Icon icon={ expandedCards.creativemail ? 'arrow-down-alt2' : 'arrow-right-alt2' } />
+							<strong>{ __( 'Creative Mail', 'jetpack-forms' ) }</strong>
+						</div>
+					</CardHeader>
+					{ expandedCards.creativemail && (
+						<CardBody>
+							<NewsletterIntegrationSettings />
+						</CardBody>
+					) }
+				</Card>
+			</div>
+		</Modal>
+	);
+};
+
+export default JetpackIntegrationsModal;

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -30,6 +30,7 @@ import { ContactFormPlaceholder } from './components/jetpack-contact-form-placeh
 import ContactFormSkeletonLoader from './components/jetpack-contact-form-skeleton-loader';
 import CRMIntegrationSettings from './components/jetpack-crm-integration/jetpack-crm-integration-settings';
 import JetpackEmailConnectionSettings from './components/jetpack-email-connection-settings';
+import IntegrationPanel from './components/jetpack-integration-panel';
 import JetpackManageResponsesSettings from './components/jetpack-manage-responses-settings';
 import NewsletterIntegrationSettings from './components/jetpack-newsletter-integration-settings';
 import SalesforceLeadFormSettings from './components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings';
@@ -126,6 +127,8 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 			'contact-form/salesforce-lead-form'
 		];
 
+	const isModalEnabled = !! window?.jpFormsBlocks?.defaults?.enableModal;
+
 	let elt;
 
 	if ( ! isModuleActive ) {
@@ -218,6 +221,12 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 						/>
 					</PanelBody>
 
+					{ isModalEnabled && (
+						<PanelBody title={ __( 'Integrations', 'jetpack-forms' ) }>
+							<IntegrationPanel attributes={ attributes } setAttributes={ setAttributes } />
+						</PanelBody>
+					) }
+
 					{ isSalesForceExtensionEnabled && salesforceData?.sendToSalesforce && (
 						<SalesforceLeadFormSettings
 							salesforceData={ salesforceData }
@@ -225,25 +234,15 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 							instanceId={ instanceId }
 						/>
 					) }
-					{ ! isSimpleSite() && (
+					{ ! isModalEnabled && ! isSimpleSite() && canUserInstallPlugins && (
 						<>
-							{ canUserInstallPlugins && (
-								<>
-									<AkismetPanel />
-									<PanelBody
-										title={ __( 'CRM Connection', 'jetpack-forms' ) }
-										initialOpen={ false }
-									>
-										<CRMIntegrationSettings
-											jetpackCRM={ jetpackCRM }
-											setAttributes={ setAttributes }
-										/>
-									</PanelBody>
-									<PanelBody title={ __( 'Creative Mail', 'jetpack-forms' ) } initialOpen={ false }>
-										<NewsletterIntegrationSettings />
-									</PanelBody>
-								</>
-							) }
+							<AkismetPanel />
+							<PanelBody title={ __( 'CRM Connection', 'jetpack-forms' ) } initialOpen={ false }>
+								<CRMIntegrationSettings jetpackCRM={ jetpackCRM } setAttributes={ setAttributes } />
+							</PanelBody>
+							<PanelBody title={ __( 'Creative Mail', 'jetpack-forms' ) } initialOpen={ false }>
+								<NewsletterIntegrationSettings />
+							</PanelBody>
 						</>
 					) }
 				</InspectorControls>

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -127,7 +127,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 			'contact-form/salesforce-lead-form'
 		];
 
-	const isModalEnabled = !! window?.jpFormsBlocks?.defaults?.enableModal;
+	const isFormModalEnabled = !! window?.jpFormsBlocks?.defaults?.isFormModalEnabled;
 
 	let elt;
 
@@ -221,7 +221,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 						/>
 					</PanelBody>
 
-					{ isModalEnabled && (
+					{ isFormModalEnabled && (
 						<PanelBody title={ __( 'Integrations', 'jetpack-forms' ) }>
 							<IntegrationPanel attributes={ attributes } setAttributes={ setAttributes } />
 						</PanelBody>
@@ -234,7 +234,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 							instanceId={ instanceId }
 						/>
 					) }
-					{ ! isModalEnabled && ! isSimpleSite() && canUserInstallPlugins && (
+					{ ! isFormModalEnabled && ! isSimpleSite() && canUserInstallPlugins && (
 						<>
 							<AkismetPanel />
 							<PanelBody title={ __( 'CRM Connection', 'jetpack-forms' ) } initialOpen={ false }>

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2347,12 +2347,12 @@ class Contact_Form_Plugin {
 	}
 
 	/**
-	 * Check if the block modal interface should be enabled.
+	 * Check if the form modal interface should be enabled.
 	 * This is a development-only feature flag.
 	 *
 	 * @return bool
 	 */
-	public static function is_block_modal_enabled() {
-		return defined( 'JETPACK_ENABLE_BLOCK_MODAL' ) && JETPACK_ENABLE_BLOCK_MODAL;
+	public static function is_form_modal_enabled() {
+		return defined( 'JETPACK_IS_FORM_MODAL_ENABLED' ) && JETPACK_IS_FORM_MODAL_ENABLED;
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2345,4 +2345,14 @@ class Contact_Form_Plugin {
 
 		return $is_wpcom || $should_enable_tracking;
 	}
+
+	/**
+	 * Check if the block modal interface should be enabled.
+	 * This is a development-only feature flag.
+	 *
+	 * @return bool
+	 */
+	public static function is_block_modal_enabled() {
+		return defined( 'JETPACK_ENABLE_BLOCK_MODAL' ) && JETPACK_ENABLE_BLOCK_MODAL;
+	}
 }

--- a/projects/plugins/jetpack/changelog/add-forms-integration-modal-scaffolding
+++ b/projects/plugins/jetpack/changelog/add-forms-integration-modal-scaffolding
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Added block integrations modal with feature flag.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:

**Adds new panel and modal behind feature flag.** This PR adds scaffolding for a new third party integrations modal in the Jetpack Form block. See this P2 for discussion and designs: p1HpG7-wnN-p2

The modal is functional but not intended to be a release-ready. It is behind a feature flag. To see or work on the modal, add this to your wp-config.php file: 

`define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );`

When true, we hide the Akismet/CRM/Creative Mail panels on the block sidebar and show a new Integrations panel. That Integrations panel has a button to open the JetpackIntegrationsModal, which currently contains the same logic for Akismet/CRM/Creative Mail, but will be subject to significant development and change in coming weeks.

**Next steps for JetpackIntegrationsPanel include:**
- Lots of design iteration to match P2 above
- Creating a shared IntegrationCard component that each integration can use
- Refactoring the three integrations so far to use shared logic. Right now, CRM and Creative Mail each have four files with hundreds of lines of near-duplicate code to handle installing/activating and showing settings. We want to consolidate the logic more. That work will leverage the new integrations endpoint created in https://github.com/Automattic/jetpack/pull/42730
- Exposing Google and possibly SalesForce in in the panel too.

**Integrations Panel (note Akismet/CRM/Creative Mail panels are gone)**
<img width="1258" alt="integrations-panel" src="https://github.com/user-attachments/assets/b487a064-f158-4fbe-ac13-8d84c7518e26" />

**Integrations Modal (when button is clicked)**
<img width="1322" alt="integrations-modal" src="https://github.com/user-attachments/assets/b55f1637-2711-4da2-98fa-5788b47b9d5f" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See this P2 for discussion and designs: p1HpG7-wnN-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Test the feature**
* Add this to your wp-config: `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );`
* Create a page with a contact form block
* Confirm that the Integrations shows on the sidebar
* Confirm that if you click the Manage Integrations button, a modal opens with Akismet, CRM, and Creative Mail sections.
* Confirm the modal is basically functional - the cards for each open and show appropriate integration settings. Keep in mind this is not release ready. For now, we kind of hackishly just showing the exact same content as was in the sidebar panels for each integration. 
* Confirm the Akismet/CRM/Creative Mail sections no longer appear on the block sidebar

**Test without the feature**
* Remove the constant definition from your wp-config file, go back to the page, and confirm the the contact form and the integration panels on the sidebar work exactly as they did before. We want to be sure that for production users, nothing has changed. 