### PR TITLE
Forms: Update IntegrationCard markup and style

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-integration-toggle-centering
+++ b/projects/packages/forms/changelog/fix-forms-integration-toggle-centering
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Update IntegrationCard markup and styles.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
@@ -69,11 +69,16 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 				<div>
 					<p>{ __( 'Your forms are automatically protected with Akismet!', 'jetpack-forms' ) }</p>
 					<div className="integration-card__links">
-						<Button variant="link" href={ formSubmissionsUrl }>
+						<Button
+							variant="link"
+							href={ formSubmissionsUrl }
+							target="_blank"
+							rel="noopener noreferrer"
+						>
 							{ __( 'View spam', 'jetpack-forms' ) }
 						</Button>
 						<span>|</span>
-						<Button variant="link" href={ settingsUrl }>
+						<Button variant="link" href={ settingsUrl } target="_blank" rel="noopener noreferrer">
 							{ __( 'View stats', 'jetpack-forms' ) }
 						</Button>
 						<span>|</span>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
@@ -56,7 +56,7 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 						) }
 					</p>
 					<Button
-						variant="primary"
+						variant="secondary"
 						href={ settingsUrl }
 						target="_blank"
 						rel="noopener noreferrer"
@@ -67,33 +67,19 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 				</div>
 			) : (
 				<div>
-					<p>
-						{ createInterpolateElement(
-							__( 'Your forms are protected from spam with <a>Akismet</a>!', 'jetpack-forms' ),
-							{
-								a: <ExternalLink href={ getRedirectUrl( 'akismet-jetpack-forms-docs' ) } />,
-							}
-						) }
-					</p>
-					<div style={ { display: 'flex', gap: '8px', justifyContent: 'flex-start' } }>
-						<Button
-							variant="primary"
-							href={ formSubmissionsUrl }
-							target="_blank"
-							rel="noopener noreferrer"
-							__next40pxDefaultSize={ true }
-						>
+					<p>{ __( 'Your forms are automatically protected with Akismet!', 'jetpack-forms' ) }</p>
+					<div className="integration-card__links">
+						<Button variant="link" href={ formSubmissionsUrl }>
 							{ __( 'View spam', 'jetpack-forms' ) }
 						</Button>
-						<Button
-							variant="primary"
-							href={ settingsUrl }
-							target="_blank"
-							rel="noopener noreferrer"
-							__next40pxDefaultSize={ true }
-						>
+						<span>|</span>
+						<Button variant="link" href={ settingsUrl }>
 							{ __( 'View stats', 'jetpack-forms' ) }
 						</Button>
+						<span>|</span>
+						<ExternalLink href={ getRedirectUrl( 'akismet-jetpack-forms-docs' ) }>
+							{ __( 'Learn about Akismet', 'jetpack-forms' ) }
+						</ExternalLink>
 					</div>
 				</div>
 			) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
@@ -1,6 +1,6 @@
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
-import { ExternalLink, ToggleControl } from '@wordpress/components';
+import { ToggleControl, Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import IntegrationCard from './integration-card';
@@ -58,15 +58,7 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 			cardData={ cardData }
 		>
 			<div>
-				<p>
-					<em>
-						{ __( "You're all setup for email marketing with Creative Mail.", 'jetpack-forms' ) }
-						<br />
-						<ExternalLink href={ settingsUrl }>
-							{ __( 'Open Creative Mail settings', 'jetpack-forms' ) }
-						</ExternalLink>
-					</em>
-				</p>
+				<p>{ __( "You're all setup for email marketing with Creative Mail.", 'jetpack-forms' ) }</p>
 				{ hasEmailBlock && (
 					<ToggleControl
 						label={ __( 'Add email permission request before submit button', 'jetpack-forms' ) }
@@ -74,6 +66,9 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 						onChange={ toggleConsent }
 					/>
 				) }
+				<Button variant="link" href={ settingsUrl } target="_blank" rel="noopener noreferrer">
+					{ __( 'Open Creative Mail settings', 'jetpack-forms' ) }
+				</Button>
 			</div>
 		</IntegrationCard>
 	);

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/plugin-action-button.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/plugin-action-button.js
@@ -1,4 +1,4 @@
-import { Button, Icon } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { usePluginInstallation } from '../hooks/usePluginInstallation';
 
@@ -32,7 +32,7 @@ const PluginActionButton = ( { slug, pluginFile, isInstalled, refreshStatus, tra
 			variant="primary"
 			onClick={ handleAction }
 			disabled={ isInstalling }
-			icon={ isInstalling ? <Icon icon="update" className="is-spinning" /> : undefined }
+			icon={ isInstalling ? <Spinner /> : undefined }
 		>
 			{ getButtonText() }
 		</Button>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -89,6 +89,12 @@
 		display: block;
 	}
 
+	&__links {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
 	.is-spinning {
 		animation: rotation 2s infinite linear;
 	}
@@ -102,5 +108,9 @@
 		to {
 			transform: rotate(359deg);
 		}
-	} 
+	}
+
+	.components-card__body {
+		padding-bottom: 30px;
+	}
 } 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -110,12 +110,10 @@
 		}
 	}
 
