### PR TITLE
wpcom-legacy-fse: Remove default pages

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-legacy-fse-default-pages
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-legacy-fse-default-pages
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Removed default pages (About and Contact) for legacy-fse themes.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-legacy-fse/wpcom-legacy-fse.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-legacy-fse/wpcom-legacy-fse.php
@@ -31,7 +31,6 @@ function populate_wp_template_data() {
 	$theme_slug        = normalize_theme_slug( get_theme_slug() );
 	$template_inserter = new WP_Template_Inserter( $theme_slug );
 	$template_inserter->insert_default_template_data();
-	$template_inserter->insert_default_pages();
 }
 register_activation_hook( __FILE__, __NAMESPACE__ . '\populate_wp_template_data' );
 add_action( 'switch_theme', __NAMESPACE__ . '\populate_wp_template_data' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Ref DOTCOM-1782

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR removes the insertion of default pages for legacy FSE themes such as Varia. The main reasoning behind this change is to remove dependency to the /vertical template API.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Just in case, delete all pages on your site.
* Head to /wp-admin/options.php and set fse-page-data-v1 to 0.
* Switch your theme to Varia or Maywood.
* Ensure that the theme is activated as intended, and no pages are created.
