### PR TITLE
Stats: update home tracking pixel

### DIFF
--- a/projects/packages/stats/changelog/update-home-tracking-pixel
+++ b/projects/packages/stats/changelog/update-home-tracking-pixel
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update home tracking pixel to match archive ones.

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -89,7 +89,7 @@ class Tracking_Pixel {
 
 		if ( $is_not_post ) {
 			if ( $wp_the_query->is_home() ) {
-				$view_data['home'] = '1';
+				$view_data['arch_home'] = '1';
 			} elseif ( $wp_the_query->is_search() ) {
 				$view_data['arch_search']  = sanitize_text_field( $wp_the_query->query['s'] );
 				$view_data['arch_filters'] = sanitize_text_field( self::build_search_filters( $wp_the_query ) );

--- a/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
+++ b/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
@@ -71,7 +71,7 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 			'srv'        => 'example.org',
 			'utm_id'     => 'some_id',
 			'utm_source' => 'a_source',
-			'home'       => '1',
+			'arch_home'  => '1',
 		);
 		$this->assertSame( $expected_view_data, $view_data );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up for #42368.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the `home` tracking pixel to match the archive ones prefixed by `arch_*`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pgbpWj-8u-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, the data is the same. Just the way it's being tracked that was changed.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Access the homepage of a site in an incognito window.
* Check the network requests. The ones made against `/g.gif` should have `arch_home=1` in their query string.

