### PR TITLE
MU: Add CSS monkey patches WP.com feature

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-add-misc-css
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-add-misc-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+MU plugin feature to add custom CSS for edge cases

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -264,6 +264,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/block-patterns/block-patterns.php';
 		require_once __DIR__ . '/features/blog-privacy/blog-privacy.php';
 		require_once __DIR__ . '/features/cloudflare-analytics/cloudflare-analytics.php';
+		require_once __DIR__ . '/features/css-monkey-patches/index.php';
 		require_once __DIR__ . '/features/error-reporting/error-reporting.php';
 		require_once __DIR__ . '/features/first-posts-stream/first-posts-stream-helpers.php';
 		require_once __DIR__ . '/features/font-smoothing-antialiased/font-smoothing-antialiased.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/css-monkey-patches/README.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/css-monkey-patches/README.md
@@ -6,7 +6,7 @@ This started because of https://github.com/elementor/elementor/pull/30540.
 
 # File naming rule
 
-Please name each CSS patch with the number of the corresponding issue on GitHub. Avoid accumulating CSS in large files. These fixes are meant to be tiny and precise.
+Please include the link to the GitHub issue of each CSS patch you add. This increases the odds of removing the patch later.
 
 # Keywords for search
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/css-monkey-patches/README.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/css-monkey-patches/README.md
@@ -4,7 +4,7 @@ This patches miscellaneous CSS issues that occur when plugins don't interplay we
 
 This started because of https://github.com/elementor/elementor/pull/30540.
 
-# File naming rule
+# Important Note
 
 Please include the link to the GitHub issue of each CSS patch you add. This increases the odds of removing the patch later.
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/css-monkey-patches/README.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/css-monkey-patches/README.md
@@ -4,6 +4,10 @@ This patches miscellaneous CSS issues that occur when plugins don't interplay we
 
 This started because of https://github.com/elementor/elementor/pull/30540.
 
+# File naming rule
+
+Please name each CSS patch with the number of the corresponding issue on GitHub. Avoid accumulating CSS in large files. These fixes are meant to be tiny and precise.
+
 # Keywords for search
 
 Custom CSS, additional CSS, CSS patch.

--- a/projects/packages/jetpack-mu-wpcom/src/features/css-monkey-patches/README.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/css-monkey-patches/README.md
@@ -1,0 +1,9 @@
+# CSS monkey patches
+
+This patches miscellaneous CSS issues that occur when plugins don't interplay well, when Core ships bad CSS, and such rare cases.
+
+This started because of https://github.com/elementor/elementor/pull/30540.
+
+# Keywords for search
+
+Custom CSS, additional CSS, CSS patch.

--- a/projects/packages/jetpack-mu-wpcom/src/features/css-monkey-patches/css-monkey-patches.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/css-monkey-patches/css-monkey-patches.css
@@ -1,3 +1,0 @@
-body {
-    color: red!important
-}

--- a/projects/packages/jetpack-mu-wpcom/src/features/css-monkey-patches/css-monkey-patches.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/css-monkey-patches/css-monkey-patches.css
@@ -1,0 +1,3 @@
+body {
+    color: red!important
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/css-monkey-patches/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/css-monkey-patches/index.php
@@ -11,5 +11,10 @@ add_action( 'admin_enqueue_scripts', 'jetpack_mu_wpcom_admin_css_monkey_patches'
  * Enqueue the CSS monkey patches.
  */
 function jetpack_mu_wpcom_admin_css_monkey_patches() {
-	wp_enqueue_style( 'css-monkey-patches', plugins_url( 'css-monkey-patches.css', __FILE__ ), array(), JETPACK_MU_WPCOM_VERSION );
+	/**
+	 * Only enqueue the Elementor fix on the Elementor admin page.
+	 */
+	if ( 'toplevel_page_elementor' === get_current_screen()->id ) {
+		wp_enqueue_style( 'jetpack-elementor-fix', plugins_url( 'jetpack-elementor-fix.css', __FILE__ ), array(), filemtime( __DIR__ . '/jetpack-elementor-fix.css' ) );
+	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/css-monkey-patches/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/css-monkey-patches/index.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * CSS monkey patches.
+ *
+ * @package jetpack-mu-wpcom
+ */
+
+add_action( 'admin_enqueue_scripts', 'jetpack_mu_wpcom_admin_css_monkey_patches' );
+
+/**
+ * Enqueue the CSS monkey patches.
+ */
+function jetpack_mu_wpcom_admin_css_monkey_patches() {
+	wp_enqueue_style( 'css-monkey-patches', plugins_url( 'css-monkey-patches.css', __FILE__ ), array(), JETPACK_MU_WPCOM_VERSION );
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/css-monkey-patches/jetpack-elementor-fix.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/css-monkey-patches/jetpack-elementor-fix.css
@@ -1,0 +1,26 @@
+/**
+ * Fix for: https://github.com/Automattic/jetpack/issues/42901
+ */
+.toplevel_page_elementor {
+	@media screen and ( min-width: 782px ) {
+		div#e-admin-top-bar-root {
+			position: relative;
+			margin-inline-start: -20px;
+			width: unset;
+			box-sizing: border-box;
+		}
+	}
+
+	@media screen and ( max-width: 782px ) {
+		div#e-admin-top-bar-root {
+			margin-inline-start: -10px;
+		}
+	}
+
+	@media screen and ( max-width: 600px ) {
+		div#e-admin-top-bar-root {
+			position: relative;
+			left: unset;
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/42901

## Proposed changes:
This adds a feature to Jetpack MU Plugin to allow monkey patching some miscellaneous CSS. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
- Make sure you can't reproduce https://github.com/Automattic/jetpack/issues/42901