-	.components-button {
-		.components-spinner {
-			margin: 0 8px;
-			width: 16px;
-			height: 16px;
-		}
+	.components-button .components-spinner {
+		margin: 0 8px;
+		width: 16px;
+		height: 16px;
 	}
 
 	.components-card__body {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -110,6 +110,14 @@
 		}
 	}
 
+	.components-button {
+		.components-spinner {
+			margin: 0 8px;
+			width: 16px;
+			height: 16px;
+		}
+	}
+
 	.components-card__body {
 		padding-bottom: 30px;
 	}

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -79,6 +79,10 @@
 		display: flex;
 		align-items: center;
 		gap: 12px;
+
+		.components-base-control.components-toggle-control {
+			margin-bottom: 0;
+		}
 	}
 
 	&__toggle-icon {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
@@ -1,6 +1,6 @@
 import colorStudio from '@automattic/color-studio';
 import { JetpackIcon } from '@automattic/jetpack-components';
-import { Button, ToggleControl } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import semver from 'semver';
@@ -53,8 +53,8 @@ const JetpackCRMCard = ( {
 							'jetpack-forms'
 						) }
 					</p>
-					<Button variant="primary" href={ settingsUrl } __next40pxDefaultSize={ true }>
-						{ __( 'Update CRM', 'jetpack-forms' ) }
+					<Button variant="secondary" href={ settingsUrl } __next40pxDefaultSize={ true }>
+						{ __( 'Update Jetpack CRM', 'jetpack-forms' ) }
 					</Button>
 				</div>
 			);
@@ -84,8 +84,8 @@ const JetpackCRMCard = ( {
 						</p>
 					) }
 					{ canActivateExtension && (
-						<Button variant="primary" href={ settingsUrl } __next40pxDefaultSize={ true }>
-							{ __( 'Enable Jetpack Forms Extension', 'jetpack-forms' ) }
+						<Button variant="secondary" href={ settingsUrl } __next40pxDefaultSize={ true }>
+							{ __( 'Enable Jetpack Forms extension', 'jetpack-forms' ) }
 						</Button>
 					) }
 				</div>
