### PR TITLE
Form: Fix file field label

### DIFF
--- a/projects/packages/forms/changelog/fix-file-upload-label
+++ b/projects/packages/forms/changelog/fix-file-upload-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add default file label"

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -988,6 +988,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 			case 'consent':
 				$str = __( 'Consent', 'jetpack-forms' );
 				break;
+			case 'file':
+				$str = __( 'Upload a file', 'jetpack-forms' );
+				break;
 			default:
 				$str = null;
 		}


### PR DESCRIPTION
This Pr fixes the missing default label from the frontend. 

Before: 
![Screenshot 2025-03-31 at 12 02 18 PM](https://github.com/user-attachments/assets/6e92585b-187c-4f35-b491-14626a35a494)

After:

![Screenshot 2025-03-31 at 12 02 27 PM](https://github.com/user-attachments/assets/2255721e-0679-41ab-b2ea-b440ba3c3abb)

## Proposed changes:
* Add a default label. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Add the file upload block. 

Notice that it has the default label is there as expected on the front end of the site. 


