### PR TITLE
[WIP] Forms: Create new base blocks to enable Global Styles support JETPACK-261

### DIFF
--- a/projects/packages/forms/changelog/add-new-form-field-blocks
+++ b/projects/packages/forms/changelog/add-new-form-field-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add label, input, option, and options blocks for improving form fields

--- a/projects/packages/forms/src/blocks/input/edit.js
+++ b/projects/packages/forms/src/blocks/input/edit.js
@@ -1,0 +1,113 @@
+import { InspectorControls, RichText, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, __experimentalNumberControl as NumberControl } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { clsx } from 'clsx';
+import useInsertAfterOnEnterKeyDown from '../shared/hooks/use-insert-after-on-enter-key-down';
+import useSyncStyleAttributes from '../shared/hooks/use-sync-style-attributes';
+import { ALLOWED_FORMATS } from '../shared/util/constants.js';
+
+const SYNCED_ATTRIBUTES = [
+	'backgroundColor',
+	'borderColor',
+	'fontFamily',
+	'fontSize',
+	'style',
+	'textColor',
+];
+
+const TEXT_FIELDS = [ 'number', 'text', 'email', 'url', 'tel' ];
+
+const getInputClass = type => {
+	if ( type === 'dropdown' ) {
+		return 'jetpack-field-dropdown__toggle';
+	}
+	if ( type && ! TEXT_FIELDS.includes( type ) ) {
+		return `jetpack-field__${ type }`;
+	}
+	return 'jetpack-field__input';
+};
+
+const InputEdit = ( { attributes, clientId, isSelected, name, setAttributes } ) => {
+	useSyncStyleAttributes( clientId, name, 'jetpack/contact-form', SYNCED_ATTRIBUTES );
+
+	const { max, min, placeholder, type } = attributes;
+	const className = clsx( getInputClass( attributes.type ), {
+		inline: type === 'checkbox' || type === 'radio',
+	} );
+	const blockProps = useBlockProps( { className } );
+	const onKeyDown = useInsertAfterOnEnterKeyDown( clientId );
+
+	const onChange = useCallback(
+		event => {
+			setAttributes( { placeholder: event.target.value } );
+		},
+		[ setAttributes ]
+	);
+
+	if ( type === 'dropdown' ) {
+		return (
+			<div { ...blockProps }>
+				<RichText
+					allowedFormats={ ALLOWED_FORMATS }
+					onChange={ onChange }
+					value={ placeholder ? placeholder : __( 'Select one option', 'jetpack-forms' ) }
+					withoutInteractiveFormatting
+				/>
+				<span className="jetpack-field-dropdown__icon" />
+			</div>
+		);
+	}
+
+	if ( type === 'textarea' ) {
+		return <textarea { ...blockProps } onChange={ onChange } value={ placeholder } />;
+	}
+
+	return (
+		<>
+			<input
+				{ ...blockProps }
+				onChange={ onChange }
+				onKeyDown={ onKeyDown }
+				type="text"
+				value={ isSelected ? placeholder : '' }
+				placeholder={ placeholder }
+			/>
+			{ type === 'number' && (
+				<InspectorControls>
+					<PanelBody title={ __( 'Settings', 'jetpack-forms' ) }>
+						<NumberControl
+							key="min"
+							label={ __( 'Minimum value', 'jetpack-forms' ) }
+							value={ min }
+							onChange={ value => setAttributes( { min: value } ) }
+							max={ max }
+							__nextHasNoMarginBottom={ true }
+							__next40pxDefaultSize={ true }
+							help={ __(
+								'The minimum value to accept in the input. Leaving empty allows any negative and positive values.',
+								'jetpack-forms'
+							) }
+						/>
+						<NumberControl
+							key="max"
+							label={ __( 'Maximum value', 'jetpack-forms' ) }
+							value={ attributes.max }
+							onChange={ value =>
+								setAttributes( {
+									max: value,
+								} )
+							}
+							min={ min }
+							__nextHasNoMarginBottom={ true }
+							__next40pxDefaultSize={ true }
+							help={ __( 'The maximum value to accept in the input.', 'jetpack-forms' ) }
+						/>
+					</PanelBody>
+				</InspectorControls>
+			) }
+		</>
+	);
+};
+
+export default InputEdit;

