### PR TITLE
Jetpack Search: fix errors caused by malformed order arguments

### DIFF
--- a/projects/packages/search/changelog/fix-jetpack-search-orderby-array-fatal
+++ b/projects/packages/search/changelog/fix-jetpack-search-orderby-array-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Search: fix errors caused by malformed order arguments

--- a/projects/packages/search/src/widgets/class-search-widget.php
+++ b/projects/packages/search/src/widgets/class-search-widget.php
@@ -607,11 +607,11 @@ class Search_Widget extends \WP_Widget {
 	private function sorting_to_wp_query_param( $sort ) {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		$parts   = explode( '|', $sort );
-		$orderby = isset( $_GET['orderby'] )
+		$orderby = isset( $_GET['orderby'] ) && is_string( $_GET['orderby'] )
 			? sanitize_sql_orderby( wp_unslash( $_GET['orderby'] ) )
 			: $parts[0];
 
-		$order = isset( $_GET['order'] )
+		$order = isset( $_GET['order'] ) && is_string( $_GET['order'] )
 			? ( strtoupper( $_GET['order'] ) === 'ASC' ? 'ASC' : 'DESC' ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- This is validating.
 			: ( ( isset( $parts[1] ) && 'ASC' === strtoupper( $parts[1] ) ) ? 'ASC' : 'DESC' );
 


### PR DESCRIPTION
## Proposed changes:

Fix fatal errors when orderby argument for search widget is malformed (array instead of string). Here's an example of an URL that would cause a fatal error without this fix: `/?s=test&orderby=date&order[]=`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Fixes p1743074015350569-slack-C02ME06LF

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Activate Jetpack Search (inline, without instant)
* Choose a theme with the classic sidebar, like twenty sixteen
* Add Jetpack Search widget to the sidebar
* Open `/?s=test&order[]=` URL on your domain

Without this fix you should see a fatal error. With this fix it should ignore the order argument as expected. 