### PR TITLE
Likes: unify likes-master rendering between wpcom and Jetpack

### DIFF
--- a/projects/plugins/jetpack/changelog/unify-likes-master-render
+++ b/projects/plugins/jetpack/changelog/unify-likes-master-render
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Likes: unify likes-master rendering between wpcom and Jetpack

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -425,8 +425,10 @@ class Jetpack_Likes {
 		$url_parts = wp_parse_url( $url );
 		$domain    = $url_parts['host'];
 
-		// Make sure to include the scripts before the iframe otherwise weird things happen.
-		add_action( 'wp_footer', 'jetpack_likes_master_iframe', 21 );
+		// Make sure to include the `queuehandler` scripts before the iframe otherwise the script won't find the iframe.
+		if ( ! has_action( 'wp_footer', 'jetpack_likes_master_iframe' ) ) {
+			add_action( 'wp_footer', 'jetpack_likes_master_iframe', 21 );
+		}
 
 		/**
 		* If the same post appears more then once on a page the page goes crazy


### PR DESCRIPTION
Another piece of the puzzle that unifies Likes implementation across WP.com and Jetpack. Here I'm removing two ways how to render the `likes-master` iframe when a Like block is rendered. Until now, WP.com/Simple used `Jetpack_Likes::likes_master()` and Jetpack/Atomic used `jetpack_likes_master_iframe`. But since 179323-ghe-automattic/wpcom both environments use the same `jetpack_likes_master_iframe` from Jetpack.

I'm also trying to prevent the `likes-master` iframe from rendering twice, when the same `wp_footer` action handler is registered at two places. Let's always do a `has_action` check first.

## Testing instructions:
Test Likes both on a self-hosted site with patched Jetpack, and also on a Simple site where the updated Jetpack files are synced to your sandbox. The `likes-master` iframe should load and function.

## Does this pull request change what data or activity we track or use?

No.