### PR TITLE
Fixing E2E tests affected by new onboarding

### DIFF
--- a/tools/e2e-commons/pages/wp-admin/sidebar.js
+++ b/tools/e2e-commons/pages/wp-admin/sidebar.js
@@ -16,7 +16,8 @@ export default class Sidebar extends WpPage {
 		const jetpackMenuSelector = '#toplevel_page_jetpack';
 		const menuItemSelector = '#toplevel_page_jetpack .wp-submenu a[href$="admin.php?page=jetpack"]';
 
-		return await this._selectMenuItem( jetpackMenuSelector, menuItemSelector );
+		// Fixing parent menu click redirecting to the new onboarding flow (until more detailed tests are added).
+		return await this._selectJetpackMenuItem( jetpackMenuSelector, menuItemSelector );
 	}
 
 	async selectJetpackBoost() {
@@ -62,6 +63,20 @@ export default class Sidebar extends WpPage {
 
 		if ( ! classes.includes( 'wp-menu-open' ) && ! classes.includes( 'wp-has-current-submenu' ) ) {
 			await menuElement.click();
+		}
+
+		return await this.click( menuItemSelector );
+	}
+
+	// Fixing parent menu click redirecting to the new onboarding flow (until more detailed tests are added.
+	async _selectJetpackMenuItem( menuSelector, menuItemSelector ) {
+		const menuElement = await this.waitForElementToBeVisible( menuSelector );
+		const classes = await this.page
+			.locator( menuSelector )
+			.evaluate( e => e.getAttribute( 'class' ) );
+
+		if ( ! classes.includes( 'wp-menu-open' ) && ! classes.includes( 'wp-has-current-submenu' ) ) {
+			await menuElement.hover();
 		}
 
 		return await this.click( menuItemSelector );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1743447327698659-slack-C01U2KGS2PQ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* After adding new Jetpack onboarding some tests got affected that were clicking on the main Jetpack sidebar menu before going to a sub menu. This change replaced click on the main Jetpack parent menu node with hover.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Verify that E2E tests are passing.