### PR TITLE
Account Protection and Brute Force Protection: Add log_failed_attempt error param default value

### DIFF
--- a/projects/packages/account-protection/changelog/fix-brute-force-protection-log-failed-attempt-missing-error-param
+++ b/projects/packages/account-protection/changelog/fix-brute-force-protection-log-failed-attempt-missing-error-param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add a default value for the error param in the wp_login_failed action callback

--- a/projects/packages/account-protection/src/class-password-detection.php
+++ b/projects/packages/account-protection/src/class-password-detection.php
@@ -148,12 +148,12 @@ class Password_Detection {
 	/**
 	 * Handle password detection validation error.
 	 *
-	 * @param string    $username The username.
-	 * @param \WP_Error $error The error object.
+	 * @param string         $username The username.
+	 * @param \WP_Error|null $error The error object.
 	 *
 	 * @return void
 	 */
-	public function handle_password_detection_validation_error( string $username, \WP_Error $error ): void {
+	public function handle_password_detection_validation_error( string $username, ?\WP_Error $error = null ): void {
 		if ( isset( $error->errors['password_detection_validation_error'] ) ) {
 			$token = $error->get_error_data()['token'];
 			$this->redirect_and_exit( $this->get_redirect_url( $token ) );

--- a/projects/packages/waf/changelog/fix-brute-force-protection-log-failed-attempt-missing-error-param
+++ b/projects/packages/waf/changelog/fix-brute-force-protection-log-failed-attempt-missing-error-param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add a default value for the error param in the wp_login_failed action callback

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -515,8 +515,8 @@ class Brute_Force_Protection {
 	 *
 	 * Fires custom, plugable action jpp_log_failed_attempt with the IP
 	 *
-	 * @param string    $username - The username or email address attempting to log in.
-	 * @param \WP_Error $error    - A WP_Error object with the authentication failure details.
+	 * @param string         $username - The username or email address attempting to log in.
+	 * @param \WP_Error|null $error    - A WP_Error object with the authentication failure details.
 	 *
 	 * @return void
 	 */

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -520,7 +520,7 @@ class Brute_Force_Protection {
 	 *
 	 * @return void
 	 */
-	public function log_failed_attempt( string $username, \WP_Error $error ) {
+	public function log_failed_attempt( string $username, ?\WP_Error $error = null ) {
 
 		// Skip if Account protection password validation error.
 		if ( isset( $error->errors['password_detection_validation_error'] ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
When the `wp_login_failed` action is triggered by an errant plugin not passing the secondary `$error` param as the hook [docs](https://developer.wordpress.org/reference/hooks/wp_login_failed/) suggest it should.

Also addresses the issue in Account Protection and WAF > Brute Force Protection package code.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://linear.app/a8c/issue/PROTECT-62/fix-bfp-log-failed-attempt-fatals

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create JN test site
* Install Jetpack Beta Tester and run bleeding edge Jetpack with Account Protection and Brute Force Protection enabled
* Install an errant plugin ([example](https://wordpress.org/plugins/tt-sidebar-login-widget/))
* Log out and (if fatal doesn't occur on logout) log back in and verify if a fatal is returned
* Check the logs to ensure they are specific the `wp_login_failed` callbacks in either package 
   * **Note**: If Account Protection is enabled, the error will be specific to it, if only BFP is, the error will be specific to it.
* Update Jetpack to this branch in recovery mode and disable recovery mode
* Log out and back in and verify that the fatal is no longer returned
* Ensure no regressions are introduced

