### PR TITLE
Social: re-enable share status for Atomic sites

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-social-enable-share-status-for-all-sites
+++ b/projects/plugins/wpcomsh/changelog/update-social-enable-share-status-for-all-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Social: Enable share status for all sites

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -1110,12 +1110,7 @@ class WPCOM_Features {
 			self::WPCOM_ALL_SITES,
 		),
 		self::SOCIAL_SHARE_STATUS               => array(
-			array(
-				// This feature isn't launched yet, so we're ensuring that it's not available on any plans.
-				'before' => '1900-01-01',
-				self::WPCOM_ALL_SITES,
-				self::JETPACK_ALL_SITES,
-			),
+			self::WPCOM_ALL_SITES,
 		),
 		self::SOCIAL_IMAGE_AUTO_CONVERT         => array(
 			self::WPCOM_ALL_SITES,


### PR DESCRIPTION
This reverts commit da9daa9b0c29c5dcbe2d2ed179e8f295c6b8be7e.

We had to revert #42962 via #43034 to avoid an issue on Atomic sites which didn't have the latest Jetapck release yet.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Redo #42962

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See #42962

