### PR TITLE
Fix single/multple field choice option font styles in editor

### DIFF
--- a/projects/packages/forms/changelog/fix-field-choice-use-inner-blocks-props
+++ b/projects/packages/forms/changelog/fix-field-choice-use-inner-blocks-props
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix broken option styles for single/multi choice fields.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-choice/item/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-choice/item/edit.js
@@ -95,9 +95,9 @@ export default function JetpackFieldChoiceItemEdit( {
 	};
 
 	const supportsSplitting = supportsParagraphSplitting();
-	const classes = clsx( 'jetpack-field-option', `field-option-${ type }`, blockProps.className );
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		className: classes,
+	const innerBlocksProps = useInnerBlocksProps( {
+		...blockProps,
+		className: clsx( 'jetpack-field-option', `field-option-${ type }`, blockProps.className ),
 		style: optionStyle,
 	} );
 	const useEnterRef = useEnter( { content: attributes.label, clientId } );

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-choice/item/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-choice/item/edit.js
@@ -95,24 +95,22 @@ export default function JetpackFieldChoiceItemEdit( {
 	const supportsSplitting = supportsParagraphSplitting();
 	const useEnterRef = useEnter( { content: attributes.label, clientId } );
 	return (
-		<>
-			<li { ...blockProps }>
-				<input type={ type } className="jetpack-option__type" tabIndex="-1" />
-				<RichText
-					ref={ useEnterRef }
-					identifier="label"
-					tagName="div"
-					className="wp-block"
-					value={ attributes.label }
-					placeholder={ __( 'Add option…', 'jetpack-forms' ) }
-					__unstableDisableFormats
-					onChange={ newLabel => setAttributes( { label: newLabel } ) }
-					preserveWhiteSpace={ false }
-					onRemove={ handleDelete }
-					onReplace={ onReplace }
-					{ ...( supportsSplitting ? {} : { onSplit: handleSplit } ) }
-				/>
-			</li>
-		</>
+		<li { ...blockProps }>
+			<input type={ type } className="jetpack-option__type" tabIndex="-1" />
+			<RichText
+				ref={ useEnterRef }
+				identifier="label"
+				tagName="div"
+				className="wp-block"
+				value={ attributes.label }
+				placeholder={ __( 'Add option…', 'jetpack-forms' ) }
+				__unstableDisableFormats
+				onChange={ newLabel => setAttributes( { label: newLabel } ) }
+				preserveWhiteSpace={ false }
+				onRemove={ handleDelete }
+				onReplace={ onReplace }
+				{ ...( supportsSplitting ? {} : { onSplit: handleSplit } ) }
+			/>
+		</li>
 	);
 }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-choice/item/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-choice/item/edit.js
@@ -1,9 +1,4 @@
-import {
-	RichText,
-	useBlockProps,
-	useInnerBlocksProps,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
+import { RichText, useBlockProps, store as blockEditorStore } from '@wordpress/block-editor';
 import { createBlock, cloneBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { useRefEffect } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -76,7 +71,10 @@ export default function JetpackFieldChoiceItemEdit( {
 		},
 		[ clientId ]
 	);
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		className: clsx( 'jetpack-field-option', `field-option-${ type }` ),
+		style: optionStyle,
+	} );
 
 	const handleSplit = label => {
 		return createBlock( name, {
@@ -95,15 +93,10 @@ export default function JetpackFieldChoiceItemEdit( {
 	};
 
 	const supportsSplitting = supportsParagraphSplitting();
-	const innerBlocksProps = useInnerBlocksProps( {
-		...blockProps,
-		className: clsx( 'jetpack-field-option', `field-option-${ type }`, blockProps.className ),
-		style: optionStyle,
-	} );
 	const useEnterRef = useEnter( { content: attributes.label, clientId } );
 	return (
 		<>
-			<li { ...innerBlocksProps }>
+			<li { ...blockProps }>
 				<input type={ type } className="jetpack-option__type" tabIndex="-1" />
 				<RichText
 					ref={ useEnterRef }

--- a/projects/plugins/jetpack/changelog/fix-field-choice-use-inner-blocks-props
+++ b/projects/plugins/jetpack/changelog/fix-field-choice-use-inner-blocks-props
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: fix broken option styles for single/multi choice fields.


### PR DESCRIPTION
Fixes part of #42447

## Proposed changes:
In the editor when you try changing the font size of a single/multiple choice block's option, the text of the option doesn't scale.

It does on the frontend.

I discovered this is due to an incorrect usage of `useInnerBlocksProps`. Element props like `className` and `style` are supposed to be passed as a property in the first argument, not the second.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Screenshots
| Before | After |
|--------|--------|
| <img width="658" alt="Screenshot 2025-04-02 at 6 12 05 pm" src="https://github.com/user-attachments/assets/ef504bb4-474e-47c2-8f55-f6643f546dc6" /> | <img width="667" alt="Screenshot 2025-04-02 at 6 11 44 pm" src="https://github.com/user-attachments/assets/c5441ef6-ac30-468e-890c-adf117d39729" /> | 

## Testing instructions:
1. Add a single or multiple choice field block in a form
2. Add some inner options blocks with label text
3. On the parent single/multiple in the block inspector, go into the 'Options styles' panel and change Font Size / Line height
4. Observe that the styling of the options should change in the canvas. In trunk this doesn't happen.

