### PR TITLE
Forms: Move shared form integration card logic

### DIFF
--- a/projects/packages/forms/changelog/update-forms-integration-card-body
+++ b/projects/packages/forms/changelog/update-forms-integration-card-body
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Move shared integration card logic.

--- a/projects/packages/forms/src/blocks/contact-form/components/hooks/usePluginInstallation.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/hooks/usePluginInstallation.js
@@ -5,13 +5,13 @@ import { installAndActivatePlugin, activatePlugin } from '../../util/plugin-mana
 /**
  * Custom hook to handle plugin installation and activation flows.
  *
- * @param {string}  pluginSlug      - The plugin slug (e.g., 'akismet')
+ * @param {string}  slug            - The plugin slug (e.g., 'akismet')
  * @param {string}  pluginPath      - The plugin path (e.g., 'akismet/akismet')
  * @param {boolean} isInstalled     - Whether the plugin is installed
  * @param {string}  tracksEventName - The name of the tracks event to record
  * @return {object} Plugin installation states and handlers
  */
-export const usePluginInstallation = ( pluginSlug, pluginPath, isInstalled, tracksEventName ) => {
+export const usePluginInstallation = ( slug, pluginPath, isInstalled, tracksEventName ) => {
 	const [ isInstalling, setIsInstalling ] = useState( false );
 	const { tracks } = useAnalytics();
 
@@ -26,7 +26,7 @@ export const usePluginInstallation = ( pluginSlug, pluginPath, isInstalled, trac
 			if ( isInstalled ) {
 				await activatePlugin( pluginPath );
 			} else {
-				await installAndActivatePlugin( pluginSlug );
+				await installAndActivatePlugin( slug );
 			}
 			return true;
 		} catch {
@@ -35,7 +35,7 @@ export const usePluginInstallation = ( pluginSlug, pluginPath, isInstalled, trac
 		} finally {
 			setIsInstalling( false );
 		}
-	}, [ pluginSlug, pluginPath, isInstalled, tracks, tracksEventName ] );
+	}, [ slug, pluginPath, isInstalled, tracks, tracksEventName ] );
 
 	return {
 		isInstalling,

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
@@ -1,68 +1,36 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { Button, ExternalLink, Spinner } from '@wordpress/components';
+import { Button, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import AkismetIcon from '../../../../icons/akismet-icon';
 import IntegrationCard from './integration-card';
-import PluginActionButton from './plugin-action-button';
 
 const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 	const formSubmissionsUrl = window?.jpFormsBlocks?.defaults?.formsAdminUrl || '';
 
-	const {
-		isInstalled = false,
-		isActive = false,
-		isConnected: akismetActiveWithKey = false,
-		settingsUrl = '',
-	} = data || {};
+	const { isConnected: akismetActiveWithKey = false, settingsUrl = '' } = data || {};
 
-	const renderContent = () => {
-		if ( ! data ) {
-			return <Spinner />;
-		}
+	const cardData = {
+		pluginSlug: 'akismet',
+		pluginFile: 'akismet/akismet',
+		refreshStatus,
+		trackEventName: 'jetpack_forms_upsell_akismet_click',
+		notInstalledMessage: createInterpolateElement(
+			__(
+				"Add one-click spam protection for your forms with <a>Akismet</a>. Simply install the plugin and you're set.",
+				'jetpack-forms'
+			),
+			{
+				a: <ExternalLink href={ getRedirectUrl( 'akismet-wordpress-org' ) } />,
+			}
+		),
+		notActivatedMessage: __(
+			"You already have Akismet installed, but it's not activated.",
+			'jetpack-forms'
+		),
+	};
 
-		if ( ! isInstalled ) {
-			return (
-				<div>
-					<p>
-						{ createInterpolateElement(
-							__(
-								"Add one-click spam protection for your forms with <a>Akismet</a>. Simply install the plugin and you're set.",
-								'jetpack-forms'
-							),
-							{
-								a: <ExternalLink href={ getRedirectUrl( 'akismet-wordpress-org' ) } />,
-							}
-						) }
-					</p>
-					<PluginActionButton
-						pluginSlug="akismet"
-						pluginFile="akismet/akismet"
-						isInstalled={ isInstalled }
-						refreshStatus={ refreshStatus }
-						trackEventName="jetpack_forms_upsell_akismet_click"
-					/>
-				</div>
-			);
-		}
-
-		if ( ! isActive ) {
-			return (
-				<div>
-					<p>
-						{ __( "You already have Akismet installed, but it's not activated.", 'jetpack-forms' ) }
-					</p>
-					<PluginActionButton
-						pluginSlug="akismet"
-						pluginFile="akismet/akismet"
-						isInstalled={ isInstalled }
-						refreshStatus={ refreshStatus }
-						trackEventName="jetpack_forms_upsell_akismet_click"
-					/>
-				</div>
-			);
-		}
-
+	const renderActiveContent = () => {
 		if ( ! akismetActiveWithKey ) {
 			return (
 				<div>
@@ -131,8 +99,10 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 			icon={ <AkismetIcon /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }
+			data={ data }
+			cardData={ cardData }
 		>
-			{ renderContent() }
+			{ renderActiveContent() }
 		</IntegrationCard>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
@@ -11,8 +11,8 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 	const { isConnected: akismetActiveWithKey = false, settingsUrl = '' } = data || {};
 
 	const cardData = {
-		pluginSlug: 'akismet',
-		pluginFile: 'akismet/akismet',
+		...data,
+		isLoading: ! data || typeof data.isInstalled === 'undefined',
 		refreshStatus,
 		trackEventName: 'jetpack_forms_upsell_akismet_click',
 		notInstalledMessage: createInterpolateElement(
@@ -99,7 +99,6 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 			icon={ <AkismetIcon /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }
-			data={ data }
 			cardData={ cardData }
 		>
 			{ renderActiveContent() }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
@@ -30,9 +30,16 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 		),
 	};
 
-	const renderActiveContent = () => {
-		if ( ! akismetActiveWithKey ) {
-			return (
+	return (
+		<IntegrationCard
+			title={ __( 'Akismet Spam Protection', 'jetpack-forms' ) }
+			description={ __( 'Akismet filters out form spam with 99% accuracy', 'jetpack-forms' ) }
+			icon={ <AkismetIcon /> }
+			isExpanded={ isExpanded }
+			onToggle={ onToggle }
+			cardData={ cardData }
+		>
+			{ ! akismetActiveWithKey ? (
 				<div>
 					<p>
 						{ createInterpolateElement(
@@ -55,53 +62,38 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 						{ __( 'Add Akismet key', 'jetpack-forms' ) }
 					</Button>
 				</div>
-			);
-		}
-
-		return (
-			<div>
-				<p>
-					{ createInterpolateElement(
-						__( 'Your forms are protected from spam with <a>Akismet</a>!', 'jetpack-forms' ),
-						{
-							a: <ExternalLink href={ getRedirectUrl( 'akismet-jetpack-forms-docs' ) } />,
-						}
-					) }
-				</p>
-				<div style={ { display: 'flex', gap: '8px', justifyContent: 'flex-start' } }>
-					<Button
-						variant="primary"
-						href={ formSubmissionsUrl }
-						target="_blank"
-						rel="noopener noreferrer"
-						__next40pxDefaultSize={ true }
-					>
-						{ __( 'View spam', 'jetpack-forms' ) }
-					</Button>
-					<Button
-						variant="primary"
-						href={ settingsUrl }
-						target="_blank"
-						rel="noopener noreferrer"
-						__next40pxDefaultSize={ true }
-					>
-						{ __( 'View stats', 'jetpack-forms' ) }
-					</Button>
+			) : (
+				<div>
+					<p>
+						{ createInterpolateElement(
+							__( 'Your forms are protected from spam with <a>Akismet</a>!', 'jetpack-forms' ),
+							{
+								a: <ExternalLink href={ getRedirectUrl( 'akismet-jetpack-forms-docs' ) } />,
+							}
+						) }
+					</p>
+					<div style={ { display: 'flex', gap: '8px', justifyContent: 'flex-start' } }>
+						<Button
+							variant="primary"
+							href={ formSubmissionsUrl }
+							target="_blank"
+							rel="noopener noreferrer"
+							__next40pxDefaultSize={ true }
+						>
+							{ __( 'View spam', 'jetpack-forms' ) }
+						</Button>
+						<Button
+							variant="primary"
+							href={ settingsUrl }
+							target="_blank"
+							rel="noopener noreferrer"
+							__next40pxDefaultSize={ true }
+						>
+							{ __( 'View stats', 'jetpack-forms' ) }
+						</Button>
+					</div>
 				</div>
-			</div>
-		);
-	};
-
-	return (
-		<IntegrationCard
-			title={ __( 'Akismet Spam Protection', 'jetpack-forms' ) }
-			description={ __( 'Akismet filters out form spam with 99% accuracy', 'jetpack-forms' ) }
-			icon={ <AkismetIcon /> }
-			isExpanded={ isExpanded }
-			onToggle={ onToggle }
-			cardData={ cardData }
-		>
-			{ renderActiveContent() }
+			) }
 		</IntegrationCard>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
@@ -20,8 +20,8 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 	);
 
 	const cardData = {
-		pluginSlug: 'creative-mail-by-constant-contact',
-		pluginFile: 'creative-mail-by-constant-contact/creative-mail-plugin',
+		...data,
+		isLoading: ! data || typeof data.isInstalled === 'undefined',
 		refreshStatus,
 		trackEventName: 'jetpack_forms_upsell_creative_mail_click',
 		notInstalledMessage: __(
@@ -76,7 +76,6 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 			icon="email"
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }
-			data={ data }
 			cardData={ cardData }
 		>
 			{ renderActiveContent() }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
@@ -1,12 +1,11 @@
 import { createBlock } from '@wordpress/blocks';
-import { ExternalLink, Spinner, ToggleControl } from '@wordpress/components';
+import { ExternalLink, ToggleControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import IntegrationCard from './integration-card';
-import PluginActionButton from './plugin-action-button';
 
 const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
-	const { isInstalled = false, isActive = false, settingsUrl = '' } = data || {};
+	const { settingsUrl = '' } = data || {};
 
 	const selectedBlock = useSelect( select => select( 'core/block-editor' ).getSelectedBlock(), [] );
 
@@ -20,6 +19,21 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 		( { name } ) => name === 'jetpack/field-consent'
 	);
 
+	const cardData = {
+		pluginSlug: 'creative-mail-by-constant-contact',
+		pluginFile: 'creative-mail-by-constant-contact/creative-mail-plugin',
+		refreshStatus,
+		trackEventName: 'jetpack_forms_upsell_creative_mail_click',
+		notInstalledMessage: __(
+			'To start sending email campaigns, install the Creative Mail plugin for WordPress.',
+			'jetpack-forms'
+		),
+		notActivatedMessage: __(
+			'To start sending email campaigns, activate the Creative Mail plugin for WordPress.',
+			'jetpack-forms'
+		),
+	};
+
 	const toggleConsent = async () => {
 		if ( consentBlock ) {
 			await removeBlock( consentBlock.clientId, false );
@@ -32,55 +46,7 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 		}
 	};
 
-	const renderContent = () => {
-		if ( ! data ) {
-			return <Spinner />;
-		}
-
-		if ( ! isInstalled ) {
-			return (
-				<div>
-					<p>
-						<em style={ { color: 'rgba(38, 46, 57, 0.7)' } }>
-							{ __(
-								'To start sending email campaigns, install the Creative Mail plugin for WordPress.',
-								'jetpack-forms'
-							) }
-						</em>
-					</p>
-					<PluginActionButton
-						pluginSlug="creative-mail-by-constant-contact"
-						pluginFile="creative-mail-by-constant-contact/creative-mail-plugin"
-						isInstalled={ isInstalled }
-						refreshStatus={ refreshStatus }
-						trackEventName="jetpack_forms_upsell_creative_mail_click"
-					/>
-				</div>
-			);
-		}
-
-		if ( ! isActive ) {
-			return (
-				<div>
-					<p>
-						<em>
-							{ __(
-								'To start sending email campaigns, activate the Creative Mail plugin for WordPress.',
-								'jetpack-forms'
-							) }
-						</em>
-					</p>
-					<PluginActionButton
-						pluginSlug="creative-mail-by-constant-contact"
-						pluginFile="creative-mail-by-constant-contact/creative-mail-plugin"
-						isInstalled={ isInstalled }
-						refreshStatus={ refreshStatus }
-						trackEventName="jetpack_forms_upsell_creative_mail_click"
-					/>
-				</div>
-			);
-		}
-
+	const renderActiveContent = () => {
 		return (
 			<div>
 				<p>
@@ -110,8 +76,10 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 			icon="email"
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }
+			data={ data }
+			cardData={ cardData }
 		>
-			{ renderContent() }
+			{ renderActiveContent() }
 		</IntegrationCard>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
@@ -46,8 +46,15 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 		}
 	};
 
-	const renderActiveContent = () => {
-		return (
+	return (
+		<IntegrationCard
+			title={ __( 'Creative Mail', 'jetpack-forms' ) }
+			description={ __( 'Manage email contacts and campaigns', 'jetpack-forms' ) }
+			icon="email"
+			isExpanded={ isExpanded }
+			onToggle={ onToggle }
+			cardData={ cardData }
+		>
 			<div>
 				<p>
 					<em>
@@ -66,19 +73,6 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 					/>
 				) }
 			</div>
-		);
-	};
-
-	return (
-		<IntegrationCard
-			title={ __( 'Creative Mail', 'jetpack-forms' ) }
-			description={ __( 'Manage email contacts and campaigns', 'jetpack-forms' ) }
-			icon="email"
-			isExpanded={ isExpanded }
-			onToggle={ onToggle }
-			cardData={ cardData }
-		>
-			{ renderActiveContent() }
 		</IntegrationCard>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.js
@@ -48,13 +48,13 @@ const IntegrationsModal = ( {
 					onToggle={ () => toggleCard( 'crm' ) }
 					jetpackCRM={ attributes.jetpackCRM }
 					setAttributes={ setAttributes }
-					data={ integrationsData?.[ 'jetpack-crm' ] }
+					data={ integrationsData?.[ 'zero-bs-crm' ] }
 					refreshStatus={ refreshIntegrations }
 				/>
 				<CreativeMailCard
 					isExpanded={ expandedCards.creativemail }
 					onToggle={ () => toggleCard( 'creativemail' ) }
-					data={ integrationsData?.[ 'creative-mail' ] }
+					data={ integrationsData?.[ 'creative-mail-by-constant-contact' ] }
 					refreshStatus={ refreshIntegrations }
 				/>
 			</div>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card-body.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card-body.js
@@ -1,11 +1,69 @@
-import { CardBody } from '@wordpress/components';
+import { CardBody, Spinner } from '@wordpress/components';
+import PluginActionButton from './plugin-action-button';
 
-const IntegrationCardBody = ( { isExpanded, children } ) => {
+const IntegrationCardBody = ( { isExpanded, children, data = null, cardData = {} } ) => {
 	if ( ! isExpanded ) {
 		return null;
 	}
 
-	return <CardBody>{ children }</CardBody>;
+	const {
+		pluginSlug = '',
+		pluginFile = '',
+		refreshStatus = () => {},
+		trackEventName = '',
+		notInstalledMessage = '',
+		notActivatedMessage = '',
+	} = cardData;
+
+	const renderContent = () => {
+		// Loading state
+		if ( ! data ) {
+			return <Spinner />;
+		}
+
+		const { isInstalled = false, isActive = false } = data || {};
+
+		// Not installed state
+		if ( ! isInstalled && pluginSlug && pluginFile ) {
+			return (
+				<div>
+					<p>{ notInstalledMessage }</p>
+					<PluginActionButton
+						pluginSlug={ pluginSlug }
+						pluginFile={ pluginFile }
+						isInstalled={ isInstalled }
+						refreshStatus={ refreshStatus }
+						trackEventName={ trackEventName }
+					/>
+				</div>
+			);
+		}
+
+		// Not activated state
+		if ( ! isActive && pluginSlug && pluginFile ) {
+			return (
+				<div>
+					<p>{ notActivatedMessage }</p>
+					<PluginActionButton
+						pluginSlug={ pluginSlug }
+						pluginFile={ pluginFile }
+						isInstalled={ isInstalled }
+						refreshStatus={ refreshStatus }
+						trackEventName={ trackEventName }
+					/>
+				</div>
+			);
+		}
+
+		// Default content when plugin is active
+		if ( isInstalled && isActive ) {
+			return children;
+		}
+
+		return null;
+	};
+
+	return <CardBody>{ renderContent() }</CardBody>;
 };
 
 export default IntegrationCardBody;

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card-body.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card-body.js
@@ -7,15 +7,15 @@ const IntegrationCardBody = ( { isExpanded, children, cardData = {} } ) => {
 	}
 
 	const {
-		pluginSlug = '',
-		pluginFile = '',
-		refreshStatus = () => {},
-		trackEventName = '',
-		notInstalledMessage = '',
-		notActivatedMessage = '',
+		slug,
+		pluginFile,
+		refreshStatus,
+		trackEventName,
+		notInstalledMessage,
+		notActivatedMessage,
 		isInstalled,
 		isActive,
-		isLoading = false,
+		isLoading,
 	} = cardData;
 
 	const renderContent = () => {
@@ -25,12 +25,12 @@ const IntegrationCardBody = ( { isExpanded, children, cardData = {} } ) => {
 		}
 
 		// Not installed state
-		if ( ! isInstalled && pluginSlug && pluginFile ) {
+		if ( ! isInstalled ) {
 			return (
 				<div>
 					<p>{ notInstalledMessage }</p>
 					<PluginActionButton
-						pluginSlug={ pluginSlug }
+						slug={ slug }
 						pluginFile={ pluginFile }
 						isInstalled={ isInstalled }
 						refreshStatus={ refreshStatus }
@@ -41,12 +41,12 @@ const IntegrationCardBody = ( { isExpanded, children, cardData = {} } ) => {
 		}
 
 		// Not activated state
-		if ( ! isActive && pluginSlug && pluginFile ) {
+		if ( ! isActive ) {
 			return (
 				<div>
 					<p>{ notActivatedMessage }</p>
 					<PluginActionButton
-						pluginSlug={ pluginSlug }
+						slug={ slug }
 						pluginFile={ pluginFile }
 						isInstalled={ isInstalled }
 						refreshStatus={ refreshStatus }
@@ -56,12 +56,7 @@ const IntegrationCardBody = ( { isExpanded, children, cardData = {} } ) => {
 			);
 		}
 
-		// Default content when plugin is active
-		if ( isInstalled && isActive ) {
-			return children;
-		}
-
-		return null;
+		return children;
 	};
 
 	return <CardBody>{ renderContent() }</CardBody>;

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card-body.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card-body.js
@@ -1,7 +1,7 @@
 import { CardBody, Spinner } from '@wordpress/components';
 import PluginActionButton from './plugin-action-button';
 
-const IntegrationCardBody = ( { isExpanded, children, data = null, cardData = {} } ) => {
+const IntegrationCardBody = ( { isExpanded, children, cardData = {} } ) => {
 	if ( ! isExpanded ) {
 		return null;
 	}
@@ -13,15 +13,16 @@ const IntegrationCardBody = ( { isExpanded, children, data = null, cardData = {}
 		trackEventName = '',
 		notInstalledMessage = '',
 		notActivatedMessage = '',
+		isInstalled,
+		isActive,
+		isLoading = false,
 	} = cardData;
 
 	const renderContent = () => {
 		// Loading state
-		if ( ! data ) {
+		if ( isLoading ) {
 			return <Spinner />;
 		}
-
-		const { isInstalled = false, isActive = false } = data || {};
 
 		// Not installed state
 		if ( ! isInstalled && pluginSlug && pluginFile ) {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card.js
@@ -10,7 +10,6 @@ const IntegrationCard = ( {
 	isExpanded,
 	onToggle,
 	children,
-	data = null,
 	cardData = {},
 } ) => {
 	return (
@@ -22,7 +21,7 @@ const IntegrationCard = ( {
 				isExpanded={ isExpanded }
 				onToggle={ onToggle }
 			/>
-			<IntegrationCardBody isExpanded={ isExpanded } data={ data } cardData={ cardData }>
+			<IntegrationCardBody isExpanded={ isExpanded } cardData={ cardData }>
 				{ children }
 			</IntegrationCardBody>
 		</Card>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card.js
@@ -10,6 +10,8 @@ const IntegrationCard = ( {
 	isExpanded,
 	onToggle,
 	children,
+	data = null,
+	cardData = {},
 } ) => {
 	return (
 		<Card className="integration-card">
@@ -20,7 +22,9 @@ const IntegrationCard = ( {
 				isExpanded={ isExpanded }
 				onToggle={ onToggle }
 			/>
-			<IntegrationCardBody isExpanded={ isExpanded }>{ children }</IntegrationCardBody>
+			<IntegrationCardBody isExpanded={ isExpanded } data={ data } cardData={ cardData }>
+				{ children }
+			</IntegrationCardBody>
 		</Card>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
@@ -24,8 +24,8 @@ const JetpackCRMCard = ( {
 	const isRecentVersion = crmVersion && semver.gte( crmVersion, '4.9.1' );
 
 	const cardData = {
-		pluginSlug: 'zero-bs-crm',
-		pluginFile: 'zero-bs-crm/ZeroBSCRM',
+		...data,
+		isLoading: ! data || typeof data.isInstalled === 'undefined',
 		refreshStatus,
 		trackEventName: 'jetpack_forms_upsell_crm_click',
 		notInstalledMessage: __(
@@ -112,7 +112,6 @@ const JetpackCRMCard = ( {
 			icon={ <JetpackIcon color={ COLOR_JETPACK } /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }
-			data={ data }
 			cardData={ cardData }
 		>
 			{ renderActiveContent() }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
@@ -1,11 +1,10 @@
 import colorStudio from '@automattic/color-studio';
 import { JetpackIcon } from '@automattic/jetpack-components';
-import { Button, Spinner, ToggleControl } from '@wordpress/components';
+import { Button, ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import semver from 'semver';
 import IntegrationCard from './integration-card';
-import PluginActionButton from './plugin-action-button';
 
 const COLOR_JETPACK = colorStudio.colors[ 'Jetpack Green 40' ];
 
@@ -17,66 +16,29 @@ const JetpackCRMCard = ( {
 	data,
 	refreshStatus,
 } ) => {
-	const {
-		isInstalled = false,
-		isActive = false,
-		settingsUrl = '',
-		version = '',
-		details = {},
-	} = data || {};
+	const { settingsUrl = '', version = '', details = {} } = data || {};
 
 	const { hasExtension = false, canActivateExtension = false } = details;
 
 	const crmVersion = semver.coerce( version );
 	const isRecentVersion = crmVersion && semver.gte( crmVersion, '4.9.1' );
 
-	const renderContent = () => {
-		if ( ! data ) {
-			return <Spinner />;
-		}
+	const cardData = {
+		pluginSlug: 'zero-bs-crm',
+		pluginFile: 'zero-bs-crm/ZeroBSCRM',
+		refreshStatus,
+		trackEventName: 'jetpack_forms_upsell_crm_click',
+		notInstalledMessage: __(
+			'You can save contacts from Jetpack contact forms in Jetpack CRM.',
+			'jetpack-forms'
+		),
+		notActivatedMessage: __(
+			"You already have the Jetpack CRM plugin installed, but it's not activated.",
+			'jetpack-forms'
+		),
+	};
 
-		// Jetpack CRM not installed
-		if ( ! isInstalled ) {
-			return (
-				<div>
-					<p>
-						{ __(
-							'You can save contacts from Jetpack contact forms in Jetpack CRM.',
-							'jetpack-forms'
-						) }
-					</p>
-					<PluginActionButton
-						pluginSlug="zero-bs-crm"
-						pluginFile="zero-bs-crm/ZeroBSCRM"
-						isInstalled={ isInstalled }
-						refreshStatus={ refreshStatus }
-						trackEventName="jetpack_forms_upsell_crm_click"
-					/>
-				</div>
-			);
-		}
-
-		// Jetpack CRM installed but not active
-		if ( ! isActive ) {
-			return (
-				<div>
-					<p>
-						{ __(
-							"You already have the Jetpack CRM plugin installed, but it's not activated.",
-							'jetpack-forms'
-						) }
-					</p>
-					<PluginActionButton
-						pluginSlug="zero-bs-crm"
-						pluginFile="zero-bs-crm/ZeroBSCRM"
-						isInstalled={ isInstalled }
-						refreshStatus={ refreshStatus }
-						trackEventName="jetpack_forms_upsell_crm_click"
-					/>
-				</div>
-			);
-		}
-
+	const renderActiveContent = () => {
 		// Jetpack CRM installed and active, but not recent version
 		if ( ! isRecentVersion ) {
 			return (
@@ -150,8 +112,10 @@ const JetpackCRMCard = ( {
 			icon={ <JetpackIcon color={ COLOR_JETPACK } /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }
+			data={ data }
+			cardData={ cardData }
 		>
-			{ renderContent() }
+			{ renderActiveContent() }
 		</IntegrationCard>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
@@ -38,7 +38,7 @@ const JetpackCRMCard = ( {
 		),
 	};
 
-	const renderActiveContent = () => {
+	const renderContent = () => {
 		// Jetpack CRM installed and active, but not recent version
 		if ( ! isRecentVersion ) {
 			return (
@@ -114,7 +114,7 @@ const JetpackCRMCard = ( {
 			onToggle={ onToggle }
 			cardData={ cardData }
 		>
-			{ renderActiveContent() }
+			{ renderContent() }
 		</IntegrationCard>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/plugin-action-button.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/plugin-action-button.js
@@ -2,15 +2,9 @@ import { Button, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { usePluginInstallation } from '../hooks';
 
-const PluginActionButton = ( {
-	pluginSlug,
-	pluginFile,
-	isInstalled,
-	refreshStatus,
-	trackEventName,
-} ) => {
+const PluginActionButton = ( { slug, pluginFile, isInstalled, refreshStatus, trackEventName } ) => {
 	const { isInstalling, installPlugin } = usePluginInstallation(
-		pluginSlug,
+		slug,
 		pluginFile,
 		isInstalled,
 		trackEventName

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -647,6 +647,8 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 
 		$response = array(
 			'type'        => 'plugin',
+			'slug'        => $plugin_slug,
+			'pluginFile'  => $plugin_config['file'],
 			'isInstalled' => $is_installed,
 			'isActive'    => $is_active,
 			'isConnected' => false,

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -660,7 +660,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		// Plugin-specific customizations
 		if ( 'akismet' === $plugin_slug ) {
 			$response['isConnected'] = class_exists( 'Jetpack' ) && \Jetpack::is_akismet_active();
-		} elseif ( 'jetpack-crm' === $plugin_slug && $is_active ) {
+		} elseif ( 'zero-bs-crm' === $plugin_slug && $is_active ) {
 			$has_extension       = function_exists( 'zeroBSCRM_isExtensionInstalled' ) && zeroBSCRM_isExtensionInstalled( 'jetpackforms' ); // @phan-suppress-current-line PhanUndeclaredFunction -- We're checking the function exists first
 			$response['details'] = array(
 				'hasExtension'         => $has_extension,

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -23,17 +23,17 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * @var array
 	 */
 	private $supported_integrations = array(
-		'akismet'       => array(
+		'akismet'                           => array(
 			'type'         => 'plugin',
 			'file'         => 'akismet/akismet.php',
 			'settings_url' => 'admin.php?page=akismet-key-config',
 		),
-		'creative-mail' => array(
+		'creative-mail-by-constant-contact' => array(
 			'type'         => 'plugin',
 			'file'         => 'creative-mail-by-constant-contact/creative-mail-plugin.php',
 			'settings_url' => 'admin.php?page=creativemail',
 		),
-		'jetpack-crm'   => array(
+		'zero-bs-crm'                       => array(
 			'type'         => 'plugin',
 			'file'         => 'zero-bs-crm/ZeroBSCRM.php',
 			'settings_url' => 'admin.php?page=zerobscrm-plugin-settings',
@@ -648,7 +648,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		$response = array(
 			'type'        => 'plugin',
 			'slug'        => $plugin_slug,
-			'pluginFile'  => $plugin_config['file'],
+			'pluginFile'  => str_replace( '.php', '', $plugin_config['file'] ),
 			'isInstalled' => $is_installed,
 			'isActive'    => $is_active,
 			'isConnected' => false,


### PR DESCRIPTION
## Proposed changes:

NOTE: This is one of many PRs to create the new third party integrations modal. All this work is behind a feature flag and only be visible if you set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.

Changes:
* There is duplication in the individual IntegrationCard's for Akismet, Jetpack CRM, and Creative Mail. Each of the outputs similar markup when loading (a spinner), and when uninstalled or unactivated (some nudge text and an install/activate button). This PR moves that shared logic, state, and markup to the IntegrationCard component. 
* Each of these cards also defines a plugin slug and file that is used by the integration endpoint. But these are now also defined in a registry in the endpoint when we fetch integtations. Rather than define them here, I updated the endpoint to return them, and the front end code now uses the same slug/file as the backend code. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

There should be no changes in behavior. This is a refactor. 

- Set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.
- Add a form block to a page - with an email field
- Click on the Manage Integrations button the block sidebar
- Confirm the modal opens and the individual integration cards behave the same as before
