### PR TITLE
Display onboarding screen to disconnected users

### DIFF
--- a/projects/packages/my-jetpack/_inc/admin.jsx
+++ b/projects/packages/my-jetpack/_inc/admin.jsx
@@ -49,7 +49,19 @@ function ScrollToTop() {
 
 const MyJetpack = () => {
 	const { loadAddLicenseScreen } = getMyJetpackWindowInitialState();
+	const container = document.getElementById( 'my-jetpack-container' );
+	const isOnboarding = container?.dataset?.route === 'onboarding';
 
+	// If we're on the onboarding route, render just the onboarding screen
+	if ( isOnboarding ) {
+		return (
+			<Providers>
+				<OnboardingScreen />
+			</Providers>
+		);
+	}
+
+	// Otherwise render the normal hash router with all other routes
 	return (
 		<Providers>
 			<HashRouter>
@@ -81,7 +93,6 @@ const MyJetpack = () => {
 					<Route path={ MyJetpackRoutes.AddSecurity } element={ <SecurityInterstitial /> } />
 					<Route path={ MyJetpackRoutes.AddGrowth } element={ <GrowthInterstitial /> } />
 					<Route path={ MyJetpackRoutes.AddComplete } element={ <CompleteInterstitial /> } />
-					<Route path={ MyJetpackRoutes.Onboarding } element={ <OnboardingScreen /> } />
 					<Route path={ MyJetpackRoutes.RedeemToken } element={ <RedeemTokenScreen /> } />
 					{ /* Fallback route. Required to prevent visiting `?page=my-jetpack#wpbody-content` from raising an exception. */ }
 					<Route path="*" element={ <MyJetpackScreen /> } />

--- a/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/connection-form.tsx
+++ b/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/connection-form.tsx
@@ -69,7 +69,7 @@ const ConnectionForm = () => {
 	}, [ isLoadingOauth, isActionInitiated, errorType ] );
 
 	// Jetpack app is not supported for login yet.
-	const services = [ 'google', 'apple', 'github' /* 'jetpack' */ ];
+	const services = [ 'google', 'apple', 'github' ];
 
 	return (
 		<div className={ styles[ 'connection-form' ] }>

--- a/projects/packages/my-jetpack/_inc/components/onboarding-screen/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/onboarding-screen/styles.module.scss
@@ -16,13 +16,9 @@
 	// override the default max-container-width since otherwise the container will be only 1128px
 	--max-container-width: 100%;
 	width: 100%;
-	height: 100vh;
+	min-height: 100vh;
 	overflow-y: hidden;
 	background-color: var(--jp-white, #ffffff);
-}
-
-.column {
-	overflow: hidden;
 }
 
 .primary-column {

--- a/projects/packages/my-jetpack/_inc/components/onboarding-screen/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/onboarding-screen/styles.module.scss
@@ -1,5 +1,5 @@
 :global(body) {
-	font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Avenir Next", "Avenir", "Segoe UI", "Helvetica Neue", "Helvetica", "Cantarell", "Ubuntu", "Roboto", "Noto Sans", "Arial", sans-serif;
+	font-family: -apple-system, BlinkMacSystemFont, "Avenir Next", "Avenir", "Segoe UI", "Helvetica Neue", "Helvetica", "Cantarell", "Ubuntu", "Roboto", "Noto Sans", "Arial", sans-serif;
 }
 
 :global(#wpwrap) {

--- a/projects/packages/my-jetpack/_inc/components/testimonials/style.scss
+++ b/projects/packages/my-jetpack/_inc/components/testimonials/style.scss
@@ -12,6 +12,8 @@
     display: flex;
     align-items: flex-end;
     padding-bottom: 50px;
+    border-radius: 12px;
+    overflow: hidden;
 
     // This is to make the image darker and let read the text
     &::before {

--- a/projects/packages/my-jetpack/_inc/constants.ts
+++ b/projects/packages/my-jetpack/_inc/constants.ts
@@ -25,7 +25,6 @@ export const MyJetpackRoutes = {
 	AddStats: '/add-stats',
 	AddLicense: '/add-license',
 	JetpackAi: '/jetpack-ai',
-	Onboarding: '/onboarding',
 	RedeemToken: '/redeem-token',
 } as const;
 

--- a/projects/packages/my-jetpack/changelog/make-onboarding-screen-default-disconnected-users
+++ b/projects/packages/my-jetpack/changelog/make-onboarding-screen-default-disconnected-users
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: disconnected users will now be shown an onboarding screen to ease their understanding of Jetpack.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -180,7 +180,6 @@ class Initializer {
 		$step = isset( $_GET['step'] ) ? sanitize_text_field( wp_unslash( $_GET['step'] ) ) : '';
 
 		// If the user is not connected, redirect to the onboarding page
-		// (skip_redirect is used to prevent infinite redirect)
 		if ( ! $connection->is_connected() && $step !== 'onboarding' ) {
 			$admin_page = add_query_arg(
 				array(
@@ -192,7 +191,7 @@ class Initializer {
 
 			$location = wp_sanitize_redirect( $admin_page );
 
-			// Remove all filters to prevent wp_get_referer filter applied in `fix_redirect` method of `Jetpack_Admin` class
+			// Remove wp_get_referer filter applied in `fix_redirect` method of `Jetpack_Admin` class
 			remove_filter( 'wp_redirect', 'wp_get_referer' );
 			wp_safe_redirect( $location );
 
@@ -200,7 +199,6 @@ class Initializer {
 		}
 
 		// If the user reaches the onboarding page, add a class to the body
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No nonce needed for redirect flow control
 		if ( $step === 'onboarding' ) {
 			add_filter( 'admin_body_class', array( __CLASS__, 'add_onboarding_admin_body_class' ) );
 		}

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -98,7 +98,7 @@ class Initializer {
 		// This is later than the admin-ui package, which runs on 1000
 		add_action( 'admin_init', array( __CLASS__, 'maybe_show_red_bubble' ), 1001 );
 
-		//  Set up the ExPlat package endpoints
+		// Set up the ExPlat package endpoints
 		ExPlat::init();
 
 		// Sets up JITMS.
@@ -174,6 +174,28 @@ class Initializer {
 	 * @return void
 	 */
 	public static function admin_init() {
+		$connection = new Connection_Manager();
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No nonce needed for redirect flow control
+		$skip_redirect = isset( $_GET['skip_redirect'] ) && sanitize_text_field( wp_unslash( $_GET['skip_redirect'] ) ) === 'true';
+
+		if ( ! $connection->is_connected() && ! $skip_redirect ) {
+			$admin_page = add_query_arg(
+				array(
+					'page'          => 'my-jetpack',
+					'skip_redirect' => 'true',
+				),
+				admin_url( 'admin.php' )
+			) . '#/onboarding';
+
+			$location = wp_sanitize_redirect( $admin_page );
+
+			// Remove all filters to prevent wp_get_referer filter applied in `fix_redirect` method of `Jetpack_Admin` class
+			remove_filter( 'wp_redirect', 'wp_get_referer' );
+			wp_safe_redirect( $location );
+
+			exit( 0 );
+		}
+
 		self::$site_info = self::get_site_info();
 		add_filter( 'identity_crisis_container_id', array( static::class, 'get_idc_container_id' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ) );

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -178,6 +178,8 @@ class Initializer {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No nonce needed for redirect flow control
 		$skip_redirect = isset( $_GET['skip_redirect'] ) && sanitize_text_field( wp_unslash( $_GET['skip_redirect'] ) ) === 'true';
 
+		// If the user is not connected, redirect to the onboarding page
+		// (skip_redirect is used to prevent infinite redirect)
 		if ( ! $connection->is_connected() && ! $skip_redirect ) {
 			$admin_page = add_query_arg(
 				array(
@@ -196,6 +198,12 @@ class Initializer {
 			exit( 0 );
 		}
 
+		// If the user reaches the onboarding page, add a class to the body
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No nonce needed for redirect flow control
+		if ( $skip_redirect && isset( $_GET['page'] ) && $_GET['page'] === 'my-jetpack' ) {
+			add_filter( 'admin_body_class', array( __CLASS__, 'add_onboarding_admin_body_class' ) );
+		}
+
 		self::$site_info = self::get_site_info();
 		add_filter( 'identity_crisis_container_id', array( static::class, 'get_idc_container_id' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ) );
@@ -203,6 +211,18 @@ class Initializer {
 		header( 'Cache-Control: no-cache, no-store, must-revalidate' );
 		header( 'Pragma: no-cache' );
 		header( 'Expires: 0' );
+	}
+
+	/**
+	 * Add a body class to the My Jetpack onboarding page.
+	 * This class hides the WP Admin toolbar and the sidebar menu.
+	 *
+	 * @param string $classes The body classes.
+	 * @return string The modified body classes.
+	 */
+	public static function add_onboarding_admin_body_class( $classes ) {
+		$classes .= 'jetpack-admin-full-screen';
+		return $classes;
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -175,19 +175,20 @@ class Initializer {
 	 */
 	public static function admin_init() {
 		$connection = new Connection_Manager();
+
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No nonce needed for redirect flow control
-		$skip_redirect = isset( $_GET['skip_redirect'] ) && sanitize_text_field( wp_unslash( $_GET['skip_redirect'] ) ) === 'true';
+		$step = isset( $_GET['step'] ) ? sanitize_text_field( wp_unslash( $_GET['step'] ) ) : '';
 
 		// If the user is not connected, redirect to the onboarding page
 		// (skip_redirect is used to prevent infinite redirect)
-		if ( ! $connection->is_connected() && ! $skip_redirect ) {
+		if ( ! $connection->is_connected() && $step !== 'onboarding' ) {
 			$admin_page = add_query_arg(
 				array(
-					'page'          => 'my-jetpack',
-					'skip_redirect' => 'true',
+					'page' => 'my-jetpack',
+					'step' => 'onboarding',
 				),
 				admin_url( 'admin.php' )
-			) . '#/onboarding';
+			);
 
 			$location = wp_sanitize_redirect( $admin_page );
 
@@ -200,7 +201,7 @@ class Initializer {
 
 		// If the user reaches the onboarding page, add a class to the body
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No nonce needed for redirect flow control
-		if ( $skip_redirect && isset( $_GET['page'] ) && $_GET['page'] === 'my-jetpack' ) {
+		if ( $step === 'onboarding' ) {
 			add_filter( 'admin_body_class', array( __CLASS__, 'add_onboarding_admin_body_class' ) );
 		}
 
@@ -448,7 +449,11 @@ class Initializer {
 	 * @return void
 	 */
 	public static function admin_page() {
-		echo '<div id="my-jetpack-container"></div>';
+		$step          = isset( $_GET['step'] ) ? sanitize_text_field( wp_unslash( $_GET['step'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$is_onboarding = $step === 'onboarding';
+
+		// Add data attribute for onboarding, otherwise render normal container
+		echo '<div id="my-jetpack-container" ' . ( $is_onboarding ? 'data-route="onboarding"' : '' ) . '></div>';
 	}
 
 	/**

--- a/projects/plugins/backup/changelog/add-link-onboarding-screen-disconnected-users
+++ b/projects/plugins/backup/changelog/add-link-onboarding-screen-disconnected-users
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Improve the onboarding experience of Jetpack guiding the users through a new onboarding process.

--- a/projects/plugins/boost/changelog/add-link-onboarding-screen-disconnected-users
+++ b/projects/plugins/boost/changelog/add-link-onboarding-screen-disconnected-users
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Improve the onboarding experience of Jetpack guiding the users through a new onboarding process.

--- a/projects/plugins/jetpack/changelog/add-link-onboarding-screen-disconnected-users
+++ b/projects/plugins/jetpack/changelog/add-link-onboarding-screen-disconnected-users
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Improve the onboarding experience of Jetpack guiding the users through a new onboarding process.

--- a/projects/plugins/protect/changelog/add-link-onboarding-screen-disconnected-users
+++ b/projects/plugins/protect/changelog/add-link-onboarding-screen-disconnected-users
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Improve the onboarding experience of Jetpack guiding the users through a new onboarding process.

--- a/projects/plugins/search/changelog/add-link-onboarding-screen-disconnected-users
+++ b/projects/plugins/search/changelog/add-link-onboarding-screen-disconnected-users
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Improve the onboarding experience of Jetpack guiding the users through a new onboarding process.

--- a/projects/plugins/social/changelog/add-link-onboarding-screen-disconnected-users
+++ b/projects/plugins/social/changelog/add-link-onboarding-screen-disconnected-users
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Improve the onboarding experience of Jetpack guiding the users through a new onboarding process.

--- a/projects/plugins/starter-plugin/changelog/add-link-onboarding-screen-disconnected-users
+++ b/projects/plugins/starter-plugin/changelog/add-link-onboarding-screen-disconnected-users
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Improve the onboarding experience of Jetpack guiding the users through a new onboarding process.

--- a/projects/plugins/videopress/changelog/add-link-onboarding-screen-disconnected-users
+++ b/projects/plugins/videopress/changelog/add-link-onboarding-screen-disconnected-users
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Improve the onboarding experience of Jetpack guiding the users through a new onboarding process.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes MARTECH-35

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR modifies the `admin_init` method of My Jetpack to ensure that disconnected users go through the new onboarding flow. It also fixes the font stack of the onboarding flow and hide the admin toolbar/sidebar on the backend.


https://github.com/user-attachments/assets/b2037a29-5d80-46e1-a8ed-a06a5fc69505



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with Jetpack Beta pointing to this branch
* Click on "Jetpack" on the sidebar menu on the left
* Confirm it redirects you to the onboarding page if you are not connected
* After you connect (site or user), if you try the same thing, you'll see My Jetpack

