### PR TITLE
Jetpack SEO: Ensure more performant practices when getting enabled features.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-seo-getEnabledFeatures
+++ b/projects/plugins/jetpack/changelog/update-jetpack-seo-getEnabledFeatures
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack SEO Enhancer: Ensure more performant practices when getting enabled features.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/selectors.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/store/selectors.ts
@@ -1,3 +1,4 @@
+import { createSelector as wpCreateSelector } from '@wordpress/data';
 /**
  * Types
  */
@@ -35,11 +36,19 @@ export function hasImageFailed( state: SeoEnhancerState, clientId: string ) {
 	return state.failedImages[ clientId ] ?? false;
 }
 
-export function getEnabledFeatures( state: SeoEnhancerState ) {
+const baseGetEnabledFeatures = ( state: SeoEnhancerState ): PromptType[] => {
 	return Object.keys( state.features ).filter(
 		feature => state.features[ feature ]
 	) as PromptType[];
-}
+};
+
+// Check if createSelector is available
+const createSelector = typeof wpCreateSelector === 'function' ? wpCreateSelector : null;
+
+// @todo: Refactor this to only use createSelector once P2 is using a version of Gutenberg that is 18.2 or higher.
+export const getEnabledFeatures = createSelector
+	? createSelector( baseGetEnabledFeatures, ( state: SeoEnhancerState ) => [ state.features ] )
+	: baseGetEnabledFeatures;
 
 export function isImageAltTextFeatureEnabled( state: SeoEnhancerState ) {
 	return getEnabledFeatures( state ).includes( 'images-alt-text' );


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/43033
Fixes VULCAN-60

## Proposed changes:
* This PR implements the same changes that were implemented in https://github.com/Automattic/jetpack/pull/43031, but with a fallback for sites using very old versions of Gutenberg (including P2 internally). Instead of importing via `rememo` as a fallback, the previous functionality will be used in those instances where `createSelector` is not available.
---
* This PR changes how `getEnabledFeatures` works by making sure we only run the selector function if the dependencies have changed.
* This change was prompted by a `useSelect` warning in the console of post editors (when script debug is enabled, running WordPress 6.8):
```
The 'useSelect' hook returns different values when called with the same state and parameters.
This can lead to unnecessary re-renders and performance issues if not fixed.`
Non-equal value keys: enabledFeatures
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1744303609023589-slack-C02TQF5VAJD

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

To replicate the issue:

* If you spin up a Jurassic Ninja site using the Jetpack Beta tester plugin (testing in bleeding edge), and make sure the WordPress version is 6.8, with Jetpack connected you should be able to replicate the console warning if opening up a post. You will also need script debug enabled in `wp-config.php`: `define( 'SCRIPT_DEBUG', 'true' );`.
* You will be able to see the console warning on a WoA test site too.

To test the fix:

* Apply this PR and follow the same steps - the warning no longer appears. 
* To confirm no impact on features, activate SEO from the SEO panel (in the Jetpack sidebar), and 'generate metadata'.

To confirm that this PR does not result in issues on P2:
* Sandbox a P2 site, and apply these changes using the command in the generated comment below in your sandbox.
* Visit the P2, and open up WP Admin in order to create a new post. In the post editor, attempt to add core blocks such as the checkbox block, task block. Also the gif block. These should work, as should auto-complete when using `@` and `+`. 
* You can also test with comments on the P2 front-end (for example with `@` and `+` autocomplete, and adding the task block and gif block - in order to replicate similar testing scenarios as were used when the issue from the earlier PR was present, you should also try adding `?concat=yes` to the URL.
* If you want to be able to replicate the original issue, you would need to check out commit `8b383cff396365100a67982f80778472257feb7a` in a WPcom sandbox. See p174463877727505-slack-C010KDAPG49 for some of the testing and issues that had been reported originally.