### PR TITLE
Jetpack SEO Enhancer: add placement prop

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-seo-enhancer-settings-events-extras
+++ b/projects/plugins/jetpack/changelog/add-jetpack-seo-enhancer-settings-events-extras
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack SEO Enhancer: add placement prop for component and track event

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
@@ -56,10 +56,11 @@ export function SeoEnhancer( {
 			tracks.recordEvent( 'jetpack_seo_enhancer_feature_toggle', {
 				feature: name,
 				toggled: ! isFeatureEnabled ? 'on' : 'off',
+				placement,
 			} );
 			setFeatureEnabled( name, ! isFeatureEnabled );
 		},
-		[ enabledFeatures, setFeatureEnabled, tracks ]
+		[ enabledFeatures, setFeatureEnabled, tracks, placement ]
 	);
 
 	const generateHandler = async () => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
@@ -26,7 +26,13 @@ import './style.scss';
  */
 const debug = debugFactory( 'seo-enhancer:index' );
 
-export function SeoEnhancer( { disableAutoEnhance = false }: { disableAutoEnhance?: boolean } ) {
+export function SeoEnhancer( {
+	disableAutoEnhance = false,
+	placement = null,
+}: {
+	disableAutoEnhance?: boolean;
+	placement?: 'jetpack-sidebar' | 'jetpack-prepublish-sidebar';
+} ) {
 	const { tracks } = useAnalytics();
 	const { isEnabled, toggleEnhancer, isToggling } = useSeoModuleSettings();
 	const isLoading = useSelect( select => {
@@ -41,8 +47,8 @@ export function SeoEnhancer( { disableAutoEnhance = false }: { disableAutoEnhanc
 	const { updateSeoData } = useSeoRequests();
 
 	const toggleSeoEnhancer = useCallback( async () => {
-		await toggleEnhancer();
-	}, [ toggleEnhancer ] );
+		await toggleEnhancer( { placement } );
+	}, [ toggleEnhancer, placement ] );
 
 	const toggleFeature = useCallback(
 		name => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-module-settings.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-module-settings.ts
@@ -22,28 +22,33 @@ export const useSeoModuleSettings = () => {
 	const setIsToggling = useDispatch( store ).setIsTogglingAutoEnhance;
 	const setIsEnabled = useDispatch( store ).setIsAutoEnhanceEnabled;
 
-	const toggleEnhancer = useCallback( async () => {
-		setIsToggling( true );
-		try {
-			await apiFetch( {
-				path: 'jetpack/v4/module/seo-tools',
-				method: 'post',
-				data: { ai_seo_enhancer_enabled: ! isEnabled },
-			} );
-			tracks.recordEvent( 'jetpack_seo_enhancer_toggle', {
-				toggled: ! isEnabled ? 'on' : 'off',
-			} );
-			setIsEnabled( ! isEnabled );
-		} catch ( error ) {
-			debug( 'Error toggling SEO enhancer', error );
-			tracks.recordEvent( 'jetpack_seo_enhancer_toggle_error', {
-				toggled: ! isEnabled ? 'on' : 'off',
-				error: error?.message,
-			} );
-		} finally {
-			setIsToggling( false );
-		}
-	}, [ isEnabled, setIsEnabled, setIsToggling, tracks ] );
+	const toggleEnhancer = useCallback(
+		async ( { placement }: { placement: 'jetpack-sidebar' | 'jetpack-prepublish-sidebar' } ) => {
+			setIsToggling( true );
+			try {
+				await apiFetch( {
+					path: 'jetpack/v4/module/seo-tools',
+					method: 'post',
+					data: { ai_seo_enhancer_enabled: ! isEnabled },
+				} );
+				tracks.recordEvent( 'jetpack_seo_enhancer_toggle', {
+					toggled: ! isEnabled ? 'on' : 'off',
+					placement,
+				} );
+				setIsEnabled( ! isEnabled );
+			} catch ( error ) {
+				debug( 'Error toggling SEO enhancer', error );
+				tracks.recordEvent( 'jetpack_seo_enhancer_toggle_error', {
+					toggled: ! isEnabled ? 'on' : 'off',
+					error: error?.message,
+					placement,
+				} );
+			} finally {
+				setIsToggling( false );
+			}
+		},
+		[ isEnabled, setIsEnabled, setIsToggling, tracks ]
+	);
 
 	return {
 		isEnabled,

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -187,7 +187,7 @@ const Seo = () => {
 						</PanelRow>
 					) }
 					{ isSeoEnhancerEnabled && hasRequiredPlanForEnhancer && (
-						<SeoEnhancer disableAutoEnhance={ ! canHaveAutoEnhance } />
+						<SeoEnhancer placement="jetpack-sidebar" disableAutoEnhance={ ! canHaveAutoEnhance } />
 					) }
 					<PanelRow
 						className={ clsx( {
@@ -216,7 +216,10 @@ const Seo = () => {
 			<PluginPrePublishPanel { ...jetpackSeoPublishPanelsProps }>
 				<div className="jetpack-seo-panel">
 					{ isSeoEnhancerEnabled && hasRequiredPlanForEnhancer && (
-						<SeoEnhancer disableAutoEnhance={ ! canHaveAutoEnhance } />
+						<SeoEnhancer
+							placement="jetpack-prepublish-sidebar"
+							disableAutoEnhance={ ! canHaveAutoEnhance }
+						/>
 					) }
 					<PanelRow>
 						<SeoTitlePanel />


### PR DESCRIPTION
## Proposed changes:
This PR adds `placement` prop for the component, allowing for further conditions to be applied on automated behavior and event tracking

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pe4Cmx-2ZI-p2#comment-1593

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add filter `add_filter( 'ai_seo_enhancer_enabled_unrestricted', '__return_true' );`. Set local storage to see debug messages.

The toggle, both on Jetpack sidebar and PrePublish sidebar should trigger an event with the usual props plus `placement`, indicating where the event originated.

The individual feature toggles (when main toggle is off) should also trigger the usual event with the new `placement` prop.