### PR TITLE
Jetpack_Upcoming_Events_Widget: Fix warning

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-warning-upcoming-events-summary
+++ b/projects/plugins/jetpack/changelog/fix-warning-upcoming-events-summary
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack_Upcoming_Events_Widget: Fix warning when `$event['SUMMARY']` does not exist

--- a/projects/plugins/jetpack/modules/widgets/upcoming-events.php
+++ b/projects/plugins/jetpack/modules/widgets/upcoming-events.php
@@ -152,7 +152,7 @@ class Jetpack_Upcoming_Events_Widget extends WP_Widget {
 				<li>
 					<strong class="event-summary">
 						<?php
-						echo $ical->escape( stripslashes( $event['SUMMARY'] ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- this method is built to escape.
+						echo $ical->escape( stripslashes( $event['SUMMARY'] ?? '' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- this method is built to escape.
 						?>
 					</strong>
 					<span class="event-when"><?php echo esc_html( $ical->formatted_date( $event ) ); ?></span>


### PR DESCRIPTION
Fix warning when $event['SUMMARY'] does not exist. The code assumes that it will always be there, but does not confirm that. As a result you can get a PHP warning:

> Warning: Undefined array key "SUMMARY"

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

