### PR TITLE
Add call to endpoint on aiowp completed

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-call-to-endpoint-on-aiowp-completed
+++ b/projects/plugins/wpcomsh/changelog/add-call-to-endpoint-on-aiowp-completed
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add hook to signal a migration has ended using AIOWP

--- a/projects/plugins/wpcomsh/wpcom-migration-helpers/site-migration-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-migration-helpers/site-migration-helpers.php
@@ -149,18 +149,19 @@ function aiowp_migration_status_helper() {
 			// Read the wpcom_blog_id from the backup file.
 			$wpcom_blog_id = false;
 			$file_contents = file_get_contents( $wpcom_blog_id_backup_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-			if ( false !== $file_contents ) {
-				$wpcom_blog_id = intval( $file_contents );
-				unlink( $wpcom_blog_id_backup_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
-			} else {
+
+			if ( false === $file_contents ) {
 				do_action( 'wpcomsh_log', 'Failed to read wpcom_blog_id_backup_file' );
 				return $params;
 			}
 
-			if ( ! $wpcom_blog_id ) {
+			if ( empty( $wpcom_blog_id ) || ! is_numeric( $wpcom_blog_id ) ) {
 				do_action( 'wpcomsh_log', 'The content of the wpcom_blog_id_backup_file is not valid' );
 				return $params;
 			}
+
+			$wpcom_blog_id = intval( $file_contents );
+			unlink( $wpcom_blog_id_backup_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
 
 			$endpoint = sprintf( '/sites/%s/migration-aiowp-notifications', $wpcom_blog_id );
 			$response = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog(

--- a/projects/plugins/wpcomsh/wpcom-migration-helpers/site-migration-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-migration-helpers/site-migration-helpers.php
@@ -125,11 +125,11 @@ function aiowp_migration_status_helper() {
 		return;
 	}
 
+	$wpcom_blog_id = _wpcom_get_current_blog_id();
 	add_filter(
 		'ai1wm_import',
-		function () {
-			$wpcom_blog_id = _wpcom_get_current_blog_id();
-			$endpoint      = sprintf( '/sites/%s/migration-aiowp-notifications', $wpcom_blog_id );
+		function ( $params = array() ) use ( $wpcom_blog_id ) {
+			$endpoint = sprintf( '/sites/%s/migration-aiowp-notifications', $wpcom_blog_id );
 
 			$response = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog(
 				$endpoint,
@@ -140,12 +140,12 @@ function aiowp_migration_status_helper() {
 			);
 
 			if ( 200 !== $response['response']['code'] || empty( $response['body'] ) ) {
-				return false;
+				return $params;
 			}
 
-			return true;
+			return $params;
 		},
-		410
+		400
 	);
 }
 

--- a/projects/plugins/wpcomsh/wpcom-migration-helpers/site-migration-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-migration-helpers/site-migration-helpers.php
@@ -125,12 +125,44 @@ function aiowp_migration_status_helper() {
 		return;
 	}
 
-	$wpcom_blog_id = _wpcom_get_current_blog_id();
+	$wpcom_blog_id             = Jetpack_Options::get_option( 'id' );
+	$wpcom_blog_id_backup_file = WP_CONTENT_DIR . '/uploads/blog_id_backup.txt';
 	add_filter(
 		'ai1wm_import',
-		function ( $params = array() ) use ( $wpcom_blog_id ) {
-			$endpoint = sprintf( '/sites/%s/migration-aiowp-notifications', $wpcom_blog_id );
+		function ( $params = array() ) use ( $wpcom_blog_id, $wpcom_blog_id_backup_file ) {
+			// This filter runs at this priority at the start of the import.
+			// We store the wpcom_blog_id in a backup file so we can use it later in the import, since
+			// the blog id is removed from the db by subsequent steps in the AIOWP migration.
+			file_put_contents( $wpcom_blog_id_backup_file, $wpcom_blog_id ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			return $params;
+		},
+		10
+	);
+	add_filter(
+		'ai1wm_import',
+		function ( $params = array() ) use ( $wpcom_blog_id_backup_file ) {
+			if ( ! file_exists( $wpcom_blog_id_backup_file ) ) {
+				do_action( 'wpcomsh_log', 'No wpcom_blog_id_backup_file found' );
+				return $params;
+			}
 
+			// Read the wpcom_blog_id from the backup file.
+			$wpcom_blog_id = false;
+			$file_contents = file_get_contents( $wpcom_blog_id_backup_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			if ( false !== $file_contents ) {
+				$wpcom_blog_id = intval( $file_contents );
+				unlink( $wpcom_blog_id_backup_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+			} else {
+				do_action( 'wpcomsh_log', 'Failed to read wpcom_blog_id_backup_file' );
+				return $params;
+			}
+
+			if ( ! $wpcom_blog_id ) {
+				do_action( 'wpcomsh_log', 'The content of the wpcom_blog_id_backup_file is not valid' );
+				return $params;
+			}
+
+			$endpoint = sprintf( '/sites/%s/migration-aiowp-notifications', $wpcom_blog_id );
 			$response = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog(
 				$endpoint,
 				'v2',
@@ -138,11 +170,9 @@ function aiowp_migration_status_helper() {
 				array( 'status' => 'completed' ),
 				'wpcom'
 			);
-
 			if ( 200 !== $response['response']['code'] || empty( $response['body'] ) ) {
 				return $params;
 			}
-
 			return $params;
 		},
 		400

--- a/projects/plugins/wpcomsh/wpcom-migration-helpers/site-migration-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-migration-helpers/site-migration-helpers.php
@@ -147,7 +147,6 @@ function aiowp_migration_status_helper() {
 			}
 
 			// Read the wpcom_blog_id from the backup file.
-			$wpcom_blog_id = false;
 			$file_contents = file_get_contents( $wpcom_blog_id_backup_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 
 			if ( false === $file_contents ) {
@@ -155,7 +154,7 @@ function aiowp_migration_status_helper() {
 				return $params;
 			}
 
-			if ( ! is_numeric( $wpcom_blog_id ) || (int) $wpcom_blog_id === 0 ) {
+			if ( ! is_numeric( $file_contents ) || (int) $file_contents === 0 ) {
 				do_action( 'wpcomsh_log', 'The content of the wpcom_blog_id_backup_file is not valid' );
 				return $params;
 			}

--- a/projects/plugins/wpcomsh/wpcom-migration-helpers/site-migration-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-migration-helpers/site-migration-helpers.php
@@ -155,7 +155,7 @@ function aiowp_migration_status_helper() {
 				return $params;
 			}
 
-			if ( empty( $wpcom_blog_id ) || ! is_numeric( $wpcom_blog_id ) ) {
+			if ( ! is_numeric( $wpcom_blog_id ) || (int) $wpcom_blog_id === 0 ) {
 				do_action( 'wpcomsh_log', 'The content of the wpcom_blog_id_backup_file is not valid' );
 				return $params;
 			}

--- a/projects/plugins/wpcomsh/wpcom-migration-helpers/site-migration-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-migration-helpers/site-migration-helpers.php
@@ -115,3 +115,38 @@ function aiowp_migration_logging_helper() {
 	);
 }
 add_action( 'plugins_loaded', 'aiowp_migration_logging_helper', 10 );
+
+/**
+ * Helper function that registers a filter that listens for the AIOWP migration completed event.
+ * Once detected, it will trigger a call to an endpoint on WPCOM to run the corresponding cleanup jobs.
+ */
+function aiowp_migration_status_helper() {
+	if ( ! class_exists( 'Ai1wm_Main_Controller' ) ) {
+		return;
+	}
+
+	add_filter(
+		'ai1wm_import',
+		function () {
+			$wpcom_blog_id = _wpcom_get_current_blog_id();
+			$endpoint      = sprintf( '/sites/%s/migration-aiowp-notifications', $wpcom_blog_id );
+
+			$response = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog(
+				$endpoint,
+				'v2',
+				array( 'method' => 'POST' ),
+				array( 'status' => 'completed' ),
+				'wpcom'
+			);
+
+			if ( 200 !== $response['response']['code'] || empty( $response['body'] ) ) {
+				return false;
+			}
+
+			return true;
+		},
+		410
+	);
+}
+
+add_action( 'plugins_loaded', 'aiowp_migration_status_helper', 10 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to DOTCOM-1799

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Add a call to WPCOM API to signal that a migration got completed using AIOWP

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This is the most contrived PR to test. Buckle up.
1. Set up a testing site outside of WPCOM (I've been using Jurassic Ninja)
2. Go to that site, install & activate`All-in-One WP Migration and Backup`
3. Go to `/wp-admin/admin.php?page=ai1wm_export` and choose `Export site to > FILE` <img width="216" alt="image" src="https://github.com/user-attachments/assets/62812325-0c16-4814-85a4-e77b41c7e950" />
4. Create a new site in WPCOM by going to `wordpress.com/start`. Select a free plan and skip the rest of the onboarding
5. Go to MC_TOOL/atomic/wpcom-dev-blogs/ and add the newly created blog id to the dev pool, remember to check the `Transfer to Atomic pool` checkbox <img width="328" alt="image" src="https://github.com/user-attachments/assets/de1eef1a-a8f7-4f18-831b-929d5e4b98d4" />
6. Move the site to Atomic. You can do that by navigating to `https://wordpress.com/hosting-features/[YOUR_SITE]`, upgrading to business and activating the hosting features
7. Log into your WoA site and add the following lines to `~/htdocs/wp-config.php`
```
define( 'JETPACK_AUTOLOAD_DEV', true );
```
8. Checkout this PR to your local machine
9. Run `pnpm jetpack build --deps plugins/wpcomsh`
10. Run `pnpm jetpack rsync wpcomsh [YOUR_WoA_SITE]@sftp.wp.com:/srv/htdocs/wp-content/mu-plugins/wpcomsh`
12. Trigger an AIOWP import from your WoA site.
  1. install & activate`All-in-One WP Migration and Backup` on the WoA site
  2. Trigger the import using the FILE created before in the origin site, by going to `[YOUR_WoA_SITE]/wp-admin/admin.php?page=ai1wm_import` and clicking the FILE option <img width="200" alt="image" src="https://github.com/user-attachments/assets/428addd8-e169-4de6-aa31-b6490b863893" />
  3. Wait and follow through the steps (this takes some time)
 13. Before the import ends the code in this PR will trigger a request to WPCOM that will enqueue a job to cleanup your site
 14. Navigating to `[YOUR_WoA_SITE]/wp-admin` should work and not require login