### PR TITLE
Blocks: update child blocks to API version v3, take 2

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-child-blocks-api-version-v3
+++ b/projects/plugins/jetpack/changelog/fix-child-blocks-api-version-v3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Blocks: ensure all child blocks use the latest version of the Blocks API.

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/deprecated/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/deprecated/index.js
@@ -1,0 +1,3 @@
+import * as deprecatedV1 from './v1';
+
+export default [ deprecatedV1 ];

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/deprecated/v1/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/deprecated/v1/attributes.js
@@ -1,0 +1,24 @@
+import PlaceholderSiteIcon from '../../../placeholder-site-icon.svg';
+
+export default {
+	id: {
+		type: 'string',
+	},
+	name: {
+		type: 'string',
+	},
+	icon: {
+		type: 'string',
+		default: PlaceholderSiteIcon,
+	},
+	is_non_wpcom_site: {
+		type: 'boolean',
+		default: false,
+	},
+	url: {
+		type: 'string',
+	},
+	description: {
+		type: 'string',
+	},
+};

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/deprecated/v1/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/deprecated/v1/index.js
@@ -1,0 +1,5 @@
+import { InnerBlocks } from '@wordpress/block-editor';
+export { default as attributes } from './attributes';
+export { default as supports } from './supports';
+
+export const save = () => <InnerBlocks.Content />;

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/deprecated/v1/supports.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/deprecated/v1/supports.js
@@ -1,0 +1,11 @@
+export default {
+	align: false,
+	alignWide: true,
+	anchor: false,
+	customClassName: true,
+	className: true,
+	html: false,
+	multiple: true,
+	reusable: true,
+	inserter: false,
+};

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/index.js
@@ -1,7 +1,8 @@
 import { getIconColor } from '@automattic/jetpack-shared-extension-utils';
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import PlaceholderSiteIcon from '../placeholder-site-icon.svg';
+import { default as deprecated } from './deprecated';
 import edit from './edit';
 import icon from './icon';
 import './editor.scss';
@@ -9,6 +10,7 @@ import './editor.scss';
 export const name = 'blogroll-item';
 export const title = __( 'Blogroll Item', 'jetpack' );
 export const settings = {
+	apiVersion: 3,
 	title,
 	description: __( 'Blogroll Item', 'jetpack' ),
 	icon: {
@@ -65,10 +67,19 @@ export const settings = {
 			type: 'string',
 		},
 	},
-	save: () => <InnerBlocks.Content />,
+	save: () => {
+		const blockProps = useBlockProps.save();
+
+		return (
+			<div { ...blockProps }>
+				<InnerBlocks.Content />
+			</div>
+		);
+	},
 	example: {
 		attributes: {
 			// @TODO: Add default values for block attributes, for generating the block preview.
 		},
 	},
+	deprecated,
 };

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/address/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/address/edit.js
@@ -1,118 +1,110 @@
-import { PlainText } from '@wordpress/block-editor';
+import { PlainText, useBlockProps } from '@wordpress/block-editor';
 import { ToggleControl } from '@wordpress/components';
