### PR TITLE
Move core widget retirement to jetpack-mu-wpcom

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-add-core-retired-widget
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-add-core-retired-widget
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Consolidating code from wpcom into jetpack-mu-wpcom. No changes.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-widgets/wpcom-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-widgets/wpcom-widgets.php
@@ -18,6 +18,8 @@ define(
 	'JETPACK_MU_WPCOM_RETIRED_WIDGETS',
 	array(
 		'i_voted' => 'Jetpack_I_Voted_Widget',
+		'links'   => 'WP_Widget_Links',
+		'meta'    => 'WP_Widget_Meta',
 	)
 );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Part of bringing wpcom and atomic in line and allowing for a vanilla WP install

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?
Part of 180003-ghe-Automattic/wpcom

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Widgets page on an atomic dev site
* Test that you cannot add the WP_Widget_Meta (meta) or WP_Widget_Links (links) widgets