### PR TITLE
Tests: Check for assets file before including it

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-tests-prevent_include_on_missing_file
+++ b/projects/plugins/jetpack/changelog/fix-tests-prevent_include_on_missing_file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Tests: Prevent warning when asset file doesn't exist.

--- a/projects/plugins/jetpack/modules/photon-cdn.php
+++ b/projects/plugins/jetpack/modules/photon-cdn.php
@@ -226,7 +226,7 @@ class Jetpack_Photon_Static_Assets_CDN {
 	 */
 	public static function get_plugin_assets( $plugin, $version ) {
 		if ( 'jetpack' === $plugin && JETPACK__VERSION === $version ) {
-			if ( ! self::is_public_version( $version ) ) {
+			if ( ! self::is_public_version( $version ) || ! file_exists( JETPACK__PLUGIN_DIR . 'modules/photon-cdn/jetpack-manifest.php' ) ) {
 				return false;
 			}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In #42314, a bunch of tests were added (yay!) but when Jetpack was bumped to a stable version, a file that the test called tried to include a file that didn't exist during tests, which resulted in PHP warnings and test failures.

This adds a check to ensure the file exists before trying to include it.

See thread for more details: p1743622279996059-slack-C01U2KGS2PQ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Does `jetpack docker phpunit-jp-multisite` pass with no warnings?