### PR TITLE
Forms: Fix integration card toggle styles

### DIFF
--- a/projects/packages/forms/changelog/fix-integration-card-header-toggle
+++ b/projects/packages/forms/changelog/fix-integration-card-header-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fixed IntegrationCardHeader toggle styles

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.js
@@ -67,12 +67,11 @@ const IntegrationCardHeader = ( {
 							trackEventName={ cardData.trackEventName }
 						/>
 					) }
-					{ showHeaderToggle && (
+					{ ( isActive || isConnected ) && showHeaderToggle && (
 						<ToggleControl
 							checked={ headerToggleValue }
 							onChange={ handleToggleChange }
 							disabled={ ! isHeaderToggleEnabled }
-							onMouseDown={ e => e.stopPropagation() }
 						/>
 					) }
 					<Icon


### PR DESCRIPTION
## Proposed changes:

NOTE: This is one of many PRs to create the new third party integrations modal. All this work is behind a feature flag and only be visible if you set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.

Changes:
* We are showing both the plugin install/activate button and the enable toggle in the IntegrationCardHeader at the same time. The toggle should only show if plugins are already installed and active. This is a small fix to update the conditional for when that shows. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.
- Deactivate or uninstall one or more of: Akismet, Jetpack CRM, Creative Mail
- Add a form block to a page - with an email field
- Click on the Manage Integrations button the block sidebar
- Confirm the whenever one the plugins above needs to be installed or activated, you only see the install / activate button on the header and not an 'enable' toggle
