### PR TITLE
Search: Fix E2E test for WordPress 6.8

### DIFF
--- a/projects/plugins/search/changelog/fix-search-e2e-for-6.8
+++ b/projects/plugins/search/changelog/fix-search-e2e-for-6.8
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix E2E test.
+
+

--- a/projects/plugins/search/tests/e2e/pages/wp-admin/search-configure.js
+++ b/projects/plugins/search/tests/e2e/pages/wp-admin/search-configure.js
@@ -19,7 +19,7 @@ export default class SearchConfigure extends WpPage {
 	}
 
 	async choosePinkAsHighlightColor() {
-		const pinkColorSelector = 'button[aria-label="Color: Pale pink"]';
+		const pinkColorSelector = 'button[aria-label="Pale pink"]';
 		return await this.click( pinkColorSelector );
 	}
 
@@ -52,7 +52,7 @@ export default class SearchConfigure extends WpPage {
 	}
 
 	async isHighlightPink() {
-		const pinkColorSelector = 'button[aria-selected="true"][aria-label="Color: Pale pink"]';
+		const pinkColorSelector = 'button[aria-selected="true"][aria-label="Pale pink"]';
 		return await this.isElementVisible( pinkColorSelector, 200 );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The aria labels for the color buttons no longer begin with "Color:".

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* E2E test happy now?