### PR TITLE
Boost: Fix missing status code when generation fails due to a 404

### DIFF
--- a/projects/js-packages/critical-css-gen/changelog/fix-boost-critical-css-no-404-status-code
+++ b/projects/js-packages/critical-css-gen/changelog/fix-boost-critical-css-no-404-status-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix not returning correct URL when a page is 404.

--- a/projects/js-packages/critical-css-gen/src/browser-interface-iframe.ts
+++ b/projects/js-packages/critical-css-gen/src/browser-interface-iframe.ts
@@ -185,7 +185,7 @@ export class BrowserInterfaceIframe extends BrowserInterface {
 					// Check HTTP status code first.
 					const is404 = await this.is404Page( fullUrl );
 					if ( is404 ) {
-						throw new HttpError( { url, code: 404 } );
+						throw new HttpError( { url: fullUrl, code: 404 } );
 					}
 
 					// Verify the inner document is readable.

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/raw-error/raw-error.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/raw-error/raw-error.tsx
@@ -5,6 +5,10 @@ import { rawError } from '../lib/describe-critical-css-recommendations';
 export default function RawError( { errorSet }: { errorSet: ErrorSet } ) {
 	const rawErrorMessage = rawError( errorSet );
 
+	if ( ! rawErrorMessage ) {
+		return null;
+	}
+
 	return (
 		<p>
 			{ sprintf(

--- a/projects/plugins/boost/changelog/fix-boost-critical-css-no-404-status-code
+++ b/projects/plugins/boost/changelog/fix-boost-critical-css-no-404-status-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Critical CSS: Fix not showing status code when generation fails for some pages.


### PR DESCRIPTION
Fixes HOG-40

## Proposed changes:

* Add missing status code when a 404 occurs for all pages in a group during generation;
* Fix showing empty error when there's no error message.

<details>
<summary>Before</summary>

![CleanShot 2025-04-02 at 13 46 17](https://github.com/user-attachments/assets/6ecfb74f-107a-4c3b-b434-e4cd2bae6f3a)

</details>


<details>
<summary>After</summary>

![CleanShot 2025-04-02 at 13 46 34](https://github.com/user-attachments/assets/1d5d1ebd-81be-48d0-880c-a70302f1c7f4)

</details>

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1743522357417129-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

### Pre-requisites

* Add this snippet to your site. It will force a 404 for all pages in the front-end:

```php
add_action( 'template_redirect', 'jb_handle_critical_css_generation' );
function jb_handle_critical_css_generation() {
	status_header( 404 );
	nocache_headers();
	die();
}
```

### Test that it breaks

<details>
<summary>Instructions</summary>

* Setup Boost free (trunk or production branch);
* Try generating Critical CSS and you should see the "Show Stopper" UI (like the "Before" screenshot above).

</details>

### Test that it works

<details>
<summary>Instructions</summary>

* Setup Boost free (this branch);
* Try generating Critical CSS and you should see the "Show Stopper" UI (like the "After" screenshot above);
* It should say 404 instead of `%d`;
* There should also be no empty error showing.

</details>