--- a/projects/packages/forms/src/blocks/input/index.js
+++ b/projects/packages/forms/src/blocks/input/index.js
@@ -1,0 +1,74 @@
+import { __ } from '@wordpress/i18n';
+import edit from './edit';
+import save from './save';
+
+const name = 'input';
+const settings = {
+	apiVersion: 3,
+	title: __( 'Input', 'jetpack-forms' ),
+	description: __( 'An input for a form field', 'jetpack-forms' ),
+	category: 'contact-form',
+	parent: [
+		'jetpack/field-date',
+		'jetpack/field-email',
+		'jetpack/field-name',
+		'jetpack/field-number',
+		'jetpack/field-select',
+		'jetpack/field-telephone',
+		'jetpack/field-text',
+		'jetpack/field-textarea',
+	],
+	supports: {
+		reusable: false,
+		html: false,
+		color: {
+			text: true,
+			background: true,
+			gradient: true,
+		},
+		__experimentalBorder: {
+			color: true,
+			radius: true,
+			style: true,
+			width: true,
+			__experimentalDefaultControls: {
+				color: true,
+				radius: true,
+				style: true,
+				width: true,
+			},
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+			},
+		},
+	},
+	attributes: {
+		placeholder: {
+			type: 'string',
+			default: '',
+		},
+		type: {
+			type: 'string',
+			default: '',
+		},
+		min: { type: 'number' },
+		max: { type: 'number' },
+	},
+	edit,
+	save,
+};
+
+export default {
+	name,
+	settings,
+};

--- a/projects/packages/forms/src/blocks/input/save.js
+++ b/projects/packages/forms/src/blocks/input/save.js
@@ -1,0 +1,1 @@
+export default () => null;

--- a/projects/packages/forms/src/blocks/label/edit.js
+++ b/projects/packages/forms/src/blocks/label/edit.js
@@ -1,0 +1,74 @@
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import { clsx } from 'clsx';
+import useSyncStyleAttributes from '../shared/hooks/use-sync-style-attributes';
+import { ALLOWED_FORMATS, DATE_FORMATS, FORM_STYLE } from '../shared/util/constants.js';
+import getBlockStyle from '../shared/util/get-block-style.js';
+
+const SYNCED_ATTRIBUTES = [ 'textColor', 'fontFamily', 'fontSize', 'style' ];
+
+const WithNotchedWrapper = ( { formStyle, children } ) => {
+	if ( formStyle === FORM_STYLE.OUTLINED ) {
+		return (
+			<div className="notched-label">
+				<div className="notched-label__leading" />
+				<div className="notched-label__notch">{ children }</div>
+				<div className="notched-label__trailing" />
+			</div>
+		);
+	}
+
+	return <>{ children }</>;
+};
+
+const LabelEdit = ( { attributes, clientId, name, setAttributes, context } ) => {
+	useSyncStyleAttributes( clientId, name, 'jetpack/contact-form', SYNCED_ATTRIBUTES );
+
+	const {
+		'jetpack/form-className': formClassName,
+		'jetpack/field-required': required,
+		'jetpack/field-dateFormat': dateFormat,
+	} = context;
+	const { label, defaultLabel, requiredText } = attributes;
+
+	const placeholder = defaultLabel ?? label ?? __( 'Add label…', 'jetpack-forms' );
+	const suffix = dateFormat
+		? `(${ DATE_FORMATS.find( f => f.value === dateFormat )?.label })`
+		: undefined;
+	const formStyle = getBlockStyle( formClassName );
+	const className = clsx( 'jetpack-field-label', {
+		'notched-label__label': formStyle === FORM_STYLE.OUTLINED,
+		'animated-label__label': formStyle === FORM_STYLE.ANIMATED,
+		'below-label__label': formStyle === FORM_STYLE.BELOW,
+	} );
+	const blockProps = useBlockProps( { className } );
+
+	return (
+		<WithNotchedWrapper formStyle={ formStyle }>
+			<div { ...blockProps }>
+				<RichText
+					allowedFormats={ ALLOWED_FORMATS }
+					className="jetpack-field-label__input"
+					onChange={ value => setAttributes( { label: value } ) }
+					placeholder={ placeholder }
+					tagName="label"
+					value={ label }
+					withoutInteractiveFormatting
+				/>
+				{ suffix && <span className="jetpack-field-label__suffix">{ suffix }</span> }
+				{ required && (
+					<RichText
+						allowedFormats={ ALLOWED_FORMATS }
+						className="required"
+						onChange={ value => setAttributes( { requiredText: value } ) }
+						tagName="span"
+						value={ requiredText || __( '(required)', 'jetpack-forms' ) }
+						withoutInteractiveFormatting
+					/>
+				) }
+			</div>
+		</WithNotchedWrapper>
+	);
+};
+
+export default LabelEdit;

--- a/projects/packages/forms/src/blocks/label/edit.js
+++ b/projects/packages/forms/src/blocks/label/edit.js
@@ -49,7 +49,7 @@ const LabelEdit = ( { attributes, clientId, name, setAttributes, context } ) => 
 				<RichText
 					allowedFormats={ ALLOWED_FORMATS }
 					className="jetpack-field-label__input"
-					onChange={ value => setAttributes( { label: value } ) }
+					onChange={ value => setAttributes( { label: value || undefined } ) }
 					placeholder={ placeholder }
 					tagName="label"
 					value={ label }

