### PR TITLE
Managed Plugins: Save list of managed plugins option on plugin update

### DIFF
--- a/projects/plugins/wpcomsh/changelog/dotobrd-52-write-one-time-script-to-save-list-of-managed-plugins-option
+++ b/projects/plugins/wpcomsh/changelog/dotobrd-52-write-one-time-script-to-save-list-of-managed-plugins-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Managed Plugin: populate managed plugin list option on first page load

--- a/projects/plugins/wpcomsh/changelog/dotobrd-52-write-one-time-script-to-save-list-of-managed-plugins-option
+++ b/projects/plugins/wpcomsh/changelog/dotobrd-52-write-one-time-script-to-save-list-of-managed-plugins-option
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Managed Plugin: populate managed plugin list option on first page load
+Managed Plugin: populate managed plugin list option on plugin install or update

--- a/projects/plugins/wpcomsh/feature-plugins/managed-plugins.php
+++ b/projects/plugins/wpcomsh/feature-plugins/managed-plugins.php
@@ -603,3 +603,17 @@ function wpcomsh_handle_update_managed_plugins_list( $upgrader, $hook_extra ): v
 	}
 }
 add_action( 'upgrader_process_complete', 'wpcomsh_handle_update_managed_plugins_list', 10, 2 );
+
+/**
+ * Update the list of managed plugins on page load when the option is missing.
+ * This is used for backfilling the option. It only runs once on the site.
+ *
+ * @return void
+ */
+function wpcomsh_update_managed_plugins_on_page_load(): void {
+	// Only run once on the site when the option is missing.
+	if ( get_option( 'wpcomsh_at_managed_plugins', false ) === false ) {
+		wpcomsh_update_managed_plugins();
+	}
+}
+add_action( 'init', 'wpcomsh_update_managed_plugins_on_page_load' );

--- a/projects/plugins/wpcomsh/feature-plugins/managed-plugins.php
+++ b/projects/plugins/wpcomsh/feature-plugins/managed-plugins.php
@@ -598,22 +598,18 @@ add_action( 'deleted_plugin', 'wpcomsh_update_managed_plugins', 100 );
  * @return void
  */
 function wpcomsh_handle_update_managed_plugins_list( $upgrader, $hook_extra ): void {
-	if ( isset( $hook_extra['type'] ) && $hook_extra['type'] === 'plugin' && isset( $hook_extra['action'] ) && $hook_extra['action'] === 'install' ) {
-		wpcomsh_update_managed_plugins();
-	}
-}
-add_action( 'upgrader_process_complete', 'wpcomsh_handle_update_managed_plugins_list', 10, 2 );
+	$is_plugin_operation = isset( $hook_extra['type'] ) && 'plugin' === $hook_extra['type'];
+	$is_valid_action     = isset( $hook_extra['action'] ) && in_array( $hook_extra['action'], array( 'install', 'update' ), true );
+	$is_update_action    = 'update' === $hook_extra['action'];
+	$has_managed_plugins = get_option( 'wpcomsh_at_managed_plugins', false );
 
-/**
- * Update the list of managed plugins on page load when the option is missing.
- * This is used for backfilling the option. It only runs once on the site.
- *
- * @return void
- */
-function wpcomsh_update_managed_plugins_on_page_load(): void {
-	// Only run once on the site when the option is missing.
-	if ( get_option( 'wpcomsh_at_managed_plugins', false ) === false ) {
+	if ( $is_plugin_operation && $is_valid_action ) {
+		// If the plugin is being updated and the managed plugins list is already set, don't update it.
+		if ( $is_update_action && $has_managed_plugins ) {
+			return;
+		}
+
 		wpcomsh_update_managed_plugins();
 	}
 }
-add_action( 'init', 'wpcomsh_update_managed_plugins_on_page_load' );
+add_action( 'upgrader_process_complete', 'wpcomsh_handle_update_managed_plugins_list', 50, 2 );

--- a/projects/plugins/wpcomsh/feature-plugins/managed-plugins.php
+++ b/projects/plugins/wpcomsh/feature-plugins/managed-plugins.php
@@ -591,7 +591,8 @@ function wpcomsh_update_managed_plugins(): void {
 add_action( 'deleted_plugin', 'wpcomsh_update_managed_plugins', 100 );
 
 /**
- * Update the list of managed plugins after a plugin is installed.
+ * Update the list of managed plugins after a plugin is installed or updated.
+ * We only update the list if the managed plugins list is not already set for the update action.
  *
  * @param WP_Upgrader $upgrader The upgrader object.
  * @param array       $hook_extra Extra arguments passed to hooked filters.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTOBRD-52

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Populate `wpcomsh_at_managed_plugins` option on plugin update event.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No. It does not change.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use the Jetpack beta plugin to check out this branch on your atomic site. 
* Open phpMyAdmin for your test site
* Look for the `wpcomsh_at_managed_plugins` option. If it exists, delete it.

### Plugin Installation (Regression)
* Install any outdated plugin on the site. E.g. Hello Dolly for Your Song plugin [https://downloads.wordpress.org/plugin/hello-dolly-for-your-song.0.14.zip]
* Goto phpMyAdmin and look for the `wpcomsh_at_managed_plugins` option. Make sure it exists. 
* Delete it. 

### Plugin Updates
* Goto /wp-admin/plugins.php
* Since the plugin is outdated, there should be an update available for this plugin. 
* Update the plugin. 
* Goto phpMyAdmin and look for the `wpcomsh_at_managed_plugins` option. Make sure it exists. 
* Delete it. 

### Plugin Deletation (Regression)
* Goto /wp-admin/plugins.php
* Deactivate and delete the plugin
* Goto phpMyAdmin and look for the `wpcomsh_at_managed_plugins` option. Make sure it exists.

### Bonus Testing
* Simulate similar events using CLI and repeat the checks. 


