### PR TITLE
Subscriptions: change default value for wpcom_featured_image_in_email setting to true

### DIFF
--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -40,10 +40,18 @@ export function getCurrentVersion( state ) {
 	return get( state.jetpack.initialState, 'currentVersion', '' );
 }
 
+/**
+ *
+ * @param state
+ */
 export function getSiteRoles( state ) {
 	return get( state.jetpack.initialState.stats, 'roles', {} );
 }
 
+/**
+ *
+ * @param state
+ */
 export function getInitialStateStatsData( state ) {
 	return get( state.jetpack.initialState.stats, 'data' );
 }
@@ -78,34 +86,66 @@ export function getCurrenUserEmailAddress( state ) {
 	return get( state.jetpack.initialState, [ 'userData', 'currentUser', 'email' ] );
 }
 
+/**
+ *
+ * @param state
+ */
 export function getSiteRawUrl( state ) {
 	return get( state.jetpack.initialState, 'rawUrl', {} );
 }
 
+/**
+ *
+ * @param state
+ */
 export function getSiteAdminUrl( state ) {
 	return get( state.jetpack.initialState, 'adminUrl', {} );
 }
 
+/**
+ *
+ * @param state
+ */
 export function getSiteTitle( state ) {
 	return get( state.jetpack.initialState, 'siteTitle', '' );
 }
 
+/**
+ *
+ * @param state
+ */
 export function isSitePublic( state ) {
 	return get( state.jetpack.initialState, [ 'connectionStatus', 'isPublic' ] );
 }
 
+/**
+ *
+ * @param state
+ */
 export function isGutenbergAvailable( state ) {
 	return get( state.jetpack.initialState, 'is_gutenberg_available', false );
 }
 
+/**
+ *
+ * @param state
+ */
 export function userIsSubscriber( state ) {
 	return ! get( state.jetpack.initialState.userData.currentUser.permissions, 'edit_posts', false );
 }
 
+/**
+ *
+ * @param state
+ */
 export function userCanPublish( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'publish_posts', false );
 }
 
+/**
+ *
+ * @param state
+ */
 export function userCanManageModules( state ) {
 	return get(
 		state.jetpack.initialState.userData.currentUser.permissions,
@@ -114,6 +154,10 @@ export function userCanManageModules( state ) {
 	);
 }
 
+/**
+ *
+ * @param state
+ */
 export function userCanManageOptions( state ) {
 	return get(
 		state.jetpack.initialState.userData.currentUser.permissions,
@@ -148,10 +192,18 @@ export function userCanManagePlugins( state ) {
 	);
 }
 
+/**
+ *
+ * @param state
+ */
 export function userCanDisconnectSite( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'disconnect', false );
 }
 
+/**
+ *
+ * @param state
+ */
 export function userCanConnectSite( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'connect', false );
 }
@@ -179,6 +231,10 @@ export function userIsMaster( state ) {
 	return get( state.jetpack.initialState.userData.currentUser, 'isMaster', false );
 }
 
+/**
+ *
+ * @param state
+ */
 export function getUserWpComLogin( state ) {
 	return get( state.jetpack.initialState.userData.currentUser, [ 'wpcomUser', 'login' ], '' );
 }
@@ -193,18 +249,34 @@ export function getUserWpComId( state ) {
 	return get( state.jetpack.initialState.userData.currentUser, [ 'wpcomUser', 'ID' ], '' );
 }
 
+/**
+ *
+ * @param state
+ */
 export function getUserWpComEmail( state ) {
 	return get( state.jetpack.initialState.userData.currentUser, [ 'wpcomUser', 'email' ], '' );
 }
 
+/**
+ *
+ * @param state
+ */
 export function getUserWpComAvatar( state ) {
 	return get( state.jetpack.initialState.userData.currentUser, [ 'wpcomUser', 'avatar' ] );
 }
 
+/**
+ *
+ * @param state
+ */
 export function getUserGravatar( state ) {
 	return get( state.jetpack.initialState.userData.currentUser, [ 'gravatar' ] );
 }
 
+/**
+ *
+ * @param state
+ */
 export function getUsername( state ) {
 	return get( state.jetpack.initialState.userData.currentUser, [ 'username' ] );
 }
@@ -230,6 +302,10 @@ export function getUserId( state ) {
 	return get( state.jetpack.initialState.userData.currentUser, 'id', '' );
 }
 
+/**
+ *
+ * @param state
+ */
 export function userCanViewStats( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'view_stats', false );
 }
@@ -276,10 +352,18 @@ export function getLatestBoostSpeedScores( state ) {
 	return get( state.jetpack.initialState.siteData, [ 'latestBoostSpeedScores' ] );
 }
 
+/**
+ *
+ * @param state
+ */
 export function getApiNonce( state ) {
 	return get( state.jetpack.initialState, 'WP_API_nonce' );
 }
 
+/**
+ *
+ * @param state
+ */
 export function getApiRootUrl( state ) {
 	return get( state.jetpack.initialState, 'WP_API_root' );
 }
@@ -327,10 +411,18 @@ export function getCalypsoEnv( state ) {
 	return get( state.jetpack.initialState, 'calypsoEnv' );
 }
 
+/**
+ *
+ * @param state
+ */
 export function getTracksUserData( state ) {
 	return get( state.jetpack.initialState, 'tracksUserData' );
 }
 
+/**
+ *
+ * @param state
+ */
 export function getCurrentIp( state ) {
 	return get( state.jetpack.initialState, 'currentIp' );
 }
