### PR TITLE
i18n: number-formatters – convert build to common JS

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14888,9 +14888,6 @@ packages:
   third-party-web@0.26.5:
     resolution: {integrity: sha512-tDuKQJUTfjvi9Fcrs1s6YAQAB9mzhTSbBZMfNgtWNmJlHuoFeXO6dzBFdGeCWRvYL50jQGK0jPsBZYxqZQJ2SA==}
 
-  third-party-web@0.26.6:
-    resolution: {integrity: sha512-GsjP92xycMK8qLTcQCacgzvffYzEqe29wyz3zdKVXlfRD5Kz1NatCTOZEeDaSd6uCZXvGd2CNVtQ89RNIhJWvA==}
-
   thread-loader@3.0.4:
     resolution: {integrity: sha512-ByaL2TPb+m6yArpqQUZvP+5S1mZtXsEP7nWKKlAUTm7fCml8kB5s1uI3+eHRP2bk5mVYfRSBI7FFf+tWEyLZwA==}
     engines: {node: '>= 10.13.0'}
@@ -17598,7 +17595,7 @@ snapshots:
 
   '@paulirish/trace_engine@0.0.50':
     dependencies:
-      third-party-web: 0.26.6
+      third-party-web: 0.26.5
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -28807,8 +28804,6 @@ snapshots:
   text-hex@1.0.0: {}
 
   third-party-web@0.26.5: {}
-
-  third-party-web@0.26.6: {}
 
   thread-loader@3.0.4(webpack@5.94.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14888,6 +14888,9 @@ packages:
   third-party-web@0.26.5:
     resolution: {integrity: sha512-tDuKQJUTfjvi9Fcrs1s6YAQAB9mzhTSbBZMfNgtWNmJlHuoFeXO6dzBFdGeCWRvYL50jQGK0jPsBZYxqZQJ2SA==}
 
+  third-party-web@0.26.6:
+    resolution: {integrity: sha512-GsjP92xycMK8qLTcQCacgzvffYzEqe29wyz3zdKVXlfRD5Kz1NatCTOZEeDaSd6uCZXvGd2CNVtQ89RNIhJWvA==}
+
   thread-loader@3.0.4:
     resolution: {integrity: sha512-ByaL2TPb+m6yArpqQUZvP+5S1mZtXsEP7nWKKlAUTm7fCml8kB5s1uI3+eHRP2bk5mVYfRSBI7FFf+tWEyLZwA==}
     engines: {node: '>= 10.13.0'}
@@ -17595,7 +17598,7 @@ snapshots:
 
   '@paulirish/trace_engine@0.0.50':
     dependencies:
-      third-party-web: 0.26.5
+      third-party-web: 0.26.6
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -28804,6 +28807,8 @@ snapshots:
   text-hex@1.0.0: {}
 
   third-party-web@0.26.5: {}
+
+  third-party-web@0.26.6: {}
 
   thread-loader@3.0.4(webpack@5.94.0):
     dependencies:

--- a/projects/js-packages/number-formatters/changelog/update-i18n-number-formatters-build-cjs
+++ b/projects/js-packages/number-formatters/changelog/update-i18n-number-formatters-build-cjs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Convert build to common-js

--- a/projects/js-packages/number-formatters/package.json
+++ b/projects/js-packages/number-formatters/package.json
@@ -27,7 +27,6 @@
 		"jest-environment-jsdom": "29.7.0",
 		"typescript": "5.8.2"
 	},
-	"type": "module",
 	"exports": {
 		".": {
 			"jetpack:src": "./src/index.ts",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

See PT: pxLjZ-9ME-p2
Part of addressing https://github.com/Automattic/i18n-issues/issues/942

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
While attempting to use number-formatters in wp-calypso (relevant PR https://github.com/Automattic/wp-calypso/pull/102475), we ran into issues with Jest not recognising/working with the ES imports/exports in the esm build. We switch the distribution build to common-js to get that end working - and hope we don't run into issues when linking the package for use in this repo 😐 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* No functional changes. The package is not currently linked in JP repo
* wp-calypso uses `yarn` and JP uses `pnpm`, so linking as expected may not work. So:
  * Build the package with `jetpack build -v js-packages/number-formatters`
  * copy the `dist` into `node_modules` on consuming end / wp-calypso: `cp -r /jetpack/.../number-formatters/dist /wp-calypso/node_modules/@automattic/number-formatters`
  * Use https://github.com/Automattic/wp-calypso/pull/102475 for testing