### PR TITLE
Forms: Update block inspector button styles

### DIFF
--- a/projects/packages/forms/changelog/update-form-inspector-button-styles
+++ b/projects/packages/forms/changelog/update-form-inspector-button-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Update button styles in inspector controls.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-manage-responses-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-manage-responses-settings.js
@@ -12,11 +12,7 @@ const JetpackManageResponsesSettings = () => {
 			<InspectorHint>
 				{ __( 'Manage and export your form responses in WPAdmin:', 'jetpack-forms' ) }
 			</InspectorHint>
-			<Button
-				variant="secondary"
-				onClick={ () => window.open( RESPONSES_PATH, '_blank' ) }
-				__next40pxDefaultSize={ true }
-			>
+			<Button variant="secondary" href={ RESPONSES_PATH } __next40pxDefaultSize={ true }>
 				{ __( 'View Form Responses', 'jetpack-forms' ) }
 				<span className="screen-reader-text">
 					{ __( '(opens in a new tab)', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-manage-responses-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-manage-responses-settings.js
@@ -12,7 +12,11 @@ const JetpackManageResponsesSettings = () => {
 			<InspectorHint>
 				{ __( 'Manage and export your form responses in WPAdmin:', 'jetpack-forms' ) }
 			</InspectorHint>
-			<Button variant="secondary" href={ RESPONSES_PATH } target="_blank">
+			<Button
+				variant="secondary"
+				onClick={ () => window.open( RESPONSES_PATH, '_blank' ) }
+				__next40pxDefaultSize={ true }
+			>
 				{ __( 'View Form Responses', 'jetpack-forms' ) }
 				<span className="screen-reader-text">
 					{ __( '(opens in a new tab)', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -156,7 +156,10 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		elt = (
 			<>
 				<InspectorControls>
-					<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
+					<PanelBody
+						title={ __( 'Manage Responses', 'jetpack-forms' ) }
+						className="jetpack-manage-responses-panel"
+					>
 						<JetpackManageResponsesSettings setAttributes={ setAttributes } />
 					</PanelBody>
 					<PanelBody title={ __( 'Action after submit', 'jetpack-forms' ) } initialOpen={ false }>
@@ -222,7 +225,10 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 					</PanelBody>
 
 					{ isFormModalEnabled && (
-						<PanelBody title={ __( 'Integrations', 'jetpack-forms' ) }>
+						<PanelBody
+							title={ __( 'Integrations', 'jetpack-forms' ) }
+							className="jetpack-integrations-panel"
+						>
 							<IntegrationPanel attributes={ attributes } setAttributes={ setAttributes } />
 						</PanelBody>
 					) }

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -158,7 +158,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 				<InspectorControls>
 					<PanelBody
 						title={ __( 'Manage Responses', 'jetpack-forms' ) }
-						className="jetpack-manage-responses-panel"
+						className="jetpack-contact-form__manage-responses-panel"
 					>
 						<JetpackManageResponsesSettings setAttributes={ setAttributes } />
 					</PanelBody>
@@ -227,7 +227,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 					{ isFormModalEnabled && (
 						<PanelBody
 							title={ __( 'Integrations', 'jetpack-forms' ) }
-							className="jetpack-integrations-panel"
+							className="jetpack-contact-form__integrations-panel"
 						>
 							<IntegrationPanel attributes={ attributes } setAttributes={ setAttributes } />
 						</PanelBody>

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -961,8 +961,8 @@
 /* Styles for form inspector panels */
 .jetpack-contact-form__manage-responses-panel,
 .jetpack-contact-form__integrations-panel {
-	button {
+	.components-button.is-secondary {
 		width: 100%;
-		display: block;
+		justify-content: center;
 	}
 }

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -957,3 +957,12 @@
 .is-style-animated .jetpack-field.has-placeholder .animated-label__label[style*="--jetpack--contact-form--label--font-size"] {
     font-size: calc(var(--jetpack--contact-form--label--font-size) * 0.75);
 }
+
+/* Styles for form inspector panels */
+.jetpack-manage-responses-panel,
+.jetpack-integrations-panel {
+	button {
+		width: 100%;
+		display: block;
+	}
+}

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -959,8 +959,8 @@
 }
 
 /* Styles for form inspector panels */
-.jetpack-manage-responses-panel,
-.jetpack-integrations-panel {
+.jetpack-contact-form__manage-responses-panel,
+.jetpack-contact-form__integrations-panel {
 	button {
 		width: 100%;
 		display: block;


### PR DESCRIPTION
## Proposed changes:

Updates button in Manage Responses and Integrations Panel to be full width, following design here: p1743160090720809-slack-C086RGTJT1D

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
On slack: p1743160090720809-slack-C086RGTJT1D

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* To see Manage Integrations panel, you'll need to add `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in wp-config.
* Add a form block to a page, and confirm that buttons in the Manage Responses and Integrations tab are full width, have the same styling and size, and still work as expected.
