### PR TITLE
Jetpack SEO Enhancer: release to production

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -3095,9 +3095,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 		);
 
-		// SEO Tools - SEO Enhancer. Only available to Automatticians.
-		// TODO: either remove this or make it available to all users by moving it to the main options array.
-		if ( apply_filters( 'ai_seo_enhancer_enabled', false ) || apply_filters( 'ai_seo_enhancer_enabled_unrestricted', false ) ) {
+		// SEO Tools - SEO Enhancer.
+		// TODO: move this to the main options array? The filter was there while developing the feature.
+		// It might come in handy to hold its availability behind the filter since it still depends on AI to be available.
+		if ( apply_filters( 'ai_seo_enhancer_enabled', true ) ) {
 			$options['ai_seo_enhancer_enabled'] = array(
 				'description'       => esc_html__( 'Automatically generate SEO title, SEO description, and image alt text for new posts.', 'jetpack' ),
 				'type'              => 'boolean',

--- a/projects/plugins/jetpack/changelog/change-jetpack-seo-enhancer-release-filters
+++ b/projects/plugins/jetpack/changelog/change-jetpack-seo-enhancer-release-filters
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack SEO Enhancer: move feature to production

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -130,10 +130,7 @@ add_action(
 				Jetpack_Gutenberg::set_extension_available( 'ai-proofread-breve' );
 			}
 
-			if ( apply_filters( 'ai_seo_enhancer_enabled_unrestricted', false ) ) {
-				Jetpack_Gutenberg::set_extension_available( 'ai-seo-enhancer-enabled-unrestricted' );
-				Jetpack_Gutenberg::set_extension_available( 'ai-seo-enhancer' );
-			} elseif ( apply_filters( 'ai_seo_enhancer_enabled', false ) ) {
+			if ( apply_filters( 'ai_seo_enhancer_enabled', true ) ) {
 				Jetpack_Gutenberg::set_availability_for_plan( 'ai-seo-enhancer' );
 			}
 

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -71,7 +71,8 @@
 		"ai-assistant-site-logo-support",
 		"ai-title-optimization-keywords-support",
 		"ai-response-feedback",
-		"ai-assistant-image-extension"
+		"ai-assistant-image-extension",
+		"ai-seo-enhancer"
 	],
 	"beta": [
 		"google-docs-embed",
@@ -82,8 +83,6 @@
 		"ai-list-to-table-transform",
 		"ai-seo-assistant",
 		"ai-use-chrome-ai-sometimes",
-		"ai-seo-enhancer",
-		"ai-seo-enhancer-enabled-unrestricted",
 		"ai-proofread-harper"
 	],
 	"experimental": [],


### PR DESCRIPTION
Fixes AGORA-49

## Proposed changes:
This PR removes the filter restriction for the feature to be available and moves the feature flag from Beta to Production.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1744038372008609-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

**Simple sites:**

Simple sites with Business plans or above that haven't still migrated to AT should have access to the feature, yet not the auto-generation toggle.

Apply this on a sandbox, sandbox public API and a simple site.
Acquire a Business plan or above for the site but do not install any plugin (so it remains a simple site).
Create a post and look for the SEO panel on the Jetpack sidebar. Manual trigger for SEO meta and images alt-text generation should be available and work as expected. 

**AT Sites:**
Install a plugin on the simple site so it migrates to AT. Install Jetpack Beta and activate this PR's branch.
Go to Jetpack settings -> Traffic. See the toggle to automatically generate metas and alt-text for images, see that it works.
Go to the block editor and look for the SEO Panel on the Jetpack sidebar. See that it now shows the auto-generation toggle and the toggle matches the value on Jetpack Settings -> Traffic.
Enable the toggle and add an image to the post, see that the alt-text is automatically generated.
Hit "Publish" and see the auto generation is triggered on the PrePublish sidebar.