### PR TITLE
Scan and Protect: add support for "in_progress" scan status value

### DIFF
--- a/projects/js-packages/scan/changelog/add-protect-scan-in-progress-status
+++ b/projects/js-packages/scan/changelog/add-protect-scan-in-progress-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add support for new 'in_progress' scan status value.

--- a/projects/js-packages/scan/src/types/status.ts
+++ b/projects/js-packages/scan/src/types/status.ts
@@ -2,7 +2,7 @@ import { Threat } from './threats.js';
 
 export type ScanStatus = {
 	/** The current status of the scanner. */
-	status: 'unavailable' | 'provisioning' | 'idle' | 'scanning' | 'scheduled';
+	status: 'unavailable' | 'provisioning' | 'idle' | 'scanning' | 'in_progress' | 'scheduled';
 
 	/** The IDs of fixable threats. */
 	fixableThreatIds: number[];

--- a/projects/plugins/protect/changelog/add-protect-scan-in-progress-status
+++ b/projects/plugins/protect/changelog/add-protect-scan-in-progress-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add support for new 'in_progress' scan status value.

--- a/projects/plugins/protect/src/js/constants.js
+++ b/projects/plugins/protect/src/js/constants.js
@@ -11,6 +11,7 @@ export const PAID_PLUGIN_SUPPORT_URL = 'https://jetpack.com/contact-support/?rel
  */
 export const SCAN_STATUS_SCHEDULED = 'scheduled';
 export const SCAN_STATUS_SCANNING = 'scanning';
+export const SCAN_STATUS_IN_PROGRESS = 'in_progress';
 export const SCAN_STATUS_OPTIMISTICALLY_SCANNING = 'optimistically_scanning';
 export const SCAN_STATUS_IDLE = 'idle';
 export const SCAN_STATUS_UNAVAILABLE = 'unavailable';
@@ -19,6 +20,7 @@ export const SCAN_IN_PROGRESS_STATUSES = [
 	SCAN_STATUS_PROVISIONING,
 	SCAN_STATUS_SCHEDULED,
 	SCAN_STATUS_SCANNING,
+	SCAN_STATUS_IN_PROGRESS,
 	SCAN_STATUS_OPTIMISTICALLY_SCANNING,
 ];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Similar to https://github.com/Automattic/jetpack/pull/42514, this PR adds support for a "in_progress" status value returned by the Scan API.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* As an Automattician, create a test site on Jurassic Ninja with Jetpack Protect. Upgrade to a scan plan, and trigger a manual scan. Watch the requests in the Network tab and validate the appropriate handling of the "in_progress" status.

