### PR TITLE
Site Visibility: Disable search engines indexing for sites with wpcomstaging.com domain

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/feat-staging-domain-disable-search-engines
+++ b/projects/packages/jetpack-mu-wpcom/changelog/feat-staging-domain-disable-search-engines
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Site Visibility: Disable search engines indexing for sites with wpcomstaging.com domain

--- a/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/site-visibility/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/site-visibility/index.tsx
@@ -164,9 +164,13 @@ const SiteVisibility = ( {
 									<div className="notice notice-warning inline">
 										<p>
 											{ createInterpolateElement(
-												__(
-													'Your site is using <strong>wpcomstaging.com</strong> as the primary domain, which is prevented from being indexed by search engines.<br />To change this, <link1>buy a custom domain</link1>, or <link2>set a custom domain as the primary domain</link2>.',
-													'jetpack-mu-wpcom'
+												sprintf(
+													// translators: %s: the primary domain of the site
+													__(
+														"Your site's current primary domain is <strong>%s</strong>. This domain is intended for temporary use and will not be indexed by search engines. To ensure your site can be indexed, please <link1>register</link1> or <link2>connect a custom primary domain</link2>.",
+														'jetpack-mu-wpcom'
+													),
+													host
 												),
 												{
 													strong: <strong />,

--- a/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/site-visibility/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/site-visibility/index.tsx
@@ -1,5 +1,8 @@
+import { ExternalLink } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { useState } from 'react';
+import { wpcomTrackEvent } from '../../../common/tracks';
 import SitePreviewLink from '../site-preview-link';
 import type { SitePreviewLinkObject } from '../site-preview-link';
 import './style.scss';
@@ -38,6 +41,9 @@ const SiteVisibility = ( {
 
 	const { blogPublic, wpcomComingSoon, wpcomPublicComingSoon, wpcomDataSharingOptOut } = fields;
 
+	const { host } = new URL( homeUrl );
+	const isWpcomStagingDomain = host.endsWith( '.wpcomstaging.com' );
+
 	// isPrivateAndUnlaunched means it is an unlaunched coming soon v1 site
 	const isPrivateAndUnlaunched = -1 === blogPublic && isUnlaunchedSite;
 	const isAnyComingSoonEnabled =
@@ -45,7 +51,8 @@ const SiteVisibility = ( {
 	const isPublicChecked = ( blogPublic === 0 && ! wpcomPublicComingSoon ) || blogPublic === 1;
 	const showPreviewLink =
 		Number( defaultWpcomPublicComingSoon ) === 1 && isAnyComingSoonEnabled && hasSitePreviewLink;
-	const discourageSearchChecked = 0 === blogPublic && ! wpcomPublicComingSoon;
+	const discourageSearchChecked =
+		( 0 === blogPublic && ! wpcomPublicComingSoon ) || isWpcomStagingDomain;
 
 	return (
 		<>
@@ -133,6 +140,8 @@ const SiteVisibility = ( {
 										type="checkbox"
 										value="0"
 										checked={ discourageSearchChecked }
+										// See https://github.com/Automattic/wp-calypso/issues/101828.
+										disabled={ isWpcomStagingDomain }
 										onChange={ () =>
 											updateFields( {
 												blogPublic:
@@ -151,6 +160,42 @@ const SiteVisibility = ( {
 										'jetpack-mu-wpcom'
 									) }
 								</p>
+								{ isWpcomStagingDomain && (
+									<div className="notice notice-warning inline">
+										<p>
+											{ createInterpolateElement(
+												__(
+													'Your site is using <strong>wpcomstaging.com</strong> as the primary domain, which is prevented from being indexed by search engines.<br />To change this, <link1>buy a custom domain</link1>, or <link2>set a custom domain as the primary domain</link2>.',
+													'jetpack-mu-wpcom'
+												),
+												{
+													strong: <strong />,
+													br: <br />,
+													link1: (
+														<ExternalLink
+															href={ `https://wordpress.com/domains/add/${ host }?redirect_to=${ window.location.href }` }
+															target="_blank"
+															onClick={ () =>
+																wpcomTrackEvent( 'wpcom_settings_reading_add_domain_button_click' )
+															}
+														/>
+													),
+													link2: (
+														<ExternalLink
+															href={ `https://wordpress.com/domains/manage/${ host }?source=${ window.location.pathname }` }
+															target="_blank"
+															onClick={ () =>
+																wpcomTrackEvent(
+																	'wpcom_settings_reading_manage_domain_button_click'
+																)
+															}
+														/>
+													),
+												}
+											) }
+										</p>
+									</div>
+								) }
 							</li>
 							<li>
 								<label htmlFor="wpcom_site_visibility_data_sharing_opt_out">
@@ -177,7 +222,7 @@ const SiteVisibility = ( {
 									{ sprintf(
 										// translators: %s: the slug of the site
 										__( 'Prevent third-party sharing for %s', 'jetpack-mu-wpcom' ),
-										new URL( homeUrl ).host
+										host
 									) }
 								</label>
 								<p className="description">

--- a/projects/plugins/mu-wpcom-plugin/changelog/feat-staging-domain-disable-search-engines
+++ b/projects/plugins/mu-wpcom-plugin/changelog/feat-staging-domain-disable-search-engines
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Site Visibility: Disable search engines indexing for sites with wpcomstaging.com domain

--- a/projects/plugins/wpcomsh/changelog/feat-staging-domain-disable-search-engines
+++ b/projects/plugins/wpcomsh/changelog/feat-staging-domain-disable-search-engines
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Site Visibility: Disable search engines indexing for sites with wpcomstaging.com domain


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/101828

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disable the search engines indexing setting for sites with wpcomstaging.com domain
* Display the notice to explain the reason and allow users to manage their domains

![image](https://github.com/user-attachments/assets/ffed81f8-3603-48b1-9962-a2c566eaf159)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your site with the `wpcomstaging.com` domain
* Go to /wp-admin/options-reading.php
* Ensure the “Discourage search engines from indexing this site” setting is disabled
* Ensure you can see the notice
  ![image](https://github.com/user-attachments/assets/e189502a-c324-4a81-8928-c6c02a81bcac)

