### PR TITLE
Add a pnpmfile hack for a "latest" dep

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -225,6 +225,15 @@ async function fixDeps( pkg ) {
 		pkg.dependencies[ 'flat-cache' ] = '^4';
 	}
 
+	// Dependency on "latest" makes for many spurious updates. Leave it for the lockfile maintenance PRs.
+	// No upstream evident to report bugs to.
+	if (
+		pkg.name === '@paulirish/trace_engine' &&
+		pkg.dependencies?.[ 'third-party-web' ] === 'latest'
+	) {
+		pkg.dependencies[ 'third-party-web' ] = '*';
+	}
+
 	return pkg;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: sha256-uaXpvT0PvT0IEEpUWl3YCJWkKnT1QTsUvPUQNwmeEek=
+pnpmfileChecksum: sha256-AJ+gkSMru7ZZQDe/JuohyBfWGVAdC0lqOM0JYAXfuLk=
 
 patchedDependencies:
   '@wordpress/dataviews':
@@ -14885,8 +14885,8 @@ packages:
   text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
 
-  third-party-web@0.26.5:
-    resolution: {integrity: sha512-tDuKQJUTfjvi9Fcrs1s6YAQAB9mzhTSbBZMfNgtWNmJlHuoFeXO6dzBFdGeCWRvYL50jQGK0jPsBZYxqZQJ2SA==}
+  third-party-web@0.26.6:
+    resolution: {integrity: sha512-GsjP92xycMK8qLTcQCacgzvffYzEqe29wyz3zdKVXlfRD5Kz1NatCTOZEeDaSd6uCZXvGd2CNVtQ89RNIhJWvA==}
 
   thread-loader@3.0.4:
     resolution: {integrity: sha512-ByaL2TPb+m6yArpqQUZvP+5S1mZtXsEP7nWKKlAUTm7fCml8kB5s1uI3+eHRP2bk5mVYfRSBI7FFf+tWEyLZwA==}
@@ -17595,7 +17595,7 @@ snapshots:
 
   '@paulirish/trace_engine@0.0.50':
     dependencies:
-      third-party-web: 0.26.5
+      third-party-web: 0.26.6
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -25695,7 +25695,7 @@ snapshots:
       robots-parser: 3.0.1
       semver: 5.7.2
       speedline-core: 1.4.3
-      third-party-web: 0.26.5
+      third-party-web: 0.26.6
       tldts-icann: 6.1.85
       ws: 7.5.10
       yargs: 17.6.2
@@ -28803,7 +28803,7 @@ snapshots:
 
   text-hex@1.0.0: {}
 
-  third-party-web@0.26.5: {}
+  third-party-web@0.26.6: {}
 
   thread-loader@3.0.4(webpack@5.94.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: sha256-AJ+gkSMru7ZZQDe/JuohyBfWGVAdC0lqOM0JYAXfuLk=
+pnpmfileChecksum: sha256-gGNXe8rPCT2HDKhrF95pBlZ5hl0DPJwG+GN4Cv72hdE=
 
 patchedDependencies:
   '@wordpress/dataviews':
@@ -14885,8 +14885,8 @@ packages:
   text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
 
-  third-party-web@0.26.6:
-    resolution: {integrity: sha512-GsjP92xycMK8qLTcQCacgzvffYzEqe29wyz3zdKVXlfRD5Kz1NatCTOZEeDaSd6uCZXvGd2CNVtQ89RNIhJWvA==}
+  third-party-web@0.26.5:
+    resolution: {integrity: sha512-tDuKQJUTfjvi9Fcrs1s6YAQAB9mzhTSbBZMfNgtWNmJlHuoFeXO6dzBFdGeCWRvYL50jQGK0jPsBZYxqZQJ2SA==}
 
   thread-loader@3.0.4:
     resolution: {integrity: sha512-ByaL2TPb+m6yArpqQUZvP+5S1mZtXsEP7nWKKlAUTm7fCml8kB5s1uI3+eHRP2bk5mVYfRSBI7FFf+tWEyLZwA==}
@@ -17595,7 +17595,7 @@ snapshots:
 
   '@paulirish/trace_engine@0.0.50':
     dependencies:
-      third-party-web: 0.26.6
+      third-party-web: 0.26.5
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -25695,7 +25695,7 @@ snapshots:
       robots-parser: 3.0.1
       semver: 5.7.2
       speedline-core: 1.4.3
-      third-party-web: 0.26.6
+      third-party-web: 0.26.5
       tldts-icann: 6.1.85
       ws: 7.5.10
       yargs: 17.6.2
@@ -28803,7 +28803,7 @@ snapshots:
 
   text-hex@1.0.0: {}
 
-  third-party-web@0.26.6: {}
+  third-party-web@0.26.5: {}
 
   thread-loader@3.0.4(webpack@5.94.0):
     dependencies:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
`@paulirish/trace_engine` depends on `third-party-web` version "latest", which means that any release of the latter will result in spurious pnpm-lock.yaml updates. Rewrite it to a dep on `*`, which should be effectively equivalent but will wait for the periodic lockfile maintenance PRs.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/42982#discussion_r2035768042

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check out the trunk version of `pnpm-lock.yaml` then do `pnpm install`. The `third-party-web` dep should remain at 0.26.5.
