### PR TITLE
Forms: file field show error and progress

### DIFF
--- a/projects/packages/forms/changelog/fix-file-field-errors
+++ b/projects/packages/forms/changelog/fix-file-field-errors
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add progress and errors to the form upload field

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -609,6 +609,10 @@ export const childBlocks = [
 					type: 'string',
 					default: '',
 				},
+				maxfiles: {
+					type: 'number',
+					default: 1,
+				},
 			},
 			isBeta: true,
 		},

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-file/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-file/index.js
@@ -1,4 +1,5 @@
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import { __experimentalNumberControl as NumberControl } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useFormWrapper } from '../../util/form';
@@ -6,6 +7,7 @@ import { withSharedFieldAttributes } from '../../util/with-shared-field-attribut
 import JetpackFieldControls from '../jetpack-field-controls';
 import JetpackFieldLabel from '../jetpack-field-label';
 import { useJetpackFieldStyles } from '../use-jetpack-field-styles';
+
 import './editor.css';
 
 const DEFAULT_ICON = `${ window?.jpFormsBlocks?.defaults?.assetsUrl }/images/upload-icon.svg`;
@@ -125,6 +127,32 @@ const JetpackFieldFile = props => {
 				width={ width }
 				setAttributes={ setAttributes }
 				attributes={ attributes }
+				extraFieldSettings={ [
+					{
+						index: 1,
+						element: (
+							<NumberControl
+								key="maxfiles"
+								label={ __( 'Number of files', 'jetpack-forms' ) }
+								value={ attributes.maxfiles }
+								onChange={ value =>
+									setAttributes( {
+										maxfiles: value,
+									} )
+								}
+								max={ 10 }
+								min={ 1 }
+								step={ 1 }
+								__nextHasNoMarginBottom={ true }
+								__next40pxDefaultSize={ true }
+								help={ __(
+									'Maximum number of files that the user is able to upload per form submission.',
+									'jetpack-forms'
+								) }
+							/>
+						),
+					},
+				] }
 			/>
 		</>
 	);

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -899,7 +899,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					id="<?php echo esc_attr( $id ); ?>"
 					type="file" class="jetpack-form-file-field"
 					accept="<?php echo esc_attr( $accepted_file_types ); ?>"
-					<?php echo ( $max_files > 1 ) ? 'multiple="multiple"' : ''; ?>
+					<?php echo ( $max_files > 1 ? 'multiple="multiple"' : '' ); ?>
 					data-wp-on--change="actions.fileAdded"  />
 			</div>
 			<div class="jetpack-form-file-field__preview-wrap" data-wp-class--is-active="state.hasFiles">

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -886,7 +886,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			data-wp-on--mouseleave="actions.dragLeave"
 			data-wp-on--drop="actions.fileDropped"
 		>
-			<div class="jetpack-form-file-field__dropzone" data-wp-class--is_dropping="context.isDropping">
+			<div class="jetpack-form-file-field__dropzone" data-wp-class--is-dropping="context.isDropping" data-wp-class--has-files="context.hasFiles">
 				<div class="jetpack-form-file-field__dropzone-inner" data-wp-on--click="actions.openFilePicker"></div>
 				<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is intentionally unescaped as it contains block content that was previously escaped ?>
 				<?php echo html_entity_decode( $this->content, ENT_COMPAT, 'UTF-8' ); ?>
@@ -894,20 +894,27 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			</div>
 			<div class="jetpack-form-file-field__preview-wrap" data-wp-class--is-active="context.hasFiles">
 				<template data-wp-each--file="context.files" data-wp-key="context.file.id">
-					<div class="jetpack-form-file-field__preview">
-						<div class="jetpack-form-file-field__progress" data-wp-bind--data-progress-id='context.file.id' data-wp-bind--aria-valuenow="context.file.progress" data-wp-style----progress="context.file.progress" role="progressbar" aria-valuenow="10" aria-valuemin="0" aria-valuemax="100"></div>
+					<div class="jetpack-form-file-field__preview" data-wp-class--is-error="context.file.hasError" data-wp-class--is-complete="context.file.hasToken">
 						<input type="hidden" name="<?php echo esc_attr( $id ); ?>_token[]" data-wp-bind--value='context.file.token' value="">