@@ -733,16 +825,6 @@ export function isBlazeDashboardEnabled( state ) {
 }
 
 /**
- * Returns true if the wp-admin Subscriber dashboard is enabled.
- *
- * @param {object} state - Global state tree.
- * @return {boolean} True if the Subscriber dashboard is enabled.
- */
-export function isWpAdminSubscriberManagementEnabled( state ) {
-	return !! state.jetpack.initialState.isWpAdminSubscriberManagementEnabled;
-}
-
-/**
  * Check if the Sharing block is available on the site.
  *
  * @param {object} state - Global state tree.
@@ -769,7 +851,7 @@ export function getJetpackManageInfo( state ) {
  * @return {boolean} True if Subscription Site feature is enabled on the site.
  */
 export function isSubscriptionSiteEnabled( state ) {
-	return !! state.jetpack.initialState.isSubscriptionSiteEnabled;
+	return !! state.jetpack.initialState.subscriptions.isSubscriptionSiteEnabled;
 }
 
 /**
@@ -779,7 +861,7 @@ export function isSubscriptionSiteEnabled( state ) {
  * @return {string} Newsletter date example.
  */
 export function getNewsletterDateExample( state ) {
-	return state.jetpack.initialState.newsletterDateExample;
+	return state.jetpack.initialState.subscriptions.newsletterDateExample;
 }
 
 /**
@@ -789,7 +871,27 @@ export function getNewsletterDateExample( state ) {
  * @return {boolean} True if Subscription Site editing feature is supported.
  */
 export function subscriptionSiteEditSupported( state ) {
-	return !! state.jetpack.initialState.subscriptionSiteEditSupported;
+	return !! state.jetpack.initialState.subscriptions.subscriptionSiteEditSupported;
+}
+
+/**
+ * Returns true if the wp-admin Subscriber dashboard is enabled.
+ *
+ * @param {object} state - Global state tree.
+ * @return {boolean} True if the Subscriber dashboard is enabled.
+ */
+export function isWpAdminSubscriberManagementEnabled( state ) {
+	return !! state.jetpack.initialState.subscriptions.isWpAdminSubscriberManagementEnabled;
+}
+
+/**
+ * Returns true if the Featured Images in emails feature is automatically enabled.
+ *
+ * @param {object} state - Global state tree.
+ * @return {boolean} True if the Featured Images in emails feature is automatically enabled.
+ */
+export function isFeaturedImagesInEmailsAutoEnabled( state ) {
+	return !! state.jetpack.initialState.subscriptions.isFeaturedImagesInEmailsAutoEnabled;
 }
 
 /**

--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -34,23 +34,27 @@ export function isDevVersion( state ) {
  * by JETPACK__VERSION
  *
  * @param {object} state - Global state tree
- * @return {string}         Version number. Empty string if the data is not yet available.
+ * @return {string} Version number. Empty string if the data is not yet available.
  */
 export function getCurrentVersion( state ) {
 	return get( state.jetpack.initialState, 'currentVersion', '' );
 }
 
 /**
+ * Gets the site roles configuration.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {object} The roles configuration
  */
 export function getSiteRoles( state ) {
 	return get( state.jetpack.initialState.stats, 'roles', {} );
 }
 
 /**
+ * Gets the initial state stats data.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {object} The initial state stats data
  */
 export function getInitialStateStatsData( state ) {
 	return get( state.jetpack.initialState.stats, 'data' );
@@ -87,64 +91,80 @@ export function getCurrenUserEmailAddress( state ) {
 }
 
 /**
+ * Gets the site's raw URL.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {string} The site's raw URL
  */
 export function getSiteRawUrl( state ) {
 	return get( state.jetpack.initialState, 'rawUrl', {} );
 }
 
 /**
+ * Gets the site's admin URL.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {string} The site's admin URL
  */
 export function getSiteAdminUrl( state ) {
 	return get( state.jetpack.initialState, 'adminUrl', {} );
 }
 
 /**
+ * Gets the site's title.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {string} The site's title
  */
 export function getSiteTitle( state ) {
 	return get( state.jetpack.initialState, 'siteTitle', '' );
 }
 
 /**
+ * Checks if the site is public.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {boolean} True if the site is public
  */
 export function isSitePublic( state ) {
 	return get( state.jetpack.initialState, [ 'connectionStatus', 'isPublic' ] );
 }
 
 /**
+ * Checks if Gutenberg is available.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {boolean} True if Gutenberg is available
  */
 export function isGutenbergAvailable( state ) {
 	return get( state.jetpack.initialState, 'is_gutenberg_available', false );
 }
 
 /**
+ * Checks if the current user is a subscriber.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {boolean} True if the user is a subscriber
  */
 export function userIsSubscriber( state ) {
 	return ! get( state.jetpack.initialState.userData.currentUser.permissions, 'edit_posts', false );
 }
 
 /**
+ * Checks if the current user can publish.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {boolean} True if the user can publish
  */
 export function userCanPublish( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'publish_posts', false );
 }
 
 /**
+ * Checks if the current user can manage modules.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {boolean} True if the user can manage modules
  */
 export function userCanManageModules( state ) {
 	return get(
@@ -155,8 +175,10 @@ export function userCanManageModules( state ) {
 }
 
 /**
+ * Checks if the current user can manage options.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {boolean} True if the user can manage options
  */
 export function userCanManageOptions( state ) {
 	return get(
@@ -193,16 +215,20 @@ export function userCanManagePlugins( state ) {
 }
 
 /**
+ * Checks if the current user can disconnect the site.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {boolean} True if the user can disconnect the site
  */
 export function userCanDisconnectSite( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'disconnect', false );
 }
 
 /**
+ * Checks if the current user can connect the site.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {boolean} True if the user can connect the site
  */
 export function userCanConnectSite( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'connect', false );
@@ -232,8 +258,10 @@ export function userIsMaster( state ) {
 }
 
 /**
+ * Gets the WordPress.com login of the connected user.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {string} The WordPress.com login
  */
 export function getUserWpComLogin( state ) {
 	return get( state.jetpack.initialState.userData.currentUser, [ 'wpcomUser', 'login' ], '' );
@@ -250,36 +278,45 @@ export function getUserWpComId( state ) {
 }
 
 /**
+ * Gets the WordPress.com email of the connected user.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {string} The WordPress.com email
  */
 export function getUserWpComEmail( state ) {
 	return get( state.jetpack.initialState.userData.currentUser, [ 'wpcomUser', 'email' ], '' );
 }
 
 /**
+ * Gets the WordPress.com avatar URL of the connected user.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {string} The WordPress.com avatar URL
  */
 export function getUserWpComAvatar( state ) {
 	return get( state.jetpack.initialState.userData.currentUser, [ 'wpcomUser', 'avatar' ] );
 }
 
 /**
+ * Gets the Gravatar URL of the current user.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {string} The Gravatar URL
  */
 export function getUserGravatar( state ) {
 	return get( state.jetpack.initialState.userData.currentUser, [ 'gravatar' ] );
 }
 
 /**
+ * Gets the username of the current user.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {string} The username
  */
 export function getUsername( state ) {
 	return get( state.jetpack.initialState.userData.currentUser, [ 'username' ] );
 }
+
 /**
  * Gets the current user display name.
  * @param {object} state - Global state tree
@@ -303,8 +340,10 @@ export function getUserId( state ) {
 }
 
 /**
+ * Checks if the current user can view stats.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {boolean} True if the user can view stats
  */
 export function userCanViewStats( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'view_stats', false );
@@ -353,16 +392,20 @@ export function getLatestBoostSpeedScores( state ) {
 }
 
 /**
+ * Gets the API nonce.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {string} The API nonce
  */
 export function getApiNonce( state ) {
 	return get( state.jetpack.initialState, 'WP_API_nonce' );
 }
 
 /**
+ * Gets the API root URL.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {string} The API root URL
  */
 export function getApiRootUrl( state ) {
 	return get( state.jetpack.initialState, 'WP_API_root' );
@@ -412,16 +455,20 @@ export function getCalypsoEnv( state ) {
 }
 
 /**
+ * Gets the Tracks user data.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {object} The Tracks user data
  */
 export function getTracksUserData( state ) {
 	return get( state.jetpack.initialState, 'tracksUserData' );
 }
 
 /**
+ * Gets the current IP address.
  *
- * @param state
+ * @param {object} state - Global state tree
+ * @return {string} The current IP address
  */
 export function getCurrentIp( state ) {
 	return get( state.jetpack.initialState, 'currentIp' );

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -20,6 +20,7 @@ use Automattic\Jetpack\Image_CDN\Image_CDN_Image;
 use Automattic\Jetpack\IP\Utils as IP_Utils;
 use Automattic\Jetpack\Licensing;
 use Automattic\Jetpack\Licensing\Endpoints as Licensing_Endpoints;
+use Automattic\Jetpack\Modules\Subscriptions\Settings as Subscriptions_Settings;
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
 use Automattic\Jetpack\My_Jetpack\Jetpack_Manage;
 use Automattic\Jetpack\Partner;
@@ -249,7 +250,7 @@ class Jetpack_Redux_State_Helper {
 				'subscriptionSiteEditSupported'        => $current_theme->is_block_theme(),
 				'newsletterDateExample'                => gmdate( get_option( 'date_format' ), time() ),
 				'isWpAdminSubscriberManagementEnabled' => apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false ),
-				'isFeaturedImagesInEmailsAutoEnabled'  => Automattic\Jetpack\Modules\Subscriptions\Settings::should_auto_enable_featured_images_emails(),
+				'isFeaturedImagesInEmailsAutoEnabled'  => (bool) Subscriptions_Settings::get_wpcom_featured_image_in_email_default(),
 			),
 		);
 	}

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -136,26 +136,26 @@ class Jetpack_Redux_State_Helper {
 		$block_availability = Jetpack_Gutenberg::get_cached_availability();
 
 		return array(
-			'WP_API_root'                          => esc_url_raw( rest_url() ),
-			'WP_API_nonce'                         => wp_create_nonce( 'wp_rest' ),
-			'registrationNonce'                    => '', // Not used, keeping it for compatibility reasons, see https://github.com/Automattic/jetpack/pull/42076
-			'purchaseToken'                        => self::get_purchase_token(),
-			'partnerCoupon'                        => Jetpack_Partner_Coupon::get_coupon(),
-			'pluginBaseUrl'                        => plugins_url( '', JETPACK__PLUGIN_FILE ),
-			'connectionStatus'                     => $connection_status,
-			'connectedPlugins'                     => Connection_Plugin_Storage::get_all(),
-			'connectUrl'                           => false == $current_user_data['isConnected'] // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+			'WP_API_root'                 => esc_url_raw( rest_url() ),
+			'WP_API_nonce'                => wp_create_nonce( 'wp_rest' ),
+			'registrationNonce'           => '', // Not used, keeping it for compatibility reasons, see https://github.com/Automattic/jetpack/pull/42076
+			'purchaseToken'               => self::get_purchase_token(),
+			'partnerCoupon'               => Jetpack_Partner_Coupon::get_coupon(),
+			'pluginBaseUrl'               => plugins_url( '', JETPACK__PLUGIN_FILE ),
+			'connectionStatus'            => $connection_status,
+			'connectedPlugins'            => Connection_Plugin_Storage::get_all(),
+			'connectUrl'                  => false == $current_user_data['isConnected'] // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 				? Jetpack::init()->build_connect_url( true, false, false )
 				: '',
-			'dismissedNotices'                     => self::get_dismissed_jetpack_notices(),
-			'isDevVersion'                         => Jetpack::is_development_version(),
-			'currentVersion'                       => JETPACK__VERSION,
-			'is_gutenberg_available'               => true,
-			'getModules'                           => $modules,
-			'rawUrl'                               => ( new Status() )->get_site_suffix(),
-			'adminUrl'                             => esc_url( admin_url() ),
-			'siteTitle'                            => (string) htmlspecialchars_decode( get_option( 'blogname' ), ENT_QUOTES ),
-			'stats'                                => array(
+			'dismissedNotices'            => self::get_dismissed_jetpack_notices(),
+			'isDevVersion'                => Jetpack::is_development_version(),
+			'currentVersion'              => JETPACK__VERSION,
+			'is_gutenberg_available'      => true,
+			'getModules'                  => $modules,
+			'rawUrl'                      => ( new Status() )->get_site_suffix(),
+			'adminUrl'                    => esc_url( admin_url() ),
+			'siteTitle'                   => (string) htmlspecialchars_decode( get_option( 'blogname' ), ENT_QUOTES ),
+			'stats'                       => array(
 				// data is populated asynchronously on page load.
 				'data'  => array(
 					'general' => false,
@@ -165,13 +165,13 @@ class Jetpack_Redux_State_Helper {
 				),
 				'roles' => $stats_roles,
 			),
-			'aff'                                  => Partner::init()->get_partner_code( Partner::AFFILIATE_CODE ),
-			'partnerSubsidiaryId'                  => Partner::init()->get_partner_code( Partner::SUBSIDIARY_CODE ),
-			'settings'                             => self::get_flattened_settings(),
-			'userData'                             => array(
+			'aff'                         => Partner::init()->get_partner_code( Partner::AFFILIATE_CODE ),
+			'partnerSubsidiaryId'         => Partner::init()->get_partner_code( Partner::SUBSIDIARY_CODE ),
+			'settings'                    => self::get_flattened_settings(),
+			'userData'                    => array(
 				'currentUser' => $current_user_data,
 			),
-			'siteData'                             => array(
+			'siteData'                    => array(
 				'blog_id'                    => Jetpack_Options::get_option( 'id', 0 ),
 				'icon'                       => has_site_icon()
 					? apply_filters( 'jetpack_photon_url', get_site_icon_url(), array( 'w' => 64 ) )
@@ -199,7 +199,7 @@ class Jetpack_Redux_State_Helper {
 				'isSharingBlockAvailable'    => (bool) isset( $block_availability['sharing-buttons'] )
 					&& $block_availability['sharing-buttons']['available'],
 			),
-			'themeData'                            => array(
+			'themeData'                   => array(
 				'name'         => $current_theme->get( 'Name' ),
 				'stylesheet'   => $current_theme->get_stylesheet(),
 				'hasUpdate'    => (bool) get_theme_update_available( $current_theme ),
@@ -211,44 +211,46 @@ class Jetpack_Redux_State_Helper {
 						&& ( function_exists( 'wp_register_webfont_provider' ) || function_exists( 'wp_register_webfonts' ) ),
 				),
 			),
-			'jetpackStateNotices'                  => array(
+			'jetpackStateNotices'         => array(
 				'messageCode'      => Jetpack::state( 'message' ),
 				'errorCode'        => Jetpack::state( 'error' ),
 				'errorDescription' => Jetpack::state( 'error_description' ),
 				'messageContent'   => Jetpack::state( 'display_update_modal' ) ? self::get_update_modal_data() : null,
 			),
-			'tracksUserData'                       => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
-			'currentIp'                            => IP_Utils::get_ip(),
-			'lastPostUrl'                          => esc_url( $last_post ),
-			'externalServicesConnectUrls'          => self::get_external_services_connect_urls(),
-			'calypsoEnv'                           => ( new Host() )->get_calypso_env(),
-			'products'                             => Jetpack::get_products_for_purchase(),
-			'recommendationsStep'                  => Jetpack_Core_Json_Api_Endpoints::get_recommendations_step()['step'],
-			'isSafari'                             => $is_safari || User_Agent_Info::is_opera_desktop(), // @todo Rename isSafari everywhere.
-			'doNotUseConnectionIframe'             => Constants::is_true( 'JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME' ),
-			'licensing'                            => array(
+			'tracksUserData'              => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
+			'currentIp'                   => IP_Utils::get_ip(),
+			'lastPostUrl'                 => esc_url( $last_post ),
+			'externalServicesConnectUrls' => self::get_external_services_connect_urls(),
+			'calypsoEnv'                  => ( new Host() )->get_calypso_env(),
+			'products'                    => Jetpack::get_products_for_purchase(),
+			'recommendationsStep'         => Jetpack_Core_Json_Api_Endpoints::get_recommendations_step()['step'],
+			'isSafari'                    => $is_safari || User_Agent_Info::is_opera_desktop(), // @todo Rename isSafari everywhere.
+			'doNotUseConnectionIframe'    => Constants::is_true( 'JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME' ),
+			'licensing'                   => array(
 				'error'                   => Licensing::instance()->last_error(),
 				'showLicensingUi'         => Licensing::instance()->is_licensing_input_enabled(),
 				'userCounts'              => Licensing_Endpoints::get_user_license_counts(),
 				'activationNoticeDismiss' => Licensing::instance()->get_license_activation_notice_dismiss(),
 			),
-			'jetpackManage'                        => array(
+			'jetpackManage'               => array(
 				'isEnabled'       => Jetpack_Manage::could_use_jp_manage(),
 				'isAgencyAccount' => Jetpack_Manage::is_agency_account(),
 			),
-			'hasSeenWCConnectionModal'             => Jetpack_Options::get_option( 'has_seen_wc_connection_modal', false ),
-			'newRecommendations'                   => Jetpack_Recommendations::get_new_conditional_recommendations(),
+			'hasSeenWCConnectionModal'    => Jetpack_Options::get_option( 'has_seen_wc_connection_modal', false ),
+			'newRecommendations'          => Jetpack_Recommendations::get_new_conditional_recommendations(),
 			// Check if WooCommerce plugin is active (based on https://docs.woocommerce.com/document/create-a-plugin/).
-			'isWooCommerceActive'                  => in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', Jetpack::get_active_plugins() ), true ),
-			'useMyJetpackLicensingUI'              => My_Jetpack_Initializer::is_licensing_ui_enabled(),
-			'isOdysseyStatsEnabled'                => Stats_Options::get_option( 'enable_odyssey_stats' ),
-			'shouldInitializeBlaze'                => Blaze::should_initialize(),
-			'isBlazeDashboardEnabled'              => Blaze::is_dashboard_enabled(),
-			'isSubscriptionSiteEnabled'            => apply_filters( 'jetpack_subscription_site_enabled', false ),
-			'newsletterDateExample'                => gmdate( get_option( 'date_format' ), time() ),
-			'subscriptionSiteEditSupported'        => $current_theme->is_block_theme(),
-			/* This filter is already documented in jetpack/modules/subscriptions.php */
-			'isWpAdminSubscriberManagementEnabled' => apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false ),
+			'isWooCommerceActive'         => in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', Jetpack::get_active_plugins() ), true ),
+			'useMyJetpackLicensingUI'     => My_Jetpack_Initializer::is_licensing_ui_enabled(),
+			'isOdysseyStatsEnabled'       => Stats_Options::get_option( 'enable_odyssey_stats' ),
+			'shouldInitializeBlaze'       => Blaze::should_initialize(),
+			'isBlazeDashboardEnabled'     => Blaze::is_dashboard_enabled(),
+			'subscriptions'               => array(
+				'isSubscriptionSiteEnabled'            => apply_filters( 'jetpack_subscription_site_enabled', false ),
+				'subscriptionSiteEditSupported'        => $current_theme->is_block_theme(),
+				'newsletterDateExample'                => gmdate( get_option( 'date_format' ), time() ),
+				'isWpAdminSubscriberManagementEnabled' => apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false ),
+				'isFeaturedImagesInEmailsAutoEnabled'  => Automattic\Jetpack\Modules\Subscriptions\Settings::should_auto_enable_featured_images_emails(),
+			),
 		);
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -12,6 +12,7 @@ use Automattic\Jetpack\Connection\REST_Connector;
 use Automattic\Jetpack\Connection\SSO;
 use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
 use Automattic\Jetpack\Jetpack_CRM_Data;
+use Automattic\Jetpack\Modules\Subscriptions\Settings as Subscriptions_Settings;
 use Automattic\Jetpack\Plugins_Installer;
 use Automattic\Jetpack\Stats\Options as Stats_Options;
 use Automattic\Jetpack\Status\Host;
@@ -2647,7 +2648,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'wpcom_featured_image_in_email'             => array(
 				'description'       => esc_html__( 'Whether to include the featured image in the email or not', 'jetpack' ),
 				'type'              => 'boolean',
-				'default'           => Automattic\Jetpack\Modules\Subscriptions\Settings::get_wpcom_featured_image_in_email_default(),
+				'default'           => Subscriptions_Settings::get_wpcom_featured_image_in_email_default(),
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'subscriptions',
 			),
@@ -2682,7 +2683,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'jetpack_subscriptions_reply_to'            => array(
 				'description'       => esc_html__( 'Reply to email behaviour for newsletters emails', 'jetpack' ),
 				'type'              => 'string',
-				'default'           => Automattic\Jetpack\Modules\Subscriptions\Settings::$default_reply_to,
+				'default'           => Subscriptions_Settings::$default_reply_to,
 				'validate_callback' => __CLASS__ . '::validate_subscriptions_reply_to',
 				'jp_group'          => 'subscriptions',
 			),

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2647,7 +2647,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'wpcom_featured_image_in_email'             => array(
 				'description'       => esc_html__( 'Whether to include the featured image in the email or not', 'jetpack' ),
 				'type'              => 'boolean',
-				'default'           => 0,
+				'default'           => Automattic\Jetpack\Modules\Subscriptions\Settings::get_wpcom_featured_image_in_email_default(),
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'subscriptions',
 			),

--- a/projects/plugins/jetpack/changelog/add-subscriptions-cache-registered-check
+++ b/projects/plugins/jetpack/changelog/add-subscriptions-cache-registered-check
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: other
 
-Subscriptions: add method to check if the site was recently connected to WordPress.com.
+Subscriptions: change the default value for the Featured Image in Email setting to true for sites created/registered after 2025-04-01.

--- a/projects/plugins/jetpack/changelog/add-subscriptions-cache-registered-check
+++ b/projects/plugins/jetpack/changelog/add-subscriptions-cache-registered-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: add method to check if the site was recently connected to WordPress.com.

--- a/projects/plugins/jetpack/changelog/add-subscriptions-cache-registered-check
+++ b/projects/plugins/jetpack/changelog/add-subscriptions-cache-registered-check
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Subscriptions: change the default value for the Featured Image in Email setting to true for sites created/registered after 2025-04-01.
+Subscriptions: change the default value for the Featured Image in Email setting to true for sites created/registered after 2025-04-04.

--- a/projects/plugins/jetpack/changelog/add-subscriptions-cache-registered-check
+++ b/projects/plugins/jetpack/changelog/add-subscriptions-cache-registered-check
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Subscriptions: change the default value for the Featured Image in Email setting to true for sites created/registered after 2025-04-04.
+Subscriptions: change the default value for the Featured Image in Email setting to true for sites created/registered after 2025-04-01.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -462,7 +462,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'posts_per_rss'                    => (int) get_option( 'posts_per_rss' ),
 						'rss_use_excerpt'                  => (bool) get_option( 'rss_use_excerpt' ),
 						'launchpad_screen'                 => (string) get_option( 'launchpad_screen' ),
-						'wpcom_featured_image_in_email'    => (bool) get_option( 'wpcom_featured_image_in_email', $this->get_wpcom_featured_image_in_email_default() ),
+						'wpcom_featured_image_in_email'    => $this->get_wpcom_featured_image_in_email_option(),
 						'jetpack_gravatar_in_email'        => (bool) get_option( 'jetpack_gravatar_in_email', true ),
 						'jetpack_author_in_email'          => (bool) get_option( 'jetpack_author_in_email', true ),
 						'jetpack_post_date_in_email'       => (bool) get_option( 'jetpack_post_date_in_email', true ),
@@ -1304,11 +1304,16 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	/**
 	 * Get the default value for the wpcom_featured_image_in_email option.
 	 *
-	 * @return int The default value for showing featured images in emails.
+	 * @return bool The default value for showing featured images in emails.
 	 */
-	protected function get_wpcom_featured_image_in_email_default() {
+	protected function get_wpcom_featured_image_in_email_option() {
+		$is_enabled = get_option( 'wpcom_featured_image_in_email', null );
+		if ( $is_enabled !== null ) {
+			return (bool) $is_enabled;
+		}
+		// If the option is not set, we need to check which default value to provide based on site creation date.
 		require_once JETPACK__PLUGIN_DIR . 'modules/subscriptions/class-settings.php';
-		return Automattic\Jetpack\Modules\Subscriptions\Settings::get_wpcom_featured_image_in_email_default();
+		return (bool) Automattic\Jetpack\Modules\Subscriptions\Settings::get_wpcom_featured_image_in_email_default();
 	}
 
 	/**

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -462,7 +462,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'posts_per_rss'                    => (int) get_option( 'posts_per_rss' ),
 						'rss_use_excerpt'                  => (bool) get_option( 'rss_use_excerpt' ),
 						'launchpad_screen'                 => (string) get_option( 'launchpad_screen' ),
-						'wpcom_featured_image_in_email'    => (bool) get_option( 'wpcom_featured_image_in_email' ),
+						'wpcom_featured_image_in_email'    => (bool) get_option( 'wpcom_featured_image_in_email', $this->get_wpcom_featured_image_in_email_default() ),
 						'jetpack_gravatar_in_email'        => (bool) get_option( 'jetpack_gravatar_in_email', true ),
 						'jetpack_author_in_email'          => (bool) get_option( 'jetpack_author_in_email', true ),
 						'jetpack_post_date_in_email'       => (bool) get_option( 'jetpack_post_date_in_email', true ),
@@ -1299,6 +1299,16 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 			return Automattic\Jetpack\Modules\Subscriptions\Settings::$default_reply_to;
 		}
 		return $reply_to;
+	}
+
+	/**
+	 * Get the default value for the wpcom_featured_image_in_email option.
+	 *
+	 * @return int The default value for showing featured images in emails.
+	 */
+	protected function get_wpcom_featured_image_in_email_default() {
+		require_once JETPACK__PLUGIN_DIR . 'modules/subscriptions/class-settings.php';
+		return Automattic\Jetpack\Modules\Subscriptions\Settings::get_wpcom_featured_image_in_email_default();
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/subscriptions/class-settings.php
+++ b/projects/plugins/jetpack/modules/subscriptions/class-settings.php
@@ -22,7 +22,7 @@ class Settings {
 	 *
 	 * @var string
 	 */
-	public const FEATURED_IMAGE_EMAIL_CUTOFF_DATE = '2025-04-01 00:00:00.000';
+	public const FEATURED_IMAGE_EMAIL_CUTOFF_DATE = '2025-04-04 00:00:00.000';
 
 	/**
 	 * The default reply-to option.

--- a/projects/plugins/jetpack/modules/subscriptions/class-settings.php
+++ b/projects/plugins/jetpack/modules/subscriptions/class-settings.php
@@ -57,8 +57,7 @@ class Settings {
 	 * @return int 1 if featured images should be enabled by default, 0 otherwise.
 	 */
 	public static function get_wpcom_featured_image_in_email_default() {
-		$res = self::should_auto_enable_featured_images_emails();
-		return $res;
+		return (int) self::should_auto_enable_featured_images_emails();
 	}
 
 	/**
@@ -96,7 +95,12 @@ class Settings {
 
 		$site_creation_date = get_transient( 'jetpack_subscriptions_site_creation' );
 		if ( false === $site_creation_date ) {
-			$site_id       = Manager::get_site_id();
+			$site_id = Manager::get_site_id();
+
+			if ( is_wp_error( $site_id ) || ! $site_id ) {
+				return $default_date;
+			}
+
 			$site_response = Client::wpcom_json_api_request_as_blog(
 				sprintf( '/sites/%d', $site_id ) . '?force=wpcom&options=created_at',
 				'1.1'

--- a/projects/plugins/jetpack/modules/subscriptions/class-settings.php
+++ b/projects/plugins/jetpack/modules/subscriptions/class-settings.php
@@ -66,7 +66,7 @@ class Settings {
 			if ( ! $site_data || ! isset( $site_data->options->created_at ) ) {
 				return false;
 			}
-			l( $site_data->options->created_at );
+
 			$site_creation_date = new DateTimeImmutable(
 				$site_data->options->created_at,
 				wp_timezone()

--- a/projects/plugins/jetpack/modules/subscriptions/class-settings.php
+++ b/projects/plugins/jetpack/modules/subscriptions/class-settings.php
@@ -69,7 +69,7 @@ class Settings {
 		$default_date = new DateTimeImmutable( '0000-00-00 00:00:00.000', wp_timezone() );
 		$blog_id      = get_current_blog_id();
 
-		if ( ! function_exists( 'get_blog_details' ) || is_wp_error( $blog_id ) ) {
+		if ( ! function_exists( 'get_blog_details' ) || ! $blog_id ) {
 			return $default_date;
 		}
 

--- a/projects/plugins/jetpack/modules/subscriptions/class-settings.php
+++ b/projects/plugins/jetpack/modules/subscriptions/class-settings.php
@@ -23,7 +23,7 @@ class Settings {
 	 *
 	 * @var string
 	 */
-	public const FEATURED_IMAGE_EMAIL_CUTOFF_DATE = '2025-03-28 00:00:00.000';
+	public const FEATURED_IMAGE_EMAIL_CUTOFF_DATE = '2025-04-01 00:00:00.000';
 
 	/**
 	 * The default reply-to option.

--- a/projects/plugins/jetpack/modules/subscriptions/class-settings.php
+++ b/projects/plugins/jetpack/modules/subscriptions/class-settings.php
@@ -9,6 +9,10 @@
 
 namespace Automattic\Jetpack\Modules\Subscriptions;
 
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager;
+use DateTimeImmutable;
+
 /**
  * Class Settings
  */
@@ -32,5 +36,46 @@ class Settings {
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Check if Featured Images in emails should be automatically enabled.
+	 * We currently only automatically enabled this for sites that were connected to WordPress.com after 2025-03-28.
+	 *
+	 * @return bool Whether Featured Images in emails should be automatically enabled.
+	 */
+	public static function should_auto_enable_featured_images_emails() {
+		if ( ! ( new Manager() )->is_connected() ) {
+			return false;
+		}
+
+		$site_creation_date = get_transient( 'jetpack_subscriptions_site_creation' );
+		if ( false !== $site_creation_date ) {
+			$site_id       = Manager::get_site_id();
+			$site_response = Client::wpcom_json_api_request_as_blog(
+				sprintf( '/sites/%d', $site_id ) . '?force=wpcom&options=created_at',
+				'1.1'
+			);
+
+			if ( is_wp_error( $site_response ) ) {
+				return false;
+			}
+
+			$site_data = json_decode( wp_remote_retrieve_body( $site_response ) );
+
+			if ( ! $site_data || ! isset( $site_data->options->created_at ) ) {
+				return false;
+			}
+			l( $site_data->options->created_at );
+			$site_creation_date = new DateTimeImmutable(
+				$site_data->options->created_at,
+				wp_timezone()
+			);
+
+			set_transient( 'jetpack_subscriptions_site_creation', $site_creation_date, DAY_IN_SECONDS );
+		}
+
+		// Check if the site was created after 2025-03-28.
+		return $site_creation_date > new DateTimeImmutable( '2025-03-28 00:00:00.000', wp_timezone() );
 	}
 }

--- a/projects/plugins/jetpack/modules/subscriptions/class-settings.php
+++ b/projects/plugins/jetpack/modules/subscriptions/class-settings.php
@@ -57,7 +57,9 @@ class Settings {
 	 * @return int 1 if featured images should be enabled by default, 0 otherwise.
 	 */
 	public static function get_wpcom_featured_image_in_email_default() {
-		return (int) self::should_auto_enable_featured_images_emails();
+		$res = self::should_auto_enable_featured_images_emails();
+		l( $res );
+		return (int) $res;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/subscriptions/class-settings.php
+++ b/projects/plugins/jetpack/modules/subscriptions/class-settings.php
@@ -22,7 +22,7 @@ class Settings {
 	 *
 	 * @var string
 	 */
-	public const FEATURED_IMAGE_EMAIL_CUTOFF_DATE = '2025-04-04 00:00:00.000';
+	public const FEATURED_IMAGE_EMAIL_CUTOFF_DATE = '2025-04-01 00:00:00.000';
 
 	/**
 	 * The default reply-to option.

--- a/projects/plugins/jetpack/modules/subscriptions/class-settings.php
+++ b/projects/plugins/jetpack/modules/subscriptions/class-settings.php
@@ -11,7 +11,6 @@ namespace Automattic\Jetpack\Modules\Subscriptions;
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager;
-use DateTimeImmutable;
 
 /**
  * Class Settings
@@ -50,64 +49,60 @@ class Settings {
 	 * Get the default setting value for wpcom_featured_image_in_email.
 	 *
 	 * This method determines the site environment (WPCOM vs Jetpack),
-	 * retrieves the appropriate site creation date, and compares it
+	 * retrieves the appropriate site creation timestamp, and compares it
 	 * against a cutoff date to determine the default setting.
 	 *
 	 * @return int 1 if featured images should be enabled by default, 0 otherwise.
 	 */
 	public static function get_wpcom_featured_image_in_email_default() {
-		$creation_date = null;
+		$creation_timestamp = null;
 
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$creation_date = self::get_wpcom_site_creation_date();
+			$creation_timestamp = self::get_wpcom_site_registered_timestamp();
 		} else {
-			$manager       = new Manager();
-			$creation_date = self::get_jetpack_cache_site_creation_date( $manager );
+			$manager            = new Manager();
+			$creation_timestamp = self::get_jetpack_cache_site_creation_timestamp( $manager );
 		}
 
-		// If $creation_date remained null for some reason, fallback to the default value.
-		if ( ! $creation_date instanceof DateTimeImmutable ) {
+		// If $creation_timestamp remained null for some reason, fallback to the default value.
+		if ( ! is_int( $creation_timestamp ) ) {
 			return 0;
 		}
 
-		return (int) self::is_site_eligible_for_new_default( $creation_date );
+		return (int) self::is_site_eligible_for_new_default( $creation_timestamp );
 	}
 
 	/**
 	 * Checks if a site, based on its creation date, qualifies for the new default.
 	 *
-	 * @param DateTimeImmutable $creation_date The site's creation date.
+	 * @param int $creation_timestamp The site's creation date as a Unix timestamp.
 	 * @return bool True if the site date is after the cutoff, false otherwise.
 	 */
-	public static function is_site_eligible_for_new_default( DateTimeImmutable $creation_date ) {
+	public static function is_site_eligible_for_new_default( $creation_timestamp ) {
+		$cutoff_timestamp = strtotime( self::FEATURED_IMAGE_EMAIL_CUTOFF_DATE );
 
-		$cutoff_date = new DateTimeImmutable(
-			self::FEATURED_IMAGE_EMAIL_CUTOFF_DATE,
-			wp_timezone()
-		);
-
-		return $creation_date > $cutoff_date;
+		return $creation_timestamp > $cutoff_timestamp;
 	}
 
 	/**
-	 * Get the WordPress.com site creation date.
+	 * Get the WordPress.com site registered date.
 	 *
-	 * @return DateTimeImmutable The site creation date or default fallback date.
+	 * @return int The site creation date as a Unix timestamp or 0 for default fallback.
 	 */
-	public static function get_wpcom_site_creation_date() {
-		$default_date = new DateTimeImmutable( '0000-00-00 00:00:00.000', wp_timezone() );
-		$blog_id      = get_current_blog_id();
+	public static function get_wpcom_site_registered_timestamp() {
+		$default_timestamp = 0;
+		$blog_id           = get_current_blog_id();
 
 		if ( ! function_exists( 'get_blog_details' ) || ! $blog_id ) {
-			return $default_date;
+			return $default_timestamp;
 		}
 
 		$details = get_blog_details( $blog_id );
 		if ( ! $details || empty( $details->registered ) ) {
-			return $default_date;
+			return $default_timestamp;
 		}
 
-		return new DateTimeImmutable( $details->registered, wp_timezone() );
+		return strtotime( $details->registered );
 	}
 
 	/**
@@ -115,26 +110,26 @@ class Settings {
 	 * Requires an instantiated Connection_Manager.
 	 *
 	 * @param Manager $manager Instantiated Connection Manager.
-	 * @return DateTimeImmutable The site creation date or default fallback date.
+	 * @return int The site creation date as a Unix timestamp or 0 for default fallback.
 	 */
-	public static function get_jetpack_cache_site_creation_date( Manager $manager ) {
-		$default_date = new DateTimeImmutable( '0000-00-00 00:00:00.000', wp_timezone() );
+	public static function get_jetpack_cache_site_creation_timestamp( Manager $manager ) {
+		$default_timestamp = 0;
 
 		if ( ! $manager->is_connected() ) {
-			return $default_date;
+			return $default_timestamp;
 		}
 
-		$transient_key        = 'jetpack_subscriptions_site_creation';
-		$cached_creation_date = get_transient( $transient_key );
+		$transient_key             = 'jetpack_subscriptions_site_creation';
+		$cached_creation_timestamp = get_transient( $transient_key );
 
-		if ( false !== $cached_creation_date ) {
-			return $cached_creation_date;
+		if ( false !== $cached_creation_timestamp ) {
+			return $cached_creation_timestamp;
 		}
 
 		$site_id = Manager::get_site_id();
 
 		if ( is_wp_error( $site_id ) || ! $site_id ) {
-			return $default_date;
+			return $default_timestamp;
 		}
 
 		$site_response = Client::wpcom_json_api_request_as_blog(
@@ -143,23 +138,20 @@ class Settings {
 		);
 
 		if ( is_wp_error( $site_response ) ) {
-			return $default_date;
+			return $default_timestamp;
 		}
 
 		$body      = wp_remote_retrieve_body( $site_response );
 		$site_data = json_decode( $body );
 
 		if ( ! $site_data || ! isset( $site_data->options->created_at ) ) {
-			return $default_date;
+			return $default_timestamp;
 		}
 
-		$site_creation_date = new DateTimeImmutable(
-			$site_data->options->created_at,
-			wp_timezone()
-		);
+		$site_creation_timestamp = strtotime( $site_data->options->created_at );
 
-		set_transient( $transient_key, $site_creation_date, DAY_IN_SECONDS );
+		set_transient( $transient_key, $site_creation_timestamp, DAY_IN_SECONDS );
 
-		return $site_creation_date;
+		return $site_creation_timestamp;
 	}
 }

--- a/projects/plugins/jetpack/modules/subscriptions/class-settings.php
+++ b/projects/plugins/jetpack/modules/subscriptions/class-settings.php
@@ -58,8 +58,7 @@ class Settings {
 	 */
 	public static function get_wpcom_featured_image_in_email_default() {
 		$res = self::should_auto_enable_featured_images_emails();
-		error_log( $res );
-		return (int) $res;
+		return $res;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/subscriptions/class-settings.php
+++ b/projects/plugins/jetpack/modules/subscriptions/class-settings.php
@@ -65,7 +65,7 @@ class Settings {
 	 *
 	 * @return DateTimeImmutable The site creation date or default date if not available.
 	 */
-	protected function get_wpcom_site_creation_date() {
+	protected static function get_wpcom_site_creation_date() {
 		$default_date = new DateTimeImmutable( '0000-00-00 00:00:00.000', wp_timezone() );
 		$blog_id      = get_current_blog_id();
 
@@ -78,7 +78,7 @@ class Settings {
 			return $default_date;
 		}
 
-		return $details->registered;
+		return new DateTimeImmutable( $details->registered, wp_timezone() );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/subscriptions/class-settings.php
+++ b/projects/plugins/jetpack/modules/subscriptions/class-settings.php
@@ -58,7 +58,7 @@ class Settings {
 	 */
 	public static function get_wpcom_featured_image_in_email_default() {
 		$res = self::should_auto_enable_featured_images_emails();
-		l( $res );
+		error_log( $res );
 		return (int) $res;
 	}
 

--- a/projects/plugins/jetpack/modules/subscriptions/class-settings.php
+++ b/projects/plugins/jetpack/modules/subscriptions/class-settings.php
@@ -69,7 +69,7 @@ class Settings {
 		$default_date = new DateTimeImmutable( '0000-00-00 00:00:00.000', wp_timezone() );
 		$blog_id      = get_current_blog_id();
 
-		if ( ! function_exists( 'get_blog_details' ) || ! $blog_id ) {
+		if ( ! function_exists( 'get_blog_details' ) || is_wp_error( $blog_id ) ) {
 			return $default_date;
 		}
 

--- a/projects/plugins/jetpack/modules/subscriptions/class-settings.php
+++ b/projects/plugins/jetpack/modules/subscriptions/class-settings.php
@@ -50,7 +50,7 @@ class Settings {
 		}
 
 		$site_creation_date = get_transient( 'jetpack_subscriptions_site_creation' );
-		if ( false !== $site_creation_date ) {
+		if ( false === $site_creation_date ) {
 			$site_id       = Manager::get_site_id();
 			$site_response = Client::wpcom_json_api_request_as_blog(
 				sprintf( '/sites/%d', $site_id ) . '?force=wpcom&options=created_at',

--- a/projects/plugins/jetpack/modules/subscriptions/class-settings.php
+++ b/projects/plugins/jetpack/modules/subscriptions/class-settings.php
@@ -18,6 +18,14 @@ use DateTimeImmutable;
  */
 class Settings {
 	/**
+	 * Cutoff date for automatically enabling featured images in emails.
+	 * Sites created/connected after this date get the new default (true/1).
+	 *
+	 * @var string
+	 */
+	public const FEATURED_IMAGE_EMAIL_CUTOFF_DATE = '2025-03-28 00:00:00.000';
+
+	/**
 	 * The default reply-to option.
 	 *
 	 * @var string
@@ -39,33 +47,54 @@ class Settings {
 	}
 
 	/**
-	 * Check if Featured Images in emails should be automatically enabled.
-	 * We currently only automatically enabled this for sites that were created on or connected to WordPress.com after 2025-03-28.
+	 * Get the default setting value for wpcom_featured_image_in_email.
 	 *
-	 * @return bool Whether Featured Images in emails should be automatically enabled.
-	 */
-	public static function should_auto_enable_featured_images_emails() {
-		$creation_date = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? self::get_wpcom_site_creation_date() : self::get_cache_site_creation_date();
-
-		// Check if the site was created after 2025-03-28.
-		return $creation_date > new DateTimeImmutable( '2025-03-28 00:00:00.000', wp_timezone() );
-	}
-
-	/**
-	 * Get the default setting for wpcom_featured_image_in_email.
+	 * This method determines the site environment (WPCOM vs Jetpack),
+	 * retrieves the appropriate site creation date, and compares it
+	 * against a cutoff date to determine the default setting.
 	 *
 	 * @return int 1 if featured images should be enabled by default, 0 otherwise.
 	 */
 	public static function get_wpcom_featured_image_in_email_default() {
-		return (int) self::should_auto_enable_featured_images_emails();
+		$creation_date = null;
+
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$creation_date = self::get_wpcom_site_creation_date();
+		} else {
+			$manager       = new Manager();
+			$creation_date = self::get_jetpack_cache_site_creation_date( $manager );
+		}
+
+		// If $creation_date remained null for some reason, fallback to the default value.
+		if ( ! $creation_date instanceof DateTimeImmutable ) {
+			return 0;
+		}
+
+		return (int) self::is_site_eligible_for_new_default( $creation_date );
+	}
+
+	/**
+	 * Checks if a site, based on its creation date, qualifies for the new default.
+	 *
+	 * @param DateTimeImmutable $creation_date The site's creation date.
+	 * @return bool True if the site date is after the cutoff, false otherwise.
+	 */
+	public static function is_site_eligible_for_new_default( DateTimeImmutable $creation_date ) {
+
+		$cutoff_date = new DateTimeImmutable(
+			self::FEATURED_IMAGE_EMAIL_CUTOFF_DATE,
+			wp_timezone()
+		);
+
+		return $creation_date > $cutoff_date;
 	}
 
 	/**
 	 * Get the WordPress.com site creation date.
 	 *
-	 * @return DateTimeImmutable The site creation date or default date if not available.
+	 * @return DateTimeImmutable The site creation date or default fallback date.
 	 */
-	protected static function get_wpcom_site_creation_date() {
+	public static function get_wpcom_site_creation_date() {
 		$default_date = new DateTimeImmutable( '0000-00-00 00:00:00.000', wp_timezone() );
 		$blog_id      = get_current_blog_id();
 
@@ -74,7 +103,7 @@ class Settings {
 		}
 
 		$details = get_blog_details( $blog_id );
-		if ( ! $details || ! isset( $details->registered ) ) {
+		if ( ! $details || empty( $details->registered ) ) {
 			return $default_date;
 		}
 
@@ -82,47 +111,54 @@ class Settings {
 	}
 
 	/**
-	 * Get the Jetpack cache site's creation date.
+	 * Get the Jetpack site's creation date (fetched via API).
+	 * Requires an instantiated Connection_Manager.
 	 *
-	 * @return DateTimeImmutable The site creation date or default date if not available.
+	 * @param Manager $manager Instantiated Connection Manager.
+	 * @return DateTimeImmutable The site creation date or default fallback date.
 	 */
-	protected static function get_cache_site_creation_date() {
+	public static function get_jetpack_cache_site_creation_date( Manager $manager ) {
 		$default_date = new DateTimeImmutable( '0000-00-00 00:00:00.000', wp_timezone() );
 
-		if ( ! ( new Manager() )->is_connected() ) {
+		if ( ! $manager->is_connected() ) {
 			return $default_date;
 		}
 
-		$site_creation_date = get_transient( 'jetpack_subscriptions_site_creation' );
-		if ( false === $site_creation_date ) {
-			$site_id = Manager::get_site_id();
+		$transient_key        = 'jetpack_subscriptions_site_creation';
+		$cached_creation_date = get_transient( $transient_key );
 
-			if ( is_wp_error( $site_id ) || ! $site_id ) {
-				return $default_date;
-			}
-
-			$site_response = Client::wpcom_json_api_request_as_blog(
-				sprintf( '/sites/%d', $site_id ) . '?force=wpcom&options=created_at',
-				'1.1'
-			);
-
-			if ( is_wp_error( $site_response ) ) {
-				return $default_date;
-			}
-
-			$site_data = json_decode( wp_remote_retrieve_body( $site_response ) );
-
-			if ( ! $site_data || ! isset( $site_data->options->created_at ) ) {
-				return $default_date;
-			}
-
-			$site_creation_date = new DateTimeImmutable(
-				$site_data->options->created_at,
-				wp_timezone()
-			);
-
-			set_transient( 'jetpack_subscriptions_site_creation', $site_creation_date, DAY_IN_SECONDS );
+		if ( false !== $cached_creation_date ) {
+			return $cached_creation_date;
 		}
+
+		$site_id = Manager::get_site_id();
+
+		if ( is_wp_error( $site_id ) || ! $site_id ) {
+			return $default_date;
+		}
+
+		$site_response = Client::wpcom_json_api_request_as_blog(
+			sprintf( '/sites/%d', $site_id ) . '?force=wpcom&options=created_at',
+			'1.1'
+		);
+
+		if ( is_wp_error( $site_response ) ) {
+			return $default_date;
+		}
+
+		$body      = wp_remote_retrieve_body( $site_response );
+		$site_data = json_decode( $body );
+
+		if ( ! $site_data || ! isset( $site_data->options->created_at ) ) {
+			return $default_date;
+		}
+
+		$site_creation_date = new DateTimeImmutable(
+			$site_data->options->created_at,
+			wp_timezone()
+		);
+
+		set_transient( $transient_key, $site_creation_date, DAY_IN_SECONDS );
 
 		return $site_creation_date;
 	}

--- a/projects/plugins/jetpack/modules/subscriptions/class-settings.php
+++ b/projects/plugins/jetpack/modules/subscriptions/class-settings.php
@@ -40,13 +40,57 @@ class Settings {
 
 	/**
 	 * Check if Featured Images in emails should be automatically enabled.
-	 * We currently only automatically enabled this for sites that were connected to WordPress.com after 2025-03-28.
+	 * We currently only automatically enabled this for sites that were created on or connected to WordPress.com after 2025-03-28.
 	 *
 	 * @return bool Whether Featured Images in emails should be automatically enabled.
 	 */
 	public static function should_auto_enable_featured_images_emails() {
+		$creation_date = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? self::get_wpcom_site_creation_date() : self::get_cache_site_creation_date();
+
+		// Check if the site was created after 2025-03-28.
+		return $creation_date > new DateTimeImmutable( '2025-03-28 00:00:00.000', wp_timezone() );
+	}
+
+	/**
+	 * Get the default setting for wpcom_featured_image_in_email.
+	 *
+	 * @return int 1 if featured images should be enabled by default, 0 otherwise.
+	 */
+	public static function get_wpcom_featured_image_in_email_default() {
+		return (int) self::should_auto_enable_featured_images_emails();
+	}
+
+	/**
+	 * Get the WordPress.com site creation date.
+	 *
+	 * @return DateTimeImmutable The site creation date or default date if not available.
+	 */
+	protected function get_wpcom_site_creation_date() {
+		$default_date = new DateTimeImmutable( '0000-00-00 00:00:00.000', wp_timezone() );
+		$blog_id      = get_current_blog_id();
+
+		if ( ! function_exists( 'get_blog_details' ) || ! $blog_id ) {
+			return $default_date;
+		}
+
+		$details = get_blog_details( $blog_id );
+		if ( ! $details || ! isset( $details->registered ) ) {
+			return $default_date;
+		}
+
+		return $details->registered;
+	}
+
+	/**
+	 * Get the Jetpack cache site's creation date.
+	 *
+	 * @return DateTimeImmutable The site creation date or default date if not available.
+	 */
+	protected static function get_cache_site_creation_date() {
+		$default_date = new DateTimeImmutable( '0000-00-00 00:00:00.000', wp_timezone() );
+
 		if ( ! ( new Manager() )->is_connected() ) {
-			return false;
+			return $default_date;
 		}
 
 		$site_creation_date = get_transient( 'jetpack_subscriptions_site_creation' );
@@ -58,13 +102,13 @@ class Settings {
 			);
 
 			if ( is_wp_error( $site_response ) ) {
-				return false;
+				return $default_date;
 			}
 
 			$site_data = json_decode( wp_remote_retrieve_body( $site_response ) );
 
 			if ( ! $site_data || ! isset( $site_data->options->created_at ) ) {
-				return false;
+				return $default_date;
 			}
 
 			$site_creation_date = new DateTimeImmutable(
@@ -75,7 +119,6 @@ class Settings {
 			set_transient( 'jetpack_subscriptions_site_creation', $site_creation_date, DAY_IN_SECONDS );
 		}
 
-		// Check if the site was created after 2025-03-28.
-		return $site_creation_date > new DateTimeImmutable( '2025-03-28 00:00:00.000', wp_timezone() );
+		return $site_creation_date;
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Settings_Test.php
@@ -11,134 +11,301 @@ use Automattic\Jetpack\Modules\Subscriptions\Settings;
 class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
-	/**
-	 * Holds filters added by tests to be removed in tear_down.
-	 *
-	 * @var array
-	 */
-	private $added_filters = array();
+	/** @var array Patchwork handles created by tests */
+	private $patchwork_handles = array();
+
+	/** @var string Transient key for storing site creation date. */
+	private const CREATION_DATE_TRANSIENT = 'jetpack_subscriptions_site_creation';
 
 	/**
-	 * Remove any filters added during tests.
+	 * Restore Patchwork redefinitions after each test.
 	 */
-	public function tear_down(): void {
-		foreach ( $this->added_filters as $filter ) {
-			remove_filter( $filter['tag'], $filter['callback'], $filter['priority'] );
+	public function tearDown(): void {
+		if ( function_exists( '\Patchwork\restore' ) ) {
+			foreach ( $this->patchwork_handles as $handle ) {
+				\Patchwork\restore( $handle );
+			}
 		}
-		$this->added_filters = array();
-		parent::tear_down();
+		$this->patchwork_handles = array(); // Reset for next test
+
+		parent::tearDown();
 	}
 
 	/**
-	 * Helper to add a filter and track it for removal in tear_down.
+	 * Creates a mock Connection Manager instance.
 	 */
-	private function add_filter( $tag, $callback, $priority = 10, $accepted_args = 1 ) {
-		$this->added_filters[] = array(
-			'tag'      => $tag,
-			'callback' => $callback,
-			'priority' => $priority,
-		);
-		add_filter( $tag, $callback, $priority, $accepted_args );
-	}
-
-	/**
-	 * Tests the flow using public helpers: calls date helper, passes result to comparison helper.
-	 * Scenario: Non-WPCOM, Connected, Cache hit with a date AFTER cutoff.
-	 * Expected: Final comparison result is true (-> 1).
-	 */
-	public function test_helper_and_comparison_yield_1_for_recent_jetpack_site_cache_hit() {
-		// --- Arrange ---
-		$recent_creation_date_string = '2025-07-01 11:00:00';
-		$test_timezone               = new DateTimeZone( 'UTC' );
-		$transient_key               = 'jetpack_subscriptions_site_creation';
-
-		// Mock Manager
+	private function get_mock_manager( $is_connected = true ) {
 		$mock_manager = $this->getMockBuilder( Manager::class )
 							->disableOriginalConstructor()->onlyMethods( array( 'is_connected' ) )->getMock();
-		$mock_manager->method( 'is_connected' )->willReturn( true ); // Site is connected
-
-		// Mock transient
-		$expected_date_object = new DateTimeImmutable( $recent_creation_date_string, $test_timezone );
-		$this->add_filter(
-			'pre_transient_' . $transient_key,
-			function () use ( $expected_date_object ) {
-				return $expected_date_object;
-			}
-		);
-
-		// Mock timezone options
-		$this->add_filter(
-			'pre_option_timezone_string',
-			function () {
-				return 'UTC';
-			}
-		);
-		$this->add_filter(
-			'pre_option_gmt_offset',
-			function () {
-				return 0;
-			}
-		);
-
-		// --- Act ---
-		$result_date = Settings::get_jetpack_cache_site_creation_date( $mock_manager );
-		$is_eligible = Settings::is_site_eligible_for_new_default( $result_date );
-
-		// --- Assert ---
-		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
-		$this->assertEquals( $expected_date_object->getTimestamp(), $result_date->getTimestamp() );
-
-		$this->assertTrue( $is_eligible, 'Comparison should return true for the recent date.' );
-		$this->assertSame( 1, (int) $is_eligible, 'Casting comparison true to int should be 1.' );
+		$mock_manager->method( 'is_connected' )->willReturn( $is_connected );
+		return $mock_manager;
 	}
 
 	/**
-	 * Tests the flow using public helpers: calls date helper, passes result to comparison helper.
-	 * Scenario: Non-WPCOM, Connected, Cache hit with a date BEFORE the cutoff.
-	 * Expected: Final comparison result is false (-> 0).
+	 * Scenario: Comparison check with a date AFTER the cutoff.
 	 */
-	public function test_helper_and_comparison_yield_0_for_old_jetpack_site_cache_hit() {
-		// --- Arrange ---
-		$old_creation_date_string = '2024-01-01 11:00:00'; // Date BEFORE cutoff
-		$test_timezone            = new DateTimeZone( 'UTC' );
-		$transient_key            = 'jetpack_subscriptions_site_creation';
+	public function test_is_site_eligible_returns_true_for_recent_date() {
+		$recent_date = new DateTimeImmutable( '2025-07-01 11:00:00', wp_timezone() );
+		// Timezone mock is handled by set_up()
 
-		// Mock Manager
-		$mock_manager = $this->getMockBuilder( Manager::class )
-								->disableOriginalConstructor()->onlyMethods( array( 'is_connected' ) )->getMock();
-		$mock_manager->method( 'is_connected' )->willReturn( true );
+		$is_eligible = Settings::is_site_eligible_for_new_default( $recent_date );
 
-		// Mock transient with old date
-		$expected_date_object = new DateTimeImmutable( $old_creation_date_string, $test_timezone );
-		$this->add_filter(
-			'pre_transient_' . $transient_key,
-			function () use ( $expected_date_object ) {
-				return $expected_date_object;
-			}
+		$this->assertTrue( $is_eligible );
+	}
+
+	/**
+	 * Scenario: Comparison check with a date BEFORE the cutoff.
+	 */
+	public function test_is_site_eligible_returns_false_for_old_date() {
+		$old_date = new DateTimeImmutable( '2024-01-01 11:00:00', wp_timezone() );
+
+		$is_eligible = Settings::is_site_eligible_for_new_default( $old_date );
+
+		$this->assertFalse( $is_eligible );
+	}
+
+	/**
+	 * Scenario: Comparison check with the default '0000' date.
+	 */
+	public function test_is_site_eligible_returns_false_for_default_date() {
+		$default_date = new DateTimeImmutable( '0000-00-00 00:00:00.000', wp_timezone() );
+
+		$is_eligible = Settings::is_site_eligible_for_new_default( $default_date );
+
+		$this->assertFalse( $is_eligible );
+	}
+
+	/**
+	 * Scenario: WPCOM, Recent Date returned via mocked get_blog_details.
+	 */
+	public function test_get_wpcom_site_creation_date_returns_recent_date() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'WPCOM helper tests require a multisite environment.' );
+		}
+		// Check if Patchwork is available (still needed for get_current_blog_id mock)
+		if ( ! function_exists( '\Patchwork\redefine' ) ) {
+			$this->markTestSkipped( 'Patchwork not available.' );
+		}
+
+		$recent_creation_date_string = '2025-08-01 12:00:00'; // Date AFTER cutoff
+		$expected_date_object        = new DateTimeImmutable( $recent_creation_date_string, wp_timezone() );
+		$test_blog_id                = 1;
+
+		$this->patchwork_handles[] = \Patchwork\redefine(
+			'get_current_blog_id',
+			\Patchwork\always( $test_blog_id )
 		);
 
-		// Mock timezone options
-		$this->add_filter(
-			'pre_option_timezone_string',
-			function () {
-				return 'UTC';
-			}
-		);
-		$this->add_filter(
-			'pre_option_gmt_offset',
-			function () {
-				return 0;
-			}
+		$mock_details              = new stdClass();
+		$mock_details->registered  = $recent_creation_date_string;
+		$this->patchwork_handles[] = \Patchwork\redefine(
+			'get_blog_details',
+			\Patchwork\always( $mock_details )
 		);
 
-		// --- Act ---
-		$result_date = Settings::get_jetpack_cache_site_creation_date( $mock_manager );
-		$is_eligible = Settings::is_site_eligible_for_new_default( $result_date );
+		$result_date = Settings::get_wpcom_site_creation_date();
 
-		// --- Assert ---
 		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
 		$this->assertEquals( $expected_date_object->getTimestamp(), $result_date->getTimestamp() );
-		$this->assertFalse( $is_eligible, 'Comparison should return false for the old date.' );
-		$this->assertSame( 0, (int) $is_eligible, 'Casting comparison false to int should be 0.' );
+	}
+
+	/**
+	 * Scenario: WPCOM, Old Date returned via mocked get_blog_details.
+	 */
+	public function test_get_wpcom_site_creation_date_returns_old_date() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'WPCOM helper tests require a multisite environment.' );
+		}
+		if ( ! function_exists( '\Patchwork\redefine' ) ) {
+			$this->markTestSkipped( 'Patchwork not available.' );
+		}
+
+		$old_creation_date_string = '2023-01-01 12:00:00'; // Date BEFORE cutoff
+		$expected_date_object     = new DateTimeImmutable( $old_creation_date_string, wp_timezone() );
+		$test_blog_id             = 1;
+
+		$this->patchwork_handles[] = \Patchwork\redefine(
+			'get_current_blog_id',
+			\Patchwork\always( $test_blog_id )
+		);
+
+		$mock_details              = new stdClass();
+		$mock_details->registered  = $old_creation_date_string;
+		$this->patchwork_handles[] = \Patchwork\redefine(
+			'get_blog_details',
+			\Patchwork\always( $mock_details )
+		);
+
+		$result_date = Settings::get_wpcom_site_creation_date();
+
+		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
+		$this->assertEquals( $expected_date_object->getTimestamp(), $result_date->getTimestamp() );
+	}
+
+	/**
+	 * Scenario: WPCOM, get_blog_details returns null.
+	 */
+	public function test_get_wpcom_site_creation_date_returns_default_date_if_details_null() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'WPCOM helper tests require a multisite environment.' );
+		}
+		if ( ! function_exists( '\Patchwork\redefine' ) ) {
+			$this->markTestSkipped( 'Patchwork not available.' );
+		}
+
+		$test_blog_id = 1;
+
+		$this->patchwork_handles[] = \Patchwork\redefine(
+			'get_current_blog_id',
+			\Patchwork\always( $test_blog_id )
+		);
+
+		$this->patchwork_handles[] = \Patchwork\redefine(
+			'get_blog_details',
+			\Patchwork\always( null )
+		);
+
+		$result_date = Settings::get_wpcom_site_creation_date();
+
+		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
+		$this->assertLessThan( 0, $result_date->getTimestamp() );
+	}
+
+	/**
+	 * Scenario: WPCOM, get_blog_details returns object without 'registered' property.
+	 */
+	public function test_get_wpcom_site_creation_date_returns_default_date_if_registered_missing() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'WPCOM helper tests require a multisite environment.' );
+		}
+		if ( ! function_exists( '\Patchwork\redefine' ) ) {
+			$this->markTestSkipped( 'Patchwork not available.' );
+		}
+
+		$test_blog_id = 1;
+
+		$this->patchwork_handles[] = \Patchwork\redefine(
+			'get_current_blog_id',
+			\Patchwork\always( $test_blog_id )
+		);
+
+		$mock_details              = new stdClass();
+		$this->patchwork_handles[] = \Patchwork\redefine(
+			'get_blog_details',
+			\Patchwork\always( $mock_details )
+		);
+
+		$result_date = Settings::get_wpcom_site_creation_date();
+
+		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
+		$this->assertLessThan( 0, $result_date->getTimestamp() );
+	}
+
+	/**
+	 * Scenario: Connected, Cache Miss, API returns RECENT date.
+	 */
+	public function test_get_jetpack_cache_site_creation_date_returns_recent_date() {
+		if ( ! function_exists( '\Patchwork\redefine' ) ) {
+			$this->markTestSkipped( 'Patchwork not available.' );
+		}
+
+		$recent_creation_date_string = '2025-08-01 12:00:00'; // Date AFTER cutoff
+		$test_site_id                = 1;
+
+		$mock_manager = $this->get_mock_manager( true );
+
+		// Mock static Manager::get_site_id
+		$this->patchwork_handles[] = \Patchwork\redefine(
+			'\Automattic\Jetpack\Connection\Manager::get_site_id',
+			\Patchwork\always( $test_site_id )
+		);
+
+		$api_response_body = json_encode( array( 'options' => (object) array( 'created_at' => $recent_creation_date_string ) ) );
+		if ( false === $api_response_body ) {
+			$this->fail( 'Failed to encode mock API response' );
+		}
+		$mock_http_response        = array(
+			'headers'  => array( 'content-type' => 'application/json' ),
+			'body'     => $api_response_body,
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'cookies'  => array(),
+			'filename' => null,
+		);
+		$this->patchwork_handles[] = \Patchwork\redefine(
+			'\Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog',
+			\Patchwork\always( $mock_http_response )
+		);
+
+		$expected_date_object = new DateTimeImmutable( $recent_creation_date_string, wp_timezone() );
+
+		$result_date = Settings::get_jetpack_cache_site_creation_date( $mock_manager );
+
+		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
+		$this->assertEquals( $expected_date_object->getTimestamp(), $result_date->getTimestamp() );
+	}
+
+	/**
+	 * Scenario: Connected, Cache Miss, API returns OLD date.
+	 */
+	public function test_get_jetpack_cache_site_creation_date_returns_old_date() {
+		if ( ! function_exists( '\Patchwork\redefine' ) ) {
+			$this->markTestSkipped( 'Patchwork not available.' );
+		}
+
+		$old_creation_date_string = '2023-01-01 12:00:00'; // Date BEFORE cutoff
+		$test_site_id             = 1;
+
+		$mock_manager = $this->get_mock_manager( true );
+
+		// Mock static Manager::get_site_id
+		$this->patchwork_handles[] = \Patchwork\redefine(
+			'\Automattic\Jetpack\Connection\Manager::get_site_id',
+			\Patchwork\always( $test_site_id )
+		);
+
+		$api_response_body = json_encode( array( 'options' => (object) array( 'created_at' => $old_creation_date_string ) ) );
+		if ( false === $api_response_body ) {
+			$this->fail( 'Failed to encode mock API response' );
+		}
+		$mock_http_response        = array(
+			'headers'  => array( 'content-type' => 'application/json' ),
+			'body'     => $api_response_body,
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'cookies'  => array(),
+			'filename' => null,
+		);
+		$this->patchwork_handles[] = \Patchwork\redefine(
+			'\Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog',
+			\Patchwork\always( $mock_http_response )
+		);
+
+		$expected_date_object = new DateTimeImmutable( $old_creation_date_string, wp_timezone() );
+
+		$result_date = Settings::get_jetpack_cache_site_creation_date( $mock_manager );
+
+		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
+		$this->assertEquals( $expected_date_object->getTimestamp(), $result_date->getTimestamp() );
+	}
+
+	/**
+	 * Scenario: Not connected
+	 */
+	public function test_get_jetpack_cache_site_creation_date_returns_default_date_with_no_connection() {
+		if ( ! function_exists( '\Patchwork\redefine' ) ) {
+			$this->markTestSkipped( 'Patchwork not available.' );
+		}
+
+		$mock_manager = $this->get_mock_manager( false );
+
+		$result_date = Settings::get_jetpack_cache_site_creation_date( $mock_manager );
+
+		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
+		$this->assertLessThan( 0, $result_date->getTimestamp() );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Settings_Test.php
@@ -9,6 +9,7 @@ use Automattic\Jetpack\Modules\Subscriptions\Settings;
  * Tests for Automattic\Jetpack\Modules\Subscriptions\Settings.
  */
 class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
 	/**
 	 * Holds filters added by tests to be removed in tear_down.
@@ -103,7 +104,7 @@ class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
 		$transient_key            = 'jetpack_subscriptions_site_creation';
 
 		// Mock Manager
-		$mock_manager = $this->getMockBuilder( Connection_Manager::class )
+		$mock_manager = $this->getMockBuilder( Manager::class )
 								->disableOriginalConstructor()->onlyMethods( array( 'is_connected' ) )->getMock();
 		$mock_manager->method( 'is_connected' )->willReturn( true );
 

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Settings_Test.php
@@ -45,10 +45,9 @@ class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
 	 * Scenario: Comparison check with a date AFTER the cutoff.
 	 */
 	public function test_is_site_eligible_returns_true_for_recent_date() {
-		$recent_date = new DateTimeImmutable( '2025-07-01 11:00:00', wp_timezone() );
-		// Timezone mock is handled by set_up()
+		$recent_timestamp = strtotime( '2025-07-01 11:00:00' );
 
-		$is_eligible = Settings::is_site_eligible_for_new_default( $recent_date );
+		$is_eligible = Settings::is_site_eligible_for_new_default( $recent_timestamp );
 
 		$this->assertTrue( $is_eligible );
 	}
@@ -57,20 +56,20 @@ class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
 	 * Scenario: Comparison check with a date BEFORE the cutoff.
 	 */
 	public function test_is_site_eligible_returns_false_for_old_date() {
-		$old_date = new DateTimeImmutable( '2024-01-01 11:00:00', wp_timezone() );
+		$old_timestamp = strtotime( '2024-01-01 11:00:00' );
 
-		$is_eligible = Settings::is_site_eligible_for_new_default( $old_date );
+		$is_eligible = Settings::is_site_eligible_for_new_default( $old_timestamp );
 
 		$this->assertFalse( $is_eligible );
 	}
 
 	/**
-	 * Scenario: Comparison check with the default '0000' date.
+	 * Scenario: Comparison check with the default '0' timestamp.
 	 */
 	public function test_is_site_eligible_returns_false_for_default_date() {
-		$default_date = new DateTimeImmutable( '0000-00-00 00:00:00.000', wp_timezone() );
+		$default_timestamp = 0;
 
-		$is_eligible = Settings::is_site_eligible_for_new_default( $default_date );
+		$is_eligible = Settings::is_site_eligible_for_new_default( $default_timestamp );
 
 		$this->assertFalse( $is_eligible );
 	}
@@ -78,7 +77,7 @@ class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
 	/**
 	 * Scenario: WPCOM, Recent Date returned via mocked get_blog_details.
 	 */
-	public function test_get_wpcom_site_creation_date_returns_recent_date() {
+	public function test_get_wpcom_site_registered_timestamp_returns_recent_date() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'WPCOM helper tests require a multisite environment.' );
 		}
@@ -88,7 +87,7 @@ class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
 		}
 
 		$recent_creation_date_string = '2025-08-01 12:00:00'; // Date AFTER cutoff
-		$expected_date_object        = new DateTimeImmutable( $recent_creation_date_string, wp_timezone() );
+		$expected_timestamp          = strtotime( $recent_creation_date_string );
 		$test_blog_id                = 1;
 
 		$this->patchwork_handles[] = \Patchwork\redefine(
@@ -103,16 +102,16 @@ class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
 			\Patchwork\always( $mock_details )
 		);
 
-		$result_date = Settings::get_wpcom_site_creation_date();
+		$result_timestamp = Settings::get_wpcom_site_registered_timestamp();
 
-		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
-		$this->assertEquals( $expected_date_object->getTimestamp(), $result_date->getTimestamp() );
+		$this->assertIsInt( $result_timestamp );
+		$this->assertEquals( $expected_timestamp, $result_timestamp );
 	}
 
 	/**
 	 * Scenario: WPCOM, Old Date returned via mocked get_blog_details.
 	 */
-	public function test_get_wpcom_site_creation_date_returns_old_date() {
+	public function test_get_wpcom_site_registered_timestamp_returns_old_date() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'WPCOM helper tests require a multisite environment.' );
 		}
@@ -121,7 +120,7 @@ class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
 		}
 
 		$old_creation_date_string = '2023-01-01 12:00:00'; // Date BEFORE cutoff
-		$expected_date_object     = new DateTimeImmutable( $old_creation_date_string, wp_timezone() );
+		$expected_timestamp       = strtotime( $old_creation_date_string );
 		$test_blog_id             = 1;
 
 		$this->patchwork_handles[] = \Patchwork\redefine(
@@ -136,16 +135,16 @@ class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
 			\Patchwork\always( $mock_details )
 		);
 
-		$result_date = Settings::get_wpcom_site_creation_date();
+		$result_timestamp = Settings::get_wpcom_site_registered_timestamp();
 
-		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
-		$this->assertEquals( $expected_date_object->getTimestamp(), $result_date->getTimestamp() );
+		$this->assertIsInt( $result_timestamp );
+		$this->assertEquals( $expected_timestamp, $result_timestamp );
 	}
 
 	/**
 	 * Scenario: WPCOM, get_blog_details returns null.
 	 */
-	public function test_get_wpcom_site_creation_date_returns_default_date_if_details_null() {
+	public function test_get_wpcom_site_registered_timestamp_returns_default_date_if_details_null() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'WPCOM helper tests require a multisite environment.' );
 		}
@@ -165,16 +164,16 @@ class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
 			\Patchwork\always( null )
 		);
 
-		$result_date = Settings::get_wpcom_site_creation_date();
+		$result_timestamp = Settings::get_wpcom_site_registered_timestamp();
 
-		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
-		$this->assertLessThan( 0, $result_date->getTimestamp() );
+		$this->assertIsInt( $result_timestamp );
+		$this->assertSame( 0, $result_timestamp );
 	}
 
 	/**
 	 * Scenario: WPCOM, get_blog_details returns object without 'registered' property.
 	 */
-	public function test_get_wpcom_site_creation_date_returns_default_date_if_registered_missing() {
+	public function test_get_wpcom_site_registered_timestamp_returns_default_timestamp_if_registered_missing() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'WPCOM helper tests require a multisite environment.' );
 		}
@@ -195,16 +194,16 @@ class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
 			\Patchwork\always( $mock_details )
 		);
 
-		$result_date = Settings::get_wpcom_site_creation_date();
+		$result_timestamp = Settings::get_wpcom_site_registered_timestamp();
 
-		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
-		$this->assertLessThan( 0, $result_date->getTimestamp() );
+		$this->assertIsInt( $result_timestamp );
+		$this->assertSame( 0, $result_timestamp );
 	}
 
 	/**
 	 * Scenario: WPCOM, blog_id is not valid.
 	 */
-	public function test_get_wpcom_site_creation_date_returns_default_date_if_no_blog_id() {
+	public function test_get_wpcom_site_registered_timestamp_returns_default_timestamp_if_no_blog_id() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'WPCOM helper tests require a multisite environment.' );
 		}
@@ -219,21 +218,22 @@ class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
 			\Patchwork\always( $test_blog_id )
 		);
 
-		$result_date = Settings::get_wpcom_site_creation_date();
+		$result_timestamp = Settings::get_wpcom_site_registered_timestamp();
 
-		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
-		$this->assertLessThan( 0, $result_date->getTimestamp() );
+		$this->assertIsInt( $result_timestamp );
+		$this->assertSame( 0, $result_timestamp );
 	}
 
 	/**
 	 * Scenario: Connected, Cache Miss, API returns RECENT date.
 	 */
-	public function test_get_jetpack_cache_site_creation_date_returns_recent_date() {
+	public function test_get_jetpack_cache_site_creation_timestamp_returns_recent_date() {
 		if ( ! function_exists( '\Patchwork\redefine' ) ) {
 			$this->markTestSkipped( 'Patchwork not available.' );
 		}
 
 		$recent_creation_date_string = '2025-08-01 12:00:00'; // Date AFTER cutoff
+		$expected_timestamp          = strtotime( $recent_creation_date_string );
 		$test_site_id                = 1;
 
 		$mock_manager = $this->get_mock_manager( true );
@@ -263,23 +263,22 @@ class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
 			\Patchwork\always( $mock_http_response )
 		);
 
-		$expected_date_object = new DateTimeImmutable( $recent_creation_date_string, wp_timezone() );
+		$result_timestamp = Settings::get_jetpack_cache_site_creation_timestamp( $mock_manager );
 
-		$result_date = Settings::get_jetpack_cache_site_creation_date( $mock_manager );
-
-		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
-		$this->assertEquals( $expected_date_object->getTimestamp(), $result_date->getTimestamp() );
+		$this->assertIsInt( $result_timestamp );
+		$this->assertEquals( $expected_timestamp, $result_timestamp );
 	}
 
 	/**
 	 * Scenario: Connected, Cache Miss, API returns OLD date.
 	 */
-	public function test_get_jetpack_cache_site_creation_date_returns_old_date() {
+	public function test_get_jetpack_cache_site_creation_timestamp_returns_old_date() {
 		if ( ! function_exists( '\Patchwork\redefine' ) ) {
 			$this->markTestSkipped( 'Patchwork not available.' );
 		}
 
 		$old_creation_date_string = '2023-01-01 12:00:00'; // Date BEFORE cutoff
+		$expected_timestamp       = strtotime( $old_creation_date_string );
 		$test_site_id             = 1;
 
 		$mock_manager = $this->get_mock_manager( true );
@@ -308,18 +307,16 @@ class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
 			\Patchwork\always( $mock_http_response )
 		);
 
-		$expected_date_object = new DateTimeImmutable( $old_creation_date_string, wp_timezone() );
+		$result_timestamp = Settings::get_jetpack_cache_site_creation_timestamp( $mock_manager );
 
-		$result_date = Settings::get_jetpack_cache_site_creation_date( $mock_manager );
-
-		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
-		$this->assertEquals( $expected_date_object->getTimestamp(), $result_date->getTimestamp() );
+		$this->assertIsInt( $result_timestamp );
+		$this->assertEquals( $expected_timestamp, $result_timestamp );
 	}
 
 	/**
 	 * Scenario: Connected, bad response
 	 */
-	public function test_get_jetpack_cache_site_creation_date_returns_default_date_with_bad_response() {
+	public function test_get_jetpack_cache_site_creation_timestamp_returns_default_date_with_bad_response() {
 		if ( ! function_exists( '\Patchwork\redefine' ) ) {
 			$this->markTestSkipped( 'Patchwork not available.' );
 		}
@@ -338,16 +335,16 @@ class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
 			\Patchwork\always( $mock_http_response )
 		);
 
-		$result_date = Settings::get_jetpack_cache_site_creation_date( $mock_manager );
+		$result_timestamp = Settings::get_jetpack_cache_site_creation_timestamp( $mock_manager );
 
-		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
-		$this->assertLessThan( 0, $result_date->getTimestamp() );
+		$this->assertIsInt( $result_timestamp );
+		$this->assertSame( 0, $result_timestamp );
 	}
 
 	/**
 	 * Scenario: Connected, bad site data
 	 */
-	public function test_get_jetpack_cache_site_creation_date_returns_default_date_with_bad_site_data() {
+	public function test_get_jetpack_cache_site_creation_timestamp_returns_default_date_with_bad_site_data() {
 		if ( ! function_exists( '\Patchwork\redefine' ) ) {
 			$this->markTestSkipped( 'Patchwork not available.' );
 		}
@@ -375,25 +372,25 @@ class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
 			\Patchwork\always( $mock_http_response )
 		);
 
-		$result_date = Settings::get_jetpack_cache_site_creation_date( $mock_manager );
+		$result_timestamp = Settings::get_jetpack_cache_site_creation_timestamp( $mock_manager );
 
-		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
-		$this->assertLessThan( 0, $result_date->getTimestamp() );
+		$this->assertIsInt( $result_timestamp );
+		$this->assertSame( 0, $result_timestamp );
 	}
 
 	/**
 	 * Scenario: Not connected
 	 */
-	public function test_get_jetpack_cache_site_creation_date_returns_default_date_with_no_connection() {
+	public function test_get_jetpack_cache_site_creation_timestamp_returns_default_date_with_no_connection() {
 		if ( ! function_exists( '\Patchwork\redefine' ) ) {
 			$this->markTestSkipped( 'Patchwork not available.' );
 		}
 
 		$mock_manager = $this->get_mock_manager( false );
 
-		$result_date = Settings::get_jetpack_cache_site_creation_date( $mock_manager );
+		$result_timestamp = Settings::get_jetpack_cache_site_creation_timestamp( $mock_manager );
 
-		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
-		$this->assertLessThan( 0, $result_date->getTimestamp() );
+		$this->assertIsInt( $result_timestamp );
+		$this->assertSame( 0, $result_timestamp );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Settings_Test.php
@@ -202,6 +202,30 @@ class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Scenario: WPCOM, blog_id is not valid.
+	 */
+	public function test_get_wpcom_site_creation_date_returns_default_date_if_no_blog_id() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'WPCOM helper tests require a multisite environment.' );
+		}
+		if ( ! function_exists( '\Patchwork\redefine' ) ) {
+			$this->markTestSkipped( 'Patchwork not available.' );
+		}
+
+		$test_blog_id = 0;
+
+		$this->patchwork_handles[] = \Patchwork\redefine(
+			'get_current_blog_id',
+			\Patchwork\always( $test_blog_id )
+		);
+
+		$result_date = Settings::get_wpcom_site_creation_date();
+
+		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
+		$this->assertLessThan( 0, $result_date->getTimestamp() );
+	}
+
+	/**
 	 * Scenario: Connected, Cache Miss, API returns RECENT date.
 	 */
 	public function test_get_jetpack_cache_site_creation_date_returns_recent_date() {
@@ -260,7 +284,6 @@ class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
 
 		$mock_manager = $this->get_mock_manager( true );
 
-		// Mock static Manager::get_site_id
 		$this->patchwork_handles[] = \Patchwork\redefine(
 			'\Automattic\Jetpack\Connection\Manager::get_site_id',
 			\Patchwork\always( $test_site_id )
@@ -291,6 +314,71 @@ class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
 		$this->assertEquals( $expected_date_object->getTimestamp(), $result_date->getTimestamp() );
+	}
+
+	/**
+	 * Scenario: Connected, bad response
+	 */
+	public function test_get_jetpack_cache_site_creation_date_returns_default_date_with_bad_response() {
+		if ( ! function_exists( '\Patchwork\redefine' ) ) {
+			$this->markTestSkipped( 'Patchwork not available.' );
+		}
+
+		$test_site_id = 1;
+
+		$mock_manager              = $this->get_mock_manager( true );
+		$this->patchwork_handles[] = \Patchwork\redefine(
+			'\Automattic\Jetpack\Connection\Manager::get_site_id',
+			\Patchwork\always( $test_site_id )
+		);
+
+		$mock_http_response        = new WP_Error();
+		$this->patchwork_handles[] = \Patchwork\redefine(
+			'\Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog',
+			\Patchwork\always( $mock_http_response )
+		);
+
+		$result_date = Settings::get_jetpack_cache_site_creation_date( $mock_manager );
+
+		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
+		$this->assertLessThan( 0, $result_date->getTimestamp() );
+	}
+
+	/**
+	 * Scenario: Connected, bad site data
+	 */
+	public function test_get_jetpack_cache_site_creation_date_returns_default_date_with_bad_site_data() {
+		if ( ! function_exists( '\Patchwork\redefine' ) ) {
+			$this->markTestSkipped( 'Patchwork not available.' );
+		}
+
+		$test_site_id = 1;
+
+		$mock_manager              = $this->get_mock_manager( true );
+		$this->patchwork_handles[] = \Patchwork\redefine(
+			'\Automattic\Jetpack\Connection\Manager::get_site_id',
+			\Patchwork\always( $test_site_id )
+		);
+
+		$mock_http_response        = array(
+			'headers'  => array( 'content-type' => 'application/json' ),
+			'body'     => json_encode( array() ),
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'cookies'  => array(),
+			'filename' => null,
+		);
+		$this->patchwork_handles[] = \Patchwork\redefine(
+			'\Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog',
+			\Patchwork\always( $mock_http_response )
+		);
+
+		$result_date = Settings::get_jetpack_cache_site_creation_date( $mock_manager );
+
+		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
+		$this->assertLessThan( 0, $result_date->getTimestamp() );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Settings_Test.php
@@ -1,0 +1,143 @@
+<?php
+
+require_once JETPACK__PLUGIN_DIR . '/modules/subscriptions/class-settings.php';
+
+use Automattic\Jetpack\Connection\Manager;
+use Automattic\Jetpack\Modules\Subscriptions\Settings;
+
+/**
+ * Tests for Automattic\Jetpack\Modules\Subscriptions\Settings.
+ */
+class Jetpack_Subscriptions_Settings_Test extends WP_UnitTestCase {
+
+	/**
+	 * Holds filters added by tests to be removed in tear_down.
+	 *
+	 * @var array
+	 */
+	private $added_filters = array();
+
+	/**
+	 * Remove any filters added during tests.
+	 */
+	public function tear_down(): void {
+		foreach ( $this->added_filters as $filter ) {
+			remove_filter( $filter['tag'], $filter['callback'], $filter['priority'] );
+		}
+		$this->added_filters = array();
+		parent::tear_down();
+	}
+
+	/**
+	 * Helper to add a filter and track it for removal in tear_down.
+	 */
+	private function add_filter( $tag, $callback, $priority = 10, $accepted_args = 1 ) {
+		$this->added_filters[] = array(
+			'tag'      => $tag,
+			'callback' => $callback,
+			'priority' => $priority,
+		);
+		add_filter( $tag, $callback, $priority, $accepted_args );
+	}
+
+	/**
+	 * Tests the flow using public helpers: calls date helper, passes result to comparison helper.
+	 * Scenario: Non-WPCOM, Connected, Cache hit with a date AFTER cutoff.
+	 * Expected: Final comparison result is true (-> 1).
+	 */
+	public function test_helper_and_comparison_yield_1_for_recent_jetpack_site_cache_hit() {
+		// --- Arrange ---
+		$recent_creation_date_string = '2025-07-01 11:00:00';
+		$test_timezone               = new DateTimeZone( 'UTC' );
+		$transient_key               = 'jetpack_subscriptions_site_creation';
+
+		// Mock Manager
+		$mock_manager = $this->getMockBuilder( Manager::class )
+							->disableOriginalConstructor()->onlyMethods( array( 'is_connected' ) )->getMock();
+		$mock_manager->method( 'is_connected' )->willReturn( true ); // Site is connected
+
+		// Mock transient
+		$expected_date_object = new DateTimeImmutable( $recent_creation_date_string, $test_timezone );
+		$this->add_filter(
+			'pre_transient_' . $transient_key,
+			function () use ( $expected_date_object ) {
+				return $expected_date_object;
+			}
+		);
+
+		// Mock timezone options
+		$this->add_filter(
+			'pre_option_timezone_string',
+			function () {
+				return 'UTC';
+			}
+		);
+		$this->add_filter(
+			'pre_option_gmt_offset',
+			function () {
+				return 0;
+			}
+		);
+
+		// --- Act ---
+		$result_date = Settings::get_jetpack_cache_site_creation_date( $mock_manager );
+		$is_eligible = Settings::is_site_eligible_for_new_default( $result_date );
+
+		// --- Assert ---
+		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
+		$this->assertEquals( $expected_date_object->getTimestamp(), $result_date->getTimestamp() );
+
+		$this->assertTrue( $is_eligible, 'Comparison should return true for the recent date.' );
+		$this->assertSame( 1, (int) $is_eligible, 'Casting comparison true to int should be 1.' );
+	}
+
+	/**
+	 * Tests the flow using public helpers: calls date helper, passes result to comparison helper.
+	 * Scenario: Non-WPCOM, Connected, Cache hit with a date BEFORE the cutoff.
+	 * Expected: Final comparison result is false (-> 0).
+	 */
+	public function test_helper_and_comparison_yield_0_for_old_jetpack_site_cache_hit() {
+		// --- Arrange ---
+		$old_creation_date_string = '2024-01-01 11:00:00'; // Date BEFORE cutoff
+		$test_timezone            = new DateTimeZone( 'UTC' );
+		$transient_key            = 'jetpack_subscriptions_site_creation';
+
+		// Mock Manager
+		$mock_manager = $this->getMockBuilder( Connection_Manager::class )
+								->disableOriginalConstructor()->onlyMethods( array( 'is_connected' ) )->getMock();
+		$mock_manager->method( 'is_connected' )->willReturn( true );
+
+		// Mock transient with old date
+		$expected_date_object = new DateTimeImmutable( $old_creation_date_string, $test_timezone );
+		$this->add_filter(
+			'pre_transient_' . $transient_key,
+			function () use ( $expected_date_object ) {
+				return $expected_date_object;
+			}
+		);
+
+		// Mock timezone options
+		$this->add_filter(
+			'pre_option_timezone_string',
+			function () {
+				return 'UTC';
+			}
+		);
+		$this->add_filter(
+			'pre_option_gmt_offset',
+			function () {
+				return 0;
+			}
+		);
+
+		// --- Act ---
+		$result_date = Settings::get_jetpack_cache_site_creation_date( $mock_manager );
+		$is_eligible = Settings::is_site_eligible_for_new_default( $result_date );
+
+		// --- Assert ---
+		$this->assertInstanceOf( DateTimeImmutable::class, $result_date );
+		$this->assertEquals( $expected_date_object->getTimestamp(), $result_date->getTimestamp() );
+		$this->assertFalse( $is_eligible, 'Comparison should return false for the old date.' );
+		$this->assertSame( 0, (int) $is_eligible, 'Casting comparison false to int should be 0.' );
+	}
+}

--- a/tools/eslint-excludelist.json
+++ b/tools/eslint-excludelist.json
@@ -7,6 +7,5 @@
 	"projects/plugins/jetpack/_inc/client/lib/accessible-focus/index.js",
 	"projects/plugins/jetpack/_inc/client/mixins/emitter/index.js",
 	"projects/plugins/jetpack/_inc/client/my-plan/index.jsx",
-	"projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js",
 	"projects/plugins/jetpack/_inc/twitter-timeline.js"
 ]


### PR DESCRIPTION
## Proposed changes:

- Change the default value for `wpcom_featured_image_in_email` site setting to `true` for sites created/registered after `2025-04-01`
- On wpcom, we'll use the blog `registered` detail for this.
- For a Jetpack site, we'll use the cache site's `created_at` option returned from the wpcom API.

<img width="1041" alt="image" src="https://github.com/user-attachments/assets/79180830-4d4b-4955-b954-793e8883d027" />

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See 605-gh-loop

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This needs to be tested on both a Simple site and a Jetpack site. [Jurassic Ninja](https://jurassic.ninja/) can be used for this.

**Simple**

- Check out this branch on your sandbox and sandbox the API. You can follow [this comment](https://github.com/Automattic/jetpack/pull/42766#issuecomment-2761755780) for checking out this branch on your sandbox.
- You will need to test three cases:
1. A site with the featured image setting explicitly set (the setting has been toggled in the UI or updated via API)
2. A site created before the cutoff date (April 1, 2025) _without the setting explicitly set_
3. A site created after the cutoff date _without the setting explicitly set_
  - If you don't have sites with the correct creation dates, you can change the [cutoff date in the code](https://github.com/Automattic/jetpack/pull/42766/files#diff-db849003095f6a3c6f321f2ea59c8c4242346bf4da919dbcd91281f94c2ae279R26) during testing to simulate the site being before or after the date. If you do this though, you will need to sync your local changes to your sandbox. This P2 has more info: PCYsg-eg0-p2
- In case 1, the setting should _not_ change when this branch is activated.
- In case 2, the setting should remain disabled when this branch is activated.
- In case 3, the setting should be enabled by default.

**Jetpack Connected**

- Check out this branch on your Jetpack site. You can use the Jetpack Beta plugin mentioned in [this comment](https://github.com/Automattic/jetpack/pull/42766#issuecomment-2761755780) to do this.
- You will need to test three cases:
1. A site with the featured image setting explicitly set (the setting has been toggled in the UI or updated via API)
2. A site created before the cutoff date (April 1, 2025) _without the setting explicitly set_
3. A site created after the cutoff date _without the setting explicitly set_
  - If you don't have sites with the correct creation dates, you can change the [cutoff date in the code](https://github.com/Automattic/jetpack/pull/42766/files#diff-db849003095f6a3c6f321f2ea59c8c4242346bf4da919dbcd91281f94c2ae279R26) during testing to simulate the site being before or after the date. If you do this though, you will need to sync your local changes to your site and you will need to use a WoA dev blog. This P2 has more info: PCYsg-eg0-p2
- In case 1, the setting should _not_ change when this branch is activated.
- In case 2, the setting should remain disabled when this branch is activated.
- In case 3, the setting should be enabled by default.