### PR TITLE
Admin Menu: Boost, VideoPress, Search -- Ensure standalone submenu items do not conflict with Akismet submenu item

### DIFF
--- a/projects/packages/search/changelog/fix-boost-search-videopress-standalone-akismet-menu
+++ b/projects/packages/search/changelog/fix-boost-search-videopress-standalone-akismet-menu
@@ -1,0 +1,6 @@
+Significance: patch
+Type: fixed
+
+Admin Menu: Ensure Akismet menu item display alongside standalone.
+
+

--- a/projects/packages/search/src/dashboard/class-dashboard.php
+++ b/projects/packages/search/src/dashboard/class-dashboard.php
@@ -47,15 +47,6 @@ class Dashboard {
 	protected $module_control;
 
 	/**
-	 * Priority for the dashboard menu
-	 * For Jetpack sites: Jetpack uses 998 and 'Admin_Menu' uses 1000, so we need to use 999.
-	 * For simple site: the value is overriden in a child class with value 100000 to wait for all menus to be registered.
-	 *
-	 * @var int
-	 */
-	protected $search_menu_priority = 999;
-
-	/**
 	 * Contructor
 	 *
 	 * @param \Automattic\Jetpack\Search\Plan           $plan - Plan instance.
@@ -82,8 +73,7 @@ class Dashboard {
 	public function init_hooks() {
 		if ( ! self::$initialized ) {
 			self::$initialized = true;
-			// Jetpack uses 998 and 'Admin_Menu' uses 1000.
-			add_action( 'admin_menu', array( $this, 'add_wp_admin_submenu' ), 1 ); // Akismet uses 4, so we use 1 to ensure both menus are added when only they exist .
+			add_action( 'admin_menu', array( $this, 'add_wp_admin_submenu' ), 1 ); // Akismet uses 4, so we use 1 to ensure both menus are added when only they exist.
 			// Check if the site plan changed and deactivate module accordingly.
 			add_action( 'current_screen', array( $this, 'check_plan_deactivate_search_module' ) );
 		}

--- a/projects/packages/search/src/dashboard/class-dashboard.php
+++ b/projects/packages/search/src/dashboard/class-dashboard.php
@@ -83,7 +83,7 @@ class Dashboard {
 		if ( ! self::$initialized ) {
 			self::$initialized = true;
 			// Jetpack uses 998 and 'Admin_Menu' uses 1000.
-			add_action( 'admin_menu', array( $this, 'add_wp_admin_submenu' ), $this->search_menu_priority );
+			add_action( 'admin_menu', array( $this, 'add_wp_admin_submenu' ), 1 ); // Akismet uses 4, so we use 1 to ensure both menus are added when only they exist .
 			// Check if the site plan changed and deactivate module accordingly.
 			add_action( 'current_screen', array( $this, 'check_plan_deactivate_search_module' ) );
 		}

--- a/projects/packages/videopress/changelog/fix-boost-search-videopress-standalone-akismet-menu
+++ b/projects/packages/videopress/changelog/fix-boost-search-videopress-standalone-akismet-menu
@@ -1,0 +1,6 @@
+Significance: patch
+Type: fixed
+
+Admin Menu: Ensure Akismet menu item display alongside standalone.
+
+

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -35,7 +35,7 @@ class Admin_UI {
 	 */
 	public static function init() {
 
-		add_action( 'admin_menu', array( __CLASS__, 'enable_menu' ) );
+		add_action( 'admin_menu', array( __CLASS__, 'enable_menu' ), 1 ); // Akismet uses 4, so we use 1 to ensure both menus are added when only they exist.
 
 		add_action( 'admin_footer-upload.php', array( __CLASS__, 'attachment_details_two_column_template' ) );
 		add_action( 'admin_footer-post.php', array( __CLASS__, 'attachment_details_template' ), 20 );

--- a/projects/plugins/boost/app/admin/class-admin.php
+++ b/projects/plugins/boost/app/admin/class-admin.php
@@ -31,7 +31,7 @@ class Admin {
 
 		add_action( 'init', array( new Analytics(), 'init' ) );
 		add_filter( 'plugin_action_links_' . JETPACK_BOOST_PLUGIN_BASE, array( $this, 'plugin_page_settings_link' ) );
-		add_action( 'admin_menu', array( $this, 'handle_admin_menu' ) );
+		add_action( 'admin_menu', array( $this, 'handle_admin_menu' ), 1 ); // Akismet uses 4, so we use 1 to ensure both menus are added when only they exist.
 	}
 
 	public function handle_admin_menu() {

--- a/projects/plugins/boost/changelog/fix-boost-search-videopress-standalone-akismet-menu
+++ b/projects/plugins/boost/changelog/fix-boost-search-videopress-standalone-akismet-menu
@@ -1,0 +1,6 @@
+Significance: patch
+Type: fixed
+
+Admin Menu: Ensure Akismet menu item display alongside standalone.
+
+


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/42497

## Proposed changes:

* This PR changes the pri for the Boost, Search and VideoPress menu items when hooked into `admin_menu`. The pri is now set to 1, to ensure that the Akismet menu item also displays under Jetpack, when those plugins are installed as individual standalones (without Jetpack active).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion



## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

This is relevant for self-hosted sites primarily, as Jetpack shouldn't be disconnected on WoA. To test the current behaviour on trunk, apply this PR if testing locally, or use the Jetpack Beta Tester plugin.

* Make sure you don't connect Jetpack -- instead, deactivate it.
* Ensure Akismet is installed and Active.
* For Jetpack Search: using the beta tester plugin, apply bleeding edge or latest stable (or just install and active the Jetpack Search plugin from WordPress.org directly).  If testing locally, ensure the Search plugin is active.
* Visit the Jetpack menu item in WP Admin, and notice that Search exists, but not Akismet (this is under 'tools' instead).
* Follow the same steps for Boost, and VideoPress.

To test the fix:
* For Jetpack Search: using the beta tester plugin, apply the branch for the Search plugin. If testing locally, ensure the Search plugin is active, and apply the PR.
* Follow the same steps as above. You should now see the Akismet menu item. You should also see it for Boost and VideoPress when testing them independently.

You can also test adding other standalones as well as Jetpack, and ensure everything works as expected.


<img width="186" alt="Screenshot 2025-03-29 at 12 41 36" src="https://github.com/user-attachments/assets/67ab870c-62d1-4de1-9d17-2348ba061789" />

