### PR TITLE
Changelogger: Allow beta.2 suffix in WordPress versioning

### DIFF
--- a/projects/packages/changelogger/changelog/fix-changelogger-allow_beta_dot_version
+++ b/projects/packages/changelogger/changelog/fix-changelogger-allow_beta_dot_version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Allow beta.2 in WordPress-style versioning.

--- a/projects/packages/changelogger/src/Plugins/WordpressVersioning.php
+++ b/projects/packages/changelogger/src/Plugins/WordpressVersioning.php
@@ -50,7 +50,7 @@ class WordpressVersioning implements VersioningPlugin {
 	 * @phan-return array{major:float,point:int,version:string,prerelease:?string,buildinfo:?string}
 	 */
 	public function parseVersion( $version ) {
-		if ( ! preg_match( '/^(?P<major>\d+\.\d)(?:\.(?P<point>\d+))?(?:-(?P<prerelease>dev|(?:alpha|beta|rc)\d*|a\.\d+))?(?:\+(?P<buildinfo>[0-9a-zA-Z.-]+))?$/', $version, $m ) ) {
+		if ( ! preg_match( '/^(?P<major>\d+\.\d)(?:\.(?P<point>\d+))?(?:-(?P<prerelease>dev|(?:alpha|beta|rc)\d*|(a|beta)\.\d+))?(?:\+(?P<buildinfo>[0-9a-zA-Z.-]+))?$/', $version, $m ) ) {
 			throw new InvalidArgumentException( "Version number \"$version\" is not in a recognized format." );
 		}
 		$ret            = array(
@@ -178,7 +178,7 @@ class WordpressVersioning implements VersioningPlugin {
 			return array( 100, 0 );
 		}
 
-		foreach ( array( 'dev', 'alpha(\d*)', 'a\.(\d+)', 'beta(\d*)', 'rc(\d*)' ) as $i => $re ) {
+		foreach ( array( 'dev', 'alpha(\d*)', 'a\.(\d+)', 'beta(\d*)', 'beta\.(\d+)', 'rc(\d*)' ) as $i => $re ) {
 			if ( preg_match( "/^{$re}\$/", $s, $m ) ) {
 				$m[0] = $i;
 				return array_map( 'intval', $m );

--- a/projects/packages/changelogger/src/Plugins/WordpressVersioning.php
+++ b/projects/packages/changelogger/src/Plugins/WordpressVersioning.php
@@ -50,7 +50,7 @@ class WordpressVersioning implements VersioningPlugin {
 	 * @phan-return array{major:float,point:int,version:string,prerelease:?string,buildinfo:?string}
 	 */
 	public function parseVersion( $version ) {
-		if ( ! preg_match( '/^(?P<major>\d+\.\d)(?:\.(?P<point>\d+))?(?:-(?P<prerelease>dev|(?:alpha|beta|rc)\d*|(a|beta)\.\d+))?(?:\+(?P<buildinfo>[0-9a-zA-Z.-]+))?$/', $version, $m ) ) {
+		if ( ! preg_match( '/^(?P<major>\d+\.\d)(?:\.(?P<point>\d+))?(?:-(?P<prerelease>dev|(?:alpha|beta|rc)\d*|(?:a|beta)\.\d+))?(?:\+(?P<buildinfo>[0-9a-zA-Z.-]+))?$/', $version, $m ) ) {
 			throw new InvalidArgumentException( "Version number \"$version\" is not in a recognized format." );
 		}
 		$ret            = array(

--- a/projects/packages/changelogger/tests/php/tests/src/Plugins/WordpressVersioningTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/Plugins/WordpressVersioningTest.php
@@ -183,6 +183,16 @@ class WordpressVersioningTest extends TestCase {
 				),
 			),
 			array(
+				'1.2-beta.2',
+				array(
+					'major'      => 1.2,
+					'point'      => 0,
+					'prerelease' => 'beta.2',
+					'buildinfo'  => null,
+					'version'    => '1.2',
+				),
+			),
+			array(
 				'1.2.3-rc',
 				array(
 					'major'      => 1.2,
@@ -515,6 +525,8 @@ class WordpressVersioningTest extends TestCase {
 			array( '1.1.1-alpha', '<', '1.1.1-beta' ),
 			array( '1.1.1-dev', '<', '1.1.1-alpha' ),
 			array( '1.1.1-alpha9', '<', '1.1.1-beta1' ),
+			array( '1.1.1-beta', '<', '1.1.1-beta.2' ),
+			array( '1.1.1-beta.2', '==', '1.1.1-beta.2' ),
 			array( '1.1.1-beta9', '>', '1.1.1-beta1' ),
 			array( '1.1.1-beta9', '==', '1.1.1-beta9' ),
 			array( '1.1.1-alpha', '==', '1.1.1-alpha0' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We rarely need a second beta of Jetpack, but when we do, it's easy to forget the proper scheme (currently `trunk` only allows `beta#`). We allow `a.#`, so let's allow `beta.#` as well.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Do the changes make sense?