--- a/projects/packages/forms/src/blocks/label/index.js
+++ b/projects/packages/forms/src/blocks/label/index.js
@@ -43,7 +43,6 @@ const settings = {
 		},
 	},
 	attributes: {
-		// TODO: Make sure previous empty string defaults aren't required and confirm no empty strings in persisted block attributes.
 		label: {
 			type: 'string',
 		},

--- a/projects/packages/forms/src/blocks/label/index.js
+++ b/projects/packages/forms/src/blocks/label/index.js
@@ -1,0 +1,65 @@
+import { __ } from '@wordpress/i18n';
+import edit from './edit';
+import save from './save';
+
+const name = 'label';
+const settings = {
+	apiVersion: 3,
+	title: __( 'Label', 'jetpack-forms' ),
+	description: __( 'A label for a form field', 'jetpack-forms' ),
+	category: 'contact-form',
+	parent: [
+		'jetpack/field-date',
+		'jetpack/field-email',
+		'jetpack/field-multiple-choice',
+		'jetpack/field-name',
+		'jetpack/field-number',
+		'jetpack/field-select',
+		'jetpack/field-single-choice',
+		'jetpack/field-telephone',
+		'jetpack/field-text',
+		'jetpack/field-textarea',
+	],
+	supports: {
+		reusable: false,
+		html: false,
+		color: {
+			text: true,
+			background: false,
+			gradient: false,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+			},
+		},
+	},
+	attributes: {
+		// TODO: Make sure previous empty string defaults aren't required and confirm no empty strings in persisted block attributes.
+		label: {
+			type: 'string',
+		},
+		defaultLabel: {
+			type: 'string',
+		},
+		requiredText: {
+			type: 'string',
+		},
+	},
+	usesContext: [ 'jetpack/form-className', 'jetpack/field-required', 'jetpack/field-dateFormat' ],
+	edit,
+	save,
+};
+
+export default {
+	name,
+	settings,
+};

--- a/projects/packages/forms/src/blocks/label/save.js
+++ b/projects/packages/forms/src/blocks/label/save.js
@@ -1,0 +1,1 @@
+export default () => null;

--- a/projects/packages/forms/src/blocks/option/edit.js
+++ b/projects/packages/forms/src/blocks/option/edit.js
@@ -1,0 +1,104 @@
+import { RichText, store as blockEditorStore, useBlockProps } from '@wordpress/block-editor';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import useSyncStyleAttributes from '../shared/hooks/use-sync-style-attributes';
+import { ALLOWED_FORMATS } from '../shared/util/constants';
+import useEnter from './use-enter';
+
+const SYNCED_ATTRIBUTES = [ 'textColor', 'fontFamily', 'fontSize', 'style' ];
+
+const OptionEdit = ( { attributes, clientId, context, name, setAttributes } ) => {
+	const {
+		'jetpack/field-defaultValue': defaultValue,
+		'jetpack/field-options-type': type = 'checkbox',
+		'jetpack/field-required': required,
+	} = context;
+	const { hideInput, label, isStandalone, requiredText } = attributes;
+
+	useSyncStyleAttributes( clientId, name, 'jetpack/contact-form', SYNCED_ATTRIBUTES );
+
+	const { removeBlock } = useDispatch( blockEditorStore );
+	const siblingsCount = useSelect(
+		select => {
+			const { getBlockCount, getBlockRootClientId } = select( blockEditorStore );
+			return getBlockCount( getBlockRootClientId( clientId ) );
+		},
+		[ clientId ]
+	);
+
+	const onRemove = () => {
+		if ( siblingsCount <= 1 ) {
+			return;
+		}
+
+		removeBlock( clientId );
+	};
+
+	const blockProps = useBlockProps( {
+		className: `jetpack-field-option field-option-${ type }`,
+	} );
+
+	const useEnterRef = useEnter( { content: label, clientId, isStandalone } );
+	const useEnterRequiredRef = useEnter( { content: label, clientId, isStandalone } );
+
+	// Some fields such as Checkbox or Consent, do not have a list of options.
+	// Additionally, a checkbox field may also be flagged as required so we need
+	// to allow for custom required text.
+	if ( isStandalone ) {
+		return (
+			<div { ...blockProps }>
+				{ ! hideInput && (
+					<input
+						className="jetpack-field-checkbox__checkbox"
+						checked={ !! defaultValue }
+						disabled
+						type={ type }
+					/>
+				) }
+				<div className="jetpack-field-option__label-wrapper">
+					<RichText
+						ref={ useEnterRef }
+						identifier="label"
+						tagName="div"
+						className="wp-block"
+						value={ label }
+						placeholder={ __( 'Add label…', 'jetpack-forms' ) }
+						__unstableDisableFormats
+						onChange={ newLabel => setAttributes( { label: newLabel } ) }
+						onRemove={ onRemove }
+					/>
+					{ required && (
+						<RichText
+							ref={ useEnterRequiredRef }
+							allowedFormats={ ALLOWED_FORMATS }
+							className="required"
+							onChange={ value => setAttributes( { requiredText: value } ) }
+							tagName="span"
+							value={ requiredText || __( '(required)', 'jetpack-forms' ) }
+							withoutInteractiveFormatting
+						/>
+					) }
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<li { ...blockProps }>
+			<input type={ type } className="jetpack-option__type" tabIndex="-1" />
+			<RichText
+				ref={ useEnterRef }
+				identifier="label"
+				tagName="div"
+				className="wp-block"
+				value={ label }
+				placeholder={ __( 'Add option…', 'jetpack-forms' ) }
+				__unstableDisableFormats
+				onChange={ newLabel => setAttributes( { label: newLabel } ) }
+				onRemove={ onRemove }
+			/>
+		</li>
+	);
+};
+
+export default OptionEdit;

--- a/projects/packages/forms/src/blocks/option/index.js
+++ b/projects/packages/forms/src/blocks/option/index.js
@@ -1,0 +1,83 @@
+import { __ } from '@wordpress/i18n';
+import edit from './edit';
+import save from './save';
+
+const name = 'option';
+const settings = {
+	apiVersion: 3,
+	title: __( 'Option', 'jetpack-forms' ),
+	description: __( 'An option for a form choice field', 'jetpack-forms' ),
+	category: 'contact-form',
+	parent: [ 'jetpack/field-checkbox', 'jetpack/field-consent', 'jetpack/options' ],
+	supports: {
+		reusable: false,
+		html: false,
+		splitting: true,
+		color: {
+			text: true,
+			background: false,
+			gradient: false,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+			},
+		},
+	},
+	attributes: {
+		defaultLabel: {
+			type: 'string',
+			default: '',
+		},
+		label: {
+			type: 'string',
+			default: '',
+		},
+		requiredText: {
+			type: 'string',
+			default: '',
+		},
+		// TODO: Work out the best approach here for type.
+		// Currently, the type attribute isn't required as it can be passed via block
+		// context. It turns out though that choice items for the single and multiple
+		// choice fields had custom and different icons. Sharing a single
+		// `jetpack/option` block for global styling purposes means that can't happen
+		// without block variations. Block variations would require the type attribute
+		// at this block's level to allow different icons for each variation.
+		//
+		// Is this really needed?
+		//
+		// type: {
+		// 	type: 'string',
+		// 	default: 'checkbox',
+		// },
+		hideInput: {
+			type: 'boolean',
+			default: false,
+		},
+		isStandalone: {
+			type: 'boolean',
+			default: false,
+		},
+	},
+	usesContext: [
+		'jetpack/field-defaultValue',
+		'jetpack/field-options-type',
+		'jetpack/field-required',
+	],
+	edit,
+	save,
+};
+
+export default {
+	name,
+	settings,
+};

