### PR TITLE
Scan Components: use variable threat/vulnerability phrasing in threat modal components

### DIFF
--- a/projects/js-packages/scan/src/components/threat-modals/details-modal/index.tsx
+++ b/projects/js-packages/scan/src/components/threat-modals/details-modal/index.tsx
@@ -2,7 +2,11 @@ import { ContextualUpgradeTrigger, Text, ThemeProvider } from '@automattic/jetpa
 import { Modal } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useContext } from 'react';
-import { Threat, ThreatsContext } from '@automattic/jetpack-scan';
+import {
+	shouldUseVulnerabilityPhrasingForThreat,
+	Threat,
+	ThreatsContext,
+} from '@automattic/jetpack-scan';
 import styles from '../styles.module.scss';
 import ThreatDetailsModalActions from './actions.js';
 import ThreatDetailsModalTechnicalDetails from './technical-details.js';
@@ -51,10 +55,15 @@ const ThreatDetailsModal = ( {
 									</Text>
 								) : (
 									<Text>
-										{ __(
-											'Jetpack cannot automatically fix this threat. We suggest that you resolve the threat manually: ensure that WordPress, your theme, and all of your plugins are up to date, and remove the offending code, theme, or plugin from your site.',
-											'jetpack-scan'
-										) }
+										{ shouldUseVulnerabilityPhrasingForThreat( threat )
+											? __(
+													'Jetpack cannot automatically fix this vulnerability. We suggest that you resolve the vulnerability manually: ensure that WordPress, your theme, and all of your plugins are up to date, and remove the offending code, theme, or plugin from your site.',
+													'jetpack-scan'
+											  )
+											: __(
+													'Jetpack cannot automatically fix this threat. We suggest that you resolve the threat manually: ensure that WordPress, your theme, and all of your plugins are up to date, and remove the offending code, theme, or plugin from your site.',
+													'jetpack-scan'
+											  ) }
 									</Text>
 								) }
 							</>

--- a/projects/js-packages/scan/src/components/threat-modals/details-modal/technical-details.tsx
+++ b/projects/js-packages/scan/src/components/threat-modals/details-modal/technical-details.tsx
@@ -4,7 +4,11 @@ import { dateI18n } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
 import { chevronDown, chevronUp, Icon } from '@wordpress/icons';
 import { useState, useCallback } from 'react';
-import { getSeverityLabel, Threat } from '@automattic/jetpack-scan';
+import {
+	getSeverityLabel,
+	shouldUseVulnerabilityPhrasingForThreat,
+	Threat,
+} from '@automattic/jetpack-scan';
 import styles from '../styles.module.scss';
 
 /**
@@ -43,7 +47,9 @@ const ThreatDetailsModalTechnicalDetails = ( { threat }: { threat: Threat } ): J
 		return (
 			<div>
 				<Button variant="link" isExternalLink={ true } weight="regular" href={ threat.source }>
-					{ __( 'See more technical details of this threat', 'jetpack-scan' ) }
+					{ shouldUseVulnerabilityPhrasingForThreat( threat )
+						? __( 'See more technical details of this vulnerability', 'jetpack-scan' )
+						: __( 'See more technical details of this threat', 'jetpack-scan' ) }
 				</Button>
 			</div>
 		);
@@ -141,7 +147,9 @@ const ThreatDetailsModalTechnicalDetails = ( { threat }: { threat: Threat } ): J
 												weight="regular"
 												href={ threat.source }
 											>
-												{ __( 'See more technical details of this threat', 'jetpack-scan' ) }
+												{ shouldUseVulnerabilityPhrasingForThreat( threat )
+													? __( 'See more technical details of this vulnerability', 'jetpack-scan' )
+													: __( 'See more technical details of this threat', 'jetpack-scan' ) }
 											</Button>
 										</div>
 									</>

--- a/projects/js-packages/scan/src/components/threat-modals/details-modal/title.tsx
+++ b/projects/js-packages/scan/src/components/threat-modals/details-modal/title.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { Threat } from '@automattic/jetpack-scan';
+import { shouldUseVulnerabilityPhrasingForThreat, Threat } from '@automattic/jetpack-scan';
 import ThreatSeverityBadge from '../../threat-severity-badge/index.js';
 import styles from '../styles.module.scss';
 
@@ -12,17 +12,25 @@ import styles from '../styles.module.scss';
  * @return {JSX.Element} The rendered threat details modal title.
  */
 const ThreatDetailsModalTitle = ( { threat }: { threat: Threat } ): JSX.Element => {
+	const useVulnerabilityPhrasing = shouldUseVulnerabilityPhrasingForThreat( threat );
+
 	let title: string;
 	switch ( threat.status ) {
 		case 'ignored':
-			title = __( 'Ignored Threat', 'jetpack-scan' );
+			title = useVulnerabilityPhrasing
+				? __( 'Ignored Vulnerability', 'jetpack-scan' )
+				: __( 'Ignored Threat', 'jetpack-scan' );
 			break;
 		case 'fixed':
-			title = __( 'Fixed Threat', 'jetpack-scan' );
+			title = useVulnerabilityPhrasing
+				? __( 'Fixed Vulnerability', 'jetpack-scan' )
+				: __( 'Fixed Threat', 'jetpack-scan' );
 			break;
 		case 'current':
 		default:
-			title = __( 'Active Threat', 'jetpack-scan' );
+			title = useVulnerabilityPhrasing
+				? __( 'Active Vulnerability', 'jetpack-scan' )
+				: __( 'Active Threat', 'jetpack-scan' );
 			break;
 	}
 

--- a/projects/js-packages/scan/src/utils/threats.ts
+++ b/projects/js-packages/scan/src/utils/threats.ts
@@ -44,3 +44,24 @@ export const getThreatSubtitle = ( threat: Threat ) => {
 			return __( 'Threat', 'jetpack-scan' );
 	}
 };
+
+/**
+ * Determines if the threat should be referred to as a "vulnerability" and not a "threat".
+ *
+ * @param {Threat} threat - The threat to check.
+ * @return {boolean} True if the threat should be phrased as a vulnerability, false otherwise.
+ */
+export const shouldUseVulnerabilityPhrasingForThreat = ( threat: Threat ): boolean => {
+	if ( threat.signature ) {
+		if (
+			threat.signature === 'Vulnerable.WP.Core' ||
+			threat.signature === 'Vulnerable.WP.Extension'
+		) {
+			return true;
+		}
+	} else if ( [ 'plugins', 'themes', 'core' ].includes( getThreatType( threat ) ) ) {
+		return true;
+	}
+
+	return false;
+};


### PR DESCRIPTION
…lity phrasing to threat modal component

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

