### PR TITLE
Repo Gardening: do not assign Scan issues to the Backup team

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-backup-assignment
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-backup-assignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Team assignments: do not assign Scan issues to the Backup team.

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/automattic-label-team-assignments.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/automattic-label-team-assignments.js
@@ -89,7 +89,6 @@ export const automatticAssignments = {
 			'[Plugin] VaultPress',
 			'[Feature] Backup & Scan',
 			'[Feature] Backups',
-			'[Feature] Scan',
 			'[Package] Backup',
 			'[Package] Transport Helper',
 		],


### PR DESCRIPTION
## Proposed changes:

Scan issues are not handled by the Backup team, so they must go to a different board.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* This can be tested once this PR is merged, by adding the "Scan" label to a bug in the monorepo, and ensuring that doesn't cause the issue to be added to the Backup GitHub board.