-						<div class="jetpack-form-file-field__image" data-wp-style--background-image="context.file.url" ></div>
+
+						<div class="jetpack-form-file-field__image-wrap" data-wp-style----progress="context.file.progress">
+							<div class="jetpack-form-file-field__image" data-wp-style--background-image="context.file.url" ></div>
+							<div class="jetpack-form-file-field__progress-bar" ></div>
+						</div>
+
 						<div class="jetpack-form-file-field__file-wrap">
 							<strong class="jetpack-form-file-field__file-name" data-wp-text="context.file.name"></strong>
-							<div class="jetpack-form-file-field__file-info" date-wp-class--is-error="context.file.error" data-wp-class--is-complete="context.file.hasToken">
+							<div class="jetpack-form-file-field__file-info">
 								<span class="jetpack-form-file-field__file-size" data-wp-text="context.file.formattedSize"></span>
 								<span class="jetpack-form-file-field__seperator"> &middot; </span>
+								<span class="jetpack-form-file-field__uploading"><?php esc_html_e( 'Uploading...', 'jetpack-forms' ); ?></span>
 								<span class="jetpack-form-file-field__success"><?php esc_html_e( 'Uploaded', 'jetpack-forms' ); ?></span>
 								<span class="jetpack-form-file-field__error" data-wp-text="context.file.error"></span>
 							</div>
 						</div>
+
 						<a href="#" class="jetpack-form-file-field__remove" data-wp-bind--data-id='context.file.id' aria-label="<?php esc_attr_e( 'Remove file', 'jetpack-forms' ); ?>" data-wp-on--click="actions.removeFile" title="<?php esc_attr_e( 'Remove', 'jetpack-forms' ); ?>"> </a>
+
 					</div>
 				</template>
 			</div>

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -850,7 +850,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		 */
 		$upload_token = apply_filters( 'jetpack_forms_file_upload_token', '' );
 
-		$global_state = array(
+		$global_config = array(
 			'i18n'          => array(
 				'language'           => get_bloginfo( 'language' ),
 				'fileSizeUnits'      => $file_size_units,
@@ -859,19 +859,20 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'folderNotSupported' => __( 'Folder uploads are not supported', 'jetpack-forms' ),
 				// translators: %s is the formatted maximum file size.
 				'fileTooLarge'       => sprintf( __( 'File is too large. Maximum allowed size is %s.', 'jetpack-forms' ), size_format( $max_file_size ) ),
-				'invalidType'        => __( 'This file type is not allowed', 'jetpack-forms' ),
+				'invalidType'        => __( 'This file type is not allowed.', 'jetpack-forms' ),
 			),
 			'maxUploadSize' => $max_file_size,
 			'endpoint'      => $this->get_unauth_endpoint_url(),
 			'uploadToken'   => $upload_token,
 		);
 
-		wp_interactivity_config( 'jetpack/field-file', $global_state );
+		wp_interactivity_config( 'jetpack/field-file', $global_config );
 
 		$context = array(
-			'isDropping' => false,
-			'files'      => array(),
-			'hasFiles'   => false,
+			'isDropping'       => false,
+			'files'            => array(),
+			'hasFiles'         => false,
+			'allowedMimeTypes' => $accepted_file_types,
 		);
 
 		$field = $this->render_label( 'file', $id, $label, $required, $required_field_text );
@@ -890,7 +891,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				<div class="jetpack-form-file-field__dropzone-inner" data-wp-on--click="actions.openFilePicker"></div>
 				<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is intentionally unescaped as it contains block content that was previously escaped ?>
 				<?php echo html_entity_decode( $this->content, ENT_COMPAT, 'UTF-8' ); ?>
-				<input id="<?php echo esc_attr( $id ); ?>" type="file" class="jetpack-form-file-field" data-wp-on--change="actions.fileAdded" />
+				<input id="<?php echo esc_attr( $id ); ?>" type="file" class="jetpack-form-file-field" data-wp-on--change="actions.fileAdded" accept="<?php echo esc_attr( $accepted_file_types ); ?>" />
 			</div>
 			<div class="jetpack-form-file-field__preview-wrap" data-wp-class--is-active="context.hasFiles">
 				<template data-wp-each--file="context.files" data-wp-key="context.file.id">

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -115,6 +115,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'fieldfontsize'          => null,
 				'min'                    => null,
 				'max'                    => null,
+				'maxfiles'               => null,
 			),
 			$attributes,
 			'contact-field'
