### PR TITLE
Fix display name when listing Gravatar accounts

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-gravatar-accounts-display-name
+++ b/projects/plugins/jetpack/changelog/fix-gravatar-accounts-display-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix display name when listing gravatar accounts

--- a/projects/plugins/jetpack/modules/widgets/gravatar-profile.php
+++ b/projects/plugins/jetpack/modules/widgets/gravatar-profile.php
@@ -151,7 +151,7 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 			}
 
 			if ( $instance['show_account_links'] ) {
-				$this->display_accounts( (array) $profile['accounts'] );
+				$this->display_accounts( (array) $profile['accounts'], $profile['displayName'] );
 			}
 
 			?>
@@ -236,9 +236,10 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 	/**
 	 * Displays the "Verified Services" accounts.
 	 *
-	 * @param array $accounts Array of social accounts.
+	 * @param array  $accounts     Array of social accounts.
+	 * @param string $display_name Display name of the user.
 	 */
-	public function display_accounts( $accounts = array() ) {
+	public function display_accounts( $accounts = array(), $display_name = '' ) {
 		if ( empty( $accounts ) ) {
 			return;
 		}
@@ -274,9 +275,9 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 
 			$sanitized_service_name = $this->get_sanitized_service_name( $account['shortname'] );
 			$link_title             = sprintf(
-				/* translators: %1$s: service username. %2$s: service name ( Facebook, Twitter, etc.) */
+				/* translators: %1$s: account display name. %2$s: service name ( Facebook, Twitter, etc.) */
 				_x( '%1$s on %2$s', '1: User Name, 2: Service Name (Facebook, Twitter, ...)', 'jetpack' ),
-				esc_html( $account['display'] ),
+				esc_html( $display_name ),
 				esc_html( $sanitized_service_name )
 			);
 			?>

--- a/projects/plugins/jetpack/modules/widgets/gravatar-profile.php
+++ b/projects/plugins/jetpack/modules/widgets/gravatar-profile.php
@@ -237,7 +237,7 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 	 * Displays the "Verified Services" accounts.
 	 *
 	 * @param array  $accounts     Array of social accounts.
-	 * @param string $display_name Display name of the user.
+	 * @param string $display_name Gravatar display name of the user.
 	 */
 	public function display_accounts( $accounts = array(), $display_name = '' ) {
 		if ( empty( $accounts ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Fix warning reported in p1743169514870399/1740656655.320889-slack-C01U2KGS2PQ

> Warning: Undefined array key "display" in /home/wpcom/public_html/wp-content/mu-plugins/jetpack-plugin/moon/modules/widgets/gravatar-profile.php on line 279

It was using `$account['display']`, but it's not trustworthy as an account name. So I replaced it with the Gravater profile display name instead.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* It was reproducible in a user site. So check this: p1743169514870399/1740656655.320889-slack-C01U2KGS2PQ

See the recordings (it's a site user, and I just replaced their username with mine to not display their user here).

#### Before

https://github.com/user-attachments/assets/9bb58980-b663-498a-8112-315ee7ec2745

#### After

https://github.com/user-attachments/assets/b8a4001e-3d07-432c-84a1-cb7933b5122d

Notice that it's not my user name on that social networks, but it's my display name on Gravatar.