### PR TITLE
Post Images: resolve php warnings for images that are just about 1200 pixels.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-warnings-for-image-resize
+++ b/projects/plugins/jetpack/changelog/fix-warnings-for-image-resize
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Resolves php warnings when the thumbnail is really close to 1200, e.g. 1201

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -1133,10 +1133,18 @@ class Jetpack_PostImages {
 			$dims = image_resize_dimensions( $width, $height, 0, $max_dimension ); // Width will be calculated automatically.
 		}
 
-		return array(
-			'width'  => $dims[4],
-			'height' => $dims[5],
-		);
+		// $dims can be false if the image is virtually the same size as the max dimension, e.g. wp_fuzzy_number_match.
+		if ( $dims && isset( $dims[4] ) && isset( $dims[5] ) ) {
+			return array(
+				'width'  => $dims[4],
+				'height' => $dims[5],
+			);
+		}
+
+			return array(
+				'width'  => $width,
+				'height' => $height,
+			);
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/media/Jetpack_PostImages_Test.php
+++ b/projects/plugins/jetpack/tests/php/media/Jetpack_PostImages_Test.php
@@ -952,7 +952,7 @@ class Jetpack_PostImages_Test extends WP_UnitTestCase {
 	 */
 	public static function provide_thumbnail_sizes_for_photon() {
 		return array(
-			'landscape_image' => array(
+			'landscape_image'           => array(
 				2000, // Original width
 				1333, // Original height
 				array(
@@ -960,7 +960,7 @@ class Jetpack_PostImages_Test extends WP_UnitTestCase {
 					'height' => 800,
 				), // Expected dimensions
 			),
-			'portrait_image'  => array(
+			'portrait_image'            => array(
 				1333, // Original width
 				2000, // Original height
 				array(
@@ -968,7 +968,7 @@ class Jetpack_PostImages_Test extends WP_UnitTestCase {
 					'height' => 1200,
 				), // Expected dimensions
 			),
-			'square_image'    => array(
+			'square_image'              => array(
 				2000, // Original width
 				2000, // Original height
 				array(
@@ -976,13 +976,21 @@ class Jetpack_PostImages_Test extends WP_UnitTestCase {
 					'height' => 1200,
 				), // Expected dimensions
 			),
-			'small_image'     => array(
+			'small_image'               => array(
 				800, // Original width
 				600, // Original height
 				array(
 					'width'  => 800,
 					'height' => 600,
 				), // Expected dimensions - no resize needed
+			),
+			'image_virtually_same_size' => array(
+				1201, // Original width
+				672, // Original height
+				array(
+					'width'  => 1201,
+					'height' => 672,
+				), // Close enough to 1200 to not resize.
 			),
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes PHP warning when image_resize_dimensions return false.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* If the resize function does not provide a value, use the original values.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack (link incoming)

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* The unit tests cover it, but add a new post with the thumbnail image with a width of 1201 (and height under 1200).
* With Sharing, Publicize, etc on, open the post so the og tags are generated.
* Before patch, php warning and the OG image URL will not have dims.
* After patch, silence is golden and the image URL will include dims args for photon.

