### PR TITLE
Subscriptions block: fix email detection

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscriptions-block-email-detection
+++ b/projects/plugins/jetpack/changelog/fix-subscriptions-block-email-detection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions block: improve check for email-specific context to render the email version when actually in an email.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -698,12 +698,10 @@ function render_block( $attributes ) {
 
 	/**
 	 * Check if we're in an email-specific context where we should render the simplified email version.
-	 * This explicitly checks for email-related filters and the WP_MAIL constant rather than relying on
-	 * jetpack_is_frontend() to avoid false positives during regular frontend requests (e.g. embed requests).
+	 * This explicitly checks for the WP_MAIL constant rather than relying on jetpack_is_frontend()
+	 * to avoid false positives during regular frontend requests (e.g. embed requests).
 	 */
-	$is_email_context = doing_filter( 'jetpack_subscriptions_email_content' ) ||
-		doing_filter( 'jetpack_subscription_email_content' ) ||
-		( defined( 'WP_MAIL' ) && WP_MAIL );
+	$is_email_context = defined( 'WP_MAIL' ) && WP_MAIL;
 
 	if ( $is_email_context ) {
 		return render_for_email( $data, $styles );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -696,7 +696,16 @@ function render_block( $attributes ) {
 		'preselected_newsletter_categories' => get_attribute( $attributes, 'preselectNewsletterCategories', false ),
 	);
 
-	if ( ! jetpack_is_frontend() ) {
+	/**
+	 * Check if we're in an email-specific context where we should render the simplified email version.
+	 * This explicitly checks for email-related filters and the WP_MAIL constant rather than relying on
+	 * jetpack_is_frontend() to avoid false positives during regular frontend requests (e.g. embed requests).
+	 */
+	$is_email_context = doing_filter( 'jetpack_subscriptions_email_content' ) ||
+		doing_filter( 'jetpack_subscription_email_content' ) ||
+		( defined( 'WP_MAIL' ) && WP_MAIL );
+
+	if ( $is_email_context ) {
 		return render_for_email( $data, $styles );
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -696,16 +696,9 @@ function render_block( $attributes ) {
 		'preselected_newsletter_categories' => get_attribute( $attributes, 'preselectNewsletterCategories', false ),
 	);
 
-	/**
-	 * Check if we're in an email-specific context where we should render the simplified email version.
-	 * This explicitly checks for email-related filters and the WP_MAIL constant rather than relying on
-	 * jetpack_is_frontend() to avoid false positives during regular frontend requests (e.g. embed requests).
-	 */
-	$is_email_context = doing_filter( 'jetpack_subscriptions_email_content' ) ||
-		doing_filter( 'jetpack_subscription_email_content' ) ||
-		( defined( 'WP_MAIL' ) && WP_MAIL );
-
-	if ( $is_email_context ) {
+	// Only render the email version in non-frontend contexts like emails, feeds, embeds etc.
+	if ( is_feed() || is_embed() || wp_is_xml_request() ||
+		( defined( 'REST_REQUEST' ) && REST_REQUEST && ! wp_is_json_request() ) ) {
 		return render_for_email( $data, $styles );
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -698,8 +698,8 @@ function render_block( $attributes ) {
 
 	/**
 	 * Check if we're in an email-specific context where we should render the simplified email version.
-	 * This explicitly checks for the WP_MAIL constant rather than relying on jetpack_is_frontend()
-	 * to avoid false positives during regular frontend requests (e.g. embed requests).
+	 * This explicitly checks for the WP_MAIL constant to ensure we only render the email version
+	 * when actually sending an email.
 	 */
 	$is_email_context = defined( 'WP_MAIL' ) && WP_MAIL;
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -696,9 +696,12 @@ function render_block( $attributes ) {
 		'preselected_newsletter_categories' => get_attribute( $attributes, 'preselectNewsletterCategories', false ),
 	);
 
-	// Only render the email version in non-frontend contexts like emails, feeds, embeds etc.
-	if ( is_feed() || is_embed() || wp_is_xml_request() ||
-		( defined( 'REST_REQUEST' ) && REST_REQUEST && ! wp_is_json_request() ) ) {
+	// Only render the email version in non-frontend contexts.
+	if ( is_feed() || wp_is_xml_request() ||
+		( defined( 'REST_REQUEST' ) && REST_REQUEST && ! wp_is_json_request() ) ||
+		( defined( 'REST_API_REQUEST' ) && REST_API_REQUEST ) ||
+		( defined( 'WP_CLI' ) && WP_CLI ) ||
+		wp_is_jsonp_request() ) {
 		return render_for_email( $data, $styles );
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -698,10 +698,12 @@ function render_block( $attributes ) {
 
 	/**
 	 * Check if we're in an email-specific context where we should render the simplified email version.
-	 * This explicitly checks for the WP_MAIL constant to ensure we only render the email version
-	 * when actually sending an email.
+	 * This explicitly checks for email-related filters and the WP_MAIL constant rather than relying on
+	 * jetpack_is_frontend() to avoid false positives during regular frontend requests (e.g. embed requests).
 	 */
-	$is_email_context = defined( 'WP_MAIL' ) && WP_MAIL;
+	$is_email_context = doing_filter( 'jetpack_subscriptions_email_content' ) ||
+		doing_filter( 'jetpack_subscription_email_content' ) ||
+		( defined( 'WP_MAIL' ) && WP_MAIL );
 
 	if ( $is_email_context ) {
 		return render_for_email( $data, $styles );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/loop/issues/651

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR fixes an issue with the Jetpack Subscriptions block where it sometimes incorrectly renders the email version instead of the website version during frontend requests. The issue occurs because the block was relying on `jetpack_is_frontend()` to determine the rendering context, which can give false negatives during certain frontend requests (like embeds). In this PR, I'm changing to a more limited version of `jetpack_is_frontend()` that shouldn't give us those false negatives.

Website version | Email version
---- | ----
<img width="762" alt="Screenshot 2025-04-09 at 1 40 36 PM" src="https://github.com/user-attachments/assets/860d495e-1bd2-46f8-a2b9-1dd8a9e03246" /> | <img width="832" alt="Screenshot 2025-04-09 at 1 40 49 PM" src="https://github.com/user-attachments/assets/8d98527a-bbff-4957-9859-e34671c837c6" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

See p1744058330747869-slack-C083ZPVVDTK -- this caused an issue on a partner site and the developer traced it to this check.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Nope.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test in Simple, Atomic, and self-hosted:

1. Create a new post with the Subscriptions block.
2. Preview the post - verify the block renders the website version with the email input field and subscribe button.
3. Preview the email - the block should render the email version with no form.
4. Send the email to check it has the email version.
5. Check that /feed has the email version after you publish the post.
6. Verify the email button and website version form work as expected.