### PR TITLE
CI: Improve selection of E2E tests to run

### DIFF
--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -138,13 +138,16 @@ switch ( process.env.GITHUB_EVENT_NAME ) {
 	case 'pull_request':
 	case 'push': {
 		const changedProjects = JSON.parse(
-			execSync( '.github/files/list-changed-projects.sh' ).toString()
+			execSync( '.github/files/list-changed-projects.sh', {
+				env: { ...process.env, EXTRA: 'e2e' },
+			} ).toString()
 		);
 
 		for ( const project of projects ) {
 			if ( ! project.targets ) {
 				// If no targets are defined, run the tests
 				matrix.push( project );
+				continue;
 			}
 
 			const targets = execSync(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If anything in `tests/e2e-commons/` changes, we should run all the E2E tests. We do this by adding an additional `infrastructureFileSets` entry in `jetpack dependencies` for use when the E2E setup calls it.

If `projects/plugins/jetpack/tests/e2e/specs/sync/` changes, we should run the "Jetpack sync" suite. We do this by adding an idea of `extraFileSets` in `jetpack dependencies`, which adds additional projects to the output if changed files match certain regexes.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1744805505081119/1744804829.885699-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a JSON file with contents like this:
   ```json
   { "pull_request": { "base": { "sha": "883046c2a8b474ed309b7f6e38679e89667c5fe8" }, "head": { "sha": "6ccc0b2a85e7b9a3f81a281a502437d09ba0cf36" } } }
   ```
* On trunk, run `GITHUB_EVENT_NAME=pull_request GITHUB_EVENT_PATH=/path/to/file.json node .github/files/e2e-tests/e2e-matrix.js`. The initial part of the output should look like this:
  ```
  GITHUB_EVENT_NAME is pull_request, checking diff from 883046c2a8b474ed309b7f6e38679e89667c5fe8...6ccc0b2a85e7b9a3f81a281a502437d09ba0cf36
  Diff touches projects/plugins/jetpack/changelog/fix-more-e2e-tests, marking plugins/jetpack as changed.
  Diff touches projects/plugins/social/changelog/fix-more-e2e-tests, marking plugins/social as changed.
  Diff touches tools/e2e-commons/pages/wp-admin/block-editor.js, marking monorepo as changed.
  ```
  The JSON should have only some Jetpack and Social entries (and no "Jetpack sync").
* Check out this PR and run the above command again. This time the initial output should look like this:
  ```
  GITHUB_EVENT_NAME is pull_request, checking diff from 883046c2a8b474ed309b7f6e38679e89667c5fe8...6ccc0b2a85e7b9a3f81a281a502437d09ba0cf36
  Diff touches projects/plugins/jetpack/changelog/fix-more-e2e-tests, marking plugins/jetpack as changed.
  Diff touches projects/plugins/jetpack/tests/e2e/specs/sync/sync.test.js, marking packages/sync as changed.
  Diff touches projects/plugins/social/changelog/fix-more-e2e-tests, marking plugins/social as changed.
  Diff touches infrastructure file tools/e2e-commons/pages/wp-admin/block-editor.js, considering all projects as changed.
  ```
  The JSON should have entries for all E2E suites.