@@ -95,15 +95,16 @@ const JetpackCRMCard = ( {
 		// All conditions met - show toggle and link to CRM settings
 		return (
 			<div>
-				<ToggleControl
-					className="jetpack-contact-form__crm_toggle"
-					label={ __( 'Jetpack CRM', 'jetpack-forms' ) }
-					checked={ jetpackCRM }
-					onChange={ value => setAttributes( { jetpackCRM: value } ) }
-					help={ __( 'Store contact form submissions in your CRM.', 'jetpack-forms' ) }
-				/>
+				<p>
+					{ jetpackCRM
+						? __( 'This form is connected to Jetpack CRM!', 'jetpack-forms' )
+						: __(
+								'To connect this form to Jetpack CRM, enable the toggle above.',
+								'jetpack-forms'
+						  ) }
+				</p>
 				<Button variant="link" href={ settingsUrl } target="_blank" rel="noopener noreferrer">
-					{ __( 'Open CRM Settings', 'jetpack-forms' ) }
+					{ __( 'Open Jetpack CRM settings', 'jetpack-forms' ) }
 				</Button>
 			</div>
 		);
@@ -112,7 +113,7 @@ const JetpackCRMCard = ( {
 	return (
 		<IntegrationCard
 			title={ __( 'Jetpack CRM', 'jetpack-forms' ) }
-			description={ __( 'Keep on top of leads as they are added to your CRM', 'jetpack-forms' ) }
+			description={ __( 'Store contact form submissions in your CRM', 'jetpack-forms' ) }
 			icon={ <JetpackIcon color={ COLOR_JETPACK } /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
@@ -112,16 +112,13 @@ const JetpackCRMCard = ( {
 		}
 
 		// All conditions met - show toggle and link to CRM settings
+		const statusMessage = jetpackCRM
+			? __( 'This form is connected to Jetpack CRM!', 'jetpack-forms' )
+			: __( 'To connect this form to Jetpack CRM, enable the toggle above.', 'jetpack-forms' );
+
 		return (
 			<div>
-				<p>
-					{ jetpackCRM
-						? __( 'This form is connected to Jetpack CRM!', 'jetpack-forms' )
-						: __(
-								'To connect this form to Jetpack CRM, enable the toggle above.',
-								'jetpack-forms'
-						  ) }
-				</p>
+				<p>{ statusMessage }</p>
 				<Button variant="link" href={ settingsUrl } target="_blank" rel="noopener noreferrer">
 					{ __( 'Open Jetpack CRM settings', 'jetpack-forms' ) }
 				</Button>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
@@ -111,10 +111,12 @@ const JetpackCRMCard = ( {
 			);
 		}
 
-		// All conditions met - show toggle and link to CRM settings
-		const statusMessage = jetpackCRM
-			? __( 'This form is connected to Jetpack CRM!', 'jetpack-forms' )
-			: __( 'To connect this form to Jetpack CRM, enable the toggle above.', 'jetpack-forms' );
+		const connectedMessage = __( 'This form is connected to Jetpack CRM!', 'jetpack-forms' );
+		const disconnectedMessage = __(
+			'To connect this form to Jetpack CRM, enable the toggle above.',
+			'jetpack-forms'
+		);
+		const statusMessage = jetpackCRM ? connectedMessage : disconnectedMessage;
 
 		return (
 			<div>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
@@ -53,7 +53,13 @@ const JetpackCRMCard = ( {
 							'jetpack-forms'
 						) }
 					</p>
-					<Button variant="secondary" href={ settingsUrl } __next40pxDefaultSize={ true }>
+					<Button
+						variant="secondary"
+						href={ settingsUrl }
+						target="_blank"
+						rel="noopener noreferrer"
+						__next40pxDefaultSize={ true }
+					>
 						{ __( 'Update Jetpack CRM', 'jetpack-forms' ) }
 					</Button>
 				</div>
@@ -71,7 +77,14 @@ const JetpackCRMCard = ( {
 								'jetpack-forms'
 							),
 							{
-								a: <Button variant="link" href={ settingsUrl } />,
+								a: (
+									<Button
+										variant="link"
+										href={ settingsUrl }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
 							}
 						) }
 					</p>
@@ -84,7 +97,13 @@ const JetpackCRMCard = ( {
 						</p>
 					) }
 					{ canActivateExtension && (
-						<Button variant="secondary" href={ settingsUrl } __next40pxDefaultSize={ true }>
+						<Button
+							variant="secondary"
+							href={ settingsUrl }
+							target="_blank"
+							rel="noopener noreferrer"
+							__next40pxDefaultSize={ true }
+						>
 							{ __( 'Enable Jetpack Forms extension', 'jetpack-forms' ) }
 						</Button>
 					) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
@@ -17,11 +17,16 @@ const JetpackCRMCard = ( {
 	refreshStatus,
 } ) => {
 	const { settingsUrl = '', version = '', details = {} } = data || {};
-
 	const { hasExtension = false, canActivateExtension = false } = details;
 
 	const crmVersion = semver.coerce( version );
 	const isRecentVersion = crmVersion && semver.gte( crmVersion, '4.9.1' );
+
+	const connectedMessage = __( 'This form is connected to Jetpack CRM!', 'jetpack-forms' );
+	const disconnectedMessage = __(
+		'To connect this form to Jetpack CRM, enable the toggle above.',
+		'jetpack-forms'
+	);
 
 	const cardData = {
 		...data,
@@ -111,16 +116,10 @@ const JetpackCRMCard = ( {
 			);
 		}
 
-		const connectedMessage = __( 'This form is connected to Jetpack CRM!', 'jetpack-forms' );
-		const disconnectedMessage = __(
-			'To connect this form to Jetpack CRM, enable the toggle above.',
-			'jetpack-forms'
-		);
-		const statusMessage = jetpackCRM ? connectedMessage : disconnectedMessage;
-
+		// All conditions met, show Jetpack CRM connected message
 		return (
 			<div>
-				<p>{ statusMessage }</p>
+				<p>{ jetpackCRM ? connectedMessage : disconnectedMessage }</p>
 				<Button variant="link" href={ settingsUrl } target="_blank" rel="noopener noreferrer">
 					{ __( 'Open Jetpack CRM settings', 'jetpack-forms' ) }
 				</Button>


### PR DESCRIPTION
## Proposed changes:

NOTE: This is one of many PRs to create the new third party integrations modal. All this work is behind a feature flag and only visible if you set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.

This PR Implements a number of markup and styling tweaks for the IntegrationCards in the integration modal for Akismet and Jetpack CRM. These changes were discussed in a zoom call with @simison. Specific changes:
- Update the plugin action button to use the core Spinner component
- Vertically center the active toggle on the IntegrationCardHeader.
- Akismet: update text description and change links from primary buttons to simple links.
- Jetpack CRM: update description in header and body; make body description conditional on whether Jetpack CRM is enabled for the current form; and remove the enable toggle from the body since it is already on the header. 
- Creative Mail: adjusted link to match styles in Akismet and CRM.

**Screenshot of modal with changes**
<img width="717" alt="forms-modal-styles" src="https://github.com/user-attachments/assets/53664dac-30b1-4d4d-a1cc-fc7bb270e189" />

**Screenshot of button with new spinner during installation**
<img width="687" alt="forms-modal-new-spinner" src="https://github.com/user-attachments/assets/2ab06321-25ac-46be-a295-6440932988c3" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file to see the modal.
* Ensure that Akismet, Jetpack CRM, and Creative Mail plugins are installed and active on the site. Also ensure you have an Akismet key added.
* Add a page with a Jetpack Form
* Confirm the card panels look like the screenshots above. 

