### PR TITLE
Add/tracks for onboarding flow

### DIFF
--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.ts
@@ -40,16 +40,19 @@ const useAnalytics = () => {
 	 * @param {string} event      - event name
 	 * @param {object} properties - event propeties
 	 */
-	const recordEvent = useCallback< TracksRecordEvent >( ( event, properties ) => {
-		jetpackAnalytics.tracks.recordEvent( event, {
-			...properties,
-			version: myJetpackVersion,
-			is_site_connected: isSiteConnected,
-			is_user_connected: isUserConnected,
-			referring_plugins: connectedPluginsSlugs,
-		} );
+	const recordEvent = useCallback< TracksRecordEvent >(
+		( event, properties ) => {
+			jetpackAnalytics.tracks.recordEvent( event, {
+				...properties,
+				version: myJetpackVersion,
+				is_site_connected: isSiteConnected,
+				is_user_connected: isUserConnected,
+				referring_plugins: connectedPluginsSlugs,
+			} );
+		},
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
+		[ isSiteConnected ]
+	);
 
 	return { recordEvent };
 };

--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.ts
@@ -40,19 +40,16 @@ const useAnalytics = () => {
 	 * @param {string} event      - event name
 	 * @param {object} properties - event propeties
 	 */
-	const recordEvent = useCallback< TracksRecordEvent >(
-		( event, properties ) => {
-			jetpackAnalytics.tracks.recordEvent( event, {
-				...properties,
-				version: myJetpackVersion,
-				is_site_connected: isSiteConnected,
-				is_user_connected: isUserConnected,
-				referring_plugins: connectedPluginsSlugs,
-			} );
-		},
+	const recordEvent = useCallback< TracksRecordEvent >( ( event, properties ) => {
+		jetpackAnalytics.tracks.recordEvent( event, {
+			version: myJetpackVersion,
+			is_site_connected: isSiteConnected,
+			is_user_connected: isUserConnected,
+			referring_plugins: connectedPluginsSlugs,
+			...properties,
+		} );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[ isSiteConnected ]
-	);
+	}, [] );
 
 	return { recordEvent };
 };

--- a/projects/packages/my-jetpack/_inc/hooks/use-oauth-connection/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-oauth-connection/index.ts
@@ -5,6 +5,7 @@ import {
 	REST_API_GET_OAUTH_AUTHORIZE_URL,
 } from '../../data/constants';
 import useSimpleQuery from '../../data/use-simple-query';
+import sideloadTracks from '../../utils/side-load-tracks';
 import useAnalytics from '../use-analytics';
 import useMyJetpackConnection from '../use-my-jetpack-connection';
 
@@ -99,6 +100,7 @@ const useOauthConnection = (): UseOauthConnectionReturn => {
 		async ( service: SocialService | null = null ) => {
 			try {
 				await handleRegisterSite();
+				await sideloadTracks();
 				recordEvent( 'jetpack_my_jetpack_onboarding_click', {
 					service: service ?? 'email',
 				} );

--- a/projects/packages/my-jetpack/_inc/hooks/use-oauth-connection/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-oauth-connection/index.ts
@@ -5,6 +5,7 @@ import {
 	REST_API_GET_OAUTH_AUTHORIZE_URL,
 } from '../../data/constants';
 import useSimpleQuery from '../../data/use-simple-query';
+import useAnalytics from '../use-analytics';
 import useMyJetpackConnection from '../use-my-jetpack-connection';
 
 export type SocialService = 'google' | 'apple' | 'github' | 'jetpack';
@@ -29,6 +30,9 @@ const useOauthConnection = (): UseOauthConnectionReturn => {
 	const [ isRedirecting, setIsRedirecting ] = useState( false );
 	const [ socialService, setSocialService ] = useState< SocialService | null >( null );
 	const [ errorType, setErrorType ] = useState< OauthErrorType | null >( null );
+
+	const { recordEvent } = useAnalytics();
+
 	const validateEmail = useCallback( ( email: string ) => {
 		const emailRegex = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
 		return emailRegex.test( email );
@@ -70,11 +74,15 @@ const useOauthConnection = (): UseOauthConnectionReturn => {
 
 	useEffect( () => {
 		if ( isErrorAuthorizeUrl ) {
+			recordEvent( 'jetpack_my_jetpack_onboarding_error', {
+				error_type: 'authorization-url',
+				service: socialService ?? 'email',
+			} );
 			setErrorType( 'authorization-url' );
 		} else {
 			setErrorType( null );
 		}
-	}, [ isErrorAuthorizeUrl ] );
+	}, [ isErrorAuthorizeUrl, recordEvent, socialService ] );
 
 	const handleSetUserEmail = useCallback(
 		( email: string ) => {
@@ -91,6 +99,9 @@ const useOauthConnection = (): UseOauthConnectionReturn => {
 		async ( service: SocialService | null = null ) => {
 			try {
 				await handleRegisterSite();
+				recordEvent( 'jetpack_my_jetpack_onboarding_click', {
+					service: service ?? 'email',
+				} );
 			} catch ( error ) {
 				// eslint-disable-next-line no-console
 				console.error( error );
@@ -101,7 +112,7 @@ const useOauthConnection = (): UseOauthConnectionReturn => {
 			setSocialService( service );
 			setShouldFetchUrl( true );
 		},
-		[ handleRegisterSite ]
+		[ handleRegisterSite, recordEvent ]
 	);
 
 	const handleSubmitEmail = useCallback(

--- a/projects/packages/my-jetpack/_inc/hooks/use-oauth-connection/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-oauth-connection/index.ts
@@ -104,7 +104,7 @@ const useOauthConnection = (): UseOauthConnectionReturn => {
 				recordEvent( 'jetpack_my_jetpack_onboarding_click', {
 					service: service ?? 'email',
 					// Overriding this value as we're waiting for the site to be registered to run this event.
-					site_connected: true,
+					is_site_connected: true,
 				} );
 			} catch ( error ) {
 				// eslint-disable-next-line no-console

--- a/projects/packages/my-jetpack/_inc/hooks/use-oauth-connection/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-oauth-connection/index.ts
@@ -103,6 +103,8 @@ const useOauthConnection = (): UseOauthConnectionReturn => {
 				await sideloadTracks();
 				recordEvent( 'jetpack_my_jetpack_onboarding_click', {
 					service: service ?? 'email',
+					// Overriding this value as we're waiting for the site to be registered to run this event.
+					site_connected: true,
 				} );
 			} catch ( error ) {
 				// eslint-disable-next-line no-console

--- a/projects/packages/my-jetpack/_inc/utils/side-load-tracks.ts
+++ b/projects/packages/my-jetpack/_inc/utils/side-load-tracks.ts
@@ -56,6 +56,10 @@ function loadScript( src: string ): Promise< void > {
  * @return {Promise<void>} A promise that resolves once the Tracks has been side loaded.
  */
 export default function sideloadTracks(): Promise< void > {
+	if ( window._tkq && document.querySelector( 'script[src*="stats.wp.com/w.js"]' ) ) {
+		return Promise.resolve();
+	}
+
 	window._tkq = window._tkq || [];
 	return loadScript( `//stats.wp.com/w.js?${ getCurrentYearAndWeek() }` );
 }


### PR DESCRIPTION
Resolves MARTECH-50

## Proposed changes:

* During onboard flow, after site connection is established, sideload tracks so we can track button clicks on these onboarding buttons

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: p1HpG7-wiG-p2

## Does this pull request change what data or activity we track or use?

Yes, we are adding tracks to the button clicks after site connection is established during the onboarding flow

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Go to `/wp-admin/admin.php?page=my-jetpack#/onboarding`
3. Click on any of the login options and monitor Tracks vigilante. Ensure that the button click is loaded after site connection is established
