### PR TITLE
Forms: Add PHP unit tests for Migrate form fields to inner blocks JETPACK-262 

### DIFF
--- a/projects/packages/forms/changelog/add-php-unit-tests-migrate-form-fields-to-inner-blocks
+++ b/projects/packages/forms/changelog/add-php-unit-tests-migrate-form-fields-to-inner-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added tests for migration of form fields to inner blocks 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -17,6 +17,7 @@ use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
 use Jetpack_Options;
 use WP_Block;
+use WP_Block_Type_Registry;
 use WP_Error;
 
 /**
@@ -328,7 +329,7 @@ class Contact_Form_Plugin {
 	 * @return array
 	 */
 	private static function get_block_support_classes_and_styles( $block_name, $attrs ) {
-		$block_type = \WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
+		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
 
 		if ( ! $block_type ) {
 			return array();
@@ -373,9 +374,9 @@ class Contact_Form_Plugin {
 	/**
 	 * Turn block attribute to shortcode attributes.
 	 *
-	 * @param array          $atts  - the block attributes.
-	 * @param string         $type  - the type.
-	 * @param \WP_Block|null $block - the block object.
+	 * @param array         $atts  - the block attributes.
+	 * @param string        $type  - the type.
+	 * @param WP_Block|null $block - the block object.
 	 *
 	 * @return array
 	 */
@@ -558,9 +559,9 @@ class Contact_Form_Plugin {
 	/**
 	 * Render the checkbox field.
 	 *
-	 * @param array     $atts - the block attributes.
-	 * @param string    $content - html content.
-	 * @param \WP_Block $block - the block instance object.
+	 * @param array    $atts - the block attributes.
+	 * @param string   $content - html content.
+	 * @param WP_Block $block - the block instance object.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
@@ -599,9 +600,9 @@ class Contact_Form_Plugin {
 	/**
 	 * Render the radio button field.
 	 *
-	 * @param array     $atts - the block attributes.
-	 * @param string    $content - html content.
-	 * @param \WP_Block $block - the block instance object.
+	 * @param array    $atts - the block attributes.
+	 * @param string   $content - html content.
+	 * @param WP_Block $block - the block instance object.
 	 *
 	 * @return string HTML for the contact form field.
 	 */

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -373,9 +373,9 @@ class Contact_Form_Plugin {
 	/**
 	 * Turn block attribute to shortcode attributes.
 	 *
-	 * @param array         $atts  - the block attributes.
-	 * @param string        $type  - the type.
-	 * @param WP_Block|null $block - the block object.
+	 * @param array          $atts  - the block attributes.
+	 * @param string         $type  - the type.
+	 * @param \WP_Block|null $block - the block object.
 	 *
 	 * @return array
 	 */
@@ -558,9 +558,9 @@ class Contact_Form_Plugin {
 	/**
 	 * Render the checkbox field.
 	 *
-	 * @param array    $atts - the block attributes.
-	 * @param string   $content - html content.
-	 * @param WP_Block $block - the block instance object.
+	 * @param array     $atts - the block attributes.
+	 * @param string    $content - html content.
+	 * @param \WP_Block $block - the block instance object.
 	 *
 	 * @return string HTML for the contact form field.
 	 */
@@ -599,9 +599,9 @@ class Contact_Form_Plugin {
 	/**
 	 * Render the radio button field.
 	 *
-	 * @param array    $atts - the block attributes.
-	 * @param string   $content - html content.
-	 * @param WP_Block $block - the block instance object.
+	 * @param array     $atts - the block attributes.
+	 * @param string    $content - html content.
+	 * @param \WP_Block $block - the block instance object.
 	 *
 	 * @return string HTML for the contact form field.
 	 */

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -15,7 +15,7 @@ use WP_Block_Type_Registry;
 /**
  * Test class for Contact_Form_Block
  *
- * @covers \Automattic\Jetpack\Forms\Contact_Form\Contact_Form_Block
+ * @covers \Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block
  */
 class Contact_Form_Block_Test extends BaseTestCase {
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -32,7 +32,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 
 		$expected_block = array_merge( $block, array( 'hasJPFormParent' => true ) );
 
-		$this->assertEquals( $expected_block, Contact_Form_Block::find_nested_html_block( $block, null, new \WP_Block( $parent_block ) ) );
+		$this->assertEquals( $expected_block, Contact_Form_Block::find_nested_html_block( $block, array(), new \WP_Block( $parent_block ) ) );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -9,6 +9,8 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use WorDBless\BaseTestCase;
+use WP_Block;
+use WP_Block_Type_Registry;
 
 /**
  * Test class for Contact_Form_Block
@@ -32,7 +34,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 
 		$expected_block = array_merge( $block, array( 'hasJPFormParent' => true ) );
 
-		$this->assertEquals( $expected_block, Contact_Form_Block::find_nested_html_block( $block, array(), new \WP_Block( $parent_block ) ) );
+		$this->assertEquals( $expected_block, Contact_Form_Block::find_nested_html_block( $block, array(), new WP_Block( $parent_block ) ) );
 	}
 
 	/**
@@ -42,7 +44,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 	 */
 	public function test_register_child_blocks( $block_name ) {
 		Contact_Form_Block::register_child_blocks();
-		$registry   = \WP_Block_Type_Registry::get_instance();
+		$registry   = WP_Block_Type_Registry::get_instance();
 		$block_type = $registry->get_registered( $block_name );
 		// @TODO should we also test supports?
 		$this->assertNotNull( $block_type );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Unit Tests for Contact_Form_Block.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
+use WorDBless\BaseTestCase;
+
+/**
+ * Test class for Contact_Form_Block
+ *
+ * @covers Automattic\Jetpack\Forms\Contact_Form\Contact_Form_Block
+ */
+class Contact_Form_Block_Test extends BaseTestCase {
+	/**
+	 * Test that ::find_nested_html_block works correctly.
+	 */
+	public function test_find_nested_html_block() {
+		$block = array(
+			'blockName'   => 'core/html',
+			'attrs'       => array(),
+			'innerBlocks' => array(),
+		);
+
+		$parent_block = array(
+			'blockName' => 'jetpack/contact-form',
+		);
+
+		$expected_block = array_merge( $block, array( 'hasJPFormParent' => true ) );
+
+		$this->assertEquals( $expected_block, Contact_Form_Block::find_nested_html_block( $block, null, new \WP_Block( $parent_block ) ) );
+	}
+
+	/**
+	 * Test that we're registering inner block types via ::register_child_blocks.
+	 *
+	 * @dataProvider data_provider_test_register_child_blocks
+	 */
+	public function test_register_child_blocks( $block_name ) {
+		Contact_Form_Block::register_child_blocks();
+		$registry   = \WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		// @TODO should we also test supports?
+		$this->assertNotNull( $block_type );
+	}
+
+	/**
+	 * Data provider for test_register_child_blocks.
+	 */
+	public static function data_provider_test_register_child_blocks() {
+		return array(
+			'jetpack/input'   => array(
+				'jetpack/input',
+			),
+			'jetpack/label'   => array(
+				'jetpack/label',
+			),
+			'jetpack/options' => array(
+				'jetpack/options',
+			),
+			'jetpack/option'  => array(
+				'jetpack/option',
+			),
+		);
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -15,7 +15,7 @@ use WP_Block_Type_Registry;
 /**
  * Test class for Contact_Form_Block
  *
- * @covers Automattic\Jetpack\Forms\Contact_Form\Contact_Form_Block
+ * @covers \Automattic\Jetpack\Forms\Contact_Form\Contact_Form_Block
  */
 class Contact_Form_Block_Test extends BaseTestCase {
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -162,55 +162,218 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 	/**
 	 * Test that ::block_attributes_to_shortcode_attributes works correctly with styles.
+	 *
+	 * @dataProvider data_provider_block_attributes_to_shortcode_attributes_with_styles
+	 * @covers Contact_Form_Plugin::block_attributes_to_shortcode_attributes
+	 *
+	 * @param array  $expected The expected shortcode attributes.
+	 * @param array  $inner_blocks The inner blocks of the block.
+	 * @param string $type The type of the field.
 	 */
-	public function test_block_attributes_to_shortcode_attributes_with_styles() {
+	public function test_block_attributes_to_shortcode_attributes_with_styles( $expected, $inner_blocks, $type = 'text' ) {
 		$block                = array(
 			'blockName'   => 'jetpack/field-name',
 			'attrs'       => array(
 				'required' => false,
 			),
-			'innerBlocks' => array(
-				array(
-					'blockName' => 'jetpack/label',
-					'attrs'     => array(
-						'label'     => 'Name',
-						'textColor' => 'swamp-green',
-						'style'     => array(
-							'elements' => array(
-								'link' => array( 'color' => array( 'text' => 'var:preset|color|accent-3' ) ),
+			'innerBlocks' => $inner_blocks,
+		);
+		$shortcode_attributes = Contact_Form_Plugin::block_attributes_to_shortcode_attributes( array(), $type, new WP_Block( $block ) );
+
+		// Sorting here so we don't have to care about the order of the attributes in the shortcode/data provider.
+		$expected_keys = array_keys( $expected );
+		$actual_keys   = array_keys( $shortcode_attributes );
+		sort( $expected_keys );
+		sort( $actual_keys );
+		$this->assertEquals( $expected_keys, $actual_keys );
+
+		foreach ( $expected as $key => $value ) {
+			$this->assertEquals( $value, $shortcode_attributes[ $key ] );
+		}
+	}
+
+	/**
+	 * Data provider for test_block_attributes_to_shortcode_attributes_with_styles
+	 *
+	 * @return array
+	 */
+	public static function data_provider_block_attributes_to_shortcode_attributes_with_styles() {
+		return array(
+			'label and input'   => array(
+				'expected'     => array(
+					'labelclasses' => 'wp-block-jetpack-label has-text-color has-accent-3-color',
+					'labelstyles'  => 'font-size:32px;',
+					'inputclasses' => 'wp-block-jetpack-input has-text-color has-background has-border-color',
+					'inputstyles'  => 'color:swamp-green;background-color:swamp-red; font-size:24px;font-style:italic;font-weight:bold;line-height:1.5;letter-spacing:0.1em; border-color:swamp-blue;border-style:dashed;border-width:1px;',
+					'label'        => 'Label and Input',
+					'requiredText' => 'Do it',
+					'placeholder'  => 'Yo',
+					'min'          => '1',
+					'max'          => '10',
+					'type'         => 'text',
+				),
+				'inner_blocks' => array(
+					array(
+						'blockName' => 'jetpack/label',
+						'attrs'     => array(
+							'label'        => 'Label and Input',
+							'textColor'    => 'accent-3',
+							'requiredText' => 'Do it',
+							'style'        => array(
+								'elements'   => array(
+									'link' => array( 'color' => array( 'text' => 'var:preset|color|accent-3' ) ),
+								),
+								'typography' => array(
+									'fontSize' => '32px',
+								),
 							),
 						),
 					),
-				),
-				array(
-					'blockName' => 'jetpack/input',
-					'attrs'     => array(
-						'style' => array(
-							'color'      => array(
-								'text'       => 'swamp-green',
-								'background' => 'swamp-red',
-							),
-							'typography' => array(
-								'fontSize'      => '24px',
-								'fontWeight'    => 'bold',
-								'fontStyle'     => 'italic',
-								'lineHeight'    => '1.5',
-								'letterSpacing' => '0.1em',
-							),
-							'border'     => array(
-								'color' => 'swamp-blue',
-								'width' => '1px',
-								'style' => 'dashed',
+					array(
+						'blockName' => 'jetpack/input',
+						'attrs'     => array(
+							'placeholder' => 'Yo',
+							'min'         => '1',
+							'max'         => '10',
+							'type'        => 'text',
+							'style'       => array(
+								'color'      => array(
+									'text'       => 'swamp-green',
+									'background' => 'swamp-red',
+								),
+								'typography' => array(
+									'fontSize'      => '24px',
+									'fontWeight'    => 'bold',
+									'fontStyle'     => 'italic',
+									'lineHeight'    => '1.5',
+									'letterSpacing' => '0.1em',
+								),
+								'border'     => array(
+									'color' => 'swamp-blue',
+									'width' => '1px',
+									'style' => 'dashed',
+								),
 							),
 						),
 					),
 				),
 			),
+			'option'            => array(
+				'expected'     => array(
+					'optionclasses' => ' has-text-color has-swamp-cheese-color',
+					'optionstyles'  => 'font-size:24px;font-style:italic;font-weight:bold;line-height:1.5;letter-spacing:0.1em;',
+					'label'         => 'Option',
+					'type'          => 'radio',
+				),
+				'inner_blocks' => array(
+					array(
+						'blockName' => 'jetpack/option',
+						'attrs'     => array(
+							'label'     => 'Option',
+							'textColor' => 'swamp-cheese',
+							'style'     => array(
+								'color'      => array(
+									'background' => 'swamp-cheese',
+								),
+								'typography' => array(
+									'fontSize'      => '24px',
+									'fontWeight'    => 'bold',
+									'fontStyle'     => 'italic',
+									'lineHeight'    => '1.5',
+									'letterSpacing' => '0.1em',
+								),
+								'border'     => array(
+									'color' => 'swamp-cheese',
+									'width' => '1px',
+									'style' => 'dashed',
+								),
+							),
+						),
+					),
+				),
+				'type'         => 'radio',
+			),
+			'label and options' => array(
+				'expected'     => array(
+					'labelclasses' => 'wp-block-jetpack-label has-text-color has-accent-3-color',
+					'labelstyles'  => 'letter-spacing:0.1em;',
+					'options'      => 'Option 1,Option 2',
+					'optionsdata'  => '[{"label":"Option 1","class":"has-text-color has-sweet-potato-option-1-color","style":"font-size:24px;font-weight:bold;line-height:1.5;letter-spacing:0.1em;"},{"label":"Option 2","class":"has-text-color has-sweet-potato-option-2-color","style":"font-size:22px;font-weight:normal;"}]',
+					'label'        => 'Label multiple options',
+					'type'         => 'checkbox-multiple',
+					'requiredText' => 'Do it again',
+				),
+				'inner_blocks' => array(
+					array(
+						'blockName' => 'jetpack/label',
+						'attrs'     => array(
+							'label'        => 'Label multiple options',
+							'textColor'    => 'accent-3',
+							'requiredText' => 'Do it again',
+							'style'        => array(
+								'elements'   => array(
+									'link' => array( 'color' => array( 'text' => 'var:preset|color|accent-3' ) ),
+								),
+								'typography' => array(
+									'letterSpacing' => '0.1em',
+								),
+							),
+						),
+					),
+					array(
+						'blockName'   => 'jetpack/options',
+						'attrs'       => array(
+							'type' => 'radio',
+						),
+						'innerBlocks' => array(
+							array(
+								'blockName' => 'jetpack/option',
+								'attrs'     => array(
+									'label'     => 'Option 1',
+									'textColor' => 'sweet-potato-option1',
+									'style'     => array(
+										'color'      => array(
+											'background' => 'sweet-potato-option1',
+										),
+										'typography' => array(
+											'fontSize'   => '24px',
+											'fontWeight' => 'bold',
+											'lineHeight' => '1.5',
+											'letterSpacing' => '0.1em',
+										),
+										'border'     => array(
+											'color' => 'sweet-potato-option1',
+											'style' => 'dashed',
+										),
+									),
+								),
+							),
+							array(
+								'blockName' => 'jetpack/option',
+								'attrs'     => array(
+									'label'     => 'Option 2',
+									'textColor' => 'sweet-potato-option2',
+									'style'     => array(
+										'color'      => array(
+											'background' => 'sweet-potato-option2',
+										),
+										'typography' => array(
+											'fontSize'   => '22px',
+											'fontWeight' => 'normal',
+										),
+										'border'     => array(
+											'color' => 'sweet-potato-option2',
+											'width' => '1px',
+											'style' => 'gotted',
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+				'type'         => 'checkbox-multiple',
+			),
 		);
-		$shortcode_attributes = Contact_Form_Plugin::block_attributes_to_shortcode_attributes( array(), 'checkbox', new WP_Block( $block ) );
-
-		$this->assertEquals( 'wp-block-jetpack-label has-text-color has-swamp-green-color', $shortcode_attributes['labelclasses'] );
-		$this->assertEquals( 'wp-block-jetpack-input has-text-color has-background has-border-color', $shortcode_attributes['inputclasses'] );
-		$this->assertEquals( 'color:swamp-green;background-color:swamp-red; font-size:24px;font-style:italic;font-weight:bold;line-height:1.5;letter-spacing:0.1em; border-color:swamp-blue;border-style:dashed;border-width:1px;', $shortcode_attributes['inputstyles'] );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -47,4 +47,19 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			),
 		);
 	}
+
+	// public function test_get_block_support_classes_and_styles() {}
+
+	// public function test_block_attributes_to_shortcode_attributes() {
+	// $attributes = array(
+	// 'label'        => 'Single',
+	// 'isStandalone' => true,
+	// 'style'        => array(
+	// 'color' => array( 'text' => 'caramel' ),
+	// ),
+	// );
+
+	// $shortcode_attributes = Contact_Form_Plugin::block_attributes_to_shortcode_attributes( $attributes, 'checkbox', null );
+	// $this->assertEquals( 'label="Single" isStandalone="1" style="color:caramel;"', $shortcode_attributes );
+	// }
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -50,11 +50,87 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test for checkbox field_renders
-	 *
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_checkbox
 	 */
 	public function test_gutenblock_render_field_checkbox() {
+		$block     = array(
+			'blockName'   => 'jetpack/field-checkbox-multiple',
+			'className'   => 'is-style-list',
+			'attrs'       => array(
+				'required' => false,
+			),
+			'innerBlocks' => array(
+				array(
+					'blockName' => 'jetpack/label',
+					'attrs'     => array(
+						'label'        => 'Choose several options',
+						'defaultLabel' => 'Add label…',
+						'textColor'    => 'swamp-green',
+						'style'        => array(
+							'elements' => array(
+								'link' => array( 'color' => array( 'text' => 'var:preset|color|accent-3' ) ),
+							),
+						),
+					),
+				),
+				array(
+					'blockName'   => 'jetpack/options',
+					'attrs'       => array(
+						'style' => array(
+							'spacing' => array(
+								'blockGap' => 'var:preset|spacing|40',
+							),
+						),
+					),
+					'innerBlocks' => array(
+						array(
+							'blockName' => 'jetpack/option',
+							'attrs'     => array(
+								'label' => 'truth',
+								'style' => array(
+									'color'      => array( 'text' => 'caramel' ),
+									'elements'   => array(
+										'link' => array( 'color' => array( 'text' => 'caramel' ) ),
+									),
+									'typography' => array(
+										'fontSize' => '24px',
+									),
+								),
+							),
+						),
+						array(
+							'blockName' => 'jetpack/option',
+							'attrs'     => array(
+								'label' => 'dare',
+								'style' => array(
+									'color'      => array( 'text' => 'gummy' ),
+									'elements'   => array(
+										'link' => array( 'color' => array( 'text' => 'gummy' ) ),
+									),
+									'typography' => array(
+										'fontSize' => '24px',
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+		$shortcode = Contact_Form_Plugin::gutenblock_render_field_checkbox_multiple( array(), '', new WP_Block( $block ) );
+		$expected  = '[contact-field type="checkbox-multiple" label="Choose several options" labelclasses="wp-block-jetpack-label has-text-color has-swamp-green-color" options="truth,dare" optionsdata="&#091;{&quot;label&quot;:&quot;truth&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:caramel; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;dare&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:gummy; font-size:24px;&quot;}&#093;"/]';
+
+		// Check that the generated shortcode is as expected.
+		// @TODO do we need this step?
+		$this->assertEquals( $expected, $shortcode );
+		$html = do_shortcode( $shortcode );
+		$this->assertEquals( $expected, $html );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_checkbox
+	 */
+	public function test_gutenblock_render_field_checkbox_multiple() {
 		$block     = array(
 			'blockName'   => 'jetpack/field-checkbox',
 			'attrs'       => array(

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -214,7 +214,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	 * Test that ::block_attributes_to_shortcode_attributes works correctly with styles.
 	 *
 	 * @dataProvider data_provider_block_attributes_to_shortcode_attributes_with_styles
-	 * @covers Contact_Form_Plugin::block_attributes_to_shortcode_attributes
+	 * @covers \Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::block_attributes_to_shortcode_attributes
 	 *
 	 * @param array  $expected The expected shortcode attributes.
 	 * @param array  $inner_blocks The inner blocks of the block.

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -161,6 +161,56 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_text
+	 */
+	public function test_gutenblock_gutenblock_render_field_text_shortcode() {
+		$block     = array(
+			'blockName'   => 'field-text',
+			'innerBlocks' => array(
+				array(
+					'blockName' => 'jetpack/label',
+					'attrs'     => array(
+						'label'        => 'Label',
+						'requiredText' => 'Do it',
+						'style'        => array(
+							'color'      => array( 'text' => 'caramel' ),
+							'elements'   => array(
+								'link' => array( 'color' => array( 'text' => 'caramel' ) ),
+							),
+							'typography' => array(
+								'fontSize' => '24px',
+							),
+						),
+					),
+				),
+				array(
+					'blockName' => 'jetpack/input',
+					'attrs'     => array(
+						'label'       => 'Label',
+						'placeholder' => 'hi!',
+						'min'         => '1',
+						'max'         => '10',
+						'style'       => array(
+							'color'      => array( 'text' => 'toot' ),
+							'border'     => array(
+								'color' => 'toot',
+								'width' => '1px',
+							),
+							'typography' => array(
+								'fontSize' => '33rem',
+							),
+						),
+					),
+				),
+			),
+		);
+		$shortcode = Contact_Form_Plugin::gutenblock_render_field_text( array(), '', new WP_Block( $block ) );
+		$expected  = '[contact-field type="text" label="Label" requiredText="Do it" labelclasses="wp-block-jetpack-label has-text-color" labelstyles="color:caramel; font-size:24px;" placeholder="hi!" min="1" max="10" inputclasses="wp-block-jetpack-input has-text-color has-border-color" inputstyles="color:toot; font-size:33rem; border-color:toot;border-width:1px;"/]';
+
+		$this->assertEquals( $expected, $shortcode );
+	}
+
+	/**
 	 * Test that ::block_attributes_to_shortcode_attributes works correctly with styles.
 	 *
 	 * @dataProvider data_provider_block_attributes_to_shortcode_attributes_with_styles

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -49,6 +49,46 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test for checkbox field_renders
+	 *
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 */
+	public function test_gutenblock_render_field_checkbox() {
+		$block     = array(
+			'blockName'   => 'jetpack/field-checkbox',
+			'attrs'       => array(
+				'required' => false,
+			),
+			'innerBlocks' => array(
+				array(
+					'blockName' => 'jetpack/option',
+					'attrs'     => array(
+						'label'        => 'single',
+						'isStandalone' => true,
+						'style'        => array(
+							'color'      => array( 'text' => 'caramel' ),
+							'elements'   => array(
+								'link' => array( 'color' => array( 'text' => 'caramel' ) ),
+							),
+							'typography' => array(
+								'fontSize' => '24px',
+							),
+						),
+					),
+				),
+			),
+		);
+		$shortcode = Contact_Form_Plugin::gutenblock_render_field_checkbox( array(), '', new \WP_Block( $block ) );
+		$expected  = '[contact-field type="checkbox" label="single" optionclasses=" has-text-color" optionstyles="color:caramel; font-size:24px;"/]';
+
+		// Check that the generated shortcode is as expected.
+		// @TODO do we need this step?
+		$this->assertEquals( $expected, $shortcode );
+		$html = do_shortcode( $shortcode );
+		$this->assertEquals( $expected, $html );
+	}
+
+	/**
 	 * Test that ::block_attributes_to_shortcode_attributes works correctly with styles.
 	 */
 	public function test_block_attributes_to_shortcode_attributes_with_styles() {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Forms\ContactForm;
 
 use WorDBless\BaseTestCase;
+use WP_Block;
 
 /**
  * Test class for Contact_Form_Plugin
@@ -78,7 +79,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 				),
 			),
 		);
-		$shortcode = Contact_Form_Plugin::gutenblock_render_field_checkbox( array(), '', new \WP_Block( $block ) );
+		$shortcode = Contact_Form_Plugin::gutenblock_render_field_checkbox( array(), '', new WP_Block( $block ) );
 		$expected  = '[contact-field type="checkbox" label="single" optionclasses=" has-text-color" optionstyles="color:caramel; font-size:24px;"/]';
 
 		// Check that the generated shortcode is as expected.
@@ -135,7 +136,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 				),
 			),
 		);
-		$shortcode_attributes = Contact_Form_Plugin::block_attributes_to_shortcode_attributes( array(), 'checkbox', new \WP_Block( $block ) );
+		$shortcode_attributes = Contact_Form_Plugin::block_attributes_to_shortcode_attributes( array(), 'checkbox', new WP_Block( $block ) );
 
 		$this->assertEquals( 'wp-block-jetpack-label has-text-color has-swamp-green-color', $shortcode_attributes['labelclasses'] );
 		$this->assertEquals( 'wp-block-jetpack-input has-text-color has-background has-border-color', $shortcode_attributes['inputclasses'] );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -52,12 +52,13 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	/**
 	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_checkbox
 	 */
-	public function test_gutenblock_render_field_checkbox() {
-		$block     = array(
+	public function test_gutenblock_render_field_checkbox_multiple_shortcode() {
+		$block = array(
 			'blockName'   => 'jetpack/field-checkbox-multiple',
-			'className'   => 'is-style-list',
 			'attrs'       => array(
-				'required' => false,
+				'required'             => false,
+				'shareFieldAttributes' => false,
+				'className'            => 'is-style-list',
 			),
 			'innerBlocks' => array(
 				array(
@@ -117,20 +118,18 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 				),
 			),
 		);
+
+		// Render the shortcode.
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_checkbox_multiple( array(), '', new WP_Block( $block ) );
 		$expected  = '[contact-field type="checkbox-multiple" label="Choose several options" labelclasses="wp-block-jetpack-label has-text-color has-swamp-green-color" options="truth,dare" optionsdata="&#091;{&quot;label&quot;:&quot;truth&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:caramel; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;dare&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:gummy; font-size:24px;&quot;}&#093;"/]';
 
-		// Check that the generated shortcode is as expected.
-		// @TODO do we need this step?
-		$this->assertEquals( $expected, $shortcode );
-		$html = do_shortcode( $shortcode );
-		$this->assertEquals( $expected, $html );
+		$this->assertEquals( $expected, $shortcode, 'Shortcode is not as expected' );
 	}
 
 	/**
 	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_checkbox
 	 */
-	public function test_gutenblock_render_field_checkbox_multiple() {
+	public function test_gutenblock_render_field_checkbox_shortcode() {
 		$block     = array(
 			'blockName'   => 'jetpack/field-checkbox',
 			'attrs'       => array(
@@ -158,11 +157,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_checkbox( array(), '', new WP_Block( $block ) );
 		$expected  = '[contact-field type="checkbox" label="single" optionclasses=" has-text-color" optionstyles="color:caramel; font-size:24px;"/]';
 
-		// Check that the generated shortcode is as expected.
-		// @TODO do we need this step?
 		$this->assertEquals( $expected, $shortcode );
-		$html = do_shortcode( $shortcode );
-		$this->assertEquals( $expected, $html );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -48,18 +48,57 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		);
 	}
 
-	// public function test_get_block_support_classes_and_styles() {}
+	/**
+	 * Test that ::block_attributes_to_shortcode_attributes works correctly with styles.
+	 */
+	public function test_block_attributes_to_shortcode_attributes_with_styles() {
+		$block                = array(
+			'blockName'   => 'jetpack/field-name',
+			'attrs'       => array(
+				'required' => false,
+			),
+			'innerBlocks' => array(
+				array(
+					'blockName' => 'jetpack/label',
+					'attrs'     => array(
+						'label'     => 'Name',
+						'textColor' => 'swamp-green',
+						'style'     => array(
+							'elements' => array(
+								'link' => array( 'color' => array( 'text' => 'var:preset|color|accent-3' ) ),
+							),
+						),
+					),
+				),
+				array(
+					'blockName' => 'jetpack/input',
+					'attrs'     => array(
+						'style' => array(
+							'color'      => array(
+								'text'       => 'swamp-green',
+								'background' => 'swamp-red',
+							),
+							'typography' => array(
+								'fontSize'      => '24px',
+								'fontWeight'    => 'bold',
+								'fontStyle'     => 'italic',
+								'lineHeight'    => '1.5',
+								'letterSpacing' => '0.1em',
+							),
+							'border'     => array(
+								'color' => 'swamp-blue',
+								'width' => '1px',
+								'style' => 'dashed',
+							),
+						),
+					),
+				),
+			),
+		);
+		$shortcode_attributes = Contact_Form_Plugin::block_attributes_to_shortcode_attributes( array(), 'checkbox', new \WP_Block( $block ) );
 
-	// public function test_block_attributes_to_shortcode_attributes() {
-	// $attributes = array(
-	// 'label'        => 'Single',
-	// 'isStandalone' => true,
-	// 'style'        => array(
-	// 'color' => array( 'text' => 'caramel' ),
-	// ),
-	// );
-
-	// $shortcode_attributes = Contact_Form_Plugin::block_attributes_to_shortcode_attributes( $attributes, 'checkbox', null );
-	// $this->assertEquals( 'label="Single" isStandalone="1" style="color:caramel;"', $shortcode_attributes );
-	// }
+		$this->assertEquals( 'wp-block-jetpack-label has-text-color has-swamp-green-color', $shortcode_attributes['labelclasses'] );
+		$this->assertEquals( 'wp-block-jetpack-input has-text-color has-background has-border-color', $shortcode_attributes['inputclasses'] );
+		$this->assertEquals( 'color:swamp-green;background-color:swamp-red; font-size:24px;font-style:italic;font-weight:bold;line-height:1.5;letter-spacing:0.1em; border-color:swamp-blue;border-style:dashed;border-width:1px;', $shortcode_attributes['inputstyles'] );
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -1192,6 +1192,21 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Tests that the form content is trimmed
+	 */
+	public function test_parse_contact_field_trims_content() {
+
+		$shortcode = '[contact-field id="1" required]     adsasd        [/contact-field]';
+		$html      = do_shortcode( $shortcode );
+
+		/*
+		 * The expected string has some quotes escaped, since we want to make
+		 * sure we don't output anything harmful
+		 */
+		$this->assertEquals( '[contact-field id="1" required]adsasd[/contact-field]', $html );
+	}
+
+	/**
 	 * Test get_export_data_for_posts with fully vaid data input.
 	 *
 	 * @group csvexport

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -1307,10 +1307,14 @@ class Contact_Form_Test extends BaseTestCase {
 						}
 					);
 					$label_style = array_values( $filtered )[0] ?? null;
-					if ( $item_label->getAttribute( 'style' ) ) {
+					// @phan-suppress-next-line PhanUndeclaredMethod - Phan doesn't know that getAttribute is available. But it is.
+					if ( ! empty( $item_label->getAttribute( 'style' ) ) ) {
+						// @phan-suppress-next-line PhanUndeclaredMethod
 						$this->assertEquals( $item_label->getAttribute( 'style' ), $label_style->style, 'Style doesn\'t match' );
 					}
-					if ( $item_label->getAttribute( 'class' ) ) {
+					// @phan-suppress-next-line PhanUndeclaredMethod
+					if ( ! empty( $item_label->getAttribute( 'class' ) ) ) {
+						// @phan-suppress-next-line PhanUndeclaredMethod
 						$this->assertContains( $label_style->class, explode( ' ', $item_label->getAttribute( 'class' ) ), 'Class doesn\'t match' );
 					}
 				}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -747,7 +747,7 @@ class Contact_Form_Test extends BaseTestCase {
 			'options' => array( '"foo"', 'bar, baz', '[b\\rackets]' ),
 			'label'   => 'fun ][ times',
 		);
-		$html = Contact_Form_Plugin::gutenblock_render_field_radio( $attr, '' );
+		$html = Contact_Form_Plugin::gutenblock_render_field_radio( $attr, '', null );
 		$this->assertEquals( '[contact-field type="radio" options="&quot;foo&quot;,bar&#044; baz,&#091;b&#092;rackets&#093;" label="fun &#093;&#091; times"/]', $html );
 	}
 
@@ -872,7 +872,7 @@ class Contact_Form_Test extends BaseTestCase {
 	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_checkbox_field_renders_as_expected() {
-		$attributes = array(
+		$attributes          = array(
 			'label'       => 'fun',
 			'type'        => 'checkbox',
 			'class'       => 'lalala',
@@ -880,9 +880,43 @@ class Contact_Form_Test extends BaseTestCase {
 			'placeholder' => 'PLACEHOLDTHIS!',
 			'id'          => 'funID',
 		);
-
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'checkbox' ) );
 		$this->assertValidCheckboxField( $this->render_field( $attributes ), $expected_attributes );
+	}
+
+	/**
+	 * Test for checkbox field_renders
+	 *
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+	 */
+	public function test_make_sure_checkbox_field_renders_as_expected_with_style() {
+		$block     = array(
+			'blockName'   => 'jetpack/field-checkbox',
+			'innerBlocks' => array(
+				array(
+					'blockName' => 'jetpack/option',
+					'attrs'     => array(
+						'label'        => 'single',
+						'isStandalone' => true,
+						'style'        => array(
+							'color'      => array( 'text' => 'caramel' ),
+							'elements'   => array(
+								'link' => array( 'color' => array( 'text' => 'caramel' ) ),
+							),
+							'typography' => array(
+								'fontSize' => '24px',
+							),
+						),
+					),
+				),
+			),
+		);
+		$shortcode = Contact_Form_Plugin::gutenblock_render_field_checkbox( array(), '', new \WP_Block( $block ) );
+
+		// use HTML processor to parse code and check HTML
+		$form = new Contact_Form( array(), $shortcode );
+		$form->parse_content( $form->__toString() );
+		// test here?
 	}
 
 	/**
@@ -948,13 +982,14 @@ class Contact_Form_Test extends BaseTestCase {
 	/**
 	 * Renders a Contact_Form_Field.
 	 *
-	 * @param array $attributes An associative array of shortcode attributes.
+	 * @param array  $attributes An associative array of shortcode attributes.
+	 * @param string $content The content of the field.
 	 *
 	 * @return string The field html string.
 	 */
-	public function render_field( $attributes ) {
+	public function render_field( $attributes, $content = '' ) {
 		$form  = new Contact_Form( array() );
-		$field = new Contact_Form_Field( $attributes, '', $form );
+		$field = new Contact_Form_Field( $attributes, $content, $form );
 		return $field->render();
 	}
 
@@ -1105,7 +1140,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$this->assertInstanceOf( DOMElement::class, $label );
 		$this->assertInstanceOf( DOMElement::class, $input );
 
-		$this->assertEquals( $label->getAttribute( 'class' ), 'grunion-field-label ' . $attributes['type'], 'label class doesn\'t match' );
+		$this->assertEquals( $label->getAttribute( 'class' ), 'wp-block-jetpack-option grunion-field-label ' . $attributes['type'], 'label class doesn\'t match' );
 
 		$this->assertEquals( $input->getAttribute( 'name' ), $attributes['id'], 'Input name doesn\'t match' );
 		$this->assertEquals( 'Yes', $input->getAttribute( 'value' ), 'Input value doesn\'t match' );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -18,6 +18,9 @@ use WorDBless\Posts;
  * Test class for Contact_Form
  *
  * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form
+ * @covers \Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+ * @covers \Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
+ * @covers \Automattic\Jetpack\Forms\ContactForm\Util
  */
 class Contact_Form_Test extends BaseTestCase {
 
@@ -593,7 +596,6 @@ class Contact_Form_Test extends BaseTestCase {
 	 * Tests that 'grunion_delete_old_spam()' deletes an old post that is marked as spam.
 	 *
 	 * @author tonykova
-	 * @covers \Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam
 	 */
 	public function test_grunion_delete_old_spam_deletes_an_old_post_marked_as_spam() {
 		// grunion_Delete_old_spam performs direct DB queries which cannot be tested outside of a working WP install.
@@ -615,7 +617,6 @@ class Contact_Form_Test extends BaseTestCase {
 	 * Tests that 'grunion_delete_old_spam' does not delete a new post that is marked as spam.
 	 *
 	 * @author tonykova
-	 * @covers \Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam
 	 */
 	public function test_grunion_delete_old_spam_does_not_delete_a_new_post_marked_as_spam() {
 		$post_id = wp_insert_post(
@@ -635,7 +636,6 @@ class Contact_Form_Test extends BaseTestCase {
 	 * Tests that token is left intact when there is not matching field.
 	 *
 	 * @author tonykova
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 */
 	public function test_token_left_intact_when_no_matching_field() {
 		$plugin       = Contact_Form_Plugin::init();
@@ -651,7 +651,6 @@ class Contact_Form_Test extends BaseTestCase {
 	 * Tests that token is replaced with an empty string when there is not value in field.
 	 *
 	 * @author tonykova
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 */
 	public function test_replaced_with_empty_string_when_no_value_in_field() {
 		$plugin       = Contact_Form_Plugin::init();
@@ -667,7 +666,6 @@ class Contact_Form_Test extends BaseTestCase {
 	 * Tests that token in curly brackets is replaced with the value when the name has whitespace.
 	 *
 	 * @author tonykova
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 */
 	public function test_token_can_replace_entire_subject_with_token_field_whose_name_has_whitespace() {
 		$plugin       = Contact_Form_Plugin::init();
@@ -683,7 +681,6 @@ class Contact_Form_Test extends BaseTestCase {
 	 * Tests that token with curly brackets is replaced with value.
 	 *
 	 * @author tonykova
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 */
 	public function test_token_with_curly_brackets_can_be_replaced() {
 		$plugin       = Contact_Form_Plugin::init();
@@ -727,8 +724,6 @@ class Contact_Form_Test extends BaseTestCase {
 
 	/**
 	 * Tests shortcode with commas and brackets.
-	 *
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_array_values_with_commas_and_brackets() {
 		$shortcode = "[contact-field type='radio' options='\"foo\",bar&#044; baz,&#091;b&#092;rackets&#093;' label='fun &#093;&#091; times'/]";
@@ -738,8 +733,6 @@ class Contact_Form_Test extends BaseTestCase {
 
 	/**
 	 * Tests Gutenblock input with commas and brackets.
-	 *
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_array_values_with_commas_and_brackets_from_gutenblock() {
 		$attr = array(
@@ -753,8 +746,6 @@ class Contact_Form_Test extends BaseTestCase {
 
 	/**
 	 * Test for text field_renders
-	 *
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_text_field_renders_as_expected() {
 		$attributes = array(
@@ -772,8 +763,6 @@ class Contact_Form_Test extends BaseTestCase {
 
 	/**
 	 * Test for email field_renders
-	 *
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_email_field_renders_as_expected() {
 		$attributes = array(
@@ -791,8 +780,6 @@ class Contact_Form_Test extends BaseTestCase {
 
 	/**
 	 * Test for url field_renders
-	 *
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_url_field_renders_as_expected() {
 		$attributes = array(
@@ -810,8 +797,6 @@ class Contact_Form_Test extends BaseTestCase {
 
 	/**
 	 * Test for telephone field_renders
-	 *
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_telephone_field_renders_as_expected() {
 		$attributes = array(
@@ -829,8 +814,6 @@ class Contact_Form_Test extends BaseTestCase {
 
 	/**
 	 * Test for date field_renders
-	 *
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_date_field_renders_as_expected() {
 		$attributes = array(
@@ -849,8 +832,6 @@ class Contact_Form_Test extends BaseTestCase {
 
 	/**
 	 * Test for textarea field_renders
-	 *
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_textarea_field_renders_as_expected() {
 		$attributes = array(
@@ -868,11 +849,9 @@ class Contact_Form_Test extends BaseTestCase {
 
 	/**
 	 * Test for checkbox field_renders
-	 *
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_checkbox_field_renders_as_expected() {
-		$attributes          = array(
+		$attributes = array(
 			'label'       => 'fun',
 			'type'        => 'checkbox',
 			'class'       => 'lalala',
@@ -880,14 +859,13 @@ class Contact_Form_Test extends BaseTestCase {
 			'placeholder' => 'PLACEHOLDTHIS!',
 			'id'          => 'funID',
 		);
+
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'checkbox' ) );
 		$this->assertValidCheckboxField( $this->render_field( $attributes ), $expected_attributes );
 	}
 
 	/**
 	 * Multiple fields
-	 *
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_checkbox_multiple_field_renders_as_expected() {
 		$attributes = array(
@@ -906,8 +884,6 @@ class Contact_Form_Test extends BaseTestCase {
 
 	/**
 	 * Test for radio field_renders
-	 *
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_radio_field_renders_as_expected() {
 		$attributes = array(
@@ -926,8 +902,6 @@ class Contact_Form_Test extends BaseTestCase {
 
 	/**
 	 * Test for select field_renders
-	 *
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
 	public function test_make_sure_select_field_renders_as_expected() {
 		$attributes = array(
@@ -947,14 +921,13 @@ class Contact_Form_Test extends BaseTestCase {
 	/**
 	 * Renders a Contact_Form_Field.
 	 *
-	 * @param array  $attributes An associative array of shortcode attributes.
-	 * @param string $content The content of the field.
+	 * @param array $attributes An associative array of shortcode attributes.
 	 *
 	 * @return string The field html string.
 	 */
-	public function render_field( $attributes, $content = '' ) {
+	public function render_field( $attributes ) {
 		$form  = new Contact_Form( array() );
-		$field = new Contact_Form_Field( $attributes, $content, $form );
+		$field = new Contact_Form_Field( $attributes, '', $form );
 		return $field->render();
 	}
 
@@ -1221,7 +1194,6 @@ class Contact_Form_Test extends BaseTestCase {
 	/**
 	 * Test get_export_data_for_posts with fully vaid data input.
 	 *
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_get_export_data_for_posts_fully_valid_data() {
@@ -1341,7 +1313,6 @@ class Contact_Form_Test extends BaseTestCase {
 	/**
 	 * Test get_export_data_for_posts with single invalid entry for post meta
 	 *
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_get_export_data_for_posts_invalid_single_entry_meta() {
@@ -1446,7 +1417,6 @@ class Contact_Form_Test extends BaseTestCase {
 	/**
 	 * Test get_export_data_for_posts with invalid all entries for post meta
 	 *
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_get_export_data_for_posts_invalid_all_entries_meta() {
@@ -1536,7 +1506,6 @@ class Contact_Form_Test extends BaseTestCase {
 	/**
 	 * Test get_export_data_for_posts with single invalid entry for parsed fields.
 	 *
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_get_export_data_for_posts_single_invalid_entry_for_parse_fields() {
@@ -1649,7 +1618,6 @@ class Contact_Form_Test extends BaseTestCase {
 	/**
 	 * Test get_export_data_for_posts with all entries for parsed fields invalid.
 	 *
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_get_export_data_for_posts_all_entries_for_parse_fields_invalid() {
@@ -1692,7 +1660,6 @@ class Contact_Form_Test extends BaseTestCase {
 	/**
 	 * Test map_parsed_field_contents_of_post_to_field_names
 	 *
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_map_parsed_field_contents_of_post_to_field_names() {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -854,7 +854,7 @@ class Contact_Form_Test extends BaseTestCase {
 	/**
 	 * Test for checkbox field_renders
 	 *
-	 * @covers Contact_Form_Field::render_checkbox_field()
+	 * @covers \Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field::render_checkbox_field()
 	 */
 	public function test_make_sure_checkbox_field_renders_as_expected() {
 		$attributes = array(
@@ -877,7 +877,7 @@ class Contact_Form_Test extends BaseTestCase {
 	/**
 	 * Multiple fields
 	 *
-	 * @covers Contact_Form_Field::render_checkbox_multiple_field()
+	 * @covers \Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field::render_checkbox_multiple_field()
 	 */
 	public function test_make_sure_checkbox_multiple_field_renders_as_expected() {
 		$attributes          = array(

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -13,6 +13,7 @@ use DOMDocument;
 use DOMElement;
 use WorDBless\BaseTestCase;
 use WorDBless\Posts;
+use WP_Block;
 
 /**
  * Test class for Contact_Form
@@ -735,12 +736,15 @@ class Contact_Form_Test extends BaseTestCase {
 	 * Tests Gutenblock input with commas and brackets.
 	 */
 	public function test_array_values_with_commas_and_brackets_from_gutenblock() {
-		$attr = array(
+		$attr  = array(
 			'type'    => 'radio',
 			'options' => array( '"foo"', 'bar, baz', '[b\\rackets]' ),
 			'label'   => 'fun ][ times',
 		);
-		$html = Contact_Form_Plugin::gutenblock_render_field_radio( $attr, '', null );
+		$block = array(
+			'blockName' => 'jetpack/field-radio',
+		);
+		$html  = Contact_Form_Plugin::gutenblock_render_field_radio( $attr, '', new WP_Block( $block ) );
 		$this->assertEquals( '[contact-field type="radio" options="&quot;foo&quot;,bar&#044; baz,&#091;b&#092;rackets&#093;" label="fun &#093;&#091; times"/]', $html );
 	}
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -849,15 +849,21 @@ class Contact_Form_Test extends BaseTestCase {
 
 	/**
 	 * Test for checkbox field_renders
+	 *
+	 * @covers Contact_Form_Field::render_checkbox_field()
 	 */
 	public function test_make_sure_checkbox_field_renders_as_expected() {
 		$attributes = array(
-			'label'       => 'fun',
-			'type'        => 'checkbox',
-			'class'       => 'lalala',
-			'default'     => 'foo',
-			'placeholder' => 'PLACEHOLDTHIS!',
-			'id'          => 'funID',
+			'label'         => 'fun',
+			'type'          => 'checkbox',
+			'class'         => 'lalala',
+			'default'       => 'foo',
+			'placeholder'   => 'PLACEHOLDTHIS!',
+			'id'            => 'funID',
+			'optionclasses' => 'option-tomato option-lettuce',
+			'optionstyles'  => 'color:cheese;font-size:11px;',
+			'labelclasses'  => 'label-tomato label-lettuce',
+			'labelstyles'   => 'color:beef;font-size:22px;',
 		);
 
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'checkbox' ) );
@@ -866,18 +872,35 @@ class Contact_Form_Test extends BaseTestCase {
 
 	/**
 	 * Multiple fields
+	 *
+	 * @covers Contact_Form_Field::render_checkbox_multiple_field()
 	 */
 	public function test_make_sure_checkbox_multiple_field_renders_as_expected() {
-		$attributes = array(
-			'label'   => 'fun',
-			'type'    => 'checkbox-multiple',
-			'class'   => 'lalala',
-			'default' => 'option 1',
-			'id'      => 'funID',
-			'options' => array( 'option 1', 'option 2' ),
-			'values'  => array( 'option 1', 'option 2' ),
+		$attributes          = array(
+			'label'         => 'fun',
+			'type'          => 'checkbox-multiple',
+			'class'         => 'lalala',
+			'default'       => 'option 1',
+			'id'            => 'funID',
+			'options'       => array( 'option 1', 'option 2' ),
+			'values'        => array( 'option 1', 'option 2' ),
+			'optionclasses' => 'option-cheese option-ham',
+			'inputclasses'  => 'input-tomato input-lettuce',
+			'optionsdata'   => wp_json_encode(
+				array(
+					array(
+						'label' => 'option 1',
+						'class' => 'has-text-color',
+						'style' => 'color:caramel; font-size:14px;',
+					),
+					array(
+						'label' => 'option 2',
+						'class' => 'has-text-color',
+						'style' => 'color:gummy; font-size:14px;',
+					),
+				)
+			),
 		);
-
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'checkbox' ) );
 		$this->assertValidFieldMultiField( $this->render_field( $attributes ), $expected_attributes );
 	}
@@ -970,12 +993,114 @@ class Contact_Form_Test extends BaseTestCase {
 			$attributes['class'] = 'jp-contact-form-date';
 		}
 
-		$css_class = "grunion-field-{$attributes['type']}-wrap {$attributes['class']}-wrap grunion-field-wrap";
+		/*
+		 * $attributes['optionclasses'] is passed to Contact_Form_Field->render_field()
+		 * via $field_class and applied to the wrapper div.
+		 */
+		$options_classes_wrap = '';
+		if ( isset( $attributes['optionclasses'] ) ) {
+			$options_classes = explode( ' ', $attributes['optionclasses'] );
+			foreach ( $options_classes as $option_class ) {
+				$options_classes_wrap .= " {$option_class}-wrap";
+			}
+		}
+
+		/*
+		 * $attributes['inputclasses'] is passed to Contact_Form_Field->render_field()
+		 * via $field_class applied to the wrapper div.
+		 */
+		$input_classes_wrap = '';
+		if ( isset( $attributes['inputclasses'] ) ) {
+			$input_classes = explode( ' ', $attributes['inputclasses'] );
+			foreach ( $input_classes as $input_class ) {
+				$input_classes_wrap .= " {$input_class}-wrap";
+			}
+		}
+
+		$css_class = "grunion-field-{$attributes['type']}-wrap {$attributes['class']}-wrap{$input_classes_wrap}{$options_classes_wrap} grunion-field-wrap";
 
 		$this->assertEquals(
 			$wrapper_div->getAttribute( 'class' ),
 			$css_class,
 			'div class attribute doesn\'t match'
+		);
+	}
+
+	/**
+	 * Tests whether the input class attribute matches the field's class attribute value.
+	 *
+	 * @param DOMElement $input The input element.
+	 * @param array      $attributes An associative array containing the field's attributes.
+	 */
+	public function assertInputClasses( $input, $attributes ) {
+		/*
+		 * $attributes['optionclasses'] is passed to
+		 * Contact_Form_Field->render_checkbox_multiple_field() as $class
+		 * and applied to the input.
+		 */
+		$options_classes_input = '';
+		if ( isset( $attributes['optionclasses'] ) ) {
+			$options_classes = explode( ' ', $attributes['optionclasses'] );
+			foreach ( $options_classes as $option_class ) {
+				$options_classes_input .= " {$option_class}";
+			}
+		}
+
+		/*
+		 * $attributes['inputclasses'] is passed to Contact_Form_Field->render_field()
+		 * via $field_class applied to the wrapper div.
+		 */
+		$input_classes_input = '';
+		if ( isset( $attributes['inputclasses'] ) ) {
+			$input_classes = explode( ' ', $attributes['inputclasses'] );
+			foreach ( $input_classes as $input_class ) {
+				$input_classes_input .= " {$input_class}";
+			}
+		}
+
+		$this->assertEquals(
+			$input->getAttribute( 'class' ),
+			$attributes['type'] . ' ' . $attributes['class'] . $input_classes_input . $options_classes_input . ' grunion-field',
+			'input class attribute doesn\'t match'
+		);
+	}
+
+	/**
+	 * Tests whether the label class attribute matches the field's class attribute value.
+	 *
+	 * @param DOMElement $input The input element.
+	 * @param array      $attributes An associative array containing the field's attributes.
+	 * @param string     $classes_prefix The prefix of the classes.
+	 */
+	public function assertLabelClasses( $label, $attributes, $classes_prefix ) {
+		/*
+		 * $attributes['optionclasses'] is added to the label class attribute in
+		 * render functions, e.g., Contact_Form_Field->render_checkbox_field().
+		 */
+		$options_classes_input = '';
+		if ( isset( $attributes['optionclasses'] ) ) {
+			$options_classes = explode( ' ', $attributes['optionclasses'] );
+			foreach ( $options_classes as $option_class ) {
+				$options_classes_input .= " {$option_class}";
+			}
+		}
+
+		/*
+		 * $attributes['labelclasses'] is assigned to $this->label_classes and applied in
+		 * render functions, e.g., Contact_Form_Field->render_checkbox_field().
+		 */
+		$label_classes_input = '';
+		if ( isset( $attributes['labelclasses'] ) ) {
+			$label_classes = explode( ' ', $attributes['labelclasses'] );
+			foreach ( $label_classes as $label_class ) {
+				$label_classes_input .= " {$label_class}";
+			}
+		}
+
+		$this->assertEquals(
+			$label->getAttribute( 'class' ),
+			$classes_prefix . $label_classes_input . $options_classes_input,
+			'input class attribute doesn\'t match'
 		);
 	}
 
@@ -1078,7 +1203,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$this->assertInstanceOf( DOMElement::class, $label );
 		$this->assertInstanceOf( DOMElement::class, $input );
 
-		$this->assertEquals( $label->getAttribute( 'class' ), 'wp-block-jetpack-option grunion-field-label ' . $attributes['type'], 'label class doesn\'t match' );
+		$this->assertLabelClasses( $label, $attributes, 'wp-block-jetpack-option grunion-field-label ' . $attributes['type'] );
 
 		$this->assertEquals( $input->getAttribute( 'name' ), $attributes['id'], 'Input name doesn\'t match' );
 		$this->assertEquals( 'Yes', $input->getAttribute( 'value' ), 'Input value doesn\'t match' );
@@ -1087,7 +1212,8 @@ class Contact_Form_Test extends BaseTestCase {
 			$this->assertEquals( 'checked', $input->getAttribute( 'checked' ), 'Input checked doesn\'t match' );
 		}
 
-		$this->assertEquals( $input->getAttribute( 'class' ), $attributes['type'] . ' ' . $attributes['class'] . ' grunion-field', 'Input class doesn\'t match' );
+		$styles = $label->getAttribute( 'style' );
+		$this->assertEquals( $attributes['labelstyles'] . $attributes['optionstyles'], $styles, 'Label styles don\'t match' );
 	}
 
 	/**
@@ -1164,11 +1290,29 @@ class Contact_Form_Test extends BaseTestCase {
 					$this->assertEquals( $input->getAttribute( 'name' ), $attributes['id'] . '[]', 'Input name doesn\'t match' );
 				}
 				$this->assertEquals( $input->getAttribute( 'value' ), $attributes['values'][ $i ], 'Input value doesn\'t match' );
-				$this->assertEquals( $input->getAttribute( 'class' ), $attributes['type'] . ' ' . $attributes['class'] . ' grunion-field', 'Input class doesn\'t match' );
+
+				$this->assertInputClasses( $input, $attributes );
+
 				if ( 0 === $i ) {
 					$this->assertEquals( 'checked', $input->getAttribute( 'checked' ), 'Input checked doesn\'t match' );
 				} else {
 					$this->assertNotEquals( 'checked', $input->getAttribute( 'checked' ), 'Input checked doesn\'t match' );
+				}
+
+				if ( ! empty( $attributes['optionsdata'] ) ) {
+					$filtered    = array_filter(
+						json_decode( $attributes['optionsdata'] ),
+						function ( $option ) use ( $input ) {
+							return $option->label === $input->getAttribute( 'value' );
+						}
+					);
+					$label_style = array_values( $filtered )[0] ?? null;
+					if ( $item_label->getAttribute( 'style' ) ) {
+						$this->assertEquals( $item_label->getAttribute( 'style' ), $label_style->style, 'Style doesn\'t match' );
+					}
+					if ( $item_label->getAttribute( 'class' ) ) {
+						$this->assertContains( $label_style->class, explode( ' ', $item_label->getAttribute( 'class' ) ), 'Class doesn\'t match' );
+					}
 				}
 			}
 		}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -885,46 +885,6 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test for checkbox field_renders
-	 *
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
-	 */
-	public function test_gutenblock_render_field_checkbox() {
-		$block     = array(
-			'blockName'   => 'jetpack/field-checkbox',
-			'attrs'       => array(
-				'required' => false,
-			),
-			'innerBlocks' => array(
-				array(
-					'blockName' => 'jetpack/option',
-					'attrs'     => array(
-						'label'        => 'single',
-						'isStandalone' => true,
-						'style'        => array(
-							'color'      => array( 'text' => 'caramel' ),
-							'elements'   => array(
-								'link' => array( 'color' => array( 'text' => 'caramel' ) ),
-							),
-							'typography' => array(
-								'fontSize' => '24px',
-							),
-						),
-					),
-				),
-			),
-		);
-		$shortcode = Contact_Form_Plugin::gutenblock_render_field_checkbox( array(), '', new \WP_Block( $block ) );
-		$expected  = '[contact-field type="checkbox" label="single" optionclasses=" has-text-color" optionstyles="color:caramel; font-size:24px;"/]';
-
-		// Check that the generated shortcode is as expected.
-		// @TODO do we need this step?
-		$this->assertEquals( $expected, $shortcode );
-		$html = do_shortcode( $shortcode );
-		$this->assertEquals( $expected, $html );
-	}
-
-	/**
 	 * Multiple fields
 	 *
 	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -889,7 +889,7 @@ class Contact_Form_Test extends BaseTestCase {
 	 *
 	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
 	 */
-	public function test_make_sure_checkbox_field_renders_as_expected_with_style() {
+	public function test_gutenblock_render_field_checkbox() {
 		$block     = array(
 			'blockName'   => 'jetpack/field-checkbox',
 			'attrs'       => array(
@@ -916,8 +916,10 @@ class Contact_Form_Test extends BaseTestCase {
 		);
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_checkbox( array(), '', new \WP_Block( $block ) );
 		$expected  = '[contact-field type="checkbox" label="single" optionclasses=" has-text-color" optionstyles="color:caramel; font-size:24px;"/]';
-		$this->assertEquals( $expected, $shortcode );
 
+		// Check that the generated shortcode is as expected.
+		// @TODO do we need this step?
+		$this->assertEquals( $expected, $shortcode );
 		$html = do_shortcode( $shortcode );
 		$this->assertEquals( $expected, $html );
 	}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -1068,7 +1068,7 @@ class Contact_Form_Test extends BaseTestCase {
 	/**
 	 * Tests whether the label class attribute matches the field's class attribute value.
 	 *
-	 * @param DOMElement $input The input element.
+	 * @param DOMElement $label The input element.
 	 * @param array      $attributes An associative array containing the field's attributes.
 	 * @param string     $classes_prefix The prefix of the classes.
 	 */

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -892,6 +892,9 @@ class Contact_Form_Test extends BaseTestCase {
 	public function test_make_sure_checkbox_field_renders_as_expected_with_style() {
 		$block     = array(
 			'blockName'   => 'jetpack/field-checkbox',
+			'attrs'       => array(
+				'required' => false,
+			),
 			'innerBlocks' => array(
 				array(
 					'blockName' => 'jetpack/option',
@@ -912,11 +915,11 @@ class Contact_Form_Test extends BaseTestCase {
 			),
 		);
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_checkbox( array(), '', new \WP_Block( $block ) );
+		$expected  = '[contact-field type="checkbox" label="single" optionclasses=" has-text-color" optionstyles="color:caramel; font-size:24px;"/]';
+		$this->assertEquals( $expected, $shortcode );
 
-		// use HTML processor to parse code and check HTML
-		$form = new Contact_Form( array(), $shortcode );
-		$form->parse_content( $form->__toString() );
-		// test here?
+		$html = do_shortcode( $shortcode );
+		$this->assertEquals( $expected, $html );
 	}
 
 	/**


### PR DESCRIPTION



Fixes https://github.com/Automattic/jetpack-roadmap/issues/2420

Related to: https://github.com/Automattic/jetpack/issues/42355


## Proposed changes:

Adds PHP unit tests for https://github.com/Automattic/jetpack/pull/42890

### Adds minimum coverage for

- [x] `Contact_Form_Plugin::gutenblock_render_*` methods to test changes to `Contact_Form_Plugin::block_attributes_to_shortcode_attributes()`
- [x] Registered blocks `Contact_Form_Block::register_child_blocks`
- [x] Attribute changes in `Contact_Form_Field::__construct()`, testing passing `optionsdata` in the contact form attributes.
- [x] For supported blocks,  `Contact_Form_Plugin::block_attributes_to_shortcode_attributes`, which will indirectly test the private method `Contact_Form_Plugin::get_block_support_classes_and_styles`
- [x] Trim changes to `Contact_Form::parse_contact_field`


## Jetpack product discussion

p1HpG7-vDW-p2


## Testing instructions:



`jetpack test php packages/forms --verbose --debug`

To run a specific test:

`jetpack test php packages/forms --filter test_gutenblock_gutenblock_render_field_text_shortcode --verbose --debug`