### PR TITLE
Boost: Exclude package from production build

### DIFF
--- a/projects/plugins/boost/.gitattributes
+++ b/projects/plugins/boost/.gitattributes
@@ -27,6 +27,7 @@ vendor/wikimedia/aho-corasick/**                production-include
 /vendor/automattic/jetpack-autoloader/**        production-exclude
 /vendor/automattic/jetpack-changelogger/**      production-exclude
 /vendor/automattic/jetpack-composer-plugin/**   production-exclude
+/vendor/automattic/jetpack-test-environment/**  production-exclude
 /.editorconfig                                  production-exclude
 /.gitattributes                                 production-exclude
 /.gitignore                                     production-exclude

--- a/projects/plugins/boost/changelog/fix-boost-exclude-package-from-mirror-repo
+++ b/projects/plugins/boost/changelog/fix-boost-exclude-package-from-mirror-repo
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Update for the monorepo. Not user facing.
+
+


### PR DESCRIPTION
## Proposed changes:

* Exclude package from mirror repo/production version of Boost.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1744807242394089/1744801496.784869-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Proof read changes.