### PR TITLE
Add features that allow restriction of the number of wpcom plugins per plan to wpsh

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-add-plugins-one-and-three-features
+++ b/projects/plugins/wpcomsh/changelog/update-add-plugins-one-and-three-features
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+wpcomsh: add plugin limit features to be used for lower tier plans

--- a/projects/plugins/wpcomsh/constants.php
+++ b/projects/plugins/wpcomsh/constants.php
@@ -33,3 +33,18 @@ define( 'JETPACK_BLOCKS_VARIATION', 'experimental' );
 
 // Date for lowering storage from 200 GB to 50 GB for business and higher plans. Ref: D108151-code.
 define( 'LEGACY_200GB_CUTOFF_DATE', '2023-07-20' );
+
+define(
+	'WOA_SOFTWARE_SET_DEFAULT',
+	array(
+		'plugins/akismet',
+		'plugins/jetpack',
+		'plugins/classic-editor',
+		'plugins/gutenberg',
+		'plugins/layout-grid',
+		'plugins/page-optimize',
+		'plugins/crowdsignal-forms',
+		'plugins/polldaddy',
+		'themes/pub/twentytwentytwo',
+	)
+);

--- a/projects/plugins/wpcomsh/feature-plugins/hooks.php
+++ b/projects/plugins/wpcomsh/feature-plugins/hooks.php
@@ -379,3 +379,31 @@ function wpcomsh_prevent_exceeding_plugin_limit( $new_value, $old_value ) {
 	return $new_value;
 }
 add_filter( 'pre_update_option_active_plugins', 'wpcomsh_prevent_exceeding_plugin_limit', 10, 2 );
+
+/**
+ * Remove activation links for non-default plugins when the plugin limit is reached.
+ *
+ * @param array  $actions     Array of plugin action links.
+ * @param string $plugin_file Path to the plugin file relative to the plugins directory.
+ * @return array Modified array of plugin action links.
+ */
+function wpcomsh_maybe_remove_activation_link( $actions, $plugin_file ) {
+	// Skip if no activate action or if it's a default plugin
+	if ( ! isset( $actions['activate'] ) || wpcomsh_is_default_plugin( $plugin_file ) ) {
+		return $actions;
+	}
+
+	// Get currently active plugins
+	$active_plugins = get_option( 'active_plugins', array() );
+
+	// Add this plugin to the list to simulate its activation
+	$active_plugins[] = $plugin_file;
+
+	// Check if activating this plugin would exceed the limit
+	if ( wpcomsh_would_exceed_plugin_limit( $active_plugins ) ) {
+		$actions['activate'] = __( 'Plugin limit reached', 'wpcomsh' );
+	}
+
+	return $actions;
+}
+add_filter( 'plugin_action_links', 'wpcomsh_maybe_remove_activation_link', 10, 2 );

