### PR TITLE
Forms: Use single endpoint request for all integration data

### DIFF
--- a/projects/packages/forms/changelog/add-forms-all-integrations-endpoint
+++ b/projects/packages/forms/changelog/add-forms-all-integrations-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add endpoint for all integrations.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-panel.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-panel.js
@@ -1,6 +1,8 @@
+import apiFetch from '@wordpress/api-fetch';
 import { Button } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useState, useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { createNotice } from '@wordpress/notices';
 import IntegrationsModal from './jetpack-integrations-modal';
 
 /**
@@ -13,6 +15,26 @@ import IntegrationsModal from './jetpack-integrations-modal';
  */
 export default function IntegrationPanel( { attributes, setAttributes } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const [ integrationsData, setIntegrationsData ] = useState( {} );
+
+	const refreshIntegrations = useCallback( async () => {
+		try {
+			const response = await apiFetch( {
+				path: '/wp/v2/feedback/integrations',
+			} );
+			setIntegrationsData( response );
+		} catch {
+			createNotice(
+				'error',
+				__( 'Failed to fetch integrations. Please try again later.', 'jetpack-forms' )
+			);
+		}
+	}, [] );
+
+	// Fetch integrations data when the panel is mounted
+	useEffect( () => {
+		refreshIntegrations();
+	}, [ refreshIntegrations ] );
 
 	return (
 		<div className="jetpack-forms-integration-panel">
@@ -28,6 +50,8 @@ export default function IntegrationPanel( { attributes, setAttributes } ) {
 				onClose={ () => setIsModalOpen( false ) }
 				attributes={ attributes }
 				setAttributes={ setAttributes }
+				integrationsData={ integrationsData }
+				refreshIntegrations={ refreshIntegrations }
 			/>
 		</div>
 	);

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
@@ -3,20 +3,18 @@ import { Button, ExternalLink, Icon, Spinner } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import AkismetIcon from '../../../../icons/akismet-icon';
-import { useIntegrationStatus, usePluginInstallation } from '../hooks';
+import { usePluginInstallation } from '../hooks';
 import IntegrationCard from './integration-card';
 
-const AkismetCard = ( { isExpanded, onToggle } ) => {
+const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 	const formSubmissionsUrl = window?.jpFormsBlocks?.defaults?.formsAdminUrl || '';
 
 	const {
-		isCheckingStatus,
-		isInstalled,
-		isActive,
-		isConnected: akismetActiveWithKey,
-		settingsUrl,
-		refreshStatus,
-	} = useIntegrationStatus( 'akismet' );
+		isInstalled = false,
+		isActive = false,
+		isConnected: akismetActiveWithKey = false,
+		settingsUrl = '',
+	} = data || {};
 
 	const { isInstalling, installPlugin } = usePluginInstallation(
 		'akismet',
@@ -42,7 +40,7 @@ const AkismetCard = ( { isExpanded, onToggle } ) => {
 	};
 
 	const renderContent = () => {
-		if ( isCheckingStatus ) {
+		if ( ! data ) {
 			return <Spinner />;
 		}
 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
@@ -1,12 +1,11 @@
 import { Button, ExternalLink, Spinner, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useIntegrationStatus, usePluginInstallation } from '../hooks';
+import { usePluginInstallation } from '../hooks';
 import ConsentBlockSettings from '../jetpack-newsletter-integration-settings-consent-block';
 import IntegrationCard from './integration-card';
 
-const CreativeMailCard = ( { isExpanded, onToggle } ) => {
-	const { isCheckingStatus, isInstalled, isActive, settingsUrl, refreshStatus } =
-		useIntegrationStatus( 'creative-mail' );
+const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
+	const { isInstalled = false, isActive = false, settingsUrl = '' } = data || {};
 
 	const { isInstalling, installPlugin } = usePluginInstallation(
 		'creative-mail-by-constant-contact',
@@ -32,7 +31,7 @@ const CreativeMailCard = ( { isExpanded, onToggle } ) => {
 	};
 
 	const renderContent = () => {
-		if ( isCheckingStatus ) {
+		if ( ! data ) {
 			return <Spinner />;
 		}
 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.js
@@ -5,7 +5,14 @@ import AkismetCard from './akismet-card';
 import CreativeMailCard from './creative-mail-card';
 import JetpackCRMCard from './jetpack-crm-card';
 
-const IntegrationsModal = ( { isOpen, onClose, attributes, setAttributes } ) => {
+const IntegrationsModal = ( {
+	isOpen,
+	onClose,
+	attributes,
+	setAttributes,
+	integrationsData,
+	refreshIntegrations,
+} ) => {
 	const [ expandedCards, setExpandedCards ] = useState( {
 		akismet: false,
 		crm: false,
@@ -33,16 +40,22 @@ const IntegrationsModal = ( { isOpen, onClose, attributes, setAttributes } ) => 
 				<AkismetCard
 					isExpanded={ expandedCards.akismet }
 					onToggle={ () => toggleCard( 'akismet' ) }
+					data={ integrationsData?.akismet }
+					refreshStatus={ refreshIntegrations }
 				/>
 				<JetpackCRMCard
 					isExpanded={ expandedCards.crm }
 					onToggle={ () => toggleCard( 'crm' ) }
 					jetpackCRM={ attributes.jetpackCRM }
 					setAttributes={ setAttributes }
+					data={ integrationsData?.[ 'jetpack-crm' ] }
+					refreshStatus={ refreshIntegrations }
 				/>
 				<CreativeMailCard
 					isExpanded={ expandedCards.creativemail }
 					onToggle={ () => toggleCard( 'creativemail' ) }
+					data={ integrationsData?.[ 'creative-mail' ] }
+					refreshStatus={ refreshIntegrations }
 				/>
 			</div>
 		</Modal>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
@@ -4,22 +4,27 @@ import { Button, Icon, Spinner, ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import semver from 'semver';
-import { useIntegrationStatus, usePluginInstallation } from '../hooks';
+import { usePluginInstallation } from '../hooks';
 import IntegrationCard from './integration-card';
 
 const COLOR_JETPACK = colorStudio.colors[ 'Jetpack Green 40' ];
 
-const JetpackCRMCard = ( { isExpanded, onToggle, jetpackCRM, setAttributes } ) => {
+const JetpackCRMCard = ( {
+	isExpanded,
+	onToggle,
+	jetpackCRM,
+	setAttributes,
+	data,
+	refreshStatus,
+} ) => {
 	const {
-		isCheckingStatus,
-		isInstalled,
-		isActive,
-		settingsUrl,
-		hasExtension,
-		canActivateExtension,
-		version,
-		refreshStatus,
-	} = useIntegrationStatus( 'jetpack-crm' );
+		isInstalled = false,
+		isActive = false,
+		settingsUrl = '',
+		hasExtension = false,
+		canActivateExtension = false,
+		version = '',
+	} = data || {};
 
 	const { isInstalling, installPlugin } = usePluginInstallation(
 		'zero-bs-crm',
@@ -48,7 +53,7 @@ const JetpackCRMCard = ( { isExpanded, onToggle, jetpackCRM, setAttributes } ) =
 	const isRecentVersion = crmVersion && semver.gte( crmVersion, '4.9.1' );
 
 	const renderContent = () => {
-		if ( isCheckingStatus ) {
+		if ( ! data ) {
 			return <Spinner />;
 		}
 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
@@ -21,10 +21,11 @@ const JetpackCRMCard = ( {
 		isInstalled = false,
 		isActive = false,
 		settingsUrl = '',
-		hasExtension = false,
-		canActivateExtension = false,
 		version = '',
+		details = {},
 	} = data || {};
+
+	const { hasExtension = false, canActivateExtension = false } = details;
 
 	const { isInstalling, installPlugin } = usePluginInstallation(
 		'zero-bs-crm',

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -18,6 +18,38 @@ use WP_REST_Response;
  */
 class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	/**
+	 * Supported integrations configuration
+	 *
+	 * @var array
+	 */
+	private $supported_integrations = array(
+		'akismet'       => array(
+			'type'         => 'plugin',
+			'file'         => 'akismet/akismet.php',
+			'settings_url' => 'admin.php?page=akismet-key-config',
+		),
+		'creative-mail' => array(
+			'type'         => 'plugin',
+			'file'         => 'creative-mail-by-constant-contact/creative-mail-plugin.php',
+			'settings_url' => 'admin.php?page=creativemail',
+		),
+		'jetpack-crm'   => array(
+			'type'         => 'plugin',
+			'file'         => 'zero-bs-crm/ZeroBSCRM.php',
+			'settings_url' => 'admin.php?page=zerobscrm-plugin-settings',
+		),
+	);
+
+	/**
+	 * Get filtered list of supported integrations
+	 *
+	 * @return array Filtered list of supported integrations
+	 */
+	private function get_supported_integrations() {
+		return apply_filters( 'jetpack_forms_supported_integrations', $this->supported_integrations );
+	}
+
+	/**
 	 * Registers the REST routes.
 	 *
 	 * @access public
@@ -34,12 +66,23 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			)
 		);
 
+		// Register integrations routes
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/integrations',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_all_integrations_status' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+			)
+		);
+
 		register_rest_route(
 			$this->namespace,
 			$this->rest_base . '/integrations/(?P<slug>[\w-]+)',
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_integration_status' ),
+				'callback'            => array( $this, 'get_single_integration_status' ),
 				'permission_callback' => array( $this, 'get_items_permissions_check' ),
 				'args'                => array(
 					'slug' => array(
@@ -47,7 +90,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 						'required'          => true,
 						'sanitize_callback' => 'sanitize_text_field',
 						'validate_callback' => function ( $param ) {
-							return preg_match( '/^[\w-]+$/', $param );
+							return isset( $this->get_supported_integrations()[ $param ] );
 						},
 					),
 				),
@@ -554,71 +597,44 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	}
 
 	/**
-	 * Get the status of a forms integration.
+	 * Get status for all supported integrations.
 	 *
-	 * @param WP_REST_Request $request The request object.
-	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 * @return WP_REST_Response Response object.
 	 */
-	public function get_integration_status( WP_REST_Request $request ) {
-		$slug = $request->get_param( 'slug' );
+	public function get_all_integrations_status() {
+		$integrations = array();
 
-		switch ( $slug ) {
-			case 'akismet':
-				return $this->get_akismet_status();
-
-			case 'creative-mail':
-				return $this->get_plugin_status( $slug );
-
-			case 'jetpack-crm':
-				return $this->get_jetpack_crm_status();
-
-			default:
-				return new WP_Error(
-					'invalid_integration',
-					/* translators: %s: integration slug */
-					sprintf( __( 'Unknown integration: %s', 'jetpack-forms' ), $slug )
-				);
+		foreach ( array_keys( $this->get_supported_integrations() ) as $slug ) {
+			$integrations[ $slug ] = $this->get_plugin_status( $slug );
 		}
+
+		return rest_ensure_response( $integrations );
+	}
+
+	/**
+	 * REST endpoint handler for single integration status.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function get_single_integration_status( $request ) {
+		$slug = $request->get_param( 'slug' );
+		return rest_ensure_response( $this->get_plugin_status( $slug ) );
 	}
 
 	/**
 	 * Get plugin status.
 	 *
 	 * @param string $plugin_slug Plugin slug.
-	 * @return WP_REST_Response Response object.
+	 * @return array Plugin status data.
 	 */
 	private function get_plugin_status( $plugin_slug ) {
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		$plugin_configs = array(
-			'akismet'       => array(
-				'file'         => 'akismet/akismet.php',
-				'settings_url' => 'admin.php?page=akismet-key-config',
-			),
-			'creative-mail' => array(
-				'file'         => 'creative-mail-by-constant-contact/creative-mail-plugin.php',
-				'settings_url' => 'admin.php?page=creativemail',
-			),
-			'jetpack-crm'   => array(
-				'file'         => 'zero-bs-crm/ZeroBSCRM.php',
-				'settings_url' => 'admin.php?page=zerobscrm-plugin-settings',
-			),
-		);
-
-		$plugin_config = $plugin_configs[ $plugin_slug ] ?? null;
-		if ( empty( $plugin_config ) ) {
-			return rest_ensure_response(
-				array(
-					'type'        => 'plugin',
-					'isInstalled' => false,
-					'isActive'    => false,
-					/* translators: %s: plugin slug */
-					'error'       => sprintf( __( 'Unknown plugin: %s', 'jetpack-forms' ), $plugin_slug ),
-				)
-			);
-		}
+		$integrations  = $this->get_supported_integrations();
+		$plugin_config = $integrations[ $plugin_slug ];
 
 		$installed_plugins = get_plugins();
 		$is_installed      = isset( $installed_plugins[ $plugin_config['file'] ] );
@@ -628,61 +644,23 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'type'        => 'plugin',
 			'isInstalled' => $is_installed,
 			'isActive'    => $is_active,
+			'isConnected' => false,
+			'version'     => $is_installed ? $installed_plugins[ $plugin_config['file'] ]['Version'] : null,
+			'settingsUrl' => $is_active ? admin_url( $plugin_config['settings_url'] ) : null,
+			'details'     => array(),
 		);
 
-		if ( $is_installed ) {
-			$response['version'] = $installed_plugins[ $plugin_config['file'] ]['Version'];
-		}
-
-		if ( $is_active ) {
-			$response['settingsUrl'] = admin_url( $plugin_config['settings_url'] );
-		}
-
-		return rest_ensure_response( $response );
-	}
-
-	/**
-	 * Get Akismet plugin status including key configuration.
-	 *
-	 * @return WP_REST_Response Response object.
-	 */
-	public function get_akismet_status() {
-		$plugin_status = $this->get_plugin_status( 'akismet' );
-		$status_data   = $plugin_status->get_data();
-
-		return rest_ensure_response(
-			array_merge(
-				$status_data,
-				array(
-					'isConnected' => class_exists( 'Jetpack' ) && \Jetpack::is_akismet_active(),
-				)
-			)
-		);
-	}
-
-	/**
-	 * Get Jetpack CRM plugin status and extension data.
-	 *
-	 * @return WP_REST_Response Plugin status data.
-	 */
-	public function get_jetpack_crm_status() {
-		$plugin_status = $this->get_plugin_status( 'jetpack-crm' );
-		$status_data   = $plugin_status->get_data();
-
-		if ( $status_data['isActive'] ) {
-			$has_extension = function_exists( 'zeroBSCRM_isExtensionInstalled' ) && zeroBSCRM_isExtensionInstalled( 'jetpackforms' ); // @phan-suppress-current-line PhanUndeclaredFunction -- We're checking the function exists first
-
-			return rest_ensure_response(
-				array_merge(
-					$status_data,
-					array(
-						'hasExtension'         => $has_extension,
-						'canActivateExtension' => current_user_can( 'manage_options' ),
-					)
-				)
+		// Plugin-specific customizations
+		if ( 'akismet' === $plugin_slug ) {
+			$response['isConnected'] = class_exists( 'Jetpack' ) && \Jetpack::is_akismet_active();
+		} elseif ( 'jetpack-crm' === $plugin_slug && $is_active ) {
+			$has_extension       = function_exists( 'zeroBSCRM_isExtensionInstalled' ) && zeroBSCRM_isExtensionInstalled( 'jetpackforms' ); // @phan-suppress-current-line PhanUndeclaredFunction -- We're checking the function exists first
+			$response['details'] = array(
+				'hasExtension'         => $has_extension,
+				'canActivateExtension' => current_user_can( 'manage_options' ),
 			);
 		}
 
-		return $plugin_status;
+		return $response;
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -605,6 +605,8 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		$integrations = array();
 
 		foreach ( array_keys( $this->get_supported_integrations() ) as $slug ) {
+			// For now, we only have plugin integrations.
+			// When needed, handle other integration types here.
 			$integrations[ $slug ] = $this->get_plugin_status( $slug );
 		}
 
@@ -618,7 +620,10 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * @return WP_REST_Response Response object.
 	 */
 	public function get_single_integration_status( $request ) {
+		// Slug validation is handled in endpoint registration.
 		$slug = $request->get_param( 'slug' );
+		// For now, we only have plugin integrations.
+		// When needed, handle other integration types here.
 		return rest_ensure_response( $this->get_plugin_status( $slug ) );
 	}
 

--- a/projects/plugins/jetpack/changelog/add-forms-all-integrations-endpoint
+++ b/projects/plugins/jetpack/changelog/add-forms-all-integrations-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Add endpoint for all integrations. 


### PR DESCRIPTION
## Proposed changes:

NOTE: This is one of many PRs to create the new third party integrations modal. All this work is behind a feature flag and only be visible if you set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.

Changes:
* Adds a new /integrations endpoint that allow us to fetch data and status for all integrations at once.
* Update jetpack integration modal to use this endpoint. Data is fetched by the integrations panel on the side bar when a form block is added or selected. The data and a refresh method is passed from the panel to the modal to the individual cards for each integration. 
* This reduces requests: 1 request total vs 1 request for each integration
* Because data is prefetched by the panel, there is no latency or spinners when opening the modal

**React query in future.** Eventually, I think we should cache this request with react query, so it is not run each time someone closes then opens the modal again. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The modal should behave the same as it did before this refactor, but without seeing loading spinners for individual integrations. 
- Set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.
- Add a form block to a page - with an email field
- Click on the Manage Integrations button the block sidebar
- Confirm the modal loads as expected
- Open the Akismet panel and confirm it loads as expected. Try loading this page when the plugin is deactivated or uninstalled and verify you see the button to install/activate, it works, and state updates correctly 
- Open the Jetpack CRM panel and confirm it loads as expected. Try loading this page when the plugin is deactivated or uninstalled and verify you see the button to install/activate, it works, and state updates correctly 
- Open the Creative Mail panel and confirm it loads as expected. Try loading this page when the plugin is deactivated or uninstalled and verify you see the button to install/activate, it works, and state updates correctly 