### PR TITLE
Social: Fix share status typo and styling

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-share-status-styling
+++ b/projects/js-packages/publicize-components/changelog/fix-social-share-status-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fix share status typo and button style

--- a/projects/js-packages/publicize-components/src/components/post-publish-share-status/share-status.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-share-status/share-status.tsx
@@ -88,8 +88,8 @@ export function ShareStatus( { reShareTimestamp }: ShareStatusProps ) {
 				{ sprintf(
 					/* translators: %d: number of connections to which a post was shared */
 					_n(
-						'You post was successfuly shared to %d connection.',
-						'You post was successfuly shared to %d connections.',
+						'Your post was successfuly shared to %d connection.',
+						'Your post was successfuly shared to %d connections.',
 						currentShares.length,
 						'jetpack-publicize-components'
 					),

--- a/projects/js-packages/publicize-components/src/components/share-status/modal-trigger.tsx
+++ b/projects/js-packages/publicize-components/src/components/share-status/modal-trigger.tsx
@@ -2,6 +2,7 @@ import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
 import { forwardRef, useCallback } from 'react';
 import { store as socialStore } from '../../social-store';
 import { getSocialScriptData } from '../../utils/script-data';
@@ -39,7 +40,13 @@ export const ModalTrigger = forwardRef(
 		}
 
 		const trigger = (
-			<Button variant="secondary" onClick={ onButtonClicked } { ...props } ref={ ref }>
+			<Button
+				variant="secondary"
+				onClick={ onButtonClicked }
+				{ ...props }
+				className={ clsx( styles.trigger, props.className ) }
+				ref={ ref }
+			>
 				{ props.children || __( 'View sharing history', 'jetpack-publicize-components' ) }
 			</Button>
 		);

--- a/projects/js-packages/publicize-components/src/components/share-status/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/share-status/styles.module.scss
@@ -1,6 +1,11 @@
 .trigger-wrapper {
-	margin-top: 1rem;
 	padding-block: 1rem;
+
+}
+
+.trigger:not(:global(.is-link)) {
+	width: 100%;
+	justify-content: center;
 }
 
 .wrapper {

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/styles.module.scss
@@ -1,7 +1,7 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
 .panel {
-	margin: 1rem 0 1.5rem;
+	margin-block: 1rem;
 
 	:global(button.is-secondary) {
 		white-space: break-spaces;


### PR DESCRIPTION
Currently, the share status button and social post UI button have different styling and alignment

<img width="273" alt="Screenshot 2025-04-09 at 5 59 43 PM" src="https://github.com/user-attachments/assets/9be4f7b1-6a1b-4dde-bdc2-972de1788891" />

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Improve the styling for share status button, making it consistent with the social post UI button
* Fix a typo

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new post
* Open Jetpack sidebar
* Confirm that the Social post UI button looks fine
* Share the post
* Confirm that the share status typo is fixed
* Confirm that the button looks fine with the Social post UI button

- For shared posts
    - <img width="295" alt="Screenshot 2025-04-08 at 4 42 10 PM" src="https://github.com/user-attachments/assets/d5c7dc5f-5e38-4881-a2a4-bcace9616638" />
    - <img width="282" alt="Screenshot 2025-04-08 at 5 00 31 PM" src="https://github.com/user-attachments/assets/6494efa8-418f-4da0-83fb-1d084cc42f91" />

- For posts, not published yet
    <img width="293" alt="Screenshot 2025-04-08 at 4 42 17 PM" src="https://github.com/user-attachments/assets/b7df739e-af02-49c1-a4fa-21dc3a9cbd5e" />

