### PR TITLE
Forms: remove 16px default padding in form patterns

### DIFF
--- a/projects/packages/forms/changelog/update-forms-patterns-remove-16px-padding
+++ b/projects/packages/forms/changelog/update-forms-patterns-remove-16px-padding
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: remove 16px default padding in form patterns

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -50,8 +50,8 @@ class Util {
 				'title'      => __( 'Contact Form', 'jetpack-forms' ),
 				'blockTypes' => array( 'jetpack/contact-form' ),
 				'categories' => array( $category_slug ),
-				'content'    => '<!-- wp:jetpack/contact-form {"style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}}} -->
-                    <div class="wp-block-jetpack-contact-form" style="padding-top:16px;padding-right:16px;padding-bottom:16px;padding-left:16px">
+				'content'    => '<!-- wp:jetpack/contact-form -->
+                    <div class="wp-block-jetpack-contact-form">
                         <!-- wp:jetpack/field-name {"required":true} /-->
                         <!-- wp:jetpack/field-email {"required":true} /-->
                         <!-- wp:jetpack/field-textarea /-->
@@ -63,8 +63,8 @@ class Util {
 				'title'      => __( 'Lead Capture Form', 'jetpack-forms' ),
 				'blockTypes' => array( 'jetpack/contact-form' ),
 				'categories' => array( $category_slug ),
-				'content'    => '<!-- wp:jetpack/contact-form {"style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}}} -->
-                    <div class="wp-block-jetpack-contact-form" style="padding-top:16px;padding-right:16px;padding-bottom:16px;padding-left:16px">
+				'content'    => '<!-- wp:jetpack/contact-form -->
+                    <div class="wp-block-jetpack-contact-form">
                         <!-- wp:jetpack/field-name {"required":true} /-->
                         <!-- wp:jetpack/field-email {"required":true} /-->
                         <!-- wp:jetpack/field-consent /-->
@@ -76,8 +76,8 @@ class Util {
 				'title'      => __( 'RSVP Form', 'jetpack-forms' ),
 				'blockTypes' => array( 'jetpack/contact-form' ),
 				'categories' => array( $category_slug ),
-				'content'    => '<!-- wp:jetpack/contact-form {"subject":"A new RSVP from your website","style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}}} -->
-                    <div class="wp-block-jetpack-contact-form" style="padding-top:16px;padding-right:16px;padding-bottom:16px;padding-left:16px">
+				'content'    => '<!-- wp:jetpack/contact-form {"subject":"A new RSVP from your website"} -->
+                    <div class="wp-block-jetpack-contact-form">
                         <!-- wp:jetpack/field-name {"required":true} /-->
                         <!-- wp:jetpack/field-email {"required":true} /-->
                         <!-- wp:jetpack/field-radio {"label":"Attending?","required":true,"options":["Yes","No"]} /-->
@@ -90,8 +90,8 @@ class Util {
 				'title'      => __( 'Registration Form', 'jetpack-forms' ),
 				'blockTypes' => array( 'jetpack/contact-form' ),
 				'categories' => array( $category_slug ),
-				'content'    => '<!-- wp:jetpack/contact-form {"subject":"A new registration from your website","style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}}} -->
-                    <div class="wp-block-jetpack-contact-form" style="padding-top:16px;padding-right:16px;padding-bottom:16px;padding-left:16px">
+				'content'    => '<!-- wp:jetpack/contact-form {"subject":"A new registration from your website"} -->
+                    <div class="wp-block-jetpack-contact-form">
                         <!-- wp:jetpack/field-name {"required":true} /-->
                         <!-- wp:jetpack/field-email {"required":true} /-->
                         <!-- wp:jetpack/field-telephone {"label":"Phone Number"} /-->
@@ -105,8 +105,8 @@ class Util {
 				'title'      => __( 'Appointment Form', 'jetpack-forms' ),
 				'blockTypes' => array( 'jetpack/contact-form' ),
 				'categories' => array( $category_slug ),
-				'content'    => '<!-- wp:jetpack/contact-form {"subject":"A new appointment booked from your website","style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}}} -->
-                    <div class="wp-block-jetpack-contact-form" style="padding-top:16px;padding-right:16px;padding-bottom:16px;padding-left:16px">
+				'content'    => '<!-- wp:jetpack/contact-form {"subject":"A new appointment booked from your website"} -->
+                    <div class="wp-block-jetpack-contact-form">
                         <!-- wp:jetpack/field-name {"required":true} /-->
                         <!-- wp:jetpack/field-email {"required":true} /-->
                         <!-- wp:jetpack/field-telephone {"required":true} /-->
@@ -121,8 +121,8 @@ class Util {
 				'title'      => __( 'Feedback Form', 'jetpack-forms' ),
 				'blockTypes' => array( 'jetpack/contact-form' ),
 				'categories' => array( $category_slug ),
-				'content'    => '<!-- wp:jetpack/contact-form {"subject":"New feedback received from your website","style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}}} -->
-                    <div class="wp-block-jetpack-contact-form" style="padding-top:16px;padding-right:16px;padding-bottom:16px;padding-left:16px">
+				'content'    => '<!-- wp:jetpack/contact-form {"subject":"New feedback received from your website"} -->
+                    <div class="wp-block-jetpack-contact-form">
                         <!-- wp:jetpack/field-name {"required":true} /-->
                         <!-- wp:jetpack/field-email {"required":true} /-->
                         <!-- wp:jetpack/field-radio {"label":"Please rate our website","required":true,"options":["1 - Very Bad","2 - Poor","3 - Average","4 - Good","5 - Excellent"]} /-->

--- a/projects/plugins/jetpack/changelog/update-forms-patterns-remove-16px-padding
+++ b/projects/plugins/jetpack/changelog/update-forms-patterns-remove-16px-padding
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: remove 16px default padding in form patterns


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow up to https://github.com/Automattic/jetpack/pull/42340 which already removed default padding in new forms inserted, but the padding was still present in patterns. Existing inserted forms will continue have the 16px padding so this is affecting just newly inserted patterns.

Issue:
- https://github.com/Automattic/jetpack/issues/29516

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove 16px padding in form patterns


Before
<img width="698" alt="Screenshot 2025-04-17 at 11 12 34" src="https://github.com/user-attachments/assets/d6478471-89dc-4417-9a21-8a8717fe6366" />


After
<img width="755" alt="Screenshot 2025-04-17 at 11 14 55" src="https://github.com/user-attachments/assets/e7fe402c-d30f-4ea0-8315-6a7f49907aa3" />




### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert form
* Go to patterns
    <img width="715" alt="Screenshot 2025-04-17 at 11 06 56" src="https://github.com/user-attachments/assets/978ccd84-211e-4904-ad98-cbffc221659c" />
* Pick a pattern and insert it
    <img width="1284" alt="Screenshot 2025-04-17 at 11 07 09" src="https://github.com/user-attachments/assets/11a45564-12ed-4abd-b208-b87c3cf500fe" />
* Notice 16px padding around the form before, and in this PR it's gone
