### PR TITLE
Add/default featured image option value

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter.jsx
@@ -74,6 +74,13 @@ function Newsletter( props ) {
 	const toggleModule = useCallback(
 		module => {
 			const status = getOptionValue( module );
+			// Track the toggle (analytics)
+			analytics.tracks.recordEvent( 'jetpack_wpa_settings_toggle', {
+				module: module,
+				setting: module,
+				toggled: status ? 'off' : 'on',
+			} );
+
 			updateOptions( { [ module ]: ! status } ).then( () => {
 				// Refresh settings if the module is being activated
 				if ( ! status ) {

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter.jsx
@@ -1,6 +1,6 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { connect } from 'react-redux';
 import Card from 'components/card';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
@@ -33,7 +33,6 @@ function Newsletter( props ) {
 	const {
 		siteRawUrl,
 		blogID,
-		toggleModuleNow,
 		isSavingAnyOption,
 		isLinked,
 		isSubscriptionsActive,
@@ -42,6 +41,9 @@ function Newsletter( props ) {
 		siteHasConnectedUser,
 		wpAdminSubscriberManagementEnabled,
 		siteAdminUrl,
+		updateOptions,
+		getOptionValue,
+		refreshSettings,
 	} = props;
 
 	const getSubClickableCard = () => {
@@ -68,6 +70,19 @@ function Newsletter( props ) {
 			</Card>
 		);
 	};
+
+	const toggleModule = useMemo(
+		module => {
+			const status = getOptionValue( module );
+			updateOptions( { [ module ]: ! status } ).then( () => {
+				// Refresh settings if the module is being activated
+				if ( ! status ) {
+					refreshSettings();
+				}
+			} );
+		},
+		[ getOptionValue, updateOptions, refreshSettings ]
+	);
 
 	return (
 		<SettingsCard
@@ -96,7 +111,7 @@ function Newsletter( props ) {
 					disabled={ ! siteHasConnectedUser || unavailableInOfflineMode }
 					activated={ isSubscriptionsActive }
 					toggling={ isSavingAnyOption( SUBSCRIPTIONS_MODULE_NAME ) }
-					toggleModule={ toggleModuleNow }
+					toggleModule={ toggleModule }
 				>
 					<span className="jp-form-toggle-explanation">
 						{ __(

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter.jsx
@@ -1,6 +1,6 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
-import React, { useMemo } from 'react';
+import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
 import Card from 'components/card';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
@@ -71,7 +71,7 @@ function Newsletter( props ) {
 		);
 	};
 
-	const toggleModule = useMemo(
+	const toggleModule = useCallback(
 		module => {
 			const status = getOptionValue( module );
 			updateOptions( { [ module ]: ! status } ).then( () => {

--- a/projects/plugins/jetpack/_inc/client/newsletter/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/newsletter/test/component.js
@@ -1,0 +1,120 @@
+import React from 'react';
+import { render, screen } from 'test/test-utils';
+import Newsletter from '../newsletter';
+
+// Mock components that do fetches in the background
+jest.mock( 'components/data/query-site', () => ( {
+	__esModule: true,
+	default: () => 'query-site',
+} ) );
+
+describe( 'Newsletter', () => {
+	const defaultProps = {
+		siteRawUrl: 'example.org',
+		blogID: 123,
+		isSavingAnyOption: () => false,
+		isLinked: true,
+		isSubscriptionsActive: true,
+		unavailableInOfflineMode: false,
+		subscriptions: {
+			name: 'subscriptions',
+			description: 'Let visitors subscribe to your posts',
+		},
+		siteHasConnectedUser: true,
+		wpAdminSubscriberManagementEnabled: true,
+		siteAdminUrl: 'https://example.org/wp-admin/',
+		getOptionValue: () => true,
+		updateOptions: jest.fn().mockResolvedValue( {} ),
+		refreshSettings: jest.fn(),
+	};
+
+	const initialState = {
+		jetpack: {
+			initialState: {
+				userData: {
+					currentUser: {
+						permissions: {
+							manage_modules: true,
+						},
+					},
+				},
+				WP_API_nonce: 'nonce',
+				WP_API_root: '/wp-admin/',
+			},
+			connection: {
+				status: {
+					siteConnected: {
+						offlineMode: {
+							isActive: false,
+						},
+						isActive: true,
+					},
+				},
+				user: {
+					currentUser: {
+						isConnected: true,
+					},
+				},
+				requests: {
+					disconnectingSite: false,
+				},
+			},
+			modules: {
+				items: {
+					subscriptions: {
+						module: 'subscriptions',
+						activated: true,
+					},
+				},
+				requests: {
+					fetchingModulesList: false,
+					activating: {},
+					deactivating: {},
+					updatingOption: {},
+				},
+			},
+			settings: {
+				items: {},
+				requests: {
+					fetchingSettingsList: false,
+					settingsSent: {},
+					updatedSettings: {},
+				},
+			},
+			dashboard: {
+				requests: {
+					fetchingVaultPressData: false,
+					checkingAkismetKey: false,
+				},
+			},
+			siteData: {
+				requests: {
+					isFetchingSiteData: false,
+					isFetchingSiteFeatures: false,
+					isFetchingSitePlans: false,
+					isFetchingSitePurchases: false,
+				},
+			},
+			pluginsData: {
+				requests: {
+					isFetchingPluginsData: false,
+				},
+			},
+			recommendations: {
+				requests: {
+					isRecommendationsDataLoaded: false,
+				},
+			},
+		},
+	};
+
+	describe( 'Initially', () => {
+		it( 'renders header and manage subscribers link', () => {
+			render( <Newsletter { ...defaultProps } />, { initialState } );
+			expect(
+				screen.getByText( 'Newsletter' ).closest( '.dops-section-header' )
+			).toBeInTheDocument();
+			expect( screen.getByRole( 'link', { name: 'Manage all subscribers' } ) ).toBeInTheDocument();
+		} );
+	} );
+} );

--- a/projects/plugins/jetpack/changelog/add-new-featured-email-option
+++ b/projects/plugins/jetpack/changelog/add-new-featured-email-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Subscriptions: Set the featured image in email option to true on module activation

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -130,7 +130,7 @@ class Jetpack_Subscriptions {
 
 		// Set "social_notifications_subscribe" option during the first-time activation.
 		add_action( 'jetpack_activate_module_subscriptions', array( $this, 'set_social_notifications_subscribe' ) );
-		add_action( 'jetpack_activate_module_subscriptions', array( $this, 'set_social_notifications_subscribe' ) );
+		add_action( 'jetpack_activate_module_subscriptions', array( $this, 'set_featured_image_in_email_default' ) );
 
 		// Hide subscription messaging in Publish panel for posts that were published in the past
 		add_action( 'init', array( $this, 'register_post_meta' ), 20 );

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -130,6 +130,7 @@ class Jetpack_Subscriptions {
 
 		// Set "social_notifications_subscribe" option during the first-time activation.
 		add_action( 'jetpack_activate_module_subscriptions', array( $this, 'set_social_notifications_subscribe' ) );
+		add_action( 'jetpack_activate_module_subscriptions', array( $this, 'set_social_notifications_subscribe' ) );
 
 		// Hide subscription messaging in Publish panel for posts that were published in the past
 		add_action( 'init', array( $this, 'register_post_meta' ), 20 );
@@ -908,6 +909,15 @@ class Jetpack_Subscriptions {
 		if ( false === get_option( 'social_notifications_subscribe' ) ) {
 			add_option( 'social_notifications_subscribe', 'off' );
 		}
+	}
+
+	/**
+	 * Set the featured image in email option to `1` when the Subscriptions module is activated in the first time.
+	 *
+	 * @return void
+	 */
+	public function set_featured_image_in_email_default() {
+		add_option( 'wpcom_featured_image_in_email', 1 );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
@@ -34,10 +34,9 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
-		// Clean up.
+		// Clean up
 		remove_all_filters( 'earn_get_user_subscriptions_for_site_id' );
 		remove_all_filters( 'jetpack_is_connection_ready' );
-		delete_option( 'wpcom_featured_image_in_email' );
 
 		parent::tear_down();
 	}
@@ -690,48 +689,5 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 			// Removing filter.
 			remove_filter( 'jetpack_is_connection_ready', '__return_true', 1000 );
 		}
-	}
-
-	/**
-	 * Test setting featured image in email default option
-	 */
-	public function test_set_featured_image_in_email_default() {
-		// Ensure option doesn't exist.
-		delete_option( 'wpcom_featured_image_in_email' );
-		$this->assertFalse( get_option( 'wpcom_featured_image_in_email' ) );
-
-		// Call the method.
-		$this->subscriptions->set_featured_image_in_email_default();
-
-		// Verify option was set to 1.
-		$this->assertSame( 1, get_option( 'wpcom_featured_image_in_email' ) );
-	}
-
-	/**
-	 * Test that setting featured image default doesn't override existing value
-	 */
-	public function test_set_featured_image_in_email_default_does_not_override_existing() {
-		// Set an existing value.
-		update_option( 'wpcom_featured_image_in_email', 0 );
-
-		// Call the method.
-		$this->subscriptions->set_featured_image_in_email_default();
-
-		// Verify value wasn't changed.
-		$this->assertSame( 0, get_option( 'wpcom_featured_image_in_email' ) );
-	}
-
-	/**
-	 * Test featured image default is set on module activation
-	 */
-	public function test_module_activation_sets_featured_image_default() {
-		// Ensure option doesn't exist.
-		delete_option( 'wpcom_featured_image_in_email' );
-
-		// Trigger module activation.
-		do_action( 'jetpack_activate_module_subscriptions' );
-
-		// Verify option was set.
-		$this->assertSame( 1, get_option( 'wpcom_featured_image_in_email' ) );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
@@ -34,9 +34,10 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
-		// Clean up
+		// Clean up.
 		remove_all_filters( 'earn_get_user_subscriptions_for_site_id' );
 		remove_all_filters( 'jetpack_is_connection_ready' );
+		delete_option( 'wpcom_featured_image_in_email' );
 
 		parent::tear_down();
 	}
@@ -689,5 +690,48 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 			// Removing filter.
 			remove_filter( 'jetpack_is_connection_ready', '__return_true', 1000 );
 		}
+	}
+
+	/**
+	 * Test setting featured image in email default option
+	 */
+	public function test_set_featured_image_in_email_default() {
+		// Ensure option doesn't exist.
+		delete_option( 'wpcom_featured_image_in_email' );
+		$this->assertFalse( get_option( 'wpcom_featured_image_in_email' ) );
+
+		// Call the method.
+		$this->subscriptions->set_featured_image_in_email_default();
+
+		// Verify option was set to 1.
+		$this->assertSame( 1, get_option( 'wpcom_featured_image_in_email' ) );
+	}
+
+	/**
+	 * Test that setting featured image default doesn't override existing value
+	 */
+	public function test_set_featured_image_in_email_default_does_not_override_existing() {
+		// Set an existing value.
+		update_option( 'wpcom_featured_image_in_email', 0 );
+
+		// Call the method.
+		$this->subscriptions->set_featured_image_in_email_default();
+
+		// Verify value wasn't changed.
+		$this->assertSame( 0, get_option( 'wpcom_featured_image_in_email' ) );
+	}
+
+	/**
+	 * Test featured image default is set on module activation
+	 */
+	public function test_module_activation_sets_featured_image_default() {
+		// Ensure option doesn't exist.
+		delete_option( 'wpcom_featured_image_in_email' );
+
+		// Trigger module activation.
+		do_action( 'jetpack_activate_module_subscriptions' );
+
+		// Verify option was set.
+		$this->assertSame( 1, get_option( 'wpcom_featured_image_in_email' ) );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Sets the `wpcom_featured_image_in_email` option when the subscription module is activated to `true`
* Settings are refreshed after that module is activated to reflect the new state in the UI

This approach allows us to change the default without disrupting any user who has the subscription module already activated. This will also allow us to undo this change in the future easily because the option will have a set value by default instead of using a default returned by `get_option` when it's unset. 

https://github.com/user-attachments/assets/a0ae303f-cd32-4f6a-8569-e41e8ae8a908

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

See 605-gh-loop

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up a fresh test site where "Enable featured image on your new post emails" has never been changed.
* Apply these changes to the site by checking out the feature branch in the Jetpack plugin (using Jetpack beta).
* Go back to Jetpack > Settings > Newsletter.
* Enable the newsletter module: "Let visitors subscribe to this site and receive emails when you publish a post."
* Verify that "Enable featured image on your new post emails" is enabled.
* Disable "Enable featured image on your new post emails".
* Disable and re-enable the newsletter module: "Let visitors subscribe to this site and receive emails when you publish a post."
* Verify that "Enable featured image on your new post emails" is still disabled. 
* The module will be activated by default on Atomic, but you can test re-enabling it with these changes applied results in the featured image being enabled by default.
* Test for regressions on Simple.

