### PR TITLE
Forms: Update email notification template

### DIFF
--- a/projects/packages/forms/changelog/update-feedback-emails
+++ b/projects/packages/forms/changelog/update-feedback-emails
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Updated: email template that gets sent out

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1896,7 +1896,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		$template = '';
-
+		$style    = '';
 		/**
 		 * Filter the filename of the template HTML surrounding the response email. The PHP file will return the template in a variable called $template.
 		 *
@@ -1907,9 +1907,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 * @param string the filename of the HTML template used for response emails to the form owner.
 		 */
 		require apply_filters( 'jetpack_forms_response_email_template', __DIR__ . '/templates/email-response.php' );
-		if ( ! isset( $style ) ) {
-			$style = '';
-		}
 		$html_message = sprintf(
 			// The tabs are just here so that the raw code is correctly formatted for developers
 			// They're removed so that they don't affect the final message sent to users

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1653,11 +1653,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 			apply_filters(
 				'jetpack_forms_response_email_footer',
 				array(
-					'<br />',
-					'<hr />',
-					'<span style="font-size: 12px">',
+					'<span>',
 					$footer_time . '<br />',
-					$footer_ip ? $footer_ip . '<br />' : null,
+					$footer_ip ? $footer_ip : null,
 					$footer_url . '<br />',
 					$sent_by_text,
 					'</span>',

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1606,7 +1606,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 *
 		 * @param string the title of the email
 		 */
-		$title   = (string) apply_filters( 'jetpack_forms_response_email_title', '' );
+		$title   = (string) apply_filters( 'jetpack_forms_response_email_title', $subject );
 		$message = self::get_compiled_form_for_email( $post_id, $this );
 
 		if ( is_user_logged_in() ) {
@@ -1661,7 +1661,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 					$footer_url . '<br />',
 					$sent_by_text,
 					'</span>',
-					'<hr />',
 				)
 			)
 		);
@@ -1908,6 +1907,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 * @param string the filename of the HTML template used for response emails to the form owner.
 		 */
 		require apply_filters( 'jetpack_forms_response_email_template', __DIR__ . '/templates/email-response.php' );
+		if ( ! isset( $style ) ) {
+			$style = '';
+		}
 		$html_message = sprintf(
 			// The tabs are just here so that the raw code is correctly formatted for developers
 			// They're removed so that they don't affect the final message sent to users
@@ -1920,7 +1922,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$body,
 			'',
 			'',
-			$footer
+			$footer,
+			$style
 		);
 
 		return $html_message;

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -49,7 +49,12 @@ $template = '
 						</tr>
 						<tr>
 							<td class="content-block powered-by">
-								Powered by <a href="https://jetpack.com/forms/">Jetpack Forms</a>
+								' .
+								sprintf(
+									// translators: %1$s is a link to the Jetpack Forms page.
+									__( 'Powered by %1$s', 'jetpack-forms' ),
+									'<a href="https://jetpack.com/forms/?utm_source=jetpack-forms&utm_medium=email&utm_campaign=form-submissions">Jetpack Forms</a>'
+								) . '
 							</td>
 						</tr>
 						</table>

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -46,7 +46,7 @@ $template = '
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- used in class-contact-form.php
 $style = '<style>
 body {
-  font-family: Arial, sans-serif;
+  font-family: sans-serif;
   background-color: #f7f7f7;
   margin: 0;
   padding: 0;

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -16,69 +16,193 @@ $template = '
 <!DOCTYPE html>
 <html>
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  %6$s
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	%6$s
 </head>
 <body>
-  <div class="container">
-    <div class="header">
-		%1$s
-    </div>
-    <div class="content">
-	<!-- response -->
-		<p>%2$s</p>
-		%3$s
-		%4$s
-    </div>
-  </div>
-  <div class="container container-meta">
-		<div class="meta">
-			<!-- footer -->
-			<p>%5$s</p>
-		</div>
-		<p class="meta">' . __( 'Powered by Jetpack Forms', 'jetpack-forms' ) . '</p>
-    </div>
+	<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body">
+	<tr>
+		<td>&nbsp;</td>
+			<td class="container">
+				<div class="content">
+					<span class="preheader">%1$s</span>
+					<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="main">
+						<tr>
+						<td class="wrapper">
+							<!-- response -->
+							<p>%2$s</p>
+							%3$s
+							%4$s
+						</td>
+						</tr>
+					</table>
+
+					<!-- START FOOTER -->
+					<div class="footer">
+						<table role="presentation" border="0" cellpadding="0" cellspacing="0">
+						<tr>
+							<td class="content-block wrapper">
+								<!-- footer -->
+								<p>%5$s</p>
+							</td>
+						</tr>
+						<tr>
+							<td class="content-block powered-by">
+								Powered by <a href="https://jetpack.com/forms/">Jetpack Forms</a>
+							</td>
+						</tr>
+						</table>
+					</div>
+				</div>
+			</td>
+			<td>&nbsp;</td>
+		</tr>
+	</table>
 </body>
 </html>
 ';
 
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- used in class-contact-form.php
-$style = '<style>
-body {
-  font-family: sans-serif;
-  background-color: #f7f7f7;
-  margin: 0;
-  padding: 0;
-}
-.container {
-  max-width: 640px;
-  margin: 40px auto 0;
-  background-color: #FFF;
-  overflow: hidden;
-}
-.container-meta {
-	margin-top: 0;
-	background-color: #f7f7f7;
-}
-hr { display: none; }
-.header {
-  padding: 24px;
-  border-bottom: 1px solid #eee;
-}
-.header h1 {
-  margin: 0 0 10px;
-  font-size: 24px;
-}
-.meta {
-  color: #888;
-  font-size: 14px;
-  padding: 0 24px;
-}
-.content {
-  padding: 24px;
-  font-size: 16px;
-  line-height: 1.6;
-  color: #333;
-}
+$style = '<style media="all" type="text/css">
+	body {
+		font-family: sans-serif;
+		-webkit-font-smoothing: antialiased;
+		font-size: 16px;
+		line-height: 1.3;
+		-ms-text-size-adjust: 100%;
+		-webkit-text-size-adjust: 100%;
+	}
+
+	table {
+		border-collapse: separate;
+		mso-table-lspace: 0pt;
+		mso-table-rspace: 0pt;
+		width: 100%;
+	}
+
+	table td {
+		font-family: Helvetica, sans-serif;
+		font-size: 16px;
+		vertical-align: top;
+	}
+
+	body {
+		background-color: #f4f5f6;
+		margin: 0;
+		padding: 0;
+	}
+
+	.body {
+		background-color: #f4f5f6;
+		width: 100%;
+	}
+
+	.container {
+		margin: 0 auto !important;
+		max-width: 640px;
+		padding: 0;
+		padding-top: 24px;
+		width: 640px;
+	}
+
+	.content {
+		box-sizing: border-box;
+		display: block;
+		margin: 0 auto;
+		max-width: 640px;
+		padding: 0;
+	}
+
+	.main {
+		background: #ffffff;
+		width: 100%;
+	}
+
+	.wrapper {
+		box-sizing: border-box;
+		padding: 24px;
+	}
+	.content-block {
+		box-sizing: border-box;
+		padding: 0 24px;
+
+	}
+
+	.footer {
+		clear: both;
+		padding-top: 24px;
+		width: 100%;
+	}
+	.footer td,
+	.footer p,
+	.footer span,
+	.footer a {
+		color: #9a9ea6;
+		font-size: 12px;
+	}
+	p {
+		font-family: sans-serif;
+		font-size: 16px;
+		font-weight: normal;
+		margin: 0;
+		margin-bottom: 16px;
+	}
+
+	.powered-by a {
+		text-decoration: none;
+	}
+	@media only screen and (max-width: 640px) {
+		.main p,
+		.main td,
+		.main span {
+			font-size: 16px !important;
+		}
+		.wrapper {
+			padding: 8px !important;
+		}
+		.content {
+			padding: 0 !important;
+		}
+		.container {
+			padding: 0 !important;
+			padding-top: 8px !important;
+			width: 100% !important;
+		}
+		.main {
+			border-left-width: 0 !important;
+			border-radius: 0 !important;
+			border-right-width: 0 !important;
+		}
+	}
+
+	@media all {
+		.ExternalClass {
+			width: 100%;
+		}
+		.ExternalClass,
+		.ExternalClass p,
+		.ExternalClass span,
+		.ExternalClass font,
+		.ExternalClass td,
+		.ExternalClass div {
+			line-height: 100%;
+		}
+		.apple-link a {
+			color: inherit !important;
+			font-family: inherit !important;
+			font-size: inherit !important;
+			font-weight: inherit !important;
+			line-height: inherit !important;
+			text-decoration: none !important;
+		}
+		#MessageViewBody a {
+			color: inherit;
+			text-decoration: none;
+			font-size: inherit;
+			font-family: inherit;
+			font-weight: inherit;
+			line-height: inherit;
+		}
+	}
 </style>';

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -22,8 +22,8 @@ $template = '
 </head>
 <body>
 	<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body">
-	<tr>
-		<td>&nbsp;</td>
+		<tr>
+			<td class="collapse">&nbsp;</td>
 			<td class="container">
 				<div class="content">
 					<span class="preheader">%1$s</span>
@@ -56,7 +56,7 @@ $template = '
 					</div>
 				</div>
 			</td>
-			<td>&nbsp;</td>
+			<td class="collapse">&nbsp;</td>
 		</tr>
 	</table>
 </body>
@@ -88,13 +88,13 @@ $style = '<style media="all" type="text/css">
 	}
 
 	body {
-		background-color: #f4f5f6;
+		background-color: #f6f7f7;
 		margin: 0;
 		padding: 0;
 	}
 
 	.body {
-		background-color: #f4f5f6;
+		background-color: #f6f7f7;
 		width: 100%;
 	}
 
