### PR TITLE
Forms: Fix Creative Mail SVG

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-modal-svg-issue
+++ b/projects/packages/forms/changelog/fix-forms-modal-svg-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fixed Creative Mail SVG issue.

--- a/projects/packages/forms/src/icons/creative-mail-icon.js
+++ b/projects/packages/forms/src/icons/creative-mail-icon.js
@@ -9,7 +9,7 @@ const CreativeMailIcon = props => (
 		fill="none"
 		xmlns="http://www.w3.org/2000/svg"
 	>
-		<G clip-path="url(#clip0)">
+		<G clipPath="url(#clip0)">
 			<Rect width="258" height="258" fill="#F2EFF8" />
 			<Path
 				d="M473.616 242.393C286.085 103.281 -48.1297 232.191 -99.1903 253.521L-170.675 265.578L-322 187.675L-273.725 -72L572.952 -57.1614C602.351 89.0605 623.642 353.682 473.616 242.393Z"


### PR DESCRIPTION
## Proposed changes:

I noticed a console error when loading the forms integration modal. It comes from the Creative Mail SVG using cliip-path vs ClipPath. This PR is a small fix for that. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load the forms integration modal in the block editor and confirm the Creative Mail SVG loads correctly, and that there is no associated SVG error in the console.

