### PR TITLE
Jetpack Newsletter: Set the post access level to everyone when deleting the paywall block. 

### DIFF
--- a/projects/plugins/jetpack/changelog/update-post-access-when-deleting-paywall
+++ b/projects/plugins/jetpack/changelog/update-post-access-when-deleting-paywall
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Reset access level of  the post to everyone when a paywall is removed. 

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
@@ -19,6 +19,16 @@ function PaywallEdit() {
 	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
 	const accessLevel = useAccessLevel( postType );
 	const isUserConnected = useIsUserConnected();
+	const setAccess = useSetAccess();
+
+	// Add cleanup effect to reset access level when paywall is removed
+	useEffect( () => {
+		// This function will run when the component unmounts
+		return () => {
+			// Reset access level to "everybody" when the paywall block is removed
+			setAccess( accessOptions.everybody.key );
+		};
+	}, [ setAccess ] );
 
 	const { stripeConnectUrl, hasTierPlans } = useSelect( select => {
 		const { getNewsletterTierProducts, getConnectUrl } = select( 'jetpack/membership-products' );
@@ -30,7 +40,6 @@ function PaywallEdit() {
 
 	const [ showDialog, setShowDialog ] = useState( false );
 	const closeDialog = () => setShowDialog( false );
-	const setAccess = useSetAccess();
 
 	useEffect( () => {
 		if ( ! accessLevel || accessLevel === accessOptions.everybody.key ) {

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
@@ -28,7 +28,8 @@ function PaywallEdit() {
 			// Reset access level to "everybody" when the paywall block is removed
 			setAccess( accessOptions.everybody.key );
 		};
-	}, [ setAccess ] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 
 	const { stripeConnectUrl, hasTierPlans } = useSelect( select => {
 		const { getNewsletterTierProducts, getConnectUrl } = select( 'jetpack/membership-products' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/42663

When the paywall is added, the post's access status also changes with it. 
<img width="246" alt="Screenshot 2025-04-01 at 2 06 55 PM" src="https://github.com/user-attachments/assets/6f2bc66b-60e3-41bd-9de4-905d3d18468e" />

The paywall gives you only two options -> Anyone subscribed/paid subscribers only. These options are in sync with what we see in the right sidebar. 

However, when we delete the paywall block in Gutenberg, the previously saved option is persisted. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When the paywall block is deleted, set the post access status to 'everyone'. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1743498522711249-slack-C083ZPVVDTK
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You need to setup a paid newsletter site on simple/atomic/jetpack to test this. 

* Without this branch, and on trunk, create a paid newsletter site.  
* Now, add a [paywall block](https://jetpack.com/support/newsletter/paid-newsletters/#use-the-paywall-block) and create a post with partially paywalled content.  

<img width="831" alt="Screenshot 2025-04-01 at 3 39 00 PM" src="https://github.com/user-attachments/assets/d06d011b-be13-42e9-ab02-0ef7443ef010" />

* In an incognito window, confirm that the post is paywalled as expected.  
* Now, return to the post and remove the paywall block. In the right sidebar, you will see that the option you selected earlier when you added the paywall block is still persisted.  

<img width="246" alt="Screenshot 2025-04-01 at 2 06 55 PM" src="https://github.com/user-attachments/assets/f36414d8-c64e-4e4b-ac87-b38b56043ba0" />

* If you open a new incognito window, the paid content will still not be visible. This is because deleting the block does not change the post's access status.  

* Run the command in [this comment](https://github.com/Automattic/jetpack/pull/42788#issuecomment-2766030202) to run this branch on your sandbox. You can skip this step on Jetpack/Atomic.  
* Create a new post with paywalled content and confirm that a user in an incognito window cannot see the paywalled content.  
* Now, delete the paywall from your post. Notice that in the right sidebar, the access level of the post is set to "Everyone."  


https://github.com/user-attachments/assets/601dce58-458c-4fd0-a93d-c14489516391


* Save the post and load it in an incognito window. You will see that the previously paywalled content loads.