@@ -115,7 +115,7 @@ $style = '<style media="all" type="text/css">
 	}
 
 	.main {
-		background: #ffffff;
+		background: #fff;
 		width: 100%;
 	}
 
@@ -125,21 +125,23 @@ $style = '<style media="all" type="text/css">
 	}
 	.content-block {
 		box-sizing: border-box;
-		padding: 0 24px;
-
+		padding: 0 24px 24px;
 	}
 
 	.footer {
 		clear: both;
-		padding-top: 24px;
+		padding: 24px 0;
 		width: 100%;
 	}
 	.footer td,
 	.footer p,
 	.footer span,
 	.footer a {
-		color: #9a9ea6;
+		color: #101517;
 		font-size: 12px;
+	}
+	h1 {
+		font-size: 20px;
 	}
 	p {
 		font-family: sans-serif;
@@ -159,7 +161,7 @@ $style = '<style media="all" type="text/css">
 			font-size: 16px !important;
 		}
 		.wrapper {
-			padding: 8px !important;
+			padding: 8px 16px !important;
 		}
 		.content {
 			padding: 0 !important;
@@ -174,6 +176,8 @@ $style = '<style media="all" type="text/css">
 			border-radius: 0 !important;
 			border-right-width: 0 !important;
 		}
+		.collapse { display: none; }
+		h1 { padding:0 16px; }
 	}
 
 	@media all {

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -168,6 +168,9 @@ $style = '<style media="all" type="text/css">
 		.wrapper {
 			padding: 8px 16px !important;
 		}
+		.powered-by {
+			padding: 0 16px 16px!important;
+		}
 		.content {
 			padding: 0 !important;
 		}

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -13,18 +13,72 @@
 
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- used in class-contact-form.php
 $template = '
-<!doctype html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  %6$s
+</head>
 <body>
-<!-- title -->
-%1$s
-
-<!-- response -->
-<p>%2$s</p>
-%3$s
-%4$s
-<!-- footer -->
-<p>%5$s</p>
+  <div class="container">
+    <div class="header">
+		%1$s
+    </div>
+    <div class="content">
+	<!-- response -->
+		<p>%2$s</p>
+		%3$s
+		%4$s
+    </div>
+  </div>
+  <div class="container container-meta">
+		<div class="meta">
+			<!-- footer -->
+			<p>%5$s</p>
+		</div>
+		<p class="meta">' . __( 'Powered by Jetpack Forms', 'jetpack-forms' ) . '</p>
+    </div>
 </body>
 </html>
 ';
+
+// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- used in class-contact-form.php
+$style = '<style>
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f7f7f7;
+  margin: 0;
+  padding: 0;
+}
+.container {
+  max-width: 640px;
+  margin: 40px auto 0;
+  background-color: #FFF;
+  overflow: hidden;
+}
+.container-meta {
+	margin-top: 0;
+	background-color: #f7f7f7;
+}
+hr { display: none; }
+.header {
+  padding: 24px;
+  border-bottom: 1px solid #eee;
+}
+.header h1 {
+  margin: 0 0 10px;
+  font-size: 24px;
+}
+.meta {
+  color: #888;
+  font-size: 14px;
+  padding: 0 24px;
+}
+.content {
+  padding: 24px;
+  font-size: 16px;
+  line-height: 1.6;
+  color: #333;
+}
+</style>';

--- a/projects/plugins/jetpack/changelog/update-feedback-emails
+++ b/projects/plugins/jetpack/changelog/update-feedback-emails
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Update the email notification template


### PR DESCRIPTION
This PR make updates the HTML template to be more nicer. 

Before:
![Screenshot 2025-04-15 at 3 47 15 PM](https://github.com/user-attachments/assets/1b1376e2-7bb5-4133-add6-4c82f60038a2)


After:
![Screenshot 2025-04-15 at 3 47 08 PM](https://github.com/user-attachments/assets/b90636fc-3cf9-4658-86ce-a78163618d1e)

## Proposed changes:
* Make a nicer default template. The design is loosely based on the current newsletter template. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?


## Testing instructions:
Fill out the form. 

How does the new email template look like? 

Does it work nicely in different email clients?
