### PR TITLE
Classic Theme Helper: Theme compat - remove duplicated functionality

### DIFF
--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -20,7 +20,7 @@ return [
     // PhanDeprecatedFunction : 60+ occurrences
     // PhanPossiblyUndeclaredVariable : 55+ occurrences
     // PhanTypeArraySuspiciousNullable : 55+ occurrences
-    // PhanRedefineFunction : 50+ occurrences
+    // PhanRedefineFunction : 45+ occurrences
     // PhanTypeMismatchArgumentNullable : 45+ occurrences
     // PhanPluginDuplicateAdjacentStatement : 40+ occurrences
     // PhanTypeMismatchArgumentInternal : 40+ occurrences
@@ -390,8 +390,6 @@ return [
         'modules/subscriptions.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeSuspiciousNonTraversableForeach'],
         'modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php' => ['PhanTypeMismatchReturnNullable'],
         'modules/subscriptions/views.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMissingReturn', 'PhanTypePossiblyInvalidDimOffset'],
-        'modules/theme-tools/compat/twentyfourteen.php' => ['PhanRedefineFunction'],
-        'modules/theme-tools/compat/twentynineteen.php' => ['PhanRedefineFunction'],
         'modules/theme-tools/content-options.php' => ['PhanRedefineFunction'],
         'modules/theme-tools/content-options/author-bio.php' => ['PhanRedefineFunction', 'PhanTypeMismatchArgument'],
         'modules/theme-tools/content-options/blog-display.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanRedefineFunction'],

--- a/projects/plugins/jetpack/changelog/update-theme-tools-compat-remove-duplication
+++ b/projects/plugins/jetpack/changelog/update-theme-tools-compat-remove-duplication
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Theme compat: Removing duplicated code where it is now served by the Classic Theme Helper package

--- a/projects/plugins/jetpack/modules/theme-tools/compat/twentyfifteen.php
+++ b/projects/plugins/jetpack/modules/theme-tools/compat/twentyfifteen.php
@@ -7,17 +7,6 @@
  */
 
 /**
- * Add Jetpack theme supports for Twenty Fifteen.
- */
-function twentyfifteen_jetpack_setup() {
-	/**
-	 * Add theme support for Responsive Videos.
-	 */
-	add_theme_support( 'jetpack-responsive-videos' );
-}
-add_action( 'after_setup_theme', 'twentyfifteen_jetpack_setup' );
-
-/**
  * Enqueue Jetpack compat styles for Twenty Fifteen.
  */
 function twentyfifteen_init_jetpack() {

--- a/projects/plugins/jetpack/modules/theme-tools/compat/twentyfourteen.php
+++ b/projects/plugins/jetpack/modules/theme-tools/compat/twentyfourteen.php
@@ -6,51 +6,6 @@
  * @package automattic/jetpack
  */
 
-if ( ! function_exists( 'twentyfourteen_featured_content_post_ids' ) ) {
-	/**
-	 * A last try to show posts, in case the Featured Content plugin returns no IDs.
-	 *
-	 * @param array $featured_ids Array of 'featured' post IDs.
-	 * @return array
-	 */
-	function twentyfourteen_featured_content_post_ids( $featured_ids ) {
-		if ( empty( $featured_ids ) ) {
-			$featured_ids = array_slice( get_option( 'sticky_posts', array() ), 0, 6 );
-		}
-
-		return $featured_ids;
-	}
-	add_action( 'featured_content_post_ids', 'twentyfourteen_featured_content_post_ids' );
-}
-
-if ( ! function_exists( 'twentyfourteen_customizer_default' ) ) {
-	/**
-	 * Set the default tag name for Featured Content.
-	 *
-	 * @param WP_Customize_Manager $wp_customize Theme Customizer object.
-	 * @return void
-	 */
-	function twentyfourteen_customizer_default( $wp_customize ) {
-		$wp_customize->get_setting( 'featured-content[tag-name]' )->default = 'featured';
-	}
-	add_action( 'customize_register', 'twentyfourteen_customizer_default' );
-}
-
-if ( ! function_exists( 'twentyfourteen_featured_content_default_settings' ) ) {
-	/**
-	 * Sets a default tag of 'featured' for Featured Content.
-	 *
-	 * @param array $settings Featured content settings.
-	 * @return array
-	 */
-	function twentyfourteen_featured_content_default_settings( $settings ) {
-		$settings['tag-name'] = 'featured';
-
-		return $settings;
-	}
-	add_action( 'featured_content_default_settings', 'twentyfourteen_featured_content_default_settings' );
-}
-
 /**
  * Removes sharing markup from post content if we're not in the loop and it's a
  * formatted post.

--- a/projects/plugins/jetpack/modules/theme-tools/compat/twentynineteen.php
+++ b/projects/plugins/jetpack/modules/theme-tools/compat/twentynineteen.php
@@ -23,34 +23,6 @@ function twentynineteen_jetpack_setup() {
 			'footer'    => 'page',
 		)
 	);
-
-	/**
-	 * Add theme support for Responsive Videos.
-	 */
-	add_theme_support( 'jetpack-responsive-videos' );
-
-	/**
-	 * Add theme support for Content Options.
-	 */
-	add_theme_support(
-		'jetpack-content-options',
-		array(
-			'blog-display'    => array( 'content', 'excerpt' ),
-			'post-details'    => array(
-				'stylesheet' => 'twentynineteen-style',
-				'date'       => '.posted-on',
-				'categories' => '.cat-links',
-				'tags'       => '.tags-links',
-				'author'     => '.byline',
-				'comment'    => '.comments-link',
-			),
-			'featured-images' => array(
-				'archive' => true,
-				'post'    => true,
-				'page'    => true,
-			),
-		)
-	);
 }
 add_action( 'after_setup_theme', 'twentynineteen_jetpack_setup' );
 
