### PR TITLE
AGORA-40: toggle on PrePublish sidebar triggers the auto-generation process

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-seo-enhancer-toggle-trigger-on-prepublish
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-seo-enhancer-toggle-trigger-on-prepublish
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack SEO Enhancer: enabling the toggle on PrePublish sidebar triggers the auto-generation process

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
@@ -47,8 +47,13 @@ export function SeoEnhancer( {
 	const { updateSeoData } = useSeoRequests();
 
 	const toggleSeoEnhancer = useCallback( async () => {
+		const isEnabling = ! isEnabled;
 		await toggleEnhancer( { placement } );
-	}, [ toggleEnhancer, placement ] );
+		// If the feature is being enabled while in the pre-publish panel, trigger the tool.
+		if ( placement === 'jetpack-prepublish-sidebar' && isEnabling ) {
+			updateSeoData();
+		}
+	}, [ toggleEnhancer, placement, updateSeoData, isEnabled ] );
 
 	const toggleFeature = useCallback(
 		name => {
@@ -81,7 +86,7 @@ export function SeoEnhancer( {
 					{ ! disableAutoEnhance && (
 						<ToggleControl
 							checked={ isEnabled }
-							disabled={ isToggling }
+							disabled={ isToggling || isLoading }
 							onChange={ toggleSeoEnhancer }
 							label={ __( 'Auto-generate metadata', 'jetpack' ) }
 							__nextHasNoMarginBottom={ true }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/AGORA-40/fix-auto-generate-toggle-trigger-on-prepublish

## Proposed changes:
Make the auto-generation toggle trigger the process if enabled from PrePublish sidebar

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1743197410986709/1743184817.077419-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add the feature filter: `add_filter( 'ai_seo_enhancer_enabled', '__return_true' );`.
Get a Jetpack Complete or Business plan and above for your site, or add the bypass filter `add_filter( 'ai_seo_enhancer_enabled_unrestricted', '__return_true' );`
Make sure you have "enable pre-publish checks" on your editor's preferences (so the PrePublish sidebar shows before publishing).

Open the editor and add some content and image on the post. Open the Jetpack sidebar and verify the SEO auto-generation toggle is disabled.
Hit "Publish" to see the PrePublish sidebar and the SEO panel in it.
See that the auto-generation process, as expected, has not triggered.
Enable the auto-generation toggle, see that it immediately triggers the generation process and the toggle becomes disabled until it's finished.

