### PR TITLE
Feature Suggestions: load by default again

### DIFF
--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -74,7 +74,6 @@
 
 ## 14.5-a.3 - 2025-03-12
 ### Enhancements
-- Feature suggestions: Do not automatically load when a site is connected to WordPress.com. [#42337]
 - Publicize Components: Add a schedule button. [#42313]
 - Sharing block: Improve the description of the "Native Share" feature. [#42336]
 

--- a/projects/plugins/jetpack/changelog/revert-rm-plugin-search-loading
+++ b/projects/plugins/jetpack/changelog/revert-rm-plugin-search-loading
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Feature Hints: revert previous PR, thus cancelling previous changelog entry.
+
+

--- a/projects/plugins/jetpack/modules/module-extras.php
+++ b/projects/plugins/jetpack/modules/module-extras.php
@@ -34,6 +34,7 @@ $tools = array(
 // Some features are only available when connected to WordPress.com.
 $connected_tools = array(
 	'external-media/external-media.php',
+	'plugin-search.php',
 	'scan/scan.php', // Shows Jetpack Scan alerts in the admin bar if threats found.
 	'simple-payments/simple-payments.php',
 	'wpcom-tos/wpcom-tos.php',

--- a/projects/plugins/jetpack/modules/plugin-search.php
+++ b/projects/plugins/jetpack/modules/plugin-search.php
@@ -3,7 +3,6 @@
  * Plugin Search Hints, aka Feature Suggestions.
  *
  * @since 7.1.0
- * @since 14.5 This file is no longer loaded. See https://github.com/Automattic/jetpack/pull/42337 for more info.
  *
  * @package automattic/jetpack
  */


### PR DESCRIPTION
This reverts #42337

## Proposed changes:

Let's bring the feature back, as it can still provide useful information to folks looking to install features already available in their installation of WordPress.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1HpG7-wfr-p2#comment-75901
* p1741964276644249/1741287719.247389-slack-C01264051NE

## Does this pull request change what data or activity we track or use?

* Yes, its adds back tracking events that were triggered when using the feature.

## Testing instructions:

* Start with a site that's connected to WordPress.com.
* Go to Plugins > Add New
* Search for "Jetpack VideoPress" 
    * You should see a Jetpack feature card as the first result.

