### PR TITLE
WAF BFP: fix type errors with unexpected parameter types in wp_login_failed hook

### DIFF
--- a/projects/packages/waf/changelog/fix-protect-bfp-type-errors
+++ b/projects/packages/waf/changelog/fix-protect-bfp-type-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Brute Force Protection: properly handle unexpected parameter types from third-party plugins during login failure processing.

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -515,16 +515,16 @@ class Brute_Force_Protection {
 	 *
 	 * Fires custom, plugable action jpp_log_failed_attempt with the IP
 	 *
-	 * @param string|null    $username - The username or email address attempting to log in.
-	 * @param \WP_Error|null $error    - A WP_Error object with the authentication failure details.
+	 * @param string|null           $username - The username or email address attempting to log in.
+	 * @param \WP_Error|string|null $error    - A WP_Error object or error message with the authentication failure details.
 	 *
 	 * @return void
 	 */
-	public function log_failed_attempt( $username, ?\WP_Error $error = null ) {
+	public function log_failed_attempt( $username, $error = null ) {
 		$username = $username ?? '';
 
 		// Skip if Account protection password validation error.
-		if ( isset( $error->errors['password_detection_validation_error'] ) ) {
+		if ( is_object( $error ) && isset( $error->errors['password_detection_validation_error'] ) ) {
 			return;
 		}
 

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -515,12 +515,13 @@ class Brute_Force_Protection {
 	 *
 	 * Fires custom, plugable action jpp_log_failed_attempt with the IP
 	 *
-	 * @param string         $username - The username or email address attempting to log in.
+	 * @param string|null    $username - The username or email address attempting to log in.
 	 * @param \WP_Error|null $error    - A WP_Error object with the authentication failure details.
 	 *
 	 * @return void
 	 */
-	public function log_failed_attempt( string $username, ?\WP_Error $error = null ) {
+	public function log_failed_attempt( $username, ?\WP_Error $error = null ) {
+		$username = $username ?? '';
 
 		// Skip if Account protection password validation error.
 		if ( isset( $error->errors['password_detection_validation_error'] ) ) {

--- a/projects/packages/waf/tests/php/integration/BruteForceProtectionTest.php
+++ b/projects/packages/waf/tests/php/integration/BruteForceProtectionTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Test for Brute Force Protection class.
+ *
+ * @package automattic/jetpack-waf
+ */
+
+use Automattic\Jetpack\Waf\Brute_Force_Protection\Brute_Force_Protection;
+
+/**
+ * Brute Force Protection test case.
+ */
+class BruteForceProtectionTest extends WorDBless\BaseTestCase {
+
+	/**
+	 * Test instance.
+	 *
+	 * @var Brute_Force_Protection|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $instance;
+
+	/**
+	 * Set up each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->instance = $this->getMockBuilder( Brute_Force_Protection::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'protect_call', 'get_transient' ) )
+			->getMock();
+
+		// Configure the mocked methods to do nothing or return simple values.
+		$this->instance->method( 'protect_call' )->willReturn( array() );
+		$this->instance->method( 'get_transient' )->willReturn( 3 );
+	}
+
+	/**
+	 * Test that log_failed_attempt can handle null usernames.
+	 */
+	public function test_log_failed_attempt_handles_null_username() {
+		// Ensure no errors are triggered when null is passed as username.
+		$this->instance->expects( $this->once() )
+			->method( 'protect_call' )
+			->with( 'failed_attempt' );
+
+		$this->instance->log_failed_attempt( null );
+	}
+
+	/**
+	 * Test that log_failed_attempt can handle string error messages.
+	 */
+	public function test_log_failed_attempt_handles_string_error() {
+		// Ensure no errors are triggered when a string is passed as error.
+		$this->instance->expects( $this->once() )
+			->method( 'protect_call' )
+			->with( 'failed_attempt' );
+
+		$this->instance->log_failed_attempt( 'username', 'Invalid password' );
+	}
+
+	/**
+	 * Test that log_failed_attempt properly handles WP_Error objects with password validation errors.
+	 */
+	public function test_log_failed_attempt_handles_password_validation_error() {
+		// Mock a WP_Error-like object for testing
+		$error = $this->createMock( 'WP_Error' );
+
+		// Set up the errors property for the mock
+		$error->errors = array(
+			'password_detection_validation_error' => array( 'Password validation error' ),
+		);
+
+		// Method should return early and not call protect_call.
+		$this->instance->expects( $this->never() )
+			->method( 'protect_call' );
+
+		$this->instance->log_failed_attempt( 'username', $error );
+	}
+
+	/**
+	 * Test that log_failed_attempt properly handles WP_Error objects with other errors.
+	 */
+	public function test_log_failed_attempt_handles_wp_error() {
+		// Mock a WP_Error-like object for testing
+		$error = $this->createMock( 'WP_Error' );
+
+		// Set up the errors property for the mock
+		$error->errors = array(
+			'incorrect_password' => array( 'Incorrect password' ),
+		);
+
+		// Method should process the failed attempt.
+		$this->instance->expects( $this->once() )
+			->method( 'protect_call' )
+			->with( 'failed_attempt' );
+
+		$this->instance->log_failed_attempt( 'username', $error );
+	}
+}

--- a/projects/packages/waf/tests/php/integration/BruteForceProtectionTest.php
+++ b/projects/packages/waf/tests/php/integration/BruteForceProtectionTest.php
@@ -63,13 +63,7 @@ class BruteForceProtectionTest extends WorDBless\BaseTestCase {
 	 * Test that log_failed_attempt properly handles WP_Error objects with password validation errors.
 	 */
 	public function test_log_failed_attempt_handles_password_validation_error() {
-		// Mock a WP_Error-like object for testing
-		$error = $this->createMock( 'WP_Error' );
-
-		// Set up the errors property for the mock
-		$error->errors = array(
-			'password_detection_validation_error' => array( 'Password validation error' ),
-		);
+		$error = new WP_Error( 'password_detection_validation_error', 'Password validation error' );
 
 		// Method should return early and not call protect_call.
 		$this->instance->expects( $this->never() )
@@ -82,13 +76,7 @@ class BruteForceProtectionTest extends WorDBless\BaseTestCase {
 	 * Test that log_failed_attempt properly handles WP_Error objects with other errors.
 	 */
 	public function test_log_failed_attempt_handles_wp_error() {
-		// Mock a WP_Error-like object for testing
-		$error = $this->createMock( 'WP_Error' );
-
-		// Set up the errors property for the mock
-		$error->errors = array(
-			'incorrect_password' => array( 'Incorrect password' ),
-		);
+		$error = new WP_Error( 'incorrect_password', 'Incorrect password' );
 
 		// Method should process the failed attempt.
 		$this->instance->expects( $this->once() )


### PR DESCRIPTION
Fixes PROTECT-74

## Proposed changes:
* Update `log_failed_attempt` method to accept `null` usernames by converting them to empty strings
* Modify parameter type handling to accept `string` error messages in addition to `WP_Error` objects
* Improve type safety with proper object type checking before accessing properties

The changes address compatibility issues with third-party plugins that pass unexpected parameter types to the `wp_login_failed` hook, causing PHP fatal type errors in production environments.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1744645697314949-slack-C080AF0NF0R

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This change is focused on fixing type errors in the Brute Force Protection module. The fix has been covered with tests, so running the tests is the most reliable way to verify the changes.

* Run unit tests and ensure it passes
```
    cd projects/packages/waf
    composer phpunit
```

The changes are defensive in nature and only affect error handling, so they should not cause any regressions in normal usage. The CI checks should confirm this.