### PR TITLE
Module Activation: only require_once to avoid any race conditions

### DIFF
--- a/projects/packages/status/changelog/fix-require_once
+++ b/projects/packages/status/changelog/fix-require_once
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Module Activation: use require_once to avoid potential redeclaration errors

--- a/projects/packages/status/src/class-modules.php
+++ b/projects/packages/status/src/class-modules.php
@@ -468,7 +468,7 @@ class Modules {
 			ob_start();
 			$module_path = $this->get_path( $module );
 			if ( file_exists( $module_path ) ) {
-				require $this->get_path( $module ); // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
+				require_once $this->get_path( $module ); // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
 			}
 
 			$active[] = $module;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes PHP errors upon WoA post-transfer.

This is my hypothesis behind the errors mentioned in p1744835387938139-slack-CDLH4C1UZ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Only require_once to avoid any potential redeclaration issues.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1744835387938139-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Unsure how to test, but the errors would stop upon merging to `wpcomsh` to WoA (`status` pkg dep via `jetpack-mu-wpcom`)