### PR TITLE
E2E Tests: Fix jetpack connection util assuming 'wordpress' is the correct site username

### DIFF
--- a/tools/e2e-commons/env/prerequisites.js
+++ b/tools/e2e-commons/env/prerequisites.js
@@ -6,6 +6,7 @@ import { provisionJetpackStartConnection } from '../helpers/partner-provisioning
 import {
 	execWpCommand,
 	getDotComCredentials,
+	getSiteCredentials,
 	isLocalSite,
 	resetWordpressInstall,
 } from '../helpers/utils-helper.js';
@@ -136,14 +137,15 @@ export async function ensureConnectedState( requiredConnected = false ) {
  */
 async function connect() {
 	const creds = getDotComCredentials();
-	await execWpCommand( `user update wordpress --user_email=${ creds.email }` );
+	const siteCreds = getSiteCredentials();
+	await execWpCommand( `user update ${ siteCreds.username } --user_email=${ creds.email }` );
 
 	try {
-		provisionJetpackStartConnection( creds.userId, 'free' );
+		provisionJetpackStartConnection( creds.userId, 'free', siteCreds.username );
 	} catch ( error ) {
 		// Let's try to re-try the provisioning if it fails the first time.
 		if ( error.message.startsWith( 'Jetpack Start provisioning failed' ) ) {
-			provisionJetpackStartConnection( creds.userId, 'free' );
+			provisionJetpackStartConnection( creds.userId, 'free', siteCreds.username );
 		} else {
 			throw error;
 		}


### PR DESCRIPTION
## Proposed changes:
Jetpack's docker environment and E2E testing environment allow changing of the default user credentials through the `.env` and `local.cjs` files.

For the end-to-end test `prerequisite` system, which does stuff like configuring a jetpack connection, the username has been hardcoded to 'wordpress' in a couple of places, meaning it'll fail if a non-standard username is being used.

The result is that the Jetpack connection step will fail.

This PR replaces those hard-coded strings with the site username from the credentials file.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
E2E tests should pass
