### PR TITLE
CRM: Fix success message when accepting a quote via the Client Portal

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-client_portal_quote_acceptance
+++ b/projects/plugins/crm/changelog/fix-crm-client_portal_quote_acceptance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Client Portal: Show success message when quote is accepted.

--- a/projects/plugins/crm/js/ZeroBSCRM.public.proposals.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.public.proposals.js
@@ -53,6 +53,7 @@ jQuery( function () {
  * Send quote acceptance AJAX.
  * @param {string} quoteHash - Quote hash.
  * @param {number} quoteID   - Quote ID.
+ * @return {object} jQuery AJAX call Promise object.
  */
 function zbsCRM_JS_acceptProp( quoteHash, quoteID ) {
 	// postbag!
@@ -66,7 +67,7 @@ function zbsCRM_JS_acceptProp( quoteHash, quoteID ) {
 	};
 
 	// Send
-	jQuery.ajax( {
+	return jQuery.ajax( {
 		type: 'POST',
 		url: window.jpcrm_proposal_data.ajax_url,
 		data: data,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/jpop-issues#9713 - Fix success message when accepting a quote via the Client Portal

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

When doing JS linting in #40249, a `return` was removed, resulting in a JS error after accepting a quote and preventing the success message from showing. This adds back the `return`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a quote.
2. Open it in the Client Portal.
3. Click "Accept".

In `trunk` it will do nothing on the page and you'll see a JS error. It does actually accept the quote, as seen if you refresh or go to the quote on the backend.

In the `fix/crm/client_portal_quote_acceptance` branch, it will show a success message after clicking "Accept".

