### PR TITLE
Social: Do not load on private WPCOM sites

### DIFF
--- a/projects/packages/publicize/changelog/update-social-disable-on-wpcom-private-sites
+++ b/projects/packages/publicize/changelog/update-social-disable-on-wpcom-private-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Do not load the module on private WPCOM sites

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Publicize;
 
 use Automattic\Jetpack\Current_Plan;
+use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 
 /**
@@ -37,12 +38,39 @@ class Publicize_Setup {
 	}
 
 	/**
+	 * Whether to load the Publicize module.
+	 *
+	 * @return bool
+	 */
+	private static function should_load() {
+
+		/**
+		 * We do not want to load Publicize on WPCOM private sites.
+		 */
+		$is_wpcom_platform_private_site = ( new Host() )->is_wpcom_platform() && ( new Status() )->is_private_site();
+
+		$should_load = ! $is_wpcom_platform_private_site;
+
+		/**
+		 * Filters the flag to decide whether to load the Publicize module.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $should_load Whether to load the Publicize module.
+		 */
+		return (bool) apply_filters( 'jetpack_publicize_should_load', $should_load );
+	}
+
+	/**
 	 * Initialization of publicize logic that should always be loaded,
 	 * regardless of whether Publicize is enabled or not.
 	 *
 	 * You should justify everyting that is done here, as it will be loaded on every pageload.
 	 */
 	public static function pre_initialization() {
+		if ( ! self::should_load() ) {
+			return;
+		}
 
 		$is_wpcom_simple = ( new Host() )->is_wpcom_simple();
 
@@ -79,7 +107,7 @@ class Publicize_Setup {
 	 * To configure the publicize package, when called via the Config package.
 	 */
 	public static function on_jetpack_feature_publicize_enabled() {
-		if ( self::$initialized ) {
+		if ( self::$initialized || ! self::should_load() ) {
 			return;
 		}
 


### PR DESCRIPTION
From the related issue

> On a private WoA site, there is a nudge to enable Publicize in the editor sidebar, but that's not possible as the module is not available on private sites.
> 
> We should not load the editor extension for private sites, or hide the panel entirely
>
> 
> Things to consider
> - Not loading Publicize in Publicize_Setup if the site is private
> - We should keep the idea of a private site to WPCOM specific code

Apart from that, this PR also fixes the issue of JS error on p2 sites

```
Uncaught TypeError: (0 , s.createSelector) is not a function
```

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a `should_load` method to `Publicize_Setup` to have the logic encapsulated.
* `should_load` method returns `false` if a site is hosted on WPCOM (both Simple and WoA) and is private.
* Use `should_load` in `Publicize_Setup::pre_initialization` and `Publicize_Setup:: on_jetpack_feature_publicize_enabled` to bail early if we should not load the module

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox
* Point your Simple site and the public API to your sandbox
* Verify that the Social admin page works fine and the Social UI loads in the editor
* Mark the site as private at `https://wordpress.com/sites/settings/site/:site`
* Confirm that the Social menu item under Jetpack is not visible.
* Try to manually goto `/wp-admin/admin.php?page=jetpack-social`
* Confirm that the page doesn't exist
* Goto the editor and open Jetpack sidebar
* Confirm that no Social UI is loaded
* Point a p2 site to your sandbox
* Goto the editor on the p2 site
* Confirm that you don't see the TypeError mentioned above
* Confirm that the Social UI is not loaded in Jetpack sidebar 
* Apply this PR to your WoA site using the Jetpack Beta Tester plugin
* Verify the above steps
* Apply the branch to a Jetpack site
* Confirm that the Social admin page loads regardless of any settings like `"Search engine visibility"` in `/wp-admin/options-reading.php`
* Confirm that the UI in the editor loads fine
