### PR TITLE
Forms: Update IntegrationCard header markup and styles

### DIFF
--- a/projects/packages/forms/changelog/update-form-integration-card-header
+++ b/projects/packages/forms/changelog/update-form-integration-card-header
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Update IntegrationCard header markup and style.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
@@ -12,7 +12,9 @@ const AkismetCard = ( { isExpanded, onToggle } ) => {
 
 	return (
 		<IntegrationCard
-			title={ __( 'Akismet', 'jetpack-forms' ) }
+			title={ __( 'Akismet Spam Protection', 'jetpack-forms' ) }
+			description={ __( 'Akismet filters out form spam with 99% accuracy', 'jetpack-forms' ) }
+			icon="shield"
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }
 		>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
@@ -6,6 +6,8 @@ const CreativeMailCard = ( { isExpanded, onToggle } ) => {
 	return (
 		<IntegrationCard
 			title={ __( 'Creative Mail', 'jetpack-forms' ) }
+			description={ __( 'Manage email contacts and campaigns', 'jetpack-forms' ) }
+			icon="email"
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }
 		>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card.js
@@ -1,12 +1,31 @@
 import { Card, CardHeader, CardBody, Icon } from '@wordpress/components';
+import './integration-card.scss';
 
-const IntegrationCard = ( { title, isExpanded, onToggle, children } ) => {
+const IntegrationCard = ( {
+	title,
+	description,
+	icon = 'admin-plugins', // Default to admin-plugins icon if none provided
+	isExpanded,
+	onToggle,
+	children,
+} ) => {
 	return (
-		<Card>
-			<CardHeader onClick={ onToggle } style={ { cursor: 'pointer' } }>
-				<div style={ { display: 'flex', alignItems: 'center', gap: '8px' } }>
-					<Icon icon={ isExpanded ? 'arrow-down-alt2' : 'arrow-right-alt2' } />
-					<strong>{ title }</strong>
+		<Card className="integration-card">
+			<CardHeader onClick={ onToggle } className="integration-card__header">
+				<div className="integration-card__header-content">
+					<div className="integration-card__header-main">
+						<Icon icon={ icon } className="integration-card__service-icon" size={ 30 } />
+						<div className="integration-card__title-section">
+							<h3 className="integration-card__title">{ title }</h3>
+							{ description && (
+								<span className="integration-card__description">{ description }</span>
+							) }
+						</div>
+					</div>
+					<Icon
+						icon={ isExpanded ? 'arrow-up-alt2' : 'arrow-down-alt2' }
+						className="integration-card__toggle-icon"
+					/>
 				</div>
 			</CardHeader>
 			{ isExpanded && <CardBody>{ children }</CardBody> }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card.scss
@@ -1,0 +1,53 @@
+.integration-card {
+	&__header {
+		cursor: pointer;
+	}
+
+	&__header-content {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+	}
+
+	&__header-main {
+		display: flex;
+		align-items: center;
+		gap: 16px;
+	}
+
+	&__title-section {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	&__title-row {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	&__service-icon {
+		color: var(--jp-gray-80);
+		flex-shrink: 0;
+		margin-top: 2px;
+	}
+
+	&__title {
+		margin: 0;
+		font-size: var(--font-body);
+		font-weight: 600;
+		line-height: 1.4;
+	}
+
+	&__description {
+		color: var(--jp-gray-50);
+		font-size: 13px;
+		line-height: 1.4;
+	}
+
+	&__toggle-icon {
+		display: block;
+	}
+} 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
@@ -6,6 +6,8 @@ const JetpackCRMCard = ( { isExpanded, onToggle, jetpackCRM, setAttributes } ) =
 	return (
 		<IntegrationCard
 			title={ __( 'Jetpack CRM', 'jetpack-forms' ) }
+			description={ __( 'Keep on top of leads as they are added to your CRM', 'jetpack-forms' ) }
+			icon="groups"
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }
 		>


### PR DESCRIPTION
## Proposed changes:

NOTE: This is one of many upcoming PRs to create the new third party integrations modal based on designs in Figma. All this work is behind a feature flag and will only be visible if you set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.

Updates the header section for the IntegrationCards in the new third party integration modal for the forms block. Specific changes:
* Display an icon. Right now I'm supplying WordPress icons, but these will be updated later to brand SVGs. 
* Add a description under the title/name of the integration, and populate the descriptions for Akismet, Jetpack CRM, and Creative Mail.
* Move the expand/collapse arrow to the right edge of the header. 
* Update Akismet title to Akismet Spam Protection
* Add new scss file for the integration card.

Next: I think we'll shortly move the integration header into it's own component and folder with that CSS file. There will be a fair amount of logic in the header of each integration card with toggles, connected status, etc. 

**Current state of integrations modal and header as of this PR**
<img width="1497" alt="integration-header-w" src="https://github.com/user-attachments/assets/1d3fe06a-c602-4750-b514-26253047e878" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
On slack: p1743160090720809-slack-C086RGTJT1D

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.
* Add a page with a form block
* Click the Manage Integrations in the sidebar.
* Confirm the modal opens, looks like the screenshot above, and behaves as expected. Keep in mind it is a work in progress, not a final project. So no need to give feedback on, say, the integrations settings for each service.