### PR TITLE
MU WPCOM: Add agency settings to Settings > General for agency sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/feat-agencies-settings
+++ b/projects/packages/jetpack-mu-wpcom/changelog/feat-agencies-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+MU WPCOM: Add agency settings to Settings > General for agency sites

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -444,7 +444,7 @@ class Jetpack_Mu_Wpcom {
 	 * Load A4A features.
 	 */
 	public static function load_a4a_features() {
-		if ( ! get_option( 'is_a4a_dev_site' ) ) {
+		if ( ! is_wpcom_agency_site() ) {
 			return;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -39,6 +39,9 @@ class Jetpack_Mu_Wpcom {
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_user_features' ) );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_etk_features' ) );
 
+		// Load features that only apply to a4a sites.
+		add_action( 'plugins_loaded', array( __CLASS__, 'load_a4a_features' ) );
+
 		// Load ETK features flag to turn off the features in the ETK plugin.
 		// It needs higher priority than the ETK plugin.
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_etk_features_flags' ), 0 );
@@ -435,6 +438,17 @@ class Jetpack_Mu_Wpcom {
 			require_once __DIR__ . '/features/wpcom-global-styles/index.php';
 			require_once __DIR__ . '/features/wpcom-legacy-fse/wpcom-legacy-fse.php';
 		}
+	}
+
+	/**
+	 * Load A4A features.
+	 */
+	public static function load_a4a_features() {
+		if ( ! get_option( 'is_a4a_dev_site' ) ) {
+			return;
+		}
+
+		require_once __DIR__ . '/features/a4a-settings/a4a-options-general.php';
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/a4a-settings/a4a-options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/a4a-settings/a4a-options-general.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Registers settings fields to options-general.php for a4a sites.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Load dependencies.
+ */
+require_once __DIR__ . '/../../utils.php';
+
+/**
+ * Render the Agency settings.
+ */
+function a4a_render_agency_settings() {
+	$is_fully_managed_agency_site_label = sprintf(
+		wp_kses(
+			/* translators: Placeholder is a link to a support document. */
+			__( 'Allow clients to use the <a href="%1$s" target="_blank" rel="noopener noreferrer">WordPress.com Help Center ↗</a> and <a href="%1$s" target="_blank" rel="noopener noreferrer">hosting features ↗</a>.', 'jetpack-mu-wpcom' ),
+			array(
+				'a' => array(
+					'href'   => array(),
+					'target' => array(),
+					'rel'    => array(),
+				),
+			)
+		),
+		esc_url( 'https://wordpress.com/support/help-support-options/#how-to-contact-us' ),
+		esc_url( 'https://developer.wordpress.com/docs/developer-tools/web-server-settings/' )
+	);
+
+	?>
+	<ul id="a4a-agency-settings">
+		<li>
+			<label>
+				<input name="is_fully_managed_agency_site" type="checkbox" value="1" <?php checked( is_fully_managed_agency_site(), true, false ); ?> />
+				<?php echo $is_fully_managed_agency_site_label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- we escape things above. ?>
+			</label>
+		</li>
+	</ul>
+	<?php
+}
+
+/**
+ * Register a4a settings fields.
+ */
+function a4a_register_options_general_fields() {
+	add_settings_field(
+		'a4a-settings',
+		__( 'Agency settings', 'jetpack-mu-wpcom' ),
+		'a4a_render_agency_settings',
+		'general'
+	);
+}
+add_action( 'load-options-general.php', 'a4a_register_options_general_fields' );
+
+/**
+ * Register a4a allowed options.
+ *
+ * @param array $allowed_options The allowed options list.
+ * @return array
+ */
+function a4a_register_allowed_options( $allowed_options ) {
+	$new_options = array(
+		'general' => array( 'is_fully_managed_agency_site' ),
+	);
+
+	$allowed_options = add_allowed_options( $new_options, $allowed_options );
+
+	return $allowed_options;
+}
+add_filter( 'allowed_options', 'a4a_register_allowed_options' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/a4a-settings/a4a-options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/a4a-settings/a4a-options-general.php
@@ -14,32 +14,58 @@ require_once __DIR__ . '/../../utils.php';
  * Render the Agency settings.
  */
 function a4a_render_agency_settings() {
-	$is_fully_managed_agency_site_label = sprintf(
-		wp_kses(
-			/* translators: Placeholder is a link to a support document. */
-			__( 'Allow clients to use the <a href="%1$s" target="_blank" rel="noopener noreferrer">WordPress.com Help Center ↗</a> and <a href="%1$s" target="_blank" rel="noopener noreferrer">hosting features ↗</a>.', 'jetpack-mu-wpcom' ),
-			array(
-				'a' => array(
-					'href'   => array(),
-					'target' => array(),
-					'rel'    => array(),
-				),
-			)
-		),
-		esc_url( 'https://wordpress.com/support/help-support-options/#how-to-contact-us' ),
-		esc_url( 'https://developer.wordpress.com/docs/developer-tools/web-server-settings/' )
-	);
+	if ( is_wpcom_agency_dev_site() ) {
+		$description = sprintf(
+			wp_kses(
+				/* translators: Placeholder is a link to a support document. */
+				__( 'Clients can\'t access the <a href="%1$s" target="_blank" rel="noopener noreferrer">WordPress.com Help Center ↗</a> or <a href="%2$s" target="_blank" rel="noopener noreferrer">hosting features ↗</a> on development sites. You may configure access after the site is launched.', 'jetpack-mu-wpcom' ),
+				array(
+					'a' => array(
+						'href'   => array(),
+						'target' => array(),
+						'rel'    => array(),
+					),
+				)
+			),
+			esc_url( 'https://wordpress.com/support/help-support-options/#how-to-contact-us' ),
+			esc_url( 'https://developer.wordpress.com/docs/developer-tools/web-server-settings/' )
+		);
 
-	?>
-	<ul id="a4a-agency-settings">
-		<li>
-			<label>
-				<input name="is_fully_managed_agency_site" type="checkbox" value="1" <?php checked( is_fully_managed_agency_site(), true, false ); ?> />
+		?>
+		<p class="description">
+			<?php echo $description; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- we escape things above. ?>
+			<a href="<?php echo esc_url( 'https://agencieshelp.automattic.com/knowledge-base/free-development-licenses-for-wordpress-com-hosting/' ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Learn more', 'jetpack-mu-wpcom' ); ?></a>.
+		</p>
+		<?php
+	} else {
+		$is_fully_managed_agency_site_label = sprintf(
+			wp_kses(
+				/* translators: Placeholder is a link to a support document. */
+				__( 'Allow clients to use the <a href="%1$s" target="_blank" rel="noopener noreferrer">WordPress.com Help Center ↗</a> and <a href="%2$s" target="_blank" rel="noopener noreferrer">hosting features ↗</a>.', 'jetpack-mu-wpcom' ),
+				array(
+					'a' => array(
+						'href'   => array(),
+						'target' => array(),
+						'rel'    => array(),
+					),
+				)
+			),
+			esc_url( 'https://wordpress.com/support/help-support-options/#how-to-contact-us' ),
+			esc_url( 'https://developer.wordpress.com/docs/developer-tools/web-server-settings/' )
+		);
+
+		$is_fully_managed_agency_site_value = checked( is_fully_managed_agency_site(), true, false );
+
+		?>
+		<fieldset id="a4a-agency-settings">
+			<legend class="screen-reader-text"><?php esc_html_e( 'Agency settings', 'jetpack-mu-wpcom' ); ?></legend>
+			<label for="is_fully_managed_agency_site">
+				<input name="is_fully_managed_agency_site" type="checkbox" value="1" <?php $is_fully_managed_agency_site_value; ?> />
 				<?php echo $is_fully_managed_agency_site_label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- we escape things above. ?>
 			</label>
-		</li>
-	</ul>
-	<?php
+		</fieldset>
+		<?php
+	}
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/a4a-settings/a4a-options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/a4a-settings/a4a-options-general.php
@@ -60,7 +60,7 @@ function a4a_render_agency_settings() {
 		<fieldset id="a4a-agency-settings">
 			<legend class="screen-reader-text"><?php esc_html_e( 'Agency settings', 'jetpack-mu-wpcom' ); ?></legend>
 			<label for="is_fully_managed_agency_site">
-				<input name="is_fully_managed_agency_site" type="checkbox" value="1" <?php $is_fully_managed_agency_site_value; ?> />
+				<input name="is_fully_managed_agency_site" type="checkbox" value="1" <?php echo $is_fully_managed_agency_site_value; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- we escape things above. ?> />
 				<?php echo $is_fully_managed_agency_site_label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- we escape things above. ?>
 			</label>
 		</fieldset>

--- a/projects/packages/jetpack-mu-wpcom/src/utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/utils.php
@@ -61,13 +61,6 @@ function is_wpcom_agency_dev_site() {
 }
 
 /**
- * Whether the user is the owner of the agency site.
- */
-function is_wpcom_agency_owner() {
-	return ! empty( get_wpcom_agency_blog_data() );
-}
-
-/**
  * Whether the site is fully managed agency site.
  *
  * @return bool True if the site is fully managed agency site.

--- a/projects/packages/jetpack-mu-wpcom/src/utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/utils.php
@@ -5,8 +5,67 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
+use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+/**
+ * Get the wpcom agency blog data.
+ */
+function get_wpcom_agency_blog_data() {
+	if ( ! is_woa_site() ) {
+		return null;
+	}
+
+	$blog_id                = get_wpcom_blog_id();
+	$cache_group            = 'wpcom_agency';
+	$cache_key              = "wpcom_agency_blog_$blog_id";
+	$found_in_cache         = false;
+	$wpcom_agency_blog_data = wp_cache_get( $cache_key, $cache_group, false, $found_in_cache );
+	if ( ! $found_in_cache ) {
+		$response = Client::wpcom_json_api_request_as_user( "/agency/blog/$blog_id" );
+		if ( wp_remote_retrieve_response_code( $response ) !== 200 ) {
+			$wpcom_agency_blog_data = null;
+		} else {
+			$wpcom_agency_blog_data = json_decode( wp_remote_retrieve_body( $response ) );
+		}
+
+		wp_cache_set( $cache_key, $wpcom_agency_blog_data, $cache_group, DAY_IN_SECONDS );
+	}
+
+	return $wpcom_agency_blog_data;
+}
+
+/**
+ * Whether the site is an agency site.
+ */
+function is_wpcom_agency_site() {
+	return (bool) get_wpcom_agency_blog_data();
+}
+
+/**
+ * Whether the site is an agency site for development.
+ */
+function is_wpcom_agency_dev_site() {
+	$blog_id      = get_wpcom_blog_id();
+	$blog_sticker = 'a4a-is-dev-site';
+	if ( function_exists( 'has_blog_sticker' ) && has_blog_sticker( $blog_sticker, $blog_id ) ) {
+		return true;
+	}
+
+	if ( function_exists( 'wpcomsh_is_site_sticker_active' ) && wpcomsh_is_site_sticker_active( $blog_sticker ) ) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Whether the user is the owner of the agency site.
+ */
+function is_wpcom_agency_owner() {
+	return ! empty( get_wpcom_agency_blog_data() );
+}
 
 /**
  * Whether the site is fully managed agency site.

--- a/projects/plugins/mu-wpcom-plugin/changelog/feat-agencies-settings
+++ b/projects/plugins/mu-wpcom-plugin/changelog/feat-agencies-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+MU WPCOM: Add agency settings to Settings > General for agency sites 

--- a/projects/plugins/wpcomsh/changelog/feat-agencies-settings
+++ b/projects/plugins/wpcomsh/changelog/feat-agencies-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+MU WPCOM: Add agency settings to Settings > General for agency sites 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/DOTCOM-1860

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add agency settings to Settings > General for agency sites on WP Admin

| Site | Screenshot |
| - | - |
| Agency Site | ![image](https://github.com/user-attachments/assets/9c10ef06-3266-4894-a693-13b3f397e441) |
| Agency Dev Site | ![image](https://github.com/user-attachments/assets/f526715e-329b-4190-a132-1505f250024e) |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create an agency site or agency dev site via https://agencies.automattic.com/sites
* Install Jetpack Beta Tester to your site
* Follow comments to apply changes to WordPress.com Features via Jetpack Beta Tester
* Go to Settings > General
* Ensure you can see the Agency settings as the screenshots above

