### PR TITLE
WAF: allow trusted headers to be controlled with a filter

### DIFF
--- a/projects/packages/waf/changelog/add-trusted-headers-filter
+++ b/projects/packages/waf/changelog/add-trusted-headers-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add jetpack_waf_trusted_headers filter

--- a/projects/packages/waf/src/class-waf-request.php
+++ b/projects/packages/waf/src/class-waf-request.php
@@ -75,6 +75,24 @@ class Waf_Request {
 	}
 
 	/**
+	 * Returns the list of trusted headers.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return array
+	 */
+	public function get_trusted_headers() {
+		/**
+		 * Filter the list of trusted headers.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $headers List of trusted headers.
+		 */
+		return apply_filters( 'jetpack_waf_trusted_headers', $this->trusted_headers );
+	}
+
+	/**
 	 * Determines the users real IP address based on the settings passed to set_trusted_proxies() and
 	 * set_trusted_headers() before. On CLI, this will be null.
 	 *
@@ -84,7 +102,7 @@ class Waf_Request {
 		$remote_addr = ! empty( $_SERVER['REMOTE_ADDR'] ) ? wp_unslash( $_SERVER['REMOTE_ADDR'] ) : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		if ( in_array( $remote_addr, $this->trusted_proxies, true ) ) {
-			$ip_by_header = $this->get_ip_by_header( array_merge( $this->trusted_headers, array( 'REMOTE_ADDR' ) ) );
+			$ip_by_header = $this->get_ip_by_header( array_merge( $this->get_trusted_headers(), array( 'REMOTE_ADDR' ) ) );
 			if ( ! empty( $ip_by_header ) ) {
 				return $ip_by_header;
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `jetpack_waf_trusted_headers` filter

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* TBD

