### PR TITLE
Forms: Update Jetpack CRM integration to hooks

### DIFF
--- a/projects/packages/forms/changelog/update-forms-crm-integration-to-hooks
+++ b/projects/packages/forms/changelog/update-forms-crm-integration-to-hooks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Update CRM integration to hooks.

--- a/projects/packages/forms/src/blocks/contact-form/components/hooks/useIntegrationStatus.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/hooks/useIntegrationStatus.js
@@ -14,6 +14,9 @@ export const useIntegrationStatus = slug => {
 		isActive: false,
 		isConnected: false,
 		settingsUrl: '',
+		version: '',
+		hasExtension: false,
+		canActivateExtension: false,
 		error: null,
 	} );
 
@@ -29,6 +32,9 @@ export const useIntegrationStatus = slug => {
 				isActive: response.isActive,
 				isConnected: response.isConnected || false,
 				settingsUrl: response.settingsUrl || '',
+				version: response.version || '',
+				hasExtension: response.hasExtension || false,
+				canActivateExtension: response.canActivateExtension || false,
 				error: null,
 			} );
 		} catch ( error ) {
@@ -38,6 +44,9 @@ export const useIntegrationStatus = slug => {
 				isActive: false,
 				isConnected: false,
 				settingsUrl: '',
+				version: '',
+				hasExtension: false,
+				canActivateExtension: false,
 				error,
 			} );
 		}

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
@@ -1,8 +1,157 @@
+import { Button, Icon, Spinner } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import CRMIntegrationSettings from '../jetpack-crm-integration/jetpack-crm-integration-settings';
+import semver from 'semver';
+import { useIntegrationStatus, usePluginInstallation } from '../hooks';
 import IntegrationCard from './integration-card';
 
