### PR TITLE
Forms: use componentry instead of CSS in integrations modal

### DIFF
--- a/projects/packages/forms/changelog/update-forms-integrations-modal-cleanup
+++ b/projects/packages/forms/changelog/update-forms-integrations-modal-cleanup
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: use componentry instead of CSS for some elements in integrations modal.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.js
@@ -1,4 +1,10 @@
-import { CardHeader, Icon, ToggleControl, Tooltip } from '@wordpress/components';
+import {
+	CardHeader,
+	Icon,
+	ToggleControl,
+	Tooltip,
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { chevronDown, chevronUp } from '@wordpress/icons';
 import PluginActionButton from './plugin-action-button';
@@ -80,7 +86,7 @@ const IntegrationCardHeader = ( {
 						) }
 					</div>
 				</div>
-				<div className="integration-card__actions">
+				<HStack spacing="3" alignment="center" justify="end" expanded={ false }>
 					{ showPluginAction && (
 						<PluginActionButton
 							slug={ cardData.slug }
@@ -103,7 +109,7 @@ const IntegrationCardHeader = ( {
 						</Tooltip>
 					) }
 					<Icon icon={ isExpanded ? chevronUp : chevronDown } />
-				</div>
+				</HStack>
 			</div>
 		</CardHeader>
 	);

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/plugin-action-button.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/plugin-action-button.js
@@ -37,6 +37,7 @@ const PluginActionButton = ( { slug, pluginFile, isInstalled, refreshStatus, tra
 				onClick={ handleAction }
 				disabled={ isInstalling }
 				icon={ isInstalling ? <Spinner /> : undefined }
+				__next40pxDefaultSize
 			>
 				{ getButtonText() }
 			</Button>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -84,31 +84,10 @@
 		line-height: 1.4;
 	}
 
-	&__actions {
-		display: flex;
-		align-items: center;
-		gap: 12px;
-	}
-
 	&__links {
 		display: flex;
 		align-items: center;
 		gap: 8px;
-	}
-
-	.is-spinning {
-		animation: rotation 2s infinite linear;
-	}
-	
-	@keyframes rotation {
-
-		from {
-			transform: rotate(0deg);
-		}
-
-		to {
-			transform: rotate(359deg);
-		}
 	}
 
 	.components-button .components-spinner {
@@ -120,4 +99,4 @@
 	.components-card__body {
 		padding-bottom: 30px;
 	}
-} 
+}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Some minor optimizations to use componentry instead of CSS in some parts of the integrations modal.

Only visual change should be the button size.

Before

<img width="735" alt="Screenshot 2025-04-16 at 17 44 26" src="https://github.com/user-attachments/assets/cfadf8ae-fb76-49f6-a754-98a5cbb8fa14" />

After

<img width="728" alt="Screenshot 2025-04-16 at 22 20 57" src="https://github.com/user-attachments/assets/8ac6af72-cb4a-4219-b0a0-63048d8c3ac7" />


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use `HStack` instead of CSS+div
* Remove un-used `is-spinning` CSS + animation
* Set margin-bottom to 0 in toggle component instead of using CSS
* Opt-in button CTA to slightly larger button sizes with `__next40pxDefaultSize` — @ilonagl smaller button looked a bit more balanced and I'm not sure which ones we use in Figma library, but the larger ones are sort of the future version in Gutenberg componentry. We can at this point use either smaller or bigger.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