-import { Component, Fragment } from '@wordpress/element';
+import { useCallback, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import save from './save';
 
-class AddressEdit extends Component {
-	constructor( ...args ) {
-		super( ...args );
+const AddressEdit = props => {
+	const {
+		attributes: {
+			address,
+			addressLine2,
+			addressLine3,
+			city,
+			region,
+			postal,
+			country,
+			linkToGoogleMaps,
+		},
+		isSelected,
+		setAttributes,
+	} = props;
+	const hasContent = [ address, addressLine2, addressLine3, city, region, postal, country ].some(
+		value => value !== ''
+	);
+	const classNames = clsx( {
+		'jetpack-address-block': true,
+		'is-selected': isSelected,
+	} );
 
-		this.preventEnterKey = this.preventEnterKey.bind( this );
-	}
-
-	preventEnterKey( event ) {
+	const preventEnterKey = useCallback( event => {
 		if ( event.key === 'Enter' ) {
 			event.preventDefault();
 		}
-	}
+	}, [] );
+	const blockProps = useBlockProps( {
+		className: classNames,
+	} );
 
-	render() {
-		const {
-			attributes: {
-				address,
-				addressLine2,
-				addressLine3,
-				city,
-				region,
-				postal,
-				country,
-				linkToGoogleMaps,
-			},
-			isSelected,
-			setAttributes,
-		} = this.props;
+	const externalLink = (
+		<ToggleControl
+			__nextHasNoMarginBottom={ true }
+			label={ __( 'Link address to Google Maps', 'jetpack' ) }
+			checked={ linkToGoogleMaps }
+			onChange={ newlinkToGoogleMaps => setAttributes( { linkToGoogleMaps: newlinkToGoogleMaps } ) }
+		/>
+	);
 
-		const hasContent = [ address, addressLine2, addressLine3, city, region, postal, country ].some(
-			value => value !== ''
-		);
-		const classNames = clsx( {
-			'jetpack-address-block': true,
-			'is-selected': isSelected,
-		} );
-
-		const externalLink = (
-			<ToggleControl
-				__nextHasNoMarginBottom={ true }
-				label={ __( 'Link address to Google Maps', 'jetpack' ) }
-				checked={ linkToGoogleMaps }
-				onChange={ newlinkToGoogleMaps =>
-					setAttributes( { linkToGoogleMaps: newlinkToGoogleMaps } )
-				}
-			/>
-		);
-
-		return (
-			<div className={ classNames }>
-				{ ! isSelected && hasContent && save( this.props ) }
-				{ ( isSelected || ! hasContent ) && (
-					<Fragment>
-						<PlainText
-							value={ address }
-							placeholder={ __( 'Street Address', 'jetpack' ) }
-							aria-label={ __( 'Street Address', 'jetpack' ) }
-							onChange={ newAddress => setAttributes( { address: newAddress } ) }
-							onKeyDown={ this.preventEnterKey }
-						/>
-						<PlainText
-							value={ addressLine2 }
-							placeholder={ __( 'Address Line 2', 'jetpack' ) }
-							aria-label={ __( 'Address Line 2', 'jetpack' ) }
-							onChange={ newAddressLine2 => setAttributes( { addressLine2: newAddressLine2 } ) }
-							onKeyDown={ this.preventEnterKey }
-						/>
-						<PlainText
-							value={ addressLine3 }
-							placeholder={ __( 'Address Line 3', 'jetpack' ) }
-							aria-label={ __( 'Address Line 3', 'jetpack' ) }
-							onChange={ newAddressLine3 => setAttributes( { addressLine3: newAddressLine3 } ) }
-							onKeyDown={ this.preventEnterKey }
-						/>
-						<PlainText
-							value={ city }
-							placeholder={ __( 'City', 'jetpack' ) }
-							aria-label={ __( 'City', 'jetpack' ) }
-							onChange={ newCity => setAttributes( { city: newCity } ) }
-							onKeyDown={ this.preventEnterKey }
-						/>
-						<PlainText
-							value={ region }
-							placeholder={ __( 'State/Province/Region', 'jetpack' ) }
-							aria-label={ __( 'State/Province/Region', 'jetpack' ) }
-							onChange={ newRegion => setAttributes( { region: newRegion } ) }
-							onKeyDown={ this.preventEnterKey }
-						/>
-						<PlainText
-							value={ postal }
-							placeholder={ __( 'Postal/Zip Code', 'jetpack' ) }
-							aria-label={ __( 'Postal/Zip Code', 'jetpack' ) }
-							onChange={ newPostal => setAttributes( { postal: newPostal } ) }
-							onKeyDown={ this.preventEnterKey }
-						/>
-						<PlainText
-							value={ country }
-							placeholder={ __( 'Country', 'jetpack' ) }
-							aria-label={ __( 'Country', 'jetpack' ) }
-							onChange={ newCountry => setAttributes( { country: newCountry } ) }
-							onKeyDown={ this.preventEnterKey }
-						/>
-						{ externalLink }
-					</Fragment>
-				) }
-			</div>
-		);
-	}
-}
+	return (
+		<div { ...blockProps }>
+			{ ! isSelected && hasContent && save( props ) }
+			{ ( isSelected || ! hasContent ) && (
+				<Fragment>
+					<PlainText
+						value={ address }
+						placeholder={ __( 'Street Address', 'jetpack' ) }
+						aria-label={ __( 'Street Address', 'jetpack' ) }
+						onChange={ newAddress => setAttributes( { address: newAddress } ) }
+						onKeyDown={ preventEnterKey }
+					/>
+					<PlainText
+						value={ addressLine2 }
+						placeholder={ __( 'Address Line 2', 'jetpack' ) }
+						aria-label={ __( 'Address Line 2', 'jetpack' ) }
+						onChange={ newAddressLine2 => setAttributes( { addressLine2: newAddressLine2 } ) }
+						onKeyDown={ preventEnterKey }
+					/>
+					<PlainText
+						value={ addressLine3 }
+						placeholder={ __( 'Address Line 3', 'jetpack' ) }
+						aria-label={ __( 'Address Line 3', 'jetpack' ) }
+						onChange={ newAddressLine3 => setAttributes( { addressLine3: newAddressLine3 } ) }
+						onKeyDown={ preventEnterKey }
+					/>
+					<PlainText
+						value={ city }
+						placeholder={ __( 'City', 'jetpack' ) }
+						aria-label={ __( 'City', 'jetpack' ) }
+						onChange={ newCity => setAttributes( { city: newCity } ) }
+						onKeyDown={ preventEnterKey }
+					/>
+					<PlainText
+						value={ region }
+						placeholder={ __( 'State/Province/Region', 'jetpack' ) }
+						aria-label={ __( 'State/Province/Region', 'jetpack' ) }
+						onChange={ newRegion => setAttributes( { region: newRegion } ) }
+						onKeyDown={ preventEnterKey }
+					/>
+					<PlainText
+						value={ postal }
+						placeholder={ __( 'Postal/Zip Code', 'jetpack' ) }
+						aria-label={ __( 'Postal/Zip Code', 'jetpack' ) }
+						onChange={ newPostal => setAttributes( { postal: newPostal } ) }
+						onKeyDown={ preventEnterKey }
+					/>
+					<PlainText
+						value={ country }
+						placeholder={ __( 'Country', 'jetpack' ) }
+						aria-label={ __( 'Country', 'jetpack' ) }
+						onChange={ newCountry => setAttributes( { country: newCountry } ) }
+						onKeyDown={ preventEnterKey }
+					/>
+					{ externalLink }
+				</Fragment>
+			) }
+		</div>
+	);
+};
 
 export default AddressEdit;

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/address/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/address/index.js
@@ -43,6 +43,7 @@ const attributes = {
 export const name = 'address';
 
 export const settings = {
+	apiVersion: 3,
 	title: __( 'Address', 'jetpack' ),
 	description: __( 'Lets you add a physical address with Schema markup.', 'jetpack' ),
 	keywords: [

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/address/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/address/save.js
@@ -1,3 +1,4 @@
+import { useBlockProps } from '@wordpress/block-editor';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -56,9 +57,15 @@ export const googleMapsUrl = ( {
 	);
 };
 
-const save = props =>
-	hasAddress( props.attributes ) && (
-		<div className={ props.className }>
+const save = props => {
+	if ( ! hasAddress( props.attributes ) ) {
+		return null;
+	}
+
+	const blockProps = useBlockProps.save();
+
+	return (
+		<div { ...blockProps }>
 			{ props.attributes.linkToGoogleMaps && (
 				<a
 					href={ googleMapsUrl( props ) }
@@ -72,5 +79,6 @@ const save = props =>
 			{ ! props.attributes.linkToGoogleMaps && <Address { ...props } /> }
 		</div>
 	);
+};
 
 export default save;

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/edit.js
@@ -2,6 +2,15 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import AddressEdit from '../edit';
 
+jest.mock( '@wordpress/block-editor', () => {
+	const useBlockProps = () => ( {} );
+	useBlockProps.save = () => ( {} );
+	return {
+		...jest.requireActual( '@wordpress/block-editor' ),
+		useBlockProps,
+	};
+} );
+
 const defaultAttributes = {
 	address: '',
 	addressLine2: '',

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/edit.js
@@ -28,17 +28,16 @@ const ALLOWED_BLOCKS = [
 const TEMPLATE = [ [ 'jetpack/email' ], [ 'jetpack/phone' ], [ 'jetpack/address' ] ];
 
 const ContactInfoEdit = props => {
-	const { isSelected } = props;
-	const blockProps = useBlockProps();
+	const { className, isSelected } = props;
+	const blockProps = useBlockProps( {
+		className: clsx( className, {
+			'jetpack-contact-info-block': true,
+			'is-selected': isSelected,
+		} ),
+	} );
 
 	return (
-		<div
-			{ ...blockProps }
-			className={ clsx( blockProps.className, {
-				'jetpack-contact-info-block': true,
-				'is-selected': isSelected,
-			} ) }
-		>
+		<div { ...blockProps }>
 			<InnerBlocks allowedBlocks={ ALLOWED_BLOCKS } templateLock={ false } template={ TEMPLATE } />
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/email/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/email/edit.js
@@ -1,11 +1,19 @@
+import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import simpleInput from '../../../shared/simple-input';
 import save from './save';
 
 const EmailEdit = props => {
+	const blockProps = useBlockProps();
 	const { setAttributes } = props;
-	return simpleInput( 'email', props, __( 'Email', 'jetpack' ), save, nextValue =>
-		setAttributes( { email: nextValue } )
+
+	return simpleInput(
+		'email',
+		props,
+		__( 'Email', 'jetpack' ),
+		save,
+		nextValue => setAttributes( { email: nextValue } ),
+		blockProps
 	);
 };
 

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/email/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/email/index.js
@@ -14,6 +14,7 @@ const attributes = {
 export const name = 'email';
 
 export const settings = {
+	apiVersion: 3,
 	title: __( 'Email Address', 'jetpack' ),
 	description: __(
 		'Lets you add an email address with an automatically generated click-to-email link.',

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/email/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/email/save.js
@@ -1,3 +1,4 @@
+import { useBlockProps } from '@wordpress/block-editor';
 import { Fragment } from '@wordpress/element';
 import emailValidator from 'email-validator';
 
@@ -27,7 +28,14 @@ const renderEmail = inputText => {
 	return explodedInput;
 };
 
-const save = ( { attributes: { email }, className } ) =>
-	email && <div className={ className }>{ renderEmail( email ) }</div>;
+const save = ( { attributes: { email } } ) => {
+	if ( ! email ) {
+		return null;
+	}
+
+	const blockProps = useBlockProps.save();
+
+	return <div { ...blockProps }>{ renderEmail( email ) }</div>;
+};
 
 export default save;

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/email/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/email/test/edit.js
@@ -2,6 +2,15 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import EmailEdit from '../edit';
 
+jest.mock( '@wordpress/block-editor', () => {
+	const useBlockProps = () => ( {} );
+	useBlockProps.save = () => ( {} );
+	return {
+		...jest.requireActual( '@wordpress/block-editor' ),
+		useBlockProps,
+	};
+} );
+
 const setAttributes = jest.fn();
 
 const defaultAttributes = {

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/phone/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/phone/edit.js
@@ -1,11 +1,19 @@
+import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import simpleInput from '../../../shared/simple-input';
 import save from './save';
 
 const PhoneEdit = props => {
+	const blockProps = useBlockProps();
 	const { setAttributes } = props;
-	return simpleInput( 'phone', props, __( 'Phone number', 'jetpack' ), save, nextValue =>
-		setAttributes( { phone: nextValue } )
+
+	return simpleInput(
+		'phone',
+		props,
+		__( 'Phone number', 'jetpack' ),
+		save,
+		nextValue => setAttributes( { phone: nextValue } ),
+		blockProps
 	);
 };
 

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/phone/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/phone/index.js
@@ -14,6 +14,7 @@ const attributes = {
 export const name = 'phone';
 
 export const settings = {
+	apiVersion: 3,
 	title: __( 'Phone Number', 'jetpack' ),
 	description: __(
 		'Lets you add a phone number with an automatically generated click-to-call link.',

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/phone/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/phone/save.js
@@ -1,3 +1,5 @@
+import { useBlockProps } from '@wordpress/block-editor';
+
 export function renderPhone( inputText ) {
 	const arrayOfNumbers = inputText.match( /\d+\.\d+|\d+\b|\d+(?=\w)/g );
 	if ( ! arrayOfNumbers ) {
@@ -37,7 +39,14 @@ export function renderPhone( inputText ) {
 	];
 }
 
-const save = ( { attributes: { phone }, className } ) =>
-	phone && <div className={ className }>{ renderPhone( phone ) }</div>;
+const save = ( { attributes: { phone } } ) => {
+	if ( ! phone ) {
+		return null;
+	}
+
+	const blockProps = useBlockProps.save();
+
+	return <div { ...blockProps }>{ renderPhone( phone ) }</div>;
+};
 
 export default save;

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/phone/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/phone/test/edit.js
@@ -2,6 +2,15 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PhoneEdit from '../edit';
 
+jest.mock( '@wordpress/block-editor', () => {
+	const useBlockProps = () => ( {} );
+	useBlockProps.save = () => ( {} );
+	return {
+		...jest.requireActual( '@wordpress/block-editor' ),
+		useBlockProps,
+	};
+} );
+
 const setAttributes = jest.fn();
 
 const defaultAttributes = {

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/logged-out-view/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/logged-out-view/index.js
@@ -9,6 +9,7 @@ import save from './save';
 
 const name = 'premium-content/logged-out-view';
 const settings = {
+	apiVersion: 3,
 	title: __( 'Guest View', 'jetpack' ),
 	description: __(
 		'The container for all content shown to site visitors who are not subscribers.',

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/logged-out-view/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/logged-out-view/save.js
@@ -1,4 +1,4 @@
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 /**
  * Block Save function
@@ -6,8 +6,12 @@ import { InnerBlocks } from '@wordpress/block-editor';
  * @return {string} HTML markup.
  */
 export default function Save() {
+	const blockProps = useBlockProps.save( {
+		className: 'wp-block-premium-content-logged-out-view entry-content',
+	} );
+
 	return (
-		<div className="wp-block-premium-content-logged-out-view entry-content">
+		<div { ...blockProps }>
 			<InnerBlocks.Content />
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/index.js
@@ -19,6 +19,7 @@ const name = 'premium-content/login-button';
  * @type {BlockConfiguration}
  */
 const settings = {
+	apiVersion: 3,
 	title: __( 'Premium Content login button', 'jetpack' ),
 	description: __(
 		'Prompt subscriber visitors to log in with a button-style link (only visible for logged out users).',

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/subscriber-view/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/subscriber-view/index.js
@@ -6,6 +6,7 @@ import save from './save';
 
 const name = 'premium-content/subscriber-view';
 const settings = {
+	apiVersion: 3,
 	title: __( 'Subscriber View', 'jetpack' ),
 	description: __( 'The container for all content shown to subscribers.', 'jetpack' ),
 	icon,

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/subscriber-view/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/subscriber-view/save.js
@@ -1,4 +1,4 @@
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 /**
  * Block Save function
@@ -6,8 +6,12 @@ import { InnerBlocks } from '@wordpress/block-editor';
  * @return {string} HTML markup.
  */
 export default function Save() {
+	const blockProps = useBlockProps.save( {
+		className: 'wp-block-premium-content-subscriber-view entry-content',
+	} );
+
 	return (
-		<div className="wp-block-premium-content-subscriber-view entry-content">
+		<div { ...blockProps }>
 			<InnerBlocks.Content />
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/recipe/details/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/details/edit.js
@@ -1,4 +1,4 @@
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { TextControl, __experimentalUnitControl as UnitControl } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import './editor.scss';
 
@@ -9,8 +9,10 @@ const units = [
 
 function RecipeDetailsEdit( { className, attributes, setAttributes } ) {
 	const { prepTime, prepTimeLabel, cookTime, cookTimeLabel, servings, servingsLabel } = attributes;
+	const blockProps = useBlockProps( { className } );
+
 	return (
-		<div className={ className }>
+		<div { ...blockProps }>
 			<div className="wp-container wp-recipe-block-details">
 				<div className="group">
 					<TextControl

--- a/projects/plugins/jetpack/extensions/blocks/recipe/details/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/details/index.js
@@ -10,6 +10,7 @@ import './editor.scss';
 export const name = 'recipe-details';
 
 export const settings = {
+	apiVersion: 3,
 	title: __( 'Recipe Details', 'jetpack' ),
 	description: __( 'Recipe Details', 'jetpack' ),
 	keywords: [],

--- a/projects/plugins/jetpack/extensions/blocks/recipe/details/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/details/save.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
-const RecipeSave = ( { attributes, className } ) => {
+const RecipeSave = ( { attributes } ) => {
 	const { prepTime, prepTimeLabel, cookTime, cookTimeLabel, servings, servingsLabel } = attributes;
+	const blockProps = useBlockProps.save();
 
 	return (
-		<div className={ className }>
+		<div { ...blockProps }>
 			<div className="wp-block-jetpack-recipe-details__detail">
 				<p>{ prepTimeLabel }</p>
 				<p itemProp="prepTime" content={ `PT${ prepTime.toUpperCase() }` }>

--- a/projects/plugins/jetpack/extensions/blocks/recipe/hero/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/hero/edit.js
@@ -1,11 +1,12 @@
 /**
  * External dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 function RecipeHeroEdit( { className, hasInnerBlocks } ) {
+	const blockProps = useBlockProps( { className } );
 	return (
-		<div className={ className }>
+		<div { ...blockProps }>
 			<InnerBlocks
 				allowedBlocks={ [ 'core/image', 'jetpack/slideshow', 'core/cover' ] }
 				renderAppender={ ! hasInnerBlocks && InnerBlocks.ButtonBlockAppender }

--- a/projects/plugins/jetpack/extensions/blocks/recipe/hero/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/hero/index.js
@@ -7,6 +7,7 @@ import save from './save';
 export const name = 'recipe-hero';
 export const title = __( 'Recipe Hero', 'jetpack' );
 export const settings = {
+	apiVersion: 3,
 	title,
 	description: __( 'Image area for the recipe.', 'jetpack' ),
 	keywords: [],

--- a/projects/plugins/jetpack/extensions/blocks/recipe/hero/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/hero/save.js
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
-const RecipeHeroSave = ( { className } ) => (
-	<div className={ className }>
-		<InnerBlocks.Content />
-	</div>
-);
+const RecipeHeroSave = () => {
+	const blockProps = useBlockProps.save();
+	return (
+		<div { ...blockProps }>
+			<InnerBlocks.Content />
+		</div>
+	);
+};
 
 export default RecipeHeroSave;

--- a/projects/plugins/jetpack/extensions/blocks/recipe/ingredient-item/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/ingredient-item/edit.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-import { RichText } from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 function RecipeIngredientItemEdit( { className, attributes, setAttributes } ) {
 	const { ingredient } = attributes;
+	const blockProps = useBlockProps( { className } );
 
 	return (
-		<div className={ className }>
+		<div { ...blockProps }>
 			<RichText
 				tagName="p"
 				className="ingredientText"

--- a/projects/plugins/jetpack/extensions/blocks/recipe/ingredient-item/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/ingredient-item/index.js
@@ -8,6 +8,7 @@ import save from './save';
 export const name = 'recipe-ingredient-item';
 export const title = __( 'Recipe Ingredient Item', 'jetpack' );
 export const settings = {
+	apiVersion: 3,
 	title,
 	description: __( 'A single ingredient associated with a recipe.', 'jetpack' ),
 	keywords: [],

--- a/projects/plugins/jetpack/extensions/blocks/recipe/ingredient-item/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/ingredient-item/save.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-import { RichText } from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 
-const RecipeIngredientItemSave = ( { className, attributes } ) => {
+const RecipeIngredientItemSave = ( { attributes } ) => {
 	const { ingredient } = attributes;
+	const blockProps = useBlockProps.save();
 
 	return (
-		<div className={ className }>
+		<div { ...blockProps }>
 			<RichText.Content tagName="p" itemprop="recipeIngredient" value={ ingredient } />
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/recipe/ingredients-list/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/ingredients-list/edit.js
@@ -1,10 +1,11 @@
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 import './editor.scss';
 
 function RecipeIngredientsListEdit( { className } ) {
+	const blockProps = useBlockProps( { className } );
 	return (
-		<div className={ className }>
+		<div { ...blockProps }>
 			<InnerBlocks
 				allowedBlocks={ [ 'jetpack/recipe-ingredient-item' ] }
 				renderAppender={ InnerBlocks.ButtonBlockAppender }

--- a/projects/plugins/jetpack/extensions/blocks/recipe/ingredients-list/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/ingredients-list/index.js
@@ -10,6 +10,7 @@ import './editor.scss';
 export const name = 'recipe-ingredients-list';
 export const title = __( 'Recipe Ingredients List', 'jetpack' );
 export const settings = {
+	apiVersion: 3,
 	title,
 	description: __( 'Recipe ingredient list', 'jetpack' ),
 	icon: getBlockIconProp( metadata ),

--- a/projects/plugins/jetpack/extensions/blocks/recipe/ingredients-list/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/ingredients-list/save.js
@@ -1,11 +1,13 @@
 /**
  * External dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
-const RecipeIngredientsListSave = ( { className } ) => {
+const RecipeIngredientsListSave = () => {
+	const blockProps = useBlockProps.save();
+
 	return (
-		<div className={ className }>
+		<div { ...blockProps }>
 			<InnerBlocks.Content />
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/recipe/step/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/step/edit.js
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 function RecipeStepEdit( { className } ) {
+	const blockProps = useBlockProps( { className } );
 	return (
 		<li>
-			<div className={ className }>
+			<div { ...blockProps }>
 				<InnerBlocks
 					allowedBlocks={ [
 						'core/image',

--- a/projects/plugins/jetpack/extensions/blocks/recipe/step/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/step/index.js
@@ -7,6 +7,7 @@ import save from './save';
 export const name = 'recipe-step';
 export const title = __( 'Recipe Step', 'jetpack' );
 export const settings = {
+	apiVersion: 3,
 	title,
 	description: __( 'A single recipe step.', 'jetpack' ),
 	keywords: [],

--- a/projects/plugins/jetpack/extensions/blocks/recipe/step/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/step/save.js
@@ -1,11 +1,13 @@
 /**
  * External dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 const RecipeStepSave = () => {
+	const blockProps = useBlockProps.save();
+
 	return (
-		<li itemProp="step" itemScope itemType="https://schema.org/HowToStep">
+		<li itemProp="step" itemScope itemType="https://schema.org/HowToStep" { ...blockProps }>
 			<InnerBlocks.Content />
 		</li>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/recipe/steps/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/steps/edit.js
@@ -1,6 +1,7 @@
 import {
 	ContrastChecker,
 	InnerBlocks,
+	useBlockProps,
 	InspectorControls,
 	PanelColorSettings,
 } from '@wordpress/block-editor';
@@ -10,6 +11,8 @@ import './editor.scss';
 
 function RecipeStepsEdit( { className, attributes, setAttributes } ) {
 	const { stepHighlightColor, stepTextColor } = attributes;
+	const blockProps = useBlockProps( { className } );
+
 	return (
 		<>
 			<InspectorControls>
@@ -40,7 +43,7 @@ function RecipeStepsEdit( { className, attributes, setAttributes } ) {
 					}
 				</PanelColorSettings>
 			</InspectorControls>
-			<ol className={ className }>
+			<ol { ...blockProps }>
 				<InnerBlocks
 					allowedBlocks={ [ 'jetpack/recipe-step' ] }
 					renderAppender={ InnerBlocks.ButtonBlockAppender }

--- a/projects/plugins/jetpack/extensions/blocks/recipe/steps/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/steps/index.js
@@ -9,6 +9,7 @@ import './editor.scss';
 export const name = 'recipe-steps';
 export const title = __( 'Recipe Steps', 'jetpack' );
 export const settings = {
+	apiVersion: 3,
 	title,
 	description: __( 'Step by step instructions for the recipe.', 'jetpack' ),
 	keywords: [],

--- a/projects/plugins/jetpack/extensions/blocks/recipe/steps/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/steps/save.js
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 const RecipeStepsSave = ( { attributes } ) => {
 	const { stepHighlightColor, stepTextColor } = attributes;
+	const blockProps = useBlockProps.save();
 
 	const styles = {
 		'--step-highlight-color': stepHighlightColor,
@@ -17,6 +18,7 @@ const RecipeStepsSave = ( { attributes } ) => {
 			itemScope=""
 			itemProp="recipeInstructions"
 			itemType="https://schema.org/HowTo"
+			{ ...blockProps }
 		>
 			<InnerBlocks.Content />
 		</ol>

--- a/projects/plugins/jetpack/extensions/blocks/send-a-message/whatsapp-button/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/send-a-message/whatsapp-button/edit.js
@@ -1,4 +1,4 @@
-import { BlockControls, InspectorControls, RichText } from '@wordpress/block-editor';
+import { BlockControls, InspectorControls, RichText, useBlockProps } from '@wordpress/block-editor';
 import { useDispatch } from '@wordpress/data';
 import { useEffect, useCallback } from '@wordpress/element';
 import clsx from 'clsx';
@@ -8,7 +8,9 @@ import '../view.scss';
 
 export default function WhatsAppButtonEdit( { attributes, setAttributes, className, clientId } ) {
 	const { countryCode, buttonText, colorClass, backgroundColor } = attributes;
-
+	const blockProps = useBlockProps( {
+		className: clsx( className, colorClass && `is-color-${ colorClass }` ),
+	} );
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 
 	const getCountryCode = useCallback( async () => {
@@ -44,12 +46,8 @@ export default function WhatsAppButtonEdit( { attributes, setAttributes, classNa
 		}
 	}, [ clientId, countryCode, getCountryCode, selectBlock ] );
 
-	const getBlockClassNames = () => {
-		return clsx( className, colorClass ? 'is-color-' + colorClass : undefined );
-	};
-
 	return (
-		<div className={ getBlockClassNames() }>
+		<div { ...blockProps }>
 			<BlockControls>
 				<WhatsAppButtonConfiguration
 					context="toolbar"

--- a/projects/plugins/jetpack/extensions/blocks/send-a-message/whatsapp-button/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/send-a-message/whatsapp-button/index.js
@@ -17,6 +17,7 @@ export const defaultFirstMessage = __(
 );
 
 export const settings = {
+	apiVersion: 3,
 	title,
 	description: __(
 		'Let your visitors send you a message on WhatsApp with the tap of a button.',

--- a/projects/plugins/jetpack/extensions/blocks/send-a-message/whatsapp-button/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/send-a-message/whatsapp-button/save.js
@@ -1,8 +1,8 @@
-import { RichText } from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 import clsx from 'clsx';
 import { whatsAppURL } from './index';
 
-export default function SendAMessageSave( { attributes, className } ) {
+export default function SendAMessageSave( { attributes } ) {
 	const {
 		countryCode,
 		phoneNumber,
@@ -12,6 +12,7 @@ export default function SendAMessageSave( { attributes, className } ) {
 		colorClass,
 		openInNewTab,
 	} = attributes;
+	const blockProps = useBlockProps.save();
 
 	const fullPhoneNumber =
 		countryCode && phoneNumber
@@ -29,7 +30,7 @@ export default function SendAMessageSave( { attributes, className } ) {
 	};
 
 	const cssClassNames = clsx(
-		className,
+		blockProps?.className,
 		colorClass ? 'is-color-' + colorClass : undefined,
 		! buttonText.length ? 'has-no-text' : undefined
 	);
@@ -37,7 +38,7 @@ export default function SendAMessageSave( { attributes, className } ) {
 	const target = openInNewTab ? '_blank' : '_self';
 
 	return (
-		<div className={ cssClassNames }>
+		<div { ...blockProps } className={ cssClassNames }>
 			<a
 				className="whatsapp-block__button"
 				href={ getWhatsAppUrl() }

--- a/projects/plugins/jetpack/extensions/shared/simple-input.js
+++ b/projects/plugins/jetpack/extensions/shared/simple-input.js
@@ -1,12 +1,16 @@
 import { PlainText } from '@wordpress/block-editor';
+import clsx from 'clsx';
 
-const simpleInput = ( type, props, label, view, onChange ) => {
+const simpleInput = ( type, props, label, view, onChange, rootProps = {} ) => {
 	const { isSelected } = props;
 	const value = props.attributes[ type ];
+
+	rootProps.className = clsx( rootProps.className, `jetpack-${ type }-block`, {
+		'is-selected': isSelected,
+	} );
+
 	return (
-		<div
-			className={ isSelected ? `jetpack-${ type }-block is-selected` : `jetpack-${ type }-block` }
-		>
+		<div { ...rootProps }>
 			{ ! isSelected && value !== '' && view( props ) }
 			{ ( isSelected || value === '' ) && (
 				<PlainText


### PR DESCRIPTION
Fixes #40678

> [!NOTE]
> This is the second take on #40685, after it was reverted in #42922.
>
> We first needed to update the Calypso e2e tests. This was done in https://github.com/Automattic/wp-calypso/pull/102395 

## Proposed changes:

**Original PR description**

It seems that we had forgotten to update a few of our child blocks in #34120.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

> [!NOTE] 
> 1. You'll need to test all the blocks touched by this PR on a site running Gutenberg (can be a simple site for example), and not using Gutenberg (can be a fresh JN site).
> 2.  To test the recipe block on non-simple sites, you will need to add a filter to your site on self-hosted (`add_filter( 'jetpack_blocks_variation', function () { return 'beta'; } );`) or use the option in Settings > Jetpack constants on JN. On simple sites, you will get the Beta blocks if you are proxied.

1. Before you switch to this branch, create posts with each one of the touched blocks.
2. Then switch to this branch.
3. Edit each one of the posts and ensure that there are no errors in the console, that the blocks can still be edited, and that they look good on the frontend (still use the right CSS classes).
