### PR TITLE
Forms: Fix display of label and option fallback values in transform previews JETPACK-278

### DIFF
--- a/projects/packages/forms/src/blocks/label/edit.js
+++ b/projects/packages/forms/src/blocks/label/edit.js
@@ -1,4 +1,5 @@
-import { RichText, useBlockProps } from '@wordpress/block-editor';
+import { RichText, store as blockEditorStore, useBlockProps } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { clsx } from 'clsx';
 import { useSyncedAttributes } from '../shared/hooks/use-synced-attributes';
@@ -46,6 +47,13 @@ const LabelEdit = ( { attributes, name, setAttributes, context } ) => {
 	} );
 	const blockProps = useBlockProps( { className } );
 
+	// The label value to use for the RichText field must manually fall back to the
+	// placeholder to be rendered in previews.
+	const isPreviewMode = useSelect( select => {
+		return select( blockEditorStore ).getSettings().isPreviewMode;
+	}, [] );
+	const labelValue = isPreviewMode ? emptyToNull( label ) ?? placeholder : label;
+
 	return (
 		<WithNotchedWrapper formStyle={ formStyle }>
 			<div { ...blockProps }>
@@ -55,7 +63,7 @@ const LabelEdit = ( { attributes, name, setAttributes, context } ) => {
 					onChange={ value => setAttributes( { label: value } ) }
 					placeholder={ placeholder }
 					tagName="label"
-					value={ label }
+					value={ labelValue }
 					withoutInteractiveFormatting
 				/>
 				{ suffix && <span className="jetpack-field-label__suffix">{ suffix }</span> }

--- a/projects/packages/forms/src/blocks/label/edit.js
+++ b/projects/packages/forms/src/blocks/label/edit.js
@@ -7,6 +7,7 @@ import { ALLOWED_FORMATS, DATE_FORMATS, FORM_STYLE } from '../shared/util/consta
 import getBlockStyle from '../shared/util/get-block-style.js';
 
 const SYNCED_ATTRIBUTE_KEYS = [ 'textColor', 'fontFamily', 'fontSize', 'style' ];
+const emptyToNull = str => ( str === '' ? null : str );
 
 const WithNotchedWrapper = ( { formStyle, children } ) => {
 	if ( formStyle === FORM_STYLE.OUTLINED ) {
@@ -33,7 +34,6 @@ const LabelEdit = ( { attributes, name, setAttributes, context } ) => {
 
 	const { label, defaultLabel, requiredText } = attributes;
 
-	const emptyToNull = str => ( str === '' ? null : str );
 	const placeholder =
 		emptyToNull( defaultLabel ) ?? emptyToNull( label ) ?? __( 'Add label…', 'jetpack-forms' );
 	const suffix = dateFormat

--- a/projects/packages/forms/src/blocks/option/edit.js
+++ b/projects/packages/forms/src/blocks/option/edit.js
@@ -7,6 +7,14 @@ import useEnter from './use-enter';
 
 const SYNCED_ATTRIBUTE_KEYS = [ 'textColor', 'fontFamily', 'fontSize', 'style' ];
 
+const getLabelOrFallback = ( label, placeholder ) => {
+	if ( label === '' ) {
+		return placeholder;
+	}
+
+	return label ?? placeholder;
+};
+
 const OptionEdit = ( { attributes, clientId, context, name, setAttributes } ) => {
 	const {
 		'jetpack/field-defaultValue': defaultValue,
@@ -46,10 +54,9 @@ const OptionEdit = ( { attributes, clientId, context, name, setAttributes } ) =>
 		return select( blockEditorStore ).getSettings().isPreviewMode;
 	}, [] );
 	const placeholder = __( 'Add label…', 'jetpack-forms' );
-	const emptyToNull = str => ( str === '' ? null : str );
 	// The label value to use for the RichText field must manually fall back to the
 	// placeholder to be rendered in previews.
-	const labelValue = isPreviewMode ? emptyToNull( label ) ?? placeholder : label;
+	const labelValue = isPreviewMode ? getLabelOrFallback( label, placeholder ) : label;
 
 	// Some fields such as Checkbox or Consent, do not have a list of options.
 	// Additionally, a checkbox field may also be flagged as required so we need

--- a/projects/packages/forms/src/blocks/option/edit.js
+++ b/projects/packages/forms/src/blocks/option/edit.js
@@ -42,6 +42,15 @@ const OptionEdit = ( { attributes, clientId, context, name, setAttributes } ) =>
 	const useEnterRef = useEnter( { content: label, clientId, isStandalone } );
 	const useEnterRequiredRef = useEnter( { content: label, clientId, isStandalone } );
 
+	const isPreviewMode = useSelect( select => {
+		return select( blockEditorStore ).getSettings().isPreviewMode;
+	}, [] );
+	const placeholder = __( 'Add label…', 'jetpack-forms' );
+	const emptyToNull = str => ( str === '' ? null : str );
+	// The label value to use for the RichText field must manually fall back to the
+	// placeholder to be rendered in previews.
+	const labelValue = isPreviewMode ? emptyToNull( label ) ?? placeholder : label;
+
 	// Some fields such as Checkbox or Consent, do not have a list of options.
 	// Additionally, a checkbox field may also be flagged as required so we need
 	// to allow for custom required text.
@@ -62,8 +71,8 @@ const OptionEdit = ( { attributes, clientId, context, name, setAttributes } ) =>
 						identifier="label"
 						tagName="div"
 						className="wp-block"
-						value={ label }
-						placeholder={ __( 'Add label…', 'jetpack-forms' ) }
+						value={ labelValue }
+						placeholder={ placeholder }
 						__unstableDisableFormats
 						onChange={ newLabel => setAttributes( { label: newLabel } ) }
 						onRemove={ onRemove }
@@ -92,7 +101,7 @@ const OptionEdit = ( { attributes, clientId, context, name, setAttributes } ) =>
 				identifier="label"
 				tagName="div"
 				className="wp-block"
-				value={ label }
+				value={ labelValue }
 				placeholder={ __( 'Add option…', 'jetpack-forms' ) }
 				__unstableDisableFormats
 				onChange={ newLabel => setAttributes( { label: newLabel } ) }


### PR DESCRIPTION
JETPACK-278

Related: #42890

## Proposed changes:

- Detect when the Label and Option blocks are within a block preview
- When being previewed apply any fallback to the value passed to the inner RichText components so the fallback can be displayed in previews

Note: The RichText component culls most props and simply renders out the `value` as inner HTML when in preview mode.


## Does this pull request change what data or activity we track or use?

No change.

## Testing instructions:

1. Add a contact form to a post
2. Select the Name field
3. Open the transforms menu in the block toolbar
4. Hover over all the different field types and check that label and option fallbacks apply

Label and Option blocks have fallback labels mostly for fields like Dropdown, Checkbox, and Single/Multiple Choice fields


## Screenshots

<img width="754" alt="Screenshot 2025-04-16 at 5 27 40 pm" src="https://github.com/user-attachments/assets/91b49f65-08b2-4ea5-b005-a5fdf7890ac6" />
<img width="712" alt="Screenshot 2025-04-16 at 5 27 28 pm" src="https://github.com/user-attachments/assets/46ea3550-c3d5-42dc-bed1-07032d3c500f" />
<img width="702" alt="Screenshot 2025-04-16 at 5 27 21 pm" src="https://github.com/user-attachments/assets/e67a5ae3-8237-455b-ae24-06ea45beb057" />

