### PR TITLE
Stylelint: Update the config to allow `:global` pseudo selector

### DIFF
--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -1,3 +1,6 @@
+/**
+ * @type {import('stylelint').Config}
+ */
 const config = {
 	extends: 'jetpack-js-tools/stylelint.config.base.mjs',
 };

--- a/tools/js-tools/stylelint.config.base.mjs
+++ b/tools/js-tools/stylelint.config.base.mjs
@@ -1,7 +1,18 @@
 import { fileURLToPath } from 'node:url';
 
+/**
+ * @type {import('stylelint').Config}
+ */
 const baseConfig = {
 	extends: fileURLToPath( import.meta.resolve( '@wordpress/stylelint-config/scss' ) ),
+	rules: {
+		'selector-pseudo-class-no-unknown': [
+			true,
+			{
+				ignorePseudoClasses: [ 'global' ],
+			},
+		],
+	},
 };
 
 export default baseConfig;


### PR DESCRIPTION
When using CSS modules, we often need to target the selectors for external components. For that, we use [`:global()` pseudo selector](https://github.com/css-modules/css-modules/blob/c7bf6c02472fdce4dd8e569abc10d2aeb234e1c2/docs/composition.md#exceptions).

By default, the [`selector-pseudo-class-no-unknown`](https://stylelint.io/user-guide/rules/selector-pseudo-class-no-unknown/) rule reports that `:global` pseudo selector as unknown and thus shows an error.

Since the Jetpack repo extensively uses CSS modules, we can ignore the errors for `:global`

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disable stylelint errors reported for the usage of `:global` pseudo selector

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Reload the IDE like VS Code
* Open any CSS file that has `:global`, like `js-packages/publicize-components/src/components/post-publish-share-status/styles.module.scss`
* Confirm that you don't see the error about `:global` being an unknown pseudo selector
* Add an unknown pseudo selector like this
```scss
:unknown(.test) {
    color: #fff;
}
```
* Confirm that it still reports an error for that pseudo selector

| BEFORE | AFTER |
|--------|--------|
| <img width="930" alt="Screenshot 2025-04-03 at 11 25 35 AM" src="https://github.com/user-attachments/assets/c10ce0a4-43b5-49f9-b2af-21f2625b00dd" /> | <img width="929" alt="Screenshot 2025-04-03 at 11 25 10 AM" src="https://github.com/user-attachments/assets/20c9f95e-1313-47a2-a8d4-a52e66e86ba1" /> | 
