### PR TITLE
Publicize: Re-enable unit tests for share status

### DIFF
--- a/projects/packages/publicize/.phan/baseline.php
+++ b/projects/packages/publicize/.phan/baseline.php
@@ -11,15 +11,15 @@ return [
     // # Issue statistics:
     // PhanPluginMixedKeyNoKey : 8 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 6 occurrences
-    // PhanPluginUnreachableCode : 5 occurrences
+    // PhanPluginUnreachableCode : 4 occurrences
     // PhanTypeMismatchArgument : 4 occurrences
     // PhanUndeclaredClassMethod : 3 occurrences
-    // PhanNoopNew : 2 occurrences
     // PhanPossiblyUndeclaredVariable : 2 occurrences
     // PhanTypeMismatchArgumentNullable : 2 occurrences
     // PhanTypeMismatchReturnProbablyReal : 2 occurrences
     // PhanTypeMissingReturn : 2 occurrences
     // PhanImpossibleCondition : 1 occurrence
+    // PhanNoopNew : 1 occurrence
     // PhanParamSignatureMismatch : 1 occurrence
     // PhanPluginDuplicateExpressionAssignmentOperation : 1 occurrence
     // PhanPluginSimplifyExpressionBool : 1 occurrence
@@ -52,7 +52,6 @@ return [
         'src/social-image-generator/class-settings.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/social-image-generator/class-setup.php' => ['PhanTypeMismatchArgumentNullable'],
         'tests/php/Connections_Post_Field_Test.php' => ['PhanPluginUnreachableCode', 'PhanTypeMismatchArgument'],
-        'tests/php/Share_Status_Test.php' => ['PhanPluginUnreachableCode'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/publicize/changelog/update-publicize-re-enable-unit-test-for-share-status
+++ b/projects/packages/publicize/changelog/update-publicize-re-enable-unit-test-for-share-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Re-enabled unit tests for share status

--- a/projects/packages/publicize/tests/php/Share_Status_Test.php
+++ b/projects/packages/publicize/tests/php/Share_Status_Test.php
@@ -36,15 +36,6 @@ class Share_Status_Test extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		/**
-		 * This test is disabled because of a bug in the WorDBless library.
-		 *
-		 * @see https://github.com/Automattic/wordbless/issues/76
-		 *
-		 * TODO: Remove this comment when the bug is fixed.
-		 */
-		$this->markTestIncomplete();
-
 		static::$admin_id = wp_insert_user(
 			array(
 				'user_login' => 'dummy_admin',

--- a/tools/php-test-env/composer.json
+++ b/tools/php-test-env/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=7.2",
-		"automattic/wordbless": "^0.5.0",
+		"automattic/wordbless": "^0.5.3",
 		"yoast/phpunit-polyfills": "^3.0.0"
 	},
 	"scripts": {


### PR DESCRIPTION
We had to disable unit tests for Share Status logic in Publicize in #42978 because of a [bug in WorDBless](https://github.com/Automattic/wordbless/issues/76), which is now fixed.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Publicize: Re-enable unit tests for share status following the bug fix in WorDBless

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI should be happy

