### PR TITLE
Boost: Fix Image Guide state not resetting

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/image-guide/image-guide.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/image-guide/image-guide.tsx
@@ -1,0 +1,74 @@
+import { useSingleModuleState } from '$features/module/lib/stores';
+import Module from '$features/module/module';
+import InterstitialModalCTA from '$features/upgrade-cta/interstitial-modal-cta';
+import { Notice } from '@automattic/jetpack-components';
+import { __ } from '@wordpress/i18n';
+
+const ImageGuide = () => {
+	const [ isaState ] = useSingleModuleState( 'image_size_analysis' );
+	const { canResizeImages } = Jetpack_Boost;
+
+	/**
+	 * Reset the Image Guide state to active when the module is enabled
+	 */
+	const resetImageGuideState = () => {
+		// Remove the paused state from localStorage to reset it
+		localStorage.removeItem( 'jetpack-boost-guide' );
+	};
+
+	return (
+		<Module
+			slug="image_guide"
+			title={ __( 'Image Guide', 'jetpack-boost' ) }
+			onDisable={ resetImageGuideState }
+			description={
+				<>
+					<p>
+						{ __(
+							`This feature helps you discover images that are too large. When you browse your site, the image guide will show you an overlay with information about each image's size.`,
+							'jetpack-boost'
+						) }
+					</p>
+					{ ! isaState?.available && (
+						<InterstitialModalCTA
+							identifier="image-guide"
+							description={ __(
+								'Upgrade to scan your site for issues - automatically!',
+								'jetpack-boost'
+							) }
+						/>
+					) }
+				</>
+			}
+		>
+			{ false === canResizeImages && (
+				<Notice
+					level="warning"
+					title={ __( 'Image resizing is unavailable', 'jetpack-boost' ) }
+					hideCloseButton={ true }
+				>
+					<p>
+						{ __(
+							"It looks like your server doesn't have Imagick or GD extensions installed.",
+							'jetpack-boost'
+						) }
+					</p>
+					<p>
+						{ __(
+							"Jetpack Boost is able to work without these extensions, but it's likely that it's going to be difficult for you to optimize the images that the Image Guide will identify without one of these extensions.",
+							'jetpack-boost'
+						) }
+					</p>
+					<p>
+						{ __(
+							'Please contact your hosting provider or system administrator and ask them to install or activate one of these extensions.',
+							'jetpack-boost'
+						) }
+					</p>
+				</Notice>
+			) }
+		</Module>
+	);
+};
+
+export default ImageGuide;

--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
@@ -3,6 +3,7 @@ import CloudCssMeta from '$features/critical-css/cloud-css-meta/cloud-css-meta';
 import CriticalCssMeta from '$features/critical-css/critical-css-meta/critical-css-meta';
 import { useRegenerateCriticalCssAction } from '$features/critical-css/lib/stores/critical-css-state';
 import { ImageCdnLiar, QualitySettings } from '$features/image-cdn';
+import ImageGuide from '$features/image-guide/image-guide';
 import { RecommendationsMeta } from '$features/image-size-analysis';
 import MinifyCss from '$features/minify-css/minify-css';
 import MinifyJs from '$features/minify-js/minify-js';
@@ -14,7 +15,7 @@ import Pill from '$features/ui/pill/pill';
 import Upgraded from '$features/ui/upgraded/upgraded';
 import InterstitialModalCTA from '$features/upgrade-cta/interstitial-modal-cta';
 import { recordBoostEvent } from '$lib/utils/analytics';
-import { Notice, getRedirectUrl } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import styles from './index.module.scss';
@@ -30,7 +31,6 @@ const Index = () => {
 	const requestRegenerateCriticalCss = () => {
 		regenerateCssAction.mutate();
 	};
-	const { canResizeImages } = Jetpack_Boost;
 
 	const [ imageCdnQualityState ] = useSingleModuleState( 'image_cdn_quality' );
 	const [ imageCdnLiarState ] = useSingleModuleState( 'image_cdn_liar' );
@@ -203,56 +203,7 @@ const Index = () => {
 			</Module>
 
 			<div className={ styles.settings }>
-				<Module
-					slug="image_guide"
-					title={ __( 'Image Guide', 'jetpack-boost' ) }
-					description={
-						<>
-							<p>
-								{ __(
-									`This feature helps you discover images that are too large. When you browse your site, the image guide will show you an overlay with information about each image's size.`,
-									'jetpack-boost'
-								) }
-							</p>
-							{ ! isaState?.available && (
-								<InterstitialModalCTA
-									identifier="image-guide"
-									description={ __(
-										'Upgrade to scan your site for issues - automatically!',
-										'jetpack-boost'
-									) }
-								/>
-							) }
-						</>
-					}
-				>
-					{ false === canResizeImages && (
-						<Notice
-							level="warning"
-							title={ __( 'Image resizing is unavailable', 'jetpack-boost' ) }
-							hideCloseButton={ true }
-						>
-							<p>
-								{ __(
-									"It looks like your server doesn't have Imagick or GD extensions installed.",
-									'jetpack-boost'
-								) }
-							</p>
-							<p>
-								{ __(
-									"Jetpack Boost is able to work without these extensions, but it's likely that it's going to be difficult for you to optimize the images that the Image Guide will identify without one of these extensions.",
-									'jetpack-boost'
-								) }
-							</p>
-							<p>
-								{ __(
-									'Please contact your hosting provider or system administrator and ask them to install or activate one of these extensions.',
-									'jetpack-boost'
-								) }
-							</p>
-						</Notice>
-					) }
-				</Module>
+				<ImageGuide />
 
 				<Module
 					slug="image_size_analysis"

--- a/projects/plugins/boost/changelog/fix-boost-isa-guide-state-resetting
+++ b/projects/plugins/boost/changelog/fix-boost-isa-guide-state-resetting
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Image Size Analysis: Fix Image Guide state not resetting to Active if Image Guide was disabled, and enabled.
+Image Guide: Fix front-end state not being in sync with Boost settings.

--- a/projects/plugins/boost/changelog/fix-boost-isa-guide-state-resetting
+++ b/projects/plugins/boost/changelog/fix-boost-isa-guide-state-resetting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Image Size Analysis: Fix Image Guide state not resetting to Active if Image Guide was disabled, and enabled.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves [HOG-12](https://linear.app/a8c/issue/HOG-12/image-guide-remains-paused-after-disablere-enable-feature-in-boost)

## Proposed changes:

- Extracts Image Guide component into its own dedicated file
- Adds functionality to reset the Image Guide state when the module is enabled after being disabled
- Ensures Image Guide returns to Active state when re-enabled, rather than remaining in its previous state

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:

- Enable the Image Guide feature in Jetpack Boost
- Browse your site to confirm the Image Guide overlay appears
- Return to the Jetpack Boost dashboard and disable the Image Guide
- Re-enable the Image Guide
- Browse your site again - the Image Guide overlay should now appear (before this fix it would remain disabled despite the module being enabled)

