### PR TITLE
CI: Sync wpcom-filename-restrictions with upstream

### DIFF
--- a/.github/files/test-wpcom-filename-restrictions.sh
+++ b/.github/files/test-wpcom-filename-restrictions.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 source "$GITHUB_WORKSPACE/trunk/.github/files/gh-funcs.sh"
 
-# Based on Automattic/pre-receive-hooks/blob/8bf13a23/common/050-stop-underscores.sh
+# Based on Automattic/pre-receive-hooks/blob/221f27e6/common/050-stop-underscores.sh
 IGNORE_UNDERSCORE_RULE_FOR='bin/wp-cli|bin/wp-cli-wpcom|wp-includes/sodium_compat|wp-content/plugins/glotpress|.phabricator-linter|wp-content/lib/nosara/ThriftSQL.src/ThriftGenerated/|wp-content/lib/aws/vendor/|wp-content/plugins/woocommerce/|wp-content/plugins/woocommerce-payments/|wp-content/plugins/woocommerce-subscriptions/|wp-content/plugins/p2(-wpcom)?|wp-content/lib/google/|wp-content/plugins/woo-gutenberg-products-block/vendor/|/autoload_|/vendor/composer/|wp-content/a8c-plugins/one-offs/a8cmaileditor/'
 function check_underscores {
 	local FILE="$1"
@@ -22,7 +22,7 @@ function check_underscores {
 	fi
 }
 
-# Based on Automattic/pre-receive-hooks/blob/8bf13a23/common/120-stop-invalid-chars.sh
+# Based on Automattic/pre-receive-hooks/blob/221f27e6/common/120-stop-invalid-chars.sh
 function check_invalid_chars {
 	local FILE="$1"
 	local Z=$( LC_ALL=C grep -aP '[^a-zA-Z._0-9/-]' <<<"$FILE" || true )
@@ -36,7 +36,7 @@ function check_invalid_chars {
 	fi
 }
 
-# Based on Automattic/pre-receive-hooks/blob/8bf13a23/common/130-stop-executables.sh
+# Based on Automattic/pre-receive-hooks/blob/221f27e6/common/130-stop-executables.sh
 function check_executable {
 	local FILE="$1"
 	if [[ "$( git ls-files -s "${FILE}" | awk '{ print $1 }' )" == "100755" ]]; then
@@ -45,7 +45,7 @@ function check_executable {
 	fi
 }
 
-# Based on Automattic/pre-receive-hooks/blob/8bf13a23/common/160-stop-symlinks.sh
+# Based on Automattic/pre-receive-hooks/blob/221f27e6/common/160-stop-symlinks.sh
 function check_symlink {
 	local FILE="$1"
 	if [[ "$( git ls-files -s "${FILE}" | awk '{ print $1 }' )" == "120000" ]]; then

--- a/.github/files/test-wpcom-filename-restrictions.sh
+++ b/.github/files/test-wpcom-filename-restrictions.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 source "$GITHUB_WORKSPACE/trunk/.github/files/gh-funcs.sh"
 
 # Based on Automattic/pre-receive-hooks/blob/8bf13a23/common/050-stop-underscores.sh
-IGNORE_UNDERSCORE_RULE_FOR='bin/wp-cli|bin/atoum|bin/wp-cli-wpcom|wp-includes/random_compat|wp-includes/sodium_compat|wp-content/plugins/glotpress|.phabricator-linter|wp-content/lib/customer-lists/|wp-content/lib/feature-store/vendor/|wp-content/lib/nosara/ThriftSQL.src/ThriftGenerated/|wp-content/mu-plugins/jetpack-plugin/vendor/|wp-content/lib/aws/vendor/|wp-content/mu-plugins/crowdsignal-forms/vendor/|wp-content/plugins/woocommerce/|wp-content/plugins/amp-2.0/|wp-content/plugins/woocommerce-payments/|wp-content/plugins/woocommerce-subscriptions/|wp-content/plugins/p2(-wpcom)?|wp-content/lib/google/|wp-content/lib/tus-php/|wp-content/vip-plugins/facebook-instant-articles-3.2/|wp-content/vip-plugins/facebook-instant-articles-4.0/|wp-content/mu-plugins/jetpack-packages/|wp-content/plugins/woo-gutenberg-products-block/vendor/|/autoload_|/vendor/composer/'
+IGNORE_UNDERSCORE_RULE_FOR='bin/wp-cli|bin/wp-cli-wpcom|wp-includes/sodium_compat|wp-content/plugins/glotpress|.phabricator-linter|wp-content/lib/nosara/ThriftSQL.src/ThriftGenerated/|wp-content/lib/aws/vendor/|wp-content/plugins/woocommerce/|wp-content/plugins/woocommerce-payments/|wp-content/plugins/woocommerce-subscriptions/|wp-content/plugins/p2(-wpcom)?|wp-content/lib/google/|wp-content/plugins/woo-gutenberg-products-block/vendor/|/autoload_|/vendor/composer/|wp-content/a8c-plugins/one-offs/a8cmaileditor/'
 function check_underscores {
 	local FILE="$1"
 	if echo "$PREFIX/$FILE" |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
None of the changes here should make a difference to us, but no reason not to sync it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Compare list with upstream, did it pick up 89-ghe-Automattic/pre-receive-hooks and 90-ghe-Automattic/pre-receive-hooks correctly?