### PR TITLE
SAL: Cast gmt_offset to float when retrieving offset from option to prevent type errors

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-gmt-offset-float-cast
+++ b/projects/plugins/jetpack/changelog/fix-gmt-offset-float-cast
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+SAL: Cast gmt_offset to float when retrieving offset from option to prevent type errors

--- a/projects/plugins/jetpack/sal/class.json-api-date.php
+++ b/projects/plugins/jetpack/sal/class.json-api-date.php
@@ -47,7 +47,7 @@ class WPCOM_JSON_API_Date {
 						$offset = $timezone->getOffset( $date_time );
 					}
 				} else {
-					$offset = 3600 * get_option( 'gmt_offset' );
+					$offset = 3600 * floatval( get_option( 'gmt_offset' ) );
 				}
 			} else {
 				$offset = $timestamp - $timestamp_gmt;

--- a/projects/plugins/jetpack/sal/class.json-api-date.php
+++ b/projects/plugins/jetpack/sal/class.json-api-date.php
@@ -47,7 +47,7 @@ class WPCOM_JSON_API_Date {
 						$offset = $timezone->getOffset( $date_time );
 					}
 				} else {
-					$offset = 3600 * floatval( get_option( 'gmt_offset' ) );
+					$offset = 3600 * (float) get_option( 'gmt_offset' );
 				}
 			} else {
 				$offset = $timestamp - $timestamp_gmt;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Seeing `Uncaught TypeError: Unsupported operand types: string * int` when retrieving the `gmt_offset` option.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Cast `gmt_offset` to float when retrieving offset from option to prevent type errors

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1744863967597409-slack-C034JEXD1RD
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Check the product discussion.