### PR TITLE
Likes: remove unused liked/like CSS class

### DIFF
--- a/projects/plugins/jetpack/changelog/likes-remove-liked-css
+++ b/projects/plugins/jetpack/changelog/likes-remove-liked-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Likes: remove unused liked/like CSS class

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -156,20 +156,15 @@ function JetpackLikesMessageListener( event ) {
 
 			break;
 
-		case 'showLikeWidget': {
-			// Add a `liked` class to the wrapper if the post already has likes.
-			if ( data.total > 0 ) {
-				document.querySelector( `#${ data.id }` ).classList.add( 'liked' );
-			}
-
+		// We're keeping this for planned future follow ups.
+		// @see: https://github.com/Automattic/jetpack/pull/42361#discussion_r1995338815
+		case 'showLikeWidget':
 			break;
-		}
 
 		// We're keeping this for planned future follow ups.
 		// @see: https://github.com/Automattic/jetpack/pull/42361#discussion_r1995338815
-		case 'showCommentLikeWidget': {
+		case 'showCommentLikeWidget':
 			break;
-		}
 
 		case 'killCommentLikes':
 			// If kill switch for comment likes is enabled remove all widgets wrappers and `Loading...` placeholders.
@@ -188,16 +183,6 @@ function JetpackLikesMessageListener( event ) {
 			hideLikersPopover();
 			break;
 		}
-
-		case 'clickPostLike':
-			// Add or remove the wrapper `liked` class based on the total likes.
-			if ( data.total > 0 ) {
-				document.querySelector( `#${ data.id }` ).classList.add( 'liked' );
-			} else {
-				document.querySelector( `#${ data.id }` ).classList.remove( 'liked' );
-			}
-
-			break;
 
 		case 'showOtherGravatars': {
 			const container = document.querySelector( '#likes-other-gravatars' );


### PR DESCRIPTION
Removes redundant code that adds `liked`/`like` classes to the Like widget wrapper. There is no styling for these classes, and the WP.com version of the `queuehandler.js` doesn't do this. This PR synces the Jetpack version to be closer to the WP.com version.

There are `liked`/`like` styles on the `wpl-button` element inside the iframe, and they determine the type of the "star" icon that is displayed on the button. But that's something different.

## Testing instructions:
Test Likes on a jurassic.ninja site or something similar. There should be no behavior or style change.

## Does this pull request change what data or activity we track or use?
No.