### PR TITLE
Forms: Simplify IntegrationCardBody content

### DIFF
--- a/projects/packages/forms/changelog/update-simplify-form-integration-card
+++ b/projects/packages/forms/changelog/update-simplify-form-integration-card
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Simplify IntegrationCardBody content.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
@@ -28,7 +28,7 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 			}
 		),
 		notActivatedMessage: __(
-			"You already have Akismet installed, but it's not activated.",
+			'Akismet is installed! Just activate the plugin to start blocking spam.',
 			'jetpack-forms'
 		),
 	};

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
@@ -27,11 +27,11 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 		refreshStatus,
 		trackEventName: 'jetpack_forms_upsell_creative_mail_click',
 		notInstalledMessage: __(
-			'To start sending email campaigns, install the Creative Mail plugin for WordPress.',
+			'To start sending email campaigns, install the Creative Mail plugin.',
 			'jetpack-forms'
 		),
 		notActivatedMessage: __(
-			'To start sending email campaigns, activate the Creative Mail plugin for WordPress.',
+			'Creative Mail is installed! To start sending email campaigns, simply activate the plugin.',
 			'jetpack-forms'
 		),
 	};

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-body.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-body.js
@@ -1,65 +1,20 @@
 import { CardBody, Spinner } from '@wordpress/components';
-import PluginActionButton from './plugin-action-button';
 
 const IntegrationCardBody = ( { isExpanded, children, cardData = {} } ) => {
 	if ( ! isExpanded ) {
 		return null;
 	}
 
-	const {
-		slug,
-		pluginFile,
-		refreshStatus,
-		trackEventName,
-		notInstalledMessage,
-		notActivatedMessage,
-		isInstalled,
-		isActive,
-		isLoading,
-	} = cardData;
+	const { notInstalledMessage, notActivatedMessage, isInstalled, isActive, isLoading } = cardData;
 
-	const renderContent = () => {
-		// Loading state
-		if ( isLoading ) {
-			return <Spinner />;
-		}
-
-		// Not installed state
-		if ( ! isInstalled ) {
-			return (
-				<div>
-					<p>{ notInstalledMessage }</p>
-					<PluginActionButton
-						slug={ slug }
-						pluginFile={ pluginFile }
-						isInstalled={ isInstalled }
-						refreshStatus={ refreshStatus }
-						trackEventName={ trackEventName }
-					/>
-				</div>
-			);
-		}
-
-		// Not activated state
-		if ( ! isActive ) {
-			return (
-				<div>
-					<p>{ notActivatedMessage }</p>
-					<PluginActionButton
-						slug={ slug }
-						pluginFile={ pluginFile }
-						isInstalled={ isInstalled }
-						refreshStatus={ refreshStatus }
-						trackEventName={ trackEventName }
-					/>
-				</div>
-			);
-		}
-
-		return children;
-	};
-
-	return <CardBody>{ renderContent() }</CardBody>;
+	return (
+		<CardBody>
+			{ isLoading && <Spinner /> }
+			{ ! isLoading && ! isInstalled && <p>{ notInstalledMessage }</p> }
+			{ ! isLoading && isInstalled && ! isActive && <p>{ notActivatedMessage }</p> }
+			{ ! isLoading && isInstalled && isActive && children }
+		</CardBody>
+	);
 };
 
 export default IntegrationCardBody;

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
@@ -38,11 +38,11 @@ const JetpackCRMCard = ( {
 		refreshStatus,
 		trackEventName: 'jetpack_forms_upsell_crm_click',
 		notInstalledMessage: __(
-			'You can save contacts from Jetpack contact forms in Jetpack CRM.',
+			'You can save your form contacts in Jetpack CRM! To get started, please install the plugin.',
 			'jetpack-forms'
 		),
 		notActivatedMessage: __(
-			"You already have the Jetpack CRM plugin installed, but it's not activated.",
+			'Jetpack CRM is installed! To start saving contacts, simply activate the plugin.',
 			'jetpack-forms'
 		),
 	};

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -282,4 +282,5 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		</ThemeProvider>
 	);
 }
+
 export default JetpackContactFormEdit;

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -282,5 +282,4 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		</ThemeProvider>
 	);
 }
-
 export default JetpackContactFormEdit;


### PR DESCRIPTION
## Proposed changes:

NOTE: This is one of many PRs to create the new third party integrations modal. All this work is behind a feature flag and only visible if you set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file.

Changes:
- Removes the plugin installation / activation button from the body of our IntegrationCards because we already show the same button on the card header. 
- Since the install / activate button is gone from the card body, I also adjusted the install/activate nudges for each plugin to work better with the separate install /activate button that is now on the header. 

**Akismet panel when not installed or active**
<img width="615" alt="akismet-panel-install" src="https://github.com/user-attachments/assets/5ab47d50-93cd-4cf3-aa19-a458951ea890" />

<img width="621" alt="akismet-panel-activate" src="https://github.com/user-attachments/assets/da6c42d6-2fdd-466f-b530-655beaa9705d" />


**Jetpack CRM panel when not installed or active**
<img width="620" alt="jetpack-panel-install" src="https://github.com/user-attachments/assets/dbf8f499-7409-4528-8d88-7fea1dbccbcd" />

<img width="621" alt="jetpack-panel-activate" src="https://github.com/user-attachments/assets/50f87055-dabd-4f92-b200-3480ee61fec2" />


**Creative Mail panel when not installed or active**
<img width="618" alt="creative-mail-install2" src="https://github.com/user-attachments/assets/11fe3e25-e74f-40e5-af53-c48df62341a9" />

<img width="619" alt="creative-mail-activate2" src="https://github.com/user-attachments/assets/21994377-640a-435a-9830-0642e4912e3b" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in your wp-config.php file to see the modal.
* Deactivate and/or uninstall Akismet, Jetpack CRM, and Creative Mail plugins.
* Add a page with a Jetpack Form.
* Click the Manage Integrations button to open the modal.
* Confirm the card panels look like the screenshots above. 

