### PR TITLE
Form inner blocks: supplement existing PHP unit tests

### DIFF
--- a/projects/packages/forms/changelog/add-more-form-inner-block-php-unit-tests
+++ b/projects/packages/forms/changelog/add-more-form-inner-block-php-unit-tests
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adding block supports checks for new inner blocks, and radio field unit test coverage

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -138,7 +138,7 @@ class Contact_Form_Block {
 			array(
 				'supports'         => array(
 					'spacing' => array(
-						'blockGap' => true,
+						'blockGap' => false,
 					),
 				),
 				'provides_context' => array(

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -113,7 +113,7 @@ class Contact_Form_Block {
 				'supports'     => array(
 					'color'      => array(
 						'text'       => true,
-						'background' => true,
+						'background' => false,
 						'gradient'   => false,
 					),
 					'typography' => array(

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -90,7 +90,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 				array(
 					'color'      => array(
 						'text'       => true,
-						'background' => false,
+						'background' => true,
 						'gradient'   => false,
 					),
 					'typography' => array(

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -90,7 +90,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 				array(
 					'color'      => array(
 						'text'       => true,
-						'background' => true,
+						'background' => false,
 						'gradient'   => false,
 					),
 					'typography' => array(

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -42,12 +42,16 @@ class Contact_Form_Block_Test extends BaseTestCase {
 	 *
 	 * @dataProvider data_provider_test_register_child_blocks
 	 */
-	public function test_register_child_blocks( $block_name ) {
+	public function test_register_child_blocks( $block_name, $expected_supports = array() ) {
 		Contact_Form_Block::register_child_blocks();
 		$registry   = WP_Block_Type_Registry::get_instance();
 		$block_type = $registry->get_registered( $block_name );
-		// @TODO should we also test supports?
 		$this->assertNotNull( $block_type );
+
+		// Test block supports if provided
+		if ( ! empty( $expected_supports ) ) {
+			$this->assertSame( $expected_supports, $block_type->supports, 'Block supports do not match expected values' );
+		}
 	}
 
 	/**
@@ -57,15 +61,175 @@ class Contact_Form_Block_Test extends BaseTestCase {
 		return array(
 			'jetpack/input'   => array(
 				'jetpack/input',
+				array(
+					'__experimentalBorder' => array(
+						'color'  => true,
+						'radius' => true,
+						'style'  => true,
+						'width'  => true,
+					),
+					'color'                => array(
+						'text'       => true,
+						'background' => true,
+						'gradient'   => true,
+					),
+					'typography'           => array(
+						'fontSize'                     => true,
+						'lineHeight'                   => true,
+						'__experimentalFontFamily'     => true,
+						'__experimentalFontWeight'     => true,
+						'__experimentalFontStyle'      => true,
+						'__experimentalTextTransform'  => true,
+						'__experimentalTextDecoration' => true,
+						'__experimentalLetterSpacing'  => true,
+					),
+				),
 			),
 			'jetpack/label'   => array(
 				'jetpack/label',
+				array(
+					'color'      => array(
+						'text'       => true,
+						'background' => true,
+						'gradient'   => false,
+					),
+					'typography' => array(
+						'fontSize'                     => true,
+						'lineHeight'                   => true,
+						'__experimentalFontFamily'     => true,
+						'__experimentalFontWeight'     => true,
+						'__experimentalFontStyle'      => true,
+						'__experimentalTextTransform'  => true,
+						'__experimentalTextDecoration' => true,
+						'__experimentalLetterSpacing'  => true,
+					),
+				),
 			),
 			'jetpack/options' => array(
 				'jetpack/options',
+				array(
+					'spacing' => array(
+						'blockGap' => true,
+					),
+				),
 			),
 			'jetpack/option'  => array(
 				'jetpack/option',
+				array(
+					'color'      => array(
+						'text'       => true,
+						'background' => false,
+						'gradient'   => false,
+					),
+					'typography' => array(
+						'fontSize'                     => true,
+						'lineHeight'                   => true,
+						'__experimentalFontFamily'     => true,
+						'__experimentalFontWeight'     => true,
+						'__experimentalFontStyle'      => true,
+						'__experimentalTextTransform'  => true,
+						'__experimentalTextDecoration' => true,
+						'__experimentalLetterSpacing'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Test that block supports are properly configured.
+	 *
+	 * @dataProvider data_provider_test_block_supports
+	 * @param string $block_name The name of the block.
+	 * @param array  $expected_supports The expected support configuration.
+	 */
+	public function test_child_blocks_block_supports( $block_name, $expected_supports ) {
+		Contact_Form_Block::register_child_blocks();
+		$registry = WP_Block_Type_Registry::get_instance();
+		$block    = $registry->get_registered( $block_name );
+
+		$this->assertNotNull( $block );
+		$this->assertEquals( $expected_supports, $block->supports );
+	}
+
+	/**
+	 * Data provider for test_child_blocks_block_supports.
+	 */
+	public static function data_provider_test_block_supports() {
+		return array(
+			'jetpack/input supports'   => array(
+				'jetpack/input',
+				array(
+					'__experimentalBorder' => array(
+						'color'  => true,
+						'radius' => true,
+						'style'  => true,
+						'width'  => true,
+					),
+					'color'                => array(
+						'text'       => true,
+						'background' => true,
+						'gradient'   => true,
+					),
+					'typography'           => array(
+						'fontSize'                     => true,
+						'lineHeight'                   => true,
+						'__experimentalFontFamily'     => true,
+						'__experimentalFontWeight'     => true,
+						'__experimentalFontStyle'      => true,
+						'__experimentalTextTransform'  => true,
+						'__experimentalTextDecoration' => true,
+						'__experimentalLetterSpacing'  => true,
+					),
+				),
+			),
+			'jetpack/label supports'   => array(
+				'jetpack/label',
+				array(
+					'color'      => array(
+						'text'       => true,
+						'background' => true,
+						'gradient'   => false,
+					),
+					'typography' => array(
+						'fontSize'                     => true,
+						'lineHeight'                   => true,
+						'__experimentalFontFamily'     => true,
+						'__experimentalFontWeight'     => true,
+						'__experimentalFontStyle'      => true,
+						'__experimentalTextTransform'  => true,
+						'__experimentalTextDecoration' => true,
+						'__experimentalLetterSpacing'  => true,
+					),
+				),
+			),
+			'jetpack/options supports' => array(
+				'jetpack/options',
+				array(
+					'spacing' => array(
+						'blockGap' => true,
+					),
+				),
+			),
+			'jetpack/option supports'  => array(
+				'jetpack/option',
+				array(
+					'color'      => array(
+						'text'       => true,
+						'background' => false,
+						'gradient'   => false,
+					),
+					'typography' => array(
+						'fontSize'                     => true,
+						'lineHeight'                   => true,
+						'__experimentalFontFamily'     => true,
+						'__experimentalFontWeight'     => true,
+						'__experimentalFontStyle'      => true,
+						'__experimentalTextTransform'  => true,
+						'__experimentalTextDecoration' => true,
+						'__experimentalLetterSpacing'  => true,
+					),
+				),
 			),
 		);
 	}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -109,109 +109,11 @@ class Contact_Form_Block_Test extends BaseTestCase {
 				'jetpack/options',
 				array(
 					'spacing' => array(
-						'blockGap' => true,
+						'blockGap' => false,
 					),
 				),
 			),
 			'jetpack/option'  => array(
-				'jetpack/option',
-				array(
-					'color'      => array(
-						'text'       => true,
-						'background' => false,
-						'gradient'   => false,
-					),
-					'typography' => array(
-						'fontSize'                     => true,
-						'lineHeight'                   => true,
-						'__experimentalFontFamily'     => true,
-						'__experimentalFontWeight'     => true,
-						'__experimentalFontStyle'      => true,
-						'__experimentalTextTransform'  => true,
-						'__experimentalTextDecoration' => true,
-						'__experimentalLetterSpacing'  => true,
-					),
-				),
-			),
-		);
-	}
-
-	/**
-	 * Test that block supports are properly configured.
-	 *
-	 * @dataProvider data_provider_test_block_supports
-	 * @param string $block_name The name of the block.
-	 * @param array  $expected_supports The expected support configuration.
-	 */
-	public function test_child_blocks_block_supports( $block_name, $expected_supports ) {
-		Contact_Form_Block::register_child_blocks();
-		$registry = WP_Block_Type_Registry::get_instance();
-		$block    = $registry->get_registered( $block_name );
-
-		$this->assertNotNull( $block );
-		$this->assertEquals( $expected_supports, $block->supports );
-	}
-
-	/**
-	 * Data provider for test_child_blocks_block_supports.
-	 */
-	public static function data_provider_test_block_supports() {
-		return array(
-			'jetpack/input supports'   => array(
-				'jetpack/input',
-				array(
-					'__experimentalBorder' => array(
-						'color'  => true,
-						'radius' => true,
-						'style'  => true,
-						'width'  => true,
-					),
-					'color'                => array(
-						'text'       => true,
-						'background' => true,
-						'gradient'   => true,
-					),
-					'typography'           => array(
-						'fontSize'                     => true,
-						'lineHeight'                   => true,
-						'__experimentalFontFamily'     => true,
-						'__experimentalFontWeight'     => true,
-						'__experimentalFontStyle'      => true,
-						'__experimentalTextTransform'  => true,
-						'__experimentalTextDecoration' => true,
-						'__experimentalLetterSpacing'  => true,
-					),
-				),
-			),
-			'jetpack/label supports'   => array(
-				'jetpack/label',
-				array(
-					'color'      => array(
-						'text'       => true,
-						'background' => true,
-						'gradient'   => false,
-					),
-					'typography' => array(
-						'fontSize'                     => true,
-						'lineHeight'                   => true,
-						'__experimentalFontFamily'     => true,
-						'__experimentalFontWeight'     => true,
-						'__experimentalFontStyle'      => true,
-						'__experimentalTextTransform'  => true,
-						'__experimentalTextDecoration' => true,
-						'__experimentalLetterSpacing'  => true,
-					),
-				),
-			),
-			'jetpack/options supports' => array(
-				'jetpack/options',
-				array(
-					'spacing' => array(
-						'blockGap' => true,
-					),
-				),
-			),
-			'jetpack/option supports'  => array(
 				'jetpack/option',
 				array(
 					'color'      => array(

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -211,6 +211,78 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
+	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_radio
+	 */
+	public function test_gutenblock_gutenblock_render_field_radio() {
+		$block = array(
+			'blockName'   => 'jetpack/field-radio',
+			'attrs'       => array(
+				'required' => true,
+				'width'    => '100%',
+			),
+			'innerBlocks' => array(
+				array(
+					'blockName' => 'jetpack/label',
+					'attrs'     => array(
+						'label'        => 'Radio gaga',
+						'defaultLabel' => 'Radio gaga…',
+						'textColor'    => 'turmoil-purple',
+						'style'        => array(
+							'elements' => array(
+								'link' => array( 'color' => array( 'text' => 'var:preset|color|turmoil-purple' ) ),
+							),
+						),
+					),
+				),
+				array(
+					'blockName'   => 'jetpack/options',
+					'attrs'       => array(
+						'type' => 'radio',
+					),
+					'innerBlocks' => array(
+						array(
+							'blockName' => 'jetpack/option',
+							'attrs'     => array(
+								'label' => 'freddy',
+								'style' => array(
+									'color'      => array( 'text' => 'reddo' ),
+									'elements'   => array(
+										'link' => array( 'color' => array( 'text' => 'greeno' ) ),
+									),
+									'typography' => array(
+										'fontSize' => '24px',
+									),
+								),
+							),
+						),
+						array(
+							'blockName' => 'jetpack/option',
+							'attrs'     => array(
+								'label' => 'brian',
+								'style' => array(
+									'color'      => array( 'text' => 'blueo' ),
+									'elements'   => array(
+										'link' => array( 'color' => array( 'text' => 'orango' ) ),
+									),
+									'typography' => array(
+										'fontSize' => '100rem',
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		// Render the shortcode.
+		$shortcode = Contact_Form_Plugin::gutenblock_render_field_radio( array(), '', new WP_Block( $block ) );
+		$expected  = '[contact-field type="radio" label="Radio gaga" labelclasses="wp-block-jetpack-label has-text-color has-turmoil-purple-color" options="freddy,brian" optionsdata="&#091;{&quot;label&quot;:&quot;freddy&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:reddo; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;brian&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:blueo; font-size:100rem;&quot;}&#093;"/]';
+
+		$this->assertEquals( $expected, $shortcode, 'Shortcode is not as expected' );
+	}
+
+	/**
 	 * Test that ::block_attributes_to_shortcode_attributes works correctly with styles.
 	 *
 	 * @dataProvider data_provider_block_attributes_to_shortcode_attributes_with_styles


### PR DESCRIPTION


## Proposed changes:

More tests to support https://github.com/Automattic/jetpack/pull/42890

Adds:

- block support checks for new blocks
-  radio field coverage


Overkill?



## Testing instructions:

`jetpack test php packages/forms --verbose --debug`
