### PR TITLE
Forms: Add header, body, button components for integrations modal

### DIFF
--- a/projects/packages/forms/changelog/update-refactor-form-integration-cards
+++ b/projects/packages/forms/changelog/update-refactor-form-integration-cards
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Added integration header, body, button components.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
@@ -1,10 +1,10 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { Button, ExternalLink, Icon, Spinner } from '@wordpress/components';
+import { Button, ExternalLink, Spinner } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import AkismetIcon from '../../../../icons/akismet-icon';
-import { usePluginInstallation } from '../hooks';
 import IntegrationCard from './integration-card';
+import PluginActionButton from './plugin-action-button';
 
 const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 	const formSubmissionsUrl = window?.jpFormsBlocks?.defaults?.formsAdminUrl || '';
@@ -15,29 +15,6 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 		isConnected: akismetActiveWithKey = false,
 		settingsUrl = '',
 	} = data || {};
-
-	const { isInstalling, installPlugin } = usePluginInstallation(
-		'akismet',
-		'akismet/akismet',
-		isInstalled,
-		'jetpack_forms_upsell_akismet_click'
-	);
-
-	const handleInstallAction = async () => {
-		const success = await installPlugin();
-		if ( success ) {
-			refreshStatus();
-		}
-	};
-
-	const getButtonText = () => {
-		return (
-			( isInstalling && isInstalled && __( 'Activating…', 'jetpack-forms' ) ) ||
-			( isInstalling && __( 'Installing…', 'jetpack-forms' ) ) ||
-			( isInstalled && __( 'Activate', 'jetpack-forms' ) ) ||
-			__( 'Install', 'jetpack-forms' )
-		);
-	};
 
 	const renderContent = () => {
 		if ( ! data ) {
@@ -58,15 +35,13 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 							}
 						) }
 					</p>
-					<Button
-						variant="primary"
-						onClick={ handleInstallAction }
-						disabled={ isInstalling }
-						icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
-						__next40pxDefaultSize={ true }
-					>
-						{ getButtonText() }
-					</Button>
+					<PluginActionButton
+						pluginSlug="akismet"
+						pluginFile="akismet/akismet"
+						isInstalled={ isInstalled }
+						onSuccess={ refreshStatus }
+						trackEventName="jetpack_forms_upsell_akismet_click"
+					/>
 				</div>
 			);
 		}
@@ -77,15 +52,13 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 					<p>
 						{ __( "You already have Akismet installed, but it's not activated.", 'jetpack-forms' ) }
 					</p>
-					<Button
-						variant="primary"
-						onClick={ handleInstallAction }
-						disabled={ isInstalling }
-						icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
-						__next40pxDefaultSize={ true }
-					>
-						{ getButtonText() }
-					</Button>
+					<PluginActionButton
+						pluginSlug="akismet"
+						pluginFile="akismet/akismet"
+						isInstalled={ isInstalled }
+						onSuccess={ refreshStatus }
+						trackEventName="jetpack_forms_upsell_akismet_click"
+					/>
 				</div>
 			);
 		}

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
@@ -39,7 +39,7 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 						pluginSlug="akismet"
 						pluginFile="akismet/akismet"
 						isInstalled={ isInstalled }
-						onSuccess={ refreshStatus }
+						refreshStatus={ refreshStatus }
 						trackEventName="jetpack_forms_upsell_akismet_click"
 					/>
 				</div>
@@ -56,7 +56,7 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 						pluginSlug="akismet"
 						pluginFile="akismet/akismet"
 						isInstalled={ isInstalled }
-						onSuccess={ refreshStatus }
+						refreshStatus={ refreshStatus }
 						trackEventName="jetpack_forms_upsell_akismet_click"
 					/>
 				</div>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
@@ -1,9 +1,9 @@
 import { createBlock } from '@wordpress/blocks';
-import { Button, ExternalLink, Spinner, Icon, ToggleControl } from '@wordpress/components';
+import { ExternalLink, Spinner, ToggleControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { usePluginInstallation } from '../hooks';
 import IntegrationCard from './integration-card';
+import PluginActionButton from './plugin-action-button';
 
 const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 	const { isInstalled = false, isActive = false, settingsUrl = '' } = data || {};
@@ -20,20 +20,6 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 		( { name } ) => name === 'jetpack/field-consent'
 	);
 
