### PR TITLE
Social | Fix Manual Sharing not being visible on post publish screen

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-manual-sharing-in-post-publish-panel
+++ b/projects/js-packages/publicize-components/changelog/fix-social-manual-sharing-in-post-publish-panel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social | Fix Manual Sharing not being visible on post publish screen

--- a/projects/js-packages/publicize-components/src/components/post-publish-manual-sharing/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-manual-sharing/index.tsx
@@ -18,9 +18,12 @@ const PluginPostPublishPanel = EditorPluginPostPublishPanel || DeprecatedPluginP
  * @return {import('react').JSX.Element} Post Publish Manual Sharing component.
  */
 export default function PostPublishManualSharing() {
-	const { isCurrentPostPublished } = useSelect( select => select( editorStore ), [] );
+	const isCurrentPostPublished = useSelect(
+		select => select( editorStore ).isCurrentPostPublished(),
+		[]
+	);
 
-	if ( ! isCurrentPostPublished() ) {
+	if ( ! isCurrentPostPublished ) {
 		return null;
 	}
 


### PR DESCRIPTION
While trying to debug the issue mentioned [here](https://github.com/Automattic/wp-calypso/blob/57688961668b1f5930bf6efabeebf19bf11ae352/test/e2e/specs/jetpack/social__editor-features.ts#L240-L242), I found out the reason being that the `isCurrentPostPublished` selector being called outside the callback which doesn't trigger a re-render when the store changes. It's explained in detail in [this post on Core Dev Blog](https://developer.wordpress.org/news/2024/03/how-to-work-effectively-with-the-useselect-hook/#call-selector-functions-inside-the-callback-not-outside)

The bug seems to have been introduced in #34354

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix Social Manual Sharing not being visible on post publish screen by calling the `isCurrentPostPublished` selector inside the callback passed to `useSelect`
* The corresponding change for E2E tests is being made in https://github.com/Automattic/wp-calypso/pull/102465

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a post
* Publish it
* Confirm that you see the Manual Sharing UI on the post publish screen

<img width="316" alt="Screenshot 2025-04-08 at 11 55 47 AM" src="https://github.com/user-attachments/assets/78b068ec-b351-4057-8148-48808864c687" />

