### PR TITLE
My Jetpack: Hide new onboarding tour

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -41,13 +41,11 @@ import useAnalytics from '../../hooks/use-analytics';
 import useIsJetpackUserNew from '../../hooks/use-is-jetpack-user-new';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import useNotificationWatcher from '../../hooks/use-notification-watcher';
-import { useQueryParameter } from '../../hooks/use-query-parameter';
 import ConnectionsSection from '../connections-section';
 import EvaluationRecommendations from '../evaluation-recommendations';
 import IDCModal from '../idc-modal';
 import JetpackManageBanner from '../jetpack-manage-banner';
 import LoadingBlock from '../loading-block';
-import OnboardingTour from '../onboarding-tour';
 import PlansSection from '../plans-section';
 import ProductCardsSection from '../product-cards-section';
 import WelcomeFlow from '../welcome-flow';
@@ -179,9 +177,6 @@ export default function MyJetpackScreen() {
 		setReloading( true );
 	}
 
-	// show welcome tour if user is redirected from the onboarding flow
-	const isRedirectingFromOnboarding = useQueryParameter( 'from' ) === 'jetpack-onboarding';
-
 	if ( reloading ) {
 		return null;
 	}
@@ -250,8 +245,6 @@ export default function MyJetpackScreen() {
 			{ ! isWelcomeBannerVisible && isSectionVisible && userIsAdmin && (
 				<EvaluationRecommendations />
 			) }
-
-			{ isRedirectingFromOnboarding && <OnboardingTour /> }
 
 			<ProductCardsSection />
 

--- a/projects/packages/my-jetpack/changelog/update-jpmt-59-hide-onboarding-tour
+++ b/projects/packages/my-jetpack/changelog/update-jpmt-59-hide-onboarding-tour
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Removing the new onboarding tour to improve it and release later.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes MARTECH-59

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* hiding the new onboarding tour for this release so we can improve it and ship later

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin the PR with new JN site
* go to My Jetpack
* add `from=jetpack-onboarding` parameter
* verify that the tour doesn't show up

