### PR TITLE
Subscribe block: Match front-end wrapping behavior

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-block-responsiveness
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-block-responsiveness
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscribe block: match the frontend wrapping behavior when editing.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -60,11 +60,6 @@
 			cursor: pointer;
 		}
 
-		// Prevent white-space issues on Firefox
-		.wp-block-jetpack-subscriptions__button[contenteditable="true"] {
-			white-space: pre-wrap !important;
-		}
-
 		input[type="email"]::placeholder,
 		input[type="email"]:disabled {
 			color: currentColor;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/jetpack/issues/22693 and https://github.com/Automattic/jetpack/issues/33100

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the Firefox spacing fix so that the text wraps the same way in the editor as it does on the front-end. 

Before | After
---- | ----
<img width="344" alt="Screenshot 2025-04-02 at 11 50 07 AM" src="https://github.com/user-attachments/assets/0f5bcf8b-8dd4-45e6-8bfd-76d53904fe49" /> | <img width="318" alt="Screenshot 2025-04-02 at 4 31 33 PM" src="https://github.com/user-attachments/assets/4591691a-7276-449a-9629-fe20fa80fe01" />


This is the bug the Firefox spacing fix was there for: https://github.com/Automattic/jetpack/issues/32837
I can't replicate it on the latest version of Firefox, only version 117 (which was 20 versions ago). We support the latest two versions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test on Simple, Atomic, and Jetpack following [the instructions below](https://github.com/Automattic/jetpack/pull/42869#issuecomment-2773262894).

* Go the site or post editor.
* Add the Subscribe block.
* Add a long subscribe button copy and restrict the width of the group the block's in (or change the spacing width to 25%).
* You'll see the text wrap like in the before screenshot.
* Apply this change and repeat. You should see the text stay inline like on the front-end.
* Check that you can still type a space in the button copy, on Firefox.

