### PR TITLE
Forms: Prevent errors when synced attribute context is not available

### DIFF
--- a/projects/packages/forms/src/blocks/shared/hooks/use-synced-attributes.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-synced-attributes.js
@@ -7,9 +7,9 @@ import { isEqual } from 'lodash';
 /**
  * Context for managing synced attributes across blocks.
  *
- * @type {React.Context<?{syncedAttributes: object, setSyncedAttributes: Function}>}
+ * @type {React.Context<[object, Function]>}
  */
-const SyncedAttributeContext = createContext( {} );
+const SyncedAttributeContext = createContext( [ {}, () => {} ] );
 
 /**
  * Provider component that manages synced attributes across blocks.
@@ -40,22 +40,16 @@ export function SyncedAttributeProvider( { children } ) {
  * The `setSyncedAttributes` function it returns is also adjusted so that it only updates
  * the attributes for the given block type.
  *
- * @param {string} name - The name of the block.
- *
+ * @param {string}             name         - The name of the block.
+ * @param {[object, Function]} contextValue - The context value from SyncedAttributeContext.
  * @return {Array} Array containing the synced attributes and the function to update them.
  */
-function useSyncedAttributesForBlock( name ) {
-	const contextValue = useContext( SyncedAttributeContext );
+function useSyncedAttributesForBlock( name, contextValue ) {
+	const [ syncedAttributes, setSyncedAttributes ] = contextValue;
 
 	return useMemo( () => {
-		// When context isn't available, e.g. for previews/transforms, return no-op values.
-		if ( ! contextValue || ! Array.isArray( contextValue ) ) {
-			return [ null, () => {} ];
-		}
-
-		const [ syncedAttributes = {}, setSyncedAttributes ] = contextValue;
 		return [ syncedAttributes[ name ], attributes => setSyncedAttributes( { name, attributes } ) ];
-	}, [ name, contextValue ] );
+	}, [ name, setSyncedAttributes, syncedAttributes ] );
 }
 
 /**
@@ -126,7 +120,10 @@ export function useSyncedAttributes(
 	// They can be updated using the `setSyncedAttributes` function.
 	// These attributes are the source of truth for all blocks that are synced.
 	// If they change, the current block will be updated to match the synced attributes using its `setAttributes` function.
-	const [ syncedAttributes, setSyncedAttributes ] = useSyncedAttributesForBlock( name );
+	const [ syncedAttributes, setSyncedAttributes ] = useSyncedAttributesForBlock(
+		name,
+		contextValue
+	);
 
 	// The own attributes belong to the current block that this hook operates on.
 	// If these change and the block is synced, the synced attributes will be updated on the parent form using

--- a/projects/packages/forms/src/blocks/shared/hooks/use-synced-attributes.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-synced-attributes.js
@@ -45,14 +45,17 @@ export function SyncedAttributeProvider( { children } ) {
  * @return {Array} Array containing the synced attributes and the function to update them.
  */
 function useSyncedAttributesForBlock( name ) {
-	const [ syncedAttributes, setSyncedAttributes ] = useContext( SyncedAttributeContext );
+	const contextValue = useContext( SyncedAttributeContext );
 
 	return useMemo( () => {
-		return [
-			syncedAttributes?.[ name ],
-			attributes => setSyncedAttributes( { name, attributes } ),
-		];
-	}, [ name, setSyncedAttributes, syncedAttributes ] );
+		// When context isn't available, e.g. for previews/transforms, return no-op values.
+		if ( ! contextValue || ! Array.isArray( contextValue ) ) {
+			return [ null, () => {} ];
+		}
+
+		const [ syncedAttributes = {}, setSyncedAttributes ] = contextValue;
+		return [ syncedAttributes[ name ], attributes => setSyncedAttributes( { name, attributes } ) ];
+	}, [ name, contextValue ] );
 }
 
 /**
@@ -117,6 +120,7 @@ export function useSyncedAttributes(
 	setOwnAttributes
 ) {
 	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch( 'core/block-editor' );
+	const contextValue = useContext( SyncedAttributeContext );
 
 	// The synced attributes are pulled from the parent form block via react context.
 	// They can be updated using the `setSyncedAttributes` function.
@@ -124,7 +128,7 @@ export function useSyncedAttributes(
 	// If they change, the current block will be updated to match the synced attributes using its `setAttributes` function.
 	const [ syncedAttributes, setSyncedAttributes ] = useSyncedAttributesForBlock( name );
 
-	// The  own attributes belong to the current block that this hook operates on.
+	// The own attributes belong to the current block that this hook operates on.
 	// If these change and the block is synced, the synced attributes will be updated on the parent form using
 	// the `setSyncedAttributes` function.
 	const ownAttributes = useMemo(
@@ -134,7 +138,10 @@ export function useSyncedAttributes(
 	const previousOwnAttributes = usePrevious( ownAttributes ) ?? ownAttributes;
 
 	useEffect( () => {
-		if ( ! isSynced ) {
+		// Skip syncing if not needed or possible.
+		// When a field is rendered in a preview i.e. without a parent form the useFormWrapper hook will
+		// wrap the field in a new block leading to a moment when the synced attribute context is not yet available.
+		if ( ! isSynced || ! contextValue ) {
 			return;
 		}
 
@@ -183,5 +190,6 @@ export function useSyncedAttributes(
 		previousOwnAttributes,
 		syncedAttributes,
 		__unstableMarkNextChangeAsNotPersistent,
+		contextValue,
 	] );
 }

--- a/projects/packages/forms/src/blocks/shared/hooks/use-synced-attributes.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-synced-attributes.js
@@ -7,7 +7,7 @@ import { isEqual } from 'lodash';
 /**
  * Context for managing synced attributes across blocks.
  *
- * @type {React.Context<[object, Function]>}
+ * @type {React.Context<[syncedAttributes: object, setSyncedAttributes: Function]>}
  */
 const SyncedAttributeContext = createContext( [ {}, () => {} ] );
 


### PR DESCRIPTION
Related:
- https://github.com/Automattic/jetpack/pull/42890
- https://github.com/Automattic/jetpack/pull/43004

## Proposed changes:

* Adds some guards against missing context

**Note this PR will be merged into #42890**

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->


## Testing instructions:

### Steps to replicate errors

The easiest approach (until transforms are merged in #42890) is to:

1. On trunk, add a form with fields
2. Ensure one form is opting into synced styles and customize its styles
3. Copy that field
4. Paste that field outside of a form e.g. at the top level of the post etc

The `useFormWrapper` hook wraps the field in a form that will setup the appropriate context however there is a moment when that context isn't available to the style syncing hook throws an error.

Switch to this PR branch to confirm the fix:

1. Repeat the replication steps above
2. Ensure all style syncing for Label, Input, and Option blocks continue to function as expected
