### PR TITLE
Forms: don't show colon after question mark for form labels

### DIFF
--- a/projects/packages/forms/changelog/update-forms-adjust-key
+++ b/projects/packages/forms/changelog/update-forms-adjust-key
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: don't show colon after question mark for form labels

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -124,7 +124,9 @@ const InboxResponse = ( { loading, response } ) => {
 			<div className="jp-forms__inbox-response-data">
 				{ map( response.fields, ( value, key ) => (
 					<div key={ key } className="jp-forms__inbox-response-item">
-						<div className="jp-forms__inbox-response-data-label">{ key }:</div>
+						<div className="jp-forms__inbox-response-data-label">
+							{ key.endsWith( '?' ) ? key : `${ key }:` }
+						</div>
 						<div className="jp-forms__inbox-response-data-value">{ renderFieldValue( value ) }</div>
 					</div>
 				) ) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Don't show colon after question mark for form labels when browsing responses in WP Admin.

Alternatively could get rid of colon `:` entirely, WDYT @ilonagl ?

Before

<img width="665" alt="Screenshot 2025-04-17 at 14 14 15" src="https://github.com/user-attachments/assets/688933a4-f563-474a-9351-e7af6797dcd6" />


After

<img width="660" alt="Screenshot 2025-04-17 at 14 15 44" src="https://github.com/user-attachments/assets/602733ee-cef6-442e-ad09-95aff7e3be42" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

