### PR TITLE
Forms: Fix sorting of responses in classic view

### DIFF
--- a/projects/packages/forms/changelog/fix-feedback-classic-view-sorting
+++ b/projects/packages/forms/changelog/fix-feedback-classic-view-sorting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix sorting of responses in classic view

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -64,11 +64,11 @@ class Admin {
 		add_filter( 'views_edit-feedback', array( $this, 'grunion_admin_view_tabs' ) );
 		add_filter( 'manage_feedback_posts_columns', array( $this, 'grunion_post_type_columns_filter' ) );
 
-		add_action( 'manage_pages_custom_column', array( $this, 'grunion_manage_post_columns' ), 10, 2 );
+		add_action( 'manage_posts_custom_column', array( $this, 'grunion_manage_post_columns' ), 10, 2 );
 		add_action( 'restrict_manage_posts', array( $this, 'grunion_source_filter' ) );
 		add_action( 'pre_get_posts', array( $this, 'grunion_source_filter_results' ) );
 
-		add_filter( 'page_row_actions', array( $this, 'grunion_manage_post_row_actions' ), 10, 2 );
+		add_filter( 'post_row_actions', array( $this, 'grunion_manage_post_row_actions' ), 10, 2 );
 
 		add_action( 'wp_ajax_grunion_shortcode', array( $this, 'grunion_ajax_shortcode' ) );
 		add_action( 'wp_ajax_grunion_shortcode_to_json', array( $this, 'grunion_ajax_shortcode_to_json' ) );
@@ -84,27 +84,6 @@ class Admin {
 
 		add_action( 'wp_ajax_grunion_export_to_gdrive', array( $this, 'export_to_gdrive' ) );
 		add_action( 'wp_ajax_grunion_gdrive_connection', array( $this, 'test_gdrive_connection' ) );
-
-		add_action( 'pre_get_posts', array( $this, 'change_feedback_list_order' ) );
-	}
-
-	/**
-	 * Change the `orderby` to `date` and `order` to `desc` of the feedback list.
-	 * This was needed since we made the `feedback` post type `hierarchical`
-	 * and the default order was changed.
-	 *
-	 * This is fine for now because the wp-admin list is going to be removed soon and
-	 * additionally it doesn't provide any sorting option in any of the columns.
-	 *
-	 * @param \WP_Query $query Current query.
-	 *
-	 * @return void
-	 */
-	public function change_feedback_list_order( $query ) {
-		if ( $query->get( 'post_type' ) === 'feedback' ) {
-			$query->set( 'orderby', 'date' );
-			$query->set( 'order', 'desc' );
-		}
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -155,6 +155,13 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	public function get_item_schema() {
 		$schema = parent::get_item_schema();
 
+		$schema['properties']['parent'] = array(
+			'description' => __( 'The ID for the parent of the post. This refers to the post/page where the feedback was created.', 'jetpack-forms' ),
+			'type'        => 'integer',
+			'context'     => array( 'view', 'edit', 'embed' ),
+			'readonly'    => true,
+		);
+
 		$schema['properties']['uid'] = array(
 			'description' => __( 'Unique identifier for the form response.', 'jetpack-forms' ),
 			'type'        => 'string',
@@ -342,6 +349,35 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			);
 		}
 		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Retrieves the query params for the feedback collection.
+	 *
+	 * @return array Collection parameters.
+	 */
+	public function get_collection_params() {
+		$query_params = parent::get_collection_params();
+
+		// Add parent related query parameters since the `feedback` post type is not hierarchical, but
+		// it uses the `parent` field to store the ID of the post/page where the feedback was created.
+		$query_params['parent']         = array(
+			'description' => __( 'Limit result set to items with particular parent IDs.', 'jetpack-forms' ),
+			'type'        => 'array',
+			'items'       => array(
+				'type' => 'integer',
+			),
+			'default'     => array(),
+		);
+		$query_params['parent_exclude'] = array(
+			'description' => __( 'Limit result set to all items except those of a particular parent ID.', 'jetpack-forms' ),
+			'type'        => 'array',
+			'items'       => array(
+				'type' => 'integer',
+			),
+			'default'     => array(),
+		);
+		return $query_params;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -221,7 +221,6 @@ class Contact_Form_Plugin {
 				'query_var'             => false,
 				'capability_type'       => 'page',
 				'show_in_rest'          => true,
-				'hierarchical'          => true,
 				'rest_controller_class' => '\Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint',
 				'capabilities'          => array(
 					'create_posts'        => 'do_not_allow',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes: https://github.com/Automattic/jetpack/issues/42599

In https://github.com/Automattic/jetpack/pull/41602 we updated the new responses inbox view and utilized the `WP_REST_Posts_Controller` for handling the data actions. While the `feedback` post type is not `hierarchical` in the traditional sense ( parent of the same post type), it behaves like one because we store the id of the post/page where the feedback was created in its `parent` property.

That was the reason for [updating](https://github.com/Automattic/jetpack/pull/41602/files#diff-8553b10e9f86366e46982a8e498ca06c0784d5e64c168a19ed759c2be4b2a986R219) its `hierarchical` value in that PR, so we could also filter by `parent` and fetch the `parent` prop in the REST responses 'for free'.

It seems though that particular change affects the classic view (wp-admin) in a quite convoluted way.
1. The `WP_Posts_List_Table` class used to render the admin list has no extension points
2. For `hierarchical` post types it [renders through ](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-admin/includes/class-wp-posts-list-table.php#L812)a different function that groups records by their `parent` value.

### Proposed changes
This PR reverts the `hierarchical` change to feedback post type and adds the neccessary arguments to the REST API endpoint to be able to filter by `parent` and fetch the `parent` prop in the REST responses.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
1. In responses classic (wp-admin) view ensure that the items are sorted by date  in descending order and there is no grouping by their parent
2. Ensure everything else works as before and no regressions are introduced
3. In responses `inbox` view ensure the filtering by parent works as expected and the `source` field have correct values
4. Ensure everything else works as before and no regressions are introduced

