### PR TITLE
Forms: Fix responses management compatibility with 6.6

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dataviews-with-6-6
+++ b/projects/packages/forms/changelog/fix-forms-dataviews-with-6-6
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix responses management compatibility with 6.6

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -87,15 +87,9 @@ function getStatusFilter( urlStatus ) {
 export default function InboxView() {
 	const [ view, setView ] = useView();
 	const [ searchParams, setSearchParams ] = useSearchParams();
-	const [ containerWidth, setContainerWidth ] = useState( 0 );
 	const [ queryArgs, setQueryArgs ] = useState( EMPTY_OBJECT );
 	const dateSettings = getDateSettings();
-	const containerRef = useResizeObserver(
-		resizeObserverEntries => {
-			setContainerWidth( resizeObserverEntries[ 0 ].borderBoxSize[ 0 ].inlineSize );
-		},
-		{ box: 'border-box' }
-	);
+	const [ resizeListener, { width: containerWidth } ] = useResizeObserver();
 	const isMobile = containerWidth <= MOBILE_BREAKPOINT;
 	const { setCurrentQuery, setSelectedResponses } = useDispatch( dashboardStore );
 	const selectedResponses = searchParams.get( 'r' );
@@ -285,9 +279,9 @@ export default function InboxView() {
 			spacing={ 5 }
 			alignment="top"
 			justify="flex-start"
-			ref={ containerRef }
 			className="jp-forms__inbox__dataviews__container"
 		>
+			{ resizeListener }
 			<div className="jp-forms__inbox__dataviews">
 				<DataViews
 					paginationInfo={ paginationInfo }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes:  https://github.com/Automattic/jetpack/issues/42873


When we merged: https://github.com/Automattic/jetpack/pull/41602, there were a couple of [issues](https://github.com/WordPress/gutenberg/blob/trunk/packages/compose/CHANGELOG.md#780-2024-09-19) that broke back compat with  WP `6.6` version.

This PR fixes these.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Test form responses management screen thoroughly that everything works as expected
2. Test especially that updating the `search` either from the URL or the search input in DataViews is working well and is synced (URL, input, and shown results)
3. Test the the `view response` action is only added for smaller viewports (the breakpoint is 780px for DataViews container).
4. Check for `6.6`, `6.7` and `6.8` versions

