### PR TITLE
Protect Status: Fix Plan and Status Cache

### DIFF
--- a/projects/packages/protect-status/changelog/fix-protect-status-cache
+++ b/projects/packages/protect-status/changelog/fix-protect-status-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure scan status is refreshed immediately after upgrading plan.

--- a/projects/packages/protect-status/src/class-protect-status.php
+++ b/projects/packages/protect-status/src/class-protect-status.php
@@ -53,14 +53,13 @@ class Protect_Status extends Status {
 	 * @return Status_Model
 	 */
 	public static function get_status( $refresh_from_wpcom = false ) {
-		if ( self::$status !== null && self::$status->data_source === 'protect_report' && ! $refresh_from_wpcom ) {
-			// We already have a result from the correct data source, and we're not forcing a refresh, so return the memoized result.
-			$status = self::$status;
-		} elseif ( $refresh_from_wpcom || ! self::should_use_cache() || self::is_cache_expired() ) {
-			// We are forcing a refresh, or the cache is expired, so fetch from the API.
+		if ( ! $refresh_from_wpcom && self::$status !== null && self::$status->data_source === 'protect_report' ) {
+			return self::$status;
+		}
+
+		if ( $refresh_from_wpcom || ! self::should_use_cache() || self::is_cache_expired() ) {
 			$status = self::fetch_from_server();
 		} else {
-			// We have a valid cached status, so use that.
 			$status = self::get_from_options();
 		}
 

--- a/projects/packages/protect-status/src/class-protect-status.php
+++ b/projects/packages/protect-status/src/class-protect-status.php
@@ -53,13 +53,14 @@ class Protect_Status extends Status {
 	 * @return Status_Model
 	 */
 	public static function get_status( $refresh_from_wpcom = false ) {
-		if ( self::$status !== null ) {
-			return self::$status;
-		}
-
-		if ( $refresh_from_wpcom || ! self::should_use_cache() || self::is_cache_expired() ) {
+		if ( self::$status !== null && self::$status->data_source === 'protect_report' && ! $refresh_from_wpcom ) {
+			// We already have a result from the correct data source, and we're not forcing a refresh, so return the memoized result.
+			$status = self::$status;
+		} elseif ( $refresh_from_wpcom || ! self::should_use_cache() || self::is_cache_expired() ) {
+			// We are forcing a refresh, or the cache is expired, so fetch from the API.
 			$status = self::fetch_from_server();
 		} else {
+			// We have a valid cached status, so use that.
 			$status = self::get_from_options();
 		}
 

--- a/projects/packages/protect-status/src/class-scan-status.php
+++ b/projects/packages/protect-status/src/class-scan-status.php
@@ -59,14 +59,13 @@ class Scan_Status extends Status {
 	 * @return Status_Model
 	 */
 	public static function get_status( $refresh_from_wpcom = false ) {
-		if ( self::$status !== null && self::$status->data_source === 'scan_api' && ! $refresh_from_wpcom ) {
-			// We already have a result from the correct data source, and we're not forcing a refresh, so return the memoized result.
-			$status = self::$status;
-		} elseif ( $refresh_from_wpcom || ! self::should_use_cache() || self::is_cache_expired() ) {
-			// We are forcing a refresh, or the cache is expired, so fetch from the API.
+		if ( ! $refresh_from_wpcom && self::$status !== null && self::$status->data_source === 'scan_api' ) {
+			return self::$status;
+		}
+
+		if ( $refresh_from_wpcom || ! self::should_use_cache() || self::is_cache_expired() ) {
 			$status = self::fetch_from_api();
 		} else {
-			// We have a valid cached status, so use that.
 			$status = self::get_from_options();
 		}
 

--- a/projects/packages/protect-status/src/class-scan-status.php
+++ b/projects/packages/protect-status/src/class-scan-status.php
@@ -59,13 +59,14 @@ class Scan_Status extends Status {
 	 * @return Status_Model
 	 */
 	public static function get_status( $refresh_from_wpcom = false ) {
-		if ( self::$status !== null ) {
-			return self::$status;
-		}
-
-		if ( $refresh_from_wpcom || ! self::should_use_cache() || self::is_cache_expired() ) {
+		if ( self::$status !== null && self::$status->data_source === 'scan_api' && ! $refresh_from_wpcom ) {
+			// We already have a result from the correct data source, and we're not forcing a refresh, so return the memoized result.
+			$status = self::$status;
+		} elseif ( $refresh_from_wpcom || ! self::should_use_cache() || self::is_cache_expired() ) {
+			// We are forcing a refresh, or the cache is expired, so fetch from the API.
 			$status = self::fetch_from_api();
 		} else {
+			// We have a valid cached status, so use that.
 			$status = self::get_from_options();
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensures the status value is refreshed when the `$refresh_from_wpcom` parameter is passed, or when the existing static value does not have a data source that matches the current plan.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start for free with Jetpack Protect
* Wait for the first report to be generated
* Upgrade Protect from the plugin
* Once redirected back to the scan page, validate `window.jetpackProtectInitialState` has the correct `hasPlan` and `status.dataSource` values.