@@ -91,37 +63,6 @@ function twentynineteen_gallery_widget_content_width() {
 	return 390;
 }
 add_filter( 'gallery_widget_content_width', 'twentynineteen_gallery_widget_content_width' );
-
-if ( ! function_exists( 'twentynineteen_override_post_thumbnail' ) ) {
-	/**
-	 * Alter featured-image default visibility for content-options.
-	 */
-	function twentynineteen_override_post_thumbnail() {
-		$options         = get_theme_support( 'jetpack-content-options' );
-		$featured_images = ( ! empty( $options[0]['featured-images'] ) ) ? $options[0]['featured-images'] : null;
-
-		$settings = array(
-			'post-default' => ( isset( $featured_images['post-default'] ) && false === $featured_images['post-default'] ) ? '' : 1,
-			'page-default' => ( isset( $featured_images['page-default'] ) && false === $featured_images['page-default'] ) ? '' : 1,
-		);
-
-		$settings = array_merge(
-			$settings,
-			array(
-				'post-option' => get_option( 'jetpack_content_featured_images_post', $settings['post-default'] ),
-				'page-option' => get_option( 'jetpack_content_featured_images_page', $settings['page-default'] ),
-			)
-		);
-
-		if ( ( ! $settings['post-option'] && is_single() )
-		|| ( ! $settings['page-option'] && is_singular() && is_page() ) ) {
-			return false;
-		} else {
-			return ! post_password_required() && ! is_attachment() && has_post_thumbnail();
-		}
-	}
-	add_filter( 'twentynineteen_can_show_post_thumbnail', 'twentynineteen_override_post_thumbnail', 10, 2 );
-}
 
 /**
  * Adds custom classes to the array of body classes.

--- a/projects/plugins/jetpack/modules/theme-tools/compat/twentysixteen.php
+++ b/projects/plugins/jetpack/modules/theme-tools/compat/twentysixteen.php
@@ -7,17 +7,6 @@
  */
 
 /**
- * Add Jetpack theme supports for Twenty Sixteen.
- */
-function twentysixteen_jetpack_setup() {
-	/**
-	 * Add theme support for Responsive Videos.
-	 */
-	add_theme_support( 'jetpack-responsive-videos' );
-}
-add_action( 'after_setup_theme', 'twentysixteen_jetpack_setup' );
-
-/**
  * Enqueue Jetpack compat styles for Twenty Sixteen.
  */
 function twentysixteen_init_jetpack() {

--- a/projects/plugins/jetpack/modules/theme-tools/compat/twentytwenty.php
+++ b/projects/plugins/jetpack/modules/theme-tools/compat/twentytwenty.php
@@ -30,26 +30,6 @@ function twentytwenty_jetpack_setup() {
 			),
 		)
 	);
