### PR TITLE
Forms: add field-file as paid block

### DIFF
--- a/projects/packages/forms/changelog/add-field-file-as-paid-block
+++ b/projects/packages/forms/changelog/add-field-file-as-paid-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+File Upload field: add registration with plan check

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -211,7 +211,7 @@ class Contact_Form_Block {
 			'jetpack_register_gutenberg_extensions',
 			function () {
 				if ( apply_filters( 'jetpack_unauth_file_upload_plan_check', true ) ) {
-						add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );
+					add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );
 				}
 			}
 		);

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -199,7 +199,21 @@ class Contact_Form_Block {
 			'jetpack/field-file',
 			array(
 				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_file' ),
+				// See https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/extensions/README.md#paid-blocks
+				'plan_check'      => apply_filters( 'jetpack_unauth_file_upload_plan_check', true ),
 			)
+		);
+
+		// We only need to enable the jetpack_block_editor_enable_upgrade_nudge filter if the plan check is true
+		// This way, packages/blocks/src/class-blocks.php:101 handles the availability method (set_availability_for_plan or set_extension_available)
+		// TODO: once we remove the featire filter, we can just set upgrade nudge filter to return true.
+		add_action(
+			'jetpack_register_gutenberg_extensions',
+			function () {
+				if ( apply_filters( 'jetpack_unauth_file_upload_plan_check', true ) ) {
+						add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );
+				}
+			}
 		);
 	}
 

--- a/projects/packages/plans/changelog/add-field-file-as-paid-block
+++ b/projects/packages/plans/changelog/add-field-file-as-paid-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack Forms: add feature/block field-file support to Personal and Complete plans

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -79,6 +79,7 @@ class Current_Plan {
 				'akismet',
 				'payments',
 				'videopress',
+				'field-file', // Forms
 			),
 		),
 		'premium'  => array(
@@ -146,7 +147,9 @@ class Current_Plan {
 				'jetpack_complete_monthly',
 				'vip',
 			),
-			'supports' => array(),
+			'supports' => array(
+				'field-file', // Forms
+			),
 		),
 	);
 

--- a/projects/plugins/jetpack/changelog/add-field-file-as-paid-block
+++ b/projects/plugins/jetpack/changelog/add-field-file-as-paid-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack Forms: add field-file to beta blocks variation

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -81,7 +81,8 @@
 		"videopress/video-chapters",
 		"ai-assistant-backend-prompts",
 		"ai-list-to-table-transform",
-		"ai-use-chrome-ai-sometimes"
+		"ai-use-chrome-ai-sometimes",
+		"field-file"
 	],
 	"experimental": [],
 	"no-post-editor": [


### PR DESCRIPTION
Fixes #

## Proposed changes:
Set File Upload field block registration for paid plans.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
peKye1-1vf-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Build packages/plans, packages/forms and plugins/jetpack.
Open the editor, add a form and then insert a File Upload field block.