### PR TITLE
Boost: Remove unnecessary textdomain initialization

### DIFF
--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -98,9 +98,6 @@ class Jetpack_Boost {
 		$this->connection = new Connection();
 		$this->connection->init();
 
-		// Require plugin features.
-		$this->init_textdomain();
-
 		$this->register_deactivation_hook();
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {

--- a/projects/plugins/boost/changelog/fix-boost-textdomain-init-notice
+++ b/projects/plugins/boost/changelog/fix-boost-textdomain-init-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Misc: Fix incorrectly registering plugin text domain.


### PR DESCRIPTION
Fixes HOG-31

This PR fixes a notice that shows up when Jetpack Boost is activated. The notice was shown because the text domain registration happened directly on [`plugins_loaded`](https://github.com/Automattic/jetpack/blob/fe9217f1c9c661419b34f46282414735d8818734/projects/plugins/boost/jetpack-boost.php#L170) (where Jetpack_Boost is initialized) and later on [`init`](https://github.com/Automattic/jetpack/blob/3abe0fd963a8539e02b4065e96576c09a374da4c/projects/plugins/boost/app/class-jetpack-boost.php#L122) (where it should be properly initialized):

```
PHP Notice:  Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>jetpack-boost</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.7.0.) in /var/www/html/wp-includes/functions.php on line 6114
```

## Proposed changes:

- Fix notice for incorrectly registering jetpack boost text domain.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

-

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Activate Jetpack Boost and make sure there's no notice about the text domain being incorrectly registered.