### PR TITLE
RDV: Force treatment group for everyone on WPCom

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-force-rdv-true-by-default
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-force-rdv-true-by-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Enabled the RDV treatment group for everyone

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -6,7 +6,6 @@
  */
 
 use Automattic\Jetpack\Connection\Client;
-use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
 use Automattic\Jetpack\Masterbar\Admin_Menu;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
@@ -336,96 +335,14 @@ const RDV_EXPERIMENT_FORCE_ASSIGN_OPTION = 'remove_duplicate_views_experiment_as
  * @return boolean
  */
 function wpcom_is_duplicate_views_experiment_enabled() {
-	$experiment_platform = 'calypso';
-	$experiment_name     = "{$experiment_platform}_post_onboarding_holdout_160125";
-	$aa_test_name        = "{$experiment_platform}_post_onboarding_aa_150125";
-
-	static $is_enabled = null;
-	if ( $is_enabled !== null ) {
-		return $is_enabled;
-	}
-
-	$host = new Host();
-
-	if ( $host->is_wpcom_simple() && is_automattician() || $host->is_atomic_platform() && wpcom_atomic_rdv_maybe_is_a11n() ) {
-		wpcom_rdv_reset_cache_if_needed();
-	}
-
+	// Check the forced assignment option.
 	$variation = get_user_option( RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, get_current_user_id() );
-
-	/**
-	 * We cache it for both AT and Simple because we want to give a12s to be able to switch between variations for their accounts - this can be useful during support.
-	 * Note that switching the variations can only be achieved through the escape hatch, not via ExPlat.
-	 *
-	 * If we don't cache it, the is_automattician conditions will force treatment every time.
-	 */
 	if ( false !== $variation ) {
-		$is_enabled = 'treatment' === $variation;
-		return $is_enabled;
+		return 'treatment' === $variation;
 	}
 
-	if ( $host->is_wpcom_simple() ) {
-		\ExPlat\assign_current_user( $aa_test_name );
-		$is_enabled = 'treatment' === \ExPlat\assign_current_user( $experiment_name );
-
-		if ( is_automattician() ) {
-			$is_enabled = true;
-			update_user_option( get_current_user_id(), RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, 'treatment', true );
-			wpcom_set_rdv_calypso_preference( 'treatment' );
-		}
-
-		return $is_enabled;
-	}
-
-	if ( wpcom_atomic_rdv_maybe_is_a11n() ) {
-		update_user_option( get_current_user_id(), RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, 'treatment', true );
-		wpcom_set_rdv_calypso_preference( 'treatment' );
-		$is_enabled = true;
-
-		return true;
-	}
-
-	if ( ! ( new Jetpack_Connection() )->is_user_connected() ) {
-		$is_enabled = false;
-		return $is_enabled;
-	}
-
-	$aa_test_request_path = add_query_arg(
-		array( 'experiment_name' => $aa_test_name ),
-		"/experiments/0.1.0/assignments/{$experiment_platform}"
-	);
-	Client::wpcom_json_api_request_as_user( $aa_test_request_path, 'v2' );
-
-	$request_path = add_query_arg(
-		array( 'experiment_name' => $experiment_name ),
-		"/experiments/0.1.0/assignments/{$experiment_platform}"
-	);
-	$response     = Client::wpcom_json_api_request_as_user( $request_path, 'v2' );
-
-	if ( is_wp_error( $response ) ) {
-		$is_enabled = false;
-		return $is_enabled;
-	}
-
-	$response_code = wp_remote_retrieve_response_code( $response );
-
-	if ( 200 !== $response_code ) {
-		$is_enabled = false;
-		return $is_enabled;
-	}
-
-	$data = json_decode( wp_remote_retrieve_body( $response ), true );
-
-	if ( isset( $data['variations'] ) && array_key_exists( $experiment_name, $data['variations'] ) ) {
-		$variation = $data['variations'][ $experiment_name ];
-		update_user_option( get_current_user_id(), RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, $variation, true );
-
-		$is_enabled = 'treatment' === $variation;
-		return $is_enabled;
-	} else {
-		$is_enabled = false;
-		return $is_enabled;
-	}
+	// We default to true for everyone else.
+	return true;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -121,27 +121,6 @@ function wpcom_admin_interface_pre_update_option( $new_value, $old_value ) {
 		);
 	}
 
