### PR TITLE
Remove `default_rendering_mode` hotfix

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-default_rendering_mode-hotfix
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-default_rendering_mode-hotfix
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Remove `default_rendering_mode` hotfix since there's no need for it anymore.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-hotfixes/wpcom-hotfixes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-hotfixes/wpcom-hotfixes.php
@@ -8,26 +8,6 @@
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 
 /**
- * Hotfix for a Gutenberg 19.8.0 bug preventing lower-capability users from editing pages.
- * See: p1734525664059729-slack-C02FMH4G8
- * See: https://github.com/WordPress/gutenberg/issues/68053#issuecomment-2550730705
- */
-add_filter(
-	'register_post_type_args',
-	function ( $args ) {
-		if ( current_user_can( 'manage_options' ) ) {
-			// Admins still need default_rendering_mode for the site editor to select the correct default template.
-			// See: p1736989403607879-slack-C02FMH4G8
-			return $args;
-		}
-
-		unset( $args['default_rendering_mode'] );
-		return $args;
-	},
-	20
-);
-
-/**
  * Hotfix for a {Gutenberg 20.0.0, WP 6.7.x} bug causing the Content block to output truncated HTML.
  * See: https://github.com/WordPress/gutenberg/issues/68614
  */

--- a/projects/plugins/mu-wpcom-plugin/changelog/remove-default_rendering_mode-hotfix
+++ b/projects/plugins/mu-wpcom-plugin/changelog/remove-default_rendering_mode-hotfix
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Remove `default_rendering_mode` hotfix since there's no need for it anymore. 

--- a/projects/plugins/wpcomsh/changelog/remove-default_rendering_mode-hotfix
+++ b/projects/plugins/wpcomsh/changelog/remove-default_rendering_mode-hotfix
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Remove `default_rendering_mode` hotfix since there's no need for it anymore. 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-803

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* A hotfix was introduced on https://github.com/Automattic/jetpack/pull/40664 so that new page creation wasn't using the `template-locked` mode. Debugging shows that [GB 20.0.4 is setting `default_rendering_mode` to `post-only`](https://github.com/WordPress/gutenberg/blob/v20.0.4/lib/compat/wordpress-6.8/post.php#L44), so the fix's not needed anymore.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox
* Sandbox a simple site
* On that site, try creating a new page
* Check that you can edit the page
* Check that the `Show template` setting is set to `off`
![image](https://github.com/user-attachments/assets/7e284531-376a-42ed-9f53-8a437efb70a7)


