### PR TITLE
Forms: new integrations modal

### DIFF
--- a/projects/packages/forms/changelog/update-forms-integrations-modal-release
+++ b/projects/packages/forms/changelog/update-forms-integrations-modal-release
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: new integrations setup modal

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -249,7 +249,7 @@ class Contact_Form_Block {
 				'akismetActiveWithKey' => $akismet_active_with_key,
 				'akismetUrl'           => $akismet_key_url,
 				'assetsUrl'            => Jetpack_Forms::assets_url(),
-				'isFormModalEnabled'   => Contact_Form_Plugin::is_form_modal_enabled(),
+				'isFormModalEnabled'   => true, // Disable or enable integrations modal and use sidebar panels instead
 			),
 		);
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2344,14 +2344,4 @@ class Contact_Form_Plugin {
 
 		return $is_wpcom || $should_enable_tracking;
 	}
-
-	/**
-	 * Check if the form modal interface should be enabled.
-	 * This is a development-only feature flag.
-	 *
-	 * @return bool
-	 */
-	public static function is_form_modal_enabled() {
-		return defined( 'JETPACK_IS_FORM_MODAL_ENABLED' ) && JETPACK_IS_FORM_MODAL_ENABLED;
-	}
 }

--- a/projects/plugins/jetpack/changelog/update-forms-integrations-modal-release
+++ b/projects/plugins/jetpack/changelog/update-forms-integrations-modal-release
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: new integrations setup modal


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Forms: release new integration setup modal instead of sidebar panels

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add forms block in the editor
* Go to sidebar
* Manage integrations
* You can disable/enable integrations in the modal, whereas previously these were handled in the sidebar

