### PR TITLE
Forms: Close block panels by default

### DIFF
--- a/projects/packages/forms/changelog/update-close-form-block-panels
+++ b/projects/packages/forms/changelog/update-close-form-block-panels
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Close block panels by default.

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -157,7 +157,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 			<>
 				<InspectorControls>
 					<PanelBody
-						title={ __( 'Manage Responses', 'jetpack-forms' ) }
+						title={ __( 'Manage responses', 'jetpack-forms' ) }
 						className="jetpack-contact-form__manage-responses-panel"
 						initialOpen={ false }
 					>
@@ -215,7 +215,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 							</div>
 						) }
 					</PanelBody>
-					<PanelBody title={ __( 'Email Connection', 'jetpack-forms' ) } initialOpen={ false }>
+					<PanelBody title={ __( 'Email connection', 'jetpack-forms' ) } initialOpen={ false }>
 						<JetpackEmailConnectionSettings
 							emailAddress={ to }
 							emailSubject={ subject }
@@ -227,7 +227,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 
 					{ isFormModalEnabled && (
 						<PanelBody
-							title={ __( 'Manage Integrations', 'jetpack-forms' ) }
+							title={ __( 'Manage integrations', 'jetpack-forms' ) }
 							className="jetpack-contact-form__integrations-panel"
 							initialOpen={ false }
 						>
@@ -245,7 +245,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 					{ ! isFormModalEnabled && ! isSimpleSite() && canUserInstallPlugins && (
 						<>
 							<AkismetPanel />
-							<PanelBody title={ __( 'CRM Connection', 'jetpack-forms' ) } initialOpen={ false }>
+							<PanelBody title={ __( 'CRM connection', 'jetpack-forms' ) } initialOpen={ false }>
 								<CRMIntegrationSettings jetpackCRM={ jetpackCRM } setAttributes={ setAttributes } />
 							</PanelBody>
 							<PanelBody title={ __( 'Creative Mail', 'jetpack-forms' ) } initialOpen={ false }>

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -159,6 +159,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 					<PanelBody
 						title={ __( 'Manage Responses', 'jetpack-forms' ) }
 						className="jetpack-contact-form__manage-responses-panel"
+						initialOpen={ false }
 					>
 						<JetpackManageResponsesSettings setAttributes={ setAttributes } />
 					</PanelBody>
@@ -214,7 +215,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 							</div>
 						) }
 					</PanelBody>
-					<PanelBody title={ __( 'Email Connection', 'jetpack-forms' ) }>
+					<PanelBody title={ __( 'Email Connection', 'jetpack-forms' ) } initialOpen={ false }>
 						<JetpackEmailConnectionSettings
 							emailAddress={ to }
 							emailSubject={ subject }
@@ -228,6 +229,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 						<PanelBody
 							title={ __( 'Manage Integrations', 'jetpack-forms' ) }
 							className="jetpack-contact-form__integrations-panel"
+							initialOpen={ false }
 						>
 							<IntegrationPanel attributes={ attributes } setAttributes={ setAttributes } />
 						</PanelBody>

--- a/projects/plugins/jetpack/changelog/update-close-form-block-panels
+++ b/projects/plugins/jetpack/changelog/update-close-form-block-panels
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Close block panels by default.


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Closes all the form inspector controls panel by default to reduce clutter. 
* Also updates panel titles to sentence case for consistency

**Screenshot (with integrations panel feature flag on)**
<img width="1255" alt="form-panels-closed-sentence-case" src="https://github.com/user-attachments/assets/2287e408-6c72-45a6-95a3-269076393f75" />

**Screenshot (with integrations panel feature flag off)**
<img width="1259" alt="form-block-panels-closed-all-panels" src="https://github.com/user-attachments/assets/63908b6f-e1d4-4a68-b40d-be727feab8ec" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: p1744048910549769-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Add a form block to a page
- Check inspector sidebar and confirm panels are initially closed, but otherwise work like normal
- Confirm panel titles are now sentence case