### PR TITLE
Jetpack SEO Enhancer: fix post publish panel styles

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-seo-enahncer-post-publish-panel
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-seo-enahncer-post-publish-panel
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack SEO Enhancer: remove post publish panel loading status and fix summaries and styles

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer-task-list.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer-task-list.tsx
@@ -18,7 +18,6 @@ import type { PromptType } from './types';
 
 export function SeoEnhancerTaskList( {
 	isPrePublish,
-	imageBlocks,
 }: {
 	isPrePublish: boolean;
 	imageBlocks: Block[];
@@ -56,15 +55,11 @@ export function SeoEnhancerTaskList( {
 			</div>
 			<div className="jetpack-seo-sidebar__feature-list">
 				{ FEATURES.map( feature => {
-					const extraLabel =
-						feature === 'images-alt-text' && imageBlocks.length > 0
-							? ` (${ imageBlocks.length })`
-							: '';
 					if ( ! isPrePublish ) {
 						return (
 							<div className="jetpack-seo-enhancer__feature-list-item" key={ feature }>
 								<div className="jetpack-seo-enhancer__feature-list-item-icon-container" />
-								<div>{ FEATURE_LABELS[ feature ] + extraLabel }</div>
+								<div>{ FEATURE_LABELS[ feature ] }</div>
 							</div>
 						);
 					}
@@ -79,7 +74,7 @@ export function SeoEnhancerTaskList( {
 								/>
 							</div>
 							<div className="jetpack-seo-enhancer__feature-list-item-label">
-								{ FEATURE_LABELS[ feature ] + extraLabel }
+								{ FEATURE_LABELS[ feature ] }
 							</div>
 						</div>
 					);

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
@@ -116,24 +116,17 @@ export function SeoEnhancer( {
 					) }
 					{ ( ! isEnabled || disableAutoEnhance ) && (
 						<div className="feature-checkboxes-container">
-							{ FEATURES.map( feature => {
-								const extraLabel =
-									feature === 'images-alt-text' && imageBlocks.length > 0
-										? ` (${ imageBlocks.length })`
-										: '';
-
-								return (
-									<CheckboxControl
-										key={ feature }
-										label={ FEATURE_LABELS[ feature ] + extraLabel }
-										checked={ enabledFeatures.includes( feature ) }
-										onChange={ () => toggleFeature( feature ) }
-										__nextHasNoMarginBottom={ true }
-										disabled={ isLoading }
-										className={ isLoading ? 'is-disabled' : '' }
-									/>
-								);
-							} ) }
+							{ FEATURES.map( feature => (
+								<CheckboxControl
+									key={ feature }
+									label={ FEATURE_LABELS[ feature ] }
+									checked={ enabledFeatures.includes( feature ) }
+									onChange={ () => toggleFeature( feature ) }
+									__nextHasNoMarginBottom={ true }
+									disabled={ isLoading }
+									className={ isLoading ? 'is-disabled' : '' }
+								/>
+							) ) }
 						</div>
 					) }
 					{ isEnabled && ! disableAutoEnhance && (

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-summary.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-summary.tsx
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { store as blockEditorStore } from '@wordpress/block-editor';
-import { PanelRow, Button, BaseControl, Spinner } from '@wordpress/components';
+import { getAllBlocks } from '@automattic/jetpack-ai-client';
+import { PanelRow, Button, BaseControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useEffect, useMemo, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Icon, check, closeSmall } from '@wordpress/icons';
+import { Icon, check } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
@@ -17,8 +17,6 @@ import './style.scss';
 /**
  * Types
  */
-import type { PromptType } from './types';
-import type { Block } from '@automattic/jetpack-ai-client';
 
 export function SeoSummary( { onEdit }: { onEdit: () => void } ) {
 	const { title, description } = useSelect( select => {
@@ -40,65 +38,55 @@ export function SeoSummary( { onEdit }: { onEdit: () => void } ) {
 		};
 	}, [] );
 
-	const { getBlocksByName, getBlock } = useSelect(
-		select =>
-			select( blockEditorStore ) as {
-				getBlocksByName: ( name: string ) => string[];
-				getBlock: ( id: string ) => Block;
-			},
-		[]
-	);
-
-	const [ allImagesHaveAltText, setAllImagesHaveAltText ] = useState( false );
-
 	const [ imageAltTextHelpText, setImageAltTextHelpText ] = useState( null );
 
 	const seoTitleHelpText = useMemo( () => {
-		return title
-			? title
-			: __( 'No title found. Add it for better search engine visibility.', 'jetpack' );
+		return title ? title : '';
 	}, [ title ] );
 
 	const seoDescriptionHelpText = useMemo( () => {
-		return description
-			? description
-			: __( 'No description found. Add it for better search engine visibility.', 'jetpack' );
+		return description ? description : '';
 	}, [ description ] );
 
 	useEffect( () => {
-		if ( ! imageBusy ) {
-			const imageBlockIds = getBlocksByName( 'core/image' );
+		const imageBlocks = getAllBlocks().filter(
+			block => block.name === 'core/image' && block.attributes.url
+		);
 
-			if ( imageBlockIds.length === 0 ) {
-				setImageAltTextHelpText( __( 'No images in the post.', 'jetpack' ) );
+		if ( imageBlocks.length === 0 ) {
+			setImageAltTextHelpText( '' );
 
-				setAllImagesHaveAltText( true );
-			} else {
-				const imageBlocks = imageBlockIds.map( blockId => getBlock( blockId ) );
-				const imageBlocksWithAltText = imageBlocks.filter( block => block.attributes.alt );
-
-				if ( imageBlocksWithAltText.length === imageBlockIds.length ) {
-					setImageAltTextHelpText(
-						// Translators: %d is the number of images.
-						sprintf( __( 'Alt text added to all %d images', 'jetpack' ), imageBlockIds.length )
-					);
-
-					setAllImagesHaveAltText( true );
-				} else {
-					setImageAltTextHelpText(
-						sprintf(
-							// Translators: %1$d is the number of images with alt text, %2$d is the total number of images.
-							__( 'Alt text added to %1$d of %2$d images', 'jetpack' ),
-							imageBlocksWithAltText.length,
-							imageBlockIds.length
-						)
-					);
-
-					setAllImagesHaveAltText( false );
-				}
-			}
+			return;
 		}
-	}, [ getBlock, getBlocksByName, imageBusy ] );
+
+		const imageBlocksWithAlt = imageBlocks.filter( block => !! block.attributes.alt );
+
+		if ( imageBlocksWithAlt.length === 0 ) {
+			setImageAltTextHelpText( '' );
+
+			return;
+		}
+
+		if ( imageBlocksWithAlt.length === imageBlocks.length ) {
+			setImageAltTextHelpText(
+				// Translators: %d is the number of images.
+				sprintf( __( 'Alt text added to all %d images', 'jetpack' ), imageBlocks.length )
+			);
+
+			return;
+		}
+
+		if ( imageBlocksWithAlt.length < imageBlocks.length ) {
+			setImageAltTextHelpText(
+				sprintf(
+					// Translators: %1$d is the number of images with alt text, %2$d is the total number of images.
+					__( 'Alt text added to %1$d of %2$d images', 'jetpack' ),
+					imageBlocksWithAlt.length,
+					imageBlocks.length
+				)
+			);
+		}
+	}, [] );
 
 	const helpTexts = useMemo( () => {
 		return {
@@ -115,39 +103,15 @@ export function SeoSummary( { onEdit }: { onEdit: () => void } ) {
 		titleBusy,
 	] );
 
-	const getIcon = ( feature: PromptType ) => {
-		if ( feature === 'seo-title' ) {
-			if ( titleBusy ) {
-				return <Spinner />;
-			}
+	const allHelpTextsEmpty = useMemo( () => {
+		return Object.values( helpTexts ).every( text => ! text );
+	}, [ helpTexts ] );
 
-			if ( title ) {
-				return check;
-			}
-		}
-
-		if ( feature === 'seo-meta-description' ) {
-			if ( descriptionBusy ) {
-				return <Spinner />;
-			}
-
-			if ( description ) {
-				return check;
-			}
-		}
-
-		if ( feature === 'images-alt-text' ) {
-			if ( imageBusy ) {
-				return <Spinner />;
-			}
-
-			if ( allImagesHaveAltText ) {
-				return check;
-			}
-		}
-
-		return closeSmall;
-	};
+	const editMetadataFurtherText = __( 'Want to fine-tune this metadata further?', 'jetpack' );
+	const noMetadataText = __(
+		'No metadata found. Add it to improve search engine visibility.',
+		'jetpack'
+	);
 
 	return (
 		<>
@@ -155,31 +119,34 @@ export function SeoSummary( { onEdit }: { onEdit: () => void } ) {
 				<BaseControl
 					__nextHasNoMarginBottom={ true }
 					className="ai-seo-enhancer-toggle"
-					help={ __( 'Want to fine-tune this metadata further?', 'jetpack' ) }
+					help={ allHelpTextsEmpty ? noMetadataText : editMetadataFurtherText }
 					label={ __( 'Metadata', 'jetpack' ) }
 					id="jetpack-seo-enhancer-generated-metadata"
 				>
-					{ FEATURES.map( feature => (
-						<div key={ feature } className="jetpack-seo-enhancer-summary-feature">
-							<div className="jetpack-seo-enhancer-summary-feature__icon-container">
-								<Icon
-									className="jetpack-seo-enhancer-summary-feature__icon"
-									icon={ getIcon( feature ) }
-								/>
-							</div>
+					{ ! allHelpTextsEmpty &&
+						FEATURES.map( feature => {
+							if ( ! helpTexts[ feature ] ) {
+								return null;
+							}
+							return (
+								<div key={ feature } className="jetpack-seo-enhancer-summary-feature">
+									<div className="jetpack-seo-enhancer-summary-feature__icon-container">
+										<Icon className="jetpack-seo-enhancer-summary-feature__icon" icon={ check } />
+									</div>
 
-							<BaseControl
-								className="jetpack-seo-enhancer-summary-feature__control"
-								key={ feature }
-								label={ FEATURE_LABELS[ feature ] }
-								id={ feature }
-								help={ helpTexts[ feature ] }
-								__nextHasNoMarginBottom={ true }
-							>
-								{ null }
-							</BaseControl>
-						</div>
-					) ) }
+									<BaseControl
+										className="jetpack-seo-enhancer-summary-feature__control"
+										key={ feature }
+										label={ FEATURE_LABELS[ feature ] }
+										id={ feature }
+										help={ helpTexts[ feature ] }
+										__nextHasNoMarginBottom={ true }
+									>
+										{ null }
+									</BaseControl>
+								</div>
+							);
+						} ) }
 				</BaseControl>
 
 				<Button

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-summary.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-summary.tsx
@@ -68,10 +68,7 @@ export function SeoSummary( { onEdit }: { onEdit: () => void } ) {
 		}
 
 		if ( imageBlocksWithAlt.length === imageBlocks.length ) {
-			setImageAltTextHelpText(
-				// Translators: %d is the number of images.
-				sprintf( __( 'Alt text added to all %d images', 'jetpack' ), imageBlocks.length )
-			);
+			setImageAltTextHelpText( __( 'Alt text added to all images', 'jetpack' ) );
 
 			return;
 		}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/style.scss
@@ -71,10 +71,6 @@
 	margin-bottom: 8px;
 	gap: 6px;
 
-	&:last-child {
-		// margin-bottom: 2em;
-	}
-
 	.jetpack-seo-enhancer-summary-feature__control {
 		flex-grow: 1;
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/style.scss
@@ -2,6 +2,10 @@
 	.ai-seo-enhancer-label {
 		margin-bottom: 24px;
 	}
+
+	.ai-seo-enhancer-toggle > p {
+		margin-top: 16px;
+	}
 }
 
 .jetpack-seo-panel {
@@ -64,23 +68,27 @@
 
 .jetpack-seo-enhancer-summary-feature {
 	display: flex;
-	margin-bottom: 12px;
+	margin-bottom: 8px;
+	gap: 6px;
 
 	&:last-child {
-		margin-bottom: 2em;
+		// margin-bottom: 2em;
 	}
 
 	.jetpack-seo-enhancer-summary-feature__control {
 		flex-grow: 1;
+
+		& .components-base-control__label {
+			text-transform: none;
+			font-size: 13px;
+			margin-top: 3px;
+		}
 	}
 
 	.jetpack-seo-enhancer-summary-feature__icon-container {
 		flex-shrink: 0;
-		width: 40px;
-	}
-
-	.components-spinner.jetpack-seo-enhancer-summary-feature__icon {
-		margin: 4px 4px 4px 0;
+		width: 34px;
+		text-align: end;
 	}
 }
 


### PR DESCRIPTION
Fixes AGORA-37

## Proposed changes:
This PR removes the loading states included on the post publish panel and fixes some styling issues.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1743541991984729/1743460306.593219-slack-C054LN8RNVA
LIp2rWnrg6h6bgs6KAKZ8j-fi-4665_3100

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add the feature filter: `add_filter( 'ai_seo_enhancer_enabled', '__return_true' );`.

Get a Jetpack Complete or Business plan and above for your site, or add the bypass filter `add_filter( 'ai_seo_enhancer_enabled_unrestricted', '__return_true' );`

Open the editor, add some content to the post. Publish and wait for generation, then hit publish again. Verify the PostPublish panel shows a summary and that it fits the designs and performed tasks.
Maybe repeat the process with or without missing metas/alt-texts to see the different summaries.

<img width="705" alt="image" src="https://github.com/user-attachments/assets/5993236e-4bb4-45dd-b983-9c6f2cc6df2f" />

