### PR TITLE
Fix field block examples

### DIFF
--- a/projects/packages/forms/src/blocks/field-select/index.js
+++ b/projects/packages/forms/src/blocks/field-select/index.js
@@ -57,9 +57,7 @@ const settings = {
 			},
 			{
 				name: 'jetpack/input',
-				attributes: {
-					type: 'text',
-				},
+				attributes: { type: 'dropdown', placeholder: __( 'Select one option', 'jetpack-forms' ) },
 			},
 		],
 	},

--- a/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
@@ -9,12 +9,12 @@ export default function useFormWrapper( { attributes, clientId, name } ) {
 	const { replaceBlock, __unstableMarkNextChangeAsNotPersistent } = useDispatch( blockEditorStore );
 	const { getBlocks } = useSelect( blockEditorStore );
 
-	const forms = useSelect( select => {
+	const parentForms = useSelect( select => {
 		return select( blockEditorStore ).getBlockParentsByBlockName( clientId, FORM_BLOCK_NAME );
 	} );
 
 	useEffect( () => {
-		if ( ! forms?.length ) {
+		if ( ! parentForms?.length ) {
 			// As this is an automated update, ensure it doesn't end up in the undo stack
 			// by calling `__unstableMarkNextChangeAsNotPersistent`.
 			__unstableMarkNextChangeAsNotPersistent();

--- a/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
@@ -9,9 +9,12 @@ export default function useFormWrapper( { attributes, clientId, name } ) {
 	const { replaceBlock, __unstableMarkNextChangeAsNotPersistent } = useDispatch( blockEditorStore );
 	const { getBlocks } = useSelect( blockEditorStore );
 
-	const parentForms = useSelect( select => {
-		return select( blockEditorStore ).getBlockParentsByBlockName( clientId, FORM_BLOCK_NAME );
-	} );
+	const parentForms = useSelect(
+		select => {
+			return select( blockEditorStore ).getBlockParentsByBlockName( clientId, FORM_BLOCK_NAME );
+		},
+		[ clientId ]
+	);
 
 	useEffect( () => {
 		if ( ! parentForms?.length ) {

--- a/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
@@ -6,29 +6,27 @@ import { __ } from '@wordpress/i18n';
 import { FORM_BLOCK_NAME } from '../util/constants';
 
 export default function useFormWrapper( { attributes, clientId, name } ) {
-	const BUTTON_BLOCK_NAME = 'jetpack/button';
-	const SUBMIT_BUTTON_ATTR = {
-		text: __( 'Submit', 'jetpack-forms' ),
-		element: 'button',
-		lock: { remove: true },
-	};
-
 	const { replaceBlock, __unstableMarkNextChangeAsNotPersistent } = useDispatch( blockEditorStore );
+	const { getBlocks } = useSelect( blockEditorStore );
 
-	const parents = useSelect( select => {
+	const forms = useSelect( select => {
 		return select( blockEditorStore ).getBlockParentsByBlockName( clientId, FORM_BLOCK_NAME );
 	} );
 
 	useEffect( () => {
-		if ( ! parents?.length ) {
+		if ( ! forms?.length ) {
 			// As this is an automated update, ensure it doesn't end up in the undo stack
 			// by calling `__unstableMarkNextChangeAsNotPersistent`.
 			__unstableMarkNextChangeAsNotPersistent();
 			replaceBlock(
 				clientId,
 				createBlock( FORM_BLOCK_NAME, {}, [
-					createBlock( name, attributes ),
-					createBlock( BUTTON_BLOCK_NAME, SUBMIT_BUTTON_ATTR ),
+					createBlock( name, attributes, getBlocks( clientId ) ),
+					createBlock( 'jetpack/button', {
+						text: __( 'Submit', 'jetpack-forms' ),
+						element: 'button',
+						lock: { remove: true },
+					} ),
 				] )
 			);
 		}

--- a/projects/plugins/jetpack/tests/e2e/specs/editor/sidebar-social.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/editor/sidebar-social.test.js
@@ -13,7 +13,7 @@ test.beforeEach( async ( { page } ) => {
 } );
 
 test.describe( 'Editor sidebar: Social', () => {
-	test( 'Activation of publicize from the editor', async ( { page } ) => {
+	test( 'Activation of publicize from the editor', async ( { editor, page } ) => {
 		logger.sync( 'Creating new post' );
 
 		/**
@@ -25,7 +25,9 @@ test.describe( 'Editor sidebar: Social', () => {
 		await blockEditor.waitForEditor();
 
 		logger.action( 'Close "Welcome to the block editor" dialog' );
-		await blockEditor.closeWelcomeGuide();
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+		} );
 
 		logger.action( 'Open Jetpack sidebar' );
 		await blockEditor.openSettings( 'Jetpack' );


### PR DESCRIPTION
Fixes JETPACK-297

Note - this PR merges into the branch from #42890, not trunk.

## Proposed changes:
For some fields, the examples in the inserter were not reflective of the actual example in the block definition.

This looks to be caused by `useFormWrapper`. When a field as a parent of it, as is the case in the block examples, `useFormWrapper` adds one. However, `useFormWrapper` wasn't preserving the inner blocks of the field.

In this PR I'm ensuring it does preserve inner blocks by passing the result of `getBlocks` for the field through to the `replaceBlock` call that `useFormWrapper` makes.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Create a new post
2. Open the block inserter
3. Type 'field' in the search box
4. Hover over the block examples, in particular 'Single Choice (Radio)' and 'Multiple Choice (Checkbox)' should have a few options with labels within them. In #42890 those options aren't shown.

You can also reproduce this bug if you try dragging one of those blocks (with multiple options defined) out of a form. The inner options get removed.