### PR TITLE
Forms: Add plugin actions to integration card header

### DIFF
--- a/projects/packages/forms/changelog/add-plugin-actions-integration-card-header
+++ b/projects/packages/forms/changelog/add-plugin-actions-integration-card-header
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Added plugin actions to integration card header.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
@@ -1,67 +1,48 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { Button, ExternalLink, Spinner } from '@wordpress/components';
+import { Button, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import AkismetIcon from '../../../../icons/akismet-icon';
 import IntegrationCard from './integration-card';
-import PluginActionButton from './plugin-action-button';
 
 const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 	const formSubmissionsUrl = window?.jpFormsBlocks?.defaults?.formsAdminUrl || '';
 
-	const {
-		isInstalled = false,
-		isActive = false,
-		isConnected: akismetActiveWithKey = false,
-		settingsUrl = '',
-	} = data || {};
+	const { isConnected: akismetActiveWithKey = false, settingsUrl = '' } = data || {};
 
-	const pluginInfo = {
-		pluginSlug: 'akismet',
-		pluginFile: 'akismet/akismet',
-		isInstalled,
-		isActive,
+	const cardData = {
+		...data,
 		onComplete: refreshStatus,
 		trackingId: 'jetpack_forms_upsell_akismet_click',
 	};
 
-	const renderContent = () => {
-		if ( ! data ) {
-			return <Spinner />;
+	const installDescription = createInterpolateElement(
+		__(
+			"Add one-click spam protection for your forms with <a>Akismet</a>. Simply install the plugin and you're set.",
+			'jetpack-forms'
+		),
+		{
+			a: <ExternalLink href={ getRedirectUrl( 'akismet-wordpress-org' ) } />,
 		}
+	);
 
-		if ( ! isInstalled ) {
-			return (
-				<div>
-					<p>
-						{ createInterpolateElement(
-							__(
-								"Add one-click spam protection for your forms with <a>Akismet</a>. Simply install the plugin and you're set.",
-								'jetpack-forms'
-							),
-							{
-								a: <ExternalLink href={ getRedirectUrl( 'akismet-wordpress-org' ) } />,
-							}
-						) }
-					</p>
-					<PluginActionButton { ...pluginInfo } />
-				</div>
-			);
-		}
+	const activateDescription = __(
+		"You already have Akismet installed, but it's not activated.",
+		'jetpack-forms'
+	);
 
-		if ( ! isActive ) {
-			return (
-				<div>
-					<p>
-						{ __( "You already have Akismet installed, but it's not activated.", 'jetpack-forms' ) }
-					</p>
-					<PluginActionButton { ...pluginInfo } />
-				</div>
-			);
-		}
-
-		if ( ! akismetActiveWithKey ) {
-			return (
+	return (
+		<IntegrationCard
+			title={ __( 'Akismet Spam Protection', 'jetpack-forms' ) }
+			description={ __( 'Akismet filters out form spam with 99% accuracy', 'jetpack-forms' ) }
+			icon={ <AkismetIcon /> }
+			isExpanded={ isExpanded }
+			onToggle={ onToggle }
+			data={ cardData }
+			installDescription={ installDescription }
+			activateDescription={ activateDescription }
+		>
+			{ ! akismetActiveWithKey ? (
 				<div>
 					<p>
 						{ createInterpolateElement(
@@ -84,53 +65,38 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 						{ __( 'Add Akismet key', 'jetpack-forms' ) }
 					</Button>
 				</div>
-			);
-		}
-
-		return (
-			<div>
-				<p>
-					{ createInterpolateElement(
-						__( 'Your forms are protected from spam with <a>Akismet</a>!', 'jetpack-forms' ),
-						{
-							a: <ExternalLink href={ getRedirectUrl( 'akismet-jetpack-forms-docs' ) } />,
-						}
-					) }
-				</p>
-				<div style={ { display: 'flex', gap: '8px', justifyContent: 'flex-start' } }>
-					<Button
-						variant="primary"
-						href={ formSubmissionsUrl }
-						target="_blank"
-						rel="noopener noreferrer"
-						__next40pxDefaultSize={ true }
-					>
-						{ __( 'View spam', 'jetpack-forms' ) }
-					</Button>
-					<Button
-						variant="primary"
-						href={ settingsUrl }
-						target="_blank"
-						rel="noopener noreferrer"
-						__next40pxDefaultSize={ true }
-					>
-						{ __( 'View stats', 'jetpack-forms' ) }
-					</Button>
+			) : (
+				<div>
+					<p>
+						{ createInterpolateElement(
+							__( 'Your forms are protected from spam with <a>Akismet</a>!', 'jetpack-forms' ),
+							{
+								a: <ExternalLink href={ getRedirectUrl( 'akismet-jetpack-forms-docs' ) } />,
+							}
+						) }
+					</p>
+					<div style={ { display: 'flex', gap: '8px', justifyContent: 'flex-start' } }>
+						<Button
+							variant="primary"
+							href={ formSubmissionsUrl }
+							target="_blank"
+							rel="noopener noreferrer"
+							__next40pxDefaultSize={ true }
+						>
+							{ __( 'View spam', 'jetpack-forms' ) }
+						</Button>
+						<Button
+							variant="primary"
+							href={ settingsUrl }
+							target="_blank"
+							rel="noopener noreferrer"
+							__next40pxDefaultSize={ true }
+						>
+							{ __( 'View stats', 'jetpack-forms' ) }
+						</Button>
+					</div>
 				</div>
-			</div>
-		);
-	};
-
-	return (
-		<IntegrationCard
-			title={ __( 'Akismet Spam Protection', 'jetpack-forms' ) }
-			description={ __( 'Akismet filters out form spam with 99% accuracy', 'jetpack-forms' ) }
-			icon={ <AkismetIcon /> }
-			isExpanded={ isExpanded }
-			onToggle={ onToggle }
-			pluginInfo={ pluginInfo }
-		>
-			{ renderContent() }
+			) }
 		</IntegrationCard>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
@@ -1,10 +1,10 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { Button, ExternalLink, Icon, Spinner } from '@wordpress/components';
+import { Button, ExternalLink, Spinner } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import AkismetIcon from '../../../../icons/akismet-icon';
-import { usePluginInstallation } from '../hooks';
 import IntegrationCard from './integration-card';
+import PluginActionButton from './plugin-action-button';
 
 const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 	const formSubmissionsUrl = window?.jpFormsBlocks?.defaults?.formsAdminUrl || '';
@@ -16,27 +16,13 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 		settingsUrl = '',
 	} = data || {};
 
-	const { isInstalling, installPlugin } = usePluginInstallation(
-		'akismet',
-		'akismet/akismet',
+	const pluginInfo = {
+		pluginSlug: 'akismet',
+		pluginFile: 'akismet/akismet',
 		isInstalled,
-		'jetpack_forms_upsell_akismet_click'
-	);
-
-	const handleInstallAction = async () => {
-		const success = await installPlugin();
-		if ( success ) {
-			refreshStatus();
-		}
-	};
-
-	const getButtonText = () => {
-		return (
-			( isInstalling && isInstalled && __( 'Activating…', 'jetpack-forms' ) ) ||
-			( isInstalling && __( 'Installing…', 'jetpack-forms' ) ) ||
-			( isInstalled && __( 'Activate', 'jetpack-forms' ) ) ||
-			__( 'Install', 'jetpack-forms' )
-		);
+		isActive,
+		onComplete: refreshStatus,
+		trackingId: 'jetpack_forms_upsell_akismet_click',
 	};
 
 	const renderContent = () => {
@@ -58,15 +44,7 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 							}
 						) }
 					</p>
-					<Button
-						variant="primary"
-						onClick={ handleInstallAction }
-						disabled={ isInstalling }
-						icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
-						__next40pxDefaultSize={ true }
-					>
-						{ getButtonText() }
-					</Button>
+					<PluginActionButton { ...pluginInfo } />
 				</div>
 			);
 		}
@@ -77,15 +55,7 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 					<p>
 						{ __( "You already have Akismet installed, but it's not activated.", 'jetpack-forms' ) }
 					</p>
-					<Button
-						variant="primary"
-						onClick={ handleInstallAction }
-						disabled={ isInstalling }
-						icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
-						__next40pxDefaultSize={ true }
-					>
-						{ getButtonText() }
-					</Button>
+					<PluginActionButton { ...pluginInfo } />
 				</div>
 			);
 		}
@@ -158,6 +128,7 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 			icon={ <AkismetIcon /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }
+			pluginInfo={ pluginInfo }
 		>
 			{ renderContent() }
 		</IntegrationCard>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
@@ -1,9 +1,9 @@
 import { createBlock } from '@wordpress/blocks';
-import { Button, ExternalLink, Spinner, Icon, ToggleControl } from '@wordpress/components';
+import { ExternalLink, Spinner, ToggleControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { usePluginInstallation } from '../hooks';
 import IntegrationCard from './integration-card';
+import PluginActionButton from './plugin-action-button';
 
 const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 	const { isInstalled = false, isActive = false, settingsUrl = '' } = data || {};
@@ -20,20 +20,6 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 		( { name } ) => name === 'jetpack/field-consent'
 	);
 
-	const { isInstalling, installPlugin } = usePluginInstallation(
-		'creative-mail-by-constant-contact',
-		'creative-mail-by-constant-contact/creative-mail-plugin',
-		isInstalled,
-		'jetpack_forms_upsell_creative_mail_click'
-	);
-
-	const handleInstallAction = async () => {
-		const success = await installPlugin();
-		if ( success ) {
-			refreshStatus();
-		}
-	};
-
 	const toggleConsent = async () => {
 		if ( consentBlock ) {
 			await removeBlock( consentBlock.clientId, false );
@@ -46,13 +32,13 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 		}
 	};
 
-	const getButtonText = () => {
-		return (
-			( isInstalling && isInstalled && __( 'Activating…', 'jetpack-forms' ) ) ||
-			( isInstalling && __( 'Installing…', 'jetpack-forms' ) ) ||
-			( isInstalled && __( 'Activate Creative Mail Plugin', 'jetpack-forms' ) ) ||
-			__( 'Install Creative Mail plugin', 'jetpack-forms' )
-		);
+	const pluginInfo = {
+		pluginSlug: 'creative-mail-by-constant-contact',
+		pluginFile: 'creative-mail-by-constant-contact/creative-mail-plugin',
+		isInstalled,
+		isActive,
+		onComplete: refreshStatus,
+		trackingId: 'jetpack_forms_upsell_creative_mail_click',
 	};
 
 	const renderContent = () => {
@@ -71,15 +57,7 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 							) }
 						</em>
 					</p>
-					<Button
-						variant="primary"
-						onClick={ handleInstallAction }
-						disabled={ isInstalling }
-						icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
-						__next40pxDefaultSize={ true }
-					>
-						{ getButtonText() }
-					</Button>
+					<PluginActionButton { ...pluginInfo } />
 				</div>
 			);
 		}
