### PR TITLE
Form Global Styles: Update CSS specificity to 0-1-0 for default editor styles

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -322,10 +322,8 @@
 }
 
 .jetpack-field {
-
 	.jetpack-field__input, .jetpack-field__textarea {
 		width: 100%;
-		font: inherit;
 		box-sizing: border-box;
 		box-shadow: unset;
 		padding: 16px;
@@ -334,6 +332,7 @@
 
 	// Reduced specificity to 0,1,0 so that global styles can override it.
 	:where( .jetpack-field__input, .jetpack-field__textarea ) {
+		font: inherit;
 		border: 1px solid #8c8f94;
 		border-radius: 0;
 	}

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -359,20 +359,26 @@
 
 	.jetpack-option__type.jetpack-option__type {
 		align-items: center;
-		all: initial;
 		appearance: none;
-		color: var(--jetpack--contact-form--text-color);
 		display: flex;
-		border: none;
-		font-size: var(--jetpack--contact-form--font-size, 16px );
-		font-family: var(--jetpack--contact-form--font-family);
-		height: var(--jetpack--contact-form--font-size, 16px );
 		justify-content: center;
 		margin: 0 10px 0 0;
 		outline: none;
 		position: relative;
-		width: var(--jetpack--contact-form--font-size, 16px);
 		pointer-events: none;
+	}
+
+	:where(.jetpack-option__type) {
+		all: initial;
+		color: var(--jetpack--contact-form--text-color);
+		border: none;
+		// Inherit the font size from the parent element, this needs
+		// to override the `all: initial` above.
+		// Set the height and width to 1em, so that the input scales
+		// with the font size.
+		font-size: inherit;
+		height: 1em;
+		width: 1em;
 
 		&::after, &::before {
 			all: initial;
@@ -391,9 +397,9 @@
 			content: ' ';
 			display: flex;
 			font-weight: 700;
-			height: var(--jetpack--contact-form--font-size, 16px);
+			height: 1em;
 			justify-content: center;
-			width: var(--jetpack--contact-form--font-size, 16px);
+			width: 1em;
 		}
 
 		&[type="radio"]::before {
@@ -447,6 +453,8 @@
 		border-width: var(--jetpack--contact-form--button-outline--border-size);
 		border-color: currentColor;
 		border-radius: var(--jetpack--contact-form--button-outline--border-radius);
+		font-size: var(--jetpack--contact-form--font-size, 16px );
+		font-family: var(--jetpack--contact-form--font-family);
 		padding: var(--jetpack--contact-form--button-outline--padding);
 		line-height: var(--jetpack--contact-form--button-outline--line-height);
 	}

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -332,11 +332,13 @@
 		margin: 0;
 	}
 
+	// Reduced specificity to 0,1,0 so that global styles can override it.
 	:where( .jetpack-field__input, .jetpack-field__textarea ) {
 		border: 1px solid #8c8f94;
 		border-radius: 0;
 	}
 
+	// Reduced specificity to 0,1,0 so that global styles can override it.
 	:where( .jetpack-field__textarea ) {
 		border: var(--jetpack--contact-form--border, 1px solid #8c8f94);
 		border-color: var(--jetpack--contact-form--border-color, #8c8f94);
@@ -400,68 +402,6 @@
 		}
 	}
 
-	&.jetpack-field-multiple {
-
-		&.is-style-button {
-
-			.jetpack-field-option,
-			.wp-block-jetpack-field-option-checkbox,
-			.wp-block-jetpack-field-option-radio {
-				background: var(--jetpack--contact-form--button-outline--background-color);
-				color: var(--jetpack--contact-form--button-outline--text-color);
-				border: var(--jetpack--contact-form--button-outline--border);
-				border-width: var(--jetpack--contact-form--button-outline--border-size);
-				border-color: currentColor;
-				border-radius: var(--jetpack--contact-form--button-outline--border-radius);
-				padding: var(--jetpack--contact-form--button-outline--padding);
-				line-height: var(--jetpack--contact-form--button-outline--line-height);
-				align-items: center;
-
-				&.field-option-radio {
-					position: relative;
-					flex-direction: row-reverse;
-					gap: 16px;
-
-					.jetpack-option__type {
-						display: none;
-					}
-				}
-
-				.jetpack-option__type {
-					color: var(--jetpack--contact-form--button-outline--color);
-				}
-			}
-
-			.wp-block-jetpack-field-option-radio {
-
-				.jetpack-option__type {
-					display: none;
-				}
-			}
-		}
-
-		.jetpack-field-multiple__add-option {
-			margin: 0;
-			padding: 0;
-
-			.dashicon {
-				width: 1rem;
-				height: 1rem;
-				display: flex;
-				margin-left: 0;
-				margin-right: 0.75rem;
-
-				&::before {
-					font-size: 1rem;
-				}
-			}
-
-			svg {
-				margin-right: 12px;
-			}
-		}
-	}
-
 	.jetpack-field-consent__checkbox + .jetpack-field-label {
 		line-height: normal;
 	}
@@ -495,6 +435,71 @@
 		.jetpack-option__type {
 			transform: translateY(5%); /* Small offset to compensate the slightly odd perceived alignment that's due to the circular shape */
 		}
+	}
+}
+
+.jetpack-field-multiple:where(.is-style-button) {
+	// Reduced specificity to 0,1,0 so that global styles can override it.
+	:where(.jetpack-field-option) {
+		background: var(--jetpack--contact-form--button-outline--background-color);
+		color: var(--jetpack--contact-form--button-outline--text-color);
+		border: var(--jetpack--contact-form--button-outline--border);
+		border-width: var(--jetpack--contact-form--button-outline--border-size);
+		border-color: currentColor;
+		border-radius: var(--jetpack--contact-form--button-outline--border-radius);
+		padding: var(--jetpack--contact-form--button-outline--padding);
+		line-height: var(--jetpack--contact-form--button-outline--line-height);
+	}
+
+	// Increase specificity to override the `align-items: baseline` from the `jetpack-field-option` class.
+	.jetpack-field-option.jetpack-field-option {
+		align-items: center;
+	}
+
+	.jetpack-field-option.field-option-radio {
+		// TODO - Investigate if this is needed.
+		position: relative;
+		flex-direction: row-reverse;
+		gap: 16px;
+
+		// Hide the radio input when in the button style.
+		// TODO - Check why this isn't done for the checkboxes.
+		.jetpack-option__type {
+			display: none;
+		}
+	}
+
+	.jetpack-field-option .jetpack-option__type {
+		color: inherit;
+	}
+
+	.wp-block-jetpack-field-option-radio {
+
+		.jetpack-option__type {
+			display: none;
+		}
+	}
+}
+
+// TODO - See if we can find usage of this class. It's possibly a dead style.
+.jetpack-field-multiple .jetpack-field-multiple__add-option {
+	margin: 0;
+	padding: 0;
+
+	.dashicon {
+		width: 1rem;
+		height: 1rem;
+		display: flex;
+		margin-left: 0;
+		margin-right: 0.75rem;
+
+		&::before {
+			font-size: 1rem;
+		}
+	}
+
+	svg {
+		margin-right: 12px;
 	}
 }
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -337,7 +337,7 @@
 		border-radius: 0;
 	}
 