-	const { isInstalling, installPlugin } = usePluginInstallation(
-		'creative-mail-by-constant-contact',
-		'creative-mail-by-constant-contact/creative-mail-plugin',
-		isInstalled,
-		'jetpack_forms_upsell_creative_mail_click'
-	);
-
-	const handleInstallAction = async () => {
-		const success = await installPlugin();
-		if ( success ) {
-			refreshStatus();
-		}
-	};
-
 	const toggleConsent = async () => {
 		if ( consentBlock ) {
 			await removeBlock( consentBlock.clientId, false );
@@ -44,15 +30,6 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 			const newConsentBlock = await createBlock( 'jetpack/field-consent' );
 			await insertBlock( newConsentBlock, buttonBlockIndex, selectedBlock.clientId, false );
 		}
-	};
-
-	const getButtonText = () => {
-		return (
-			( isInstalling && isInstalled && __( 'Activating…', 'jetpack-forms' ) ) ||
-			( isInstalling && __( 'Installing…', 'jetpack-forms' ) ) ||
-			( isInstalled && __( 'Activate Creative Mail Plugin', 'jetpack-forms' ) ) ||
-			__( 'Install Creative Mail plugin', 'jetpack-forms' )
-		);
 	};
 
 	const renderContent = () => {
@@ -71,15 +48,13 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 							) }
 						</em>
 					</p>
-					<Button
-						variant="primary"
-						onClick={ handleInstallAction }
-						disabled={ isInstalling }
-						icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
-						__next40pxDefaultSize={ true }
-					>
-						{ getButtonText() }
-					</Button>
+					<PluginActionButton
+						pluginSlug="creative-mail-by-constant-contact"
+						pluginFile="creative-mail-by-constant-contact/creative-mail-plugin"
+						isInstalled={ isInstalled }
+						onSuccess={ refreshStatus }
+						trackEventName="jetpack_forms_upsell_creative_mail_click"
+					/>
 				</div>
 			);
 		}
@@ -95,15 +70,13 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 							) }
 						</em>
 					</p>
-					<Button
-						variant="primary"
-						onClick={ handleInstallAction }
-						disabled={ isInstalling }
-						icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
-						__next40pxDefaultSize={ true }
-					>
-						{ getButtonText() }
-					</Button>
+					<PluginActionButton
+						pluginSlug="creative-mail-by-constant-contact"
+						pluginFile="creative-mail-by-constant-contact/creative-mail-plugin"
+						isInstalled={ isInstalled }
+						onSuccess={ refreshStatus }
+						trackEventName="jetpack_forms_upsell_creative_mail_click"
+					/>
 				</div>
 			);
 		}

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
@@ -52,7 +52,7 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 						pluginSlug="creative-mail-by-constant-contact"
 						pluginFile="creative-mail-by-constant-contact/creative-mail-plugin"
 						isInstalled={ isInstalled }
-						onSuccess={ refreshStatus }
+						refreshStatus={ refreshStatus }
 						trackEventName="jetpack_forms_upsell_creative_mail_click"
 					/>
 				</div>
@@ -74,7 +74,7 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 						pluginSlug="creative-mail-by-constant-contact"
 						pluginFile="creative-mail-by-constant-contact/creative-mail-plugin"
 						isInstalled={ isInstalled }
-						onSuccess={ refreshStatus }
+						refreshStatus={ refreshStatus }
 						trackEventName="jetpack_forms_upsell_creative_mail_click"
 					/>
 				</div>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card-body.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card-body.js
@@ -1,0 +1,11 @@
+import { CardBody } from '@wordpress/components';
+
+const IntegrationCardBody = ( { isExpanded, children } ) => {
+	if ( ! isExpanded ) {
+		return null;
+	}
+
+	return <CardBody>{ children }</CardBody>;
+};
+
+export default IntegrationCardBody;

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card-header.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card-header.js
@@ -1,0 +1,25 @@
+import { CardHeader, Icon } from '@wordpress/components';
+
+const IntegrationCardHeader = ( { title, description, icon, isExpanded, onToggle } ) => {
+	return (
+		<CardHeader onClick={ onToggle } className="integration-card__header">
+			<div className="integration-card__header-content">
+				<div className="integration-card__header-main">
+					<Icon icon={ icon } className="integration-card__service-icon" size={ 30 } />
+					<div className="integration-card__title-section">
+						<h3 className="integration-card__title">{ title }</h3>
+						{ description && (
+							<span className="integration-card__description">{ description }</span>
+						) }
+					</div>
+				</div>
+				<Icon
+					icon={ isExpanded ? 'arrow-up-alt2' : 'arrow-down-alt2' }
+					className="integration-card__toggle-icon"
+				/>
+			</div>
+		</CardHeader>
+	);
+};
+
+export default IntegrationCardHeader;

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card.js
@@ -1,5 +1,7 @@
-import { Card, CardHeader, CardBody, Icon } from '@wordpress/components';
+import { Card } from '@wordpress/components';
 import './integration-card.scss';
