### PR TITLE
Jetpack Connection: Add Jetpack package versions' info to Heartbeat

### DIFF
--- a/projects/packages/connection/changelog/update-add-jp-package-versions-to-heartbeat
+++ b/projects/packages/connection/changelog/update-add-jp-package-versions-to-heartbeat
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Jetpack Connection: Add Jetpack package versions' info to Heartbeat

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -2728,6 +2728,8 @@ class Manager {
 	/**
 	 * If the site-level connection is active, add the list of plugins using connection to the heartbeat (except Jetpack itself)
 	 *
+	 * @since $$next-version$$ Add the list of Jetpack package versions to the heartbeat.
+	 *
 	 * @param array $stats The Heartbeat stats array.
 	 * @return array $stats
 	 */
@@ -2744,6 +2746,9 @@ class Manager {
 				$stats[ $stats_group ][] = $plugin_slug;
 			}
 		}
+
+		$stats['jetpack_package_versions'] = apply_filters( 'jetpack_package_versions', array() );
+
 		return $stats;
 	}
 

--- a/projects/plugins/jetpack/changelog/update-add-jp-package-versions-to-heartbeat
+++ b/projects/plugins/jetpack/changelog/update-add-jp-package-versions-to-heartbeat
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Added a unit test for Jetpack Heartbeat
+
+

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Module_Stats_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Module_Stats_Test.php
@@ -35,6 +35,25 @@ class Jetpack_Sync_Module_Stats_Test extends Jetpack_Sync_TestBase {
 	}
 
 	/**
+	 * Tests that jetpack_package_versions is present in stats data.
+	 */
+	public function test_sends_jetpack_package_versions_data_on_heartbeat() {
+		$heartbeat = Heartbeat::init();
+
+		add_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
+		$heartbeat->cron_exec();
+		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
+
+		$this->sender->do_sync();
+
+		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_heartbeat_stats' );
+
+		$this->assertArrayHasKey( 'jetpack_package_versions', $action->args[0] );
+		$this->assertArrayHasKey( 'connection', $action->args[0]['jetpack_package_versions'] );
+		$this->assertArrayHasKey( 'sync', $action->args[0]['jetpack_package_versions'] );
+	}
+
+	/**
 	 * Tests that expensive data is not sent on heartbeat.
 	 *
 	 * @return void


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Adds Jetpack package versions' info to Heartbeat. This will allow us to process the corresponding Heartbeat info on WordPress.com and ensure the `jetpack_package_versions` we store in the Cache sites are up-to-date.
This step will allow us to switch the option to a callable, similar to what we did in the past for `jetpack_connection_active_plugins`

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Connection\Manager::add_stats_to_heartbeat`: Add `jetpack_package_versions` to Jetpack Connection related Heartbeat info.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
180553-ghe-Automattic/wpcom

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No, we already track `jetpack_package_versions` option via the Sync package. This PR just adds the same info in the Heartbeat in order to ensure the corresponding option on WPCOM is always up-to-date.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* WPCOM counterpart: 180553-ghe-Automattic/wpcom