### PR TITLE
Jetpack SEO Enhancer: fix manual trigger on published posts

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-seo-enhancer-manual-trigger-published-post
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-seo-enhancer-manual-trigger-published-post
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack SEO Enhancer: cancel meta and alt-text edits if auto generation requests come back and the post status is publish(ed)


### PR DESCRIPTION
Fixes AGORA-51

## Proposed changes:
This PR fixes a bug where the manual trigger of meta and alt-text won't be applied if the post is already published.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1744047136772489-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add the feature filter: `add_filter( 'ai_seo_enhancer_enabled', '__return_true' );`.

Get a Jetpack Complete or Business plan and above for your site, or add the bypass filter `add_filter( 'ai_seo_enhancer_enabled_unrestricted', '__return_true' );`

Open the editor, add some content and image to the post and publish it.
Look for the SEO panel on Jetpack sidebar. Empty the title and description metas and the image alt-text if needed.
Trigger the generation manually and see the metas and alt-texts are applied.