### PR TITLE
Forms: Update Creative Mail integration to hooks

### DIFF
--- a/projects/packages/forms/changelog/update-forms-creative-mail-to-hooks
+++ b/projects/packages/forms/changelog/update-forms-creative-mail-to-hooks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Update Creative Mail integration to hooks.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
@@ -1,8 +1,91 @@
+import { Button, ExternalLink, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import NewsletterIntegrationSettings from '../jetpack-newsletter-integration-settings';
+import { useIntegrationStatus, usePluginInstallation } from '../hooks';
+import ConsentBlockSettings from '../jetpack-newsletter-integration-settings-consent-block';
 import IntegrationCard from './integration-card';
 
 const CreativeMailCard = ( { isExpanded, onToggle } ) => {
+	// Integration Status Hook
+	const { isCheckingStatus, isInstalled, isActive, settingsUrl, refreshStatus } =
+		useIntegrationStatus( 'creative-mail' );
+
+	// Plugin Installation Hook
+	const { isInstalling, installPlugin } = usePluginInstallation(
+		'creative-mail-by-constant-contact',
+		'creative-mail-by-constant-contact/creative-mail-plugin.php',
+		isInstalled,
+		'jetpack_forms_upsell_creative_mail_click'
+	);
+
+	// Handle Install/Activate
+	const handleInstallAction = async () => {
+		const success = await installPlugin();
+		if ( success ) {
+			refreshStatus();
+		}
+	};
+
+	// Render Content Based on State
+	const renderContent = () => {
+		if ( isCheckingStatus ) {
+			return <Spinner />;
+		}
+
+		if ( ! isInstalled ) {
+			return (
+				<p>
+					<em style={ { color: 'rgba(38, 46, 57, 0.7)' } }>
+						{ __(
+							'To start sending email campaigns, install the Creative Mail plugin for WordPress.',
+							'jetpack-forms'
+						) }
+						<br />
+						<Button variant="secondary" onClick={ handleInstallAction } disabled={ isInstalling }>
+							{ isInstalling
+								? __( 'Installing…', 'jetpack-forms' )
+								: __( 'Install Creative Mail plugin', 'jetpack-forms' ) }
+						</Button>
+					</em>
+				</p>
+			);
+		}
+
+		if ( ! isActive ) {
+			return (
+				<p>
+					<em>
+						{ __(
+							'To start sending email campaigns, activate the Creative Mail plugin for WordPress.',
+							'jetpack-forms'
+						) }
+						<br />
+						<Button variant="secondary" onClick={ handleInstallAction } disabled={ isInstalling }>
+							{ isInstalling
+								? __( 'Activating…', 'jetpack-forms' )
+								: __( 'Activate Creative Mail Plugin', 'jetpack-forms' ) }
+						</Button>
+					</em>
+				</p>
+			);
+		}
+
+		// Active state
+		return (
+			<>
+				<p>
+					<em>
+						{ __( "You're all setup for email marketing with Creative Mail.", 'jetpack-forms' ) }
+						<br />
+						<ExternalLink href={ settingsUrl }>
+							{ __( 'Open Creative Mail settings', 'jetpack-forms' ) }
+						</ExternalLink>
+					</em>
+				</p>
+				<ConsentBlockSettings />
+			</>
+		);
+	};
+
 	return (
 		<IntegrationCard
 			title={ __( 'Creative Mail', 'jetpack-forms' ) }
@@ -11,7 +94,7 @@ const CreativeMailCard = ( { isExpanded, onToggle } ) => {
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }
 		>
-			<NewsletterIntegrationSettings />
+			{ renderContent() }
 		</IntegrationCard>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
@@ -1,4 +1,4 @@
-import { Button, ExternalLink, Spinner } from '@wordpress/components';
+import { Button, ExternalLink, Spinner, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useIntegrationStatus, usePluginInstallation } from '../hooks';
 import ConsentBlockSettings from '../jetpack-newsletter-integration-settings-consent-block';
@@ -10,7 +10,7 @@ const CreativeMailCard = ( { isExpanded, onToggle } ) => {
 
 	const { isInstalling, installPlugin } = usePluginInstallation(
 		'creative-mail-by-constant-contact',
-		'creative-mail-by-constant-contact/creative-mail-plugin.php',
+		'creative-mail-by-constant-contact/creative-mail-plugin',
 		isInstalled,
 		'jetpack_forms_upsell_creative_mail_click'
 	);
@@ -22,6 +22,15 @@ const CreativeMailCard = ( { isExpanded, onToggle } ) => {
 		}
 	};
 
+	const getButtonText = () => {
+		return (
+			( isInstalling && isInstalled && __( 'Activating…', 'jetpack-forms' ) ) ||
+			( isInstalling && __( 'Installing…', 'jetpack-forms' ) ) ||
+			( isInstalled && __( 'Activate Creative Mail Plugin', 'jetpack-forms' ) ) ||
+			__( 'Install Creative Mail plugin', 'jetpack-forms' )
+		);
+	};
+
 	const renderContent = () => {
 		if ( isCheckingStatus ) {
 			return <Spinner />;
@@ -29,44 +38,54 @@ const CreativeMailCard = ( { isExpanded, onToggle } ) => {
 
 		if ( ! isInstalled ) {
 			return (
-				<p>
-					<em style={ { color: 'rgba(38, 46, 57, 0.7)' } }>
-						{ __(
-							'To start sending email campaigns, install the Creative Mail plugin for WordPress.',
-							'jetpack-forms'
-						) }
-						<br />
-						<Button variant="secondary" onClick={ handleInstallAction } disabled={ isInstalling }>
-							{ isInstalling
-								? __( 'Installing…', 'jetpack-forms' )
-								: __( 'Install Creative Mail plugin', 'jetpack-forms' ) }
-						</Button>
-					</em>
-				</p>
+				<div>
+					<p>
+						<em style={ { color: 'rgba(38, 46, 57, 0.7)' } }>
+							{ __(
+								'To start sending email campaigns, install the Creative Mail plugin for WordPress.',
+								'jetpack-forms'
+							) }
+						</em>
+					</p>
+					<Button
+						variant="primary"
+						onClick={ handleInstallAction }
+						disabled={ isInstalling }
+						icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
+						__next40pxDefaultSize={ true }
+					>
+						{ getButtonText() }
+					</Button>
+				</div>
 			);
 		}
 
 		if ( ! isActive ) {
 			return (
-				<p>
-					<em>
-						{ __(
-							'To start sending email campaigns, activate the Creative Mail plugin for WordPress.',
-							'jetpack-forms'
-						) }
-						<br />
-						<Button variant="secondary" onClick={ handleInstallAction } disabled={ isInstalling }>
-							{ isInstalling
-								? __( 'Activating…', 'jetpack-forms' )
-								: __( 'Activate Creative Mail Plugin', 'jetpack-forms' ) }
-						</Button>
-					</em>
-				</p>
+				<div>
+					<p>
+						<em>
+							{ __(
+								'To start sending email campaigns, activate the Creative Mail plugin for WordPress.',
+								'jetpack-forms'
+							) }
+						</em>
+					</p>
+					<Button
+						variant="primary"
+						onClick={ handleInstallAction }
+						disabled={ isInstalling }
+						icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
+						__next40pxDefaultSize={ true }
+					>
+						{ getButtonText() }
+					</Button>
+				</div>
 			);
 		}
 
 		return (
-			<>
+			<div>
 				<p>
 					<em>
 						{ __( "You're all setup for email marketing with Creative Mail.", 'jetpack-forms' ) }
@@ -77,7 +96,7 @@ const CreativeMailCard = ( { isExpanded, onToggle } ) => {
 					</em>
 				</p>
 				<ConsentBlockSettings />
-			</>
+			</div>
 		);
 	};
 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
@@ -5,11 +5,9 @@ import ConsentBlockSettings from '../jetpack-newsletter-integration-settings-con
 import IntegrationCard from './integration-card';
 
 const CreativeMailCard = ( { isExpanded, onToggle } ) => {
-	// Integration Status Hook
 	const { isCheckingStatus, isInstalled, isActive, settingsUrl, refreshStatus } =
 		useIntegrationStatus( 'creative-mail' );
 
-	// Plugin Installation Hook
 	const { isInstalling, installPlugin } = usePluginInstallation(
 		'creative-mail-by-constant-contact',
 		'creative-mail-by-constant-contact/creative-mail-plugin.php',
@@ -17,7 +15,6 @@ const CreativeMailCard = ( { isExpanded, onToggle } ) => {
 		'jetpack_forms_upsell_creative_mail_click'
 	);
 
-	// Handle Install/Activate
 	const handleInstallAction = async () => {
 		const success = await installPlugin();
 		if ( success ) {
@@ -25,7 +22,6 @@ const CreativeMailCard = ( { isExpanded, onToggle } ) => {
 		}
 	};
 
-	// Render Content Based on State
 	const renderContent = () => {
 		if ( isCheckingStatus ) {
 			return <Spinner />;
@@ -69,7 +65,6 @@ const CreativeMailCard = ( { isExpanded, onToggle } ) => {
 			);
 		}
 
-		// Active state
 		return (
 			<>
 				<p>


### PR DESCRIPTION
## Proposed changes:

NOTE: This is one of many upcoming PRs to create the new third party integrations modal based on designs in Figma. All this work is behind a feature flag and will only be visible if you set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.

In a recent PR, we added hooks to determine plugin status and handle installation, and update the Akismet card in the integrations modal to use those hooks. This PR updates the Creative Mail card to use those hooks. 

**Creative Mail not installed**
<img width="1486" alt="creative-mail-install" src="https://github.com/user-attachments/assets/38a36c02-ef6f-4458-91fa-bd6482efc213" />

**Creative Mail installed but not active**
<img width="1494" alt="creative-mail-activate" src="https://github.com/user-attachments/assets/774bc22d-76a5-4efc-b279-148bc14058c1" />

**Creative Mail active**
<img width="1468" alt="creative-mail-active" src="https://github.com/user-attachments/assets/3d3651fb-6cc0-4864-8136-5323c9df0541" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.
- Add a form block to a page
- Click on the Manage Integrations button the block sidebar
- Open the Creative Mail panel and be sure it renders correct and updates based on state:
   - Creative Mail not installed
      - Will see "Install" button
      - Clicking will install the plugin - you'll see 'Installing...' and spinner on button
      - When active, will see "Creative Mail activated state" below
   - Creative Mail installed but not activated
      - Will see "Activate" button
      - Clicking will activate the plugin - you'll see 'Installing...' and spinner on button
      - When active, will see "Creative Mail activated" below
   - Creative Mail activated
     - You'll see "You're all setup for email marketing with Creative Mail" plus a link to settings. Confirm the link works.
     - If you haven't already added, you'll see a button to add a consent block to your form. Also try clicking this, and confirm consent block is added to form. 

