### PR TITLE
Revert "Social: Enable share status for all WPCOM sites"

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-social-enable-share-status-for-all-sites
+++ b/projects/plugins/wpcomsh/changelog/update-social-enable-share-status-for-all-sites
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Social: Enable share status for all sites

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -1110,7 +1110,12 @@ class WPCOM_Features {
 			self::WPCOM_ALL_SITES,
 		),
 		self::SOCIAL_SHARE_STATUS               => array(
-			self::WPCOM_ALL_SITES,
+			array(
+				// This feature isn't launched yet, so we're ensuring that it's not available on any plans.
+				'before' => '1900-01-01',
+				self::WPCOM_ALL_SITES,
+				self::JETPACK_ALL_SITES,
+			),
 		),
 		self::SOCIAL_IMAGE_AUTO_CONVERT         => array(
 			self::WPCOM_ALL_SITES,


### PR DESCRIPTION
Reverts Automattic/jetpack#42962

We are reverting this before the next release as Atomic sites can have a messed up structure

p1744317827962109-slack-C02LK1W8T4Z