+import IntegrationCardBody from './integration-card-body';
+import IntegrationCardHeader from './integration-card-header';
 
 const IntegrationCard = ( {
 	title,
@@ -11,24 +13,14 @@ const IntegrationCard = ( {
 } ) => {
 	return (
 		<Card className="integration-card">
-			<CardHeader onClick={ onToggle } className="integration-card__header">
-				<div className="integration-card__header-content">
-					<div className="integration-card__header-main">
-						<Icon icon={ icon } className="integration-card__service-icon" size={ 30 } />
-						<div className="integration-card__title-section">
-							<h3 className="integration-card__title">{ title }</h3>
-							{ description && (
-								<span className="integration-card__description">{ description }</span>
-							) }
-						</div>
-					</div>
-					<Icon
-						icon={ isExpanded ? 'arrow-up-alt2' : 'arrow-down-alt2' }
-						className="integration-card__toggle-icon"
-					/>
-				</div>
-			</CardHeader>
-			{ isExpanded && <CardBody>{ children }</CardBody> }
+			<IntegrationCardHeader
+				title={ title }
+				description={ description }
+				icon={ icon }
+				isExpanded={ isExpanded }
+				onToggle={ onToggle }
+			/>
+			<IntegrationCardBody isExpanded={ isExpanded }>{ children }</IntegrationCardBody>
 		</Card>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
@@ -1,11 +1,11 @@
 import colorStudio from '@automattic/color-studio';
 import { JetpackIcon } from '@automattic/jetpack-components';
-import { Button, Icon, Spinner, ToggleControl } from '@wordpress/components';
+import { Button, Spinner, ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import semver from 'semver';
-import { usePluginInstallation } from '../hooks';
 import IntegrationCard from './integration-card';
+import PluginActionButton from './plugin-action-button';
 
 const COLOR_JETPACK = colorStudio.colors[ 'Jetpack Green 40' ];
 
@@ -27,29 +27,6 @@ const JetpackCRMCard = ( {
 
 	const { hasExtension = false, canActivateExtension = false } = details;
 
-	const { isInstalling, installPlugin } = usePluginInstallation(
-		'zero-bs-crm',
-		'zero-bs-crm/ZeroBSCRM',
-		isInstalled,
-		'jetpack_forms_upsell_crm_click'
-	);
-
-	const handleInstallAction = async () => {
-		const success = await installPlugin();
-		if ( success ) {
-			refreshStatus();
-		}
-	};
-
-	const getButtonText = () => {
-		return (
-			( isInstalling && isInstalled && __( 'Activating…', 'jetpack-forms' ) ) ||
-			( isInstalling && __( 'Installing…', 'jetpack-forms' ) ) ||
-			( isInstalled && __( 'Activate', 'jetpack-forms' ) ) ||
-			__( 'Install', 'jetpack-forms' )
-		);
-	};
-
 	const crmVersion = semver.coerce( version );
 	const isRecentVersion = crmVersion && semver.gte( crmVersion, '4.9.1' );
 
@@ -68,15 +45,13 @@ const JetpackCRMCard = ( {
 							'jetpack-forms'
 						) }
 					</p>
-					<Button
-						variant="primary"
-						onClick={ handleInstallAction }
-						disabled={ isInstalling }
-						icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
-						__next40pxDefaultSize={ true }
-					>
-						{ getButtonText() }
-					</Button>
+					<PluginActionButton
+						pluginSlug="zero-bs-crm"
+						pluginFile="zero-bs-crm/ZeroBSCRM"
+						isInstalled={ isInstalled }
+						onSuccess={ refreshStatus }
+						trackEventName="jetpack_forms_upsell_crm_click"
+					/>
 				</div>
 			);
 		}
@@ -91,15 +66,13 @@ const JetpackCRMCard = ( {
 							'jetpack-forms'
 						) }
 					</p>
-					<Button
-						variant="primary"
-						onClick={ handleInstallAction }
-						disabled={ isInstalling }
-						icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
-						__next40pxDefaultSize={ true }
-					>
-						{ getButtonText() }
-					</Button>
+					<PluginActionButton
+						pluginSlug="zero-bs-crm"
+						pluginFile="zero-bs-crm/ZeroBSCRM"
+						isInstalled={ isInstalled }
+						onSuccess={ refreshStatus }
+						trackEventName="jetpack_forms_upsell_crm_click"
+					/>
 				</div>
 			);
 		}

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
@@ -49,7 +49,7 @@ const JetpackCRMCard = ( {
 						pluginSlug="zero-bs-crm"
 						pluginFile="zero-bs-crm/ZeroBSCRM"
 						isInstalled={ isInstalled }
-						onSuccess={ refreshStatus }
+						refreshStatus={ refreshStatus }
 						trackEventName="jetpack_forms_upsell_crm_click"
 					/>
 				</div>
@@ -70,7 +70,7 @@ const JetpackCRMCard = ( {
 						pluginSlug="zero-bs-crm"
 						pluginFile="zero-bs-crm/ZeroBSCRM"
 						isInstalled={ isInstalled }
-						onSuccess={ refreshStatus }
+						refreshStatus={ refreshStatus }
 						trackEventName="jetpack_forms_upsell_crm_click"
 					/>
 				</div>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/plugin-action-button.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/plugin-action-button.js
@@ -1,0 +1,48 @@
+import { Button, Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { usePluginInstallation } from '../hooks';
+
+const PluginActionButton = ( {
+	pluginSlug,
+	pluginFile,
+	isInstalled,
+	onSuccess,
+	trackEventName,
+} ) => {
+	const { isInstalling, installPlugin } = usePluginInstallation(
+		pluginSlug,
+		pluginFile,
+		isInstalled,
+		trackEventName
+	);
+
+	const handleAction = async () => {
+		const success = await installPlugin();
+		if ( success && onSuccess ) {
+			onSuccess();
+		}
+	};
+
+	const getButtonText = () => {
+		return (
+			( isInstalling && isInstalled && __( 'Activating…', 'jetpack-forms' ) ) ||
+			( isInstalling && __( 'Installing…', 'jetpack-forms' ) ) ||
+			( isInstalled && __( 'Activate', 'jetpack-forms' ) ) ||
+			__( 'Install', 'jetpack-forms' )
+		);
+	};
+
+	return (
+		<Button
+			variant="primary"
+			onClick={ handleAction }
+			disabled={ isInstalling }
+			icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
+			__next40pxDefaultSize={ true }
+		>
+			{ getButtonText() }
+		</Button>
+	);
+};
+
+export default PluginActionButton;

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/plugin-action-button.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/plugin-action-button.js
@@ -6,7 +6,7 @@ const PluginActionButton = ( {
 	pluginSlug,
 	pluginFile,
 	isInstalled,
-	onSuccess,
+	refreshStatus,
 	trackEventName,
 } ) => {
 	const { isInstalling, installPlugin } = usePluginInstallation(
@@ -18,8 +18,8 @@ const PluginActionButton = ( {
 
 	const handleAction = async () => {
 		const success = await installPlugin();
-		if ( success && onSuccess ) {
-			onSuccess();
+		if ( success && refreshStatus ) {
+			refreshStatus();
 		}
 	};
 


### PR DESCRIPTION
## Proposed changes:

NOTE: This is one of many PRs to create the new third party integrations modal. All this work is behind a feature flag and only be visible if you set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.

Changes:
* This PR refactors the existing code for the IntegrationCard and the Akismet, CRM, and Creative Mail cards, to have separate CardHeader, CardBody, and button components. This is preparing the way for subsequent PRs to add more complex logic and markup to each of those components. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

There should be no changes in behavior. This is a refactor. 

- Set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.
- Add a form block to a page - with an email field
- Click on the Manage Integrations button the block sidebar
- Confirm the modal opens and the individual integration cards behave the same as before
