### PR TITLE
Jetpack SEO: Ensure more performant practices when getting enabled features.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-seo-getEnabledFeatures
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-seo-getEnabledFeatures
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO Enhancer: Ensure more performant practices when getting enabled features.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/selectors.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/selectors.ts
@@ -1,3 +1,4 @@
+import { createSelector } from '@wordpress/data';
 /**
  * Types
  */
@@ -35,12 +36,11 @@ export function hasImageFailed( state: SeoEnhancerState, clientId: string ) {
 	return state.failedImages[ clientId ] ?? false;
 }
 
-export function getEnabledFeatures( state: SeoEnhancerState ) {
-	return Object.keys( state.features ).filter(
-		feature => state.features[ feature ]
-	) as PromptType[];
-}
-
+export const getEnabledFeatures = createSelector(
+	( state: SeoEnhancerState ): PromptType[] =>
+		Object.keys( state.features ).filter( feature => state.features[ feature ] ) as PromptType[],
+	( state: SeoEnhancerState ) => [ state.features ]
+);
 export function isImageAltTextFeatureEnabled( state: SeoEnhancerState ) {
 	return getEnabledFeatures( state ).includes( 'images-alt-text' );
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/43033

## Proposed changes:

* This PR changes how `getEnabledFeatures` works by making sure we only run the selector function if the dependencies have changed.
* This change was prompted by a `useSelect` warning in the console of post editors (when script debug is enabled, running WordPress 6.8):
```
The 'useSelect' hook returns different values when called with the same state and parameters.
This can lead to unnecessary re-renders and performance issues if not fixed.`
Non-equal value keys: enabledFeatures
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1744303609023589-slack-C02TQF5VAJD

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

This may need expansion, but:

* If you spin up a Jurassic Ninja site using the Jetpack Beta tester plugin (testing in bleeding edge), and also install the WordPress Beta Tester plugin, with Jetpack connected you should be able to replicate the console warning if opening up a post. You will also need script debug enabled in `wp-config.php`: `define( 'SCRIPT_DEBUG', 'true' );`.

* With this PR applied, the warning no longer appears. 
* To confirm no impact on features, activate SEO from the SEO panel (in the Jetpack sidebar), and 'generate metadata'.