### PR TITLE
Dashboard: Use new onboarding flow for user connection

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
@@ -18,7 +18,6 @@ import {
 	isFetchingConnectUrl as _isFetchingConnectUrl,
 	getConnectUrl as _getConnectUrl,
 	unlinkUser,
-	connectUser as _connectUser,
 	isCurrentUserLinked as _isCurrentUserLinked,
 	isUnlinkingUser as _isUnlinkingUser,
 	isConnectingUser as _isConnectingUser,
@@ -28,8 +27,6 @@ import {
 } from 'state/connection';
 import {
 	getSiteRawUrl,
-	isSafari,
-	doNotUseConnectionIframe,
 	getApiNonce,
 	getApiRootUrl,
 	getInitialStateConnectedPlugins,
@@ -53,8 +50,6 @@ export class ConnectButton extends React.Component {
 		asLink: PropTypes.bool,
 		asBanner: PropTypes.bool,
 		connectLegend: PropTypes.string,
-		connectInPlace: PropTypes.bool,
-		customConnect: PropTypes.func,
 		autoOpenInDisconnectRoute: PropTypes.bool,
 		rna: PropTypes.bool,
 		compact: PropTypes.bool,
@@ -65,7 +60,6 @@ export class ConnectButton extends React.Component {
 		connectUser: false,
 		from: '',
 		asLink: false,
-		connectInPlace: true,
 		autoOpenInDisconnectRoute: false,
 		rna: false,
 		compact: false,
@@ -294,8 +288,6 @@ export default connect(
 			isLinked: _isCurrentUserLinked( state ),
 			isUnlinking: _isUnlinkingUser( state ),
 			isAuthorizing: _isConnectingUser( state ),
-			isSafari: isSafari( state ),
-			doNotUseConnectionIframe: doNotUseConnectionIframe( state ),
 			apiNonce: getApiNonce( state ),
 			apiRoot: getApiRootUrl( state ),
 			connectedPlugins: getInitialStateConnectedPlugins( state ),
@@ -317,9 +309,6 @@ export default connect(
 			},
 			unlinkUser: () => {
 				return dispatch( unlinkUser() );
-			},
-			doConnectUser: ( featureLabel, from ) => {
-				return dispatch( _connectUser( featureLabel, from ) );
 			},
 		};
 	}

--- a/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
@@ -1,5 +1,6 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { DisconnectDialog } from '@automattic/jetpack-connection';
+import { getMyJetpackUrl } from '@automattic/jetpack-script-data';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -110,20 +111,10 @@ export class ConnectButton extends React.Component {
 		if ( e ) {
 			e.preventDefault();
 		}
-		// If the iframe is already loaded or we don't have a connectUrl yet, return.
-		if ( this.props.isAuthorizing || this.props.fetchingConnectUrl ) {
-			return;
-		}
-
 		// Track click
 		analytics.tracks.recordJetpackClick( 'link_account_in_place' );
 
-		if ( this.props.customConnect ) {
-			this.props.customConnect();
-		} else {
-			// Dispatch user in place authorization.
-			this.props.doConnectUser( null, this.props.from );
-		}
+		window.location.href = getMyJetpackUrl( '&step=onboarding' );
 	};
 
 	renderDisconnectStepComponent = () => {

--- a/projects/plugins/jetpack/changelog/change-jp-dashboard-user-connection
+++ b/projects/plugins/jetpack/changelog/change-jp-dashboard-user-connection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Use the new onboarding flow for JP user connection


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes MARTECH-61

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changed the user connection CTA button to navigate to the new onboarding flow instead of the in-place banner

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Disconnect your blog `jetpack docker wp jetpack disconnect blog`
* Start the onboarding flow, but do not login with an account
* Navigate to JP Dashboard, you should have site connection but not user connection
* Check that the action for user connection uses the new flow
* Make sure that loggin in still works


https://github.com/user-attachments/assets/14d53d1c-de53-4c6c-b568-f35aceb8fd6b