@@ -833,7 +834,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$input_attrs['aria-required'] = 'true';
 		}
 
-		$max_files       = 2; // max number of files.
+		$max_files       = $this->get_attribute( 'maxfiles' ); // max number of files.
 		$max_file_size   = wp_max_upload_size();
 		$file_size_units = array(
 			_x( 'B', 'unit symbol', 'jetpack-forms' ),

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -833,6 +833,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$input_attrs['aria-required'] = 'true';
 		}
 
+		$max_files       = 2; // max number of files.
 		$max_file_size   = wp_max_upload_size();
 		$file_size_units = array(
 			_x( 'B', 'unit symbol', 'jetpack-forms' ),
@@ -851,7 +852,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$upload_token = apply_filters( 'jetpack_forms_file_upload_token', '' );
 
 		$global_config = array(
-			'i18n'          => array(
+			'i18n'        => array(
 				'language'           => get_bloginfo( 'language' ),
 				'fileSizeUnits'      => $file_size_units,
 				'zeroBytes'          => __( '0 Bytes', 'jetpack-forms' ),
@@ -860,10 +861,10 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				// translators: %s is the formatted maximum file size.
 				'fileTooLarge'       => sprintf( __( 'File is too large. Maximum allowed size is %s.', 'jetpack-forms' ), size_format( $max_file_size ) ),
 				'invalidType'        => __( 'This file type is not allowed.', 'jetpack-forms' ),
+				'maxFiles'           => __( 'You have exeeded the number of files that you can upload.', 'jetpack-forms' ),
 			),
-			'maxUploadSize' => $max_file_size,
-			'endpoint'      => $this->get_unauth_endpoint_url(),
-			'uploadToken'   => $upload_token,
+			'endpoint'    => $this->get_unauth_endpoint_url(),
+			'uploadToken' => $upload_token,
 		);
 
 		wp_interactivity_config( 'jetpack/field-file', $global_config );
@@ -873,6 +874,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			'files'            => array(),
 			'hasFiles'         => false,
 			'allowedMimeTypes' => $accepted_file_types,
+			'maxUploadSize'    => $max_file_size,
+			'maxFiles'         => $max_files, // max number of files.
+			'hasMaxFiles'      => false,
 		);
 
 		$field = $this->render_label( 'file', $id, $label, $required, $required_field_text );
@@ -887,13 +891,18 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			data-wp-on--mouseleave="actions.dragLeave"
 			data-wp-on--drop="actions.fileDropped"
 		>
-			<div class="jetpack-form-file-field__dropzone" data-wp-class--is-dropping="context.isDropping" data-wp-class--has-files="context.hasFiles">
+			<div class="jetpack-form-file-field__dropzone" data-wp-class--is-dropping="context.isDropping" data-wp-class--is-hidden="state.hasMaxFiles">
 				<div class="jetpack-form-file-field__dropzone-inner" data-wp-on--click="actions.openFilePicker"></div>
 				<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is intentionally unescaped as it contains block content that was previously escaped ?>
 				<?php echo html_entity_decode( $this->content, ENT_COMPAT, 'UTF-8' ); ?>
-				<input id="<?php echo esc_attr( $id ); ?>" type="file" class="jetpack-form-file-field" data-wp-on--change="actions.fileAdded" accept="<?php echo esc_attr( $accepted_file_types ); ?>" />
+				<input
+					id="<?php echo esc_attr( $id ); ?>"
+					type="file" class="jetpack-form-file-field"
+					accept="<?php echo esc_attr( $accepted_file_types ); ?>"
+					<?php echo ( $max_files > 1 ) ? 'multiple="multiple"' : ''; ?>
+					data-wp-on--change="actions.fileAdded"  />
 			</div>
-			<div class="jetpack-form-file-field__preview-wrap" data-wp-class--is-active="context.hasFiles">
+			<div class="jetpack-form-file-field__preview-wrap" data-wp-class--is-active="state.hasFiles">
 				<template data-wp-each--file="context.files" data-wp-key="context.file.id">
 					<div class="jetpack-form-file-field__preview" data-wp-class--is-error="context.file.hasError" data-wp-class--is-complete="context.file.hasToken">
 						<input type="hidden" name="<?php echo esc_attr( $id ); ?>_token[]" data-wp-bind--value='context.file.token' value="">

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -899,7 +899,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					id="<?php echo esc_attr( $id ); ?>"
 					type="file" class="jetpack-form-file-field"
 					accept="<?php echo esc_attr( $accepted_file_types ); ?>"
-					<?php echo ( $max_files > 1 ? 'multiple="multiple"' : '' ); ?>
+					<?php echo ( (int) $max_files > 1 ? 'multiple="multiple"' : '' ); ?>
 					data-wp-on--change="actions.fileAdded"  />
 			</div>
 			<div class="jetpack-form-file-field__preview-wrap" data-wp-class--is-active="state.hasFiles">

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -834,7 +834,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$input_attrs['aria-required'] = 'true';
 		}
 
