### PR TITLE
Hides the Blaze badge on the Stats page when the feature is disabled

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-blaze-badge-stats-page
+++ b/projects/packages/stats-admin/changelog/fix-blaze-badge-stats-page
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Hides the Blaze badge when the feature is disabled
+
+

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -6,6 +6,7 @@
 	"require": {
 		"php": ">=7.2",
 		"automattic/jetpack-connection": "@dev",
+		"automattic/jetpack-blaze": "@dev",
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-plans": "@dev",
 		"automattic/jetpack-stats": "@dev",

--- a/projects/packages/stats-admin/src/class-odyssey-config-data.php
+++ b/projects/packages/stats-admin/src/class-odyssey-config-data.php
@@ -40,6 +40,8 @@ class Odyssey_Config_Data {
 		$blog_id = Jetpack_Options::get_option( 'id' );
 		$host    = new Host();
 
+		$can_blaze = class_exists( 'Automattic\Jetpack\Blaze' ) && \Automattic\Jetpack\Blaze::should_initialize()['can_init'] === true;
+
 		return array(
 			'admin_page_base'                => $this->get_admin_path(),
 			'api_root'                       => esc_url_raw( rest_url() ),
@@ -96,6 +98,7 @@ class Odyssey_Config_Data {
 								'jetpack_version'       => defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '',
 								'stats_admin_version'   => Main::VERSION,
 								'software_version'      => $wp_version,
+								'can_blaze'             => $can_blaze,
 							),
 						),
 					),

--- a/projects/packages/stats-admin/src/class-odyssey-config-data.php
+++ b/projects/packages/stats-admin/src/class-odyssey-config-data.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Stats_Admin;
 
+use Automattic\Jetpack\Blaze;
 use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Status\Host;
@@ -40,7 +41,7 @@ class Odyssey_Config_Data {
 		$blog_id = Jetpack_Options::get_option( 'id' );
 		$host    = new Host();
 
-		$can_blaze = class_exists( 'Automattic\Jetpack\Blaze' ) && \Automattic\Jetpack\Blaze::should_initialize()['can_init'] === true;
+		$can_blaze = class_exists( 'Automattic\Jetpack\Blaze' ) && Blaze::should_initialize()['can_init'];
 
 		return array(
 			'admin_page_base'                => $this->get_admin_path(),

--- a/projects/plugins/jetpack/changelog/fix-blaze-badge-stats-page
+++ b/projects/plugins/jetpack/changelog/fix-blaze-badge-stats-page
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2704,9 +2704,10 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/stats-admin",
-				"reference": "ba5965287a795a75d5f05b923bdc478d9d71743a"
+				"reference": "d6c733cb5102f8189dcaa1d9b77e5b34403fa32e"
 			},
 			"require": {
+				"automattic/jetpack-blaze": "@dev",
 				"automattic/jetpack-connection": "@dev",
 				"automattic/jetpack-constants": "@dev",
 				"automattic/jetpack-jitm": "@dev",

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-blaze-badge-stats-page
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-blaze-badge-stats-page
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1473,9 +1473,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "ba5965287a795a75d5f05b923bdc478d9d71743a"
+                "reference": "d6c733cb5102f8189dcaa1d9b77e5b34403fa32e"
             },
             "require": {
+                "automattic/jetpack-blaze": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
                 "automattic/jetpack-jitm": "@dev",

--- a/projects/plugins/wpcomsh/changelog/fix-blaze-badge-stats-page
+++ b/projects/plugins/wpcomsh/changelog/fix-blaze-badge-stats-page
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1681,9 +1681,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "ba5965287a795a75d5f05b923bdc478d9d71743a"
+                "reference": "d6c733cb5102f8189dcaa1d9b77e5b34403fa32e"
             },
             "require": {
+                "automattic/jetpack-blaze": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
                 "automattic/jetpack-jitm": "@dev",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/101987

We are displaying the Blaze link on the Stats page when the Blaze feature is off; if users click it, they will end up on an invalid page. The main problem is that the site and user connection are now handled separately, and it's more common to land on this case. (Blaze needs both connections to work correctly).

## Proposed changes:

Include the `can_blaze` flag as one of the initial parameters for the Jetpack Stats module (Odyssey app). 

**Note for Reviewers:** Because of a phan error, I had to include the blaze package as a dependency in the Stats. Please let me know if there are different ways to do this. I guarded my code in case the stats module is working on a standalone solution.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

You will need to have a site with some stats, so try to access the posts a couple of times before starting the test.

* Access any self-hosted and navigate to Jetpack->Stats
* Verify that you see the Blaze badge on any of the posts from the "Post & Pages" section:
![Screenshot 2025-04-11 at 5 02 40 PM](https://github.com/user-attachments/assets/d488406f-3d79-44cf-98f2-1329f0fff677)
* Now disconnect your user from WPCOM (just the user)
* Go back to Jetpack->Stats and verify that you no longer see the Blaze Badge.

