### PR TITLE
Jetpack SEO Enhancer: cancel edits if post is published

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-seo-enhancer-cancel-requests-for-published-posts
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-seo-enhancer-cancel-requests-for-published-posts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack SEO Enhancer: cancel metas/alt-text updates if the post has been published

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-requests.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-requests.ts
@@ -106,7 +106,7 @@ export const useSeoRequests = () => {
 	const updateTitle = useCallback(
 		async ( force: boolean = false ) => {
 			const hasTitle =
-				!! globalSelect( 'core/editor' ).getEditedPostAttribute( 'meta' )?.jetpack_seo_html_title;
+				!! globalSelect( editorStore ).getEditedPostAttribute( 'meta' )?.jetpack_seo_html_title;
 
 			if ( hasTitle && force !== true ) {
 				return null;
@@ -139,7 +139,7 @@ export const useSeoRequests = () => {
 	const updateDescription = useCallback(
 		async ( force: boolean = false ) => {
 			const hasDescription =
-				!! globalSelect( 'core/editor' ).getEditedPostAttribute( 'meta' )?.advanced_seo_description;
+				!! globalSelect( editorStore ).getEditedPostAttribute( 'meta' )?.advanced_seo_description;
 
 			if ( hasDescription && force !== true ) {
 				return null;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-requests.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-requests.ts
@@ -117,11 +117,13 @@ export const useSeoRequests = () => {
 				const response = await request( 'seo-title' );
 				const title = parseResponse( response ).titles?.[ 0 ];
 
-				editPost( {
-					meta: {
-						jetpack_seo_html_title: title,
-					},
-				} );
+				if ( ! globalSelect( editorStore ).isCurrentPostPublished() ) {
+					editPost( {
+						meta: {
+							jetpack_seo_html_title: title,
+						},
+					} );
+				}
 
 				return true;
 			} catch ( error ) {
@@ -147,11 +149,14 @@ export const useSeoRequests = () => {
 				setDescriptionBusy( true );
 				const response = await request( 'seo-meta-description' );
 				const description = parseResponse( response ).descriptions?.[ 0 ];
-				editPost( {
-					meta: {
-						advanced_seo_description: description,
-					},
-				} );
+
+				if ( ! globalSelect( editorStore ).isCurrentPostPublished() ) {
+					editPost( {
+						meta: {
+							advanced_seo_description: description,
+						},
+					} );
+				}
 
 				return true;
 			} catch ( error ) {
@@ -191,7 +196,10 @@ export const useSeoRequests = () => {
 
 				const altText = parseResponse( response ).texts?.[ 0 ];
 
-				await updateBlockAttributes( block.clientId, { alt: altText } );
+				if ( ! globalSelect( editorStore ).isCurrentPostPublished() ) {
+					await updateBlockAttributes( block.clientId, { alt: altText } );
+				}
+
 				setImageBusy( block.clientId, false );
 
 				return true;


### PR DESCRIPTION
Fixes AGORA-38

## Proposed changes:
This PR checks for post status before editing metas or image alt-texts and cancels the edits if the post is published.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1743706732503029-slack-C054LN8RNVA


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add the feature filter: `add_filter( 'ai_seo_enhancer_enabled', '__return_true' );`.

Get a Jetpack Complete or Business plan and above for your site, or add the bypass filter `add_filter( 'ai_seo_enhancer_enabled_unrestricted', '__return_true' );`

Open the editor, add some content and images to the post. Enable "Auto generate" toggle on Jetpack sidebar's SEO panel.

Hit Publish twice in quick succession (first click will open PrePublish panel, second will actually publish the post) so to not allow the the auto generation requests to finish.
Depending on how fast you hit the second time, some or all the generation requests won't finish in time. PostPublish summary should show consistently what has been generated and what not.

Verify the PostPublish panel doesn't auto close (it used to due to the requests editing the post once they returned).
Verify the summary is accurate by going back to SEO panel and checking the meta title and description and by checking if images got alt-text attribute generated or not. 