### PR TITLE
 Forms: move @covers to class level in PHP unit tests

### DIFF
--- a/projects/packages/forms/changelog/update-cover-annotation-migrate-form-fields-to-inner-blocks
+++ b/projects/packages/forms/changelog/update-cover-annotation-migrate-form-fields-to-inner-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Hoisting `@cover` annotation in PHP unit tests to class level.

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -50,7 +50,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_checkbox
+	 * Tests the render output of gutenblock_render_field_checkbox_multiple.
 	 */
 	public function test_gutenblock_render_field_checkbox_multiple_shortcode() {
 		$block = array(
@@ -127,7 +127,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_checkbox
+	 * Tests the render output of gutenblock_render_field_checkbox.
 	 */
 	public function test_gutenblock_render_field_checkbox_shortcode() {
 		$block     = array(
@@ -161,7 +161,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_text
+	 * Tests the render output of gutenblock_render_field_text.
 	 */
 	public function test_gutenblock_gutenblock_render_field_text_shortcode() {
 		$block     = array(
@@ -211,7 +211,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
-	 * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::gutenblock_render_field_radio
+	 * Tests the render output of gutenblock_render_field_radio.
 	 */
 	public function test_gutenblock_gutenblock_render_field_radio() {
 		$block = array(
@@ -286,7 +286,6 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	 * Test that ::block_attributes_to_shortcode_attributes works correctly with styles.
 	 *
 	 * @dataProvider data_provider_block_attributes_to_shortcode_attributes_with_styles
-	 * @covers \Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::block_attributes_to_shortcode_attributes
 	 *
 	 * @param array  $expected The expected shortcode attributes.
 	 * @param array  $inner_blocks The inner blocks of the block.

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -835,7 +835,7 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test for textarea field_renders
+	 * Test for textarea field_renders.
 	 */
 	public function test_make_sure_textarea_field_renders_as_expected() {
 		$attributes = array(
@@ -852,9 +852,7 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test for checkbox field_renders
-	 *
-	 * @covers \Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field::render_checkbox_field()
+	 * Test for checkbox field_renders.
 	 */
 	public function test_make_sure_checkbox_field_renders_as_expected() {
 		$attributes = array(
@@ -875,9 +873,7 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Multiple fields
-	 *
-	 * @covers \Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field::render_checkbox_multiple_field()
+	 * Multiple fields.
 	 */
 	public function test_make_sure_checkbox_multiple_field_renders_as_expected() {
 		$attributes          = array(


### PR DESCRIPTION


Hoists @cover annotations to class level for new PHP unit tests I added for https://github.com/Automattic/jetpack/pull/42890

See https://github.com/Automattic/jetpack/pull/42902 for past efforts.



