### PR TITLE
Marketplace: Allow WPCOM Personal and Premium plans to install plugins

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-enable-plugins-personal-premium
+++ b/projects/plugins/wpcomsh/changelog/update-enable-plugins-personal-premium
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+wpcomsh: allow WPCOM Personal and Premium plans to install plugins

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -525,7 +525,8 @@ class WPCOM_Features {
 			self::WPCOM_PRO_PLANS,
 		),
 		self::ATOMIC                            => array(
-			self::WPCOM_PRO_PLANS,
+			self::WPCOM_PERSONAL_PLANS,
+			self::WPCOM_PREMIUM_PLANS,
 			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
 			self::WPCOM_STAGING_PRODUCT,
 			array( 'product_type' => array( 'marketplace_plugin', 'saas_plugin' ) ),
@@ -755,6 +756,8 @@ class WPCOM_Features {
 			self::JETPACK_COMPLETE_PLANS,
 		),
 		self::INSTALL_PLUGINS                   => array(
+			self::WPCOM_PERSONAL_PLANS,
+			self::WPCOM_PREMIUM_PLANS,
 			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
 			self::WPCOM_PRO_PLANS,
 			self::EXCLUDE_PLANS => array(
@@ -762,6 +765,8 @@ class WPCOM_Features {
 			),
 		),
 		self::INSTALL_PURCHASED_PLUGINS         => array(
+			self::WPCOM_PERSONAL_PLANS,
+			self::WPCOM_PREMIUM_PLANS,
 			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
 			self::WPCOM_PRO_PLANS,
 			self::WPCOM_STARTER_PLANS,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related 180910-ghe-Automattic/wpcom

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the relevant features so that the Personal and Premium plans can install plugins

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow instructions from 180910-ghe-Automattic/wpcom
* Add the site to the WoA with the `Transfers to Atomic dev server pool` (needed for write permissions to change the wpcomsh files)
* Try to install a plugin (it will stall but it should trigger the atomic transfer)
* Once the plan is atomic, go to the Blog Report  card and enable a `Support SFTP User` 
* Use the credentials to run `pnpm jetpack rsync wpcomsh {username}@sftp.wp.com:~/htdocs/wp-content/mu-plugins`
* Installing a plugin should work now
