### PR TITLE
Typekit Custom Fonts: update to version 2.0.2

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-custom-fonts-typekit
+++ b/projects/plugins/wpcomsh/changelog/update-custom-fonts-typekit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Typekit Custom Fonts: add license

--- a/projects/plugins/wpcomsh/changelog/update-custom-fonts-typekit#2
+++ b/projects/plugins/wpcomsh/changelog/update-custom-fonts-typekit#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Typekit Custom Fonts: avoid deprecation notices in PHP 8.2

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -53,23 +53,26 @@
         },
         {
             "name": "automattic/custom-fonts-typekit",
-            "version": "v2.0.0",
+            "version": "v2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/custom-fonts-typekit.git",
-                "reference": "0be6c997f3c576fc86844b5d57130d6ed81fe624"
+                "reference": "d576a78495b78d0d6acc465beecaf4079463d24c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/custom-fonts-typekit/zipball/0be6c997f3c576fc86844b5d57130d6ed81fe624",
-                "reference": "0be6c997f3c576fc86844b5d57130d6ed81fe624",
+                "url": "https://api.github.com/repos/Automattic/custom-fonts-typekit/zipball/d576a78495b78d0d6acc465beecaf4079463d24c",
+                "reference": "d576a78495b78d0d6acc465beecaf4079463d24c",
                 "shasum": ""
             },
             "require-dev": {
                 "10up/wp_mock": "dev-master"
             },
-            "type": "library",
-            "time": "2023-05-01T20:00:28+00:00"
+            "type": "wordpress-plugin",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "time": "2025-04-02T12:48:49+00:00"
         },
         {
             "name": "automattic/jetpack-a8c-mc-stats",


### PR DESCRIPTION
## Proposed changes:

See https://github.com/Automattic/custom-fonts-typekit/releases/tag/v2.0.2
This includes 2 changes:

- Added license information. by @zinigor in https://github.com/Automattic/custom-fonts-typekit/pull/105
- General: avoid PHP 8.2 deprecation warning by @jeherve in https://github.com/Automattic/custom-fonts-typekit/pull/106

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1743586260639929-slack-C7YPW6K40

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

To test this (on a WoA site), I would recommend checking the site's PHP error logs while browsing around. You should not see deprecation notices like this one:

```
PHP Deprecated:  Creation of dynamic property Jetpack_Typekit_Font_Provider::$manager is deprecated in /wordpress/plugins/wpcomsh/6.1.0-alpha+rolling.1743534357.g9c932d1/vendor/automattic/custom-fonts-typekit/providers/typekit.php on line 61
```
