### PR TITLE
Blogroll block: Prevent console / PHP warnings and broken block with blogroll items

### DIFF
--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -166,7 +166,6 @@ return [
         'enhanced-open-graph.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable'],
         'extensions/blocks/ai-chat/ai-chat.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument'],
         'extensions/blocks/blog-stats/blog-stats.php' => ['PhanTypeMismatchReturnProbablyReal'],
-        'extensions/blocks/blogroll/blogroll-item/blogroll-item.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'extensions/blocks/calendly/calendly.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/donations/donations.php' => ['PhanTypeMismatchArgument'],
         'extensions/blocks/gif/gif.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],

--- a/projects/plugins/jetpack/changelog/fix-blogroll-block-key-some-console-warnings
+++ b/projects/plugins/jetpack/changelog/fix-blogroll-block-key-some-console-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Blogroll block: Prevent console warnings and block validation issues when adding new items to the blogroll.

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php
@@ -46,12 +46,12 @@ function load_assets( $attr, $content, $block ) {
 	 */
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 	$kses_defaults             = wp_kses_allowed_html( 'post' );
-	$name                      = wp_kses( $attr['name'], $kses_defaults );
-	$name_attr                 = esc_attr( $attr['name'] );
-	$id                        = esc_attr( $attr['id'] );
-	$url                       = esc_url( $attr['url'] );
-	$description               = wp_kses( $attr['description'], $kses_defaults );
-	$icon                      = esc_attr( isset( $attr['icon'] ) ? $attr['icon'] : null );
+	$name                      = wp_kses( $attr['name'] ?? '', $kses_defaults );
+	$name_attr                 = esc_attr( $attr['name'] ?? '' );
+	$id                        = esc_attr( $attr['id'] ?? '' );
+	$url                       = esc_url( $attr['url'] ?? '' );
+	$description               = wp_kses( $attr['description'] ?? '', $kses_defaults );
+	$icon                      = esc_attr( $attr['icon'] ?? null );
 	$target                    = esc_attr( $block->context['openLinksNewWindow'] ? '_blank' : '_self' );
 	$email                     = esc_attr( get_current_user_id() ? get_userdata( get_current_user_id() )->user_email : '' );
 	$wp_nonce                  = esc_attr( wp_create_nonce( 'blogsub_subscribe_' . $id ) );

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/components/blogroll-appender-results/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/components/blogroll-appender-results/index.js
@@ -41,14 +41,17 @@ export default function BlogrollAppenderResults( { results, onSelect, searchInpu
 			) }
 			{ results.length > 0 && (
 				<ul aria-live="polite">
-					{ results.map( result => {
+					{ results.map( ( result, index ) => {
 						const isDuplicate =
 							siteRecommendations?.some?.( siteRecommendation => {
 								return siteRecommendation?.id === result?.blog_id;
 							} ) || false;
 
 						return (
-							<li key={ result.blog_id } className="jetpack-blogroll__appender-result-container">
+							<li
+								key={ `${ result.blog_id }-${ index }` }
+								className="jetpack-blogroll__appender-result-container"
+							>
 								<button
 									className="jetpack-blogroll__appender-result-title"
 									disabled={ isDuplicate }

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/components/blogroll-appender-results/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/components/blogroll-appender-results/index.js
@@ -42,9 +42,10 @@ export default function BlogrollAppenderResults( { results, onSelect, searchInpu
 			{ results.length > 0 && (
 				<ul aria-live="polite">
 					{ results.map( result => {
-						const isDuplicate = siteRecommendations.some( siteRecommendation => {
-							return siteRecommendation?.id === result?.blog_id;
-						} );
+						const isDuplicate =
+							siteRecommendations?.some?.( siteRecommendation => {
+								return siteRecommendation?.id === result?.blog_id;
+							} ) || false;
 
 						return (
 							<li key={ result.blog_id } className="jetpack-blogroll__appender-result-container">


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/43041

## Proposed changes:

* This PR prevents two console warnings and a block validation issue with the Blogroll block. It also prevents a PHP warning
* Both console warnings were related to the Blogroll block blogroll item inserter. The first issue occurs when attempting to add an item on an existing blogroll block. The warning is `Uncaught TypeError: Cannot read properties of null (reading 'some')` - and a block validation error shows in the block itself, fixable only by refreshing the page (though adding a new item becomes difficult).
* The second occurs on a newly added Blogroll block, again when attempting to add an item. This warning is only replicable with script debug enabled: `Warning: Encountered two children with the same key, `0`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behaviour is unsupported and could change in a future version.`
* There is also a PHP warning when loading a page with the block - `PHP Warning:  Undefined array key "id"` related to `projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php on line 51`. Several items do not have default fallbacks so adding these would help prevent the warnings (assuming they could occur for other attributes as well).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

To replicate the issue: 

First console warning:
* Self-hosted only: On a Jetpack-connected test site, add a new post and add a Blogroll block
* Once the block has loaded with a few blogroll items, click on the icon to add a new blogroll item
* If you have script debug enabled (`define( 'SCRIPT_DEBUG', 'true' );` added to `wp-config.php`) you will see a console warning related to encountering two children with the same key

Second console warning:
* Self-hosted, WoA and Simple: Save and refresh the post / page where you previously added a Blogroll block
* Click the icon to add a new blogroll item
* This time you should see a different console warning (related to not being able to read properties of null (reading 'some')
* You should also see a block validation issue on the block itself

PHP warning: 
*On refreshing  / opening a page with an existing block, I could see a PHP warning as well: `PHP Warning:  Undefined array key "id"` related to `projects/plugins/jetpack/extensions/blocks/blogroll/blogroll-item/blogroll-item.php on line 51`.

To test the fix:

* Apply this PR locally (or using the Jetpack beta tester plugin on self-hosted or WoA sites). On Simple, use the command in the generated comment below for a sandboxed Simple site).
* Follow the same steps as above
* The console warnings should no longer show (nor the PHP warning if you were able to see this), and you should be able to insert new items without issue

