### PR TITLE
Social: Do not load in the Classic editor if module is off

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-do-not-load-in-the-editor-if-module-is-off
+++ b/projects/packages/publicize/changelog/fix-social-do-not-load-in-the-editor-if-module-is-off
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Do not load in the editor if module is off

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Publicize;
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Current_Plan;
+use Automattic\Jetpack\Publicize\Publicize_Utils as Utils;
 use Automattic\Jetpack\Status\Host;
 
 /**
@@ -46,12 +47,12 @@ class Publicize_UI {
 	 * Initialize UI-related functionality.
 	 */
 	public function init() {
-		$this->publicize_settings_url = $this->publicize->publicize_connections_url();
-
 		// Show only to users with the capability required to manage their Publicize connections.
-		if ( ! $this->publicize->current_user_can_access_publicize_data() ) {
+		if ( ! Utils::is_publicize_active() || ! $this->publicize->current_user_can_access_publicize_data() ) {
 			return;
 		}
+
+		$this->publicize_settings_url = $this->publicize->publicize_connections_url();
 
 		// Assets (css, js).
 		add_action( 'admin_head-post.php', array( $this, 'post_page_metabox_assets' ) );

--- a/projects/plugins/jetpack/changelog/fix-social-do-not-load-in-the-editor-if-module-is-off
+++ b/projects/plugins/jetpack/changelog/fix-social-do-not-load-in-the-editor-if-module-is-off
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Do not load in the editor if module is off

--- a/projects/plugins/social/changelog/fix-social-do-not-load-in-the-editor-if-module-is-off
+++ b/projects/plugins/social/changelog/fix-social-do-not-load-in-the-editor-if-module-is-off
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Do not load in the editor if sharing is disabled


### PR DESCRIPTION
Currently, and forever, we have been loading Social in the classic editor even if the module is off.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Do not load Social in the editor if module is off

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Turn off Social on the Social admin page
* Goto classic editor
* Confirm that you don't see the Social UI in the post submit box
* Now turn ON Social again
* Confirm that you now see the Social UI
* Confirm that the settings link points to the Social admin page

