### PR TITLE
Forms: Fix timing error for multiple choice fields

### DIFF
--- a/projects/packages/forms/src/blocks/shared/hooks/use-sync-style-attributes.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-sync-style-attributes.js
@@ -93,7 +93,7 @@ export default function useSyncStyleAttributes( clientId, name, parentName, shar
 					// Single and multiple choice fields nest their individual option blocks
 					// within a `jetpack/options` block. If we're syncing option block styles
 					// all the individual options within a choice field need to be included.
-					if ( name === 'jetpack/option' && isChoiceField ) {
+					if ( name === 'jetpack/option' && isChoiceField && innerFieldBlocks?.length ) {
 						const optionsBlock = innerFieldBlocks.find( block => block.name === 'jetpack/options' );
 
 						blockEditor.getBlocks( optionsBlock.clientId ).forEach( block => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Fixes #42997

## Proposed changes:

In our [refactor PR](https://github.com/Automattic/jetpack/pull/42890), there's a timing issue that causes an error on field options for single/multiple choice blocks IF you add more than one to a page. The linked issue above describes the issue in detail. 

This PR fixes it by just adding a check that we have some innerFieldBlocks before continuing to relevant code. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form to a page
* Add a single or multiple choice field, and then a second to the same form
* Confirm there are no block errors on the first field 

