### PR TITLE
Forms: Fix integrations modal tracks events

### DIFF
--- a/projects/packages/forms/changelog/fix-form-integrations-tracks-events
+++ b/projects/packages/forms/changelog/fix-form-integrations-tracks-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix integration modal tracks events.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/hooks/usePluginInstallation.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/hooks/usePluginInstallation.js
@@ -19,7 +19,10 @@ export const usePluginInstallation = ( slug, pluginPath, isInstalled, tracksEven
 		setIsInstalling( true );
 
 		if ( tracksEventName ) {
-			tracks.recordEvent( tracksEventName );
+			tracks.recordEvent( tracksEventName, {
+				screen: 'block-editor',
+				intent: isInstalled ? 'activate-plugin' : 'install-plugin',
+			} );
 		}
 
 		try {


### PR DESCRIPTION
## Proposed changes:

NOTE: This is one of many PRs to create the new third party integrations modal. All this work is behind a feature flag and only be visible if you set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.

Changes:
* We fire tracks events when installing or activating plugins from the Jetpack Forms interface. The tracks events fired from the integration modal were missing needed props for 'screen' and 'intent' (as seen, for example, in the old creative mail panel code [here](https://github.com/Automattic/jetpack/blob/773e8423cc2805e649894835f2515b58e95fb429/projects/packages/forms/src/blocks/contact-form/components/jetpack-newsletter-integration-settings-plugin-state.js#L50)). This PR adds the missing props to our usePluginIntegration hook, which means they'll apply for all plugin install/activate actions now. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.
- You'll need to have [Tracks Vigilante](https://github.com/Automattic/tracks-chrome-extension) installed, or another way to monitor tracks events.
- Deactivate or uninstall one or more of: Akismet, Jetpack CRM, Creative Mail
- Add a form block to a page - with an email field
- Click on the Manage Integrations button the block sidebar
- While monitoring tracks events, click to install or activate a plugin. Confirm that the correct 'jetpack_forms_upsell_{plugin name}_click event' fires, with screen set to 'block-editor' and intent set to 'install-plugin' or 'activate-plugin' depending on which you are doing.