--- a/projects/plugins/wpcomsh/feature-plugins/hooks.php
+++ b/projects/plugins/wpcomsh/feature-plugins/hooks.php
@@ -356,6 +356,7 @@ add_action( 'admin_menu', 'wpcomsh_remove_jetpack_manage_menu_item', 1001 ); // 
  * @return array|WP_Error The filtered value.
  */
 function wpcomsh_prevent_exceeding_plugin_limit( $new_value, $old_value ) {
+	// Skip check for network-wide operations
 	if ( is_multisite() && is_network_admin() ) {
 		return $new_value;
 	}
@@ -365,8 +366,17 @@ function wpcomsh_prevent_exceeding_plugin_limit( $new_value, $old_value ) {
 		return $new_value;
 	}
 
-	// Plugins are manually activated one by one
-	if ( 1 === count( $newly_activated ) && wpcomsh_is_default_plugin( $newly_activated[0] ) ) {
+	// Check if all newly activated plugins are default plugins
+	$has_non_default = false;
+	foreach ( $newly_activated as $plugin ) {
+		if ( ! wpcomsh_is_default_plugin( $plugin ) ) {
+			$has_non_default = true;
+			break;
+		}
+	}
+
+	// If all newly activated plugins are default plugins, allow the activation
+	if ( ! $has_non_default ) {
 		return $new_value;
 	}
 

--- a/projects/plugins/wpcomsh/feature-plugins/hooks.php
+++ b/projects/plugins/wpcomsh/feature-plugins/hooks.php
@@ -347,3 +347,35 @@ function wpcomsh_remove_jetpack_manage_menu_item() {
 }
 
 add_action( 'admin_menu', 'wpcomsh_remove_jetpack_manage_menu_item', 1001 ); // Automattic\Jetpack\Admin_UI\Admin_Menu uses 1000.
+
+/**
+ * Prevent plugin activation if it would exceed the plan's plugin limit.
+ *
+ * @param array $new_value The new value of the option.
+ * @param array $old_value The old value of the option.
+ * @return array|WP_Error The filtered value.
+ */
+function wpcomsh_prevent_exceeding_plugin_limit( $new_value, $old_value ) {
+	if ( is_multisite() && is_network_admin() ) {
+		return $new_value;
+	}
+
+	$newly_activated = array_diff( $new_value, $old_value );
+	if ( empty( $newly_activated ) ) {
+		return $new_value;
+	}
+
+	// Plugins are manually activated one by one
+	if ( 1 === count( $newly_activated ) && wpcomsh_is_default_plugin( $newly_activated[0] ) ) {
+		return $new_value;
+	}
+
+	// Otherwise check if we would exceed the limit
+	if ( wpcomsh_would_exceed_plugin_limit( $new_value ) ) {
+		// Return the old value to prevent the update
+		return $old_value;
+	}
+
+	return $new_value;
+}
+add_filter( 'pre_update_option_active_plugins', 'wpcomsh_prevent_exceeding_plugin_limit', 10, 2 );

--- a/projects/plugins/wpcomsh/functions.php
+++ b/projects/plugins/wpcomsh/functions.php
@@ -434,3 +434,63 @@ add_filter( 'likes_new_layout', '__return_true' );
  * @see https://github.com/Automattic/wp-calypso/issues/100279
  */
 add_filter( 'send_email_change_email', '__return_false' );
+
+/**
+ * Check if a plugin is part of the default WOA software set.
+ *
+ * @param string $plugin Plugin path relative to the plugins directory (e.g. 'akismet/akismet.php').
+ * @return bool True if the plugin is part of the default set, false otherwise.
+ */
+function wpcomsh_is_default_plugin( $plugin ) {
+	if ( ! defined( 'WOA_SOFTWARE_SET_DEFAULT' ) ) {
+		return false;
+	}
+
+	// Extract the plugin folder name from the full plugin path
+	$plugin_folder = explode( '/', $plugin )[0];
+
+	// Check if the plugin folder exists in the default set
+	foreach ( WOA_SOFTWARE_SET_DEFAULT as $default_item ) {
+		if ( strpos( $default_item, 'plugins/' ) === 0 && $plugin_folder === substr( $default_item, 8 ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Check if the given list of plugins would exceed the plan's plugin limit.
+ *
+ * @param array $plugins Array of plugin paths to check.
+ * @return bool True if the plugin count would exceed the limit, false otherwise.
+ */
+function wpcomsh_would_exceed_plugin_limit( $plugins ) {
+	if ( ! is_array( $plugins ) ) {
+		return false;
+	}
+
+	// If site doesn't have either limit feature, no limit applies
+	if ( ! wpcom_site_has_feature( WPCOM_Features::PLUGINS_ALLOW_ONE ) && ! wpcom_site_has_feature( WPCOM_Features::PLUGINS_ALLOW_THREE ) ) {
+		return false;
+	}
+
+	// Count non-default active plugins
+	$active_count = 0;
+	foreach ( $plugins as $plugin ) {
+		if ( ! wpcomsh_is_default_plugin( $plugin ) ) {
+			++$active_count;
+		}
+	}
+
+	// Check against plan limits
+	if ( wpcom_site_has_feature( WPCOM_Features::PLUGINS_ALLOW_ONE ) && $active_count > 1 ) {
+		return true;
+	}
+
+	if ( wpcom_site_has_feature( WPCOM_Features::PLUGINS_ALLOW_THREE ) && $active_count > 3 ) {
+		return true;
+	}
+
+	return false;
+}

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -397,6 +397,8 @@ class WPCOM_Features {
 	public const OPTIONS_PERMALINK                 = 'options-permalink';
 	public const PAYMENTS                          = 'payments';
 	public const PERFORMANCE_HISTORY               = 'performance-history';
+	public const PLUGINS_ALLOW_ONE                 = 'plugins-allow-one';
+	public const PLUGINS_ALLOW_THREE               = 'plugins-allow-three';
 	public const POLLDADDY                         = 'polldaddy';
 	public const PREMIUM_CONTENT_CONTAINER         = 'premium-content/container';
 	public const PERSONAL_THEMES                   = 'personal-themes';
@@ -883,6 +885,12 @@ class WPCOM_Features {
 		self::PERFORMANCE_HISTORY               => array(
 			self::JETPACK_BOOST_PLANS,
 			self::JETPACK_COMPLETE_PLANS,
+		),
+		self::PLUGINS_ALLOW_ONE                 => array(
+			self::WPCOM_PERSONAL_PLANS,
+		),
+		self::PLUGINS_ALLOW_THREE               => array(
+			self::WPCOM_PREMIUM_PLANS,
 		),
 		self::POLLDADDY                         => array(
 			self::JETPACK_BUSINESS_PLANS,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

_This change is not fine to be merged without @claudiucelfilip's work on conditionally enabling plugins on a couple of other plans. It will work but is not easily testable._

## Proposed changes:

* Provides two new features that will restrict the number of non-default plugins to 1 or 3

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
This is a WPCOMSH change for WPCOM atomic sites. It's only meant to be tested from wp-admin, the Calypso part will come separately.

* Using a Business plan dev blog on WPCOM
* Modify wpcom-features - PLUGINS_ALLOW_ONE or THREE to include self::WPCOM_BUSINESS_PLANS
* Install 1 or 3 plugins

<img width="631" alt="Screenshot 2025-04-16 at 17 16 01" src="https://github.com/user-attachments/assets/8514e9fe-13f3-4da6-88ca-16198782e7ca" />
<img width="391" alt="Screenshot 2025-04-16 at 17 15 39" src="https://github.com/user-attachments/assets/d7265b42-0a27-40bf-affe-698ebda677e6" />

* Removing the plugin_action_links will allow you to attempt activating plugins beyond the limit. This should also not work, although without an error as I couldn't find a hook that would handle wp_error properly