### PR TITLE
Forms: Add consent toggle to Creative Mail card

### DIFF
--- a/projects/packages/forms/changelog/update-move-creative-mail-consent-toggle
+++ b/projects/packages/forms/changelog/update-move-creative-mail-consent-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Add consent toggle to Creative Mail card.


### PR DESCRIPTION
## Proposed changes:

NOTE: This is one of many PRs to create the new third party integrations modal. All this work is behind a feature flag and only be visible if you set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.

Changes:
* In the Creative Mail block panel, there was a button to add a 'consent' block before the submit button. This code will be deleted once the integrations modal is launched. 
* I've added the same logic to the new CreateiveMailCard in the integrations modal.
* As part of this, we updated it from a button to a toggle. Before you'd click the button, the consent block would be added, and the button would disappear forever. Now you can toggle to add/remove the consent block. 

This new code will effectively [replace this file](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/forms/src/blocks/contact-form/components/jetpack-newsletter-integration-settings-consent-block.js), which will be deleted when the integrations modal is launched. 

**Creative Mail Card with consent toggle**
<img width="1407" alt="creative-mail-consent-toggle" src="https://github.com/user-attachments/assets/8941ba6c-e36e-4f7a-b4b2-b47e284d2a54" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.
- Add a form block to a page - with an email field
- With the Form block selected scroll down so you can see the submit button.
- Click on the Manage Integrations button the block sidebar
- Open the Creative Mail panel
   - Confirm the toggle renders like in the screenshot above
   - Click the toggle on/off and confirm you can see a consent block appear/disappear on the page just above the submit button. 
   - Also try removing the email field from the form and confirm that the toggle does not show in that case