-const JetpackCRMCard = ( { isExpanded, onToggle, jetpackCRM, setAttributes } ) => {
+const JetpackCRMCard = ( { isExpanded, onToggle } ) => {
+	const {
+		isCheckingStatus,
+		isInstalled,
+		isActive,
+		settingsUrl,
+		hasExtension,
+		canActivateExtension,
+		version,
+		refreshStatus,
+	} = useIntegrationStatus( 'jetpack-crm' );
+
+	const { isInstalling, installPlugin } = usePluginInstallation(
+		'zero-bs-crm',
+		'zero-bs-crm/ZeroBSCRM',
+		isInstalled,
+		'jetpack_forms_upsell_crm_click'
+	);
+
+	const handleInstallAction = async () => {
+		const success = await installPlugin();
+		if ( success ) {
+			refreshStatus();
+		}
+	};
+
+	const getButtonText = () => {
+		return (
+			( isInstalling && isInstalled && __( 'Activating…', 'jetpack-forms' ) ) ||
+			( isInstalling && __( 'Installing…', 'jetpack-forms' ) ) ||
+			( isInstalled && __( 'Activate', 'jetpack-forms' ) ) ||
+			__( 'Install', 'jetpack-forms' )
+		);
+	};
+
+	const crmVersion = semver.coerce( version );
+	const isVersion491OrHigher = crmVersion && semver.gte( crmVersion, '4.9.1' );
+
+	const renderContent = () => {
+		if ( isCheckingStatus ) {
+			return <Spinner />;
+		}
+
+		if ( ! isInstalled ) {
+			return (
+				<div>
+					<p>
+						{ __(
+							'You can save contacts from Jetpack contact forms in Jetpack CRM.',
+							'jetpack-forms'
+						) }
+					</p>
+					<Button
+						variant="primary"
+						onClick={ handleInstallAction }
+						disabled={ isInstalling }
+						icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
+						__next40pxDefaultSize={ true }
+					>
+						{ getButtonText() }
+					</Button>
+				</div>
+			);
+		}
+
+		if ( ! isActive ) {
+			return (
+				<div>
+					<p>
+						{ __(
+							"You already have the Jetpack CRM plugin installed, but it's not activated.",
+							'jetpack-forms'
+						) }
+					</p>
+					<Button
+						variant="primary"
+						onClick={ handleInstallAction }
+						disabled={ isInstalling }
+						icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
+						__next40pxDefaultSize={ true }
+					>
+						{ getButtonText() }
+					</Button>
+				</div>
+			);
+		}
+
+		// First, check version
+		if ( ! isVersion491OrHigher ) {
+			return (
+				<div>
+					<p>
+						{ __(
+							'Please update to the latest version of the Jetpack CRM plugin to integrate your contact form with your CRM.',
+							'jetpack-forms'
+						) }
+					</p>
+					<Button variant="primary" href={ settingsUrl } __next40pxDefaultSize={ true }>
+						{ __( 'Update CRM', 'jetpack-forms' ) }
+					</Button>
+				</div>
+			);
+		}
+
+		// Then, check extension status
+		if ( ! hasExtension ) {
+			return (
+				<div>
+					<p>
+						{ createInterpolateElement(
+							__(
+								"You can integrate this contact form with Jetpack CRM by enabling Jetpack CRM's <a>Jetpack Forms extension</a>.",
+								'jetpack-forms'
+							),
+							{
+								a: <Button variant="link" href={ settingsUrl } />,
+							}
+						) }
+					</p>
+					{ ! canActivateExtension && (
+						<p>
+							{ __(
+								'A site administrator must enable the CRM Jetpack Forms extension.',
+								'jetpack-forms'
+							) }
+						</p>
+					) }
+					{ canActivateExtension && (
+						<Button variant="primary" href={ settingsUrl } __next40pxDefaultSize={ true }>
+							{ __( 'Enable Jetpack Forms Extension', 'jetpack-forms' ) }
+						</Button>
+					) }
+				</div>
+			);
+		}
+
+		// Only show storage message when both version and extension requirements are met
+		return (
+			<div>
+				<p>{ __( 'Contacts from this form will be stored in Jetpack CRM.', 'jetpack-forms' ) }</p>
+				<Button variant="primary" href={ settingsUrl } __next40pxDefaultSize={ true }>
+					{ __( 'Open CRM Settings', 'jetpack-forms' ) }
+				</Button>
+			</div>
+		);
+	};
+
 	return (
 		<IntegrationCard
 			title={ __( 'Jetpack CRM', 'jetpack-forms' ) }
@@ -11,7 +160,7 @@ const JetpackCRMCard = ( { isExpanded, onToggle, jetpackCRM, setAttributes } ) =
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }
 		>
-			<CRMIntegrationSettings jetpackCRM={ jetpackCRM } setAttributes={ setAttributes } />
+			{ renderContent() }
 		</IntegrationCard>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
@@ -1,11 +1,11 @@
-import { Button, Icon, Spinner } from '@wordpress/components';
+import { Button, Icon, Spinner, ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import semver from 'semver';
 import { useIntegrationStatus, usePluginInstallation } from '../hooks';
 import IntegrationCard from './integration-card';
 
-const JetpackCRMCard = ( { isExpanded, onToggle } ) => {
+const JetpackCRMCard = ( { isExpanded, onToggle, jetpackCRM, setAttributes } ) => {
 	const {
 		isCheckingStatus,
 		isInstalled,
@@ -41,13 +41,14 @@ const JetpackCRMCard = ( { isExpanded, onToggle } ) => {
 	};
 
 	const crmVersion = semver.coerce( version );
-	const isVersion491OrHigher = crmVersion && semver.gte( crmVersion, '4.9.1' );
+	const isRecentVersion = crmVersion && semver.gte( crmVersion, '4.9.1' );
 
 	const renderContent = () => {
 		if ( isCheckingStatus ) {
 			return <Spinner />;
 		}
 
+		// Jetpack CRM not installed
 		if ( ! isInstalled ) {
 			return (
 				<div>
@@ -70,6 +71,7 @@ const JetpackCRMCard = ( { isExpanded, onToggle } ) => {
 			);
 		}
 
+		// Jetpack CRM installed but not active
 		if ( ! isActive ) {
 			return (
 				<div>
@@ -92,8 +94,8 @@ const JetpackCRMCard = ( { isExpanded, onToggle } ) => {
 			);
 		}
 
-		// First, check version
-		if ( ! isVersion491OrHigher ) {
+		// Jetpack CRM installed and active, but not recent version
+		if ( ! isRecentVersion ) {
 			return (
 				<div>
 					<p>
@@ -109,7 +111,7 @@ const JetpackCRMCard = ( { isExpanded, onToggle } ) => {
 			);
 		}
 
-		// Then, check extension status
+		// Jetpack CRM installed, active, and recent, but no extension
 		if ( ! hasExtension ) {
 			return (
 				<div>
@@ -141,11 +143,17 @@ const JetpackCRMCard = ( { isExpanded, onToggle } ) => {
 			);
 		}
 
-		// Only show storage message when both version and extension requirements are met
+		// All conditions met - show toggle and link to CRM settings
 		return (
 			<div>
-				<p>{ __( 'Contacts from this form will be stored in Jetpack CRM.', 'jetpack-forms' ) }</p>
-				<Button variant="primary" href={ settingsUrl } __next40pxDefaultSize={ true }>
+				<ToggleControl
+					className="jetpack-contact-form__crm_toggle"
+					label={ __( 'Jetpack CRM', 'jetpack-forms' ) }
+					checked={ jetpackCRM }
+					onChange={ value => setAttributes( { jetpackCRM: value } ) }
+					help={ __( 'Store contact form submissions in your CRM.', 'jetpack-forms' ) }
+				/>
+				<Button variant="link" href={ settingsUrl } target="_blank" rel="noopener noreferrer">
 					{ __( 'Open CRM Settings', 'jetpack-forms' ) }
 				</Button>
 			</div>

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -670,7 +670,10 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		$status_data   = $plugin_status->get_data();
 
 		if ( $status_data['isActive'] ) {
-			$has_extension = function_exists( '\zeroBSCRM_isExtensionInstalled' ) && \zeroBSCRM_isExtensionInstalled( 'jetpackforms' );
+			$has_extension = false;
+			if ( function_exists( '\zeroBSCRM_isExtensionInstalled' ) ) {
+				$has_extension = \zeroBSCRM_isExtensionInstalled( 'jetpackforms' );
+			}
 
 			return rest_ensure_response(
 				array_merge(

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -582,10 +582,10 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	}
 
 	/**
-	 * Get basic plugin status (installed/active).
+	 * Get plugin status.
 	 *
-	 * @param string $plugin_slug The plugin slug (e.g. 'akismet' or 'creative-mail').
-	 * @return WP_REST_Response Plugin status data.
+	 * @param string $plugin_slug Plugin slug.
+	 * @return WP_REST_Response Response object.
 	 */
 	private function get_plugin_status( $plugin_slug ) {
 		if ( ! function_exists( 'get_plugins' ) ) {
@@ -629,6 +629,10 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'isInstalled' => $is_installed,
 			'isActive'    => $is_active,
 		);
+
+		if ( $is_installed ) {
+			$response['version'] = $installed_plugins[ $plugin_config['file'] ]['Version'];
+		}
 
 		if ( $is_active ) {
 			$response['settingsUrl'] = admin_url( $plugin_config['settings_url'] );

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -670,7 +670,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		$status_data   = $plugin_status->get_data();
 
 		if ( $status_data['isActive'] ) {
-			$has_extension = function_exists( 'zeroBSCRM_isExtensionInstalled' ) && zeroBSCRM_isExtensionInstalled( 'jetpackforms' );
+			$has_extension = function_exists( '\zeroBSCRM_isExtensionInstalled' ) && \zeroBSCRM_isExtensionInstalled( 'jetpackforms' );
 
 			return rest_ensure_response(
 				array_merge(

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -670,10 +670,8 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		$status_data   = $plugin_status->get_data();
 
 		if ( $status_data['isActive'] ) {
-			$has_extension = false;
-			if ( function_exists( '\zeroBSCRM_isExtensionInstalled' ) ) {
-				$has_extension = \zeroBSCRM_isExtensionInstalled( 'jetpackforms' );
-			}
+			// @phan-suppress-next-line UndefError
+			$has_extension = function_exists( 'zeroBSCRM_isExtensionInstalled' ) && zeroBSCRM_isExtensionInstalled( 'jetpackforms' );
 
 			return rest_ensure_response(
 				array_merge(

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -567,8 +567,10 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				return $this->get_akismet_status();
 
 			case 'creative-mail':
-			case 'jetpack-crm':
 				return $this->get_plugin_status( $slug );
+
+			case 'jetpack-crm':
+				return $this->get_jetpack_crm_status();
 
 			default:
 				return new WP_Error(
@@ -652,5 +654,31 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				)
 			)
 		);
+	}
+
+	/**
+	 * Get Jetpack CRM plugin status and extension data.
+	 *
+	 * @return WP_REST_Response Plugin status data.
+	 */
+	public function get_jetpack_crm_status() {
+		$plugin_status = $this->get_plugin_status( 'jetpack-crm' );
+		$status_data   = $plugin_status->get_data();
+
+		if ( $status_data['isActive'] ) {
+			$has_extension = function_exists( 'zeroBSCRM_isExtensionInstalled' ) && zeroBSCRM_isExtensionInstalled( 'jetpackforms' );
+
+			return rest_ensure_response(
+				array_merge(
+					$status_data,
+					array(
+						'hasExtension'         => $has_extension,
+						'canActivateExtension' => current_user_can( 'manage_options' ),
+					)
+				)
+			);
+		}
+
+		return $plugin_status;
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -670,8 +670,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		$status_data   = $plugin_status->get_data();
 
 		if ( $status_data['isActive'] ) {
-			// @phan-suppress-next-line UndefError
-			$has_extension = function_exists( 'zeroBSCRM_isExtensionInstalled' ) && zeroBSCRM_isExtensionInstalled( 'jetpackforms' );
+			$has_extension = function_exists( 'zeroBSCRM_isExtensionInstalled' ) && zeroBSCRM_isExtensionInstalled( 'jetpackforms' ); // @phan-suppress-current-line PhanUndeclaredFunction -- We're checking the function exists first
 
 			return rest_ensure_response(
 				array_merge(


### PR DESCRIPTION
## Proposed changes:

NOTE: This is one of many upcoming PRs to create the new third party integrations modal based on designs in Figma. All this work is behind a feature flag and will only be visible if you set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.

In a recent PR, we added hooks to determine plugin status and handle installation, and update the Akismet card in the integrations modal to use those hooks. This PR updates the Jetpack CRM card to use those hooks. 

**Jetpack CRM not installed**
<img width="1426" alt="crm-install" src="https://github.com/user-attachments/assets/cfb015ba-e957-4f68-8f4a-4264bb0f576c" />

**Jetpack CRM installed but not active**
<img width="1462" alt="crm-activate" src="https://github.com/user-attachments/assets/27f8d854-43e7-4bc0-8f58-b175c36b602b" />

**Jetpack CRM active**
<img width="1453" alt="crm-active" src="https://github.com/user-attachments/assets/e9be573d-b40a-4c34-b16d-4b5ef6d2da41" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.
- Add a form block to a page
- Click on the Manage Integrations button the block sidebar
- Open the Jetpack CRM panel and be sure it renders correct and updates based on state:
   - Jetpack CRM not installed
      - Will see "Install" button
      - Clicking will install the plugin - you'll see 'Installing...' and spinner on button
      - When active, will see "Jetpack CRM active" below
   - Jetpack CRM installed but not activated
      - Will see "Activate" button
      - Clicking will activate the plugin - you'll see 'Installing...' and spinner on button
      - When active, will see "Jetpack CRM active" state below
   - Jetpack CRM active
     - You'll see a the toggle to enable CRM for this form, followed by a link to CRM settings

