### PR TITLE
Full sync: Get only whitelisted comment types

### DIFF
--- a/projects/packages/sync/changelog/update-full-sync-filter-by-whitelisted-comment-types
+++ b/projects/packages/sync/changelog/update-full-sync-filter-by-whitelisted-comment-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Full Sync: Ensure we take comment type whitelisting when full syncing

--- a/projects/packages/sync/src/modules/class-comments.php
+++ b/projects/packages/sync/src/modules/class-comments.php
@@ -219,6 +219,18 @@ class Comments extends Module {
 	}
 
 	/**
+	 * Returns escaped SQL for whitelisted comment types.
+	 * Can be injected directly into a WHERE clause.
+	 *
+	 * @access public
+	 *
+	 * @return string SQL WHERE clause.
+	 */
+	public function get_whitelisted_comment_types_sql() {
+		return 'comment_type IN (\'' . implode( '\', \'', array_map( 'esc_sql', $this->get_whitelisted_comment_types() ) ) . '\')';
+	}
+
+	/**
 	 * Prevents any comment types that are not in the whitelist from being enqueued and sent to WordPress.com.
 	 *
 	 * @param array $args Arguments passed to wp_insert_comment, deleted_comment, spammed_comment, etc.
@@ -378,11 +390,13 @@ class Comments extends Module {
 	 * @return string WHERE SQL clause, or `null` if no comments are specified in the module config.
 	 */
 	public function get_where_sql( $config ) {
+		$where_sql = $this->get_whitelisted_comment_types_sql();
+
 		if ( is_array( $config ) && ! empty( $config ) ) {
 			return 'comment_ID IN (' . implode( ',', array_map( 'intval', $config ) ) . ')';
 		}
 
-		return '1=1';
+		return $where_sql;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/vulcan/issues/686

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Consider whitelisted comment types in Full Sync by adding it to the `get_where_sql` function.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

In a Jetpack connected site, 
- Create a comment that is not of one of the default whitelisted types `('', 'comment', 'trackback', 'pingback', 'review')`.
- Run a Full Sync in **trunk** for `comments`.
- Check that the comment was synced in your cached site.

Now **checkout this branch** 

- Run a Full Sync for comments.
- The comment should not appear in the cached site.
