### PR TITLE
Jetpack SEO Enhancer: fix auto generation trigger all features

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-seo-enhancer-auto-triggers-all-features
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-seo-enhancer-auto-triggers-all-features
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack SEO: fix bug where auto generation would only trigger the last enabled features set by user on manual mode

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
@@ -3,6 +3,7 @@
  */
 import { getAllBlocks } from '@automattic/jetpack-ai-client';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import {
 	BaseControl,
 	ToggleControl,
@@ -11,7 +12,6 @@ import {
 	CheckboxControl,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
@@ -23,6 +23,7 @@ import { SeoEnhancerTaskList } from './seo-enhancer-task-list';
 import { store } from './store';
 import { useSeoModuleSettings } from './use-seo-module-settings';
 import { useSeoRequests } from './use-seo-requests';
+import type { BlockInstance } from '@wordpress/blocks';
 import './style.scss';
 /**
  * Types
@@ -46,7 +47,10 @@ export function SeoEnhancer( {
 	}, [] );
 
 	const enabledFeatures = useSelect( select => select( store ).getEnabledFeatures(), [] );
-	const blocks = useSelect( select => select( editorStore ).getBlocks(), [] );
+	const blocks = useSelect(
+		select => ( select( blockEditorStore ) as { getBlocks: () => BlockInstance[] } ).getBlocks(),
+		[]
+	);
 
 	const imageBlocks = useMemo( () => {
 		return blocks.length

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-requests.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-requests.ts
@@ -259,20 +259,29 @@ export const useSeoRequests = () => {
 				images_alt_text: false,
 			};
 
-			enabledFeatures.forEach( feature => {
-				if ( feature === 'seo-title' ) {
-					promises.push( updateTitle() );
-					trackData.seo_title = true;
-				}
-				if ( feature === 'seo-meta-description' ) {
-					promises.push( updateDescription() );
-					trackData.seo_meta_description = true;
-				}
-				if ( feature === 'images-alt-text' ) {
-					promises.push( updateAltTexts() );
-					trackData.images_alt_text = true;
-				}
-			} );
+			if ( trigger === 'auto' ) {
+				promises.push( updateTitle() );
+				promises.push( updateDescription() );
+				promises.push( updateAltTexts() );
+				trackData.seo_title = true;
+				trackData.seo_meta_description = true;
+				trackData.images_alt_text = true;
+			} else {
+				enabledFeatures.forEach( feature => {
+					if ( feature === 'seo-title' ) {
+						promises.push( updateTitle() );
+						trackData.seo_title = true;
+					}
+					if ( feature === 'seo-meta-description' ) {
+						promises.push( updateDescription() );
+						trackData.seo_meta_description = true;
+					}
+					if ( feature === 'images-alt-text' ) {
+						promises.push( updateAltTexts() );
+						trackData.images_alt_text = true;
+					}
+				} );
+			}
 
 			tracks.recordEvent( 'jetpack_seo_enhancer_trigger', trackData );
 


### PR DESCRIPTION
Fixes AGORA-48

## Proposed changes:
This PR addresses an issue where the auto generation would only trigger last features set by user.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1743706901280909-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add the feature filter: `add_filter( 'ai_seo_enhancer_enabled', '__return_true' );`.

Get a Jetpack Complete or Business plan and above for your site, or add the bypass filter `add_filter( 'ai_seo_enhancer_enabled_unrestricted', '__return_true' );`

Open the editor, add some content to the post. Look for the SEO panel on Jetpack sidebar. Disable (uncheck) any or all generation features, then enable the auto-generation toggle.

Hitting publish should trigger all auto-generation features disregarding what features were enabled while the toggle was off.