### PR TITLE
Forms: Update integration card header controls

### DIFF
--- a/projects/packages/forms/changelog/add-integration-card-header-details
+++ b/projects/packages/forms/changelog/add-integration-card-header-details
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add controls to IntegrationCard header.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
@@ -12,6 +12,9 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 
 	const cardData = {
 		...data,
+		showHeaderToggle: true,
+		headerToggleValue: data?.isConnected,
+		isHeaderToggleEnabled: false,
 		isLoading: ! data || typeof data.isInstalled === 'undefined',
 		refreshStatus,
 		trackEventName: 'jetpack_forms_upsell_akismet_click',

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
@@ -22,6 +22,7 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 
 	const cardData = {
 		...data,
+		showHeaderToggle: false,
 		isLoading: ! data || typeof data.isInstalled === 'undefined',
 		refreshStatus,
 		trackEventName: 'jetpack_forms_upsell_creative_mail_click',

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/index.js
@@ -20,6 +20,7 @@ const IntegrationCard = ( {
 				icon={ icon }
 				isExpanded={ isExpanded }
 				onToggle={ onToggle }
+				cardData={ cardData }
 			/>
 			<IntegrationCardBody isExpanded={ isExpanded } cardData={ cardData }>
 				{ children }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/index.js
@@ -1,7 +1,7 @@
 import { Card } from '@wordpress/components';
 import IntegrationCardBody from './integration-card-body';
 import IntegrationCardHeader from './integration-card-header';
-import './index.scss';
+import './style.scss';
 
 const IntegrationCard = ( {
 	title,

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/index.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/index.scss
@@ -41,10 +41,23 @@
 		line-height: 1.4;
 	}
 
+	&__plugin-badge {
+		background: #F0F0F0;
+		border-radius: 2px;
+		padding: 4px 8px;
+		font-size: 12px;
+	}
+
 	&__description {
 		color: var(--jp-gray-50);
 		font-size: 13px;
 		line-height: 1.4;
+	}
+
+	&__actions {
+		display: flex;
+		align-items: center;
+		gap: 12px;
 	}
 
 	&__toggle-icon {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.js
@@ -9,8 +9,9 @@ const IntegrationCardHeader = ( {
 	onToggle,
 	cardData = {},
 } ) => {
-	const { isInstalled, isActive } = cardData;
-	const showPluginAction = ! isInstalled || ! isActive;
+	const { isInstalled, isActive, isConnected, type } = cardData;
+	const showPluginAction = type === 'plugin' && ( ! isInstalled || ! isActive );
+	const showConnectedBadge = isActive && isConnected;
 
 	return (
 		<CardHeader onClick={ onToggle } className="integration-card__header">
@@ -21,6 +22,12 @@ const IntegrationCardHeader = ( {
 						<div className="integration-card__title-row">
 							<h3 className="integration-card__title">{ title }</h3>
 							{ showPluginAction && <span className="integration-card__plugin-badge">Plugin</span> }
+							{ showConnectedBadge && (
+								<span className="integration-card__connected-badge">
+									<Icon icon="yes-alt" size={ 16 } />
+									Connected
+								</span>
+							) }
 						</div>
 						{ description && (
 							<span className="integration-card__description">{ description }</span>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.js
@@ -1,22 +1,47 @@
 import { CardHeader, Icon } from '@wordpress/components';
+import PluginActionButton from './plugin-action-button';
 
-const IntegrationCardHeader = ( { title, description, icon, isExpanded, onToggle } ) => {
+const IntegrationCardHeader = ( {
+	title,
+	description,
+	icon,
+	isExpanded,
+	onToggle,
+	cardData = {},
+} ) => {
+	const { isInstalled, isActive } = cardData;
+	const showPluginAction = ! isInstalled || ! isActive;
+
 	return (
 		<CardHeader onClick={ onToggle } className="integration-card__header">
 			<div className="integration-card__header-content">
 				<div className="integration-card__header-main">
 					<Icon icon={ icon } className="integration-card__service-icon" size={ 30 } />
 					<div className="integration-card__title-section">
-						<h3 className="integration-card__title">{ title }</h3>
+						<div className="integration-card__title-row">
+							<h3 className="integration-card__title">{ title }</h3>
+							{ showPluginAction && <span className="integration-card__plugin-badge">Plugin</span> }
+						</div>
 						{ description && (
 							<span className="integration-card__description">{ description }</span>
 						) }
 					</div>
 				</div>
-				<Icon
-					icon={ isExpanded ? 'arrow-up-alt2' : 'arrow-down-alt2' }
-					className="integration-card__toggle-icon"
-				/>
+				<div className="integration-card__actions">
+					{ showPluginAction && (
+						<PluginActionButton
+							slug={ cardData.slug }
+							pluginFile={ cardData.pluginFile }
+							isInstalled={ isInstalled }
+							refreshStatus={ cardData.refreshStatus }
+							trackEventName={ cardData.trackEventName }
+						/>
+					) }
+					<Icon
+						icon={ isExpanded ? 'arrow-up-alt2' : 'arrow-down-alt2' }
+						className="integration-card__toggle-icon"
+					/>
+				</div>
 			</div>
 		</CardHeader>
 	);

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.js
@@ -1,4 +1,4 @@
-import { CardHeader, Icon } from '@wordpress/components';
+import { CardHeader, Icon, ToggleControl } from '@wordpress/components';
 import PluginActionButton from './plugin-action-button';
 
 const IntegrationCardHeader = ( {
@@ -9,12 +9,34 @@ const IntegrationCardHeader = ( {
 	onToggle,
 	cardData = {},
 } ) => {
-	const { isInstalled, isActive, isConnected, type } = cardData;
+	const {
+		isInstalled,
+		isActive,
+		isConnected,
+		type,
+		showHeaderToggle,
+		headerToggleValue,
+		isHeaderToggleEnabled,
+		onHeaderToggleChange,
+	} = cardData;
 	const showPluginAction = type === 'plugin' && ( ! isInstalled || ! isActive );
 	const showConnectedBadge = isActive && isConnected;
 
+	const handleToggleChange = value => {
+		if ( onHeaderToggleChange ) {
+			onHeaderToggleChange( value );
+		}
+	};
+
+	const handleHeaderClick = e => {
+		if ( e.target.closest( '.components-form-toggle' ) ) {
+			return;
+		}
+		onToggle( e );
+	};
+
 	return (
-		<CardHeader onClick={ onToggle } className="integration-card__header">
+		<CardHeader onClick={ handleHeaderClick } className="integration-card__header">
 			<div className="integration-card__header-content">
 				<div className="integration-card__header-main">
 					<Icon icon={ icon } className="integration-card__service-icon" size={ 30 } />
@@ -42,6 +64,14 @@ const IntegrationCardHeader = ( {
 							isInstalled={ isInstalled }
 							refreshStatus={ cardData.refreshStatus }
 							trackEventName={ cardData.trackEventName }
+						/>
+					) }
+					{ showHeaderToggle && (
+						<ToggleControl
+							checked={ headerToggleValue }
+							onChange={ handleToggleChange }
+							disabled={ ! isHeaderToggleEnabled }
+							onMouseDown={ e => e.stopPropagation() }
 						/>
 					) }
 					<Icon

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.js
@@ -29,6 +29,7 @@ const IntegrationCardHeader = ( {
 	};
 
 	const handleHeaderClick = e => {
+		// Without this, toggle click bubbles and opens/closes the card.
 		if ( e.target.closest( '.components-form-toggle' ) ) {
 			return;
 		}

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/plugin-action-button.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/plugin-action-button.js
@@ -10,7 +10,8 @@ const PluginActionButton = ( { slug, pluginFile, isInstalled, refreshStatus, tra
 		trackEventName
 	);
 
-	const handleAction = async () => {
+	const handleAction = async event => {
+		event.stopPropagation();
 		const success = await installPlugin();
 		if ( success && refreshStatus ) {
 			refreshStatus();
@@ -32,7 +33,6 @@ const PluginActionButton = ( { slug, pluginFile, isInstalled, refreshStatus, tra
 			onClick={ handleAction }
 			disabled={ isInstalling }
 			icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
-			__next40pxDefaultSize={ true }
 		>
 			{ getButtonText() }
 		</Button>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -41,11 +41,31 @@
 		line-height: 1.4;
 	}
 
+	&__plugin-badge,
+	&__connected-badge {
+		font-size: 11px;
+		padding: 4px 8px;
+		border-radius: 3px;
+		margin-left: 8px;
+		font-weight: 500;
+		line-height: 16px;
+	}
+
 	&__plugin-badge {
 		background: #F0F0F0;
-		border-radius: 2px;
-		padding: 4px 8px;
-		font-size: 12px;
+		color: #646970;
+	}
+
+	&__connected-badge {
+		background: #E5F5E8;
+		color: #008710;
+		display: flex;
+		align-items: center;
+		gap: 4px;
+
+		.components-icon {
+			color: #93c692;
+		}
 	}
 
 	&__description {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
@@ -25,6 +25,10 @@ const JetpackCRMCard = ( {
 
 	const cardData = {
 		...data,
+		showHeaderToggle: true,
+		headerToggleValue: jetpackCRM,
+		isHeaderToggleEnabled: true,
+		onHeaderToggleChange: value => setAttributes( { jetpackCRM: value } ),
 		isLoading: ! data || typeof data.isInstalled === 'undefined',
 		refreshStatus,
 		trackEventName: 'jetpack_forms_upsell_crm_click',


### PR DESCRIPTION
## Proposed changes:

NOTE: This is one of many PRs to create the new third party integrations modal. All this work is behind a feature flag and only visible if you set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.

This PR adds some state elements and controls to the IntegrationCardHeader component in the modal. 
- Title badge:
   - When plugins are not installed/active, we add a 'Plugin' badge by the title. This goes away when active. 
   - [in progress]: For installed/connected services, we show a green connected badge by the title.
- Actions
  - When plugins are not installed/active, we show an Install (or Activate) button on the right side by the dropdown chevron. This goes away when plugins are active.
  - [in progress]: For installed/connected services, we show a toggle to enable the integration for this form. This is always on for Akismet. For Jetpack CRM, it follows the toggle in the settings / card body. For Creative Mail, we do not show this, as there is not any integration with specific forms.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

There should be no changes in behavior. This is a refactor. 

- Set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.
- Add a form block to a page - with an email field
- Click on the Manage Integrations button the block sidebar to open the modal
- Test with plugin uninstalled
   - When Akismet, Jetpack CRM, and Creative Mail are uninstalled, you should see a a Plugin badge and an Install button on the header.
   - Click the install button and confirm the plugin installs and activates. 
   - Once active, the Plugin bad and Activate button should disappear
- Test with plugins installed but not active
   - When Akismet, Jetpack CRM, and Creative Mail are uninstalled, you should see a a Plugin badge and an Activate button on the header.
   - Click the Activate button and confirm the plugin activates. 
   - Once active, the Plugin bad and Activate button should disappear
- Test with plugins active
   - You should see no Plugin badge or Install/Activate button
   - For akismet you should see and always on toggle on the right
   - For Jetpack CRM, you should see a working toggle. When you toggle it, the toggle in the card body for Jetpack shoudl also turn on/off. 