--- a/projects/packages/forms/src/blocks/option/save.js
+++ b/projects/packages/forms/src/blocks/option/save.js
@@ -1,0 +1,1 @@
+export default () => null;

--- a/projects/packages/forms/src/blocks/option/use-enter.js
+++ b/projects/packages/forms/src/blocks/option/use-enter.js
@@ -1,0 +1,83 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { createBlock, cloneBlock, getDefaultBlockName } from '@wordpress/blocks';
+import { useRefEffect } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useRef } from '@wordpress/element';
+
+const useEnter = props => {
+	const { replaceBlocks, insertBlock, selectionChange } = useDispatch( blockEditorStore );
+	const { getBlock, getBlockRootClientId, getBlockIndex } = useSelect( blockEditorStore );
+
+	const propsRef = useRef( props );
+	propsRef.current = props;
+
+	return useRefEffect( element => {
+		function onKeyDown( event ) {
+			if ( event.defaultPrevented || event.key !== 'Enter' ) {
+				return;
+			}
+
+			const { clientId, content, isStandalone } = propsRef.current;
+
+			if ( content.length && ! isStandalone ) {
+				return;
+			}
+
+			event.preventDefault();
+
+			if ( isStandalone ) {
+				const fieldBlockId = getBlockRootClientId( clientId );
+				const formBlockId = getBlockRootClientId( fieldBlockId );
+				const insertIndex = getBlockIndex( fieldBlockId );
+				const newBlock = createBlock( getDefaultBlockName() );
+
+				insertBlock( newBlock, insertIndex + 1, formBlockId );
+				selectionChange( newBlock.clientId );
+			} else {
+				const optionsBlockId = getBlockRootClientId( clientId );
+				const optionsBlock = getBlock( optionsBlockId );
+				const fieldBlockId = getBlockRootClientId( optionsBlockId );
+				const fieldBlock = getBlock( fieldBlockId );
+
+				if ( ! optionsBlock || ! fieldBlock ) {
+					return;
+				}
+
+				const optionIndex = getBlockIndex( clientId );
+				const allOptions = optionsBlock.innerBlocks;
+				const beforeOptions = allOptions.slice( 0, optionIndex );
+				const afterOptions = allOptions.slice( optionIndex + 1 );
+				const labelBlock = fieldBlock.innerBlocks[ 0 ];
+				const fieldBlockIndex = getBlockIndex( fieldBlockId );
+
+				const cloneField = optionSlice =>
+					cloneBlock( {
+						...fieldBlock,
+						innerBlocks: [
+							cloneBlock( labelBlock ),
+							cloneBlock( {
+								...optionsBlock,
+								innerBlocks: optionSlice,
+							} ),
+						],
+					} );
+
+				const headField = cloneField( beforeOptions );
+				const middleBlock = createBlock( getDefaultBlockName() );
+				const tailField = afterOptions.length ? [ cloneField( afterOptions ) ] : [];
+
+				replaceBlocks(
+					fieldBlock.clientId,
+					[ headField, middleBlock, ...tailField ],
+					fieldBlockIndex
+				);
+				selectionChange( middleBlock.clientId );
+			}
+		}
+
+		element.addEventListener( 'keydown', onKeyDown );
+		return () => element.removeEventListener( 'keydown', onKeyDown );
+	}, [] );
+};
+
+export default useEnter;

