### PR TITLE
Jetpack CRM: Improve Error Handling in jpcrm-fonts.php 

### DIFF
--- a/projects/plugins/crm/changelog/crm-fix-error-on-activation
+++ b/projects/plugins/crm/changelog/crm-fix-error-on-activation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: try catch small change
+
+

--- a/projects/plugins/crm/includes/jpcrm-fonts.php
+++ b/projects/plugins/crm/includes/jpcrm-fonts.php
@@ -331,86 +331,93 @@ class JPCRM_Fonts {
 	 */
 	public function install_font_family($dompdf, $fontname, $normal, $bold = null, $italic = null, $bold_italic = null, $debug = false) {
 
-	  try {
+		try {
 
-			$fontMetrics = $dompdf->getFontMetrics();
+			$font_metrics = $dompdf->getFontMetrics();
 
 			// Check if the base filename is readable
-			if ( !is_readable($normal) ) {
-				throw new Exception("Unable to read '$normal'.");
+			if ( ! is_readable( $normal ) ) {
+				throw new Exception( "Unable to read '$normal'." );
 			}
 
-			$dir = dirname($normal);
-			$basename = basename($normal);
-			$last_dot = strrpos($basename, '.');
-			if ($last_dot !== false) {
-				$file = substr($basename, 0, $last_dot);
-				$ext = strtolower(substr($basename, $last_dot));
+			$dir      = dirname( $normal );
+			$basename = basename( $normal );
+			$last_dot = strrpos( $basename, '.' );
+			if ( $last_dot !== false ) {
+				$file = substr( $basename, 0, $last_dot );
+				$ext  = strtolower( substr( $basename, $last_dot ) );
 			} else {
 				$file = $basename;
-				$ext = '';
+				$ext  = '';
 			}
 
 			// dompdf will eventually support .otf, but for now limit to .ttf
-			if ( !in_array($ext, array(".ttf")) ) {
-				throw new Exception("Unable to process fonts of type '$ext'.");
+			if ( ! in_array( $ext, array( '.ttf' ), true ) ) {
+				throw new Exception( "Unable to process fonts of type '$ext'." );
 			}
 
 			// Try $file_Bold.$ext etc.
 			$path = "$dir/$file";
 
 			$patterns = array(
-				"bold"        => array("_Bold", "b", "B", "bd", "BD"),
-				"italic"      => array("_Italic", "i", "I"),
-				"bold_italic" => array("_Bold_Italic", "bi", "BI", "ib", "IB"),
+				'bold'        => array( '_Bold', 'b', 'B', 'bd', 'BD' ),
+				'italic'      => array( '_Italic', 'i', 'I' ),
+				'bold_italic' => array( '_Bold_Italic', 'bi', 'BI', 'ib', 'IB' ),
 			);
 
-			foreach ($patterns as $type => $_patterns) {
-				if ( !isset($$type) || !is_readable($$type) ) {
-					foreach($_patterns as $_pattern) {
-						if ( is_readable("$path$_pattern$ext") ) {
+			foreach ( $patterns as $type => $_patterns ) {
+				if ( ! isset( $$type ) || ! is_readable( $$type ) ) {
+					foreach ( $_patterns as $_pattern ) {
+						if ( is_readable( "$path$_pattern$ext" ) ) {
 							$$type = "$path$_pattern$ext";
 							break;
 						}
 					}
 
-					if ( is_null($$type) )
-						if ($debug) echo ("Unable to find $type face file.\n");
+					if ( $$type === null ) {
+						if ( $debug ) {
+							echo esc_html( "Unable to find $type face file.\n" );
+						}
+					}
 				}
 			}
 
-			$fonts = compact("normal", "bold", "italic", "bold_italic");
+			$fonts = compact( 'normal', 'bold', 'italic', 'bold_italic' );
 			$entry = array();
 
 			// Copy the files to the font directory.
-			foreach ($fonts as $var => $src) {
-				if ( is_null($src) ) {
-					$entry[$var] = $dompdf->getOptions()->get('fontDir') . '/' . mb_substr(basename($normal), 0, -4);
+			foreach ( $fonts as $var => $src ) {
+				if ( $src === null ) {
+					$entry[ $var ] = $dompdf->getOptions()->get( 'fontDir' ) . '/' . mb_substr( basename( $normal ), 0, -4 );
 					continue;
 				}
 
 				// Verify that the fonts exist and are readable
-				if ( !is_readable($src) ) {
-					throw new Exception("Requested font '$src' is not readable");
+				if ( ! is_readable( $src ) ) {
+					throw new Exception( "Requested font '$src' is not readable" );
 				}
 
-				$dest = $dompdf->getOptions()->get('fontDir') . '/' . basename($src);
+				$dest = $dompdf->getOptions()->get( 'fontDir' ) . '/' . basename( $src );
 
 				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable, Generic.WhiteSpace.ScopeIndent.IncorrectExact -- TODO: Fix these.
 				if ( ! is_writable( dirname( $dest ) ) ) {
-					throw new Exception("Unable to write to destination '$dest'.");
+					throw new Exception( "Unable to write to destination '$dest'." );
 				}
 
-				if ($debug) echo "Copying $src to $dest...\n";
-
-				if ( !copy($src, $dest) ) {
-					throw new Exception("Unable to copy '$src' to '$dest'");
+				if ( $debug ) {
+					echo esc_html( "Copying $src to $dest...\n" );
 				}
 
-				$entry_name = mb_substr($dest, 0, -4);
-				
-				if ($debug) echo "Generating Adobe Font Metrics for $entry_name...\n";
-				
+				if ( ! copy( $src, $dest ) ) {
+					throw new Exception( "Unable to copy '$src' to '$dest'" );
+				}
+
+				$entry_name = mb_substr( $dest, 0, -4 );
+
+				if ( $debug ) {
+					echo esc_html( "Generating Adobe Font Metrics for $entry_name...\n" );
+				}
+
 				try {
 					$font_obj = Font::load( $dest );
 					if ( $font_obj === null ) {
@@ -429,10 +436,10 @@ class JPCRM_Fonts {
 			}
 
 			// Store the fonts in the lookup table
-			$fontMetrics->setFontFamily($fontname, $entry);
+			$font_metrics->setFontFamily( $fontname, $entry );
 
 			// Save the changes
-			$fontMetrics->saveFontFamilies();
+			$font_metrics->saveFontFamilies();
 
 			// Fini
 			return true;
@@ -444,7 +451,6 @@ class JPCRM_Fonts {
 		}
 
 		return false;
-
 	}
 
 	/*

--- a/projects/plugins/crm/includes/jpcrm-fonts.php
+++ b/projects/plugins/crm/includes/jpcrm-fonts.php
@@ -411,9 +411,16 @@ class JPCRM_Fonts {
 				
 				if ($debug) echo "Generating Adobe Font Metrics for $entry_name...\n";
 				
-				$font_obj = Font::load($dest);
-				$font_obj->saveAdobeFontMetrics("$entry_name.ufm");
-				$font_obj->close();
+				try {
+					$font_obj = Font::load( $dest );
+					if ( $font_obj === null ) {
+						throw new Exception( "Failed to load font from '$dest'. Please check the file path and ensure the font file exists." );
+					}
+					$font_obj->saveAdobeFontMetrics( "$entry_name.ufm" );
+					$font_obj->close();
+				} catch ( Exception $e ) {
+					throw new Exception( 'An error occurred while processing the font: ' . $e->getMessage() );
+				}
 
 				$entry[$var] = $entry_name;
 


### PR DESCRIPTION
Fixes #42785

Proposed changes:
Wrapped font loading operations in a try-catch block to handle exceptions gracefully - this was in response to a periodic fatal where I suspect the issue was it was trying to load the font before it had been downloaded or migrations running.

This will catch rather than fatal but loading order deeper down should be addressed at some point if it appears again.

## Testing instructions
- This one was hard to replicate - but the P2 error details are below
- Small fix to wrap into a try catch to the area of code that gave the error.

```
An error of type E_ERROR was caused in line 415 of the file /home2/wrymmhmy/public_html/wp-content/plugins/zero-bs-crm/includes/jpcrm-fonts.php. Error message: Uncaught Error: Call to a member function saveAdobeFontMetrics() on null in /home2/wrymmhmy/public_html/wp-content/plugins/zero-bs-crm/includes/jpcrm-fonts.php:415
Stack trace:
#0 /home2/wrymmhmy/public_html/wp-content/plugins/zero-bs-crm/includes/jpcrm-fonts.php(605): JPCRM_Fonts->install_font_family(Object(Dompdf\Dompdf), 'NotoSansGlobal', '/home2/wrymmhmy...', '/home2/wrymmhmy...', '/home2/wrymmhmy...', '/home2/wrymmhmy...')
#1 /home2/wrymmhmy/public_html/wp-content/plugins/zero-bs-crm/includes/jpcrm-fonts.php(290): JPCRM_Fonts->load_font('NotoSansGlobal', '/home2/wrymmhmy...', '/home2/wrymmhmy...', '/home2/wrymmhmy...', '/home2/wrymmhmy...')
#2 /home2/wrymmhmy/public_html/wp-content/plugins/zero-bs-crm/includes/jpcrm-fonts.php(553): JPCRM_Fonts->install_default_fonts()
#3 /home2/wrymmhmy/public_html/wp-content/plugins/zero-bs-crm/includes/ZeroBSCRM.Migrations.php(795): JPCRM_Fonts->extract_and_install_default_fonts()
#4 /home2/wrymmhmy/public_html/wp-content/plugins/zero-bs-crm/includes/ZeroBSCRM.Migrations.php(207): zeroBSCRM_migration_544()
#5 /home2/wrymmhmy/public_html/wp-content/plugins/zero-bs-crm/includes/ZeroBSCRM.Core.php(3079): zeroBSCRM_migrations_run(Array, 'init')
#6 /home2/wrymmhmy/public_html/wp-content/plugins/zero-bs-crm/includes/ZeroBSCRM.Core.php(1764): ZeroBSCRM->run_migrations('init')
#7 /home2/wrymmhmy/public_html/wp-includes/class-wp-hook.php(324): ZeroBSCRM->init('')
#8 /home2/wrymmhmy/public_html/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#9 /home2/wrymmhmy/public_html/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#10 /home2/wrymmhmy/public_html/wp-settings.php(704): do_action('init')
#11 /home2/wrymmhmy/public_html/wp-config.php(111): require_once('/home2/wrymmhmy...')
#12 /home2/wrymmhmy/public_html/wp-load.php(50): require_once('/home2/wrymmhmy...')
#13 /home2/wrymmhmy/public_html/wp-admin/admin.php(34): require_once('/home2/wrymmhmy...')
#14 {main}
  thrown
```

## Does this pull request change what data or activity we track or use?

My PR does not change the data we track or use

Other information:

[NA ] Have you written new tests for your changes, if applicable?
[NA] Have you checked the E2E test CI results, and verified that your changes do not break them?
[NA] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?