### PR TITLE
Add fallback styles for dropdown block when css vars are not populated

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -339,8 +339,8 @@
 	.jetpack-field__textarea {
 		border: var(--jetpack--contact-form--border, 1px solid #8c8f94);
 		border-color: var(--jetpack--contact-form--border-color, #8c8f94);
-		border-style: var(--jetpack--contact-form--border-style, solid );
-		border-width: var(--jetpack--contact-form--border-size, 1px );
+		border-style: var(--jetpack--contact-form--border-style, solid);
+		border-width: var(--jetpack--contact-form--border-size, 1px);
 	}
 
 	.components-base-control__field {
@@ -648,16 +648,16 @@
 	}
 
 	&__toggle {
-		border: var(--jetpack--contact-form--border);
-		border-color: var(--jetpack--contact-form--border-color);
-		border-style: var(--jetpack--contact-form--border-style);
-		border-width: var(--jetpack--contact-form--border-size);
+		border: var(--jetpack--contact-form--border, 1px solid #8c8f94);
+		border-color: var(--jetpack--contact-form--border-color, #8c8f94);
+		border-style: var(--jetpack--contact-form--border-style, solid);
+		border-width: var(--jetpack--contact-form--border-size, 1px);
 		border-radius: var(--jetpack--contact-form--border-radius);
-		background-color: var(--jetpack--contact-form--input-background);
+		background-color: var(--jetpack--contact-form--input-background, #fff);
 		color: var(--jetpack--contact-form--text-color);
 		font-size: var(--jetpack--contact-form--font-size, 16px);
 		line-height: var(--jetpack--contact-form--line-height);
-		padding: var(--jetpack--contact-form--input-padding);
+		padding: var(--jetpack--contact-form--input-padding, 16px);
 		display: flex;
 		align-items: center;
 		justify-content: space-between;


### PR DESCRIPTION
Note - this PR merges into #42890 rather than trunk.

## Proposed changes:
It was noted in https://github.com/Automattic/jetpack/pull/43096#pullrequestreview-2770658052 that often when dropdown field is shown in a preview, it's missing styles.

One of the reasons this happens is explained in #41418.

I noticed there's also another contributing factor that explains why this happens for the dropdown block but not the multiline/textarea block.

The latter has fallback values set in its CSS, while the former doesn't.

In this PR I'm also setting fallbacks for the dropdown, and it seems to mostly solve the preview problems, at least in situations where the theme isn't changing the styles of the form much.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Create a new post
2. Open the inserter
3. Search for 'Dropdown'
4. Hover the dropdown field block to see the preview

Expected: The block should have proper border styles and padding.

## Screenshots

### Before
<img width="276" alt="Screenshot 2025-04-16 at 5 18 22 pm" src="https://github.com/user-attachments/assets/d6d0c06c-20e2-4870-9ac3-f3461633662f" />

### After
<img width="267" alt="Screenshot 2025-04-16 at 5 18 54 pm" src="https://github.com/user-attachments/assets/05ce56c0-43c0-42bb-96df-3e8d18c9701b" />

