### PR TITLE
Fix cookie consent switch padding

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-cookie-consent-padding
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-cookie-consent-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix misaligned cookie consent switch

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/EmailForm/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/EmailForm/style.scss
@@ -64,10 +64,7 @@
 
 	.verbum-mail-form-cookie-consent {
 		margin-bottom: 16px;
-
-		.verbum-toggle-control {
-			padding: 0 21px;
-		}
+		padding: 0 21px;
 
 		.verbum-toggle-control__text {
 			font-size: 0.875rem;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

| Before  | After |
| ------------- | ------------- |
|  <img width="621" alt="Screenshot 2025-04-09 at 10 28 10" src="https://github.com/user-attachments/assets/48ec53a4-5f04-46a1-ab8c-5e9823f177f8" /> |  <img width="628" alt="Screenshot 2025-04-09 at 10 27 47" src="https://github.com/user-attachments/assets/7159cd10-a9bd-43f0-8f89-42274408e741" /> |

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Misaligned consent switch

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
* Sync this PR to simple and atomic site
* Ensure that the consent switch is properly aligned

