### PR TITLE
Connection: add 'offline mode' flag to IDC secret check endpoint

### DIFF
--- a/projects/packages/connection/changelog/add-idc-secret-check-offline-mode-flag
+++ b/projects/packages/connection/changelog/add-idc-secret-check-offline-mode-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+IDC: add "Offliine Mode" flag to secret check endpoint.

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -508,7 +508,7 @@ class REST_Connector {
 				/** This filter is documented in packages/status/src/class-status.php */
 				'filter'          => ( apply_filters( 'jetpack_development_mode', false ) || apply_filters( 'jetpack_offline_mode', false ) ), // jetpack_development_mode is deprecated.
 				'wpLocalConstant' => defined( 'WP_LOCAL_DEV' ) && WP_LOCAL_DEV,
-				'option'          => get_option( 'jetpack_offline_mode' ),
+				'option'          => (bool) get_option( 'jetpack_offline_mode' ),
 			),
 			'isPublic'          => '1' == get_option( 'blog_public' ), // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 		);

--- a/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
+++ b/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
@@ -667,6 +667,12 @@ class Identity_Crisis {
 	 * phpcs:ignore Squiz.Commenting.FunctionCommentThrowTag -- The exception is being caught, false positive.
 	 */
 	public static function add_secret_to_url_validation_response( array $response ) {
+		// Only checking the database option to limit the effect.
+		if ( get_option( 'jetpack_offline_mode' ) ) {
+			$response['offline_mode'] = '1';
+			return $response;
+		}
+
 		try {
 			$secret = new URL_Secret();
 

--- a/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
@@ -982,6 +982,28 @@ class Identity_Crisis_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test the `add_secret_to_url_validation_response()` method in Offline Mode.
+	 *
+	 * @return void
+	 */
+	public static function test_add_secret_to_url_validation_response_offline_mode() {
+		$data = array(
+			'key1' => 'value1',
+			'key2' => 'value2',
+		);
+
+		update_option( 'jetpack_offline_mode', '1' );
+		$data_updated = Identity_Crisis::add_secret_to_url_validation_response( $data );
+		delete_option( 'jetpack_offline_mode' );
+
+		$data['offline_mode'] = '1';
+
+		static::assertEquals( $data, $data_updated );
+		static::assertArrayNotHasKey( 'url_secret_error', $data_updated );
+		static::assertArrayNotHasKey( 'url_secret', $data_updated );
+	}
+
+	/**
 	 * Test the `reverse_wpcom_urls_for_idc()` method.
 	 *
 	 * @return void


### PR DESCRIPTION
## Proposed changes:
* Indicate the offline mode status in `/jetpack/v4/identity-crisis/idc-url-validation` endpoint.
* Only activate the functionality if offline mode is set via DB option.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Part of p1741107156488199-slack-C0299DMPG

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
_To test the endpoint via Jetpack Debug's REST API tester, you'll need to force the `url_secret_permission_check()` method to return `true` [here](https://github.com/Automattic/jetpack/blob/4c4573cee854d7bbe88e14531a5ed02f7a977414/projects/packages/connection/src/identity-crisis/class-rest-endpoints.php#L297)._

1. Connect Jetpack.
2. Send a GET request to the `/jetpack/v4/identity-crisis/idc-url-validation` endpoint, confirm it returns `home` and `siteurl` as well as the secret.
4. Switch the site to Offline Mode via the DB option (`jetpack option update jetpack_offline_mode 1`)
5. Repeat the API request, confirm it no longer contains the secret, but has `offline_mode: 1` flag instead.