### PR TITLE
Forms: Fix upload file endpoint CORS 

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-file-upload-endpoint-cors
+++ b/projects/packages/forms/changelog/fix-forms-file-upload-endpoint-cors
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+under feature flag

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Unauth_File_Upload_Handler;
 
 /**
  * Class for the contact-field shortcode.
@@ -834,6 +835,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			_x( 'GB', 'unit symbol', 'jetpack-forms' ),
 		);
 
+		require_once JETPACK__PLUGIN_DIR . '/_inc/lib/class-unauth-file-upload-handler.php';
 		$global_state = array(
 			'i18n'          => array(
 				'language'           => get_bloginfo( 'language' ),
@@ -847,8 +849,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			),
 			'maxUploadSize' => $max_file_size,
 			'endpoint'      => $this->get_unauth_endpoint_url(),
-			'wp_nonce'      => wp_create_nonce( 'wp_rest' ),
-			'jp_nonce'      => wp_create_nonce( 'jetpack_file_upload_jetpack-form' ),
+			'uploadToken'   => ( new Unauth_File_Upload_Handler() )->generate_upload_token(),
 		);
 
 		wp_interactivity_config( 'jetpack/field-file', $global_state );

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -789,6 +789,12 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string HTML for the file upload field.
 	 */
 	private function render_file_field( $id, $label, $class, $required, $required_field_text ) {
+		if ( ! defined( 'JETPACK__PLUGIN_DIR' ) ) {
+			// Jetpack is not active, so we don't need to render the file field
+			// TODO: Move upload field and jwt token to their own packages, so we can use them in other projects.
+			return '';
+		}
+
 		// Enqueue necessary scripts and styles.
 		$this->enqueue_file_field_assets();
 
@@ -835,7 +841,14 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			_x( 'GB', 'unit symbol', 'jetpack-forms' ),
 		);
 
-		require_once JETPACK__PLUGIN_DIR . '/_inc/lib/class-unauth-file-upload-handler.php';
+		// Only include the file handler if we're sure it exists
+		if ( file_exists( JETPACK__PLUGIN_DIR . '/_inc/lib/class-unauth-file-upload-handler.php' ) ) {
+			require_once JETPACK__PLUGIN_DIR . '/_inc/lib/class-unauth-file-upload-handler.php';
+			$upload_token = ( new Unauth_File_Upload_Handler() )->generate_upload_token();
+		} else {
+			$upload_token = '';
+		}
+
 		$global_state = array(
 			'i18n'          => array(
 				'language'           => get_bloginfo( 'language' ),
@@ -849,7 +862,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			),
 			'maxUploadSize' => $max_file_size,
 			'endpoint'      => $this->get_unauth_endpoint_url(),
-			'uploadToken'   => ( new Unauth_File_Upload_Handler() )->generate_upload_token(),
+			'uploadToken'   => $upload_token,
 		);
 
 		wp_interactivity_config( 'jetpack/field-file', $global_state );
@@ -910,19 +923,20 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return void
 	 */
 	private function enqueue_file_field_assets() {
+		$version = defined( 'JETPACK__VERSION' ) ? \JETPACK__VERSION : '0.1';
 
 		\wp_enqueue_script_module(
 			'jetpack-form-file-field',
 			plugins_url( '../../dist/modules/file-field/view.js', __FILE__ ),
 			array( '@wordpress/interactivity' ),
-			\JETPACK__VERSION
+			$version
 		);
 
 		\wp_enqueue_style(
 			'jetpack-form-file-field',
 			plugins_url( '../../dist/contact-form/css/file-field.css', __FILE__ ),
 			array(),
-			\JETPACK__VERSION
+			$version
 		);
 	}
 	/**
@@ -931,6 +945,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string
 	 */
 	private function get_unauth_endpoint_url() {
+		// Return a placeholder URL if Jetpack is not active
+		if ( ! defined( 'JETPACK__PLUGIN_DIR' ) ) {
+			return '#jetpack-not-active';
+		}
+
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			return sprintf( 'https://public-api.wordpress.com/wpcom/v2/sites/%d/unauth-file-upload', get_current_blog_id() );
 		}
@@ -1397,6 +1416,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				}
 			);
 			return count( $non_empty_options ) > 0;
+		}
+
+		// File field requires Jetpack to be active
+		if ( $type === 'file' && ! defined( 'JETPACK__PLUGIN_DIR' ) ) {
+			return false;
 		}
 
 		return true;

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Assets;
-use Automattic\Jetpack\Unauth_File_Upload_Handler;
 
 /**
  * Class for the contact-field shortcode.
@@ -789,10 +788,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string HTML for the file upload field.
 	 */
 	private function render_file_field( $id, $label, $class, $required, $required_field_text ) {
+		// Check if Jetpack is active
 		if ( ! defined( 'JETPACK__PLUGIN_DIR' ) ) {
-			// Jetpack is not active, so we don't need to render the file field
-			// TODO: Move upload field and jwt token to their own packages, so we can use them in other projects.
-			return '';
+			return '<div class="jetpack-form-field-error">' .
+				esc_html__( 'File upload field requires Jetpack to be active.', 'jetpack-forms' ) .
+				'</div>';
 		}
 
 		// Enqueue necessary scripts and styles.
@@ -841,13 +841,14 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			_x( 'GB', 'unit symbol', 'jetpack-forms' ),
 		);
 
