### PR TITLE
Forms: Update integrations endpoint

### DIFF
--- a/projects/packages/forms/changelog/update-form-integrations-endpoint
+++ b/projects/packages/forms/changelog/update-form-integrations-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Change path and return for form integrations endpoint.

--- a/projects/packages/forms/src/blocks/contact-form/components/hooks/useIntegrationStatus.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/hooks/useIntegrationStatus.js
@@ -20,7 +20,7 @@ export const useIntegrationStatus = slug => {
 	const checkStatus = useCallback( async () => {
 		try {
 			const response = await apiFetch( {
-				path: `/wp/v2/feedback/integration-status/${ slug }`,
+				path: `/wp/v2/feedback/integrations/${ slug }`,
 			} );
 
 			setStatus( {
@@ -28,7 +28,7 @@ export const useIntegrationStatus = slug => {
 				isInstalled: response.isInstalled,
 				isActive: response.isActive,
 				isConnected: response.isConnected || false,
-				settingsUrl: response.configurationUrl || '',
+				settingsUrl: response.settingsUrl || '',
 				error: null,
 			} );
 		} catch ( error ) {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-akismet-panel.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-akismet-panel.js
@@ -23,11 +23,11 @@ const AkismetPanel = () => {
 	const checkAkismetStatus = useCallback( async () => {
 		try {
 			const response = await apiFetch( {
-				path: '/wp/v2/feedback/integration-status/akismet',
+				path: '/wp/v2/feedback/integrations/akismet',
 			} );
 			setAkismetActiveWithKey( response.isConnected );
-			if ( response.configurationUrl ) {
-				setAkismetUrl( response.configurationUrl );
+			if ( response.settingsUrl ) {
+				setAkismetUrl( response.settingsUrl );
 			}
 		} catch {
 			setAkismetActiveWithKey( false );

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -628,7 +628,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'isActive'    => $is_active,
 		);
 
-		if ( $is_active && isset( $plugin_config['settings_url'] ) ) {
+		if ( $is_active ) {
 			$response['settingsUrl'] = admin_url( $plugin_config['settings_url'] );
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -36,7 +36,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/integration-status/(?P<slug>[\w-]+)',
+			$this->rest_base . '/integrations/(?P<slug>[\w-]+)',
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_integration_status' ),
@@ -590,14 +590,23 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		$plugin_files = array(
-			'akismet'       => 'akismet/akismet.php',
-			'creative-mail' => 'creative-mail-by-constant-contact/creative-mail-by-constant-contact.php',
-			'jetpack-crm'   => 'zero-bs-crm/ZeroBSCRM.php',
+		$plugin_configs = array(
+			'akismet'       => array(
+				'file'         => 'akismet/akismet.php',
+				'settings_url' => 'admin.php?page=akismet-key-config',
+			),
+			'creative-mail' => array(
+				'file'         => 'creative-mail-by-constant-contact/creative-mail-plugin.php',
+				'settings_url' => 'admin.php?page=creativemail',
+			),
+			'jetpack-crm'   => array(
+				'file'         => 'zero-bs-crm/ZeroBSCRM.php',
+				'settings_url' => 'admin.php?page=zerobscrm-plugin-settings',
+			),
 		);
 
-		$plugin_file = $plugin_files[ $plugin_slug ] ?? '';
-		if ( empty( $plugin_file ) ) {
+		$plugin_config = $plugin_configs[ $plugin_slug ] ?? null;
+		if ( empty( $plugin_config ) ) {
 			return rest_ensure_response(
 				array(
 					'type'        => 'plugin',
@@ -610,16 +619,20 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		}
 
 		$installed_plugins = get_plugins();
-		$is_installed      = isset( $installed_plugins[ $plugin_file ] );
-		$is_active         = is_plugin_active( $plugin_file );
+		$is_installed      = isset( $installed_plugins[ $plugin_config['file'] ] );
+		$is_active         = is_plugin_active( $plugin_config['file'] );
 
-		return rest_ensure_response(
-			array(
-				'type'        => 'plugin',
-				'isInstalled' => $is_installed,
-				'isActive'    => $is_active,
-			)
+		$response = array(
+			'type'        => 'plugin',
+			'isInstalled' => $is_installed,
+			'isActive'    => $is_active,
 		);
+
+		if ( $is_active && isset( $plugin_config['settings_url'] ) ) {
+			$response['settingsUrl'] = admin_url( $plugin_config['settings_url'] );
+		}
+
+		return rest_ensure_response( $response );
 	}
 
 	/**
@@ -635,8 +648,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			array_merge(
 				$status_data,
 				array(
-					'isConnected'      => class_exists( 'Jetpack' ) && \Jetpack::is_akismet_active(),
-					'configurationUrl' => admin_url( 'admin.php?page=akismet-key-config' ),
+					'isConnected' => class_exists( 'Jetpack' ) && \Jetpack::is_akismet_active(),
 				)
 			)
 		);

--- a/projects/plugins/jetpack/changelog/update-form-integrations-endpoint
+++ b/projects/plugins/jetpack/changelog/update-form-integrations-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Forms: Change path and return for form integrations endpoint.


### PR DESCRIPTION
## Proposed changes:
I'm working on extending the use of this endpoint to other plugins beside Akismet, and realized it needed a couple changes. I want to keep those changes in a separate PR. Specficially:
- Updates the endpoint path from integrations-status/slug to integrations/slug for simplicity
- Updates the plugin mapping to contain the settings url for each plugin. We often need to return that to provide links to settings after we install/activate plugins on the frontend. 
- Returns plugin settingsUrl from the endpoint (and then removes the same return from the Akismet method since no longer needed)
- Updated configurationUrl to settingsUrl for simplicity and consistency

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Behavior should be unchanged before and after this PR. It's a refactor. 
* Test Akismet block panel. 
   - Add form block to page
   - Check Akismet panel on sidebar, and confirm it displays the right content depending on whether Akismet is not installed, not active, and has a key or not. If you see the install/activate button, click it and confirm state updates. 
   - You'll want to go to plugins page and try deactivating / deleting Akismet and then come back and refresh the block editor to test again.
* Test Akismet card in form integrations modal.
   - Set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true ); in your wp-config.php` file
   - Add form block to page, and click the Manage Integrations button on sidebar to open the modal
   - Confirm the Akismet card displays the right content depending on whether Akismet is not installed, not active, and has a key or not. If you see the install/activate button, click it and confirm state updates. 
   - You'll want to go to plugins page and try deactivating / deleting Akismet and then come back and refresh the block editor to test again.

