### PR TITLE
E2E Tests: Suggest UI mode in docs before headed or debug modes

### DIFF
--- a/projects/plugins/jetpack/changelog/update-e2e-docs-suggesting-ui-mode
+++ b/projects/plugins/jetpack/changelog/update-e2e-docs-suggesting-ui-mode
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Contributor docs
+
+

--- a/projects/plugins/jetpack/tests/e2e/README.md
+++ b/projects/plugins/jetpack/tests/e2e/README.md
@@ -83,22 +83,28 @@ Once your target WP environment is running on `localhost:8889` you can run the t
 
 Run all tests: `pnpm test:run`
 
-Playwright runs headless by default (i.e. browser is not visible). However, sometimes it's useful to observe the browser while running tests. To see the browser window, and the running tests you can use the `--headed` flag:
+Playwright runs headless by default (i.e. browser is not visible). When developing or debugging tests it's usually useful to see what's happening. Playwright's [UI Mode](https://playwright.dev/docs/test-ui-mode) is a good option, it allows running individual or groups of tests, watching tests and has handy time travel feature. To launch it use the `--ui` flag:
 
 ```bash
-pnpm test:run --headed
-```
-
-To run an individual test, use the direct path to the spec. For example:
-
-```bash
-pnpm test:run ./specs/dummy.test.js
+pnpm test:run --ui
 ```
 
 To run in debug mode, use the `--debug` flag. Debug mode uses a headed browser and opens the [Playwright inspector](https://playwright.dev/docs/inspector/).
 
 ```bash
 pnpm test:run --debug
+```
+
+A simpler option is `headed` mode, which runs tests in your regular browser window:
+
+```bash
+pnpm test:run --headed
+```
+
+To run an individual test, use the direct path to the spec. This can be done in conjunction with any of the previously mentioned flags. For example:
+
+```bash
+pnpm test:run ./specs/dummy.test.js
 ```
 
 ### Selecting tests to run

--- a/projects/plugins/search/changelog/update-e2e-docs-suggesting-ui-mode
+++ b/projects/plugins/search/changelog/update-e2e-docs-suggesting-ui-mode
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Contributor docs
+
+

--- a/projects/plugins/search/tests/e2e/README.md
+++ b/projects/plugins/search/tests/e2e/README.md
@@ -88,22 +88,28 @@ Once your target WP environment is running on `localhost:8889` you can run the t
 
 Run all tests: `pnpm test:run`
 
-Playwright runs headless by default (i.e. browser is not visible). However, sometimes it's useful to observe the browser while running tests. To see the browser window, and the running tests you can use the `--headed` flag:
+Playwright runs headless by default (i.e. browser is not visible). When developing or debugging tests it's usually useful to see what's happening. Playwright's [UI Mode](https://playwright.dev/docs/test-ui-mode) is a good option, it allows running individual or groups of tests, watching tests and has handy time travel feature. To launch it use the `--ui` flag:
 
 ```bash
-pnpm test:run --headed
-```
-
-To run an individual test, use the direct path to the spec. For example:
-
-```bash
-pnpm test:run ./specs/search.test.js
+pnpm test:run --ui
 ```
 
 To run in debug mode, use the `--debug` flag. Debug mode uses a headed browser and opens the [Playwright inspector](https://playwright.dev/docs/inspector/).
 
 ```bash
 pnpm test:run --debug
+```
+
+A simpler option is `headed` mode, which runs tests in your regular browser window:
+
+```bash
+pnpm test:run --headed
+```
+
+To run an individual test, use the direct path to the spec. This can be done in conjunction with any of the previously mentioned flags. For example:
+
+```bash
+pnpm test:run ./specs/dummy.test.js
 ```
 
 ## Tests Architecture

--- a/projects/plugins/social/changelog/update-e2e-docs-suggesting-ui-mode
+++ b/projects/plugins/social/changelog/update-e2e-docs-suggesting-ui-mode
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Contributor docs
+
+

--- a/projects/plugins/social/tests/e2e/README.md
+++ b/projects/plugins/social/tests/e2e/README.md
@@ -82,22 +82,28 @@ Once your target WP environment is running on `localhost:8889` you can run the t
 
 Run all tests: `pnpm test:run`
 
-Playwright runs headless by default (i.e. browser is not visible). However, sometimes it's useful to observe the browser while running tests. To see the browser window, and the running tests you can use the `--headed` flag:
+Playwright runs headless by default (i.e. browser is not visible). When developing or debugging tests it's usually useful to see what's happening. Playwright's [UI Mode](https://playwright.dev/docs/test-ui-mode) is a good option, it allows running individual or groups of tests, watching tests and has handy time travel feature. To launch it use the `--ui` flag:
 
 ```bash
-pnpm test:run --headed
-```
-
-To run an individual test, use the direct path to the spec. For example:
-
-```bash
-pnpm test:run ./specs/connection.test.js
+pnpm test:run --ui
 ```
 
 To run in debug mode, use the `--debug` flag. Debug mode uses a headed browser and opens the [Playwright inspector](https://playwright.dev/docs/inspector/).
 
 ```bash
 pnpm test:run --debug
+```
+
+A simpler option is `headed` mode, which runs tests in your regular browser window:
+
+```bash
+pnpm test:run --headed
+```
+
+To run an individual test, use the direct path to the spec. This can be done in conjunction with any of the previously mentioned flags. For example:
+
+```bash
+pnpm test:run ./specs/dummy.test.js
 ```
 
 ### Selecting tests to run


### PR DESCRIPTION
## Proposed changes:
Playwright has a 'UI' mode, which is significantly better than the debug mode. For most developers creating or debugging tests I expect this is the best option. It makes it much quicker to start/stop different tests individually and has a watch mode. 

You can read about it here - https://playwright.dev/docs/test-ui-mode.

The docs don't mention that it exists, so I thought I'd update them.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Try following the updated docs to ensure they work and make sense.