-		// Only include the file handler if we're sure it exists
-		if ( file_exists( JETPACK__PLUGIN_DIR . '/_inc/lib/class-unauth-file-upload-handler.php' ) ) {
-			require_once JETPACK__PLUGIN_DIR . '/_inc/lib/class-unauth-file-upload-handler.php';
-			$upload_token = ( new Unauth_File_Upload_Handler() )->generate_upload_token();
-		} else {
-			$upload_token = '';
-		}
+		/**
+		 * Filters the upload token for the file field.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string $upload_token Default empty token.
+		 */
+		$upload_token = apply_filters( 'jetpack_forms_file_upload_token', '' );
 
 		$global_state = array(
 			'i18n'          => array(

--- a/projects/plugins/jetpack/_inc/lib/class-unauth-file-upload-handler.php
+++ b/projects/plugins/jetpack/_inc/lib/class-unauth-file-upload-handler.php
@@ -40,7 +40,7 @@ class Unauth_File_Upload_Handler {
 	/**
 	 * Get the secret key for signing upload tokens.
 	 *
-	 * @return string The secret key.
+	 * @return string|false The secret key or false if not available.
 	 */
 	private function get_upload_token_secret() {
 		if ( ( new Host() )->is_wpcom_simple() ) {

--- a/projects/plugins/jetpack/_inc/lib/class-unauth-file-upload-handler.php
+++ b/projects/plugins/jetpack/_inc/lib/class-unauth-file-upload-handler.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Unauthenticated File Upload Handler for Jetpack Forms.
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack;
+
+use Automattic\Jetpack\Connection\Tokens;
+use Automattic\Jetpack\Extensions\Premium_Content\JWT;
+use Automattic\Jetpack\Status\Host;
+
+/**
+ * Handles temporary file uploads from unauthenticated users.
+ */
+class Unauth_File_Upload_Handler {
+	/**
+	 * Generate a JWT token for file upload authorization.
+	 *
+	 * @param array $claims The claims to include in the token.
+	 * @return string The generated JWT token.
+	 */
+	public function generate_upload_token( $claims = array() ) {
+		$default_claims = array(
+			'exp' => time() + 3600, // 1 hour expiration
+			'ip'  => isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '',
+			'iat' => time(),
+		);
+
+		$claims = wp_parse_args( $claims, $default_claims );
+
+		// Get the secret key for signing
+		$secret = $this->get_upload_token_secret();
+
+		// Generate and return the token
+		return JWT::encode( $claims, $secret, 'HS256' );
+	}
+
+	/**
+	 * Get the secret key for signing upload tokens.
+	 *
+	 * @return string The secret key.
+	 */
+	private function get_upload_token_secret() {
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			// phpcs:ignore ImportDetection.Imports.RequireImports.Symbol
+			// TODO: This is a temporary solution to get the secret key for the upload token.
+			return defined( 'EARN_JWT_SIGNING_KEY' ) ? EARN_JWT_SIGNING_KEY : false;
+		}
+		$token = ( new Tokens() )->get_access_token();
+		if ( ! isset( $token->secret ) ) {
+			return false;
+		}
+		return $token->secret;
+	}
+
+	/**
+	 * Verify a JWT upload token.
+	 *
+	 * @param string $token The JWT token to verify.
+	 * @return object|false The token claims if valid, false if invalid.
+	 */
+	public function verify_upload_token( $token ) {
+		try {
+			$secret = $this->get_upload_token_secret();
+			return JWT::decode( $token, $secret, array( 'HS256' ) );
+		} catch ( \Exception $e ) {
+			return false;
+		}
+	}
+}

--- a/projects/plugins/jetpack/_inc/lib/forms-integration.php
+++ b/projects/plugins/jetpack/_inc/lib/forms-integration.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * File that sets up Jetpack integration with the Forms package.
+ *
+ * @package automattic/jetpack
+ */
+
+/**
+ * Registers filters for integration with Forms package.
+ */
+function jetpack_forms_integration_init() {
+	// Only add the hook if we have the forms package
+	if ( ! class_exists( 'Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field' ) ) {
+		return;
+	}
+
+	// Add filter to provide the upload token
+	add_filter( 'jetpack_forms_file_upload_token', 'jetpack_forms_provide_upload_token' );
+}
+add_action( 'init', 'jetpack_forms_integration_init' );
+
+/**
+ * Provides an upload token using the Unauth_File_Upload_Handler.
+ *
+ * @return string The generated upload token.
+ */
+function jetpack_forms_provide_upload_token() {
+	require_once JETPACK__PLUGIN_DIR . '/_inc/lib/class-unauth-file-upload-handler.php';
+	$handler = new Automattic\Jetpack\Unauth_File_Upload_Handler();
+	return $handler->generate_upload_token();
+}

--- a/projects/plugins/jetpack/changelog/fix-forms-file-upload-endpoint-cors
+++ b/projects/plugins/jetpack/changelog/fix-forms-file-upload-endpoint-cors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+under feature flag

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -39,6 +39,7 @@ require_once JETPACK__PLUGIN_DIR . 'class.jetpack-autoupdate.php';
 require_once JETPACK__PLUGIN_DIR . 'class.frame-nonce-preview.php';
 require_once JETPACK__PLUGIN_DIR . 'modules/module-headings.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-plan.php';
+require_once JETPACK__PLUGIN_DIR . '_inc/lib/forms-integration.php';
 // Used by the API endpoints.
 require_once JETPACK__PLUGIN_DIR . 'modules/seo-tools/class-jetpack-seo-utils.php';
 require_once JETPACK__PLUGIN_DIR . 'modules/seo-tools/class-jetpack-seo-titles.php';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes CORS issues and nonce verification for the file upload endpoint.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use a JWT, similar to how Premium Content does.
* This way, we avoid CORS since we’re not sending new headers or nonce verifications, which can complicate things—especially for logged-in users on Simple sites.
* We also avoid writing to the database for every visit to a contact form that requires a nonce.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test adding a file to the dropzone. The request should succeed on both Jetpack and Simple sites, whether logged in or logged out 