-
-	// Add theme support for Content Options.
-	add_theme_support(
-		'jetpack-content-options',
-		array(
-			'post-details'    => array(
-				'stylesheet' => 'twentytwenty-style',
-				'date'       => '.post-date',
-				'categories' => '.entry-categories',
-				'tags'       => '.post-tags',
-				'author'     => '.post-author',
-			),
-			'featured-images' => array(
-				'archive'  => true,
-				'post'     => true,
-				'page'     => true,
-				'fallback' => false,
-			),
-		)
-	);
 }
 add_action( 'after_setup_theme', 'twentytwenty_jetpack_setup' );
 

--- a/projects/plugins/jetpack/modules/theme-tools/compat/twentytwentyone.php
+++ b/projects/plugins/jetpack/modules/theme-tools/compat/twentytwentyone.php
@@ -23,26 +23,6 @@ function twentytwentyone_jetpack_setup() {
 			'footer'    => 'main',
 		)
 	);
-
-	/**
-	 * Add theme support for Content Options.
-	 */
-	add_theme_support(
-		'jetpack-content-options',
-		array(
-			'blog-display'    => array( 'content', 'excerpt' ),
-			'post-details'    => array(
-				'stylesheet' => 'twenty-twenty-one-style',
-				'date'       => '.posted-on',
-				'categories' => '.cat-links',
-			),
-			'featured-images' => array(
-				'archive' => true,
-				'post'    => true,
-				'page'    => true,
-			),
-		)
-	);
 }
 add_action( 'after_setup_theme', 'twentytwentyone_jetpack_setup' );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/vulcan/issues/714 (also - same issue: VULCAN-7/classic-theme-helper-theme-compat-remove-duplicated-functionality )

## Proposed changes:

* This PR removes sections of code that were moved to the Classic Theme Helper package, that had been kept for a period of time in both locations to ensure the package version of code was in use in all current versions of Jetpack.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a
## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

To test, use a self-hosted test site with Jetpack installed and active, and this PR applied (using the Jetpack Beta Tester plugin if using a Jurassic Ninja site). The same testing steps apply for WoA and Simple (minus any code modification to test on Simple):

Twenty Fourteen:
* With the Twenty Fourteen theme active, open the Customizer > Featured Content. If you did not previously have a tag name set, the default 'featured' tag name will appear. 

Twenty Fifteen:
* With the Twenty Fifteen theme active, create a post or page and embed a video. I found that the best way to ensure I was using responsive videos was to use the VideoPress block (which requires enabling VideoPress at Settings > Performance > Media: `/wp-admin/admin.php?page=jetpack#/performance`, so you'll need a WordPress.com connected site to test that)
* View the post / page source for the published post / page. Notice the `jetpack-responsive-videos-js` script in the page source (and that it's source is from the jetpack plugin (or jetpack-dev if using the beta tester plugin, or jetpack-mu-wpcom-plugin from Simple) ), and that the video is wrapped in a div with the class `jetpack-video-wrapper`.

Twenty Sixteen:
* For Twenty Sixteen, you can test responsive videos as with Twenty Fifteen.

Twenty Nineteen:
* For Twenty Nineteen, you can test responsive videos as with Twenty Fifteen.
* To test Content Options Post Thumbnail override:  create a post and add a featured image to it. Open that post on the front-end - the featured image should show as a banner at the top of the site.
* Open up the customizer and then Content Options. Under 'featured images', unselect 'display on single posts'. Refresh the post with the featured image, and the image should be gone.
* To confirm we're using the code from the package, you can comment out `add_filter( 'twentynineteen_can_show_post_thumbnail', 'twentynineteen_override_post_thumbnail', 10, 2 );` in `projects/packages/classic-theme-helper/src/compat/twentynineteen.php` (or if using the Jetpack Beta Tester plugin, `plugins/jetpack-dev/jetpack_vendor/automattic/jetpack-classic-theme-helper/src/compat/twentynineteen.php`.
* Refresh the page again, the featured image should show at the top of the page.
* To test Content Options generally: The Content Options section should show in the customizer. If you comment out `add_action( 'after_setup_theme', 'twentynineteen__jetpack_setup' );` from the same file mentioned above, it will not.

Twenty Twenty:
* For Twenty Twenty you can test Content Options generally by following the same steps as the last point under Twenty Nineteen.

Twenty Twenty One:
* For Twenty Twenty One you can also test Content Options generally by following the same steps as the last point under Twenty Nineteen.