### PR TITLE
Slideshow block: Prevent invalid API requests in block preview

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-slideshow-block-invalid-api-example
+++ b/projects/plugins/jetpack/changelog/fix-slideshow-block-invalid-api-example
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Slideshow block: Ensure block preview doesn't generate an invalid API request

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/editor.js
@@ -16,24 +16,20 @@ registerJetpackBlockFromMetadata( metadata, {
 		attributes: {
 			align: 'center',
 			autoplay: true,
-			ids: [ 22, 23 ],
 			images: [
 				{
 					alt: '',
 					caption: '',
-					id: 22,
 					url: slideshowExample1,
 				},
 				{
 					alt: '',
 					caption: '',
-					id: 23,
 					url: slideshowExample2,
 				},
 				{
 					alt: '',
 					caption: '',
-					id: 23,
 					url: slideshowExample3,
 				},
 			],


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/18215

## Proposed changes:

* This PR removes the example ids from the Slideshow example attributes. These weren't necessary, but by being included they were resulting in invalid API requests (logged in the browser console) if those image IDs don't actually exist on the site. Those invalid API requests happen when viewing (previewing) the block from the block picker.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

To test, on a self-hosted site running Jetpack on trunk or the latest stable versions (using the Beta tester plugin if not testing locally, or if testing on a WoA site), or Simple:
* Add a new post, and use the 'Add block' block picker to then 'browse all' blocks. Search for Slideshow, and with a mouse hover over the block. You should see a preview of the block.
* Check the console at the same time, you should see a couple of warnings similar to `GET https://example-site.com/wp-json/wp/v2/media/22?context=edit&_locale=user 404 (Not Found)` and `GET https://example-site.com/wp-json/wp/v2/media/23?context=edit&_locale=user 404 (Not Found)` - only if you don't have media items with those IDs already.
* You can also test the block preview via the site editor, the outcome should be the same.

To test the fix:
* Apply the PR (on Simple using the command in the generated comment below), and follow the same steps.
* You should not see an invalid API call, and the preview should work as expected.

