### PR TITLE
Add error handling for onboarding form

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/connection-form.tsx
+++ b/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/connection-form.tsx
@@ -68,7 +68,8 @@ const ConnectionForm = () => {
 		return isLoadingOauth || isActionInitiated;
 	}, [ isLoadingOauth, isActionInitiated, errorType ] );
 
-	const services = [ 'google', 'apple', 'github', 'jetpack' ];
+	// Jetpack app is not supported for login yet.
+	const services = [ 'google', 'apple', 'github' /* 'jetpack' */ ];
 
 	return (
 		<div className={ styles[ 'connection-form' ] }>

--- a/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/connection-form.tsx
+++ b/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/connection-form.tsx
@@ -1,10 +1,12 @@
 import { TermsOfService, Text } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import useOauthConnection from '../../../hooks/use-oauth-connection';
 import preventWidows from '../../../utils/prevent-widows';
 import EmailInput from './email-input';
 import SocialButton from './social-button';
 import styles from './styles.module.scss';
+import type { SocialService, SubmitType } from '../../../hooks/use-oauth-connection';
 
 const Separator = () => {
 	return (
@@ -19,16 +21,54 @@ const Separator = () => {
 };
 
 const ConnectionForm = () => {
-	const [ isButtonDisabled, setIsButtonDisabled ] = useState( false );
+	const [ isActionInitiated, setIsActionInitiated ] = useState( false );
+	const [ lastClicked, setLastClicked ] = useState< SubmitType | null >( null );
+	const oauthConnectionData = useOauthConnection();
+	const {
+		errorType,
+		handleSubmitEmail,
+		handleSocialLogin,
+		isLoading: isLoadingOauth,
+		resetState,
+	} = oauthConnectionData;
+
 	const socialConnectionTitle = __( 'Start with Jetpack for free', 'jetpack-my-jetpack' );
 	const socialConnectionDescription = __(
 		'Log in with your WordPress.com account to supercharge your site with powerful growth, performance, and security tools.',
 		'jetpack-my-jetpack'
 	);
 
-	const handleSubmit = useCallback( () => {
-		setIsButtonDisabled( true );
-	}, [] );
+	useEffect( () => {
+		if ( errorType && lastClicked ) {
+			setIsActionInitiated( false );
+		}
+	}, [ errorType, lastClicked ] );
+
+	const handleSubmit: ( submitType: SubmitType ) => void = useCallback(
+		submitType => {
+			resetState();
+			setLastClicked( submitType );
+
+			if ( submitType === 'email' ) {
+				handleSubmitEmail();
+			} else {
+				handleSocialLogin( submitType );
+			}
+
+			setIsActionInitiated( true );
+		},
+		[ handleSubmitEmail, handleSocialLogin, resetState ]
+	);
+
+	const isLoading = useMemo( () => {
+		if ( errorType ) {
+			return false;
+		}
+
+		return isLoadingOauth || isActionInitiated;
+	}, [ isLoadingOauth, isActionInitiated, errorType ] );
+
+	const services = [ 'google', 'apple', 'github', 'jetpack' ];
 
 	return (
 		<div className={ styles[ 'connection-form' ] }>
@@ -40,14 +80,27 @@ const ConnectionForm = () => {
 				{ preventWidows( socialConnectionDescription ) }
 			</Text>
 
-			<SocialButton service="google" disabled={ isButtonDisabled } onSubmit={ handleSubmit } />
-			<SocialButton service="apple" disabled={ isButtonDisabled } onSubmit={ handleSubmit } />
-			<SocialButton service="github" disabled={ isButtonDisabled } onSubmit={ handleSubmit } />
-			<SocialButton service="jetpack" disabled={ isButtonDisabled } onSubmit={ handleSubmit } />
+			{ services.map( ( service: SocialService ) => (
+				<SocialButton
+					key={ service }
+					service={ service }
+					disabled={ isActionInitiated }
+					onSubmit={ handleSubmit }
+					loading={ isLoading }
+					lastClicked={ lastClicked }
+					errorType={ errorType }
+				/>
+			) ) }
 
 			<Separator />
 
-			<EmailInput isDisabled={ isButtonDisabled } onSubmit={ handleSubmit } />
+			<EmailInput
+				isDisabled={ isActionInitiated }
+				loading={ isLoading }
+				onSubmit={ handleSubmit }
+				lastClicked={ lastClicked }
+				oauthConnectionData={ oauthConnectionData }
+			/>
 
 			<TermsOfService isTextOnly={ true } className={ styles.tos } />
 		</div>

--- a/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/email-input.tsx
+++ b/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/email-input.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 import ErrorMessage from './error-message';
 import styles from './styles.module.scss';
 import type { SubmitType, UseOauthConnectionReturn } from '../../../hooks/use-oauth-connection';
@@ -21,7 +21,6 @@ const EmailInput: FC< EmailInputProps > = ( {
 	oauthConnectionData,
 } ) => {
 	const { userEmail, setUserEmail, errorType } = oauthConnectionData;
-	const inputRef = useRef< HTMLInputElement >( null );
 
 	const handleOnInput = useCallback(
 		( event: ChangeEvent< HTMLInputElement > ) => {
@@ -67,7 +66,6 @@ const EmailInput: FC< EmailInputProps > = ( {
 	return (
 		<form onSubmit={ handleOnSubmit } className={ styles[ 'email-input-container' ] }>
 			<input
-				ref={ inputRef }
 				className={ `${ styles[ 'email-input' ] } ${
 					errorType === 'email-validation' ? styles[ 'email-input-error' ] : ''
 				}` }

--- a/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/email-input.tsx
+++ b/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/email-input.tsx
@@ -1,29 +1,27 @@
 import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useCallback, useMemo, useState } from 'react';
-import useMyJetpackConnection from '../../../hooks/use-my-jetpack-connection';
-import useOauthConnection from '../../../hooks/use-oauth-connection';
+import { useCallback, useMemo, useRef } from 'react';
+import ErrorMessage from './error-message';
 import styles from './styles.module.scss';
+import type { SubmitType, UseOauthConnectionReturn } from '../../../hooks/use-oauth-connection';
 import type { ChangeEvent, FC, FormEvent } from 'react';
-
 interface EmailInputProps {
-	onSubmit?: () => void;
+	onSubmit: ( submitType: SubmitType ) => void;
+	loading: boolean;
 	isDisabled: boolean;
+	lastClicked: SubmitType | null;
+	oauthConnectionData: UseOauthConnectionReturn;
 }
 
-const EmailInput: FC< EmailInputProps > = ( { isDisabled, onSubmit } ) => {
-	const [ isClicked, setIsClicked ] = useState( false );
-	const {
-		userEmail,
-		setUserEmail,
-		isValidEmail,
-		handleSubmitEmail,
-		isLoadingAuthorizeUrl,
-		isError,
-		isRedirecting,
-	} = useOauthConnection();
-
-	const { siteIsRegistering } = useMyJetpackConnection();
+const EmailInput: FC< EmailInputProps > = ( {
+	isDisabled,
+	onSubmit,
+	loading,
+	lastClicked,
+	oauthConnectionData,
+} ) => {
+	const { userEmail, setUserEmail, errorType } = oauthConnectionData;
+	const inputRef = useRef< HTMLInputElement >( null );
 
 	const handleOnInput = useCallback(
 		( event: ChangeEvent< HTMLInputElement > ) => {
@@ -34,38 +32,44 @@ const EmailInput: FC< EmailInputProps > = ( { isDisabled, onSubmit } ) => {
 
 	const handleOnSubmit = useCallback(
 		async ( event: FormEvent< HTMLFormElement > ) => {
-			setIsClicked( true );
 			event.preventDefault();
-			onSubmit?.();
-			handleSubmitEmail();
+			onSubmit?.( 'email' );
 		},
-		[ onSubmit, handleSubmitEmail ]
+		[ onSubmit ]
 	);
 
-	const getErrorMessage = () => {
-		if ( ! isValidEmail ) {
-			// Third argument is to avoid a compilation issue with ternary operator
-			return __( 'Please enter a valid email address', 'jetpack-my-jetpack', 0 );
-		}
+	const isLastClicked = useMemo( () => {
+		return lastClicked === 'email';
+	}, [ lastClicked ] );
 
-		return __( 'An error occurred. Please try again.', 'jetpack-my-jetpack' );
-	};
-
-	const isLoading = isLoadingAuthorizeUrl || isRedirecting || ( isClicked && siteIsRegistering );
+	// Purpose of this is to only show errors and loading indicators
+	// on the last clicked button, not on all buttons.
+	const isThisLoading = useMemo( () => {
+		return loading && isLastClicked;
+	}, [ loading, isLastClicked ] );
 
 	const getAriaLabel = useMemo( () => {
-		if ( isLoading ) {
+		if ( isThisLoading ) {
 			return __( 'Connecting…', 'jetpack-my-jetpack', 0 );
 		}
 
 		return __( 'Start with email', 'jetpack-my-jetpack' );
-	}, [ isLoading ] );
+	}, [ isThisLoading ] );
+
+	const isInputDisabled = useMemo( () => {
+		return isDisabled || isThisLoading;
+	}, [ isDisabled, isThisLoading ] );
+
+	const isFormDisabled = useMemo( () => {
+		return isInputDisabled || errorType === 'email-validation';
+	}, [ isInputDisabled, errorType ] );
 
 	return (
 		<form onSubmit={ handleOnSubmit } className={ styles[ 'email-input-container' ] }>
 			<input
+				ref={ inputRef }
 				className={ `${ styles[ 'email-input' ] } ${
-					! isValidEmail ? styles[ 'email-input-error' ] : ''
+					errorType === 'email-validation' ? styles[ 'email-input-error' ] : ''
 				}` }
 				type="email"
 				autoComplete="email"
@@ -74,30 +78,21 @@ const EmailInput: FC< EmailInputProps > = ( { isDisabled, onSubmit } ) => {
 				name="user-email"
 				placeholder={ __( 'Enter your email address', 'jetpack-my-jetpack' ) }
 				aria-label={ __( 'Email address', 'jetpack-my-jetpack' ) }
-				aria-invalid={ ! isValidEmail || isError }
-				aria-describedby={ ! isValidEmail || isError ? 'email-error-message' : undefined }
+				aria-invalid={ errorType === 'email-validation' }
+				aria-describedby={ errorType ? 'email-error-message' : undefined }
 				value={ userEmail }
-				disabled={ isDisabled }
+				disabled={ isInputDisabled }
 				onInput={ handleOnInput }
 			/>
-			{ ( ! isValidEmail || isError ) && (
-				<div
-					id="email-error-message"
-					role="alert"
-					aria-live="polite"
-					className={ styles[ 'email-error-message' ] }
-				>
-					{ getErrorMessage() }
-				</div>
-			) }
+			{ isLastClicked && <ErrorMessage errorType={ errorType } /> }
 			<button
 				className={ styles[ 'submit-button' ] }
-				disabled={ isDisabled || ! userEmail || isLoading }
-				aria-busy={ isLoading }
+				disabled={ isFormDisabled }
+				aria-busy={ isThisLoading }
 				aria-label={ getAriaLabel }
 				type="submit"
 			>
-				{ isLoading ? (
+				{ isThisLoading ? (
 					<Spinner className={ styles.spinner } />
 				) : (
 					<span>{ __( 'Start with email', 'jetpack-my-jetpack' ) }</span>

--- a/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/error-message.tsx
+++ b/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/error-message.tsx
@@ -1,0 +1,55 @@
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import styles from './styles.module.scss';
+import type { OauthErrorType, SocialService } from '../../../hooks/use-oauth-connection';
+import type { FC } from 'react';
+
+interface ErrorMessageProps {
+	errorType: OauthErrorType;
+	service?: SocialService;
+}
+
+const ErrorMessage: FC< ErrorMessageProps > = ( { errorType, service = 'Wordpress.com' } ) => {
+	if ( ! errorType ) {
+		return null;
+	}
+
+	const getMessage = () => {
+		switch ( errorType ) {
+			case 'email-validation':
+				// Third argument is to avoid a compilation issue with ternary operator
+				return __( 'Please enter a valid email address', 'jetpack-my-jetpack', 0 );
+			case 'site-connection':
+				return __( 'Site connection failed. Please try again.', 'jetpack-my-jetpack' );
+			case 'authorization-url':
+				return createInterpolateElement(
+					sprintf(
+						// translators: %s is the name of the service we are trying to connect to
+						__(
+							"We couldn't connect to <span>%s</span> at this time. Please try again or select another sign-in method.",
+							'jetpack-my-jetpack'
+						),
+						service
+					),
+					{
+						span: <span className={ styles.capitalize }>{ service }</span>,
+					}
+				);
+			default:
+				return __( 'An error occurred. Please try again.', 'jetpack-my-jetpack' );
+		}
+	};
+
+	return (
+		<div
+			id="email-error-message"
+			role="alert"
+			aria-live="polite"
+			className={ styles[ 'error-message' ] }
+		>
+			{ getMessage() }
+		</div>
+	);
+};
+
+export default ErrorMessage;

--- a/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/error-message.tsx
+++ b/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/error-message.tsx
@@ -9,7 +9,7 @@ interface ErrorMessageProps {
 	service?: SocialService;
 }
 
-const ErrorMessage: FC< ErrorMessageProps > = ( { errorType, service = 'Wordpress.com' } ) => {
+const ErrorMessage: FC< ErrorMessageProps > = ( { errorType, service = 'Wordpress' } ) => {
 	if ( ! errorType ) {
 		return null;
 	}

--- a/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/error-message.tsx
+++ b/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/error-message.tsx
@@ -1,5 +1,6 @@
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { useCallback } from 'react';
 import styles from './styles.module.scss';
 import type { OauthErrorType, SocialService } from '../../../hooks/use-oauth-connection';
 import type { FC } from 'react';
@@ -10,11 +11,7 @@ interface ErrorMessageProps {
 }
 
 const ErrorMessage: FC< ErrorMessageProps > = ( { errorType, service = 'Wordpress' } ) => {
-	if ( ! errorType ) {
-		return null;
-	}
-
-	const getMessage = () => {
+	const getMessage = useCallback( () => {
 		switch ( errorType ) {
 			case 'email-validation':
 				// Third argument is to avoid a compilation issue with ternary operator
@@ -38,7 +35,11 @@ const ErrorMessage: FC< ErrorMessageProps > = ( { errorType, service = 'Wordpres
 			default:
 				return __( 'An error occurred. Please try again.', 'jetpack-my-jetpack' );
 		}
-	};
+	}, [ errorType, service ] );
+
+	if ( ! errorType ) {
+		return null;
+	}
 
 	return (
 		<div

--- a/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/social-button.tsx
+++ b/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/social-button.tsx
@@ -1,66 +1,84 @@
 import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useCallback, useMemo, useState } from 'react';
-import useMyJetpackConnection from '../../../hooks/use-my-jetpack-connection';
-import useOauthConnection from '../../../hooks/use-oauth-connection';
+import { useCallback, useMemo } from 'react';
 import appleIcon from '../icons/apple.svg';
 import githubIcon from '../icons/github.svg';
 import googleIcon from '../icons/google.svg';
 import jetpackIcon from '../icons/jetpack.svg';
+import ErrorMessage from './error-message';
 import styles from './styles.module.scss';
-import type { SocialService } from '../../../hooks/use-oauth-connection';
+import type {
+	OauthErrorType,
+	SocialService,
+	SubmitType,
+} from '../../../hooks/use-oauth-connection';
 import type { FC } from 'react';
 
 type SocialButtonProps = {
 	service: SocialService;
+	loading: boolean;
 	disabled: boolean;
-	onSubmit?: () => void;
+	onSubmit: ( submitType: SubmitType ) => void;
+	lastClicked: SubmitType | null;
+	errorType: OauthErrorType;
 };
 
-const SocialButton: FC< SocialButtonProps > = ( { service, disabled, onSubmit } ) => {
-	const [ isClicked, setIsClicked ] = useState( false );
-	const { handleSocialLogin, isLoadingAuthorizeUrl, isRedirecting } = useOauthConnection();
+const buttonText: Record< SocialService, { label: string; icon: string } > = {
+	google: { label: __( 'Start with Google', 'jetpack-my-jetpack' ), icon: googleIcon },
+	apple: { label: __( 'Start with Apple', 'jetpack-my-jetpack' ), icon: appleIcon },
+	github: { label: __( 'Start with GitHub', 'jetpack-my-jetpack' ), icon: githubIcon },
+	jetpack: { label: __( 'Start with Jetpack app', 'jetpack-my-jetpack' ), icon: jetpackIcon },
+};
 
-	const { siteIsRegistering } = useMyJetpackConnection();
-
-	const buttonText: Record< SocialService, { label: string; icon: string } > = {
-		google: { label: __( 'Start with Google', 'jetpack-my-jetpack' ), icon: googleIcon },
-		apple: { label: __( 'Start with Apple', 'jetpack-my-jetpack' ), icon: appleIcon },
-		github: { label: __( 'Start with GitHub', 'jetpack-my-jetpack' ), icon: githubIcon },
-		jetpack: { label: __( 'Start with Jetpack app', 'jetpack-my-jetpack' ), icon: jetpackIcon },
-	};
-
+const SocialButton: FC< SocialButtonProps > = ( {
+	service,
+	loading,
+	disabled,
+	onSubmit,
+	lastClicked,
+	errorType,
+} ) => {
 	const handleOnClick = useCallback( () => {
-		setIsClicked( true );
-		onSubmit?.();
-		handleSocialLogin( service );
-	}, [ service, onSubmit, handleSocialLogin ] );
+		onSubmit?.( service );
+	}, [ service, onSubmit ] );
 
-	const isLoading = isLoadingAuthorizeUrl || isRedirecting || ( isClicked && siteIsRegistering );
+	const isLastClicked = useMemo( () => {
+		return service === lastClicked;
+	}, [ lastClicked, service ] );
+
+	// Purpose of this is to only show errors and loading indicators
+	// on the last clicked button, not on all buttons.
+	const isThisLoading = useMemo( () => {
+		return loading && isLastClicked;
+	}, [ loading, isLastClicked ] );
+
 	const serviceText = buttonText[ service ];
 	const { label, icon } = serviceText;
 
 	const getAriaLabel = useMemo( () => {
-		if ( isLoading ) {
+		if ( isThisLoading ) {
 			return __( 'Connecting…', 'jetpack-my-jetpack', 0 );
 		}
 
 		return label;
-	}, [ isLoading, label ] );
+	}, [ isThisLoading, label ] );
 
 	return (
-		<button
-			className={ styles[ 'social-button' ] }
-			disabled={ disabled || isLoading }
-			onClick={ handleOnClick }
-			aria-busy={ isLoading }
-			aria-label={ getAriaLabel }
-		>
-			<img src={ icon } alt="" aria-hidden="true" />
-			<span className={ styles[ 'social-button-text' ] }>
-				{ isLoading ? <Spinner className={ styles.spinner } /> : label }
-			</span>
-		</button>
+		<>
+			<button
+				className={ styles[ 'social-button' ] }
+				disabled={ disabled || loading }
+				onClick={ handleOnClick }
+				aria-busy={ isThisLoading }
+				aria-label={ getAriaLabel }
+			>
+				<img src={ icon } alt="" aria-hidden="true" />
+				<span className={ styles[ 'social-button-text' ] }>
+					{ isThisLoading ? <Spinner className={ styles.spinner } /> : label }
+				</span>
+			</button>
+			{ isLastClicked && <ErrorMessage errorType={ errorType } service={ service } /> }
+		</>
 	);
 };
 

--- a/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/styles.module.scss
@@ -104,13 +104,6 @@
 		}
 	}
 
-	.email-error-message {
-		color: var(--jp-red-50, #d63638);
-		font-size: 14px;
-		line-height: 20px;
-		margin-top: -8px;
-	}
-
 	.submit-button {
 		width: 100%;
 		padding: 12px 16px;
@@ -154,8 +147,19 @@
 	}
 }
 
+.error-message {
+	color: var(--jp-red-50, #d63638);
+	font-size: 14px;
+	line-height: 20px;
+	margin-top: -8px;
+}
+
 svg.spinner {
 	margin: 0;
 	vertical-align: middle;
 	bottom: 2px;
+}
+
+.capitalize {
+	text-transform: capitalize;
 }

--- a/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/styles.module.scss
@@ -149,7 +149,7 @@
 
 .error-message {
 	color: var(--jp-red-50, #d63638);
-	font-size: 14px;
+	font-size: var(--font-body-small);
 	line-height: 20px;
 	margin-top: -8px;
 }

--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.ts
@@ -42,11 +42,11 @@ const useAnalytics = () => {
 	 */
 	const recordEvent = useCallback< TracksRecordEvent >( ( event, properties ) => {
 		jetpackAnalytics.tracks.recordEvent( event, {
-			...properties,
 			version: myJetpackVersion,
 			is_site_connected: isSiteConnected,
 			is_user_connected: isUserConnected,
 			referring_plugins: connectedPluginsSlugs,
+			...properties,
 		} );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );

--- a/projects/packages/my-jetpack/_inc/hooks/use-oauth-connection/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-oauth-connection/index.ts
@@ -5,6 +5,8 @@ import {
 	REST_API_GET_OAUTH_AUTHORIZE_URL,
 } from '../../data/constants';
 import useSimpleQuery from '../../data/use-simple-query';
+import sideloadTracks from '../../utils/side-load-tracks';
+import useAnalytics from '../use-analytics';
 import useMyJetpackConnection from '../use-my-jetpack-connection';
 
 export type SocialService = 'google' | 'apple' | 'github' | 'jetpack';
@@ -29,6 +31,9 @@ const useOauthConnection = (): UseOauthConnectionReturn => {
 	const [ isRedirecting, setIsRedirecting ] = useState( false );
 	const [ socialService, setSocialService ] = useState< SocialService | null >( null );
 	const [ errorType, setErrorType ] = useState< OauthErrorType | null >( null );
+
+	const { recordEvent } = useAnalytics();
+
 	const validateEmail = useCallback( ( email: string ) => {
 		const emailRegex = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
 		return emailRegex.test( email );
@@ -70,11 +75,15 @@ const useOauthConnection = (): UseOauthConnectionReturn => {
 
 	useEffect( () => {
 		if ( isErrorAuthorizeUrl ) {
+			recordEvent( 'jetpack_my_jetpack_onboarding_error', {
+				error_type: 'authorization-url',
+				service: socialService ?? 'email',
+			} );
 			setErrorType( 'authorization-url' );
 		} else {
 			setErrorType( null );
 		}
-	}, [ isErrorAuthorizeUrl ] );
+	}, [ isErrorAuthorizeUrl, recordEvent, socialService ] );
 
 	const handleSetUserEmail = useCallback(
 		( email: string ) => {
@@ -91,6 +100,12 @@ const useOauthConnection = (): UseOauthConnectionReturn => {
 		async ( service: SocialService | null = null ) => {
 			try {
 				await handleRegisterSite();
+				await sideloadTracks();
+				recordEvent( 'jetpack_my_jetpack_onboarding_click', {
+					service: service ?? 'email',
+					// Overriding this value as we're waiting for the site to be registered to run this event.
+					is_site_connected: true,
+				} );
 			} catch ( error ) {
 				// eslint-disable-next-line no-console
 				console.error( error );
@@ -101,7 +116,7 @@ const useOauthConnection = (): UseOauthConnectionReturn => {
 			setSocialService( service );
 			setShouldFetchUrl( true );
 		},
-		[ handleRegisterSite ]
+		[ handleRegisterSite, recordEvent ]
 	);
 
 	const handleSubmitEmail = useCallback(

--- a/projects/packages/my-jetpack/_inc/hooks/use-oauth-connection/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-oauth-connection/index.ts
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import {
 	QUERY_GET_OAUTH_AUTHORIZE_URL_KEY,
 	REST_API_GET_OAUTH_AUTHORIZE_URL,
@@ -8,40 +8,40 @@ import useSimpleQuery from '../../data/use-simple-query';
 import useMyJetpackConnection from '../use-my-jetpack-connection';
 
 export type SocialService = 'google' | 'apple' | 'github' | 'jetpack';
+export type SubmitType = 'email' | SocialService;
+export type OauthErrorType = 'email-validation' | 'site-connection' | 'authorization-url';
 
-type UseOauthConnectionReturn = {
+export type UseOauthConnectionReturn = {
 	userEmail: string;
 	setUserEmail: ( email: string ) => void;
-	isValidEmail: boolean;
 	validateEmail: ( email: string ) => boolean;
 	handleSubmitEmail: ( email?: string ) => void;
 	handleSocialLogin: ( service: SocialService ) => void;
-	isLoadingAuthorizeUrl: boolean;
-	isError: boolean;
+	isLoading: boolean;
+	errorType: OauthErrorType;
 	authorizeUrl: string | null;
-	isRedirecting: boolean;
+	resetState: () => void;
 };
 
 const useOauthConnection = (): UseOauthConnectionReturn => {
 	const [ userEmail, setUserEmail ] = useState( '' );
-	const [ isValidEmail, setIsValidEmail ] = useState( true );
 	const [ shouldFetchUrl, setShouldFetchUrl ] = useState( false );
 	const [ isRedirecting, setIsRedirecting ] = useState( false );
 	const [ socialService, setSocialService ] = useState< SocialService | null >( null );
-
+	const [ errorType, setErrorType ] = useState< OauthErrorType | null >( null );
 	const validateEmail = useCallback( ( email: string ) => {
 		const emailRegex = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
 		return emailRegex.test( email );
 	}, [] );
 
-	const { handleRegisterSite, siteIsRegistered } = useMyJetpackConnection( {
+	const { handleRegisterSite, siteIsRegistered, siteIsRegistering } = useMyJetpackConnection( {
 		skipUserConnection: true,
 		redirectUri: '',
 	} );
 
 	const {
 		data,
-		isError,
+		isError: isErrorAuthorizeUrl,
 		isLoading: isLoadingAuthorizeUrl,
 	} = useSimpleQuery< { authorizeUrl: string } >( {
 		name: `${ QUERY_GET_OAUTH_AUTHORIZE_URL_KEY }_${ userEmail ? 'link' : socialService ?? '' }`,
@@ -61,6 +61,32 @@ const useOauthConnection = (): UseOauthConnectionReturn => {
 		),
 	} );
 
+	const resetState = useCallback( () => {
+		setShouldFetchUrl( false );
+		setSocialService( null );
+		setErrorType( null );
+		setIsRedirecting( false );
+	}, [] );
+
+	useEffect( () => {
+		if ( isErrorAuthorizeUrl ) {
+			setErrorType( 'authorization-url' );
+		} else {
+			setErrorType( null );
+		}
+	}, [ isErrorAuthorizeUrl ] );
+
+	const handleSetUserEmail = useCallback(
+		( email: string ) => {
+			if ( shouldFetchUrl || errorType ) {
+				resetState();
+			}
+
+			setUserEmail( email );
+		},
+		[ resetState, shouldFetchUrl, errorType ]
+	);
+
 	const handleConnectionSetup = useCallback(
 		async ( service: SocialService | null = null ) => {
 			try {
@@ -68,7 +94,8 @@ const useOauthConnection = (): UseOauthConnectionReturn => {
 			} catch ( error ) {
 				// eslint-disable-next-line no-console
 				console.error( error );
-				// Fail silently
+				setErrorType( 'site-connection' );
+				return;
 			}
 
 			setSocialService( service );
@@ -82,11 +109,11 @@ const useOauthConnection = (): UseOauthConnectionReturn => {
 			const emailToUse = email || userEmail;
 
 			if ( ! validateEmail( emailToUse ) ) {
-				setIsValidEmail( false );
+				setErrorType( 'email-validation' );
 				return;
 			}
 
-			setIsValidEmail( true );
+			setErrorType( null );
 
 			if ( email ) {
 				setUserEmail( email );
@@ -112,17 +139,24 @@ const useOauthConnection = (): UseOauthConnectionReturn => {
 		}
 	}, [ data, siteIsRegistered, isRedirecting ] );
 
+	const isLoading = useMemo( () => {
+		if ( errorType ) {
+			return false;
+		}
+
+		return isLoadingAuthorizeUrl || isRedirecting || siteIsRegistering;
+	}, [ isLoadingAuthorizeUrl, isRedirecting, siteIsRegistering, errorType ] );
+
 	return {
 		userEmail,
-		setUserEmail,
-		isValidEmail,
+		setUserEmail: handleSetUserEmail,
 		validateEmail,
 		handleSubmitEmail,
 		handleSocialLogin,
-		isLoadingAuthorizeUrl,
-		isError,
+		isLoading,
+		errorType,
 		authorizeUrl: data?.authorizeUrl || null,
-		isRedirecting,
+		resetState,
 	};
 };
 

--- a/projects/packages/my-jetpack/_inc/utils/side-load-tracks.ts
+++ b/projects/packages/my-jetpack/_inc/utils/side-load-tracks.ts
@@ -56,6 +56,10 @@ function loadScript( src: string ): Promise< void > {
  * @return {Promise<void>} A promise that resolves once the Tracks has been side loaded.
  */
 export default function sideloadTracks(): Promise< void > {
+	if ( window._tkq && document.querySelector( 'script[src*="stats.wp.com/w.js"]' ) ) {
+		return Promise.resolve();
+	}
+
 	window._tkq = window._tkq || [];
 	return loadScript( `//stats.wp.com/w.js?${ getCurrentYearAndWeek() }` );
 }

--- a/projects/packages/my-jetpack/changelog/add-error-handling-for-onboarding-form
+++ b/projects/packages/my-jetpack/changelog/add-error-handling-for-onboarding-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add error handling to onboarding form


### PR DESCRIPTION
Resolves MARTECH-17

## Proposed changes:

* Rework loading states to be synced between email and social button components
* Add ErrorMessage component for both Social buttons and email input to use separately
* Handle all possible known errors to show contextual errors when they occur
* Hide the Jetpack login button as we will not have support ready for that in this release

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: p1HpG7-wiG-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

To test the error states, it's easier to test this on your local environment

1. Checkout this branch locally
2. Go to `/wp-admin/admin.php?page=my-jetpack#/onboarding`
3. Try typing `user@domain.c` in the email input box and submitting the form. You should see an error for an invalid email
![image](https://github.com/user-attachments/assets/7dc8f3c7-195b-4493-b649-455d06231885)
4. Make sure you can edit the email and that the error goes away once you do (until you submit an invalid email again)
![image](https://github.com/user-attachments/assets/bb4d48ae-b641-4ed9-b499-d280212fcc14)
5. Also make sure that the social buttons are still clickable when the email validation error is active
6. Now, go to `projects/packages/my-jetpack/_inc/hooks/use-oauth-connection/index.ts` line 93 and insert the following code above the site registration function
```ts
throw new Error( 'test' );
```
7. Try to submit an email or click any of the social buttons and ensure that it does not work and throws the relevant error
![image](https://github.com/user-attachments/assets/c27f7376-6321-41fd-8e5a-18655b4d5cb9)
8. Lastly, go to `projects/packages/connection/src/class-rest-connector.php` line 1155 and insert the following code
```php
return new WP_Error(
	'test_error',
	'This is a test error',
	array( 'status' => 400 )
);
```
9. Try to submit the form and and ensure that the error after the API fails makes sense for each service
![image](https://github.com/user-attachments/assets/e8c7d0bd-6299-40ff-8964-71c3945d5671)
