### PR TITLE
Forms: Add custom hooks for integrations

### DIFF
--- a/projects/packages/forms/changelog/add-form-block-integrations-hooks
+++ b/projects/packages/forms/changelog/add-form-block-integrations-hooks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add custom hooks for integrations.

--- a/projects/packages/forms/src/blocks/contact-form/components/hooks/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/hooks/index.js
@@ -1,0 +1,2 @@
+export { useIntegrationStatus } from './useIntegrationStatus';
+export { usePluginInstallation } from './usePluginInstallation';

--- a/projects/packages/forms/src/blocks/contact-form/components/hooks/useIntegrationStatus.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/hooks/useIntegrationStatus.js
@@ -1,0 +1,63 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useState, useEffect, useCallback } from '@wordpress/element';
+
+/**
+ * Custom hook to fetch and manage integration status.
+ *
+ * @param {string} slug - The integration slug (e.g., 'akismet', 'jetpack-crm', 'creative-mail')
+ * @return {object} Integration status and loading state
+ */
+export const useIntegrationStatus = slug => {
+	const [ status, setStatus ] = useState( {
+		isCheckingStatus: true,
+		isInstalled: false,
+		isActive: false,
+		isConnected: false,
+		settingsUrl: '',
+		error: null,
+	} );
+
+	const checkStatus = useCallback( async () => {
+		try {
+			const response = await apiFetch( {
+				path: `/wp/v2/feedback/integration-status/${ slug }`,
+			} );
+
+			setStatus( {
+				isCheckingStatus: false,
+				isInstalled: response.isInstalled,
+				isActive: response.isActive,
+				isConnected: response.isConnected || false,
+				settingsUrl: response.configurationUrl || '',
+				error: null,
+			} );
+		} catch ( error ) {
+			setStatus( {
+				isCheckingStatus: false,
+				isInstalled: false,
+				isActive: false,
+				isConnected: false,
+				settingsUrl: '',
+				error,
+			} );
+		}
+	}, [ slug ] );
+
+	// Function to manually refresh the status
+	const refreshStatus = useCallback( async () => {
+		setStatus( current => ( {
+			...current,
+			isCheckingStatus: true,
+		} ) );
+		await checkStatus();
+	}, [ checkStatus ] );
+
+	useEffect( () => {
+		checkStatus();
+	}, [ checkStatus ] );
+
+	return {
+		...status,
+		refreshStatus,
+	};
+};

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
@@ -32,16 +32,12 @@ const AkismetCard = ( { isExpanded, onToggle } ) => {
 	};
 
 	const getButtonText = () => {
-		if ( isInstalling ) {
-			if ( isInstalled ) {
-				return __( 'Activating…', 'jetpack-forms' );
-			}
-			return __( 'Installing…', 'jetpack-forms' );
-		}
-		if ( isInstalled ) {
-			return __( 'Activate', 'jetpack-forms' );
-		}
-		return __( 'Install', 'jetpack-forms' );
+		return (
+			( isInstalling && isInstalled && __( 'Activating…', 'jetpack-forms' ) ) ||
+			( isInstalling && __( 'Installing…', 'jetpack-forms' ) ) ||
+			( isInstalled && __( 'Activate', 'jetpack-forms' ) ) ||
+			__( 'Install', 'jetpack-forms' )
+		);
 	};
 
 	const renderContent = () => {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
@@ -1,14 +1,160 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { Button, ExternalLink } from '@wordpress/components';
+import { Button, ExternalLink, Icon, Spinner } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import PluginIntegrationPanel from '../shared/plugin-integration-panel';
+import { useIntegrationStatus, usePluginInstallation } from '../hooks';
 import IntegrationCard from './integration-card';
 
 const AkismetCard = ( { isExpanded, onToggle } ) => {
-	const adminUrl = window?.jpFormsBlocks?.defaults?.formsAdminUrl || '';
-	const akismetActiveWithKey = window?.jpFormsBlocks?.defaults?.akismetActiveWithKey || false;
-	const akismetUrl = window?.jpFormsBlocks?.defaults?.akismetUrl || '';
+	const formSubmissionsUrl = window?.jpFormsBlocks?.defaults?.formsAdminUrl || '';
+
+	const {
+		isCheckingStatus,
+		isInstalled,
+		isActive,
+		isConnected: akismetActiveWithKey,
+		settingsUrl,
+		refreshStatus,
+	} = useIntegrationStatus( 'akismet' );
+
+	const { isInstalling, installPlugin } = usePluginInstallation(
+		'akismet',
+		'akismet/akismet',
+		isInstalled,
+		'jetpack_forms_upsell_akismet_click'
+	);
+
+	const handleInstallAction = async () => {
+		const success = await installPlugin();
+		if ( success ) {
+			refreshStatus();
+		}
+	};
+
+	const getButtonText = () => {
+		if ( isInstalling ) {
+			if ( isInstalled ) {
+				return __( 'Activating…', 'jetpack-forms' );
+			}
+			return __( 'Installing…', 'jetpack-forms' );
+		}
+		if ( isInstalled ) {
+			return __( 'Activate', 'jetpack-forms' );
+		}
+		return __( 'Install', 'jetpack-forms' );
+	};
+
+	const renderContent = () => {
+		if ( isCheckingStatus ) {
+			return <Spinner />;
+		}
+
+		if ( ! isInstalled ) {
+			return (
+				<div>
+					<p>
+						{ createInterpolateElement(
+							__(
+								"Add one-click spam protection for your forms with <a>Akismet</a>. Simply install the plugin and you're set.",
+								'jetpack-forms'
+							),
+							{
+								a: <ExternalLink href={ getRedirectUrl( 'akismet-wordpress-org' ) } />,
+							}
+						) }
+					</p>
+					<Button
+						variant="primary"
+						onClick={ handleInstallAction }
+						disabled={ isInstalling }
+						icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
+						__next40pxDefaultSize={ true }
+					>
+						{ getButtonText() }
+					</Button>
+				</div>
+			);
+		}
+
+		if ( ! isActive ) {
+			return (
+				<div>
+					<p>
+						{ __( "You already have Akismet installed, but it's not activated.", 'jetpack-forms' ) }
+					</p>
+					<Button
+						variant="primary"
+						onClick={ handleInstallAction }
+						disabled={ isInstalling }
+						icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
+						__next40pxDefaultSize={ true }
+					>
+						{ getButtonText() }
+					</Button>
+				</div>
+			);
+		}
+
+		if ( ! akismetActiveWithKey ) {
+			return (
+				<div>
+					<p>
+						{ createInterpolateElement(
+							__(
+								'Akismet is active! There is one step left. Please add your <a>Akismet key</a>.',
+								'jetpack-forms'
+							),
+							{
+								a: <ExternalLink href={ settingsUrl } />,
+							}
+						) }
+					</p>
+					<Button
+						variant="primary"
+						href={ settingsUrl }
+						target="_blank"
+						rel="noopener noreferrer"
+						__next40pxDefaultSize={ true }
+					>
+						{ __( 'Add Akismet key', 'jetpack-forms' ) }
+					</Button>
+				</div>
+			);
+		}
+
+		return (
+			<div>
+				<p>
+					{ createInterpolateElement(
+						__( 'Your forms are protected from spam with <a>Akismet</a>!', 'jetpack-forms' ),
+						{
+							a: <ExternalLink href={ getRedirectUrl( 'akismet-jetpack-forms-docs' ) } />,
+						}
+					) }
+				</p>
+				<div style={ { display: 'flex', gap: '8px', justifyContent: 'flex-start' } }>
+					<Button
+						variant="primary"
+						href={ formSubmissionsUrl }
+						target="_blank"
+						rel="noopener noreferrer"
+						__next40pxDefaultSize={ true }
+					>
+						{ __( 'View spam', 'jetpack-forms' ) }
+					</Button>
+					<Button
+						variant="primary"
+						href={ settingsUrl }
+						target="_blank"
+						rel="noopener noreferrer"
+						__next40pxDefaultSize={ true }
+					>
+						{ __( 'View stats', 'jetpack-forms' ) }
+					</Button>
+				</div>
+			</div>
+		);
+	};
 
 	return (
 		<IntegrationCard
@@ -18,81 +164,7 @@ const AkismetCard = ( { isExpanded, onToggle } ) => {
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }
 		>
-			<PluginIntegrationPanel
-				title={ __( 'Spam protection', 'jetpack-forms' ) }
-				pluginSlug="akismet"
-				pluginPath="akismet/akismet"
-				pluginTitle="Akismet"
-				installText={ __( 'Install Akismet', 'jetpack-forms' ) }
-				activateText={ __( 'Activate Akismet', 'jetpack-forms' ) }
-				description={ createInterpolateElement(
-					__(
-						"Add one-click spam protection for your forms with <a>Akismet</a>. Simply install the plugin and you're set.",
-						'jetpack-forms'
-					),
-					{
-						a: <ExternalLink href={ getRedirectUrl( 'akismet-wordpress-org' ) } />,
-					}
-				) }
-				tracksEventName="jetpack_forms_upsell_akismet_click"
-				hideWrapper
-			>
-				{ akismetActiveWithKey ? (
-					<>
-						<p>
-							{ createInterpolateElement(
-								__( 'Your forms are protected from spam with <a>Akismet</a>!', 'jetpack-forms' ),
-								{
-									a: <ExternalLink href={ getRedirectUrl( 'akismet-jetpack-forms-docs' ) } />,
-								}
-							) }
-						</p>
-						<div style={ { display: 'flex', gap: '8px', justifyContent: 'flex-start' } }>
-							<Button
-								variant="secondary"
-								href={ adminUrl }
-								target="_blank"
-								rel="noopener noreferrer"
-								__next40pxDefaultSize={ true }
-							>
-								{ __( 'View spam', 'jetpack-forms' ) }
-							</Button>
-							<Button
-								variant="secondary"
-								href={ akismetUrl }
-								target="_blank"
-								rel="noopener noreferrer"
-								__next40pxDefaultSize={ true }
-							>
-								{ __( 'View stats', 'jetpack-forms' ) }
-							</Button>
-						</div>
-					</>
-				) : (
-					<>
-						<p>
-							{ createInterpolateElement(
-								__(
-									'Akismet is active! There is one step left. Please add your <a>Akismet key</a>.',
-									'jetpack-forms'
-								),
-								{
-									a: <ExternalLink href={ akismetUrl } />,
-								}
-							) }
-						</p>
-						<Button
-							variant="secondary"
-							href={ akismetUrl }
-							target="_blank"
-							rel="noopener noreferrer"
-							__next40pxDefaultSize={ true }
-						>
-							{ __( 'Add Akismet key', 'jetpack-forms' ) }
-						</Button>
-					</>
-				) }
-			</PluginIntegrationPanel>
+			{ renderContent() }
 		</IntegrationCard>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card.scss
@@ -50,4 +50,17 @@
 	&__toggle-icon {
 		display: block;
 	}
+
+	.is-spinning {
+		animation: rotation 2s infinite linear;
+	}
+	
+	@keyframes rotation {
+		from {
+			transform: rotate(0deg);
+		}
+		to {
+			transform: rotate(359deg);
+		}
+	} 
 } 

--- a/projects/plugins/jetpack/changelog/add-form-block-integrations-hooks
+++ b/projects/plugins/jetpack/changelog/add-form-block-integrations-hooks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Added custom hooks for integrations.


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
NOTE: This is one of many upcoming PRs to create the new third party integrations modal based on designs in Figma. All this work is behind a feature flag and will only be visible if you set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.

Changes:
* **useIntegrationStatus:** Adds useIntegrationStatus custom hook that check the installed / active / connected status of forms integration using the new integrations endpoint. 
* **usePluginInstallation:** Adds a usePluginInstallation custom hook that handles activating / installing plugins, and keeps track of state during the process. 
* **Akismet Card:** Updates the Akismet card in the third party integrations modal to use both hooks. 
* **Future applications:** In a future PR, will update the Jetpack CRM and Creative Mail cards to use these hooks. And the idea is that other future integrations (Google Drive, Zapier, etc) can use the same hooks. In theory, these hooks can also be used on the Integrations tab in our centralized form management dashboard when built. 
   - This also improves and replaces the logic in the PluginIntegrationPanel, which will be deleted when the modal and these hooks are released. 
   
**Akismet not installed**
<img width="1463" alt="akismet-install" src="https://github.com/user-attachments/assets/a1765ad1-07ff-45a9-9a9e-20819efeb3a1" />

**Akismet installed but not activated**
<img width="1465" alt="akismet-activate" src="https://github.com/user-attachments/assets/a336d987-3758-4a9c-8faf-39e43a68f5a7" />

**Akismet installed with key**
<img width="1462" alt="akismet-active-with-key" src="https://github.com/user-attachments/assets/a83006a0-3057-4021-b840-c7f96bc4309d" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

There will still be a lot of polishing to this modal and to the individual cards. Detailed feedback on styling or text, etc, is welcome but will likely be handled in a separate PR. Adding 2 hooks and refactoring the Akismet panel is enough for one PR.

- Set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.
- Add a form block to a page
- Click on the Manage Integrations button the block sidebar
- Open the Akismet panel and be sure it renders correct and updates based on state:
   - Akismet not installed
      - Will see "Install" button
      - Clicking will install the plugin - you'll see 'Installing...' and spinner on button
      - When active, will see "Akismet activated" below
   - Akismet installed but not activated
      - Will see "Activate" button
      - Clicking will activate the plugin - you'll see 'Installing...' and spinner on button
      - When active, will see "Akismet activated" below
   - Akismet activated
     - If no key, you'll see an "Activate key" button. It link to the Akismet setting page to add key.
     - If active key, you'll see View Spam and View Stats button that go to feedback page and Akismet stats page

