### PR TITLE
Fix form undo redo issues

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/util/form.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/form.js
@@ -21,7 +21,7 @@ export const useFormWrapper = ( { attributes, clientId, name } ) => {
 		lock: { remove: true },
 	};
 
-	const { replaceBlock } = useDispatch( blockEditorStore );
+	const { replaceBlock, __unstableMarkNextChangeAsNotPersistent } = useDispatch( blockEditorStore );
 
 	const parents = useSelect( select => {
 		return select( blockEditorStore ).getBlockParentsByBlockName( clientId, FORM_BLOCK_NAME );
@@ -29,6 +29,9 @@ export const useFormWrapper = ( { attributes, clientId, name } ) => {
 
 	useEffect( () => {
 		if ( ! parents?.length ) {
+			// As this is an automated update, ensure if doesn't end up in the undo stack
+			// by calling `__unstableMarkNextChangeAsNotPersistent`.
+			__unstableMarkNextChangeAsNotPersistent();
 			replaceBlock(
 				clientId,
 				createBlock( FORM_BLOCK_NAME, {}, [

--- a/projects/packages/forms/src/blocks/contact-form/util/form.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/form.js
@@ -29,7 +29,7 @@ export const useFormWrapper = ( { attributes, clientId, name } ) => {
 
 	useEffect( () => {
 		if ( ! parents?.length ) {
-			// As this is an automated update, ensure if doesn't end up in the undo stack
+			// As this is an automated update, ensure it doesn't end up in the undo stack
 			// by calling `__unstableMarkNextChangeAsNotPersistent`.
 			__unstableMarkNextChangeAsNotPersistent();
 			replaceBlock(

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.js
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.js
@@ -5,7 +5,7 @@ import {
 } from '@wordpress/block-editor';
 import { createBlock, store as blocksStore } from '@wordpress/blocks';
 import { Button, Modal } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
@@ -21,6 +21,7 @@ const createBlocksFromInnerBlocksTemplate = innerBlocksTemplate => {
 };
 
 export default function VariationPicker( { blockName, setAttributes, clientId, classNames } ) {
+	const registry = useRegistry();
 	const [ isPatternsModalOpen, setIsPatternsModalOpen ] = useState( false );
 	const { replaceInnerBlocks, selectBlock } = useDispatch( blockEditorStore );
 	const { blockType, defaultVariation, variations } = useSelect(
@@ -57,18 +58,20 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 				) }
 				variations={ filter( variations, v => ! v.hiddenFromPicker ) }
 				onSelect={ ( nextVariation = defaultVariation ) => {
-					if ( nextVariation.attributes ) {
-						setAttributes( nextVariation.attributes );
-					}
+					registry.batch( () => {
+						if ( nextVariation.attributes ) {
+							setAttributes( nextVariation.attributes );
+						}
 
-					if ( nextVariation.innerBlocks ) {
-						replaceInnerBlocks(
-							clientId,
-							createBlocksFromInnerBlocksTemplate( nextVariation.innerBlocks )
-						);
-					}
+						if ( nextVariation.innerBlocks ) {
+							replaceInnerBlocks(
+								clientId,
+								createBlocksFromInnerBlocksTemplate( nextVariation.innerBlocks )
+							);
+						}
 
-					selectBlock( clientId );
+						selectBlock( clientId );
+					} );
 				} }
 			/>
 			<div className="form-placeholder__footer">

--- a/projects/packages/forms/src/blocks/field-consent/edit.js
+++ b/projects/packages/forms/src/blocks/field-consent/edit.js
@@ -68,7 +68,8 @@ export default function ConsentFieldEdit( props ) {
 	);
 	const { clientId: optionBlockId } = optionBlock ?? {};
 
-	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const { updateBlockAttributes, __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
 
 	const prevConsentType = usePrevious( consentType );
 	const prevLabel = usePrevious( optionBlock?.attributes?.label );
@@ -78,6 +79,9 @@ export default function ConsentFieldEdit( props ) {
 		if ( optionBlockId && consentType !== prevConsentType ) {
 			const label = consentType === 'explicit' ? explicitConsentMessage : implicitConsentMessage;
 
+			// As this is an automated update, ensure if doesn't end up in the undo stack
+			// by calling `__unstableMarkNextChangeAsNotPersistent`.
+			__unstableMarkNextChangeAsNotPersistent();
 			updateBlockAttributes( optionBlockId, {
 				label,
 				defaultLabel: sprintf(
@@ -95,6 +99,7 @@ export default function ConsentFieldEdit( props ) {
 		explicitConsentMessage,
 		implicitConsentMessage,
 		updateBlockAttributes,
+		__unstableMarkNextChangeAsNotPersistent,
 	] );
 
 	// Persist user-edited labels to the correct parent attribute.
@@ -109,6 +114,9 @@ export default function ConsentFieldEdit( props ) {
 		const isNewlyTyped = prevLabel && currentLabel !== prevLabel && currentLabel !== defaultLabel;
 
 		if ( isNewlyTyped ) {
+			// As this is an automated update, ensure if doesn't end up in the undo stack
+			// by calling `__unstableMarkNextChangeAsNotPersistent`.
+			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( {
 				[ consentType === 'explicit' ? 'explicitConsentMessage' : 'implicitConsentMessage' ]:
 					currentLabel,
@@ -121,6 +129,7 @@ export default function ConsentFieldEdit( props ) {
 		prevConsentType,
 		defaultLabels,
 		setAttributes,
+		__unstableMarkNextChangeAsNotPersistent,
 	] );
 
 	const onShareFieldAttributesChange = useCallback(

--- a/projects/packages/forms/src/blocks/field-consent/edit.js
+++ b/projects/packages/forms/src/blocks/field-consent/edit.js
@@ -79,7 +79,7 @@ export default function ConsentFieldEdit( props ) {
 		if ( optionBlockId && consentType !== prevConsentType ) {
 			const label = consentType === 'explicit' ? explicitConsentMessage : implicitConsentMessage;
 
-			// As this is an automated update, ensure if doesn't end up in the undo stack
+			// As this is an automated update, ensure it doesn't end up in the undo stack
 			// by calling `__unstableMarkNextChangeAsNotPersistent`.
 			__unstableMarkNextChangeAsNotPersistent();
 			updateBlockAttributes( optionBlockId, {
@@ -114,7 +114,7 @@ export default function ConsentFieldEdit( props ) {
 		const isNewlyTyped = prevLabel && currentLabel !== prevLabel && currentLabel !== defaultLabel;
 
 		if ( isNewlyTyped ) {
-			// As this is an automated update, ensure if doesn't end up in the undo stack
+			// As this is an automated update, ensure it doesn't end up in the undo stack
 			// by calling `__unstableMarkNextChangeAsNotPersistent`.
 			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( {

--- a/projects/packages/forms/src/blocks/field-textarea/edit.js
+++ b/projects/packages/forms/src/blocks/field-textarea/edit.js
@@ -28,7 +28,7 @@ export default function TextareaFieldEdit( props ) {
 	const templateLabel = label ?? '';
 	const template = useMemo( () => {
 		return [
-			[ 'jetpack/label', { label: templateLabel, required, defaultLabel, requiredText } ],
+			[ 'jetpack/label', { label: templateLabel, defaultLabel, requiredText } ],
 			[ 'jetpack/input', { type: 'textarea' } ],
 		];
 	}, [ templateLabel, defaultLabel, required, requiredText ] );

--- a/projects/packages/forms/src/blocks/field-textarea/edit.js
+++ b/projects/packages/forms/src/blocks/field-textarea/edit.js
@@ -1,5 +1,5 @@
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
-import { useEffect, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import JetpackFieldControls from '../shared/components/jetpack-field-controls';
@@ -13,7 +13,6 @@ export default function TextareaFieldEdit( props ) {
 	const { required, width } = attributes;
 
 	useFormWrapper( props );
-
 	const { blockStyle } = useJetpackFieldStyles( attributes );
 	const { isInnerBlockSelected, hasPlaceholder } = useFieldSelected( clientId );
 	const blockProps = useBlockProps( {
@@ -25,25 +24,20 @@ export default function TextareaFieldEdit( props ) {
 	} );
 
 	const defaultLabel = __( 'Message', 'jetpack-forms' );
+
+	const templateLabel = label ?? '';
 	const template = useMemo( () => {
 		return [
-			[ 'jetpack/label', { label, required, defaultLabel, requiredText } ],
+			[ 'jetpack/label', { label: templateLabel, required, defaultLabel, requiredText } ],
 			[ 'jetpack/input', { type: 'textarea' } ],
 		];
-	}, [ label, defaultLabel, required, requiredText ] );
+	}, [ templateLabel, defaultLabel, required, requiredText ] );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_INNER_BLOCKS,
 		template,
 		templateLock: 'all',
 	} );
-
-	useEffect( () => {
-		if ( label === null || label === undefined ) {
-			setAttributes( { label: '' } );
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
 
 	return (
 		<>

--- a/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
@@ -13,7 +13,7 @@ export default function useFormWrapper( { attributes, clientId, name } ) {
 		lock: { remove: true },
 	};
 
-	const { replaceBlock } = useDispatch( blockEditorStore );
+	const { replaceBlock, __unstableMarkNextChangeAsNotPersistent } = useDispatch( blockEditorStore );
 
 	const parents = useSelect( select => {
 		return select( blockEditorStore ).getBlockParentsByBlockName( clientId, FORM_BLOCK_NAME );
@@ -21,6 +21,9 @@ export default function useFormWrapper( { attributes, clientId, name } ) {
 
 	useEffect( () => {
 		if ( ! parents?.length ) {
+			// As this is an automated update, ensure if doesn't end up in the undo stack
+			// by calling `__unstableMarkNextChangeAsNotPersistent`.
+			__unstableMarkNextChangeAsNotPersistent();
 			replaceBlock(
 				clientId,
 				createBlock( FORM_BLOCK_NAME, {}, [

--- a/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
@@ -21,7 +21,7 @@ export default function useFormWrapper( { attributes, clientId, name } ) {
 
 	useEffect( () => {
 		if ( ! parents?.length ) {
-			// As this is an automated update, ensure if doesn't end up in the undo stack
+			// As this is an automated update, ensure it doesn't end up in the undo stack
 			// by calling `__unstableMarkNextChangeAsNotPersistent`.
 			__unstableMarkNextChangeAsNotPersistent();
 			replaceBlock(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

NOTE: This branch merges into the branch from #42890 and not trunk. It's part of a number of iterative improvements to that branch which are being split into separate PRs to make things easier to review.

## Proposed changes:
There are a few undo/redo stack issues with form and field blocks, some present in #42890 and some probably in trunk too.

This generally happens when `useEffect` is used in a block and that effect updates block attributes. This generally modifies the underlying post, and so causes undo stack entries, but it can be confusing for the user if they didn't take an action that could cause these entries.

The current way to mitigate this is to use the `__unstableMarkNextChangeAsNotPersistent` action. This merges the next action with the previous one on the undo stack.

In the Multiline text field block it was a little more complicated, as the effect also causes the templated inner blocks to be updated. My fix there is to remove the effect as I'm not sure it's required now.

Another cause of undo stack issues can be dispatching multiple actions without batching them (using registry.batch). In the `VariationPicker`, this was causing multiple undo entries where you could undo once to return to the placeholder, and undo a second time to undo some padding that's added to the form.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
### Multi line text field
1. Create a new post
2. Add a contact form
3. Remove all fields apart from the multi-line text field
4. Save the post
5. Reload the page
6. Observe that the Undo button isn't enabled (in trunk or [#42890](https://github.com/Automattic/jetpack/pull/42890) it is active) 

### Consent
1. Create a new post
2. Add a contact form
3. Add a consent field
4. Change the 'Permission to email' setting back and forth a few times
5. Try using undo to undo the changes.
6. Undo should work without any problems (in [#42890](https://github.com/Automattic/jetpack/pull/42890) it can take two clicks and sometimes get stuck)

### useFormWrapper
1. Start with a new empty post
2. Open the inserter and select a Number input field (or any field block that implements `useFormWrapper`.
3. Observe that the number field is inserted and automatically wrapped in a form with a button
4. Press undo, the number should be removed (in trunk or [#42890](https://github.com/Automattic/jetpack/pull/42890) it can take two undo clicks and sometimes get stuck)

### RSVP Variation
1. Start with a new empty post
2. Insert a form block and select the RSVP variation
3. Press undo
4. You should be taken back to the block placeholder state (in [#42890](https://github.com/Automattic/jetpack/pull/42890) it can take two clicks on the undo button to get back to the placeholder). Check also that there's no additional padding above and below the block when the placeholder is visible.

### Lead capture variation
1. Start with a new empty post
2. Insert a form block and select the Lead capture variation
3. Press undo
4. You should be taken back to the block placeholder state (in [#42890](https://github.com/Automattic/jetpack/pull/42890) it can take two undo clicks and the form styles can appear broken between undos). Check also that there's no additional padding above and below the block when the placeholder is visible.