-	.jetpack-field__textarea {
+	:where( .jetpack-field__textarea ) {
 		border: var(--jetpack--contact-form--border, 1px solid #8c8f94);
 		border-color: var(--jetpack--contact-form--border-color, #8c8f94);
 		border-style: var(--jetpack--contact-form--border-style, solid);

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -322,6 +322,7 @@
 }
 
 .jetpack-field {
+
 	.jetpack-field__input, .jetpack-field__textarea {
 		width: 100%;
 		box-sizing: border-box;
@@ -533,6 +534,7 @@
 		display: none;
 	}
 
+	// TODO - This looks like dead code, it looks like field select can't contain a multiple list.
 	// TODO: make this a class, @enej
 	[data-type='jetpack/field-select'] & {
 		border: 1px solid rgba( 0, 0, 0, 0.4 );
@@ -551,6 +553,7 @@
 	margin-top: 0;
 }
 
+// TODO - This looks like dead code, along with the `JetpackOption` component.
 // Duplicated to elevate specificity in order to overwrite core styles
 .jetpack-option__input.jetpack-option__input.jetpack-option__input {
 	color: inherit;
@@ -575,6 +578,7 @@
 	font-size: inherit;
 }
 
+// TODO - This is possibly dead CSS.
 // Duplicated to elevate specificity in order to overwrite calypso styles
 .jetpack-option__remove.jetpack-option__remove {
 	padding: 6px;


### PR DESCRIPTION
Note - this PR merges into https://github.com/Automattic/jetpack/pull/42890 rather than trunk.
Part of JETPACK-277

## Proposed changes:
Adjusts CSS specificity for form input, label and options to 0-1-0 where needed.

This PR only addresses editor styles, the frontend styles still need to be updated. It also only addresses the default style variation, the outlined/animated are a bit more challenging, and there are also a few bugs (with border) that might be best to tackle first before attempting to reduce the specificity.

In general, the aim here is that fields look the same as the frontend in trunk when they have no theme.json/global/editor styles applied.

When applying theme.json/global/editor styles, there should be an order of precedence, editor styles override global styles, and global styles override theme.json styles. This order of precedence isn't too much of a concern as core handles that. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
This requires quite a lot of testing.

The first thing is to check that this PR doesn't modify the default styles of blocks when compared to trunk.

Next, update the theme.json file for your active theme to add styles for option, label, and input blocks. Here's a little code snippet to get you started, but you should try every possible style property (colors and typography for the label and option. Colors, typography and border for inputs). Add this to the `styles.blocks` property in the theme.json and then tinker, refresh your editor to check that the styles apply consistenty to all fields:
<details><summary>Click here to view snippet</summary>

```json
"jetpack/label": {
	"color": {
		"text": "var(--wp--preset--color--accent)"
	},
	"typography": {
		"fontFamily": "var(--wp--preset--font-family--body)",
		"fontSize": "3rem",
		"fontStyle": "italic",
		"fontWeight": "1000"
	}
},
"jetpack/input": {
	"border": {
		"width": "5px",
		"radius": "var(--wp--preset--spacing--20)"
	},
	"color": {
		"text": "var(--wp--preset--color--accent)"
	}
},
"jetpack/option": {
	"border": {
		"width": "5px",
		"radius": "var(--wp--preset--spacing--20)"
	},
	"color": {
		"text": "var(--wp--preset--color--accent)"
	}
},
```

</details> 

Next, using the site editor, modify the global styles for these blocks and check that the changes apply consistently to every field.

Finally modify the styles on the block instances themselves and check that the styles apply consistently.