### PR TITLE
VideoPress: Prevent unload during thumbnail processing or update

### DIFF
--- a/projects/packages/videopress/changelog/fix-prevent-unload-during-thumbnail-update
+++ b/projects/packages/videopress/changelog/fix-prevent-unload-during-thumbnail-update
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: It slightly improves the user experience not letting the user refresh the page during the thumbnail update. Considered insignificant.
+
+

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -233,8 +233,11 @@ const EditVideoDetails = () => {
 		'jetpack-videopress-pkg'
 	);
 
+	const hasUnsavedChanges = hasChanges && ! updated && ! deleted && canPerformAction;
+	const videoThumbnailUpdateInProgress = processing || isUpdatingPoster;
+
 	useUnloadPrevent( {
-		shouldPrevent: hasChanges && ! updated && ! deleted && canPerformAction,
+		shouldPrevent: hasUnsavedChanges || videoThumbnailUpdateInProgress,
 		message: unsavedChangesMessage,
 	} );
 

--- a/projects/plugins/jetpack/changelog/fix-prevent-unload-during-thumbnail-update
+++ b/projects/plugins/jetpack/changelog/fix-prevent-unload-during-thumbnail-update
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: It slightly improves the user experience not letting the user refresh the page during the thumbnail update. Considered insignificant.
+
+

--- a/projects/plugins/videopress/changelog/fix-prevent-unload-during-thumbnail-update
+++ b/projects/plugins/videopress/changelog/fix-prevent-unload-during-thumbnail-update
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: It slightly improves the user experience not letting the user refresh the page during the thumbnail update. Considered insignificant.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #39524

We have an asynchronous process that could be broken if the user reloads or leaves the page.
For this reason, we want the user to be warned about the ongoing process.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Prevent unload (i.e., leaving or refreshing the page) when video thumbnail is processing or updating.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to 'Jetpack -> VideoPress'
* Upload a video.
* Click "Edit video details".
* Click on the pencil on the video thumbnail and pick "Select from video"
* Select a frame for the thumbnail and click "Select this frame"
* Click "Save changes"
* While you see "Processing" on the video thumbnail, try to refresh the page.
* Make sure you see a system prompt: "Reload site?" (or similar, depending on your browser)

## Screenshot
<img width="1690" alt="VideoPress Thumbnail Update" src="https://github.com/user-attachments/assets/c631557f-e620-41b7-bd39-bb61c1ad20c0" />


