### PR TITLE
Sitemaps: Use xmlwriter

### DIFF
--- a/projects/plugins/jetpack/changelog/add-sitemap-performance
+++ b/projects/plugins/jetpack/changelog/add-sitemap-performance
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Sitemaps: when available, use XMLWriter for a more performant sitemap generation.

--- a/projects/plugins/jetpack/class.jetpack-cli.php
+++ b/projects/plugins/jetpack/class.jetpack-cli.php
@@ -1323,9 +1323,6 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 * @param array $assoc_args Named args.
 	 */
 	public function sitemap( $args, $assoc_args ) {
-		if ( ! Jetpack::is_connection_ready() ) {
-			WP_CLI::error( __( 'Jetpack is not currently connected to WordPress.com', 'jetpack' ) );
-		}
 		if ( ! Jetpack::is_module_active( 'sitemaps' ) ) {
 			WP_CLI::error( __( 'Jetpack Sitemaps module is not currently active. Activate it first if you want to work with sitemaps.', 'jetpack' ) );
 		}
@@ -1336,6 +1333,11 @@ class Jetpack_CLI extends WP_CLI_Command {
 		if ( isset( $assoc_args['purge'] ) && $assoc_args['purge'] ) {
 			$librarian = new Jetpack_Sitemap_Librarian();
 			$librarian->delete_all_stored_sitemap_data();
+
+			// Clear sitemap-related transients
+			delete_transient( 'jetpack_news_sitemap_xml' );
+			delete_transient( 'jetpack-sitemap-state-lock' );
+			WP_CLI::success( 'Purged all sitemap data and cleared sitemap transients.' );
 		}
 
 		$sitemap_builder = new Jetpack_Sitemap_Builder();

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-factory.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-factory.php
@@ -1,0 +1,53 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Factory class for creating sitemap buffers.
+ *
+ * @since $$next-version$$
+ * @package automattic/jetpack
+ */
+
+/**
+ * Creates the appropriate sitemap buffer based on available PHP extensions.
+ *
+ * @since $$next-version$$
+ */
+class Jetpack_Sitemap_Buffer_Factory {
+
+	/**
+	 * Create a new sitemap buffer instance.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $type       The type of sitemap buffer ('page', 'image', 'video', etc.).
+	 * @param int    $item_limit The maximum number of items in the buffer.
+	 * @param int    $byte_limit The maximum number of bytes in the buffer.
+	 * @param string $time       The initial datetime of the buffer.
+	 *
+	 * @return Jetpack_Sitemap_Buffer|null The created buffer or null if type is invalid.
+	 */
+	public static function create( $type, $item_limit, $byte_limit, $time = '1970-01-01 00:00:00' ) {
+		// First try XMLWriter if available
+		if ( class_exists( 'XMLWriter' ) ) {
+			$class_name = 'Jetpack_Sitemap_Buffer_' . ucfirst( $type ) . '_XMLWriter';
+			if ( class_exists( $class_name ) ) {
+				return new $class_name( $item_limit, $byte_limit, $time );
+			}
+		}
+
+		// Then try DOMDocument
+		if ( class_exists( 'DOMDocument' ) ) {
+			$class_name = 'Jetpack_Sitemap_Buffer_' . ucfirst( $type );
+			if ( class_exists( $class_name ) ) {
+				return new $class_name( $item_limit, $byte_limit, $time );
+			}
+		}
+
+		// Finally fall back to the basic implementation
+		$class_name = 'Jetpack_Sitemap_Buffer_' . ucfirst( $type ) . '_Fallback';
+		if ( class_exists( $class_name ) ) {
+			return new $class_name( $item_limit, $byte_limit, $time );
+		}
+
+		return null;
+	}
+}

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-image-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-image-xmlwriter.php
@@ -12,7 +12,6 @@
  * @since $$next-version$$
  */
 class Jetpack_Sitemap_Buffer_Image_XMLWriter extends Jetpack_Sitemap_Buffer_XMLWriter {
-
 	/**
 	 * Initialize the buffer with required headers and root element.
 	 */
@@ -60,28 +59,43 @@ class Jetpack_Sitemap_Buffer_Image_XMLWriter extends Jetpack_Sitemap_Buffer_XMLW
 	 * @param array $array The URL item to append.
 	 */
 	protected function append_item( $array ) {
-		if ( ! empty( $array['url'] ) ) {
-			$this->writer->startElement( 'url' );
-
-			// Add URL elements
-			foreach ( $array['url'] as $tag => $value ) {
-				if ( $tag !== 'images' ) {
-					$this->writer->writeElement( $tag, strval( $value ) );
-				}
-			}
-
-			// Add image:image elements
-			if ( ! empty( $array['url']['images'] ) ) {
-				foreach ( $array['url']['images'] as $image ) {
-					$this->writer->startElement( 'image:image' );
-					foreach ( $image as $tag => $value ) {
-						$this->writer->writeElement( "image:$tag", strval( $value ) );
-					}
-					$this->writer->endElement(); // image:image
-				}
-			}
-
-			$this->writer->endElement(); // url
+		if ( ! isset( $array['url'] ) || ! is_array( $array['url'] ) ) {
+			return;
 		}
+
+		$url = $array['url'];
+
+		$this->writer->startElement( 'url' );
+
+		if ( isset( $url['loc'] ) ) {
+			$this->writer->writeElement( 'loc', esc_url( $url['loc'] ) );
+		}
+
+		if ( isset( $url['lastmod'] ) ) {
+			$this->writer->writeElement( 'lastmod', esc_html( $url['lastmod'] ) );
+		}
+
+		if ( isset( $url['image:image'] ) && is_array( $url['image:image'] ) ) {
+			$this->writer->startElement( 'image:image' );
+
+			// Required image loc
+			if ( isset( $url['image:image']['image:loc'] ) ) {
+				$this->writer->writeElement( 'image:loc', esc_url( $url['image:image']['image:loc'] ) );
+			}
+
+			// Optional image title
+			if ( ! empty( $url['image:image']['image:title'] ) ) {
+				$this->writer->writeElement( 'image:title', esc_html( $url['image:image']['image:title'] ) );
+			}
+
+			// Optional image caption
+			if ( ! empty( $url['image:image']['image:caption'] ) ) {
+				$this->writer->writeElement( 'image:caption', esc_html( $url['image:image']['image:caption'] ) );
+			}
+
+			$this->writer->endElement(); // image:image
+		}
+
+		$this->writer->endElement(); // url
 	}
 }

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-image-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-image-xmlwriter.php
@@ -1,0 +1,87 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * XMLWriter implementation of the image sitemap buffer.
+ *
+ * @since $$next-version$$
+ * @package automattic/jetpack
+ */
+
+/**
+ * A buffer for constructing sitemap image xml files using XMLWriter.
+ *
+ * @since $$next-version$$
+ */
+class Jetpack_Sitemap_Buffer_Image_XMLWriter extends Jetpack_Sitemap_Buffer_XMLWriter {
+
+	/**
+	 * Initialize the buffer with required headers and root element.
+	 */
+	protected function initialize_buffer() {
+		// Add generator comment
+		$this->writer->writeComment( "generator='jetpack-" . JETPACK__VERSION . "'" );
+		$this->writer->writeComment( 'Jetpack_Sitemap_Buffer_Image_XMLWriter' );
+
+		// Add stylesheet
+		$this->writer->writePi(
+			'xml-stylesheet',
+			'type="text/xsl" href="' . $this->finder->construct_sitemap_url( 'image-sitemap.xsl' ) . '"'
+		);
+
+		// Start root element with namespaces
+		$this->writer->startElement( 'urlset' );
+
+		/**
+		 * Filter the XML namespaces included in image sitemaps.
+		 *
+		 * @module sitemaps
+		 *
+		 * @since 4.8.0
+		 *
+		 * @param array $namespaces Associative array with namespaces and namespace URIs.
+		 */
+		$namespaces = apply_filters(
+			'jetpack_sitemap_image_ns',
+			array(
+				'xmlns:xsi'          => 'http://www.w3.org/2001/XMLSchema-instance',
+				'xsi:schemaLocation' => 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd',
+				'xmlns'              => 'http://www.sitemaps.org/schemas/sitemap/0.9',
+				'xmlns:image'        => 'http://www.google.com/schemas/sitemap-image/1.1',
+			)
+		);
+
+		foreach ( $namespaces as $name => $value ) {
+			$this->writer->writeAttribute( $name, $value );
+		}
+	}
+
+	/**
+	 * Append a URL entry with image information to the sitemap.
+	 *
+	 * @param array $array The URL item to append.
+	 */
+	protected function append_item( $array ) {
+		if ( ! empty( $array['url'] ) ) {
+			$this->writer->startElement( 'url' );
+
+			// Add URL elements
+			foreach ( $array['url'] as $tag => $value ) {
+				if ( $tag !== 'images' ) {
+					$this->writer->writeElement( $tag, strval( $value ) );
+				}
+			}
+
+			// Add image:image elements
+			if ( ! empty( $array['url']['images'] ) ) {
+				foreach ( $array['url']['images'] as $image ) {
+					$this->writer->startElement( 'image:image' );
+					foreach ( $image as $tag => $value ) {
+						$this->writer->writeElement( "image:$tag", strval( $value ) );
+					}
+					$this->writer->endElement(); // image:image
+				}
+			}
+
+			$this->writer->endElement(); // url
+		}
+	}
+}

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-master-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-master-xmlwriter.php
@@ -1,0 +1,51 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * XMLWriter implementation of the master sitemap buffer.
+ *
+ * @since $$next-version$$
+ * @package automattic/jetpack
+ */
+
+/**
+ * A buffer for constructing master sitemap xml files using XMLWriter.
+ *
+ * @since $$next-version$$
+ */
+class Jetpack_Sitemap_Buffer_Master_XMLWriter extends Jetpack_Sitemap_Buffer_XMLWriter {
+
+	/**
+	 * Initialize the buffer with required headers and root element.
+	 */
+	protected function initialize_buffer() {
+		// Add generator comment
+		$this->writer->writeComment( "generator='jetpack-" . JETPACK__VERSION . "'" );
+		$this->writer->writeComment( 'Jetpack_Sitemap_Buffer_Master_XMLWriter' );
+
+		// Add stylesheet
+		$this->writer->writePi(
+			'xml-stylesheet',
+			'type="text/xsl" href="' . $this->finder->construct_sitemap_url( 'sitemap-index.xsl' ) . '"'
+		);
+
+		// Start root element with namespaces
+		$this->writer->startElement( 'sitemapindex' );
+		$this->writer->writeAttribute( 'xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9' );
+	}
+
+	/**
+	 * Append a sitemap entry to the master sitemap.
+	 *
+	 * @param array $array The sitemap item to append.
+	 */
+	protected function append_item( $array ) {
+		if ( ! empty( $array['sitemap'] ) ) {
+			$this->writer->startElement( 'sitemap' );
+
+			foreach ( $array['sitemap'] as $tag => $value ) {
+				$this->writer->writeElement( $tag, strval( $value ) );
+			}
+
+			$this->writer->endElement(); // sitemap
+		}
+	}
+}

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-news-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-news-xmlwriter.php
@@ -1,0 +1,91 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * XMLWriter implementation of the news sitemap buffer.
+ *
+ * @since $$next-version$$
+ * @package automattic/jetpack
+ */
+
+/**
+ * A buffer for constructing sitemap news xml files using XMLWriter.
+ *
+ * @since $$next-version$$
+ */
+class Jetpack_Sitemap_Buffer_News_XMLWriter extends Jetpack_Sitemap_Buffer_XMLWriter {
+
+	/**
+	 * Initialize the buffer with required headers and root element.
+	 */
+	protected function initialize_buffer() {
+		// Add generator comment
+		$this->writer->writeComment( "generator='jetpack-" . JETPACK__VERSION . "'" );
+		$this->writer->writeComment( 'Jetpack_Sitemap_Buffer_News_XMLWriter' );
+		$this->writer->writeComment( 'TEST COMMENT - GENERATED AT: ' . gmdate( 'Y-m-d H:i:s' ) );
+
+		// Add stylesheet
+		$this->writer->writePi(
+			'xml-stylesheet',
+			'type="text/xsl" href="' . $this->finder->construct_sitemap_url( 'news-sitemap.xsl' ) . '"'
+		);
+
+		// Start root element with namespaces
+		$this->writer->startElement( 'urlset' );
+
+		/**
+		 * Filter the attribute value pairs used for namespace and namespace URI mappings.
+		 *
+		 * @module sitemaps
+		 *
+		 * @since 4.8.0
+		 *
+		 * @param array $namespaces Associative array with namespaces and namespace URIs.
+		 */
+		$namespaces = apply_filters(
+			'jetpack_sitemap_news_ns',
+			array(
+				'xmlns'              => 'http://www.sitemaps.org/schemas/sitemap/0.9',
+				'xmlns:news'         => 'http://www.google.com/schemas/sitemap-news/0.9',
+				'xmlns:xsi'          => 'http://www.w3.org/2001/XMLSchema-instance',
+				'xsi:schemaLocation' => 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd',
+			)
+		);
+
+		foreach ( $namespaces as $name => $value ) {
+			$this->writer->writeAttribute( $name, $value );
+		}
+	}
+
+	/**
+	 * Append a URL entry with news information to the sitemap.
+	 *
+	 * @param array $array The URL item to append.
+	 */
+	protected function append_item( $array ) {
+		if ( ! empty( $array['url'] ) ) {
+			$this->writer->startElement( 'url' );
+
+			// Add URL elements
+			foreach ( $array['url'] as $tag => $value ) {
+				if ( $tag === 'news:news' ) {
+					$this->writer->startElement( 'news:news' );
+					foreach ( $value as $news_tag => $news_value ) {
+						if ( $news_tag === 'news:publication' ) {
+							$this->writer->startElement( 'news:publication' );
+							foreach ( $news_value as $pub_tag => $pub_value ) {
+								$this->writer->writeElement( $pub_tag, strval( $pub_value ) );
+							}
+							$this->writer->endElement(); // news:publication
+						} else {
+							$this->writer->writeElement( $news_tag, strval( $news_value ) );
+						}
+					}
+					$this->writer->endElement(); // news:news
+				} else {
+					$this->writer->writeElement( $tag, strval( $value ) );
+				}
+			}
+
+			$this->writer->endElement(); // url
+		}
+	}
+}

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-page-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-page-xmlwriter.php
@@ -1,0 +1,72 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * XMLWriter implementation of the page sitemap buffer.
+ *
+ * @since $$next-version$$
+ * @package automattic/jetpack
+ */
+
+/**
+ * A buffer for constructing sitemap page xml files using XMLWriter.
+ *
+ * @since $$next-version$$
+ */
+class Jetpack_Sitemap_Buffer_Page_XMLWriter extends Jetpack_Sitemap_Buffer_XMLWriter {
+
+	/**
+	 * Initialize the buffer with required headers and root element.
+	 */
+	protected function initialize_buffer() {
+		// Add generator comment
+		$this->writer->writeComment( "generator='jetpack-" . JETPACK__VERSION . "'" );
+		$this->writer->writeComment( 'Jetpack_Sitemap_Buffer_Page_XMLWriter' );
+
+		// Add stylesheet
+		$this->writer->writePi(
+			'xml-stylesheet',
+			'type="text/xsl" href="' . $this->finder->construct_sitemap_url( 'sitemap.xsl' ) . '"'
+		);
+
+		// Start root element with namespaces
+		$this->writer->startElement( 'urlset' );
+
+		/**
+		 * Filter the attribute value pairs used for namespace and namespace URI mappings.
+		 *
+		 * @module sitemaps
+		 *
+		 * @since 3.9.0
+		 *
+		 * @param array $namespaces Associative array with namespaces and namespace URIs.
+		 */
+		$namespaces = apply_filters(
+			'jetpack_sitemap_ns',
+			array(
+				'xmlns:xsi'          => 'http://www.w3.org/2001/XMLSchema-instance',
+				'xsi:schemaLocation' => 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd',
+				'xmlns'              => 'http://www.sitemaps.org/schemas/sitemap/0.9',
+			)
+		);
+
+		foreach ( $namespaces as $name => $value ) {
+			$this->writer->writeAttribute( $name, $value );
+		}
+	}
+
+	/**
+	 * Append a URL entry to the sitemap.
+	 *
+	 * @param array $array The URL item to append.
+	 */
+	protected function append_item( $array ) {
+		if ( ! empty( $array['url'] ) ) {
+			$this->writer->startElement( 'url' );
+
+			foreach ( $array['url'] as $tag => $value ) {
+				$this->writer->writeElement( $tag, strval( $value ) );
+			}
+
+			$this->writer->endElement(); // url
+		}
+	}
+}

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-video-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-video-xmlwriter.php
@@ -1,0 +1,87 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * XMLWriter implementation of the video sitemap buffer.
+ *
+ * @since $$next-version$$
+ * @package automattic/jetpack
+ */
+
+/**
+ * A buffer for constructing sitemap video xml files using XMLWriter.
+ *
+ * @since $$next-version$$
+ */
+class Jetpack_Sitemap_Buffer_Video_XMLWriter extends Jetpack_Sitemap_Buffer_XMLWriter {
+
+	/**
+	 * Initialize the buffer with required headers and root element.
+	 */
+	protected function initialize_buffer() {
+		// Add generator comment
+		$this->writer->writeComment( "generator='jetpack-" . JETPACK__VERSION . "'" );
+		$this->writer->writeComment( 'Jetpack_Sitemap_Buffer_Video_XMLWriter' );
+
+		// Add stylesheet
+		$this->writer->writePi(
+			'xml-stylesheet',
+			'type="text/xsl" href="' . $this->finder->construct_sitemap_url( 'video-sitemap.xsl' ) . '"'
+		);
+
+		// Start root element with namespaces
+		$this->writer->startElement( 'urlset' );
+
+		/**
+		 * Filter the XML namespaces included in video sitemaps.
+		 *
+		 * @module sitemaps
+		 *
+		 * @since 4.8.0
+		 *
+		 * @param array $namespaces Associative array with namespaces and namespace URIs.
+		 */
+		$namespaces = apply_filters(
+			'jetpack_sitemap_video_ns',
+			array(
+				'xmlns:xsi'          => 'http://www.w3.org/2001/XMLSchema-instance',
+				'xsi:schemaLocation' => 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd',
+				'xmlns'              => 'http://www.sitemaps.org/schemas/sitemap/0.9',
+				'xmlns:video'        => 'http://www.google.com/schemas/sitemap-video/1.1',
+			)
+		);
+
+		foreach ( $namespaces as $name => $value ) {
+			$this->writer->writeAttribute( $name, $value );
+		}
+	}
+
+	/**
+	 * Append a URL entry with video information to the sitemap.
+	 *
+	 * @param array $array The URL item to append.
+	 */
+	protected function append_item( $array ) {
+		if ( ! empty( $array['url'] ) ) {
+			$this->writer->startElement( 'url' );
+
+			// Add URL elements
+			foreach ( $array['url'] as $tag => $value ) {
+				if ( $tag !== 'videos' ) {
+					$this->writer->writeElement( $tag, strval( $value ) );
+				}
+			}
+
+			// Add video:video elements
+			if ( ! empty( $array['url']['videos'] ) ) {
+				foreach ( $array['url']['videos'] as $video ) {
+					$this->writer->startElement( 'video:video' );
+					foreach ( $video as $tag => $value ) {
+						$this->writer->writeElement( "video:$tag", strval( $value ) );
+					}
+					$this->writer->endElement(); // video:video
+				}
+			}
+
+			$this->writer->endElement(); // url
+		}
+	}
+}

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-xmlwriter.php
@@ -1,0 +1,236 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * XMLWriter implementation of the sitemap buffer.
+ *
+ * @since $$next-version$$
+ * @package automattic/jetpack
+ */
+
+/**
+ * A buffer for constructing sitemap xml files using XMLWriter.
+ *
+ * @since $$next-version$$
+ */
+abstract class Jetpack_Sitemap_Buffer_XMLWriter {
+
+	/**
+	 * Largest number of items the buffer can hold.
+	 *
+	 * @access protected
+	 * @since $$next-version$$
+	 * @var int $item_capacity The item capacity.
+	 */
+	protected $item_capacity;
+
+	/**
+	 * Largest number of bytes the buffer can hold.
+	 *
+	 * @access protected
+	 * @since $$next-version$$
+	 * @var int $byte_capacity The byte capacity.
+	 */
+	protected $byte_capacity;
+
+	/**
+	 * Flag which detects when the buffer is full.
+	 *
+	 * @access protected
+	 * @since $$next-version$$
+	 * @var bool $is_full_flag The flag value.
+	 */
+	protected $is_full_flag;
+
+	/**
+	 * The most recent timestamp seen by the buffer.
+	 *
+	 * @access protected
+	 * @since $$next-version$$
+	 * @var string $timestamp Must be in 'YYYY-MM-DD hh:mm:ss' format.
+	 */
+	protected $timestamp;
+
+	/**
+	 * The XMLWriter instance used to construct the XML.
+	 *
+	 * @access protected
+	 * @since $$next-version$$
+	 * @var XMLWriter $writer
+	 */
+	protected $writer;
+
+	/**
+	 * Helper class to construct sitemap paths.
+	 *
+	 * @since $$next-version$$
+	 * @protected
+	 * @var Jetpack_Sitemap_Finder
+	 */
+	protected $finder;
+
+	/**
+	 * The XML content as a string.
+	 *
+	 * @access protected
+	 * @since $$next-version$$
+	 * @var string $content
+	 */
+	protected $content = '';
+
+	/**
+	 * Construct a new Jetpack_Sitemap_Buffer_XMLWriter.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int    $item_limit The maximum size of the buffer in items.
+	 * @param int    $byte_limit The maximum size of the buffer in bytes.
+	 * @param string $time The initial datetime of the buffer. Must be in 'YYYY-MM-DD hh:mm:ss' format.
+	 */
+	public function __construct( $item_limit, $byte_limit, $time ) {
+		$this->is_full_flag = false;
+		$this->timestamp    = $time;
+		$this->finder       = new Jetpack_Sitemap_Finder();
+
+		$this->writer = new XMLWriter();
+		$this->writer->openMemory();
+		$this->writer->setIndent( true );
+		$this->writer->startDocument( '1.0', 'UTF-8' );
+
+		$this->item_capacity = max( 1, (int) $item_limit );
+		$this->byte_capacity = max( 1, (int) $byte_limit );
+
+		$this->initialize_buffer();
+	}
+
+	/**
+	 * Initialize the buffer with any required headers or setup.
+	 * This should be implemented by child classes.
+	 *
+	 * @access protected
+	 * @since $$next-version$$
+	 */
+	abstract protected function initialize_buffer();
+
+	/**
+	 * Append an item to the buffer.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $array The item to be added.
+	 * @return bool True if the append succeeded, False if not.
+	 */
+	public function append( $array ) {
+		if ( $array === null ) {
+			return true;
+		}
+
+		if ( $this->is_full_flag ) {
+			return false;
+		}
+
+		if ( 0 >= $this->item_capacity || 0 >= $this->byte_capacity ) {
+			$this->is_full_flag = true;
+			return false;
+		}
+
+		$current_content = $this->writer->outputMemory( true );
+		$this->content  .= $current_content;
+
+		$this->append_item( $array );
+
+		$new_content    = $this->writer->outputMemory( true );
+		$this->content .= $new_content;
+
+		// Update capacities after successful append
+		$this->item_capacity -= 1;
+		$this->byte_capacity -= strlen( $new_content );
+
+		// Check both capacity limits
+		if ( 0 >= $this->item_capacity || $this->byte_capacity <= 0 ) {
+			$this->is_full_flag = true;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Append a specific item to the buffer.
+	 * This should be implemented by child classes.
+	 *
+	 * @access protected
+	 * @since $$next-version$$
+	 * @param array $array The item to be added.
+	 */
+	abstract protected function append_item( $array );
+
+	/**
+	 * Retrieve the contents of the buffer.
+	 *
+	 * @since $$next-version$$
+	 * @return string The contents of the buffer.
+	 */
+	public function contents() {
+		$this->writer->endElement(); // End root element (urlset/sitemapindex)
+		$this->writer->endDocument();
+		$final_content  = $this->writer->outputMemory( true );
+		$this->content .= $final_content;
+
+		if ( empty( $this->content ) ) {
+			// If buffer is empty, return a minimal valid XML structure
+			return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\"></urlset>";
+		}
+		return $this->content;
+	}
+
+	/**
+	 * Detect whether the buffer is full.
+	 *
+	 * @since $$next-version$$
+	 * @return bool True if the buffer is full, false otherwise.
+	 */
+	public function is_full() {
+		return $this->is_full_flag;
+	}
+
+	/**
+	 * Detect whether the buffer is empty.
+	 *
+	 * @since $$next-version$$
+	 * @return bool True if the buffer is empty, false otherwise.
+	 */
+	public function is_empty() {
+		$current        = $this->writer->outputMemory( true );
+		$this->content .= $current;
+		return empty( $this->content );
+	}
+
+	/**
+	 * Update the timestamp of the buffer.
+	 *
+	 * @since $$next-version$$
+	 * @param string $new_time A datetime string in 'YYYY-MM-DD hh:mm:ss' format.
+	 */
+	public function view_time( $new_time ) {
+		$this->timestamp = max( $this->timestamp, $new_time );
+	}
+
+	/**
+	 * Retrieve the timestamp of the buffer.
+	 *
+	 * @since $$next-version$$
+	 * @return string A datetime string in 'YYYY-MM-DD hh:mm:ss' format.
+	 */
+	public function last_modified() {
+		return $this->timestamp;
+	}
+
+	/**
+	 * Compatibility method for the old DOMDocument implementation.
+	 * This is only here to satisfy the jetpack_print_sitemap filter.
+	 *
+	 * @since $$next-version$$
+	 * @return null
+	 */
+	public function get_document() {
+		return null;
+	}
+}

--- a/projects/plugins/jetpack/modules/sitemaps/sitemaps.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemaps.php
@@ -34,6 +34,14 @@
 /* Include all of the sitemap subclasses. */
 require_once __DIR__ . '/sitemap-constants.php';
 require_once __DIR__ . '/sitemap-buffer.php';
+require_once __DIR__ . '/sitemap-buffer-fallback.php';
+require_once __DIR__ . '/sitemap-buffer-xmlwriter.php';
+require_once __DIR__ . '/sitemap-buffer-page-xmlwriter.php';
+require_once __DIR__ . '/sitemap-buffer-image-xmlwriter.php';
+require_once __DIR__ . '/sitemap-buffer-video-xmlwriter.php';
+require_once __DIR__ . '/sitemap-buffer-news-xmlwriter.php';
+require_once __DIR__ . '/sitemap-buffer-master-xmlwriter.php';
+require_once __DIR__ . '/sitemap-buffer-factory.php';
 require_once __DIR__ . '/sitemap-stylist.php';
 require_once __DIR__ . '/sitemap-librarian.php';
 require_once __DIR__ . '/sitemap-finder.php';

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Buffer_Factory_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Buffer_Factory_Test.php
@@ -7,6 +7,7 @@ require_once JETPACK__PLUGIN_DIR . 'modules/sitemaps/sitemap-buffer-factory.php'
  *
  * @since $$next-version$$
  * @package automattic/jetpack
+ * @covers Jetpack_Sitemap_Buffer_Factory
  */
 class Jetpack_Sitemap_Buffer_Factory_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
@@ -14,7 +15,6 @@ class Jetpack_Sitemap_Buffer_Factory_Test extends WP_UnitTestCase {
 	/**
 	 * Test creating a page buffer with XMLWriter.
 	 *
-	 * @covers Jetpack_Sitemap_Buffer_Factory::create
 	 * @group jetpack-sitemap
 	 */
 	public function test_create_page_buffer_xmlwriter() {
@@ -25,7 +25,6 @@ class Jetpack_Sitemap_Buffer_Factory_Test extends WP_UnitTestCase {
 	/**
 	 * Test creating an image buffer with XMLWriter.
 	 *
-	 * @covers Jetpack_Sitemap_Buffer_Factory::create
 	 * @group jetpack-sitemap
 	 */
 	public function test_create_image_buffer_xmlwriter() {
@@ -36,7 +35,6 @@ class Jetpack_Sitemap_Buffer_Factory_Test extends WP_UnitTestCase {
 	/**
 	 * Test creating a video buffer with XMLWriter.
 	 *
-	 * @covers Jetpack_Sitemap_Buffer_Factory::create
 	 * @group jetpack-sitemap
 	 */
 	public function test_create_video_buffer_xmlwriter() {
@@ -47,7 +45,6 @@ class Jetpack_Sitemap_Buffer_Factory_Test extends WP_UnitTestCase {
 	/**
 	 * Test creating a news buffer with XMLWriter.
 	 *
-	 * @covers Jetpack_Sitemap_Buffer_Factory::create
 	 * @group jetpack-sitemap
 	 */
 	public function test_create_news_buffer_xmlwriter() {
@@ -58,7 +55,6 @@ class Jetpack_Sitemap_Buffer_Factory_Test extends WP_UnitTestCase {
 	/**
 	 * Test creating a master buffer with XMLWriter.
 	 *
-	 * @covers Jetpack_Sitemap_Buffer_Factory::create
 	 * @group jetpack-sitemap
 	 */
 	public function test_create_master_buffer_xmlwriter() {
@@ -69,7 +65,6 @@ class Jetpack_Sitemap_Buffer_Factory_Test extends WP_UnitTestCase {
 	/**
 	 * Test creating a buffer with an invalid type.
 	 *
-	 * @covers Jetpack_Sitemap_Buffer_Factory::create
 	 * @group jetpack-sitemap
 	 */
 	public function test_create_invalid_type() {
@@ -80,7 +75,6 @@ class Jetpack_Sitemap_Buffer_Factory_Test extends WP_UnitTestCase {
 	/**
 	 * Test creating a buffer with a custom timestamp.
 	 *
-	 * @covers Jetpack_Sitemap_Buffer_Factory::create
 	 * @group jetpack-sitemap
 	 */
 	public function test_create_buffer_with_timestamp() {
@@ -93,7 +87,6 @@ class Jetpack_Sitemap_Buffer_Factory_Test extends WP_UnitTestCase {
 	/**
 	 * Test fallback when XMLWriter is not available.
 	 *
-	 * @covers Jetpack_Sitemap_Buffer_Factory::create
 	 * @group jetpack-sitemap
 	 */
 	public function test_create_buffer_without_xmlwriter() {
@@ -120,7 +113,6 @@ class Jetpack_Sitemap_Buffer_Factory_Test extends WP_UnitTestCase {
 	/**
 	 * Test fallback when both XMLWriter and DOMDocument are not available.
 	 *
-	 * @covers Jetpack_Sitemap_Buffer_Factory::create
 	 * @group jetpack-sitemap
 	 */
 	public function test_create_buffer_without_xmlwriter_and_domdocument() {

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Buffer_Factory_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Buffer_Factory_Test.php
@@ -1,0 +1,146 @@
+<?php
+
+require_once JETPACK__PLUGIN_DIR . 'modules/sitemaps/sitemap-buffer-factory.php';
+
+/**
+ * Test class for Jetpack_Sitemap_Buffer_Factory
+ *
+ * @since $$next-version$$
+ * @package automattic/jetpack
+ */
+class Jetpack_Sitemap_Buffer_Factory_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Test creating a page buffer with XMLWriter.
+	 *
+	 * @covers Jetpack_Sitemap_Buffer_Factory::create
+	 * @group jetpack-sitemap
+	 */
+	public function test_create_page_buffer_xmlwriter() {
+		$buffer = Jetpack_Sitemap_Buffer_Factory::create( 'page', 2, 1000 );
+		$this->assertInstanceOf( 'Jetpack_Sitemap_Buffer_Page_XMLWriter', $buffer );
+	}
+
+	/**
+	 * Test creating an image buffer with XMLWriter.
+	 *
+	 * @covers Jetpack_Sitemap_Buffer_Factory::create
+	 * @group jetpack-sitemap
+	 */
+	public function test_create_image_buffer_xmlwriter() {
+		$buffer = Jetpack_Sitemap_Buffer_Factory::create( 'image', 2, 1000 );
+		$this->assertInstanceOf( 'Jetpack_Sitemap_Buffer_Image_XMLWriter', $buffer );
+	}
+
+	/**
+	 * Test creating a video buffer with XMLWriter.
+	 *
+	 * @covers Jetpack_Sitemap_Buffer_Factory::create
+	 * @group jetpack-sitemap
+	 */
+	public function test_create_video_buffer_xmlwriter() {
+		$buffer = Jetpack_Sitemap_Buffer_Factory::create( 'video', 2, 1000 );
+		$this->assertInstanceOf( 'Jetpack_Sitemap_Buffer_Video_XMLWriter', $buffer );
+	}
+
+	/**
+	 * Test creating a news buffer with XMLWriter.
+	 *
+	 * @covers Jetpack_Sitemap_Buffer_Factory::create
+	 * @group jetpack-sitemap
+	 */
+	public function test_create_news_buffer_xmlwriter() {
+		$buffer = Jetpack_Sitemap_Buffer_Factory::create( 'news', 2, 1000 );
+		$this->assertInstanceOf( 'Jetpack_Sitemap_Buffer_News_XMLWriter', $buffer );
+	}
+
+	/**
+	 * Test creating a master buffer with XMLWriter.
+	 *
+	 * @covers Jetpack_Sitemap_Buffer_Factory::create
+	 * @group jetpack-sitemap
+	 */
+	public function test_create_master_buffer_xmlwriter() {
+		$buffer = Jetpack_Sitemap_Buffer_Factory::create( 'master', 2, 1000 );
+		$this->assertInstanceOf( 'Jetpack_Sitemap_Buffer_Master_XMLWriter', $buffer );
+	}
+
+	/**
+	 * Test creating a buffer with an invalid type.
+	 *
+	 * @covers Jetpack_Sitemap_Buffer_Factory::create
+	 * @group jetpack-sitemap
+	 */
+	public function test_create_invalid_type() {
+		$buffer = Jetpack_Sitemap_Buffer_Factory::create( 'invalid', 2, 1000 );
+		$this->assertNull( $buffer );
+	}
+
+	/**
+	 * Test creating a buffer with a custom timestamp.
+	 *
+	 * @covers Jetpack_Sitemap_Buffer_Factory::create
+	 * @group jetpack-sitemap
+	 */
+	public function test_create_buffer_with_timestamp() {
+		$time   = '2024-01-01 00:00:00';
+		$buffer = Jetpack_Sitemap_Buffer_Factory::create( 'page', 2, 1000, $time );
+		$this->assertInstanceOf( 'Jetpack_Sitemap_Buffer_Page_XMLWriter', $buffer );
+		// We can't test the timestamp directly as it's private, but at least we ensure it doesn't break
+	}
+
+	/**
+	 * Test fallback when XMLWriter is not available.
+	 *
+	 * @covers Jetpack_Sitemap_Buffer_Factory::create
+	 * @group jetpack-sitemap
+	 */
+	public function test_create_buffer_without_xmlwriter() {
+		// Mock XMLWriter being unavailable
+		if ( ! function_exists( 'runkit_function_rename' ) ) {
+			$this->markTestSkipped( 'runkit extension required.' );
+		}
+
+		runkit_function_rename( 'class_exists', 'class_exists_backup' );
+		runkit_function_add(
+			'class_exists',
+			'$class_name',
+			'if ($class_name === "XMLWriter") return false; return class_exists_backup($class_name);'
+		);
+
+		$buffer = Jetpack_Sitemap_Buffer_Factory::create( 'page', 2, 1000 );
+		$this->assertInstanceOf( 'Jetpack_Sitemap_Buffer_Page', $buffer );
+
+		// Restore class_exists
+		runkit_function_remove( 'class_exists' );
+		runkit_function_rename( 'class_exists_backup', 'class_exists' );
+	}
+
+	/**
+	 * Test fallback when both XMLWriter and DOMDocument are not available.
+	 *
+	 * @covers Jetpack_Sitemap_Buffer_Factory::create
+	 * @group jetpack-sitemap
+	 */
+	public function test_create_buffer_without_xmlwriter_and_domdocument() {
+		// Mock XMLWriter and DOMDocument being unavailable
+		if ( ! function_exists( 'runkit_function_rename' ) ) {
+			$this->markTestSkipped( 'runkit extension required.' );
+		}
+
+		runkit_function_rename( 'class_exists', 'class_exists_backup' );
+		runkit_function_add(
+			'class_exists',
+			'$class_name',
+			'if ($class_name === "XMLWriter" || $class_name === "DOMDocument") return false; return class_exists_backup($class_name);'
+		);
+
+		$buffer = Jetpack_Sitemap_Buffer_Factory::create( 'page', 2, 1000 );
+		$this->assertInstanceOf( 'Jetpack_Sitemap_Buffer_Page', $buffer );
+
+		// Restore class_exists
+		runkit_function_remove( 'class_exists' );
+		runkit_function_rename( 'class_exists_backup', 'class_exists' );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Buffer_XMLWriter_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Buffer_XMLWriter_Test.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * Tests for the XMLWriter sitemap buffer implementations.
+ *
+ * @package automattic/jetpack
+ * @since $$next-version$$
+ */
+
+require_once JETPACK__PLUGIN_DIR . 'modules/sitemaps/sitemap-constants.php';
+require_once JETPACK__PLUGIN_DIR . 'modules/sitemaps/sitemap-buffer.php';
+require_once JETPACK__PLUGIN_DIR . 'modules/sitemaps/sitemap-buffer-xmlwriter.php';
+require_once JETPACK__PLUGIN_DIR . 'modules/sitemaps/sitemap-buffer-page-xmlwriter.php';
+require_once JETPACK__PLUGIN_DIR . 'modules/sitemaps/sitemap-buffer-image-xmlwriter.php';
+require_once JETPACK__PLUGIN_DIR . 'modules/sitemaps/sitemap-buffer-video-xmlwriter.php';
+require_once JETPACK__PLUGIN_DIR . 'modules/sitemaps/sitemap-buffer-news-xmlwriter.php';
+require_once JETPACK__PLUGIN_DIR . 'modules/sitemaps/sitemap-buffer-master-xmlwriter.php';
+
+/**
+ * Test class for XMLWriter sitemap buffer implementations.
+ *
+ * @since $$next-version$$
+ */
+class Jetpack_Sitemap_Buffer_XMLWriter_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Test page sitemap buffer with XMLWriter.
+	 *
+	 * @covers Jetpack_Sitemap_Buffer_Page_XMLWriter
+	 * @group jetpack-sitemap
+	 * @since $$next-version$$
+	 */
+	public function test_page_sitemap_buffer() {
+		$buffer = new Jetpack_Sitemap_Buffer_Page_XMLWriter(
+			JP_SITEMAP_MAX_ITEMS,
+			JP_SITEMAP_MAX_BYTES,
+			'1970-01-01 00:00:00'
+		);
+
+		$url_data = array(
+			'url' => array(
+				'loc'        => 'https://example.com/test-page',
+				'lastmod'    => '2024-03-31 12:00:00',
+				'changefreq' => 'daily',
+				'priority'   => '0.8',
+			),
+		);
+
+		$buffer->append( $url_data );
+		$content = $buffer->contents();
+
+		$this->assertStringContainsString( '<?xml version="1.0" encoding="UTF-8"?>', $content );
+		$this->assertStringContainsString( '<urlset', $content );
+		$this->assertStringContainsString( 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"', $content );
+		$this->assertStringContainsString( '<url>', $content );
+		$this->assertStringContainsString( '<loc>https://example.com/test-page</loc>', $content );
+		$this->assertStringContainsString( '<lastmod>2024-03-31 12:00:00</lastmod>', $content );
+		$this->assertStringContainsString( '<changefreq>daily</changefreq>', $content );
+		$this->assertStringContainsString( '<priority>0.8</priority>', $content );
+	}
+
+	/**
+	 * Test image sitemap buffer with XMLWriter.
+	 *
+	 * @covers Jetpack_Sitemap_Buffer_Image_XMLWriter
+	 * @group jetpack-sitemap
+	 * @since $$next-version$$
+	 */
+	public function test_image_sitemap_buffer() {
+		$buffer = new Jetpack_Sitemap_Buffer_Image_XMLWriter(
+			JP_SITEMAP_MAX_ITEMS,
+			JP_SITEMAP_MAX_BYTES,
+			'1970-01-01 00:00:00'
+		);
+
+		$url_data = array(
+			'url' => array(
+				'loc'     => 'https://example.com/test-page',
+				'lastmod' => '2024-03-31 12:00:00',
+				'images'  => array(
+					array(
+						'loc'     => 'https://example.com/test-image.jpg',
+						'title'   => 'Test Image',
+						'caption' => 'A test image caption',
+					),
+				),
+			),
+		);
+
+		$buffer->append( $url_data );
+		$content = $buffer->contents();
+
+		$this->assertStringContainsString( '<?xml version="1.0" encoding="UTF-8"?>', $content );
+		$this->assertStringContainsString( '<urlset', $content );
+		$this->assertStringContainsString( 'xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"', $content );
+		$this->assertStringContainsString( '<url>', $content );
+		$this->assertStringContainsString( '<image:image>', $content );
+		$this->assertStringContainsString( '<image:loc>https://example.com/test-image.jpg</image:loc>', $content );
+		$this->assertStringContainsString( '<image:title>Test Image</image:title>', $content );
+		$this->assertStringContainsString( '<image:caption>A test image caption</image:caption>', $content );
+	}
+
+	/**
+	 * Test video sitemap buffer with XMLWriter.
+	 *
+	 * @covers Jetpack_Sitemap_Buffer_Video_XMLWriter
+	 * @group jetpack-sitemap
+	 * @since $$next-version$$
+	 */
+	public function test_video_sitemap_buffer() {
+		$buffer = new Jetpack_Sitemap_Buffer_Video_XMLWriter(
+			JP_SITEMAP_MAX_ITEMS,
+			JP_SITEMAP_MAX_BYTES,
+			'1970-01-01 00:00:00'
+		);
+
+		$url_data = array(
+			'url' => array(
+				'loc'     => 'https://example.com/test-page',
+				'lastmod' => '2024-03-31 12:00:00',
+				'videos'  => array(
+					array(
+						'title'         => 'Test Video',
+						'description'   => 'A test video description',
+						'thumbnail_loc' => 'https://example.com/thumbnail.jpg',
+						'content_loc'   => 'https://example.com/video.mp4',
+					),
+				),
+			),
+		);
+
+		$buffer->append( $url_data );
+		$content = $buffer->contents();
+
+		$this->assertStringContainsString( '<?xml version="1.0" encoding="UTF-8"?>', $content );
+		$this->assertStringContainsString( '<urlset', $content );
+		$this->assertStringContainsString( 'xmlns:video="http://www.google.com/schemas/sitemap-video/1.1"', $content );
+		$this->assertStringContainsString( '<url>', $content );
+		$this->assertStringContainsString( '<video:video>', $content );
+		$this->assertStringContainsString( '<video:title>Test Video</video:title>', $content );
+		$this->assertStringContainsString( '<video:description>A test video description</video:description>', $content );
+		$this->assertStringContainsString( '<video:thumbnail_loc>https://example.com/thumbnail.jpg</video:thumbnail_loc>', $content );
+		$this->assertStringContainsString( '<video:content_loc>https://example.com/video.mp4</video:content_loc>', $content );
+	}
+
+	/**
+	 * Test news sitemap buffer with XMLWriter.
+	 *
+	 * @covers Jetpack_Sitemap_Buffer_News_XMLWriter
+	 * @group jetpack-sitemap
+	 * @since $$next-version$$
+	 */
+	public function test_news_sitemap_buffer() {
+		$buffer = new Jetpack_Sitemap_Buffer_News_XMLWriter(
+			JP_SITEMAP_MAX_ITEMS,
+			JP_SITEMAP_MAX_BYTES,
+			'1970-01-01 00:00:00'
+		);
+
+		$url_data = array(
+			'url' => array(
+				'loc'       => 'https://example.com/test-news',
+				'lastmod'   => '2024-03-31 12:00:00',
+				'news:news' => array(
+					'news:publication'      => array(
+						'news:name'     => 'Test News Site',
+						'news:language' => 'en',
+					),
+					'news:title'            => 'Test News Article',
+					'news:publication_date' => '2024-03-31 12:00:00',
+					'news:genres'           => 'Blog',
+				),
+			),
+		);
+
+		$buffer->append( $url_data );
+		$content = $buffer->contents();
+
+		$this->assertStringContainsString( '<?xml version="1.0" encoding="UTF-8"?>', $content );
+		$this->assertStringContainsString( '<urlset', $content );
+		$this->assertStringContainsString( 'xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"', $content );
+		$this->assertStringContainsString( '<url>', $content );
+		$this->assertStringContainsString( '<news:news>', $content );
+		$this->assertStringContainsString( '<news:publication>', $content );
+		$this->assertStringContainsString( '<news:name>Test News Site</news:name>', $content );
+		$this->assertStringContainsString( '<news:language>en</news:language>', $content );
+		$this->assertStringContainsString( '<news:title>Test News Article</news:title>', $content );
+		$this->assertStringContainsString( '<news:publication_date>2024-03-31 12:00:00</news:publication_date>', $content );
+		$this->assertStringContainsString( '<news:genres>Blog</news:genres>', $content );
+	}
+
+	/**
+	 * Test master sitemap buffer with XMLWriter.
+	 *
+	 * @covers Jetpack_Sitemap_Buffer_Master_XMLWriter
+	 * @group jetpack-sitemap
+	 * @since $$next-version$$
+	 */
+	public function test_master_sitemap_buffer() {
+		$buffer = new Jetpack_Sitemap_Buffer_Master_XMLWriter(
+			JP_SITEMAP_MAX_ITEMS,
+			JP_SITEMAP_MAX_BYTES,
+			'1970-01-01 00:00:00'
+		);
+
+		$sitemap_data = array(
+			'sitemap' => array(
+				'loc'     => 'https://example.com/sitemap-1.xml',
+				'lastmod' => '2024-03-31 12:00:00',
+			),
+		);
+
+		$buffer->append( $sitemap_data );
+		$content = $buffer->contents();
+
+		$this->assertStringContainsString( '<?xml version="1.0" encoding="UTF-8"?>', $content );
+		$this->assertStringContainsString( '<sitemapindex', $content );
+		$this->assertStringContainsString( 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"', $content );
+		$this->assertStringContainsString( '<sitemap>', $content );
+		$this->assertStringContainsString( '<loc>https://example.com/sitemap-1.xml</loc>', $content );
+		$this->assertStringContainsString( '<lastmod>2024-03-31 12:00:00</lastmod>', $content );
+	}
+
+	/**
+	 * Test buffer capacity limits with XMLWriter.
+	 *
+	 * @covers Jetpack_Sitemap_Buffer_XMLWriter
+	 * @group jetpack-sitemap
+	 * @since $$next-version$$
+	 */
+	public function test_buffer_capacity() {
+		$buffer = new Jetpack_Sitemap_Buffer_Page_XMLWriter(
+			2, // Max items
+			1024, // Max bytes
+			'1970-01-01 00:00:00'
+		);
+
+		$url_data = array(
+			'url' => array(
+				'loc'     => 'https://example.com/test-page',
+				'lastmod' => '2024-03-31 12:00:00',
+			),
+		);
+
+		// First append should succeed
+		$this->assertTrue( $buffer->append( $url_data ) );
+		$this->assertFalse( $buffer->is_full() );
+
+		// Second append should succeed
+		$this->assertTrue( $buffer->append( $url_data ) );
+		$this->assertTrue( $buffer->is_full() );
+
+		// Third append should fail due to item limit
+		$this->assertFalse( $buffer->append( $url_data ) );
+	}
+
+	/**
+	 * Test last modified tracking with XMLWriter.
+	 *
+	 * @covers Jetpack_Sitemap_Buffer_XMLWriter
+	 * @group jetpack-sitemap
+	 * @since $$next-version$$
+	 */
+	public function test_last_modified_tracking() {
+		$buffer = new Jetpack_Sitemap_Buffer_Page_XMLWriter(
+			2,
+			1024,
+			'1970-01-01 00:00:00'
+		);
+
+		$this->assertEquals( '1970-01-01 00:00:00', $buffer->last_modified() );
+
+		$buffer->view_time( '2024-03-31 12:00:00' );
+		$this->assertEquals( '2024-03-31 12:00:00', $buffer->last_modified() );
+
+		// Earlier time should not update last_modified
+		$buffer->view_time( '2024-03-30 12:00:00' );
+		$this->assertEquals( '2024-03-31 12:00:00', $buffer->last_modified() );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Buffer_XMLWriter_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Buffer_XMLWriter_Test.php
@@ -19,6 +19,12 @@ require_once JETPACK__PLUGIN_DIR . 'modules/sitemaps/sitemap-buffer-master-xmlwr
  * Test class for XMLWriter sitemap buffer implementations.
  *
  * @since $$next-version$$
+ * @covers \Jetpack_Sitemap_Buffer_Image_XMLWriter
+ * @covers \Jetpack_Sitemap_Buffer_Master_XMLWriter
+ * @covers \Jetpack_Sitemap_Buffer_News_XMLWriter
+ * @covers \Jetpack_Sitemap_Buffer_Page_XMLWriter
+ * @covers \Jetpack_Sitemap_Buffer_Video_XMLWriter
+ * @covers \Jetpack_Sitemap_Buffer_XMLWriter
  */
 class Jetpack_Sitemap_Buffer_XMLWriter_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
@@ -26,7 +32,6 @@ class Jetpack_Sitemap_Buffer_XMLWriter_Test extends WP_UnitTestCase {
 	/**
 	 * Test page sitemap buffer with XMLWriter.
 	 *
-	 * @covers Jetpack_Sitemap_Buffer_Page_XMLWriter
 	 * @group jetpack-sitemap
 	 * @since $$next-version$$
 	 */
@@ -62,7 +67,6 @@ class Jetpack_Sitemap_Buffer_XMLWriter_Test extends WP_UnitTestCase {
 	/**
 	 * Test image sitemap buffer with XMLWriter.
 	 *
-	 * @covers Jetpack_Sitemap_Buffer_Image_XMLWriter
 	 * @group jetpack-sitemap
 	 * @since $$next-version$$
 	 */
@@ -73,37 +77,57 @@ class Jetpack_Sitemap_Buffer_XMLWriter_Test extends WP_UnitTestCase {
 			'1970-01-01 00:00:00'
 		);
 
+		// Test case 1: Basic image entry matching sitemap-builder.php structure
 		$url_data = array(
 			'url' => array(
-				'loc'     => 'https://example.com/test-page',
-				'lastmod' => '2024-03-31 12:00:00',
-				'images'  => array(
-					array(
-						'loc'     => 'https://example.com/test-image.jpg',
-						'title'   => 'Test Image',
-						'caption' => 'A test image caption',
-					),
+				'loc'         => 'https://example.com/test-page',
+				'lastmod'     => '2024-03-31 12:00:00',
+				'image:image' => array(
+					'image:loc' => 'https://example.com/test-image.jpg',
 				),
 			),
 		);
 
-		$buffer->append( $url_data );
+		$this->assertTrue( $buffer->append( $url_data ) );
 		$content = $buffer->contents();
 
 		$this->assertStringContainsString( '<?xml version="1.0" encoding="UTF-8"?>', $content );
 		$this->assertStringContainsString( '<urlset', $content );
 		$this->assertStringContainsString( 'xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"', $content );
-		$this->assertStringContainsString( '<url>', $content );
-		$this->assertStringContainsString( '<image:image>', $content );
+		$this->assertStringContainsString( '<loc>https://example.com/test-page</loc>', $content );
 		$this->assertStringContainsString( '<image:loc>https://example.com/test-image.jpg</image:loc>', $content );
-		$this->assertStringContainsString( '<image:title>Test Image</image:title>', $content );
-		$this->assertStringContainsString( '<image:caption>A test image caption</image:caption>', $content );
+		$this->assertStringContainsString( '</urlset>', $content );
+
+		// Test case 2: Image with optional fields
+		$buffer = new Jetpack_Sitemap_Buffer_Image_XMLWriter(
+			JP_SITEMAP_MAX_ITEMS,
+			JP_SITEMAP_MAX_BYTES,
+			'1970-01-01 00:00:00'
+		);
+
+		$url_data_with_optional = array(
+			'url' => array(
+				'loc'         => 'https://example.com/test-page-2',
+				'lastmod'     => '2024-03-31 12:00:00',
+				'image:image' => array(
+					'image:loc'     => 'https://example.com/test-image-2.jpg',
+					'image:title'   => 'Test Image Title',
+					'image:caption' => 'Test Image Caption',
+				),
+			),
+		);
+
+		$this->assertTrue( $buffer->append( $url_data_with_optional ) );
+		$content = $buffer->contents();
+
+		$this->assertStringContainsString( '<image:title>Test Image Title</image:title>', $content );
+		$this->assertStringContainsString( '<image:caption>Test Image Caption</image:caption>', $content );
+		$this->assertStringContainsString( '</urlset>', $content );
 	}
 
 	/**
 	 * Test video sitemap buffer with XMLWriter.
 	 *
-	 * @covers Jetpack_Sitemap_Buffer_Video_XMLWriter
 	 * @group jetpack-sitemap
 	 * @since $$next-version$$
 	 */
@@ -146,7 +170,6 @@ class Jetpack_Sitemap_Buffer_XMLWriter_Test extends WP_UnitTestCase {
 	/**
 	 * Test news sitemap buffer with XMLWriter.
 	 *
-	 * @covers Jetpack_Sitemap_Buffer_News_XMLWriter
 	 * @group jetpack-sitemap
 	 * @since $$next-version$$
 	 */
@@ -192,7 +215,6 @@ class Jetpack_Sitemap_Buffer_XMLWriter_Test extends WP_UnitTestCase {
 	/**
 	 * Test master sitemap buffer with XMLWriter.
 	 *
-	 * @covers Jetpack_Sitemap_Buffer_Master_XMLWriter
 	 * @group jetpack-sitemap
 	 * @since $$next-version$$
 	 */
@@ -224,7 +246,6 @@ class Jetpack_Sitemap_Buffer_XMLWriter_Test extends WP_UnitTestCase {
 	/**
 	 * Test buffer capacity limits with XMLWriter.
 	 *
-	 * @covers Jetpack_Sitemap_Buffer_XMLWriter
 	 * @group jetpack-sitemap
 	 * @since $$next-version$$
 	 */
@@ -257,7 +278,6 @@ class Jetpack_Sitemap_Buffer_XMLWriter_Test extends WP_UnitTestCase {
 	/**
 	 * Test last modified tracking with XMLWriter.
 	 *
-	 * @covers Jetpack_Sitemap_Buffer_XMLWriter
 	 * @group jetpack-sitemap
 	 * @since $$next-version$$
 	 */

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
@@ -6,6 +6,8 @@
  * @since 13.4
  */
 
+require_once JETPACK__PLUGIN_DIR . 'modules/sitemaps/sitemap-builder.php';
+
 /**
  * Test class for Jetpack_Sitemap_Builder.
  *
@@ -14,6 +16,217 @@
  */
 class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * @var Jetpack_Sitemap_Builder
+	 */
+	private $builder;
+
+	/**
+	 * Set up before each test
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->builder = new Jetpack_Sitemap_Builder();
+
+		// Reset the sitemap state
+		Jetpack_Sitemap_State::reset( JP_PAGE_SITEMAP_TYPE );
+	}
+
+	/**
+	 * Clean up after each test
+	 */
+	public function tear_down() {
+		// Clean up any registered post types
+		if ( post_type_exists( 'test_cpt' ) ) {
+			unregister_post_type( 'test_cpt' );
+		}
+
+		// Reset permalink structure
+		global $wp_rewrite;
+		$wp_rewrite->set_permalink_structure( '' );
+		$wp_rewrite->flush_rules( true );
+
+		// Clean up sitemap state and options
+		Jetpack_Sitemap_State::delete();
+		delete_option( 'jetpack_sitemap_post_types' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test constructor sets up default post types
+	 *
+	 * @covers Jetpack_Sitemap_Builder::__construct
+	 */
+	public function test_constructor_sets_default_post_types() {
+		$post_types = get_option( 'jetpack_sitemap_post_types' );
+		$this->assertEquals( array( 'post', 'page' ), $post_types );
+	}
+
+	/**
+	 * Test sitemap index generation with multiple sitemaps
+	 *
+	 * @covers Jetpack_Sitemap_Builder::build_next_sitemap_index_of_type
+	 */
+	public function test_sitemap_index_generation() {
+		// Create enough posts to generate multiple sitemaps
+		self::factory()->post->create_many(
+			2000,
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			)
+		);
+
+		// Run updates until we reach the index generation
+		for ( $i = 0; $i < 3; $i++ ) {
+			$this->builder->update_sitemap();
+		}
+
+		// Check that index files were created
+		$librarian = new Jetpack_Sitemap_Librarian();
+		$index     = $librarian->get_sitemap_text( 'sitemap-index-1.xml', JP_PAGE_SITEMAP_INDEX_TYPE );
+
+		$this->assertNotEmpty( $index );
+		$this->assertStringContainsString( '<sitemapindex', $index );
+		$this->assertStringContainsString( '<sitemap>', $index );
+	}
+
+	/**
+	 * Test master sitemap generation
+	 *
+	 * @covers Jetpack_Sitemap_Builder::build_master_sitemap
+	 */
+	public function test_master_sitemap_generation() {
+		// Create content of different types
+		self::factory()->post->create_many(
+			5,
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			)
+		);
+
+		// Use jetpack-icon.jpg from tests/php folder
+		$filename = dirname( __DIR__, 3 ) . '/jetpack-icon.jpg';
+
+		// Create an attachment with proper image metadata
+		$attachment_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => $filename,
+				'post_parent'    => 0,
+				'post_mime_type' => 'image/jpeg',
+				'post_title'     => 'Test Image',
+			)
+		);
+
+		// Add image metadata
+		$attachment_metadata = array(
+			'width'  => 100,
+			'height' => 100,
+			'file'   => 'test-image.jpg',
+			'sizes'  => array(
+				'thumbnail' => array(
+					'file'      => 'test-image-150x150.jpg',
+					'width'     => 150,
+					'height'    => 150,
+					'mime-type' => 'image/jpeg',
+				),
+			),
+		);
+		wp_update_attachment_metadata( $attachment_id, $attachment_metadata );
+
+		// Run updates until we reach master sitemap generation
+		for ( $i = 0; $i < 10; $i++ ) {
+			$this->builder->update_sitemap();
+		}
+
+		// Check master sitemap
+		$librarian = new Jetpack_Sitemap_Librarian();
+		$master    = $librarian->get_sitemap_text( 'sitemap.xml', JP_MASTER_SITEMAP_TYPE );
+
+		$this->assertNotEmpty( $master );
+		$this->assertStringContainsString( '<sitemapindex', $master );
+		$this->assertStringContainsString( 'sitemap-1.xml', $master );
+		$this->assertStringContainsString( 'image-sitemap-1.xml', $master );
+
+		// Clean up
+		wp_delete_attachment( $attachment_id, true );
+		if ( file_exists( $filename ) && strpos( $filename, 'test-image-' ) !== false ) {
+			unlink( $filename );
+		}
+	}
+
+	/**
+	 * Test sitemap generation with custom post types
+	 *
+	 * @covers Jetpack_Sitemap_Builder::build_one_page_sitemap
+	 */
+	public function test_sitemap_with_custom_post_types() {
+		// Reset the sitemap state to ensure clean test
+		Jetpack_Sitemap_State::reset( JP_PAGE_SITEMAP_TYPE );
+
+		// Register a custom post type with minimal configuration
+		register_post_type(
+			'test_cpt',
+			array(
+				'public'       => true,
+				'has_archive'  => true,
+				'show_in_rest' => false,
+				'rewrite'      => array(
+					'slug'       => 'test_cpt',
+					'with_front' => true,
+					'pages'      => true,
+					'feeds'      => true,
+					'ep_mask'    => 1,
+				),
+				'supports'     => array(),
+			)
+		);
+
+		// Ensure rewrite rules are flushed
+		global $wp_rewrite;
+		$wp_rewrite->init();
+		$wp_rewrite->flush_rules( true );
+
+		// Update sitemap post types option directly
+		update_option(
+			'jetpack_sitemap_post_types',
+			array( 'post', 'page', 'test_cpt' )
+		);
+
+		// Create some custom post type content
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'test_cpt',
+				'post_status' => 'publish',
+				'post_title'  => 'Test CPT Post',
+				'post_name'   => 'test-cpt-post',
+			)
+		);
+
+		// Force permalink structure to ensure consistent URLs
+		$wp_rewrite->set_permalink_structure( '/%postname%/' );
+		$wp_rewrite->flush_rules( true );
+
+		// Generate sitemap
+		$this->builder->update_sitemap();
+
+		// Check that custom post type URLs are included
+		$librarian = new Jetpack_Sitemap_Librarian();
+		$sitemap   = $librarian->get_sitemap_text( 'sitemap-1.xml', JP_PAGE_SITEMAP_TYPE );
+
+		$post_url = get_permalink( $post_id );
+		$this->assertStringContainsString( $post_url, $sitemap );
+
+		// Clean up
+		unregister_post_type( 'test_cpt' );
+		$wp_rewrite->set_permalink_structure( '' );
+		$wp_rewrite->flush_rules( true );
+		Jetpack_Sitemap_State::delete();
+		delete_option( 'jetpack_sitemap_post_types' );
+	}
 
 	/**
 	 * "lastmod" date from other URLs filter is considered when building a sitemap.

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
@@ -118,15 +118,18 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 				'post_parent'    => 0,
 				'post_mime_type' => 'image/jpeg',
 				'post_title'     => 'Test Image',
+				'post_content'   => 'Test Image Description',
+				'post_excerpt'   => 'Test Image Caption',
+				'post_status'    => 'publish',
 			)
 		);
 
 		// Add image metadata
 		$attachment_metadata = array(
-			'width'  => 100,
-			'height' => 100,
-			'file'   => 'test-image.jpg',
-			'sizes'  => array(
+			'width'      => 100,
+			'height'     => 100,
+			'file'       => 'test-image.jpg',
+			'sizes'      => array(
 				'thumbnail' => array(
 					'file'      => 'test-image-150x150.jpg',
 					'width'     => 150,
@@ -134,8 +137,30 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 					'mime-type' => 'image/jpeg',
 				),
 			),
+			'image_meta' => array(
+				'title'   => 'Test Image',
+				'caption' => 'Test Image Caption',
+			),
 		);
 		wp_update_attachment_metadata( $attachment_id, $attachment_metadata );
+
+		// Add a filter to transform image:image to images format
+		add_filter(
+			'jetpack_sitemap_image_sitemap_item',
+			function ( $item_array ) use ( $attachment_id ) {
+				if ( isset( $item_array['url']['image:image'] ) ) {
+					$item_array['url']['images'] = array(
+						array(
+							'loc'     => $item_array['url']['image:image']['image:loc'],
+							'title'   => get_the_title( $attachment_id ),
+							'caption' => get_the_excerpt( $attachment_id ),
+						),
+					);
+					unset( $item_array['url']['image:image'] );
+				}
+				return $item_array;
+			}
+		);
 
 		// Run updates until we reach master sitemap generation
 		for ( $i = 0; $i < 10; $i++ ) {
@@ -156,6 +181,22 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 		if ( file_exists( $filename ) && strpos( $filename, 'test-image-' ) !== false ) {
 			unlink( $filename );
 		}
+		remove_filter(
+			'jetpack_sitemap_image_sitemap_item',
+			function ( $item_array ) use ( $attachment_id ) {
+				if ( isset( $item_array['url']['image:image'] ) ) {
+					$item_array['url']['images'] = array(
+						array(
+							'loc'     => $item_array['url']['image:image']['image:loc'],
+							'title'   => get_the_title( $attachment_id ),
+							'caption' => get_the_excerpt( $attachment_id ),
+						),
+					);
+					unset( $item_array['url']['image:image'] );
+				}
+				return $item_array;
+			}
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
@@ -56,8 +56,6 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 
 	/**
 	 * Test constructor sets up default post types
-	 *
-	 * @covers Jetpack_Sitemap_Builder::__construct
 	 */
 	public function test_constructor_sets_default_post_types() {
 		$post_types = get_option( 'jetpack_sitemap_post_types' );
@@ -66,8 +64,6 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 
 	/**
 	 * Test sitemap index generation with multiple sitemaps
-	 *
-	 * @covers Jetpack_Sitemap_Builder::build_next_sitemap_index_of_type
 	 */
 	public function test_sitemap_index_generation() {
 		// Create enough posts to generate multiple sitemaps
@@ -95,8 +91,6 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 
 	/**
 	 * Test master sitemap generation
-	 *
-	 * @covers Jetpack_Sitemap_Builder::build_master_sitemap
 	 */
 	public function test_master_sitemap_generation() {
 		// Create content of different types
@@ -201,8 +195,6 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 
 	/**
 	 * Test sitemap generation with custom post types
-	 *
-	 * @covers Jetpack_Sitemap_Builder::build_one_page_sitemap
 	 */
 	public function test_sitemap_with_custom_post_types() {
 		// Reset the sitemap state to ensure clean test

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Manager_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Manager_Test.php
@@ -3,7 +3,9 @@
 require_once JETPACK__PLUGIN_DIR . 'modules/sitemaps/sitemaps.php';
 
 /**
- * @covers \Jetpack_Sitemap_Manager
+ * Test class for Jetpack_Sitemap_Manager
+ *
+ * @covers Jetpack_Sitemap_Manager
  */
 class Jetpack_Sitemap_Manager_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
@@ -76,7 +78,6 @@ class Jetpack_Sitemap_Manager_Test extends WP_UnitTestCase {
 	/**
 	 * Tests that the sitemap cron schedule is added correctly.
 	 *
-	 * @covers Jetpack_Sitemap_Manager::callback_add_sitemap_schedule
 	 * @group jetpack-sitemap
 	 */
 	public function test_sitemap_manager_adds_cron_schedule() {
@@ -91,7 +92,6 @@ class Jetpack_Sitemap_Manager_Test extends WP_UnitTestCase {
 	/**
 	 * Tests that robots.txt is modified correctly.
 	 *
-	 * @covers Jetpack_Sitemap_Manager::callback_action_do_robotstxt
 	 * @group jetpack-sitemap
 	 */
 	public function test_sitemap_manager_modifies_robotstxt() {
@@ -107,7 +107,6 @@ class Jetpack_Sitemap_Manager_Test extends WP_UnitTestCase {
 	/**
 	 * Tests that the news sitemap cache is flushed when a post is published.
 	 *
-	 * @covers Jetpack_Sitemap_Manager::callback_action_flush_news_sitemap_cache
 	 * @group jetpack-sitemap
 	 */
 	public function test_sitemap_manager_flushes_news_sitemap_cache() {
@@ -122,7 +121,6 @@ class Jetpack_Sitemap_Manager_Test extends WP_UnitTestCase {
 	/**
 	 * Tests that all sitemap data is purged correctly.
 	 *
-	 * @covers Jetpack_Sitemap_Manager::callback_action_purge_data
 	 * @group jetpack-sitemap
 	 */
 	public function test_sitemap_manager_purges_all_data() {

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Manager_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Manager_Test.php
@@ -9,6 +9,16 @@ class Jetpack_Sitemap_Manager_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
 	/**
+	 * @var Jetpack_Sitemap_Manager
+	 */
+	private $manager;
+
+	public function set_up() {
+		parent::set_up();
+		$this->manager = new Jetpack_Sitemap_Manager();
+	}
+
+	/**
 	 * Constructor does not throw any fatal errors.
 	 *
 	 * @group jetpack-sitemap
@@ -26,13 +36,11 @@ class Jetpack_Sitemap_Manager_Test extends WP_UnitTestCase {
 	 * @since 4.7.0
 	 */
 	public function test_sitemap_manager_filter_sitemap_location_sets_option_default() {
-		$manager = new Jetpack_Sitemap_Manager();
-
 		// Start with an empty option.
 		delete_option( 'jetpack_sitemap_location' );
 
 		// Check default value.
-		$manager->callback_action_filter_sitemap_location();
+		$this->manager->callback_action_filter_sitemap_location();
 		$location = get_option( 'jetpack_sitemap_location' );
 		$this->assertSame( '', $location );
 
@@ -47,8 +55,6 @@ class Jetpack_Sitemap_Manager_Test extends WP_UnitTestCase {
 	 * @since 4.7.0
 	 */
 	public function test_sitemap_manager_filter_sitemap_location_sets_option_add() {
-		$manager = new Jetpack_Sitemap_Manager();
-
 		// Start with an empty option.
 		delete_option( 'jetpack_sitemap_location' );
 
@@ -59,11 +65,72 @@ class Jetpack_Sitemap_Manager_Test extends WP_UnitTestCase {
 		}
 		add_filter( 'jetpack_sitemap_location', 'add_location' );
 
-		$manager->callback_action_filter_sitemap_location();
+		$this->manager->callback_action_filter_sitemap_location();
 		$location = get_option( 'jetpack_sitemap_location' );
 		$this->assertEquals( '/blah', $location );
 
 		// Clean up.
 		delete_option( 'jetpack_sitemap_location' );
+	}
+
+	/**
+	 * Tests that the sitemap cron schedule is added correctly.
+	 *
+	 * @covers Jetpack_Sitemap_Manager::callback_add_sitemap_schedule
+	 * @group jetpack-sitemap
+	 */
+	public function test_sitemap_manager_adds_cron_schedule() {
+		$schedules = array();
+		$result    = $this->manager->callback_add_sitemap_schedule( $schedules );
+
+		$this->assertArrayHasKey( 'sitemap-interval', $result );
+		$this->assertEquals( 'Sitemap Interval', $result['sitemap-interval']['display'] );
+		$this->assertEquals( JP_SITEMAP_INTERVAL, $result['sitemap-interval']['interval'] );
+	}
+
+	/**
+	 * Tests that robots.txt is modified correctly.
+	 *
+	 * @covers Jetpack_Sitemap_Manager::callback_action_do_robotstxt
+	 * @group jetpack-sitemap
+	 */
+	public function test_sitemap_manager_modifies_robotstxt() {
+		ob_start();
+		$this->manager->callback_action_do_robotstxt();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Sitemap: ', $output );
+		$this->assertStringContainsString( 'sitemap.xml', $output );
+		$this->assertStringContainsString( 'news-sitemap.xml', $output );
+	}
+
+	/**
+	 * Tests that the news sitemap cache is flushed when a post is published.
+	 *
+	 * @covers Jetpack_Sitemap_Manager::callback_action_flush_news_sitemap_cache
+	 * @group jetpack-sitemap
+	 */
+	public function test_sitemap_manager_flushes_news_sitemap_cache() {
+		// Set up a mock cache entry
+		set_transient( 'jetpack_news_sitemap_xml', 'test cache data' );
+
+		$this->manager->callback_action_flush_news_sitemap_cache();
+
+		$this->assertFalse( get_transient( 'jetpack_news_sitemap_xml' ) );
+	}
+
+	/**
+	 * Tests that all sitemap data is purged correctly.
+	 *
+	 * @covers Jetpack_Sitemap_Manager::callback_action_purge_data
+	 * @group jetpack-sitemap
+	 */
+	public function test_sitemap_manager_purges_all_data() {
+		// Set up mock data
+		set_transient( 'jetpack_news_sitemap_xml', 'test cache data' );
+
+		$this->manager->callback_action_purge_data();
+
+		$this->assertFalse( get_transient( 'jetpack_news_sitemap_xml' ) );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Uses XMLWriter for sitemap generation instead of domdocument.

This also adds a profile CLI command that I used to determine the variance.

Before:
Initial Memory: 67 MB
Peak Memory: 89 MB
Memory Increase: 22 MB

After:
Initial Memory: 69 MB
Peak Memory: 71 MB
Memory Increase: 2 MB

The test site had a ton of dummy content (~800k posts).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use xmlwriter instead of domdocument for xml generation.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
none yet

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `wp jetpack sitemap rebuild --purge` (on a site with sitemaps active) will rebuild. Check sitemap.xml.

