### PR TITLE
Forms: Fix loss of styling options for classic themes when switching to inner blocks JETPACK-303

### DIFF
--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -38,6 +38,9 @@ class Jetpack_Forms {
 
 		// Add hook to delete file attachments when a feedback post is deleted
 		add_action( 'before_delete_post', array( '\Automattic\Jetpack\Forms\ContactForm\Contact_Form', 'delete_feedback_files' ) );
+
+		// Enforces the availability of block support controls in the UI for classic themes.
+		add_filter( 'wp_theme_json_data_default', array( '\Automattic\Jetpack\Forms\ContactForm\Contact_Form', 'add_theme_json_data_for_classic_themes' ) );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2065,4 +2065,68 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 		return $files;
 	}
+
+	/**
+	 * Enforce required block supports UIs for Classic themes.
+	 *
+	 * @param \WP_Theme_JSON_Data $theme_json_data Theme JSON data object.
+	 *
+	 * @return \WP_Theme_JSON_Data Updated theme JSON settings.
+	 */
+	public static function add_theme_json_data_for_classic_themes( $theme_json_data ) {
+		if ( wp_is_block_theme() ) {
+			return $theme_json_data;
+		}
+
+		$data = $theme_json_data->get_data();
+
+		if ( ! isset( $data['settings']['blocks'] ) ) {
+			$data['settings']['blocks'] = array();
+		}
+
+		$data['settings']['blocks']['jetpack/input'] = array(
+			'color'      => array(
+				'text'       => true,
+				'background' => true,
+			),
+			'border'     => array(
+				'color'  => true,
+				'radius' => true,
+				'style'  => true,
+				'width'  => true,
+			),
+			'typography' => array(
+				'fontFamily'     => true,
+				'fontSize'       => true,
+				'fontStyle'      => true,
+				'fontWeight'     => true,
+				'letterSpacing'  => true,
+				'lineHeight'     => true,
+				'textDecoration' => true,
+				'textTransform'  => true,
+			),
+		);
+
+		$shared_settings                              = array(
+			'color'      => array(
+				'text'       => true,
+				'background' => false,
+			),
+			'typography' => array(
+				'fontFamily'     => true,
+				'fontSize'       => true,
+				'fontStyle'      => true,
+				'fontWeight'     => true,
+				'letterSpacing'  => true,
+				'lineHeight'     => true,
+				'textDecoration' => true,
+				'textTransform'  => true,
+			),
+		);
+		$data['settings']['blocks']['jetpack/label']  = $shared_settings;
+		$data['settings']['blocks']['jetpack/option'] = $shared_settings;
+
+		$theme_json_class = get_class( $theme_json_data );
+		return new $theme_json_class( $data, 'default' );
+	}
 }


### PR DESCRIPTION
Fixes JETPACK-303

## Proposed changes:

* Adds a `wp_theme_json_data_default` filter to enforce display of required block support controls.
* Filtering at the default origin level allows for themes to still override this as desired by opting out in any theme.json or `wp_theme_json_data_theme` filter

## Testing instructions:

1. Install and activate a classic theme such as [Shoreditch](https://github.com/Automattic/themes/tree/trunk/shoreditch)
2. Edit a post and add a form containing a variety of fields
3. Compare the available styling options with what is registered in the Input, Label, and Option block supports

Note: Depending on the classic theme's font configuration the font family control may still not display pending font availability.

## Screenshots


On #42890:

| Input | Label | Option |
|---|---|---|
| <img width="556" alt="Screenshot 2025-04-15 at 12 18 08 pm" src="https://github.com/user-attachments/assets/2f39445c-1acc-4779-94d5-ccfc7461707e" /> |  <img width="567" alt="Screenshot 2025-04-15 at 12 18 20 pm" src="https://github.com/user-attachments/assets/92755845-bdef-4da5-b889-418a35af2908" /> | <img width="567" alt="Screenshot 2025-04-15 at 12 18 20 pm" src="https://github.com/user-attachments/assets/e00e3bcd-f88d-40f1-b62d-e7465a2764d7" /> |


This PR:

| Input | Label | Option |
|---|---|---|
| <img width="593" alt="Screenshot 2025-04-15 at 12 19 03 pm" src="https://github.com/user-attachments/assets/b02b2100-9dea-4f26-9b30-9ac3826eba3c" /> | <img width="560" alt="Screenshot 2025-04-15 at 12 18 57 pm" src="https://github.com/user-attachments/assets/260596a4-d1c1-40cd-9b5c-107196a2efc9" />  | <img width="582" alt="Screenshot 2025-04-15 at 12 19 10 pm" src="https://github.com/user-attachments/assets/f57f25cf-85d4-457c-af8e-6346d726a87a" /> |

On trunk:

| Name Field | Multiple Choice Field |
|---|---|
| <img width="226" alt="Screenshot 2025-04-15 at 12 19 45 pm" src="https://github.com/user-attachments/assets/452e0867-b235-4adb-8427-4aaaa1ff0abc" /> | <img width="226" alt="Screenshot 2025-04-15 at 12 20 01 pm" src="https://github.com/user-attachments/assets/564441b5-3d0f-4c88-836e-25a49ba8c16b" /> |

_Note: On trunk all the available fields are ad hoc controls added to the field block itself._