-		$max_files       = $this->get_attribute( 'maxfiles' ); // max number of files.
+		$max_files = empty( $this->get_attribute( 'maxfiles' ) ) ? 1 : $this->get_attribute( 'maxfiles' ); // max number of files.
+
 		$max_file_size   = wp_max_upload_size();
 		$file_size_units = array(
 			_x( 'B', 'unit symbol', 'jetpack-forms' ),

--- a/projects/packages/forms/src/contact-form/css/file-field.css
+++ b/projects/packages/forms/src/contact-form/css/file-field.css
@@ -198,6 +198,16 @@
 	z-index: 2;
 }
 
+.jetpack-form-file-field__preview.is-complete .jetpack-form-file-field__image {
+	width: 46px;
+	min-width: 46px;
+	height: 46px;
+	left: 0;
+	top: 0;
+	outline: 1 solid  var( --jetpack--contact-form--button-primary--text-color, #FFF );
+	transition: width 0.5s ease-in-out;
+}
+
 .jetpack-form-file-field__progress-bar {
 	content:'';
 	position: absolute;

--- a/projects/packages/forms/src/contact-form/css/file-field.css
+++ b/projects/packages/forms/src/contact-form/css/file-field.css
@@ -2,7 +2,7 @@
 	position: relative;
 }
 
-.jetpack-form-file-field__dropzone.has-files {
+.jetpack-form-file-field__dropzone.is-hidden {
 	display: none;
 }
 

--- a/projects/packages/forms/src/contact-form/css/file-field.css
+++ b/projects/packages/forms/src/contact-form/css/file-field.css
@@ -26,7 +26,7 @@
 	cursor: pointer;
 	transition: .2s;
 	opacity: 1;
-	background-color: #EEE;
+	filter: invert(0.1);
 }
 
 .jetpack-form-file-field__dropzone:hover {
@@ -276,6 +276,10 @@
 	opacity: 0.8;
 	display: inline-flex;
 	gap: 4px;
+}
+
+.jetpack-form-file-field__file-info .jetpack-form-file-field__file-size {
+	white-space: nowrap;
 }
 
 .jetpack-form-file-field__success {

--- a/projects/packages/forms/src/contact-form/css/file-field.css
+++ b/projects/packages/forms/src/contact-form/css/file-field.css
@@ -2,6 +2,10 @@
 	position: relative;
 }
 
+.jetpack-form-file-field__dropzone.has-files {
+	display: none;
+}
+
 .jetpack-form-file-field__dropzone-inner {
 	position: absolute;
 	top: 0;
@@ -18,12 +22,11 @@
 	display: none;
 }
 
-.jetpack-form-file-field__dropzone.is_dropping {
+.jetpack-form-file-field__dropzone.is-dropping {
 	cursor: pointer;
 	transition: .2s;
 	opacity: 1;
 	background-color: #EEE;
-	border: var(--jetpack--contact-form--border-size, 1px) solid var(--jetpack--contact-form--border-color);
 }
 
 .jetpack-form-file-field__dropzone:hover {
@@ -39,7 +42,7 @@
 }
 
 .jetpack-form-file-field__icon {
-	color: currentColor;
+	color: currentcolor;
 }
 
 .jetpack-form-file-field__text {
@@ -51,7 +54,7 @@
 
 .jetpack-form-file-field__select-link {
 	text-decoration: underline;
-	font-weight: bold;
+	font-weight: 700;
 }
 
 .jetpack-form-file-field__formats {
@@ -115,18 +118,6 @@
 	}
 }
 
-.jetpack-form-file-field__image {
-	aspect-ratio: 1 / 1;
-	background-position: center;
-	background-size: cover;
-	border-radius: var(--jetpack--contact-form--border-radius, 0);
-	outline: 2px solid  var( --jetpack--contact-form--button-primary--text-color, #FFF );
-	background-color: #333;
-	border-radius: 50%;
-	outline-offset:0;
-	width: 40px;
-	min-width: 40px;
-}
 
 .jetpack-form-file-field__preview.fade-out {
 	animation: jpFadeOutFileField 0.3s forwards;
@@ -180,36 +171,44 @@
 	transform: rotate(-45deg);
 }
 
-.jetpack-form-file-field__progress {
-	opacity: 0.5;
-	--hue: 220;
-	--holesize: 64;  /* 64 */
-	--track-bg: #333;
-	height: 44px;
-	width: 44px;
-	display: block;
-	align-items: center;
-	justify-items: center;
-	place-items: center;
-	position: absolute;
-	z-index: 3;
-	left: 14px;
+.jetpack-form-file-field__image-wrap {
+	width: 46px;
+	height: 46px;
+	border-radius: calc(infinity * 1px);
+	position: relative;
 }
 
-.jetpack-form-file-field__progress.is-complete,
-.jetpack-form-file-field__progress.is-error {
-	opacity: 1;
-	transform: opacity 0.5s ease;
-}
-
-.jetpack-form-file-field__progress::before {
+.jetpack-form-file-field__image {
 	content: '';
+	aspect-ratio: 1 / 1;
+	background-position: center;
+	background-size: cover;
+	outline: 1 solid  var( --jetpack--contact-form--button-primary--text-color, #FFF );
+	background-color: #333;
+	border-radius: 50%;
+	outline-offset:0;
+	width: 40px;
+	min-width: 40px;
+	left: 3px;
+	position: absolute;
+	top: 3px;
+	z-index: 2;
+}
+
+.jetpack-form-file-field__progress-bar {
+	content:'';
 	position: absolute;
 	top: 0;
 	bottom: 0;
 	left: 0;
 	right: 0;
 	border-radius: 50%;
+	background: conic-gradient(
+		var(--outline, #333 )
+		calc(var(--progress, 3) * 1%),
+		transparent calc(var(--progress, 3) * 1%)
+	);
+
 	z-index: -1;
 	background: conic-gradient(transparent var(--progress, 0%),
 			var(--track-bg) var(--progress, 0%) 100%);
@@ -247,27 +246,17 @@
 	box-shadow: 1px 1px 0px 0px #333;
 }
 
-.jetpack-form-file-field__progress.is-error:before,
-.jetpack-form-file-field__progress.is-error:after {
-	position: absolute;
-	top: 12px;
-	left: 21px;
-	height: 20px;
-	width: 2px;
-	background-color: #FFF;
-	-webkit-mask-image: none;
-	mask-image: none;
-	z-index: 4;
-	content: "";
-	border-radius: 0;
+.jetpack-form-file-field__preview.is-error .jetpack-form-file-field__progress-bar,
+.jetpack-form-file-field__preview.is-complete .jetpack-form-file-field__progress-bar {
+	animation: none;
+	opacity: 0;
 }
 
-.jetpack-form-file-field__progress.is-error:before {
-	transform: rotate(45deg);
-}
+@keyframes spin {
 
-.jetpack-form-file-field__progress.is-error:after {
-	transform: rotate(-45deg);
+    from {transform:rotate(0deg);}
+
+    to {transform:rotate(360deg);}
 }
 
 .jetpack-form-file-field__file-info {
@@ -288,8 +277,12 @@
 	display: none;
 }
 
-.is-error .jetpack-form-file-field__seperator,
-.is-complete .jetpack-form-file-field__success {
+.jetpack-form-file-field__preview.is-error .jetpack-form-file-field__uploading,
+.jetpack-form-file-field__preview.is-complete .jetpack-form-file-field__uploading {
+	display: none;
+}
+
+.jetpack-form-file-field__preview.is-complete .jetpack-form-file-field__success {
 	display: inline;
 }
 

--- a/projects/packages/forms/src/contact-form/css/file-field.css
+++ b/projects/packages/forms/src/contact-form/css/file-field.css
@@ -84,7 +84,7 @@
 	justify-content:start;
 	border-radius: var( --jetpack--contact-form--border-radius, 0 );
 	background-color: var(--jetpack--contact-form--input-background, white);
-	color: var(--jetpack--contact-form--input-color, #333);
+	color: var(--jetpack--contact-form--text-color, #333);
 	border: var(--jetpack--contact-form--border-size, 1px) var( --jetpack--contact-form--border-style, solid) var(--jetpack--contact-form--border-color, #333 );
 	margin-top: 8px;
 	font-size: 12px;
@@ -151,19 +151,19 @@
 
 .jetpack-form-file-field__remove {
 	position: relative;
-	min-width: 32px;
-	height: 32px;
+	min-width: 33px;
+	height: 33px;
 	margin-right: 10px;
 }
 
 .jetpack-form-file-field__remove:before, .jetpack-form-file-field__remove:after {
 	position: absolute;
-	left: 15px;
+	left: 16px;
 	content: ' ';
 	height: 18px;
 	width: 1px;
-	top: 8px;
-	background-color: #000;
+	top: 7px;
+	background-color: var(--jetpack--contact-form--text-color, #333 );
 }
 
 .jetpack-form-file-field__remove:before {

--- a/projects/packages/forms/src/contact-form/css/file-field.css
+++ b/projects/packages/forms/src/contact-form/css/file-field.css
@@ -156,7 +156,16 @@
 	margin-right: 10px;
 }
 
-.jetpack-form-file-field__remove:before, .jetpack-form-file-field__remove:after {
+.jetpack-form-file-field__remove:hover {
+	cursor: pointer;
+	border-radius: 50%;
+	background-color: var(--jetpack--contact-form--input-background, white );
+	filter: invert(0.1);
+	transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
+}
+
+.jetpack-form-file-field__remove::before,
+.jetpack-form-file-field__remove::after {
 	position: absolute;
 	left: 16px;
 	content: ' ';
@@ -166,11 +175,11 @@
 	background-color: var(--jetpack--contact-form--text-color, #333 );
 }
 
-.jetpack-form-file-field__remove:before {
+.jetpack-form-file-field__remove::before {
 	transform: rotate(45deg);
 }
 
-.jetpack-form-file-field__remove:after {
+.jetpack-form-file-field__remove::after {
 	transform: rotate(-45deg);
 }
 
@@ -223,40 +232,10 @@
 	);
 
 	z-index: -1;
-	background: conic-gradient(transparent var(--progress, 0%),
-			var(--track-bg) var(--progress, 0%) 100%);
-
-	-webkit-mask-image: radial-gradient(transparent var(--holesize),
-			black calc(var(--holesize) + 0.5px));
-
-	mask-image: radial-gradient(transparent var(--holesize),
-			black calc(var(--holesize) + 0.5px));
-}
-
-.jetpack-form-file-field__progress.is-complete::before {
-	display: none;
-	position: absolute;
-	top: 10px;
-	bottom: 0;
-	left: 16px;
-	right: 0;
-	--borderWidth: 3px;
-	--height: 16px;
-	--width: 7px;
-	--borderColor: #FFF;
-	display: inline-block;
-	transform: rotate(45deg);
-	height: var(--height);
-	width: var(--width);
-	border-bottom: var(--borderWidth) solid var(--borderColor);
-	border-right: var(--borderWidth) solid var(--borderColor);
-	background: transparent;
-	-webkit-mask-image: none;
-	mask-image: none;
-	z-index: 4;
-	content: "";
-	border-radius: 0;
-	box-shadow: 1px 1px 0px 0px #333;
+	animation: spin 1.2s ease infinite;
+	opacity: 0.8;
+	width: 46px;
+	height: 46px;
 }
 
 .jetpack-form-file-field__preview.is-error .jetpack-form-file-field__progress-bar,

--- a/projects/packages/forms/src/contact-form/css/file-field.css
+++ b/projects/packages/forms/src/contact-form/css/file-field.css
@@ -70,6 +70,7 @@
 
 .jetpack-form-file-field__preview-wrap.is-active {
 	visibility: visible;
+
 }
 
 .jetpack-form-file-field__preview {
@@ -81,8 +82,10 @@
 	padding: 16px;
 	position: relative;
 	justify-content:start;
+	border-radius: var( --jetpack--contact-form--border-radius, 0 );
 	background-color: var(--jetpack--contact-form--input-background, white);
-	border: var(--jetpack--contact-form--border-size, 1px) solid var(--jetpack--contact-form--border-color);
+	color: var(--jetpack--contact-form--input-color, #333);
+	border: var(--jetpack--contact-form--border-size, 1px) var( --jetpack--contact-form--border-style, solid) var(--jetpack--contact-form--border-color, #333 );
 	margin-top: 8px;
 	font-size: 12px;
 	line-height: 18px;
@@ -148,7 +151,7 @@
 
 .jetpack-form-file-field__remove {
 	position: relative;
-	width: 32px;
+	min-width: 32px;
 	height: 32px;
 	margin-right: 10px;
 }
@@ -172,7 +175,7 @@
 }
 
 .jetpack-form-file-field__image-wrap {
-	width: 46px;
+	min-width: 46px;
 	height: 46px;
 	border-radius: calc(infinity * 1px);
 	position: relative;
@@ -204,7 +207,7 @@
 	right: 0;
 	border-radius: 50%;
 	background: conic-gradient(
-		var(--outline, #333 )
+		var(--jetpack--contact-form--border-color, #333 )
 		calc(var(--progress, 3) * 1%),
 		transparent calc(var(--progress, 3) * 1%)
 	);
@@ -260,7 +263,7 @@
 }
 
 .jetpack-form-file-field__file-info {
-	color: #6D6D6D;
+	opacity: 0.8;
 	display: inline-flex;
 	gap: 4px;
 }

--- a/projects/packages/forms/src/modules/file-field/view.js
+++ b/projects/packages/forms/src/modules/file-field/view.js
@@ -35,24 +35,28 @@ const formatBytes = ( size, decimals = 2 ) => {
 const addFileToContext = file => {
 	const reader = new FileReader();
 	reader.readAsDataURL( file );
-	reader.onload = withScope( () => {
-		const context = getContext();
-		const config = getConfig( NAMESPACE );
-		const fileId = performance.now() + '-' + Math.random();
 
-		let error = null;
-		if ( file.size > config.maxUploadSize ) {
-			error = config.i18n.fileTooLarge;
-		}
-		context.files.push( {
-			name: file.name,
-			url: 'url(' + reader.result + ')',
-			formattedSize: formatBytes( file.size, 2 ),
-			hasToken: false,
-			id: fileId,
-			error,
-		} );
-		context.hasFiles = true;
+	const config = getConfig( NAMESPACE );
+	const context = getContext();
+
+	let error = null;
+	if ( file.size > config.maxUploadSize ) {
+		error = config.i18n.fileTooLarge;
+	}
+	const fileId = performance.now() + '-' + Math.random();
+
+	context.files.push( {
+		name: file.name,
+		formattedSize: formatBytes( file.size, 2 ),
+		hasToken: false,
+		hasError: !! error,
+		id: fileId,
+		error,
+	} );
+	context.hasFiles = true;
+
+	reader.onload = withScope( () => {
+		updateFileContext( { url: 'url(' + reader.result + ')' }, fileId );
 		! error && uploadFile( file, fileId );
 	} );
 };
@@ -108,8 +112,7 @@ const onReadyStateChange = ( fileId, event ) => {
 		}
 		if ( xhr.responseText ) {
 			const response = JSON.parse( xhr.responseText );
-			// eslint-disable-next-line no-console
-			console.error( 'Error uploading file', response );
+			updateFileContext( { error: response.message, hasError: true }, fileId );
 		}
 	}
 };

--- a/projects/packages/forms/src/modules/file-field/view.js
+++ b/projects/packages/forms/src/modules/file-field/view.js
@@ -241,6 +241,7 @@ store( NAMESPACE, {
 		 * @param {Event} event - The event object.
 		 */
 		removeFile: event => {
+			event.preventDefault();
 			const context = getContext();
 			const fileId = event.target.dataset.id;
 			context.files = context.files.filter( fileObject => fileObject.id !== fileId );

--- a/projects/packages/forms/src/modules/file-field/view.js
+++ b/projects/packages/forms/src/modules/file-field/view.js
@@ -40,6 +40,8 @@ const addFileToContext = file => {
 	const context = getContext();
 
 	let error = null;
+
+	// Check that the file not more then the max size.
 	if ( file.size > config.maxUploadSize ) {
 		error = config.i18n.fileTooLarge;
 	}
@@ -49,8 +51,15 @@ const addFileToContext = file => {
 		error = config.i18n.invalidType;
 	}
 
+	// Check if the user is trying to add more files then allowed.
+	if ( context.maxFiles < context.files.length + 1 ) {
+		error = config.i18n.maxFiles;
+	}
+
 	const fileId = performance.now() + '-' + Math.random();
 
+	// Update the context.
+	context.hasFiles = true;
 	context.files.push( {
 		name: file.name,
 		formattedSize: formatBytes( file.size, 2 ),
@@ -60,14 +69,13 @@ const addFileToContext = file => {
 		error,
 	} );
 
-	context.hasFiles = true;
+	// Start the upload if we don't have any errors.
+	! error && uploadFile( file, fileId );
 
+	// Load the file so we can display it. In case it is an image.
 	reader.onload = withScope( () => {
 		updateFileContext( { url: 'url(' + reader.result + ')' }, fileId );
 	} );
-
-	// start the upload if we don't have any errors.
-	! error && uploadFile( file, fileId );
 };
 
 /**
@@ -156,6 +164,17 @@ const removeFile = fileId => {
 };
 
 store( NAMESPACE, {
+	state: {
+		get hasFiles() {
+			return !! getContext().files.length > 0;
+		},
+
+		get hasMaxFiles() {
+			const context = getContext();
+			return context.maxFiles <= context.files.length;
+		},
+	},
+
 	actions: {
 		/**
 		 * Open the file picker dialog.
@@ -225,8 +244,6 @@ store( NAMESPACE, {
 			const context = getContext();
 			const fileId = event.target.dataset.id;
 			context.files = context.files.filter( fileObject => fileObject.id !== fileId );
-			context.hasFiles = context.files.length > 0;
-
 			removeFile( fileId );
 		},
 	},

--- a/projects/packages/forms/src/modules/file-field/view.js
+++ b/projects/packages/forms/src/modules/file-field/view.js
@@ -43,6 +43,12 @@ const addFileToContext = file => {
 	if ( file.size > config.maxUploadSize ) {
 		error = config.i18n.fileTooLarge;
 	}
+
+	// Check that the file type is allowed.
+	if ( ! context.allowedMimeTypes.includes( file.type ) ) {
+		error = config.i18n.invalidType;
+	}
+
 	const fileId = performance.now() + '-' + Math.random();
 
 	context.files.push( {
@@ -53,12 +59,15 @@ const addFileToContext = file => {
 		id: fileId,
 		error,
 	} );
+
 	context.hasFiles = true;
 
 	reader.onload = withScope( () => {
 		updateFileContext( { url: 'url(' + reader.result + ')' }, fileId );
-		! error && uploadFile( file, fileId );
 	} );
+
+	// start the upload if we don't have any errors.
+	! error && uploadFile( file, fileId );
 };
 
 /**


### PR DESCRIPTION
This PR improves the way the file field show the uploading progress. 

See 

https://github.com/user-attachments/assets/24a16a1e-7dcb-46cc-984e-f6e6750cab5a

It also improves how errors are shown that come from server as well as when they come from happen right away on the client. 

## Proposed changes:
* Improves showing of errors. 
* Improved the upload process.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* In the editor, add the file upload field. (form) 
* Add a file that is to big to upload. Notice that the error show up right away. 
* Upload a file that you shouldn't be able to upload.
* 
