### PR TITLE
Blocks: Fix: Button Block - Prevent TypeError when handling border attributes

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-button-block-border-type-error
+++ b/projects/plugins/jetpack/changelog/fix-button-block-border-type-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Button Block: Prevent TypeError when handling border attributes.

--- a/projects/plugins/jetpack/extensions/blocks/button/button.php
+++ b/projects/plugins/jetpack/extensions/blocks/button/button.php
@@ -179,7 +179,7 @@ function get_button_styles( $attributes ) {
 	$has_custom_font_size        = $has_typography_styles && array_key_exists( 'fontSize', $attributes['style']['typography'] );
 	$has_custom_text_transform   = $has_typography_styles && array_key_exists( 'textTransform', $attributes['style']['typography'] );
 	$border_styles               = array();
-	$border_attribute            = isset( $attributes['style']['border'] ) ? $attributes['style']['border'] : null;
+	$border_attribute            = $attributes['style']['border'] ?? null;
 	$is_border_style_array       = is_array( $border_attribute );
 
 	$has_custom_border_color = $is_border_style_array && isset( $border_attribute['color'] );

--- a/projects/plugins/jetpack/extensions/blocks/button/button.php
+++ b/projects/plugins/jetpack/extensions/blocks/button/button.php
@@ -179,10 +179,18 @@ function get_button_styles( $attributes ) {
 	$has_custom_font_size        = $has_typography_styles && array_key_exists( 'fontSize', $attributes['style']['typography'] );
 	$has_custom_text_transform   = $has_typography_styles && array_key_exists( 'textTransform', $attributes['style']['typography'] );
 	$border_styles               = array();
-	$has_custom_border_color     = array_key_exists( 'style', $attributes ) && array_key_exists( 'border', $attributes['style'] ) && array_key_exists( 'color', $attributes['style']['border'] );
-	$has_border_style            = array_key_exists( 'style', $attributes ) && array_key_exists( 'border', $attributes['style'] ) && array_key_exists( 'style', $attributes['style']['border'] );
-	$has_border_width            = array_key_exists( 'style', $attributes ) && array_key_exists( 'border', $attributes['style'] ) && array_key_exists( 'width', $attributes['style']['border'] );
-	$has_individual_borders      = array_key_exists( 'style', $attributes ) && array_key_exists( 'border', $attributes['style'] ) && ( array_key_exists( 'top', $attributes['style']['border'] ) || array_key_exists( 'right', $attributes['style']['border'] ) || array_key_exists( 'bottom', $attributes['style']['border'] ) || array_key_exists( 'left', $attributes['style']['border'] ) );
+	$border_attribute            = isset( $attributes['style']['border'] ) ? $attributes['style']['border'] : null;
+	$is_border_style_array       = is_array( $border_attribute );
+
+	$has_custom_border_color = $is_border_style_array && isset( $border_attribute['color'] );
+	$has_border_style        = $is_border_style_array && isset( $border_attribute['style'] );
+	$has_border_width        = $is_border_style_array && isset( $border_attribute['width'] );
+	$has_individual_borders  = $is_border_style_array && (
+		isset( $border_attribute['top'] ) ||
+		isset( $border_attribute['right'] ) ||
+		isset( $border_attribute['bottom'] ) ||
+		isset( $border_attribute['left'] )
+	);
 
 	if ( $has_font_family ) {
 		$styles[] = sprintf( 'font-family: %s;', $attributes['fontFamily'] );
@@ -232,13 +240,15 @@ function get_button_styles( $attributes ) {
 
 	if ( $has_individual_borders ) {
 		foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
-			$border                 = $attributes['style']['border'][ $side ] ?? null;
-			$border_side_values     = array(
-				'width' => $border['width'] ?? null,
-				'color' => $border['color'] ?? null,
-				'style' => $border['style'] ?? null,
-			);
-			$border_styles[ $side ] = $border_side_values;
+			$border = $attributes['style']['border'][ $side ] ?? null;
+			if ( is_array( $border ) ) {
+				$border_side_values     = array(
+					'width' => $border['width'] ?? null,
+					'color' => $border['color'] ?? null,
+					'style' => $border['style'] ?? null,
+				);
+				$border_styles[ $side ] = $border_side_values;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix: Button Block - Prevent TypeError when handling border attributes

Follow up to:
- https://github.com/Automattic/jetpack/pull/41147

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*   Modified the `get_button_styles` function in the Button block (`projects/plugins/jetpack/extensions/blocks/button/button.php`).
*   Added checks to ensure `$attributes['style']['border']` is treated as an array only when it actually is one. This prevents a `TypeError` that could occur when the border attribute was saved as a CSS shorthand string instead of an array of properties.
*   Ensured individual border sides (`top`, `right`, etc.) are also checked for being arrays before accessing their properties.

### Other information:

- [ ] Have you written new tests for your changes, if applicable? *(Likely not applicable for this specific bug fix, but review if edge cases warrant tests)*
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A (Bug fix)

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1.  Identify or create a post/page containing a Jetpack Button block where the border style might have been saved in a way that previously caused the TypeError (e.g., potentially through specific editor interactions or direct database manipulation, although exact reproduction steps for the original error might be tricky without the specific user content).
2.  Ensure the site is running the code from this PR branch.
3.  Load the page containing the Button block on the front-end.
4.  Verify that no PHP Fatal Errors (specifically the `TypeError` related to `array_key_exists` in `button.php`) are logged.
5.  Verify that the Button block renders correctly with its intended border styles.
6.  Optionally, test saving Button blocks with various border configurations (no border, default radius, custom radius, custom color/width/style as an array, potentially forcing a shorthand string if possible via tooling) and confirm the front-end rendering remains correct without errors.