### PR TITLE
Brute Force Protection: Remove Acount Protection error check

### DIFF
--- a/projects/packages/waf/changelog/remove-brute-force-protection-account-protection-error-check
+++ b/projects/packages/waf/changelog/remove-brute-force-protection-account-protection-error-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Remove Account Protection error check when logging failed attempts

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -134,7 +134,7 @@ class Brute_Force_Protection {
 		add_filter( 'authenticate', array( $this, 'check_preauth' ), 10, 3 );
 		add_filter( 'jetpack_has_login_ability', array( $this, 'has_login_ability' ) );
 		add_action( 'wp_login', array( $this, 'log_successful_login' ), 10, 2 );
-		add_action( 'wp_login_failed', array( $this, 'log_failed_attempt' ), 10, 2 );
+		add_action( 'wp_login_failed', array( $this, 'log_failed_attempt' ), 10, 1 );
 		add_action( 'admin_init', array( $this, 'maybe_update_headers' ) );
 		add_action( 'admin_init', array( $this, 'maybe_display_security_warning' ) );
 
@@ -515,18 +515,11 @@ class Brute_Force_Protection {
 	 *
 	 * Fires custom, plugable action jpp_log_failed_attempt with the IP
 	 *
-	 * @param string         $username - The username or email address attempting to log in.
-	 * @param \WP_Error|null $error    - A WP_Error object with the authentication failure details.
+	 * @param string $username - The username or email address attempting to log in.
 	 *
 	 * @return void
 	 */
-	public function log_failed_attempt( string $username, ?\WP_Error $error = null ) {
-
-		// Skip if Account protection password validation error.
-		if ( isset( $error->errors['password_detection_validation_error'] ) ) {
-			return;
-		}
-
+	public function log_failed_attempt( string $username ) {
 		/**
 		 * Fires before every failed login attempt.
 		 *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Description
Now that Account Protection no longer returns an error in the `wp_autheticate_user` callback and we instead redirect and exit `wp_login_failed` is never triggered. Brute Force Protection no longer needs to account for the old error and skip logging a failed attempt. 


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://linear.app/a8c/issue/PROTECT-70/ensure-bfp-log-failed-attempt-isnt-logging-on-compromised-password

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch on JT and enable Protect with Account Protection and Brute Force Protection
* Adding error logging to `Brute_Force_Protection::log_failed_attempt()`
* Log out and back in with a known compromised password
* Verify that you enter the Account Protection password detection flow and that no error logs are output for the login attempt
* Return to the login and enter a incorrect user or password
* Ensure that BFP handle the failed attempt correctly and that the method logs it
* Ensure no regression in Account Protection or BFP functionality are introduced

