### PR TITLE
Jetpack SEO Enhancer: change auto-generation to-do list

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-seo-enhancer-generation-task-list
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-seo-enhancer-generation-task-list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack SEO Enhancer: change the to-do list for the auto-generation feature, it now only lists what's missing

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer-task-list.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer-task-list.tsx
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import { Block } from '@automattic/jetpack-ai-client';
+import { Spinner } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { FEATURE_LABELS, FEATURES } from './constants';
+import { store } from './store';
+import './style.scss';
+/**
+ * Types
+ */
+import type { PromptType } from './types';
+
+export function SeoEnhancerTaskList( {
+	isPrePublish,
+	imageBlocks,
+}: {
+	isPrePublish: boolean;
+	imageBlocks: Block[];
+} ) {
+	const { titleBusy, descriptionBusy, imageBusy } = useSelect( select => {
+		const { isTitleBusy, isDescriptionBusy, isAnyImageBusy } = select( store );
+
+		return {
+			titleBusy: isTitleBusy(),
+			descriptionBusy: isDescriptionBusy(),
+			imageBusy: isAnyImageBusy(),
+		};
+	}, [] );
+
+	const featureIsBusy = ( feature: PromptType ) => {
+		if ( feature === 'seo-title' ) {
+			return titleBusy;
+		}
+
+		if ( feature === 'seo-meta-description' ) {
+			return descriptionBusy;
+		}
+
+		if ( feature === 'images-alt-text' ) {
+			return imageBusy;
+		}
+
+		return false;
+	};
+
+	return (
+		<div className="jetpack-seo-sidebar__feature-list-container">
+			<div className="jetpack-seo-sidebar__feature-list-title">
+				{ __( "If not provided we'll automatically generate:", 'jetpack' ) }
+			</div>
+			<div className="jetpack-seo-sidebar__feature-list">
+				{ FEATURES.map( feature => {
+					const extraLabel =
+						feature === 'images-alt-text' && imageBlocks.length > 0
+							? ` (${ imageBlocks.length })`
+							: '';
+					if ( ! isPrePublish ) {
+						return (
+							<div className="jetpack-seo-enhancer__feature-list-item" key={ feature }>
+								<div className="jetpack-seo-enhancer__feature-list-item-icon-container" />
+								<div>{ FEATURE_LABELS[ feature ] + extraLabel }</div>
+							</div>
+						);
+					}
+					return (
+						<div key={ feature } className="jetpack-seo-enhancer__feature-list-item">
+							<div className="jetpack-seo-enhancer__feature-list-item-icon-container">
+								<Spinner
+									style={ {
+										marginRight: 0,
+										display: featureIsBusy( feature ) ? 'inline-block' : 'none',
+									} }
+								/>
+							</div>
+							<div className="jetpack-seo-enhancer__feature-list-item-label">
+								{ FEATURE_LABELS[ feature ] + extraLabel }
+							</div>
+						</div>
+					);
+				} ) }
+			</div>
+		</div>
+	);
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
@@ -137,14 +137,16 @@ export function SeoEnhancer( {
 					) }
 				</BaseControl>
 			</PanelRow>
-			{ ( disableAutoEnhance || ( isEnabled && neededFeatures.length > 0 ) ) && (
+			{ ( ! isEnabled || disableAutoEnhance || ( isEnabled && neededFeatures.length > 0 ) ) && (
 				<PanelRow className="jetpack-seo-sidebar__feature-section">
 					<BaseControl __nextHasNoMarginBottom={ true }>
 						{ ( ! isEnabled || disableAutoEnhance ) && (
 							<div className="feature-checkboxes-container">
 								{ FEATURES.map( feature => {
 									const extraLabel =
-										feature === 'images-alt-text' ? ` (${ imageBlocks.length })` : '';
+										feature === 'images-alt-text' && imageBlocks.length > 0
+											? ` (${ imageBlocks.length })`
+											: '';
 
 									return (
 										<CheckboxControl

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { getAllBlocks } from '@automattic/jetpack-ai-client';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import {
 	BaseControl,
@@ -10,7 +11,8 @@ import {
 	CheckboxControl,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
+import { store as editorStore } from '@wordpress/editor';
+import { useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
 /**
@@ -41,7 +43,44 @@ export function SeoEnhancer( {
 
 		return isBusy || isAnyImageBusy;
 	}, [] );
+
 	const enabledFeatures = useSelect( select => select( store ).getEnabledFeatures(), [] );
+	const blocks = useSelect( select => select( editorStore ).getBlocks(), [] );
+	const seoTitle = useSelect(
+		select => select( editorStore ).getEditedPostAttribute( 'meta' )?.jetpack_seo_html_title,
+		[]
+	);
+	const seoDescription = useSelect(
+		select => select( editorStore ).getEditedPostAttribute( 'meta' )?.advanced_seo_description,
+		[]
+	);
+
+	const imageBlocks = useMemo( () => {
+		return blocks.length
+			? getAllBlocks().filter(
+					block => block.name === 'core/image' && block.attributes.url && ! block.attributes.alt
+			  )
+			: [];
+	}, [ blocks ] );
+
+	const neededFeatures = useMemo( () => {
+		const features = [];
+
+		if ( ! seoTitle ) {
+			features.push( { name: 'seo-title', enabled: !! seoTitle } );
+		}
+
+		if ( ! seoDescription ) {
+			features.push( { name: 'seo-meta-description', enabled: !! seoDescription } );
+		}
+
+		if ( imageBlocks.length > 0 ) {
+			features.push( { name: 'images-alt-text', enabled: true, count: imageBlocks.length } );
+		}
+
+		return features;
+	}, [ seoTitle, seoDescription, imageBlocks ] );
+
 	const { setFeatureEnabled } = useDispatch( store );
 
 	const { updateSeoData } = useSeoRequests();
@@ -98,41 +137,48 @@ export function SeoEnhancer( {
 					) }
 				</BaseControl>
 			</PanelRow>
-			<PanelRow className="jetpack-seo-sidebar__feature-section">
-				<BaseControl __nextHasNoMarginBottom={ true }>
-					{ ( ! isEnabled || disableAutoEnhance ) && (
-						<div className="feature-checkboxes-container">
-							{ FEATURES.map( feature => (
-								<CheckboxControl
-									key={ feature }
-									label={ FEATURE_LABELS[ feature ] }
-									checked={ enabledFeatures.includes( feature ) }
-									onChange={ () => toggleFeature( feature ) }
-									__nextHasNoMarginBottom={ true }
-									disabled={ isLoading }
-									className={ isLoading ? 'is-disabled' : '' }
-								/>
-							) ) }
-						</div>
-					) }
-					{ isEnabled && ! disableAutoEnhance && (
-						<div className="jetpack-seo-sidebar__feature-list-container">
-							{ enabledFeatures.length > 0 ? (
-								<>
-									<p>{ __( "We'll auto-generate:", 'jetpack' ) }</p>
-									<ul className="jetpack-seo-sidebar__feature-list">
-										{ enabledFeatures.map( feature => (
-											<li key={ feature }>{ FEATURE_LABELS[ feature ] }</li>
-										) ) }
-									</ul>
-								</>
-							) : (
-								<p>{ __( 'No features selected to auto-generate', 'jetpack' ) }</p>
-							) }
-						</div>
-					) }
-				</BaseControl>
-			</PanelRow>
+			{ ( disableAutoEnhance || ( isEnabled && neededFeatures.length > 0 ) ) && (
+				<PanelRow className="jetpack-seo-sidebar__feature-section">
+					<BaseControl __nextHasNoMarginBottom={ true }>
+						{ ( ! isEnabled || disableAutoEnhance ) && (
+							<div className="feature-checkboxes-container">
+								{ FEATURES.map( feature => {
+									const extraLabel =
+										feature === 'images-alt-text' ? ` (${ imageBlocks.length })` : '';
+
+									return (
+										<CheckboxControl
+											key={ feature }
+											label={ FEATURE_LABELS[ feature ] + extraLabel }
+											checked={ enabledFeatures.includes( feature ) }
+											onChange={ () => toggleFeature( feature ) }
+											__nextHasNoMarginBottom={ true }
+											disabled={ isLoading }
+											className={ isLoading ? 'is-disabled' : '' }
+										/>
+									);
+								} ) }
+							</div>
+						) }
+						{ isEnabled && ! disableAutoEnhance && neededFeatures.length > 0 && (
+							<div className="jetpack-seo-sidebar__feature-list-container">
+								<p>{ __( "We'll auto-generate:", 'jetpack' ) }</p>
+								<ul className="jetpack-seo-sidebar__feature-list">
+									{ neededFeatures.map( feature => {
+										const extraLabel =
+											feature.name === 'images-alt-text' && feature.count > 0
+												? ` (${ feature.count })`
+												: '';
+										return (
+											<li key={ feature.name }>{ FEATURE_LABELS[ feature.name ] + extraLabel }</li>
+										);
+									} ) }
+								</ul>
+							</div>
+						) }
+					</BaseControl>
+				</PanelRow>
+			) }
 			{ ! isEnabled && (
 				<PanelRow className="jetpack-seo-sidebar__feature-section">
 					<BaseControl __nextHasNoMarginBottom={ true } className="ai-seo-enhancer-toggle">

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
@@ -46,14 +46,6 @@ export function SeoEnhancer( {
 
 	const enabledFeatures = useSelect( select => select( store ).getEnabledFeatures(), [] );
 	const blocks = useSelect( select => select( editorStore ).getBlocks(), [] );
-	const seoTitle = useSelect(
-		select => select( editorStore ).getEditedPostAttribute( 'meta' )?.jetpack_seo_html_title,
-		[]
-	);
-	const seoDescription = useSelect(
-		select => select( editorStore ).getEditedPostAttribute( 'meta' )?.advanced_seo_description,
-		[]
-	);
 
 	const imageBlocks = useMemo( () => {
 		return blocks.length
@@ -62,24 +54,6 @@ export function SeoEnhancer( {
 			  )
 			: [];
 	}, [ blocks ] );
-
-	const neededFeatures = useMemo( () => {
-		const features = [];
-
-		if ( ! seoTitle ) {
-			features.push( { name: 'seo-title', enabled: !! seoTitle } );
-		}
-
-		if ( ! seoDescription ) {
-			features.push( { name: 'seo-meta-description', enabled: !! seoDescription } );
-		}
-
-		if ( imageBlocks.length > 0 ) {
-			features.push( { name: 'images-alt-text', enabled: true, count: imageBlocks.length } );
-		}
-
-		return features;
-	}, [ seoTitle, seoDescription, imageBlocks ] );
 
 	const { setFeatureEnabled } = useDispatch( store );
 
@@ -135,52 +109,46 @@ export function SeoEnhancer( {
 							) }
 						/>
 					) }
-				</BaseControl>
-			</PanelRow>
-			{ ( ! isEnabled || disableAutoEnhance || ( isEnabled && neededFeatures.length > 0 ) ) && (
-				<PanelRow className="jetpack-seo-sidebar__feature-section">
-					<BaseControl __nextHasNoMarginBottom={ true }>
-						{ ( ! isEnabled || disableAutoEnhance ) && (
-							<div className="feature-checkboxes-container">
-								{ FEATURES.map( feature => {
+					{ ( ! isEnabled || disableAutoEnhance ) && (
+						<div className="feature-checkboxes-container">
+							{ FEATURES.map( feature => {
+								const extraLabel =
+									feature === 'images-alt-text' && imageBlocks.length > 0
+										? ` (${ imageBlocks.length })`
+										: '';
+
+								return (
+									<CheckboxControl
+										key={ feature }
+										label={ FEATURE_LABELS[ feature ] + extraLabel }
+										checked={ enabledFeatures.includes( feature ) }
+										onChange={ () => toggleFeature( feature ) }
+										__nextHasNoMarginBottom={ true }
+										disabled={ isLoading }
+										className={ isLoading ? 'is-disabled' : '' }
+									/>
+								);
+							} ) }
+						</div>
+					) }
+					{ isEnabled && ! disableAutoEnhance && (
+						<div className="jetpack-seo-sidebar__feature-list-container">
+							<span className="jetpack-seo-sidebar__feature-list-title">
+								{ __( "If not provided we'll automatically generate:", 'jetpack' ) }
+							</span>
+							<ul className="jetpack-seo-sidebar__feature-list">
+								{ enabledFeatures.map( feature => {
 									const extraLabel =
 										feature === 'images-alt-text' && imageBlocks.length > 0
 											? ` (${ imageBlocks.length })`
 											: '';
-
-									return (
-										<CheckboxControl
-											key={ feature }
-											label={ FEATURE_LABELS[ feature ] + extraLabel }
-											checked={ enabledFeatures.includes( feature ) }
-											onChange={ () => toggleFeature( feature ) }
-											__nextHasNoMarginBottom={ true }
-											disabled={ isLoading }
-											className={ isLoading ? 'is-disabled' : '' }
-										/>
-									);
+									return <li key={ feature }>{ FEATURE_LABELS[ feature ] + extraLabel }</li>;
 								} ) }
-							</div>
-						) }
-						{ isEnabled && ! disableAutoEnhance && neededFeatures.length > 0 && (
-							<div className="jetpack-seo-sidebar__feature-list-container">
-								<p>{ __( "We'll auto-generate:", 'jetpack' ) }</p>
-								<ul className="jetpack-seo-sidebar__feature-list">
-									{ neededFeatures.map( feature => {
-										const extraLabel =
-											feature.name === 'images-alt-text' && feature.count > 0
-												? ` (${ feature.count })`
-												: '';
-										return (
-											<li key={ feature.name }>{ FEATURE_LABELS[ feature.name ] + extraLabel }</li>
-										);
-									} ) }
-								</ul>
-							</div>
-						) }
-					</BaseControl>
-				</PanelRow>
-			) }
+							</ul>
+						</div>
+					) }
+				</BaseControl>
+			</PanelRow>
 			{ ! isEnabled && (
 				<PanelRow className="jetpack-seo-sidebar__feature-section">
 					<BaseControl __nextHasNoMarginBottom={ true } className="ai-seo-enhancer-toggle">

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
@@ -19,6 +19,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import { FEATURE_LABELS, FEATURES } from './constants';
+import { SeoEnhancerTaskList } from './seo-enhancer-task-list';
 import { store } from './store';
 import { useSeoModuleSettings } from './use-seo-module-settings';
 import { useSeoRequests } from './use-seo-requests';
@@ -132,20 +133,10 @@ export function SeoEnhancer( {
 						</div>
 					) }
 					{ isEnabled && ! disableAutoEnhance && (
-						<div className="jetpack-seo-sidebar__feature-list-container">
-							<span className="jetpack-seo-sidebar__feature-list-title">
-								{ __( "If not provided we'll automatically generate:", 'jetpack' ) }
-							</span>
-							<ul className="jetpack-seo-sidebar__feature-list">
-								{ enabledFeatures.map( feature => {
-									const extraLabel =
-										feature === 'images-alt-text' && imageBlocks.length > 0
-											? ` (${ imageBlocks.length })`
-											: '';
-									return <li key={ feature }>{ FEATURE_LABELS[ feature ] + extraLabel }</li>;
-								} ) }
-							</ul>
-						</div>
+						<SeoEnhancerTaskList
+							isPrePublish={ placement === 'jetpack-prepublish-sidebar' }
+							imageBlocks={ imageBlocks }
+						/>
 					) }
 				</BaseControl>
 			</PanelRow>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/style.scss
@@ -20,6 +20,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 12px;
+		margin-top: 24px;
 	}
 
 	.is-disabled {
@@ -31,11 +32,17 @@
 	}
 
 	.jetpack-seo-sidebar__feature-list-container {
+		margin-top: 16px;
 		margin-left: 40px;
+		font-size: 13px;
+	}
+
+	.jetpack-seo-sidebar__feature-list-title {
+		font-weight: 500;
 	}
 
 	.jetpack-seo-sidebar__feature-list {
-		list-style: inside;
+		margin-top: 8px;
 	}
 }
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/style.scss
@@ -1,6 +1,4 @@
 .jetpack-seo-sidebar__feature-section--toggle {
-	// min-height: unset;
-
 	.ai-seo-enhancer-label {
 		margin-bottom: 24px;
 	}
@@ -33,17 +31,35 @@
 
 	.jetpack-seo-sidebar__feature-list-container {
 		margin-top: 16px;
-		margin-left: 40px;
 		font-size: 13px;
+
+		.jetpack-seo-sidebar__feature-list-title {
+			font-weight: 500;
+			margin-left: 40px;
+		}
+	
+		.jetpack-seo-sidebar__feature-list {
+			margin-top: 8px;
+		}
+
+		.jetpack-seo-enhancer__feature-list-item {
+			display: flex;
+			align-items: center;
+			gap: 8px;
+		}
+
+		.jetpack-seo-enhancer__feature-list-item-icon-container {
+			width: 32px;
+			height: 25px;
+			text-align: end;
+		}
+
+		.jetpack-seo-enhancer__feature-list-item-icon {
+			margin-right: 0;
+		}
+		
 	}
 
-	.jetpack-seo-sidebar__feature-list-title {
-		font-weight: 500;
-	}
-
-	.jetpack-seo-sidebar__feature-list {
-		margin-top: 8px;
-	}
 }
 
 .jetpack-seo-enhancer-summary-feature {


### PR DESCRIPTION
Fixes: AGORA-39
Fixes: AGORA-41

## Proposed changes:
When the auto-generation feature is enabled, we only want to show what the tool will be generating for the user.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-wgI-p2#comment-75940

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add the feature filter: `add_filter( 'ai_seo_enhancer_enabled', '__return_true' );`.

Get a Jetpack Complete or Business plan and above for your site, or add the bypass filter `add_filter( 'ai_seo_enhancer_enabled_unrestricted', '__return_true' );`

Open the editor, add some content and image to the post.
Get to the Jetpack sidebar and to the SEO panel. Enable the auto-generate toggle.
See the list of tasks for the auto-generation appear under the toggle. The image alt text task should include the number of images needing alt-text generation (aka: images WITHOUT alt-text).
Go to the image block properties and add some alt text, then get back to the Jetpack sidebar and see the images alt text generation is not shown anymore.

Then fill the SEO TITLE textbox, you'll see the task disappearing from the auto-generation task list. The same behavior should be seen with SEO DESCRIPTION.

Verify the same behavior on the PrePublish sidebar.
