### PR TITLE
Forms: hide integrations modal on simple

### DIFF
--- a/projects/packages/forms/changelog/update-forms-integrations-modal-simple
+++ b/projects/packages/forms/changelog/update-forms-integrations-modal-simple
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: hide integrations modal CTA in the sidebar for simple sites

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -225,7 +225,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 						/>
 					</PanelBody>
 
-					{ isFormModalEnabled && (
+					{ isFormModalEnabled && ! isSimpleSite() && (
 						<PanelBody
 							title={ __( 'Manage integrations', 'jetpack-forms' ) }
 							className="jetpack-contact-form__integrations-panel"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow up to https://github.com/Automattic/jetpack/pull/43057

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add simple site check before showing integrations modal

There was a check for simple sites already for panels, but it was missing for the new panel where modal lives:

https://github.com/Automattic/jetpack/blob/aad72bee498af50a14e450fe4597fcb127f9555b/projects/packages/forms/src/blocks/contact-form/edit.js#L245

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On simple site, insert form
* At sidebar, see no more integrations panel
    <img width="288" alt="image" src="https://github.com/user-attachments/assets/269f16aa-4a0e-4146-abb3-5af5c806ec40" />


