### PR TITLE
Jetpack SEO: fix useSelect call

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-seo-bad-useselect-call
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-seo-bad-useselect-call
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack SEO Enhacner: change useSelect call to comply with more performant practices

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-requests.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/use-seo-requests.ts
@@ -46,15 +46,16 @@ export const useSeoRequests = () => {
 	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
 	const postId = useSelect( select => select( editorStore ).getCurrentPostId(), [] );
 	const { getPostContent } = usePostContent();
-	const { isBusy, enabledFeatures } = useSelect( select => {
-		const busy = select( store ).isBusy();
-		const features = select( store ).getEnabledFeatures();
-
-		return { isBusy: busy, enabledFeatures: features };
+	const { isBusy, enabledFeatures, isImageBusy, hasImageFailed } = useSelect( select => {
+		return {
+			isBusy: select( store ).isBusy(),
+			enabledFeatures: select( store ).getEnabledFeatures(),
+			isImageBusy: select( store ).isImageBusy,
+			hasImageFailed: select( store ).hasImageFailed,
+		};
 	}, [] );
-	const { setBusy, setTitleBusy, setDescriptionBusy } = useDispatch( store );
-	const { isImageBusy, hasImageFailed } = useSelect( select => select( store ), [] );
-	const { setImageBusy, setImageFailed } = useDispatch( store );
+	const { setBusy, setTitleBusy, setDescriptionBusy, setImageBusy, setImageFailed } =
+		useDispatch( store );
 	const { createInfoNotice } = useDispatch( 'core/notices' );
 	const { increaseRequestsCount, dequeueAsyncRequest, requireUpgrade } = useAiFeature();
 	const [ triggerType, setTriggerType ] = useState< 'manual' | 'auto' >( null );


### PR DESCRIPTION
## Proposed changes:
This PR changes the useSelect call on useSeoRequests hook to be more in line with [performant practices](https://developer.wordpress.org/news/2024/03/how-to-work-effectively-with-the-useselect-hook/)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1744303609023589-slack-C02TQF5VAJD

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
TBD