### PR TITLE
Boost: Fix not clearing up event on page cache deactivation

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/class-cache-preload.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/class-cache-preload.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache;
 
 use Automattic\Jetpack_Boost\Contracts\Has_Activate;
+use Automattic\Jetpack_Boost\Contracts\Has_Deactivate;
 use Automattic\Jetpack_Boost\Contracts\Is_Always_On;
 use Automattic\Jetpack_Boost\Contracts\Sub_Feature;
 use Automattic\Jetpack_Boost\Lib\Cornerstone\Cornerstone_Utils;
@@ -20,7 +21,7 @@ use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress\Logg
  * @since 3.11.0
  * @package Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache
  */
-class Cache_Preload implements Sub_Feature, Has_Activate, Is_Always_On {
+class Cache_Preload implements Sub_Feature, Has_Activate, Has_Deactivate, Is_Always_On {
 
 	/**
 	 * @since 3.11.0

--- a/projects/plugins/boost/changelog/fix-boost-page-cache-clear-preload-cornerstone-on-deactivate
+++ b/projects/plugins/boost/changelog/fix-boost-page-cache-clear-preload-cornerstone-on-deactivate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Page Cache: Fix not clearing up preload schedule on deactivation.


### PR DESCRIPTION
## Proposed changes:

* Fix not running deactivate on cache preload sub module on Page Cache deactivation.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

Setup `WP Crontrol` as it makes it easy to check what events are scheduled.

- Run Boost (free);
- Check `Tools -> Cron Events` for boost related schedules - http://jetpack-boost.test/wp-admin/tools.php?page=wp-crontrol&s=boost and note them;
- Activate Page Cache and then deactivate it. `jetpack_boost_preload_cornerstone` should be removed. Previously it stayed in the list.