### PR TITLE
Forms: Fix multi-choice field checkbox alignment with label

### DIFF
--- a/projects/packages/forms/changelog/fix-checkbox-alignment
+++ b/projects/packages/forms/changelog/fix-checkbox-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix alignment of multiple choice checkbox input with label.

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -383,7 +383,6 @@
 	}
 
 	&.jetpack-field-multiple {
-
 		&.is-style-button {
 			.jetpack-field-option,
 			.wp-block-jetpack-field-option-checkbox,
@@ -461,7 +460,6 @@
 	.wp-block-jetpack-field-option-checkbox,
 	.wp-block-jetpack-field-option-radio {
 		display: flex;
-		align-items: baseline; /* Align input with first label line */
 		flex-wrap: nowrap;
 
 		.jetpack-option__type:before {
@@ -471,6 +469,7 @@
 
 	.jetpack-field-option.field-option-radio,
 	.wp-block-jetpack-field-option-radio {
+		align-items: baseline; /* Align input with first label line */
 		.jetpack-option__type {
 			transform: translateY(5%); /* Small offset to compensate the slightly odd perceived alignment that's due to the circular shape */
 		}

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -646,8 +646,11 @@ on production builds, the attributes are being reordered, causing side-effects
 
 .contact-form .grunion-field-wrap input.radio {
 	border-radius: 50%;
-
 	transform: translateY(15%); /* Small offset to compensate the slightly odd perceived alignment that's due to the circular shape */
+}
+
+.contact-form .grunion-field-wrap input.checkbox-multiple {
+	align-self: center;
 }
 
 .contact-form .grunion-field-wrap input.checkbox-multiple:checked::before {

--- a/projects/plugins/jetpack/changelog/fix-checkbox-alignment
+++ b/projects/plugins/jetpack/changelog/fix-checkbox-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix alignment of multiple choice checkbox input with label.


### PR DESCRIPTION
## Proposed changes:
While testing another form PR, I noticed that checkboxes in the multi choice field are misaligned with the label:
<img width="244" alt="Screenshot 2025-04-02 at 4 04 24 pm" src="https://github.com/user-attachments/assets/15ccf273-3a0a-4b4f-8103-c2308a7c650e" />

In the editor this seems to have been introduced in #42440, which reduced the specificity of this rule:
https://github.com/Automattic/jetpack/blob/f09a9e2682d42950a2a7d69325a08ad43a61c1a0/projects/packages/forms/src/blocks/contact-form/editor.scss#L121-L123

The extra specificity was overriding another `align-items` style here that applies to both radio and checkboxes:
https://github.com/Automattic/jetpack/blob/f09a9e2682d42950a2a7d69325a08ad43a61c1a0/projects/packages/forms/src/blocks/contact-form/editor.scss#L461-L465

To fix this, I've changed it so that the rule doesn't have to compete for specificity by relocating that latter rule so that it only applies to radio buttons. It seems to do the job:
<img width="252" alt="Screenshot 2025-04-02 at 4 16 47 pm" src="https://github.com/user-attachments/assets/a75702ec-f3f3-4189-9e3e-8d79772949e4" />

It's also broken in the frontend where it's also `align-items: baseline`, to fix I've made sure it matches the editor and added a CSS rule to make the input `align-self: center`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Add Single Choice and Multiple Choice blocks to a form
2. Add multiple options to those blocks
3. Check alignment on the frontend and in the editor
