### PR TITLE
E2E Tests: Fix prerequisite builder not being guaranteed to run in correct order

### DIFF
--- a/tools/e2e-commons/env/prerequisites.js
+++ b/tools/e2e-commons/env/prerequisites.js
@@ -94,12 +94,8 @@ async function buildPrerequisites( state, page ) {
 
 	for ( const [ key, func ] of functions ) {
 		if ( state[ key ] !== undefined ) {
-			if ( func ) {
-				logger.prerequisites( `Ensuring '${ key }' prerequisite state` );
-				await func();
-			} else {
-				throw Error( `Unknown state "${ key }: ${ state[ key ] }"!` );
-			}
+			logger.prerequisites( `Ensuring '${ key }' prerequisite state` );
+			await func();
 		}
 	}
 }

--- a/tools/e2e-commons/env/prerequisites.js
+++ b/tools/e2e-commons/env/prerequisites.js
@@ -80,25 +80,25 @@ export function prerequisitesBuilder( page ) {
  * @param {page}    page            - Playwright page instance.
  */
 async function buildPrerequisites( state, page ) {
-	const functions = {
-		plugins: () => ensurePluginsState( state.plugins ),
-		loggedIn: () => ensureUserIsLoggedIn( page ),
-		wpComLoggedIn: () => ensureWpComUserIsLoggedIn( page ),
-		connected: () => ensureConnectedState( state.connected ),
-		plan: () => ensurePlan( state.plan, page ),
-		modules: () => ensureModulesState( state.modules ),
-		clean: () => ensureCleanState( state.clean ),
-	};
+	const functions = [
+		[ 'clean', () => ensureCleanState( state.clean ) ],
+		[ 'plugins', () => ensurePluginsState( state.plugins ) ],
+		[ 'loggedIn', () => ensureUserIsLoggedIn( page ) ],
+		[ 'wpComLoggedIn', () => ensureWpComUserIsLoggedIn( page ) ],
+		[ 'connected', () => ensureConnectedState( state.connected ) ],
+		[ 'plan', () => ensurePlan( state.plan, page ) ],
+		[ 'modules', () => ensureModulesState( state.modules ) ],
+	];
 
 	logger.prerequisites( JSON.stringify( state, null, 2 ) );
 
-	for ( const option of Object.keys( state ) ) {
-		if ( state[ option ] !== undefined ) {
-			if ( functions[ option ] ) {
-				logger.prerequisites( `Ensuring '${ option }' prerequisite state` );
-				await functions[ option ]();
+	for ( const [ key, func ] of functions ) {
+		if ( state[ key ] !== undefined ) {
+			if ( func ) {
+				logger.prerequisites( `Ensuring '${ key }' prerequisite state` );
+				await func();
 			} else {
-				throw Error( `Unknown state "${ option }: ${ state[ option ] }"!` );
+				throw Error( `Unknown state "${ key }: ${ state[ key ] }"!` );
 			}
 		}
 	}


### PR DESCRIPTION
## Proposed changes:
Jetpack E2E tests use a utility called the `prerequisiteBuilder` to help configure the environment before tests are run. For example, see the `beforeEach` code here:
https://github.com/Automattic/jetpack/blob/c7a349f44b5c70b7868cd5fbf38507f37b68575d/projects/plugins/jetpack/tests/e2e/specs/post-connection/recommendations.test.js#L8-L15

It seems like these steps are supposed to run in a predetermined order - e.g. clean environment, log in to WP, connect, setup a plan. I expect you can't setup a plan without a logged in/connected user.

However the order doesn't seem like it would be guaranteed, since the code iterates through an object to perform the steps, and JavaScript objects aren't ordered (they often will maintain an order, but are not guaranteed to):
https://github.com/Automattic/jetpack/blob/c7a349f44b5c70b7868cd5fbf38507f37b68575d/tools/e2e-commons/env/prerequisites.js#L82-L105

Likely this works most of the time, but who knows, maybe there's a small proportion of E2E test failures that are triggered by these steps being carried out in the wrong order 🤷 

This PR updates the code so that it instead iterates through an ordered `functions` array.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
E2E tests should pass on CI

