### PR TITLE
Subscriptions: do not show the widget to non-admins

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-widget-just-admins
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-widget-just-admins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: only display the dashboard widget to site admins.

--- a/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-newsletter-dashboard-widget.php
@@ -90,6 +90,11 @@ class Jetpack_Newsletter_Dashboard_Widget {
 	 * Sets up the Jetpack Newsletter widget in the WordPress admin dashboard.
 	 */
 	public static function wp_dashboard_setup() {
+		// Do not show the widget to non-admins.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
 		if ( Jetpack::is_connection_ready() ) {
 			static::load_admin_scripts(
 				'jp-newsletter-widget',


### PR DESCRIPTION
## Proposed changes:

Non-admins cannot access Subscription stats or manage subscription settings. We do not need to display the widget to them.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* no

## Testing instructions:

* Go to Jetpack > Settings > Newsletter and enable the Subscriptions module.
* Go to the main wp-admin dashboard
    * You should see the Newsletter widget
* Go to Users > Add New
* Create a new editor user.
* In a new browser, log in with that user
    * You should **not** see the Newsletter widget.
    