--- a/projects/packages/forms/src/blocks/options/edit.js
+++ b/projects/packages/forms/src/blocks/options/edit.js
@@ -1,0 +1,16 @@
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+const OptionsEdit = () => {
+	const blockProps = useBlockProps( { className: 'jetpack-field-multiple__list' } );
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		allowedBlocks: [ `jetpack/option` ],
+		defaultBlock: `jetpack/option`,
+		template: [ [ `jetpack/option` ] ],
+		templateInsertUpdatesSelection: true,
+		templateLock: false,
+	} );
+
+	return <ul { ...innerBlocksProps } />;
+};
+
+export default OptionsEdit;

--- a/projects/packages/forms/src/blocks/options/index.js
+++ b/projects/packages/forms/src/blocks/options/index.js
@@ -19,6 +19,11 @@ const settings = {
 	providesContext: {
 		'jetpack/field-options-type': 'type',
 	},
+	supports: {
+		spacing: {
+			blockGap: false,
+		},
+	},
 	edit,
 	save,
 };

--- a/projects/packages/forms/src/blocks/options/index.js
+++ b/projects/packages/forms/src/blocks/options/index.js
@@ -1,0 +1,26 @@
+import { __ } from '@wordpress/i18n';
+import edit from './edit';
+import save from './save';
+
+const name = 'options';
+const settings = {
+	apiVersion: 3,
+	title: __( 'Options', 'jetpack-forms' ),
+	description: __( 'A wrapper for a group of options', 'jetpack-forms' ),
+	category: 'contact-form',
+	parent: [ 'jetpack/field-multiple-choice', 'jetpack/field-single-choice' ],
+	attributes: {
+		type: {
+			type: 'string',
+			default: 'checkbox',
+		},
+	},
+	allowedBlocks: [ 'jetpack/field-options' ],
+	providesContext: {
+		'jetpack/field-options-type': 'type',
+	},
+	edit,
+	save,
+};
+
+export default { name, settings };

--- a/projects/packages/forms/src/blocks/options/save.js
+++ b/projects/packages/forms/src/blocks/options/save.js
@@ -1,0 +1,7 @@
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+export default () => {
+	const blockProps = useBlockProps.save();
+	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+	return <ul { ...innerBlocksProps } />;
+};

--- a/projects/packages/forms/src/blocks/shared/hooks/use-insert-after-on-enter-key-down.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-insert-after-on-enter-key-down.js
@@ -1,0 +1,42 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+
+export default function ( clientId ) {
+	const { fieldParentId, parentIndex, formParentId } = useSelect(
+		select => {
+			const blockEditor = select( blockEditorStore );
+			const parentClientIds = blockEditor.getBlockParents( clientId );
+			const parentId = parentClientIds[ parentClientIds.length - 1 ];
+
+			return {
+				fieldParentId: parentId,
+				parentIndex: parentId ? blockEditor.getBlockIndex( parentId ) : undefined,
+				formParentId: parentClientIds[ parentClientIds.length - 2 ],
+			};
+		},
+		[ clientId ]
+	);
+
+	const { insertBlock } = useDispatch( blockEditorStore );
+
+	return useCallback(
+		event => {
+			if (
+				event.key === 'Enter' &&
+				! event.shiftKey &&
+				fieldParentId &&
+				parentIndex !== undefined
+			) {
+				event.preventDefault();
+				insertBlock(
+					createBlock( getDefaultBlockName() ),
+					parentIndex + 1,
+					formParentId // Insert in the same context as the field block.
+				);
+			}
+		},
+		[ insertBlock, fieldParentId, formParentId, parentIndex ]
+	);
+}

