### PR TITLE
Revert Jetpack SEO: Ensure more performant practices when getting enabled features.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-revert-jetpack-seo-useselect-performance-change
+++ b/projects/plugins/jetpack/changelog/fix-revert-jetpack-seo-useselect-performance-change
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: This fixes an internal issue.
+
+

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/selectors.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/selectors.ts
@@ -40,6 +40,7 @@ export function getEnabledFeatures( state: SeoEnhancerState ) {
 		feature => state.features[ feature ]
 	) as PromptType[];
 }
+
 export function isImageAltTextFeatureEnabled( state: SeoEnhancerState ) {
 	return getEnabledFeatures( state ).includes( 'images-alt-text' );
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/selectors.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/selectors.ts
@@ -1,4 +1,3 @@
-import { createSelector } from '@wordpress/data';
 /**
  * Types
  */
@@ -36,11 +35,11 @@ export function hasImageFailed( state: SeoEnhancerState, clientId: string ) {
 	return state.failedImages[ clientId ] ?? false;
 }
 
-export const getEnabledFeatures = createSelector(
-	( state: SeoEnhancerState ): PromptType[] =>
-		Object.keys( state.features ).filter( feature => state.features[ feature ] ) as PromptType[],
-	( state: SeoEnhancerState ) => [ state.features ]
-);
+export function getEnabledFeatures( state: SeoEnhancerState ) {
+	return Object.keys( state.features ).filter(
+		feature => state.features[ feature ]
+	) as PromptType[];
+}
 export function isImageAltTextFeatureEnabled( state: SeoEnhancerState ) {
 	return getEnabledFeatures( state ).includes( 'images-alt-text' );
 }


### PR DESCRIPTION
## Proposed changes:
* This reverts the changes added in https://github.com/Automattic/jetpack/pull/43031
* The reason for this is that the deployed PR caused functionality issues within P2s internally. See p1744638777275059-slack-C010KDAPG49

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1744638777275059-slack-C010KDAPG49


## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* With a P2 sandboxed and this PR applied, autocomplete should work properly (using + or @ symbols).
* You should also be able to add a gif block (or task, or spoiler block).
* If replicating the issue isn't working, add `?concat_js=yes` to the end of the URL.