### PR TITLE
Remove What's New from the Help Center in WoA sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-whats-new-2
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-whats-new-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove the What's New feature from the Help Center

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -433,7 +433,6 @@ class Jetpack_Mu_Wpcom {
 			require_once __DIR__ . '/features/wpcom-documentation-links/wpcom-documentation-links.php';
 			require_once __DIR__ . '/features/wpcom-global-styles/index.php';
 			require_once __DIR__ . '/features/wpcom-legacy-fse/wpcom-legacy-fse.php';
-			require_once __DIR__ . '/features/wpcom-whats-new/wpcom-whats-new.php';
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Another attempt at https://github.com/Automattic/jetpack/pull/42672

We'll remove the unneeded files in a follow PR to avoid fatals on deploy.

Part of https://github.com/Automattic/wp-calypso/issues/100227

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the What's New feature from the Help Center.
* This feature is very under-used so let's remove it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* To test on WoA, go to the Plugins menu on a WoA dev site. Click on the "Upload" button and follow the upgrade flow to be able to upload, install, and activate [the Jetpack Beta plugin](https://jetpack.com/download-jetpack-beta/). Once the plugin is active, go to Jetpack > Jetpack Beta, select your plugin (WordPress.com Site Helper), and enable the remove/whats-new-2 branch.
* Then open the Help Center and confirm you no longer see "What's New":
<img width="485" alt="Screenshot 2025-03-24 at 17 03 04" src="https://github.com/user-attachments/assets/af6dbc70-7798-4e11-87b1-0b0f98954554" />


