### PR TITLE
Forms: Prevent Google Drive connection attempt without Jetpack user account connection

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-disconnected-account-google-drive
+++ b/projects/packages/forms/changelog/fix-forms-disconnected-account-google-drive
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Prevent Google Drive connection attempt without Jetpack user account connection

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
@@ -33,7 +33,7 @@ const GoogleDriveExport = ( { onExport } ) => {
 				} );
 				const data = await response.json();
 
-				if ( ! data.connection ) {
+				if ( data.connection !== true ) {
 					return;
 				}
 

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useConnection } from '@automattic/jetpack-connection';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
 import { useCallback, useState } from '@wordpress/element';
@@ -15,6 +16,10 @@ import { config } from '../..';
 const GoogleDriveExport = ( { onExport } ) => {
 	const [ isConnected, setIsConnected ] = useState( config( 'gdriveConnection' ) );
 	const { tracks } = useAnalytics();
+
+	const { isUserConnected, handleConnectUser, userIsConnecting, isOfflineMode } = useConnection( {
+		redirectUri: location.href.split( 'wp-admin/' )[ 1 ],
+	} );
 
 	const pollForConnection = useCallback( () => {
 		const interval = setInterval( async () => {
@@ -64,6 +69,10 @@ const GoogleDriveExport = ( { onExport } ) => {
 		} );
 	}, [ tracks, pollForConnection ] );
 
+	if ( isOfflineMode ) {
+		return null;
+	}
+
 	const buttonClasses = clsx( 'button', 'export-button', 'export-gdrive' );
 
 	return (
@@ -108,7 +117,20 @@ const GoogleDriveExport = ( { onExport } ) => {
 						</button>
 					) }
 
-					{ ! isConnected && (
+					{ ! isConnected && ! isUserConnected && (
+						<Button
+							className={ buttonClasses }
+							variant="primary"
+							rel="noopener noreferrer"
+							target="_blank"
+							onClick={ handleConnectUser }
+							isBusy={ userIsConnecting }
+						>
+							{ __( 'Connect Jetpack user account', 'jetpack-forms' ) }
+						</Button>
+					) }
+
+					{ ! isConnected && isUserConnected && (
 						<Button
 							href={ config( 'gdriveConnectURL' ) }
 							className={ buttonClasses }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #42915

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Checks if the user is connected before attempting to connect the user's Google Drive account, as that would fail without the Jetpack connection
* Changes the button to connect the user account to Jetpack instead, redirecting back to the same URL, where the user can proceed with the Google connection

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Get to a state where your site is connected to Jetpack, but your user is not
* Click on "Feedback" on the admin sidebar
* Click on Export
* Check that the button on the Google Drive card is set to connect the user account instead
* Click it
* Check that you can connect your user
* Check that you are redirected back to the Feedback page
* With the user connected, check that the Google connection works as expected

| Before | After |
| - | - |
|<img src="https://github.com/user-attachments/assets/4d4b030d-686d-410e-a5ab-2c6ce5a7b069" alt="drawing" width="500"/> | <img src="https://github.com/user-attachments/assets/5e051387-fa52-40d2-8530-795af0130f53" alt="drawing" width="500"/>


