### PR TITLE
Social: Use siteHasFeature utility for share status feature check

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-use-site-has-feature-for-share-status-check
+++ b/projects/js-packages/publicize-components/changelog/update-social-use-site-has-feature-for-share-status-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social: Use siteHasFeature utility for share status feature check

--- a/projects/js-packages/publicize-components/src/components/global-modals/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/global-modals/index.tsx
@@ -1,5 +1,5 @@
 import { siteHasFeature } from '@automattic/jetpack-script-data';
-import { features } from '../../utils';
+import { features } from '../../utils/constants';
 import { ThemedShareStatusModal as ShareStatusModal } from '../share-status';
 
 export const GlobalModals = () => {

--- a/projects/js-packages/publicize-components/src/components/global-modals/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/global-modals/index.tsx
@@ -1,8 +1,7 @@
-import { getSocialScriptData } from '../../utils/script-data';
+import { siteHasFeature } from '@automattic/jetpack-script-data';
+import { features } from '../../utils';
 import { ThemedShareStatusModal as ShareStatusModal } from '../share-status';
 
 export const GlobalModals = () => {
-	const { feature_flags } = getSocialScriptData();
-
-	return <>{ feature_flags.useShareStatus ? <ShareStatusModal /> : null }</>;
+	return <>{ siteHasFeature( features.SHARE_STATUS ) ? <ShareStatusModal /> : null }</>;
 };

--- a/projects/js-packages/publicize-components/src/components/panel/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/panel/index.tsx
@@ -3,6 +3,7 @@
  * Jetpack plugin implementation.
  */
 
+import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { PanelBody, PanelRow, ToggleControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
@@ -12,7 +13,7 @@ import usePublicizeConfig from '../../hooks/use-publicize-config';
 import useRefreshConnections from '../../hooks/use-refresh-connections';
 import { usePostJustPublished } from '../../hooks/use-saving-post';
 import useSelectSocialMediaConnections from '../../hooks/use-social-media-connections';
-import { getSocialScriptData } from '../../utils/script-data';
+import { features } from '../../utils';
 import PublicizeForm from '../form';
 import { ManualSharing } from '../manual-sharing';
 import { ReSharingPanel } from '../resharing-panel';
@@ -27,7 +28,6 @@ type PublicizePanelProps = {
 const PublicizePanel = ( { prePublish, children }: PublicizePanelProps ) => {
 	const { refresh, hasConnections, hasEnabledConnections } = useSelectSocialMediaConnections();
 	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
-	const { feature_flags } = getSocialScriptData();
 
 	const refreshConnections = useRefreshConnections();
 
@@ -83,7 +83,7 @@ const PublicizePanel = ( { prePublish, children }: PublicizePanelProps ) => {
 			) }
 			{ isPostPublished && (
 				<>
-					{ feature_flags.useShareStatus ? <ReSharingPanel /> : null }
+					{ siteHasFeature( features.SHARE_STATUS ) ? <ReSharingPanel /> : null }
 					<ManualSharing />
 				</>
 			) }

--- a/projects/js-packages/publicize-components/src/components/panel/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/panel/index.tsx
@@ -13,7 +13,7 @@ import usePublicizeConfig from '../../hooks/use-publicize-config';
 import useRefreshConnections from '../../hooks/use-refresh-connections';
 import { usePostJustPublished } from '../../hooks/use-saving-post';
 import useSelectSocialMediaConnections from '../../hooks/use-social-media-connections';
-import { features } from '../../utils';
+import { features } from '../../utils/constants';
 import PublicizeForm from '../form';
 import { ManualSharing } from '../manual-sharing';
 import { ReSharingPanel } from '../resharing-panel';

--- a/projects/js-packages/publicize-components/src/components/post-publish-share-status/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-share-status/index.tsx
@@ -1,3 +1,4 @@
+import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PluginPostPublishPanel as DeprecatedPluginPostPublishPanel } from '@wordpress/edit-post';
 import {
@@ -9,7 +10,7 @@ import { usePostMeta } from '../../hooks/use-post-meta';
 import { usePostPrePublishValue } from '../../hooks/use-post-pre-publish-value';
 import { usePostJustPublished } from '../../hooks/use-saving-post';
 import { store as socialStore } from '../../social-store';
-import { getSocialScriptData } from '../../utils/script-data';
+import { features } from '../../utils';
 import { ShareStatus } from './share-status';
 
 const PluginPostPublishPanel = EditorPluginPostPublishPanel || DeprecatedPluginPostPublishPanel;
@@ -22,7 +23,6 @@ const PluginPostPublishPanel = EditorPluginPostPublishPanel || DeprecatedPluginP
 export function PostPublishShareStatus() {
 	const { isPublicizeEnabled } = usePostMeta();
 	const { pollForPostShareStatus } = useDispatch( socialStore );
-	const { feature_flags } = getSocialScriptData();
 
 	const { isPostPublished } = useSelect( select => {
 		const _editorStore = select( editorStore );
@@ -40,7 +40,7 @@ export function PostPublishShareStatus() {
 
 	const willPostBeShared = isPublicizeEnabled && enabledConnections.length > 0 && isSharingPossible;
 
-	const showStatus = feature_flags.useShareStatus && willPostBeShared && isPostPublished;
+	const showStatus = siteHasFeature( features.SHARE_STATUS ) && willPostBeShared && isPostPublished;
 
 	usePostJustPublished( () => {
 		if ( showStatus ) {

--- a/projects/js-packages/publicize-components/src/components/post-publish-share-status/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-share-status/index.tsx
@@ -10,7 +10,7 @@ import { usePostMeta } from '../../hooks/use-post-meta';
 import { usePostPrePublishValue } from '../../hooks/use-post-pre-publish-value';
 import { usePostJustPublished } from '../../hooks/use-saving-post';
 import { store as socialStore } from '../../social-store';
-import { features } from '../../utils';
+import { features } from '../../utils/constants';
 import { ShareStatus } from './share-status';
 
 const PluginPostPublishPanel = EditorPluginPostPublishPanel || DeprecatedPluginPostPublishPanel;

--- a/projects/js-packages/publicize-components/src/components/share-post/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/share-post/index.jsx
@@ -14,7 +14,6 @@ import { useIsReSharingPossible } from '../../hooks/use-is-resharing-possible';
 import useSharePost from '../../hooks/use-share-post';
 import { store as socialStore } from '../../social-store';
 import { features } from '../../utils';
-import { getSocialScriptData } from '../../utils/script-data';
 
 /**
  * Removes the current message from resharing a post.
@@ -87,7 +86,6 @@ export function SharePostButton( { onShareCompleted, isDisabled = false } ) {
 			isSavingPost: editorSelector.isSavingPost(),
 		};
 	}, [] );
-	const { feature_flags } = getSocialScriptData();
 	const { pollForPostShareStatus } = useDispatch( socialStore );
 	const { recordEvent } = useAnalytics();
 	const savePost = dispatch( editorStore ).savePost;
@@ -136,7 +134,7 @@ export function SharePostButton( { onShareCompleted, isDisabled = false } ) {
 
 		await doPublicize();
 
-		if ( feature_flags.useShareStatus ) {
+		if ( siteHasFeature( features.SHARE_STATUS ) ) {
 			pollForPostShareStatus();
 		}
 	}, [
@@ -146,7 +144,6 @@ export function SharePostButton( { onShareCompleted, isDisabled = false } ) {
 		isAutosaveablePost,
 		hasMediaFeatures,
 		doPublicize,
-		feature_flags.useShareStatus,
 		savePost,
 		pollForPostShareStatus,
 	] );

--- a/projects/js-packages/publicize-components/src/components/share-post/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/share-post/index.jsx
@@ -13,7 +13,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useIsReSharingPossible } from '../../hooks/use-is-resharing-possible';
 import useSharePost from '../../hooks/use-share-post';
 import { store as socialStore } from '../../social-store';
-import { features } from '../../utils';
+import { features } from '../../utils/constants';
 
 /**
  * Removes the current message from resharing a post.

--- a/projects/js-packages/publicize-components/src/components/share-status/modal-trigger.tsx
+++ b/projects/js-packages/publicize-components/src/components/share-status/modal-trigger.tsx
@@ -1,3 +1,4 @@
+import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -5,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { forwardRef, useCallback } from 'react';
 import { store as socialStore } from '../../social-store';
-import { getSocialScriptData } from '../../utils/script-data';
+import { features } from '../../utils';
 import styles from './styles.module.scss';
 import type { ButtonProps } from '@wordpress/components/build-types/button/types';
 
@@ -33,9 +34,7 @@ export const ModalTrigger = forwardRef(
 			return null;
 		}
 
-		const { feature_flags } = getSocialScriptData();
-
-		if ( ! feature_flags.useShareStatus ) {
+		if ( ! siteHasFeature( features.SHARE_STATUS ) ) {
 			return null;
 		}
 

--- a/projects/js-packages/publicize-components/src/components/share-status/modal-trigger.tsx
+++ b/projects/js-packages/publicize-components/src/components/share-status/modal-trigger.tsx
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { forwardRef, useCallback } from 'react';
 import { store as socialStore } from '../../social-store';
-import { features } from '../../utils';
+import { features } from '../../utils/constants';
 import styles from './styles.module.scss';
 import type { ButtonProps } from '@wordpress/components/build-types/button/types';
 

--- a/projects/js-packages/publicize-components/src/social-store/index.ts
+++ b/projects/js-packages/publicize-components/src/social-store/index.ts
@@ -1,5 +1,5 @@
 import { createReduxStore, register } from '@wordpress/data';
-import { getSocialScriptData } from '../utils';
+import { getSocialScriptData } from '../utils/script-data';
 import actions from './actions';
 import { hydrateStores } from './hydrate-stores';
 import reducer from './reducer';

--- a/projects/js-packages/publicize-components/src/social-store/resolvers.ts
+++ b/projects/js-packages/publicize-components/src/social-store/resolvers.ts
@@ -1,7 +1,7 @@
 import { siteHasFeature } from '@automattic/jetpack-script-data';
 import apiFetch from '@wordpress/api-fetch';
 import { store as editorStore } from '@wordpress/editor';
-import { features } from '../utils';
+import { features } from '../utils/constants';
 import { normalizeShareStatus } from '../utils/share-status';
 import { setConnections } from './actions/connection-data';
 import { fetchPostShareStatus, receivePostShareStaus } from './actions/share-status';

--- a/projects/js-packages/publicize-components/src/social-store/resolvers.ts
+++ b/projects/js-packages/publicize-components/src/social-store/resolvers.ts
@@ -1,6 +1,7 @@
+import { siteHasFeature } from '@automattic/jetpack-script-data';
 import apiFetch from '@wordpress/api-fetch';
 import { store as editorStore } from '@wordpress/editor';
-import { getSocialScriptData } from '../utils/script-data';
+import { features } from '../utils';
 import { normalizeShareStatus } from '../utils/share-status';
 import { setConnections } from './actions/connection-data';
 import { fetchPostShareStatus, receivePostShareStaus } from './actions/share-status';
@@ -54,9 +55,8 @@ export function getPostShareStatus( _postId ) {
 	return async ( { dispatch, registry } ) => {
 		// Default to the current post ID if none is provided.
 		const postId = _postId || registry.select( editorStore ).getCurrentPostId();
-		const { feature_flags } = getSocialScriptData();
 
-		if ( ! feature_flags.useShareStatus ) {
+		if ( ! siteHasFeature( features.SHARE_STATUS ) ) {
 			return;
 		}
 

--- a/projects/js-packages/publicize-components/src/types.ts
+++ b/projects/js-packages/publicize-components/src/types.ts
@@ -19,7 +19,6 @@ export type SharesData = {
 export interface FeatureFlags {
 	useAdminUiV1: boolean;
 	useEditorPreview: boolean;
-	useShareStatus: boolean;
 }
 
 export type ConnectionService = {

--- a/projects/js-packages/publicize-components/src/utils/constants.ts
+++ b/projects/js-packages/publicize-components/src/utils/constants.ts
@@ -1,4 +1,5 @@
 export const features = {
 	ENHANCED_PUBLISHING: 'social-enhanced-publishing',
 	IMAGE_GENERATOR: 'social-image-generator',
+	SHARE_STATUS: 'social-share-status',
 };


### PR DESCRIPTION
Social feature flags do not work when the feature is enabled via `Store_Product_List` on wpcom. The reason for that is the Jetpack `Current_Plan:supports()` doesn't pick those features up.

But, since those features are available in the site's active features following #39817, we can use `siteHasFeature` to make it work for all sites.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replace Share status feature flad with siteHasFeature utility for the share status feature check

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply 180378-ghe-Automattic/wpcom to your sandbox
* Apply this PR on top of the above
* Point your Simple site and the public API to your sandbox
* Goto the editor
* Verify that share status is still visible
* Test the same for a Jetpack site

**Notes**
- You may need to visit `/wp-admin/admin.php?page=jetpack#/my-plan` to ensure that plan cache is updated
- Ensure that the feature is not enabled via constants or options - `jetpack docker wp option delete jetpack_social_has_share_status`