### PR TITLE
Sync: Convert to array theme data to avoid fatals when checking update changes

### DIFF
--- a/projects/packages/sync/changelog/update-sync-update-checksums-convert-to-array-theme-data-to-avoid-fatals
+++ b/projects/packages/sync/changelog/update-sync-update-checksums-convert-to-array-theme-data-to-avoid-fatals
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Fatal removal for sites with wrong info in update_themes site transient
+
+

--- a/projects/packages/sync/changelog/update-sync-update-checksums-convert-to-array-theme-data-to-avoid-warnings
+++ b/projects/packages/sync/changelog/update-sync-update-checksums-convert-to-array-theme-data-to-avoid-warnings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Warning removal for sites with wrong info in update_themes site transient
+
+

--- a/projects/packages/sync/changelog/update-sync-update-checksums-convert-to-array-theme-data-to-avoid-warnings
+++ b/projects/packages/sync/changelog/update-sync-update-checksums-convert-to-array-theme-data-to-avoid-warnings
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Warning removal for sites with wrong info in update_themes site transient
-
-

--- a/projects/packages/sync/src/modules/class-updates.php
+++ b/projects/packages/sync/src/modules/class-updates.php
@@ -230,9 +230,10 @@ class Updates extends Module {
 		switch ( $transient ) {
 			case 'update_plugins':
 				if ( ! empty( $update->response ) && is_array( $update->response ) ) {
-					foreach ( $update->response as $plugin_slug => $response ) {
-						if ( ! empty( $plugin_slug ) && isset( $response->new_version ) ) {
-							$updates[] = array( $plugin_slug => $response->new_version );
+					foreach ( $update->response as $plugin_slug => $plugin_data ) {
+						$plugin_data = (array) $plugin_data;
+						if ( ! empty( $plugin_slug ) && isset( $plugin_data['new_version'] ) ) {
+							$updates[] = array( $plugin_slug => $plugin_data['new_version'] );
 						}
 					}
 				}
@@ -247,9 +248,10 @@ class Updates extends Module {
 				break;
 			case 'update_themes':
 				if ( ! empty( $update->response ) && is_array( $update->response ) ) {
-					foreach ( $update->response as $theme_slug => $response ) {
-						if ( ! empty( $theme_slug ) && isset( $response['new_version'] ) ) {
-							$updates[] = array( $theme_slug => $response['new_version'] );
+					foreach ( $update->response as $theme_slug => $theme_data ) {
+						$theme_data = (array) $theme_data;
+						if ( ! empty( $theme_slug ) && isset( $theme_data['new_version'] ) ) {
+							$updates[] = array( $theme_slug => $theme_data['new_version'] );
 						}
 					}
 				}
@@ -261,12 +263,12 @@ class Updates extends Module {
 				break;
 			case 'update_core':
 				if ( ! empty( $update->updates ) && is_array( $update->updates ) ) {
-					foreach ( $update->updates as $response ) {
-						if ( ! empty( $response->response ) && 'latest' === $response->response ) {
+					foreach ( $update->updates as $core_update ) {
+						if ( ! empty( $core_update->response ) && 'latest' === $core_update->response ) {
 							continue;
 						}
-						if ( ! empty( $response->response ) && isset( $response->packages->full ) ) {
-							$updates[] = array( $response->response => $response->packages->full );
+						if ( ! empty( $core_update->response ) && isset( $core_update->packages->full ) ) {
+							$updates[] = array( $core_update->response => $core_update->packages->full );
 						}
 					}
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We were getting Fatal errors  `Cannot use object of type stdClass as array when trying to access $response['new_version'] `in this [line](https://github.com/Automattic/jetpack/blob/1662c02/projects/packages/sync/src/modules/class-updates.php#L251). 

This is probably due to some theme sending the wrong structure and impacting us when retrieving the `update_themes` site transient. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Prevent the possibility of Fatals by converting to arrays the responses from `update_themes` and `update_plugins`.
* Renamed the variables in the for loops for clarity.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/vulcan/issues/764

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code Review should suffice here

