### PR TITLE
Update/enforce jetpack modules setup

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-enforce-jetpack-modules-setup
+++ b/projects/plugins/wpcomsh/changelog/update-enforce-jetpack-modules-setup
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Ensure we'll always enable jetpack modules after an atomic transfer

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -393,3 +393,64 @@ function wpcomsh_woa_post_process_store_woocommerce_connection_details( $args, $
 add_action( 'wpcomsh_woa_post_clone', 'wpcomsh_woa_post_process_store_woocommerce_connection_details', 10, 2 );
 add_action( 'wpcomsh_woa_post_reset', 'wpcomsh_woa_post_process_store_woocommerce_connection_details', 10, 2 );
 add_action( 'wpcomsh_woa_post_transfer', 'wpcomsh_woa_post_process_store_woocommerce_connection_details', 10, 2 );
+
+/**
+ * Ensures that specific Jetpack modules are activated after a transfer.
+ * Addresses the issue where certain modules like blocks, account-protection and blaze
+ * may be disabled during the transfer process.
+ *
+ * @param array $args       Arguments.
+ * @param array $assoc_args Associated arguments.
+ */
+function wpcomsh_woa_post_process_activate_jetpack_modules( $args, $assoc_args ) {
+
+	if ( ! is_plugin_active( 'jetpack/jetpack.php' ) ) {
+		WP_CLI::warning( 'Jetpack plugin is not active, skipping module activation' );
+		return;
+	}
+
+	// First, make sure the jetpack_blocks_disabled option is deleted
+	delete_option( 'jetpack_blocks_disabled' );
+
+	// Array of modules to ensure are activated
+	$modules_to_activate = array(
+		'blocks',
+		'account-protection',
+		'blaze',
+	);
+
+	foreach ( $modules_to_activate as $module ) {
+		$result = WP_CLI::runcommand(
+			"jetpack module activate $module",
+			array(
+				'return'     => 'all',
+				'launch'     => false,
+				'exit_error' => false,
+			)
+		);
+
+		if ( 0 === $result->return_code ) {
+			WP_CLI::log( sprintf( 'Successfully activated Jetpack module: %s', $module ) );
+		} else {
+			WP_CLI::warning( sprintf( 'Failed to activate Jetpack module: %s - %s', $module, $result->stderr ) );
+		}
+	}
+
+	// Get a list of all active modules to verify
+	$active_modules_result = WP_CLI::runcommand(
+		'jetpack module list --status=active',
+		array(
+			'return'     => 'all',
+			'launch'     => false,
+			'exit_error' => false,
+		)
+	);
+
+	WP_CLI::log( 'Currently active Jetpack modules:' );
+	WP_CLI::log( $active_modules_result->stdout );
+
+	WP_CLI::success( 'Jetpack modules activation completed' );
+}
+
+// Add this action for all three operation types to ensure modules are always activated
+add_action( 'wpcomsh_woa_post_transfer', 'wpcomsh_woa_post_process_activate_jetpack_modules', 10, 2 );

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -454,3 +454,4 @@ function wpcomsh_woa_post_process_activate_jetpack_modules( $args, $assoc_args )
 
 // Add this action for all three operation types to ensure modules are always activated
 add_action( 'wpcomsh_woa_post_transfer', 'wpcomsh_woa_post_process_activate_jetpack_modules', 10, 2 );
+add_action( 'wpcomsh_woa_post_reset', 'wpcomsh_woa_post_process_activate_jetpack_modules', 10, 2 );

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -412,12 +412,13 @@ function wpcomsh_woa_post_process_activate_jetpack_modules( $args, $assoc_args )
 	// First, make sure the jetpack_blocks_disabled option is deleted
 	delete_option( 'jetpack_blocks_disabled' );
 
-	// Array of modules to ensure are activated
 	$modules_to_activate = array(
-		'blocks',
 		'account-protection',
 		'blaze',
+		'blocks',
 	);
+
+	$activated_modules = array();
 
 	foreach ( $modules_to_activate as $module ) {
 		$result = WP_CLI::runcommand(
@@ -431,6 +432,7 @@ function wpcomsh_woa_post_process_activate_jetpack_modules( $args, $assoc_args )
 
 		if ( 0 === $result->return_code ) {
 			WP_CLI::log( sprintf( 'Successfully activated Jetpack module: %s', $module ) );
+			$activated_modules[] = $module;
 		} else {
 			WP_CLI::warning( sprintf( 'Failed to activate Jetpack module: %s - %s', $module, $result->stderr ) );
 		}
@@ -449,7 +451,9 @@ function wpcomsh_woa_post_process_activate_jetpack_modules( $args, $assoc_args )
 	WP_CLI::log( 'Currently active Jetpack modules:' );
 	WP_CLI::log( $active_modules_result->stdout );
 
-	WP_CLI::success( 'Jetpack modules activation completed' );
+	if ( count( $activated_modules ) === count( $modules_to_activate ) ) {
+		WP_CLI::success( 'Jetpack modules activation completed' );
+	}
 }
 
 // Add this action for all three operation types to ensure modules are always activated


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Slack thread: p1744052983694779-slack-CDLH4C1UZ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We're enforcing the activation of three Jetpack modules that are getting disabled after a Commerce upgrade

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1744052983694779-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a simple site and add it to Atomic Dev Site
* Transfer it to Atomic
* Upgrade the site to Commerce plan
* Once the its on Commerce, open the editor and make sure the Jetpack blocks are disabled
* Also run `wp jetpack module list` to make sure the three modules are disabled:
	![image](https://github.com/user-attachments/assets/e1b8db7d-7c60-4f54-aa99-c240e22ed7e8)

* Install [Jetpack beta tester plugin](https://jetpack.com/download-jetpack-beta/) on the site you just created
* Open the plugin page and select the `WordPress.com Site Helper`
* Install the current PR `update/enforce-jetpack-modules-setup` on the site
* Run the `wp wpcomsh post-transfer` command to simulate an Atomic transfer and see that after another `jetpack module list` command, the three modules will be enabled:

	![image](https://github.com/user-attachments/assets/54a719cd-5ada-4ca9-9c49-81293ed35d3e)

* Jetpack modules will be enabled again:

	![image](https://github.com/user-attachments/assets/10e5bab2-074a-454c-9059-e4980185e98e)