### PR TITLE
Jetpack SEO: change panel textareas placeholders copy

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-seo-meta-panels-placeholders-copy
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-seo-meta-panels-placeholders-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack SEO: change title and description textareas placeholder and over-limit message

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-requests.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-requests.ts
@@ -117,7 +117,7 @@ export const useSeoRequests = () => {
 				const response = await request( 'seo-title' );
 				const title = parseResponse( response ).titles?.[ 0 ];
 
-				if ( title.length > 70 ) {
+				if ( title && title.length > 70 ) {
 					tracks.recordEvent( 'jetpack_seo_enhancer_title_too_long', {
 						character_count: title.length,
 					} );
@@ -156,7 +156,7 @@ export const useSeoRequests = () => {
 				const response = await request( 'seo-meta-description' );
 				const description = parseResponse( response ).descriptions?.[ 0 ];
 
-				if ( description.length > 156 ) {
+				if ( description && description.length > 156 ) {
 					tracks.recordEvent( 'jetpack_seo_enhancer_description_too_long', {
 						character_count: description.length,
 					} );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-requests.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-requests.ts
@@ -117,6 +117,12 @@ export const useSeoRequests = () => {
 				const response = await request( 'seo-title' );
 				const title = parseResponse( response ).titles?.[ 0 ];
 
+				if ( title.length > 70 ) {
+					tracks.recordEvent( 'jetpack_seo_enhancer_title_too_long', {
+						character_count: title.length,
+					} );
+				}
+
 				if ( ! globalSelect( editorStore ).isCurrentPostPublished() ) {
 					editPost( {
 						meta: {
@@ -133,7 +139,7 @@ export const useSeoRequests = () => {
 				setTitleBusy( false );
 			}
 		},
-		[ setTitleBusy, request, editPost ]
+		[ setTitleBusy, request, editPost, tracks ]
 	);
 
 	const updateDescription = useCallback(
@@ -149,6 +155,12 @@ export const useSeoRequests = () => {
 				setDescriptionBusy( true );
 				const response = await request( 'seo-meta-description' );
 				const description = parseResponse( response ).descriptions?.[ 0 ];
+
+				if ( description.length > 156 ) {
+					tracks.recordEvent( 'jetpack_seo_enhancer_description_too_long', {
+						character_count: description.length,
+					} );
+				}
 
 				if ( ! globalSelect( editorStore ).isCurrentPostPublished() ) {
 					editPost( {
@@ -166,7 +178,7 @@ export const useSeoRequests = () => {
 				setDescriptionBusy( false );
 			}
 		},
-		[ setDescriptionBusy, request, editPost ]
+		[ setDescriptionBusy, request, editPost, tracks ]
 	);
 
 	const updateAltText = useCallback(

--- a/projects/plugins/jetpack/extensions/plugins/seo/counted-textarea.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/counted-textarea.js
@@ -13,7 +13,7 @@ export const CountedTextArea = ( { suggestedLimit, value, label, ...inputProps }
 			: sprintf(
 					/* translators: Placeholder is a number of characters in a sentence. */
 					__(
-						'It’s recommended to use less than %1$d characters in this field. (%2$d used)',
+						'It’s recommended to use less than %1$d characters in this field. (%2$d/%1$d)',
 						'jetpack'
 					),
 					suggestedLimit,

--- a/projects/plugins/jetpack/extensions/plugins/seo/description-panel.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/description-panel.js
@@ -17,7 +17,7 @@ class SeoDescriptionPanel extends Component {
 
 		const placeholder = __( 'Write a description…', 'jetpack' );
 		const enhancerPlaceholder = __(
-			'Add a compelling, keyword-rich summary that appears in search results (max 156 characters)',
+			'Add a compelling, keyword-rich summary that appears in search results (ideally under 156 characters)',
 			'jetpack'
 		);
 

--- a/projects/plugins/jetpack/extensions/plugins/seo/title-panel.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/title-panel.js
@@ -17,7 +17,7 @@ class SeoTitlePanel extends Component {
 
 		const placeholder = __( 'Write a title…', 'jetpack' );
 		const enhancerPlaceholder = __(
-			'Enter a clear, keyword-focused title (max 70 characters)',
+			'Enter a clear, keyword-focused title (ideally under 70 characters)',
 			'jetpack'
 		);
 


### PR DESCRIPTION
Fixes AGORA-50

## Proposed changes:
This PR changes the SEO panel textareas placeholders:
- suggestion for character length
- message when over limit
  - Title `Enter a clear, keyword-focused title (ideally under 70 characters)`
  - Description: `Add a compelling, keyword-rich summary that appears in search results (ideally under 156 characters)`

<img width="376" alt="image" src="https://github.com/user-attachments/assets/bb5aaff4-2607-4e76-b9a0-e64a4cc320b7" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1743782075949539-slack-C054LN8RNVA
p1743718027383379-slack-C06FCT6EEHH

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Go to the editor, look for the SEO panel on Jetpack sidebar.

Confirm the placeholders on Title and Description textareas.
Fill in the textareas and go over the suggested value, confirm the new over-limit format.