### PR TITLE
Search menu registration: allow child classes to modify priority

### DIFF
--- a/projects/packages/search/changelog/fix-jetpack-menu-simple
+++ b/projects/packages/search/changelog/fix-jetpack-menu-simple
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin menu registration: allow child classes to overwrite priority.

--- a/projects/packages/search/src/dashboard/class-dashboard.php
+++ b/projects/packages/search/src/dashboard/class-dashboard.php
@@ -47,6 +47,15 @@ class Dashboard {
 	protected $module_control;
 
 	/**
+	 * Priority for the dashboard menu
+	 * For Jetpack sites: Akismet uses 4, so we use 1 to ensure both menus are added when only they exist.
+	 * For Simple sites: the value is overriden in a child class with value 100000 to wait for all menus to be registered.
+	 *
+	 * @var int
+	 */
+	protected $search_menu_priority = 1;
+
+	/**
 	 * Contructor
 	 *
 	 * @param \Automattic\Jetpack\Search\Plan           $plan - Plan instance.
@@ -73,7 +82,7 @@ class Dashboard {
 	public function init_hooks() {
 		if ( ! self::$initialized ) {
 			self::$initialized = true;
-			add_action( 'admin_menu', array( $this, 'add_wp_admin_submenu' ), 1 ); // Akismet uses 4, so we use 1 to ensure both menus are added when only they exist.
+			add_action( 'admin_menu', array( $this, 'add_wp_admin_submenu' ), $this->search_menu_priority );
 			// Check if the site plan changed and deactivate module accordingly.
 			add_action( 'current_screen', array( $this, 'check_plan_deactivate_search_module' ) );
 		}


### PR DESCRIPTION
Follow-up to #42776

## Proposed changes:

On WordPress.com Simple, we want to change the default priority. We had done that by overwriting $search_menu_priority until now, but #42776 made it impossible. This commit brings it back.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* paEFis-4qO-p2#comment-3609

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

> [!WARNING]
> This needs to be tested on self-hosted and on WordPress.com Simple.

**On WordPress.com simple**

* On a sandboxed site, go to Settings > General and pick the Calypso style as your preferred admin interface.
* Save your changes
* Hover the "Jetpack" menu item ; it should not redirect to a non-existing page.

**On self-hosted**

See instructions in #42776.