--- a/projects/packages/forms/src/blocks/shared/hooks/use-sync-style-attributes.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-sync-style-attributes.js
@@ -1,0 +1,120 @@
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect, useRef } from '@wordpress/element';
+
+const collectAttributesToSync = ( block, attributes ) => {
+	return attributes.reduce( ( acc, attr ) => {
+		acc[ attr ] = block.attributes[ attr ];
+		return acc;
+	}, {} );
+};
+
+// TODO: - Fix potential infinite loop due to syncing while block is being migrated via deprecations.
+//       - Confirm this hook syncs option styles and doesn't impact label/input styles in other fields.
+//
+// BUG: When some fields have already been migrated to inner blocks, if another legacy field is migrated
+//      this style syncing hook goes into an infinite loop. This only really an issue if legacy fields
+//      with syncing enabled is pasted into an already migrated form.
+
+/**
+ * Hook to sync specified block attributes to others of the same block type
+ * within a specified ancestor block.
+ *
+ * @param {string} clientId         - Current block client ID.
+ * @param {string} name             - Block name.
+ * @param {string} parentName       - Name of block containing all the blocks to sync.
+ * @param {Array}  sharedAttributes - List of block attributes to sync.
+ */
+export default function useSyncStyleAttributes( clientId, name, parentName, sharedAttributes ) {
+	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
+	const lastSyncedAttributesRef = useRef( null );
+	const wasSyncEnabledRef = useRef( false );
+
+	const { syncAttributes, isSyncEnabled, existingSyncedBlock, syncedBlockIds } = useSelect(
+		select => {
+			const blockEditor = select( 'core/block-editor' );
+			const currentBlock = blockEditor.getBlock( clientId );
+			if ( ! currentBlock ) {
+				return {
+					syncAttributes: null,
+					isSyncEnabled: false,
+					existingSyncedBlock: null,
+					syncedBlockIds: [],
+				};
+			}
+
+			// Get parent's `shareFieldAttributes` status
+			const parentClientIds = blockEditor.getBlockParents( clientId );
+			const parentId = parentClientIds?.[ parentClientIds.length - 1 ];
+			const parentBlock = blockEditor.getBlock( parentId );
+			const isSharingEnabled = parentBlock?.attributes.shareFieldAttributes || false;
+
+			// Only collect attributes if sharing is enabled for this block's parent
+			const attributesToSync = isSharingEnabled
+				? collectAttributesToSync( currentBlock, sharedAttributes )
+				: null;
+
+			// Find existing synced blocks
+			const parentFormId = blockEditor.getBlockParentsByBlockName( clientId, parentName )?.[ 0 ];
+			const ids = [];
+
+			let blockWithSyncedAttributes = null;
+
+			if ( parentFormId ) {
+				const fields = blockEditor
+					.getBlocks( parentFormId )
+					.filter(
+						block =>
+							block.name.indexOf( 'jetpack/field' ) > -1 && block.attributes.shareFieldAttributes
+					);
+
+				// Look for the first synced block that isn't this one
+				for ( const field of fields ) {
+					const blocks = blockEditor
+						.getBlocks( field.clientId )
+						.filter( block => block.name === name && block.clientId !== clientId );
+
+					if ( blocks.length > 0 ) {
+						blockWithSyncedAttributes = blockWithSyncedAttributes || blocks[ 0 ];
+						ids.push( blocks[ 0 ].clientId );
+					}
+				}
+			}
+
+			return {
+				syncAttributes: attributesToSync,
+				isSyncEnabled: isSharingEnabled,
+				existingSyncedBlock: blockWithSyncedAttributes,
+				syncedBlockIds: ids,
+			};
+		},
+		[ clientId, name, parentName, sharedAttributes ]
+	);
+
+	useEffect( () => {
+		const sharingJustEnabled = isSyncEnabled && ! wasSyncEnabledRef.current;
+		wasSyncEnabledRef.current = isSyncEnabled;
+
+		if ( sharingJustEnabled && existingSyncedBlock ) {
+			// When sharing is first enabled, adopt styles from existing synced block
+			const syncedAttributes = collectAttributesToSync( existingSyncedBlock, sharedAttributes );
+			updateBlockAttributes( clientId, syncedAttributes );
+			lastSyncedAttributesRef.current = syncedAttributes;
+		} else if (
+			syncAttributes &&
+			syncedBlockIds.length &&
+			JSON.stringify( syncAttributes ) !== JSON.stringify( lastSyncedAttributesRef.current )
+		) {
+			// Sync new style changes to other synced blocks.
+			updateBlockAttributes( syncedBlockIds, syncAttributes );
+			lastSyncedAttributesRef.current = syncAttributes;
+		}
+	}, [
+		syncAttributes,
+		isSyncEnabled,
+		existingSyncedBlock,
+		syncedBlockIds,
+		updateBlockAttributes,
+		clientId,
+		sharedAttributes,
+	] );
+}