-	// We want to redirect to Calypso if the user has switched interface options to 'calypso'
-	// Unfortunately we need to run this side-effect in the option updating filter because
-	// the general settings page doesn't give us a good point to hook into the form submission.
-	if ( 'calypso' === $new_value && $on_wp_admin_options_page ) {
-		add_filter(
-			'wp_redirect',
-			/**
-			 * Filters the existing redirect in wp-admin/options.php so we go to Calypso instead
-			 * of to a GET version of the WP Admin general options page.
-			 */
-			function ( $location ) {
-				$updated_settings_page = add_query_arg( 'settings-updated', 'true', wp_get_referer() );
-				if ( $location === $updated_settings_page && ! wpcom_is_duplicate_views_experiment_enabled() ) {
-					return 'https://wordpress.com/settings/general/' . wpcom_get_site_slug();
-				} else {
-					return $location;
-				}
-			}
-		);
-	}
-
 	return $new_value;
 }
 add_filter( 'pre_update_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_update_option', 10, 2 );
@@ -196,6 +175,7 @@ function wpcom_admin_get_current_screen() {
 function wpcom_admin_interface_pre_get_option( $default_value ) {
 	$current_screen = wpcom_admin_get_current_screen();
 
+	// We need to keep the experiment check here so that we can use the re-share feature on Calypso until it's ported to wp-admin.
 	if ( in_array( $current_screen, WPCOM_DUPLICATED_VIEW, true ) && wpcom_is_duplicate_views_experiment_enabled() ) {
 		return 'wp-admin';
 	}
@@ -211,10 +191,6 @@ function wpcom_admin_interface_pre_get_option( $default_value ) {
  * @return array Filtered preferred views.
  */
 function wpcom_admin_get_user_option_jetpack( $value ) {
-	if ( ! wpcom_is_duplicate_views_experiment_enabled() ) {
-		return $value;
-	}
-
 	if ( ! is_array( $value ) ) {
 		$value = array();
 	}
@@ -245,7 +221,7 @@ add_action(
 	PHP_INT_MAX
 );
 /**
- * Hides the "View" switcher on WP Admin screens enforced by the "Remove duplicate views" experiment.
+ * Hides the "View" switcher on WP Admin screens that have been untangled.
  */
 function wpcom_duplicate_views_hide_view_switcher() {
 	$admin_menu_class = wpcom_get_custom_admin_menu_class();
@@ -253,7 +229,7 @@ function wpcom_duplicate_views_hide_view_switcher() {
 		$admin_menu = $admin_menu_class::get_instance();
 
 		$current_screen = wpcom_admin_get_current_screen();
-		if ( in_array( $current_screen, WPCOM_DUPLICATED_VIEW, true ) && wpcom_is_duplicate_views_experiment_enabled() ) {
+		if ( in_array( $current_screen, WPCOM_DUPLICATED_VIEW, true ) ) {
 			remove_filter( 'in_admin_header', array( $admin_menu, 'add_dashboard_switcher' ) );
 		}
 	}
@@ -294,37 +270,6 @@ function wpcom_show_admin_interface_notice() {
 add_action( 'admin_notices', 'wpcom_show_admin_interface_notice' );
 
 /**
- * Force a cache purge.
- *
- * @return void
- */
-function wpcom_rdv_reset_cache_if_needed() {
-	if ( ! get_user_option( 'rdv_force_cache_is_deleted', get_current_user_id() ) ) {
-		update_user_option( get_current_user_id(), 'rdv_force_cache_is_deleted', true, true );
-		delete_user_option( get_current_user_id(), RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, true );
-	}
-}
-
-/**
- * Check if the might be an a11n on Atomic sites.
- *
- * @return bool
- */
-function wpcom_atomic_rdv_maybe_is_a11n() {
-	$is_proxy_atomic    = defined( 'AT_PROXIED_REQUEST' ) && AT_PROXIED_REQUEST;
-	$is_support_session = WPCOMSH_Support_Session_Detect::is_probably_support_session();
-	$admin_menu_is_a11n = isset( $_GET['admin_menu_is_a11n'] ) && function_exists( 'wpcomsh_is_admin_menu_api_request' ) && wpcomsh_is_admin_menu_api_request();
-
-	/**
-	 * This handles two contexts: Calypso and WP-Admin.
-	 *
-	 * Calypso: WPCOM admin-menu API endpoint mapper sends a "admin_menu_is_a11n" param for a12s. If the param exists, then we'll switch to treatment.
-	 * WP-Admin: We check if the user is proxied and if it's not in a support session.
-	 */
-	return $admin_menu_is_a11n || ( $is_proxy_atomic && ! $is_support_session );
-}
-
-/**
  * Option to force and cache the Remove duplicate Views experiment assigned variation.
  */
 const RDV_EXPERIMENT_FORCE_ASSIGN_OPTION = 'remove_duplicate_views_experiment_assignment_160125';
@@ -334,7 +279,7 @@ const RDV_EXPERIMENT_FORCE_ASSIGN_OPTION = 'remove_duplicate_views_experiment_as
  *
  * @return boolean
  */
-function wpcom_is_duplicate_views_experiment_enabled() {
+function wpcom_is_duplicate_views_experiment_enabled(): bool {
 	// Check the forced assignment option.
 	$variation = get_user_option( RDV_EXPERIMENT_FORCE_ASSIGN_OPTION, get_current_user_id() );
 	if ( false !== $variation ) {
@@ -456,20 +401,12 @@ function wpcom_get_custom_admin_menu_class() {
 }
 
 /**
- * Enable the Blaze dashboard (WP-Admin) for users that have the RDV experiment enabled.
+ * Enable the Blaze dashboard (WP-Admin) for users.
  *
  * @param bool $activation_status The activation status - use WP-Admin or Calypso.
  * @return mixed|true
  */
-function wpcom_enable_blaze_dashboard_for_experiment( $activation_status ) {
-	if ( ! wpcom_is_duplicate_views_experiment_enabled() ) {
-		return $activation_status;
-	}
-
-	return true;
-}
-
-add_filter( 'jetpack_blaze_dashboard_enable', 'wpcom_enable_blaze_dashboard_for_experiment' );
+add_filter( 'jetpack_blaze_dashboard_enable', '__return_true' );
 
 /**
  * Make the Jetpack Stats page to point to the Calypso Stats Admin menu - temporary. This is needed because WP-Admin pages are rolled-out individually.
@@ -487,7 +424,7 @@ function wpcom_select_calypso_admin_menu_stats_for_jetpack_post_stats( $file ) {
 
 	$is_on_stats_page = 'admin.php' === $pagenow && isset( $_GET['page'] ) && 'stats' === $_GET['page'];
 
-	if ( ! $is_on_stats_page || ! wpcom_is_duplicate_views_experiment_enabled() ) {
+	if ( ! $is_on_stats_page ) {
 		return $file;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -132,9 +132,7 @@ function wpcom_add_hosting_menu() {
 		esc_attr__( 'Site Settings', 'jetpack-mu-wpcom' ),
 		esc_attr__( 'Site Settings', 'jetpack-mu-wpcom' ),
 		'manage_options',
-		function_exists( 'wpcom_is_duplicate_views_experiment_enabled' ) && wpcom_is_duplicate_views_experiment_enabled() ?
-			esc_url( "https://wordpress.com/sites/settings/site/$domain" ) :
-			esc_url( "https://wordpress.com/settings/general/$domain" ),
+		esc_url( "https://wordpress.com/sites/settings/site/$domain" ),
 		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
 	);
 
@@ -246,17 +244,15 @@ function wpcom_add_jetpack_submenu() {
 		);
 	}
 
-	if ( function_exists( 'wpcom_is_duplicate_views_experiment_enabled' ) && wpcom_is_duplicate_views_experiment_enabled() ) {
-		// Jetpack > Podcasting
-		add_submenu_page(
-			'jetpack',
-			__( 'Podcasting', 'jetpack-mu-wpcom' ),
-			__( 'Podcasting', 'jetpack-mu-wpcom' ),
-			'manage_options',
-			$podcasting_url,
-			null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		);
-	}
+	// Jetpack > Podcasting
+	add_submenu_page(
+		'jetpack',
+		__( 'Podcasting', 'jetpack-mu-wpcom' ),
+		__( 'Podcasting', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		$podcasting_url,
+		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+	);
 
 	// Re-order menu.
 	global $submenu;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -50,8 +50,8 @@ function wpcom_site_management_panel_link() {
  */
 function wpcom_site_management_panel() {
 	$current_screen = wpcom_admin_get_current_screen();
-	if ( in_array( $current_screen, WPCOM_DUPLICATED_VIEW, true ) && wpcom_is_duplicate_views_experiment_enabled() ) {
-		add_settings_field( 'wpcom_site_management_panel_link', __( 'WordPress.com Site Settings', 'jetpack-mu-wpcom' ), 'wpcom_site_management_panel_link', 'general', 'default' );
+	if ( in_array( $current_screen, WPCOM_DUPLICATED_VIEW, true ) ) {
+		add_settings_field( 'wpcom_site_management_panel_link', __( 'WordPress.com Site Settings', 'jetpack-mu-wpcom' ), 'wpcom_site_management_panel_link', 'general' );
 	}
 }
 add_action( 'load-options-general.php', 'wpcom_site_management_panel' );

--- a/projects/packages/masterbar/changelog/add-force-rdv-true-by-default
+++ b/projects/packages/masterbar/changelog/add-force-rdv-true-by-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updated code to avoid using RDV experiment assignment since treat has won.

--- a/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
@@ -395,11 +395,6 @@ class Admin_Menu extends Base_Admin_Menu {
 		add_submenu_page( 'options-general.php', esc_attr__( 'Newsletter', 'jetpack-masterbar' ), __( 'Newsletter', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/newsletter/' . $this->domain, null, 7 );
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		add_submenu_page( 'options-general.php', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/podcasting/' . $this->domain, null, 8 );
-
-		if ( function_exists( 'wpcom_is_duplicate_views_experiment_enabled' ) && ! wpcom_is_duplicate_views_experiment_enabled() ) {
-			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			add_submenu_page( 'options-general.php', esc_attr__( 'Performance', 'jetpack-masterbar' ), __( 'Performance', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/performance/' . $this->domain, null, 9 );
-		}
 	}
 
 	/**

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -74,13 +74,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		$this->add_my_home_menu();
 		$this->remove_gutenberg_menu();
 
-		// We don't need the `My Mailboxes` when the interface is set to wp-admin or the site is a staging site,
-		if ( ! $this->use_wp_admin_interface() && ! get_option( 'wpcom_is_staging_site' ) ) {
-			if ( function_exists( 'wpcom_is_duplicate_views_experiment_enabled' ) && ! wpcom_is_duplicate_views_experiment_enabled() ) {
-				$this->add_my_mailboxes_menu();
-			}
-		}
-
 		// Not needed outside of wp-admin.
 		if ( ! $this->is_api_request ) {
 			$this->add_site_card_menu();
@@ -416,21 +409,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	public function add_options_menu() {
 		parent::add_options_menu();
 
-		if ( Jetpack_Plan::supports( 'security-settings' ) &&
-			function_exists( 'wpcom_is_duplicate_views_experiment_enabled' ) &&
-			! wpcom_is_duplicate_views_experiment_enabled()
-		) {
-			add_submenu_page(
-				'options-general.php',
-				esc_attr__( 'Security', 'jetpack-masterbar' ),
-				__( 'Security', 'jetpack-masterbar' ),
-				'manage_options',
-				'https://wordpress.com/settings/security/' . $this->domain,
-				null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-				2
-			);
-		}
-
 		$has_feature_atomic = function_exists( 'wpcom_site_has_feature' ) && wpcom_site_has_feature( \WPCOM_Features::ATOMIC );
 		add_submenu_page(
 			'options-general.php',
@@ -441,14 +419,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 			11
 		);
-
-		// The calypso based Performance screen is no longer linked from wp-admin and no longer conflicts with the Page Optimize "Performance"submenu item.
-		if ( function_exists( 'wpcom_is_duplicate_views_experiment_enabled' ) && ! wpcom_is_duplicate_views_experiment_enabled() ) {
-			// Page Optimize is active by default on all Atomic sites and registers a Settings > Performance submenu which
-			// would conflict with our own Settings > Performance that links to Calypso, so we hide it it since the Calypso
-			// performance settings already have a link to Page Optimize settings page.
-			$this->hide_submenu_page( 'options-general.php', 'page-optimize' );
-		}
 
 		// Hide Settings > Performance when the interface is set to wp-admin.
 		// This is due to these settings are mostly also available in Jetpack > Settings, in the Performance tab.

--- a/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
@@ -46,9 +46,6 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		parent::reregister_menu_items();
 
 		$this->add_my_home_menu();
-		if ( function_exists( 'wpcom_is_duplicate_views_experiment_enabled' ) && ! wpcom_is_duplicate_views_experiment_enabled() ) {
-			$this->add_my_mailboxes_menu();
-		}
 		$this->remove_gutenberg_menu();
 
 		// Not needed outside of wp-admin.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to:
- https://github.com/Automattic/wp-calypso/issues/101534

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The RDV assignment is now always treated as treatment, though no real assignments are occurring anymore. The codebase will assume the user is in the Treatment group. This change effectively enables the feature by relying on existing logic while we clean up various locations where assignment checks are currently being performed.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
No

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox.
* Use the container in this PR https://github.com/Automattic/wp-calypso/pull/102244
* Test with the AA test and AB test control and treatment groups.
* Make sure the assignment is ignored and you're always getting treatment.
* The escape hatch should continue to work.


