### PR TITLE
Revert " Remove What's New from the Help Center in WoA sites."

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-whats-new
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-whats-new
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-Remove the What's New feature from the Help Center

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -433,6 +433,7 @@ class Jetpack_Mu_Wpcom {
 			require_once __DIR__ . '/features/wpcom-documentation-links/wpcom-documentation-links.php';
 			require_once __DIR__ . '/features/wpcom-global-styles/index.php';
 			require_once __DIR__ . '/features/wpcom-legacy-fse/wpcom-legacy-fse.php';
+			require_once __DIR__ . '/features/wpcom-whats-new/wpcom-whats-new.php';
 		}
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-whats-new/class-wp-rest-wpcom-block-editor-whats-new-dot-controller.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-whats-new/class-wp-rest-wpcom-block-editor-whats-new-dot-controller.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * WP_REST_WPCOM_Block_Editor_Whats_New_Dot_Controller file.
+ *
+ * @package automattic/jetpack-mu-plugins
+ */
+
+/**
+ * Class WP_REST_WPCOM_Block_Editor_Whats_New_Dot_Controller.
+ */
+class WP_REST_WPCOM_Block_Editor_Whats_New_Dot_Controller extends \WP_REST_Controller {
+	/**
+	 * WP_REST_WPCOM_Block_Editor_Whats_New_Dot_Controller constructor.
+	 */
+	public function __construct() {
+		$this->namespace                       = 'wpcom/v2';
+		$this->rest_base                       = 'block-editor/has-seen-whats-new-modal';
+		$this->wpcom_is_site_specific_endpoint = false;
+	}
+
+	/**
+	 * Register available routes.
+	 */
+	public function register_rest_route() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'has_seen_whats_new_modal' ),
+					'permission_callback' => array( $this, 'permission_callback' ),
+				),
+			)
+		);
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'set_has_seen_whats_new_modal' ),
+					'permission_callback' => array( $this, 'permission_callback' ),
+					'args'                => array(
+						'has_seen_whats_new_modal' => array(
+							'required' => true,
+							'type'     => 'boolean',
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Callback to determine whether the request can proceed.
+	 *
+	 * @return boolean
+	 */
+	public function permission_callback() {
+		return is_user_logged_in();
+	}
+
+	/**
+	 * Whether the user has seen the whats new modal
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function has_seen_whats_new_modal() {
+		if ( ! metadata_exists( 'user', get_current_user_id(), 'has_seen_whats_new_modal' ) ) {
+			$has_seen_whats_new_modal = false;
+		} else {
+			$has_seen_whats_new_modal = filter_var( get_user_meta( get_current_user_id(), 'has_seen_whats_new_modal', true ), FILTER_VALIDATE_BOOLEAN );
+		}
+
+		return rest_ensure_response(
+			array(
+				'has_seen_whats_new_modal' => $has_seen_whats_new_modal,
+			)
+		);
+	}
+
+	/**
+	 * Update the option for whether the user has seen the whats new modal.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function set_has_seen_whats_new_modal( $request ) {
+		$params   = $request->get_json_params();
+		$has_seen = (bool) $params['has_seen_whats_new_modal'];
+		update_user_meta( get_current_user_id(), 'has_seen_whats_new_modal', $has_seen );
+		return rest_ensure_response( array( 'has_seen_whats_new_modal' => $has_seen ) );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-whats-new/class-wp-rest-wpcom-block-editor-whats-new-list-controller.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-whats-new/class-wp-rest-wpcom-block-editor-whats-new-list-controller.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * WP_REST_WPCOM_Block_Editor_Whats_New_List_Controller file.
+ *
+ * @package automattic/jetpack-mu-plugins
+ */
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Class WP_REST_WPCOM_Block_Editor_Whats_New_List_Controller.
+ */
+class WP_REST_WPCOM_Block_Editor_Whats_New_List_Controller extends \WP_REST_Controller {
+	/**
+	 * WP_REST_WPCOM_Block_Editor_Whats_New_List_Controller constructor.
+	 */
+	public function __construct() {
+		$this->namespace                       = 'wpcom/v2';
+		$this->rest_base                       = 'block-editor/whats-new-list';
+		$this->wpcom_is_site_specific_endpoint = false;
+	}
+
+	/**
+	 * Register available routes.
+	 */
+	public function register_rest_route() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_whats_new' ),
+					'permission_callback' => array( $this, 'permission_callback' ),
+					'args'                => array(
+						'_locale' => array(
+							'type'    => 'string',
+							'default' => 'en',
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Callback to determine whether the request can proceed.
+	 *
+	 * @return boolean
+	 */
+	public function permission_callback() {
+		return is_user_logged_in();
+	}
+
+	/**
+	 * Should return the whats new modal content
+	 *
+	 * @param \WP_REST_Request $request    The request sent to the API.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_whats_new( \WP_REST_Request $request ) {
+		$locale = $request['_locale'];
+
+		$query_parameters = array(
+			'_locale' => $locale,
+		);
+
+		$body = Client::wpcom_json_api_request_as_user(
+			'/whats-new/list?' . http_build_query( $query_parameters )
+		);
+		if ( is_wp_error( $body ) ) {
+			return rest_ensure_response( $body );
+		}
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
+
+		return rest_ensure_response( $response );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-whats-new/wpcom-whats-new.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-whats-new/wpcom-whats-new.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * WPCom Whats New support for WordPress.com sites.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Check if the WPCom Whats New should be loaded.
+ *
+ * @return bool
+ */
+function should_load_wpcom_whats_new_app() {
+	// Only load on the WPcom platform.
+	if ( ! class_exists( 'Automattic\Jetpack\Status\Host' ) ) {
+		return false;
+	}
+
+	global $pagenow;
+	$allowed_pages = array(
+		'post.php',
+		'post-new.php',
+		'site-editor.php',
+	);
+	return isset( $pagenow ) && in_array( $pagenow, $allowed_pages, true );
+}
+
+/**
+ * Enqueue block editor assets.
+ */
+function wpcom_whats_new_enqueue_script_and_style() {
+	if ( ! should_load_wpcom_whats_new_app() ) {
+		return;
+	}
+
+	$whats_new_handle = 'wpcom-whats-new';
+	$version          = gmdate( 'Ymd' );
+
+	$data = wp_json_encode(
+		array(
+			'siteId' => get_current_blog_id(),
+		)
+	);
+
+	wp_enqueue_script(
+		$whats_new_handle,
+		'//widgets.wp.com/whats-new/build.min.js',
+		array(
+			'lodash',
+			'react',
+			'wp-api-fetch',
+			'wp-components',
+			'wp-compose',
+			'wp-data',
+			'wp-element',
+			'wp-i18n',
+			'wp-keycodes',
+			'wp-plugins',
+			'wp-polyfill',
+		),
+		$version,
+		array(
+			'strategy'  => 'defer',
+			'in_footer' => true,
+		)
+	);
+
+	wp_add_inline_script(
+		$whats_new_handle,
+		"var whatsNewAppConfig = $data;",
+		'before'
+	);
+
+	wp_enqueue_style(
+		$whats_new_handle,
+		'//widgets.wp.com/whats-new/build.css',
+		array( 'wp-components' ),
+		$version
+	);
+}
+
+add_action( 'enqueue_block_editor_assets', 'wpcom_whats_new_enqueue_script_and_style', 100 );
+
+/**
+ * Register the WPCOM Block Editor Whats New endpoints.
+ */
+function wpcom_whats_new_register_rest_api() {
+	require_once __DIR__ . '/class-wp-rest-wpcom-block-editor-whats-new-dot-controller.php';
+	$controller = new WP_REST_WPCOM_Block_Editor_Whats_New_Dot_Controller();
+	$controller->register_rest_route();
+
+	require_once __DIR__ . '/class-wp-rest-wpcom-block-editor-whats-new-list-controller.php';
+	$controller = new WP_REST_WPCOM_Block_Editor_Whats_New_List_Controller();
+	$controller->register_rest_route();
+}
+add_action( 'rest_api_init', 'wpcom_whats_new_register_rest_api' );


### PR DESCRIPTION
Reverts Automattic/jetpack#42672

# Description

This PR contains a file removal. so it needs to be split into several PRs.

## Testing instructions:
See https://github.com/Automattic/jetpack/pull/42672
Check that "What's New" is still there!

