### PR TITLE
Update tracks event context for wpadmin-dashboard-widget 

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-dashboard-widget-context
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-dashboard-widget-context
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Change is a string change.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
@@ -64,7 +64,7 @@ function load_wpcom_dashboard_widgets() {
 		),
 	);
 
-	$launchpad_context = 'customer-home';
+	$launchpad_context = 'wpadmin-dashboard-widget';
 	$checklist_slug    = get_option( 'site_intent' );
 
 	if (

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-launchpad-widget/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-launchpad-widget/index.js
@@ -40,7 +40,7 @@ export default ( { siteDomain, siteIntent } ) => {
 				<Launchpad
 					siteSlug={ siteDomain }
 					checklistSlug={ siteIntent }
-					launchpadContext="customer-home"
+					launchpadContext="wpadmin-dashboard-widget"
 					onSiteLaunched={ () => {
 						const url = new URL( window.location.href );
 						url.searchParams.set( 'celebrate-launch', 'true' );


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes # https://github.com/Automattic/jetpack/issues/42631

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the `context` to be correct, reflecting that the tracks event fires in wpcom and not in calypso My Home.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On an unlaunched site
*  Go to '/wp-admin'
* See that the "Site Setup" widget loads in the wp-admin dashboard
* Verify that the `calypso_launchpad_task_view` tracks event fires with prop `context:wpadmin-dashboard-widget`

<img width="525" alt="image" src="https://github.com/user-attachments/assets/95ac1877-20df-4b8a-aea4-e31a9c8b7217" />

