### PR TITLE
Add checks to avoid warnings when accessing media_file variable

### DIFF
--- a/projects/plugins/jetpack/changelog/blocks-story-add-isset-check-media-files
+++ b/projects/plugins/jetpack/changelog/blocks-story-add-isset-check-media-files
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Story Block: avoid PHP warnings with specific media files.

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -73,7 +73,11 @@ function enrich_media_files( $media_files ) {
 				}
 				// VideoPress videos can sometimes have type 'file', and mime 'video/videopress' or 'video/mp4'.
 				// Let's fix `type` for those.
-				if ( 'file' === $media_file['type'] &&  isset( $media_file['mime'] ) && str_starts_with( $media_file['mime'], 'video' ) ) {
+				if (
+					'file' === $media_file['type']
+					&& isset( $media_file['mime'] )
+					&& str_starts_with( $media_file['mime'], 'video' )
+				) {
 					$media_file['type'] = 'video';
 				}
 				if ( 'video' !== $media_file['type'] ) { // we only support images and videos at this point.

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -65,12 +65,15 @@ function enrich_media_files( $media_files ) {
 	return array_filter(
 		array_map(
 			function ( $media_file ) {
+				if ( ! is_array( $media_file ) || ! isset( $media_file['type'] ) ) {
+					return null;
+				}
 				if ( 'image' === $media_file['type'] ) {
 					return enrich_image_meta( $media_file );
 				}
 				// VideoPress videos can sometimes have type 'file', and mime 'video/videopress' or 'video/mp4'.
 				// Let's fix `type` for those.
-				if ( 'file' === $media_file['type'] && str_starts_with( $media_file['mime'], 'video' ) ) {
+				if ( 'file' === $media_file['type'] &&  isset( $media_file['mime'] ) && str_starts_with( $media_file['mime'], 'video' ) ) {
 					$media_file['type'] = 'video';
 				}
 				if ( 'video' !== $media_file['type'] ) { // we only support images and videos at this point.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Warnings like 25388543493a1e4f1b3bd92c9cd20c8d-logstash
Example: `[04-Mar-2025 05:30:01 UTC] Warning: Undefined array key "type" in /home/wpcom/public_html/wp-content/mu-plugins/jetpack-plugin/moon/extensions/blocks/story/story.php on line 73 `


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add checks to avoid warnings when accessing media_file variable

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code Review should suffice