### PR TITLE
Stats: fix post count fatal error

### DIFF
--- a/projects/packages/stats/changelog/fix-tracking-pixel-fatal-error
+++ b/projects/packages/stats/changelog/fix-tracking-pixel-fatal-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHP Fatal error: Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, WP_Query given

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -93,7 +93,7 @@ class Tracking_Pixel {
 			} elseif ( $wp_the_query->is_search() ) {
 				$view_data['arch_search']  = sanitize_text_field( $wp_the_query->query['s'] );
 				$view_data['arch_filters'] = sanitize_text_field( self::build_search_filters( $wp_the_query ) );
-				$view_data['arch_results'] = $wp_the_query->posts ? count( $wp_the_query->posts ) : 0;
+				$view_data['arch_results'] = $wp_the_query->posts ? $wp_the_query->post_count : 0;
 			} elseif ( $wp_the_query->is_archive() ) {
 				if ( $wp_the_query->is_date ) {
 					$query                  = $wp_the_query->query;
@@ -116,7 +116,7 @@ class Tracking_Pixel {
 						$view_data[ 'arch_tax_' . array_keys( $query )[0] ] = array_values( $query )[0];
 					}
 				}
-				$view_data['arch_results'] = $wp_the_query->posts ? count( $wp_the_query->posts ) : 0;
+				$view_data['arch_results'] = $wp_the_query->posts ? $wp_the_query->post_count : 0;
 			} elseif ( $wp_the_query->is_404() ) {
 				$view_data['arch_err'] = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) );
 			} else {

--- a/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
+++ b/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
@@ -156,9 +156,10 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 		// testing taxonomy
 		$wp_the_query->is_tag = false;
 		$wp_the_query->parse_query( 'testtax=testterm' );
-		$wp_the_query->posts = array( 'post1', 'post2', 'post3' );
-		$view_data           = Tracking_Pixel::build_view_data();
-		$expected_view_data  = array(
+		$wp_the_query->posts      = array( 'post1', 'post2', 'post3' );
+		$wp_the_query->post_count = count( $wp_the_query->posts );
+		$view_data                = Tracking_Pixel::build_view_data();
+		$expected_view_data       = array(
 			'v'                => 'ext',
 			'blog'             => 1234,
 			'post'             => '0',
@@ -217,9 +218,10 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 		global $wp_the_query;
 		$wp_the_query->is_search = true;
 		$wp_the_query->parse_query( 's=term&posts_per_page=10&paged=2&orderby=date&order=ASC&author_name=author&testtax=testterm' );
-		$wp_the_query->posts = array( 'post1', 'post2' );
-		$view_data           = Tracking_Pixel::build_view_data();
-		$expected_view_data  = array(
+		$wp_the_query->posts      = array( 'post1', 'post2' );
+		$wp_the_query->post_count = count( $wp_the_query->posts );
+		$view_data                = Tracking_Pixel::build_view_data();
+		$expected_view_data       = array(
 			'v'            => 'ext',
 			'blog'         => 1234,
 			'post'         => '0',
@@ -235,9 +237,10 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 
 		// testing search with non-existing taxonomy
 		$wp_the_query->parse_query( 's=term&posts_per_page=10&paged=2&orderby=date&order=ASC&no-testtax=testterm' );
-		$wp_the_query->posts = array( 'post1', 'post2', 'post3' );
-		$view_data           = Tracking_Pixel::build_view_data();
-		$expected_view_data  = array(
+		$wp_the_query->posts      = array( 'post1', 'post2', 'post3' );
+		$wp_the_query->post_count = count( $wp_the_query->posts );
+		$view_data                = Tracking_Pixel::build_view_data();
+		$expected_view_data       = array(
 			'v'            => 'ext',
 			'blog'         => 1234,
 			'post'         => '0',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up for #42368.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This PR fixes the following error:

```
PHP Fatal error: Uncaught TypeError: count(): Argument #1 ($value) must be of
type Countable|array, WP_Query given in
/wordpress/plugins/jetpack/14.6-a.3/jetpack_vendor/automattic/jetpack-stats/src/class-tracking-pixel.php:119
```

As [suggested in the `WP_Query` docs][1].

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

- pgbpWj-8u-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

- No, it's a fix for the data already being tracked.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Go to your local Jetpack website, preferably in an incognito window. It won't work for logged-in requests.
- Make a search or go to an archive page, like a category.
  - Search: `/?s=world`
  - Category: `/category/writings/`
- Check requestes made against `/g.gif`.
- The request should contain `&arch_results=` with a valid integer in the query string in both cases.

### Search

URL

https://pixel.wp.com/g.gif?v=ext&blog=236297789&post=0&tz=0&srv=jetpack.myhrowp.com&arch_search=world&arch_filters=posts_per_page%3D10%26paged%3D1%26orderby%3D%26order%3DDESC&arch_results=1&j=1%3A14.6-a.3&host=jetpack.myhrowp.com&ref=https%3A%2F%2Fjetpack.myhrowp.com%2F&fcp=0&rand=0.8139773404505876

Query String Parameters

```yaml
v: ext
blog: 236297789
post: 0
tz: 0
srv: jetpack.myhrowp.com
arch_search: world
arch_filters: posts_per_page=10&paged=1&orderby=&order=DESC
arch_results: 1
j: 1:14.6-a.3
host: jetpack.myhrowp.com
ref: https://jetpack.myhrowp.com/
fcp: 0
rand: 0.8139773404505876
```

### Archive - Category

URL

https://pixel.wp.com/g.gif?v=ext&blog=236297789&post=0&tz=0&srv=jetpack.myhrowp.com&arch_cat=writings&arch_results=2&j=1%3A14.6-a.3&host=jetpack.myhrowp.com&ref=https%3A%2F%2Fjetpack.myhrowp.com%2F2025%2F03%2F12%2Fhello-world%2F&fcp=0&rand=0.181020031477662

Query String Parameters

```yaml
v: ext
blog: 236297789
post: 0
tz: 0
srv: jetpack.myhrowp.com
arch_cat: writings
arch_results: 2
j: 1:14.6-a.3
host: jetpack.myhrowp.com
ref: https://jetpack.myhrowp.com/2025/03/12/hello-world/
fcp: 0
rand: 0.181020031477662
```

[1]: https://developer.wordpress.org/reference/classes/wp_query/#properties