### PR TITLE
Social: Fix typo in media requirements notice

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-typo
+++ b/projects/js-packages/publicize-components/changelog/fix-social-typo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fix a typo in media requirements notice

--- a/projects/js-packages/publicize-components/src/components/form/media-requirements-notice.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/media-requirements-notice.tsx
@@ -47,7 +47,7 @@ export const MediaRequirementsNotice: React.FC< MediaRequirementsNoticeProps > =
 		<Notice type={ 'warning' }>
 			<p>
 				{ __(
-					'The selected media cannot be share to some social media platforms.',
+					'The selected media cannot be shared to some social media platforms.',
 					'jetpack-publicize-components'
 				) }
 			</p>


### PR DESCRIPTION
A typo that I noticed [here](https://github.com/Automattic/jpop-issues/issues/9702#issuecomment-2809442538).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Social: Fix typo in media requirements notice

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try attaching an invalid image like an AVIF image to see the invalid media notice
* Confirm that the typo is fixed

