### PR TITLE
Infinite Scroll: Fix PHP fatal when using AMP

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-infinite_scroll_fatal
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-infinite_scroll_fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Infinite Scroll: Catch an obscure PHP error when AMP is enabled.

--- a/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
+++ b/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
@@ -2062,7 +2062,7 @@ class The_Neverending_Home_Page {
 	protected static function amp_get_max_pages() {
 		global $wp_query;
 
-		return (int) $wp_query->max_num_pages - $wp_query->query_vars['paged'];
+		return (int) $wp_query->max_num_pages - (int) $wp_query->query_vars['paged'];
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

One site on Atomic is generating a bunch of these errors:

```
PHP Fatal error:  Uncaught TypeError: Unsupported operand types: int - string in /wordpress/plugins/jetpack/14.5-a.9/modules/infinite-scroll/infinity.php:2065
```

While visiting certain pages on the site in question consistently generate the error, I wasn't able to reproduce on my end; the value returned on my end is always an `int` rather than a string. In efforts to reduce noice in the logs, I've submitted this PR, which casts the string to an int.

Stack track:
```
#0 /wordpress/plugins/jetpack/14.5-a.9/modules/infinite-scroll/infinity.php(1964): The_Neverending_Home_Page::amp_get_max_pages()
#1 /wordpress/plugins/jetpack/14.5-a.9/modules/infinite-scroll/infinity.php(1942): The_Neverending_Home_Page->amp_footer_template()
#2 /wordpress/plugins/jetpack/14.5-a.9/modules/infinite-scroll/infinity.php(1858): The_Neverending_Home_Page->amp_get_footer_template()
#3 /wordpress/core/6.7.2/wp-includes/class-wp-hook.php(324): The_Neverending_Home_Page->amp_load_hooks(Object(WP))
#4 /wordpress/core/6.7.2/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#5 /wordpress/core/6.7.2/wp-includes/plugin.php(565): WP_Hook->do_action(Array)
#6 /wordpress/core/6.7.2/wp-includes/class-wp.php(830): do_action_ref_array('wp', Array)
#7 /wordpress/core/6.7.2/wp-includes/functions.php(1336): WP->main('')
#8 /wordpress/core/6.7.2/wp-blog-header.php(16): wp()
#9 /wordpress/core/6.7.2/index.php(17): require('/wordpress/core...')
#10 {main}
  thrown in /wordpress/plugins/jetpack/14.5-a.9/modules/infinite-scroll/infinity.php on line 2065
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Does the change seem safe?
