### PR TITLE
Forms: Add src alias for JavaScript imports

### DIFF
--- a/projects/packages/forms/changelog/forms-base-path-for-js-imports
+++ b/projects/packages/forms/changelog/forms-base-path-for-js-imports
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Add src alias for JavaScript imports.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
@@ -2,7 +2,7 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 import { Button, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import AkismetIcon from '../../../../icons/akismet-icon';
+import AkismetIcon from 'src/icons/akismet-icon';
 import IntegrationCard from './integration-card';
 
 const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {

--- a/projects/packages/forms/tools/webpack.config.blocks.js
+++ b/projects/packages/forms/tools/webpack.config.blocks.js
@@ -25,6 +25,10 @@ const sharedWebpackConfig = {
 	},
 	resolve: {
 		...jetpackWebpackConfig.resolve,
+		alias: {
+			...jetpackWebpackConfig.resolve.alias,
+			src: path.resolve( __dirname, '../src' ),
+		},
 	},
 	node: {},
 	plugins: [ ...jetpackWebpackConfig.StandardPlugins() ],

--- a/projects/packages/forms/tools/webpack.config.contact-form.js
+++ b/projects/packages/forms/tools/webpack.config.contact-form.js
@@ -26,6 +26,7 @@ const sharedWebpackConfig = {
 		alias: {
 			...jetpackWebpackConfig.resolve.alias,
 			fs: false,
+			src: path.resolve( __dirname, '../src' ),
 		},
 	},
 	node: {},

--- a/projects/packages/forms/tools/webpack.config.dashboard.js
+++ b/projects/packages/forms/tools/webpack.config.dashboard.js
@@ -23,6 +23,7 @@ module.exports = {
 		alias: {
 			...jetpackWebpackConfig.resolve.alias,
 			fs: false,
+			src: path.resolve( __dirname, '../src' ),
 		},
 	},
 	externals: {

--- a/projects/packages/forms/tools/webpack.config.modules.js
+++ b/projects/packages/forms/tools/webpack.config.modules.js
@@ -56,6 +56,10 @@ if ( ! fs.existsSync( moduleSrcDir ) ) {
 			resolve: {
 				...jetpackWebpackConfig.resolve,
 				modules: [ 'node_modules' ],
+				alias: {
+					...jetpackWebpackConfig.resolve.alias,
+					src: path.resolve( __dirname, '../src' ),
+				},
 			},
 			externals: {
 				...jetpackWebpackConfig.externals,


### PR DESCRIPTION
## Proposed changes:
Updates webpack configs for forms package to add an alias for JavaScript imports, so we can import from 'src/folder/file.js' rather than '../../../folder/file.js'. Updates imports for the Akismet and Creative Mail icons to use the new alias.

I searched all other packages in this repo, and I don't think any others are using this kind of alias / base path logic. Some of the plugins do. That makes me wonder if there's a reason we're not doing in Jetpack monorepo packages. So I'd like to get feedback on that, and also whether this change requires other changes (ie, ESlist), at the package or monorepo levels. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- This is a refactor, so there should be no change in functionality. 
- Confirm the branch loads with no import errors.
- As a direct test, confirm the Akismet/Creative icons loads as expected. 
   - The imports are only updated for the Jetpack integrations modal, which is behind a feature flag. You'll need to set `define( 'JETPACK_IS_FORM_MODAL_ENABLED', true );` in wp-config.php.
   - The add a form to any page, click Manage Integrations on the sidebar, and and confirm that the Akismet and Creative Mail icons in the modal load correctly.