--- a/projects/packages/forms/src/blocks/shared/hooks/use-sync-style-attributes.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-sync-style-attributes.js
@@ -28,7 +28,9 @@ export default function useSyncStyleAttributes( clientId, name, parentName, shar
 		select => {
 			const blockEditor = select( 'core/block-editor' );
 			const currentBlock = blockEditor.getBlock( clientId );
-			if ( ! currentBlock ) {
+			const isPreviewMode = blockEditor.getSettings().templateMode === 'preview';
+
+			if ( ! currentBlock || isPreviewMode ) {
 				return {
 					syncAttributes: null,
 					isSyncEnabled: false,

--- a/projects/packages/forms/src/blocks/shared/hooks/use-sync-style-attributes.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-sync-style-attributes.js
@@ -1,4 +1,4 @@
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 
 const collectAttributesToSync = ( block, attributes ) => {
@@ -7,13 +7,6 @@ const collectAttributesToSync = ( block, attributes ) => {
 		return acc;
 	}, {} );
 };
-
-// TODO: - Fix potential infinite loop due to syncing while block is being migrated via deprecations.
-//       - Confirm this hook syncs option styles and doesn't impact label/input styles in other fields.
-//
-// BUG: When some fields have already been migrated to inner blocks, if another legacy field is migrated
-//      this style syncing hook goes into an infinite loop. This only really an issue if legacy fields
-//      with syncing enabled is pasted into an already migrated form.
 
 /**
  * Hook to sync specified block attributes to others of the same block type
@@ -25,7 +18,9 @@ const collectAttributesToSync = ( block, attributes ) => {
  * @param {Array}  sharedAttributes - List of block attributes to sync.
  */
 export default function useSyncStyleAttributes( clientId, name, parentName, sharedAttributes ) {
-	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
+	const registry = useRegistry();
+	const { updateBlockAttributes, __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( 'core/block-editor' );
 	const lastSyncedAttributesRef = useRef( null );
 	const wasSyncEnabledRef = useRef( false );
 
@@ -45,7 +40,12 @@ export default function useSyncStyleAttributes( clientId, name, parentName, shar
 			// Get parent's `shareFieldAttributes` status
 			const parentClientIds = blockEditor.getBlockParents( clientId );
 			const parentId = parentClientIds?.[ parentClientIds.length - 1 ];
-			const parentBlock = blockEditor.getBlock( parentId );
+
+			let parentBlock = blockEditor.getBlock( parentId );
+			if ( parentBlock.name === 'jetpack/options' ) {
+				parentBlock = blockEditor.getBlock( parentClientIds[ parentClientIds.length - 2 ] );
+			}
+
 			const isSharingEnabled = parentBlock?.attributes.shareFieldAttributes || false;
 
 			// Only collect attributes if sharing is enabled for this block's parent
@@ -59,23 +59,59 @@ export default function useSyncStyleAttributes( clientId, name, parentName, shar
 
 			let blockWithSyncedAttributes = null;
 
+			// Recursive util to find all fields with style syncing regardless of how
+			// deeply nested in the form.
+			const getFieldsWithSharedAttributes = currentId => {
+				const blocks = blockEditor.getBlocks( currentId );
+				let result = [];
+
+				for ( const block of blocks ) {
+					if ( block.name.indexOf( 'jetpack/field' ) > -1 ) {
+						if ( block.attributes.shareFieldAttributes ) {
+							result.push( block );
+						}
+					} else {
+						result = result.concat( getFieldsWithSharedAttributes( block.clientId ) );
+					}
+				}
+
+				return result;
+			};
+
 			if ( parentFormId ) {
-				const fields = blockEditor
-					.getBlocks( parentFormId )
-					.filter(
-						block =>
-							block.name.indexOf( 'jetpack/field' ) > -1 && block.attributes.shareFieldAttributes
-					);
+				const fields = getFieldsWithSharedAttributes( parentFormId );
 
 				// Look for the first synced block that isn't this one
 				for ( const field of fields ) {
-					const blocks = blockEditor
-						.getBlocks( field.clientId )
-						.filter( block => block.name === name && block.clientId !== clientId );
+					const innerFieldBlocks = blockEditor.getBlocks( field.clientId );
+					const isChoiceField =
+						field.name === 'jetpack/field-radio' ||
+						field.name === 'jetpack/field-checkbox-multiple';
 
-					if ( blocks.length > 0 ) {
-						blockWithSyncedAttributes = blockWithSyncedAttributes || blocks[ 0 ];
-						ids.push( blocks[ 0 ].clientId );
+					// Single and multiple choice fields nest their individual option blocks
+					// within a `jetpack/options` block. If we're syncing option block styles
+					// all the individual options within a choice field need to be included.
+					if ( name === 'jetpack/option' && isChoiceField ) {
+						const optionsBlock = innerFieldBlocks.find( block => block.name === 'jetpack/options' );
+
+						blockEditor.getBlocks( optionsBlock.clientId ).forEach( block => {
+							blockWithSyncedAttributes = blockWithSyncedAttributes || block;
+							if ( block.clientId !== clientId ) {
+								ids.push( block.clientId );
+							}
+						} );
+					} else {
+						// Check for blocks to sync as normal. This will still allow
+						// `jetpack/option` blocks that are direct children of a field to be
+						// found e.g. checkbox and consent fields.
+						const blocks = innerFieldBlocks.filter(
+							block => block.name === name && block.clientId !== clientId
+						);
+
+						if ( blocks.length > 0 ) {
+							blockWithSyncedAttributes = blockWithSyncedAttributes || blocks[ 0 ];
+							ids.push( blocks[ 0 ].clientId );
+						}
 					}
 				}
 			}
@@ -105,7 +141,10 @@ export default function useSyncStyleAttributes( clientId, name, parentName, shar
 			JSON.stringify( syncAttributes ) !== JSON.stringify( lastSyncedAttributesRef.current )
 		) {
 			// Sync new style changes to other synced blocks.
-			updateBlockAttributes( syncedBlockIds, syncAttributes );
+			registry.batch( () => {
+				__unstableMarkNextChangeAsNotPersistent();
+				updateBlockAttributes( syncedBlockIds, syncAttributes );
+			} );
 			lastSyncedAttributesRef.current = syncAttributes;
 		}
 	}, [
@@ -116,5 +155,7 @@ export default function useSyncStyleAttributes( clientId, name, parentName, shar
 		updateBlockAttributes,
 		clientId,
 		sharedAttributes,
+		registry,
+		__unstableMarkNextChangeAsNotPersistent,
 	] );
 }

--- a/projects/packages/forms/src/blocks/shared/util/constants.js
+++ b/projects/packages/forms/src/blocks/shared/util/constants.js
@@ -1,0 +1,44 @@
+import { __ } from '@wordpress/i18n';
+
+export const ALLOWED_FORMATS = [ 'core/bold', 'core/italic' ];
+export const ALLOWED_INNER_BLOCKS = [ 'jetpack/label', 'jetpack/input' ];
+
+const currentYear = new Date().getFullYear();
+
+// WARNING: sync data with Contact_Form_Field::render_date_field in class-contact-form-field.php
+export const DATE_FORMATS = [
+	{
+		value: 'mm/dd/yy',
+		/* translators: date format. DD is the day of the month, MM the month, and YYYY the year (e.g., 12/31/2023). */
+		label: __( 'MM/DD/YYYY', 'jetpack-forms' ),
+		example: `12/31/${ currentYear }`,
+	},
+	{
+		value: 'dd/mm/yy',
+		/* translators: date format. DD is the day of the month, MM the month, and YYYY the year (e.g., 31/12/2023). */
+		label: __( 'DD/MM/YYYY', 'jetpack-forms' ),
+		example: `21/12/${ currentYear }`,
+	},
+	{
+		value: 'yy-mm-dd',
+		/* translators: date format. DD is the day of the month, MM the month, and YYYY the year (e.g., 2023-12-31). */
+		label: __( 'YYYY-MM-DD', 'jetpack-forms' ),
+		example: `${ currentYear }-12-31`,
+	},
+];
+
+export const DATE_FORMAT_OPTIONS = DATE_FORMATS.map(
+	( { value, label: optionLabel, example } ) => ( {
+		label: `${ optionLabel } (${ example })`,
+		value,
+	} )
+);
+
+export const FORM_BLOCK_NAME = 'jetpack/contact-form';
+
+export const FORM_STYLE = {
+	ANIMATED: 'animated',
+	BELOW: 'below',
+	DEFAULT: 'default',
+	OUTLINED: 'outlined',
+};

--- a/projects/packages/forms/src/blocks/shared/util/get-block-style.js
+++ b/projects/packages/forms/src/blocks/shared/util/get-block-style.js
@@ -1,0 +1,6 @@
+const getBlockStyle = className => {
+	const styleClass = className && className.match( /is-style-([^\s]+)/i );
+	return styleClass ? styleClass[ 1 ] : '';
+};
+
+export default getBlockStyle;

--- a/projects/plugins/jetpack/changelog/add-new-form-field-blocks
+++ b/projects/plugins/jetpack/changelog/add-new-form-field-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add label, input, option, and options blocks for improving form fields


### PR DESCRIPTION
JETPACK-261

Fixes #42355

⚠️ **Please note: This PR forms the basis for migrating form fields to inner blocks. It should not be merged until the [related PR](https://github.com/Automattic/jetpack/pull/42890) migrating to these new blocks proves they are sufficiently complete**. ⚠️ 

## Proposed changes:

* Add news blocks for greater control over styling forms and to support global styles
- New blocks include:
    - `jetpack/input`
    - `jetpack/label`
    - `jetpack/option`
    - `jetpack/options`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

TBA