### PR TITLE
Forms: tiny CSS tidy up

### DIFF
--- a/projects/packages/forms/changelog/remove-field-option-selector
+++ b/projects/packages/forms/changelog/remove-field-option-selector
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Code quality change.
+
+

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -41,8 +41,7 @@
 		}
 	}
 
-	.jetpack-contact-form,
-	[class*="wp-block-jetpack-field-option"] {
+	.jetpack-contact-form {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: flex-start;


### PR DESCRIPTION
## Proposed changes:
I noticed that #42440 added an extra selector `[class*="wp-block-jetpack-field-option"]` to the forms editor CSS.

Here I'm proposing to remove it. Reasonings:
- It looks pretty clear to me that these styles are intended to target the top level contact form block and any of its inner blocks through the inner `.wp-block` selector. It may have accidentally also targeted the multi/single choice blocks, but that doesn't seem intentional.
- From what I can tell, it has no effect on the multi/single choice blocks, [the styles for those blocks are already implemented elsewhere](https://github.com/Automattic/jetpack/blob/f09a9e2682d42950a2a7d69325a08ad43a61c1a0/projects/packages/forms/src/blocks/contact-form/editor.scss#L488-L508) and override these styles.
- I think this is misleading to other developers, it could lead to styles being added in the wrong place in the future.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Screenshots
| Before | After |
|--------|--------|
| <img width="648" alt="Screenshot 2025-04-02 at 4 46 14 pm" src="https://github.com/user-attachments/assets/08a57b20-cf22-4a39-b2e7-7ef169324fda" /> | <img width="652" alt="Screenshot 2025-04-02 at 4 46 42 pm" src="https://github.com/user-attachments/assets/d1bf75c2-a121-4b1a-b86c-3bebb660ba05" /> | 



## Testing instructions:
1. Add a multi choice and a single choice block to a form
2. Add inner options blocks
3. Try different styles for the blocks
4. Check that everything looks the same as trunk

