### PR TITLE
Resolves #36360 - Fix PHP TypeError when submenu isn't proper defined

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -123,6 +123,9 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 
 				// Add submenu items.
 				foreach ( $submenu_items as $submenu_item ) {
+					if ( ! $submenu_item ) {
+						continue;
+					}
 					$submenu_item = $this->prepare_submenu_item( $submenu_item, $menu_item );
 					if ( ! empty( $submenu_item ) ) {
 						$item['children'][] = $submenu_item;

--- a/projects/plugins/jetpack/changelog/fix-php_submenu_typeerror
+++ b/projects/plugins/jetpack/changelog/fix-php_submenu_typeerror
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix PHP error when submenu isn't defined.


### PR DESCRIPTION
Edit: There's a better fix with tests in #42140. Let's go with that.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves #36360 - Fix PHP TypeError when submenu isn't proper defined

Rather than trying to create a submenu out of a bool or `null`, this PR skips any such entries.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This occurs hundreds of times each month, I suspect as the result of some third-party code. My suspicion is that it's related to the common usage of `null` as a "hidden" submenu item like was fixed in CRM in #29945.

However, try as I might I wasn't able to reproduce despite installing dozens of plugins that existed on the affected sites, along with various themes.

There are two slightly different variants variants (one with `null` and one with a bool):
```
PHP Fatal error: Uncaught TypeError: WPCOM_REST_API_V2_Endpoint_Admin_Menu::prepare_submenu_item(): Argument #1 ($submenu_item) must be of type array, null given, called in /wordpress/plugins/jetpack/14.6-a.1/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php on line 126 and defined in /wordpress/plugins/jetpack/14.6-a.1/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php:291
```
```
PHP Fatal error: Uncaught TypeError: WPCOM_REST_API_V2_Endpoint_Admin_Menu::prepare_submenu_item(): Argument #1 ($submenu_item) must be of type array, bool given, called in /wordpress/plugins/jetpack/14.6-a.1/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php on line 126 and defined in /wordpress/plugins/jetpack/14.6-a.1/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php:291
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I hate not being able to reproduce these, but here we are. At least make sure my changes don't introduce any flaws.