@@ -95,15 +73,7 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 							) }
 						</em>
 					</p>
-					<Button
-						variant="primary"
-						onClick={ handleInstallAction }
-						disabled={ isInstalling }
-						icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
-						__next40pxDefaultSize={ true }
-					>
-						{ getButtonText() }
-					</Button>
+					<PluginActionButton { ...pluginInfo } />
 				</div>
 			);
 		}
@@ -137,6 +107,7 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 			icon="email"
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }
+			pluginInfo={ pluginInfo }
 		>
 			{ renderContent() }
 		</IntegrationCard>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
@@ -1,12 +1,11 @@
 import { createBlock } from '@wordpress/blocks';
-import { ExternalLink, Spinner, ToggleControl } from '@wordpress/components';
+import { ExternalLink, ToggleControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import IntegrationCard from './integration-card';
-import PluginActionButton from './plugin-action-button';
 
 const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
-	const { isInstalled = false, isActive = false, settingsUrl = '' } = data || {};
+	const { settingsUrl = '' } = data || {};
 
 	const selectedBlock = useSelect( select => select( 'core/block-editor' ).getSelectedBlock(), [] );
 
@@ -32,53 +31,33 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 		}
 	};
 
-	const pluginInfo = {
-		pluginSlug: 'creative-mail-by-constant-contact',
-		pluginFile: 'creative-mail-by-constant-contact/creative-mail-plugin',
-		isInstalled,
-		isActive,
+	const cardData = {
+		...data,
 		onComplete: refreshStatus,
 		trackingId: 'jetpack_forms_upsell_creative_mail_click',
 	};
 
-	const renderContent = () => {
-		if ( ! data ) {
-			return <Spinner />;
-		}
+	const installDescription = __(
+		'To start sending email campaigns, install the Creative Mail plugin for WordPress.',
+		'jetpack-forms'
+	);
 
-		if ( ! isInstalled ) {
-			return (
-				<div>
-					<p>
-						<em style={ { color: 'rgba(38, 46, 57, 0.7)' } }>
-							{ __(
-								'To start sending email campaigns, install the Creative Mail plugin for WordPress.',
-								'jetpack-forms'
-							) }
-						</em>
-					</p>
-					<PluginActionButton { ...pluginInfo } />
-				</div>
-			);
-		}
+	const activateDescription = __(
+		'To start sending email campaigns, activate the Creative Mail plugin for WordPress.',
+		'jetpack-forms'
+	);
 
-		if ( ! isActive ) {
-			return (
-				<div>
-					<p>
-						<em>
-							{ __(
-								'To start sending email campaigns, activate the Creative Mail plugin for WordPress.',
-								'jetpack-forms'
-							) }
-						</em>
-					</p>
-					<PluginActionButton { ...pluginInfo } />
-				</div>
-			);
-		}
-
-		return (
+	return (
+		<IntegrationCard
+			title={ __( 'Creative Mail', 'jetpack-forms' ) }
+			description={ __( 'Manage email contacts and campaigns', 'jetpack-forms' ) }
+			icon="email"
+			isExpanded={ isExpanded }
+			onToggle={ onToggle }
+			data={ cardData }
+			installDescription={ installDescription }
+			activateDescription={ activateDescription }
+		>
 			<div>
 				<p>
 					<em>
@@ -97,19 +76,6 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 					/>
 				) }
 			</div>
-		);
-	};
-
-	return (
-		<IntegrationCard
-			title={ __( 'Creative Mail', 'jetpack-forms' ) }
-			description={ __( 'Manage email contacts and campaigns', 'jetpack-forms' ) }
-			icon="email"
-			isExpanded={ isExpanded }
-			onToggle={ onToggle }
-			pluginInfo={ pluginInfo }
-		>
-			{ renderContent() }
 		</IntegrationCard>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card.js
@@ -1,4 +1,4 @@
-import { Card, CardHeader, CardBody, Icon } from '@wordpress/components';
+import { Card, CardHeader, CardBody, Icon, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import PluginActionButton from './plugin-action-button';
 import './integration-card.scss';
@@ -6,13 +6,41 @@ import './integration-card.scss';
 const IntegrationCard = ( {
 	title,
 	description,
-	icon = 'admin-plugins', // Default to admin-plugins icon if none provided
+	icon = 'admin-plugins',
 	isExpanded,
 	onToggle,
 	children,
-	pluginInfo,
+	data,
+	installDescription,
+	activateDescription,
 } ) => {
-	const showPluginAction = pluginInfo && ( ! pluginInfo.isInstalled || ! pluginInfo.isActive );
+	const showPluginAction = data && ( ! data.isInstalled || ! data.isActive );
+
+	const renderContent = () => {
+		if ( ! data ) {
+			return <Spinner />;
+		}
+
+		if ( ! data.isInstalled ) {
+			return (
+				<div>
+					<p>{ installDescription }</p>
+					<PluginActionButton { ...data } />
+				</div>
+			);
+		}
+
+		if ( ! data.isActive ) {
+			return (
+				<div>
+					<p>{ activateDescription }</p>
+					<PluginActionButton { ...data } />
+				</div>
+			);
+		}
+
+		return children;
+	};
 
 	return (
 		<Card className="integration-card">
@@ -37,13 +65,7 @@ const IntegrationCard = ( {
 					<div className="integration-card__header-actions">
 						{ showPluginAction && (
 							<div className="integration-card__button-container">
-								<PluginActionButton
-									pluginSlug={ pluginInfo.pluginSlug }
-									pluginFile={ pluginInfo.pluginFile }
-									isInstalled={ pluginInfo.isInstalled }
-									onComplete={ pluginInfo.onComplete }
-									trackingId={ pluginInfo.trackingId }
-								/>
+								<PluginActionButton { ...data } />
 							</div>
 						) }
 						<Icon
@@ -53,7 +75,7 @@ const IntegrationCard = ( {
 					</div>
 				</div>
 			</CardHeader>
-			{ isExpanded && <CardBody>{ children }</CardBody> }
+			{ isExpanded && <CardBody>{ renderContent() }</CardBody> }
 		</Card>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card.js
@@ -1,4 +1,6 @@
 import { Card, CardHeader, CardBody, Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import PluginActionButton from './plugin-action-button';
 import './integration-card.scss';
 
 const IntegrationCard = ( {
@@ -8,7 +10,10 @@ const IntegrationCard = ( {
 	isExpanded,
 	onToggle,
 	children,
+	pluginInfo,
 } ) => {
+	const showPluginAction = pluginInfo && ( ! pluginInfo.isInstalled || ! pluginInfo.isActive );
+
 	return (
 		<Card className="integration-card">
 			<CardHeader onClick={ onToggle } className="integration-card__header">
@@ -16,16 +21,36 @@ const IntegrationCard = ( {
 					<div className="integration-card__header-main">
 						<Icon icon={ icon } className="integration-card__service-icon" size={ 30 } />
 						<div className="integration-card__title-section">
-							<h3 className="integration-card__title">{ title }</h3>
+							<div className="integration-card__title-row">
+								<h3 className="integration-card__title">{ title }</h3>
+								{ showPluginAction && (
+									<span className="integration-card__plugin-badge">
+										{ __( 'Plugin', 'jetpack-forms' ) }
+									</span>
+								) }
+							</div>
 							{ description && (
 								<span className="integration-card__description">{ description }</span>
 							) }
 						</div>
 					</div>
-					<Icon
-						icon={ isExpanded ? 'arrow-up-alt2' : 'arrow-down-alt2' }
-						className="integration-card__toggle-icon"
-					/>
+					<div className="integration-card__header-actions">
+						{ showPluginAction && (
+							<div className="integration-card__button-container">
+								<PluginActionButton
+									pluginSlug={ pluginInfo.pluginSlug }
+									pluginFile={ pluginInfo.pluginFile }
+									isInstalled={ pluginInfo.isInstalled }
+									onComplete={ pluginInfo.onComplete }
+									trackingId={ pluginInfo.trackingId }
+								/>
+							</div>
+						) }
+						<Icon
+							icon={ isExpanded ? 'arrow-up-alt2' : 'arrow-down-alt2' }
+							className="integration-card__toggle-icon"
+						/>
+					</div>
 				</div>
 			</CardHeader>
 			{ isExpanded && <CardBody>{ children }</CardBody> }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card.scss
@@ -5,21 +5,20 @@
 
 	&__header-content {
 		display: flex;
-		align-items: center;
 		justify-content: space-between;
+		align-items: center;
 		width: 100%;
 	}
 
 	&__header-main {
 		display: flex;
-		align-items: center;
+		align-items: flex-start;
 		gap: 16px;
+		flex: 1;
 	}
 
 	&__title-section {
-		display: flex;
-		flex-direction: column;
-		gap: 4px;
+		flex: 1;
 	}
 
 	&__title-row {
@@ -28,27 +27,42 @@
 		gap: 8px;
 	}
 
-	&__service-icon {
-		color: var(--jp-gray-80);
-		flex-shrink: 0;
-		margin-top: 2px;
-	}
-
 	&__title {
 		margin: 0;
-		font-size: var(--font-body);
-		font-weight: 600;
+		font-size: 16px;
+		font-weight: 500;
+	}
+
+	&__plugin-badge {
+		background-color: #f0f0f0;
+		color: #1e1e1e;
+		padding: 2px 6px;
+		border-radius: 2px;
+		font-size: 11px;
+		font-weight: 500;
+		text-transform: uppercase;
 		line-height: 1.4;
 	}
 
 	&__description {
-		color: var(--jp-gray-50);
+		color: #757575;
 		font-size: 13px;
-		line-height: 1.4;
+		display: block;
+		margin-top: 4px;
+	}
+
+	&__header-actions {
+		display: flex;
+		align-items: center;
+		gap: 16px;
 	}
 
 	&__toggle-icon {
-		display: block;
+		flex-shrink: 0;
+	}
+
+	&__service-icon {
+		flex-shrink: 0;
 	}
 
 	.is-spinning {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
@@ -1,11 +1,11 @@
 import colorStudio from '@automattic/color-studio';
 import { JetpackIcon } from '@automattic/jetpack-components';
-import { Button, Icon, Spinner, ToggleControl } from '@wordpress/components';
+import { Button, Spinner, ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import semver from 'semver';
-import { usePluginInstallation } from '../hooks';
 import IntegrationCard from './integration-card';
+import PluginActionButton from './plugin-action-button';
 
 const COLOR_JETPACK = colorStudio.colors[ 'Jetpack Green 40' ];
 
@@ -27,27 +27,13 @@ const JetpackCRMCard = ( {
 
 	const { hasExtension = false, canActivateExtension = false } = details;
 
-	const { isInstalling, installPlugin } = usePluginInstallation(
-		'zero-bs-crm',
-		'zero-bs-crm/ZeroBSCRM',
+	const pluginInfo = {
+		pluginSlug: 'zero-bs-crm',
+		pluginFile: 'zero-bs-crm/ZeroBSCRM',
 		isInstalled,
-		'jetpack_forms_upsell_crm_click'
-	);
-
-	const handleInstallAction = async () => {
-		const success = await installPlugin();
-		if ( success ) {
-			refreshStatus();
-		}
-	};
-
-	const getButtonText = () => {
-		return (
-			( isInstalling && isInstalled && __( 'Activating…', 'jetpack-forms' ) ) ||
-			( isInstalling && __( 'Installing…', 'jetpack-forms' ) ) ||
-			( isInstalled && __( 'Activate', 'jetpack-forms' ) ) ||
-			__( 'Install', 'jetpack-forms' )
-		);
+		isActive,
+		onComplete: refreshStatus,
+		trackingId: 'jetpack_forms_upsell_crm_click',
 	};
 
 	const crmVersion = semver.coerce( version );
@@ -68,15 +54,7 @@ const JetpackCRMCard = ( {
 							'jetpack-forms'
 						) }
 					</p>
-					<Button
-						variant="primary"
-						onClick={ handleInstallAction }
-						disabled={ isInstalling }
-						icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
-						__next40pxDefaultSize={ true }
-					>
-						{ getButtonText() }
-					</Button>
+					<PluginActionButton { ...pluginInfo } />
 				</div>
 			);
 		}
@@ -91,15 +69,7 @@ const JetpackCRMCard = ( {
 							'jetpack-forms'
 						) }
 					</p>
-					<Button
-						variant="primary"
-						onClick={ handleInstallAction }
-						disabled={ isInstalling }
-						icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
-						__next40pxDefaultSize={ true }
-					>
-						{ getButtonText() }
-					</Button>
+					<PluginActionButton { ...pluginInfo } />
 				</div>
 			);
 		}
@@ -177,6 +147,7 @@ const JetpackCRMCard = ( {
 			icon={ <JetpackIcon color={ COLOR_JETPACK } /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }
+			pluginInfo={ pluginInfo }
 		>
 			{ renderContent() }
 		</IntegrationCard>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
@@ -1,11 +1,10 @@
 import colorStudio from '@automattic/color-studio';
 import { JetpackIcon } from '@automattic/jetpack-components';
-import { Button, Spinner, ToggleControl } from '@wordpress/components';
+import { Button, ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import semver from 'semver';
 import IntegrationCard from './integration-card';
-import PluginActionButton from './plugin-action-button';
 
 const COLOR_JETPACK = colorStudio.colors[ 'Jetpack Green 40' ];
 
@@ -17,63 +16,30 @@ const JetpackCRMCard = ( {
 	data,
 	refreshStatus,
 } ) => {
-	const {
-		isInstalled = false,
-		isActive = false,
-		settingsUrl = '',
-		version = '',
-		details = {},
-	} = data || {};
+	const { settingsUrl = '', version = '', details = {} } = data || {};
 
 	const { hasExtension = false, canActivateExtension = false } = details;
 
-	const pluginInfo = {
-		pluginSlug: 'zero-bs-crm',
-		pluginFile: 'zero-bs-crm/ZeroBSCRM',
-		isInstalled,
-		isActive,
+	const cardData = {
+		...data,
 		onComplete: refreshStatus,
 		trackingId: 'jetpack_forms_upsell_crm_click',
 	};
+
+	const installDescription = __(
+		'You can save contacts from Jetpack contact forms in Jetpack CRM.',
+		'jetpack-forms'
+	);
+
+	const activateDescription = __(
+		"You already have the Jetpack CRM plugin installed, but it's not activated.",
+		'jetpack-forms'
+	);
 
 	const crmVersion = semver.coerce( version );
 	const isRecentVersion = crmVersion && semver.gte( crmVersion, '4.9.1' );
 
 	const renderContent = () => {
-		if ( ! data ) {
-			return <Spinner />;
-		}
-
-		// Jetpack CRM not installed
-		if ( ! isInstalled ) {
-			return (
-				<div>
-					<p>
-						{ __(
-							'You can save contacts from Jetpack contact forms in Jetpack CRM.',
-							'jetpack-forms'
-						) }
-					</p>
-					<PluginActionButton { ...pluginInfo } />
-				</div>
-			);
-		}
-
-		// Jetpack CRM installed but not active
-		if ( ! isActive ) {
-			return (
-				<div>
-					<p>
-						{ __(
-							"You already have the Jetpack CRM plugin installed, but it's not activated.",
-							'jetpack-forms'
-						) }
-					</p>
-					<PluginActionButton { ...pluginInfo } />
-				</div>
-			);
-		}
-
 		// Jetpack CRM installed and active, but not recent version
 		if ( ! isRecentVersion ) {
 			return (
@@ -147,7 +113,9 @@ const JetpackCRMCard = ( {
 			icon={ <JetpackIcon color={ COLOR_JETPACK } /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }
-			pluginInfo={ pluginInfo }
+			data={ cardData }
+			installDescription={ installDescription }
+			activateDescription={ activateDescription }
 		>
 			{ renderContent() }
 		</IntegrationCard>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/plugin-action-button.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/plugin-action-button.js
@@ -1,0 +1,51 @@
+import { Button, Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { usePluginInstallation } from '../hooks';
+
+const PluginActionButton = ( { pluginSlug, pluginFile, isInstalled, onComplete, trackingId } ) => {
+	const { isInstalling, installPlugin } = usePluginInstallation(
+		pluginSlug,
+		pluginFile,
+		isInstalled,
+		trackingId
+	);
+
+	const handleAction = async event => {
+		// Always stop propagation since this button is used in clickable card headers
+		event.stopPropagation();
+
+		const success = await installPlugin();
+		if ( success && onComplete ) {
+			onComplete();
+		}
+	};
+
+	const handleKeyDown = event => {
+		// Always stop propagation for keyboard events too
+		event.stopPropagation();
+	};
+
+	const getButtonText = () => {
+		return (
+			( isInstalling && isInstalled && __( 'Activating…', 'jetpack-forms' ) ) ||
+			( isInstalling && __( 'Installing…', 'jetpack-forms' ) ) ||
+			( isInstalled && __( 'Activate', 'jetpack-forms' ) ) ||
+			__( 'Install', 'jetpack-forms' )
+		);
+	};
+
+	return (
+		<Button
+			variant="primary"
+			onClick={ handleAction }
+			onKeyDown={ handleKeyDown }
+			disabled={ isInstalling }
+			icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
+			__next40pxDefaultSize={ true }
+		>
+			{ getButtonText() }
+		</Button>
+	);
+};
+
+export default PluginActionButton;

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -647,6 +647,8 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 
 		$response = array(
 			'type'        => 'plugin',
+			'slug'        => $plugin_slug,
+			'pluginFile'  => $plugin_config['file'],
 			'isInstalled' => $is_installed,
 			'isActive'    => $is_active,
 			'isConnected' => false,


### PR DESCRIPTION
## Proposed changes:

NOTE: This is one of many PRs to create the new third party integrations modal. All work is behind a feature flag and only visible if you set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.

Changes:
* For plugin-based integrations, this PR adds a 'Plugin' badge and 'Install'/'Activate' buttons when the plugin needs to be installed or activated.
* Both plugin badge and button are hidden when plugin is fully active. 
* Based on designs here: p1HpG7-wqy-p2

**Screenshot: Integration modal now when plugins are not installed**
Coming...

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file
- Deactivate or uninstall Akismet, Creative Mail, and Jetpack CRM
- Add a form block to a page
- Click on the Manage Integrations button the block sidebar
- Confirm you see a 'Plugin' badge and Install or Activate buttons on the header of each card. They should look like the screenshot above. 
- Click the install/activate buttons and confirm that plugins are installed/activated, that the badge/buttons disappear once active, and that plugins info or settings are now shown inside the card. 