### PR TITLE
Sync: Add jetpack_sync_active_modules to MUST_SYNC_DATA_SETTINGS callable whitelist

### DIFF
--- a/projects/packages/backup/changelog/add-new-sync-active-modules-callable-to-whitelist
+++ b/projects/packages/backup/changelog/add-new-sync-active-modules-callable-to-whitelist
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Sync: Add Sync Active Modules callable to whitelist of must-sync callables

--- a/projects/packages/sync/changelog/add-new-sync-active-modules-callable-to-whitelist
+++ b/projects/packages/sync/changelog/add-new-sync-active-modules-callable-to-whitelist
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Sync: Add Sync Active Modules callable to whitelist of must-sync callables

--- a/projects/packages/sync/src/class-data-settings.php
+++ b/projects/packages/sync/src/class-data-settings.php
@@ -36,6 +36,7 @@ class Data_Settings {
 			'wp_get_environment_type'           => 'wp_get_environment_type',
 			'wp_max_upload_size'                => 'wp_max_upload_size',
 			'wp_version'                        => array( 'Automattic\\Jetpack\\Sync\\Functions', 'wp_version' ),
+			'jetpack_sync_active_modules'       => array( 'Automattic\\Jetpack\\Sync\\Functions', 'get_jetpack_sync_active_modules' ),
 		),
 		'jetpack_sync_constants_whitelist' => array(
 			'ABSPATH',

--- a/projects/packages/sync/tests/php/data-test-data-settings.php
+++ b/projects/packages/sync/tests/php/data-test-data-settings.php
@@ -158,6 +158,7 @@ class Data_Test_Data_Settings {
 					'wp_get_environment_type'           => 'wp_get_environment_type',
 					'wp_max_upload_size'                => 'wp_max_upload_size',
 					'wp_version'                        => array( 'Automattic\\Jetpack\\Sync\\Functions', 'wp_version' ),
+					'jetpack_sync_active_modules'       => array( 'Automattic\\Jetpack\\Sync\\Functions', 'get_jetpack_sync_active_modules' ),
 					'test_input_2_callable'             => array( 'Automattic\\Jetpack\\Sync\\Test_Input_2', 'test_method_input_2' ),
 				),
 				'jetpack_sync_multisite_callable_whitelist' => \Automattic\Jetpack\Sync\Defaults::$default_multisite_callable_whitelist,

--- a/projects/packages/sync/tests/php/data-test-data-settings.php
+++ b/projects/packages/sync/tests/php/data-test-data-settings.php
@@ -286,6 +286,7 @@ class Data_Test_Data_Settings {
 					'wp_get_environment_type'           => 'wp_get_environment_type',
 					'wp_max_upload_size'                => 'wp_max_upload_size',
 					'wp_version'                        => array( 'Automattic\\Jetpack\\Sync\\Functions', 'wp_version' ),
+					'jetpack_sync_active_modules'       => array( 'Automattic\\Jetpack\\Sync\\Functions', 'get_jetpack_sync_active_modules' ),
 					'test_input_2_callable'             => array( 'Automattic\\Jetpack\\Sync\\Test_Input_2', 'test_method_input_2' ),
 				),
 				'jetpack_sync_multisite_callable_whitelist' => array(),
@@ -933,6 +934,7 @@ class Data_Test_Data_Settings {
 					'wp_get_environment_type'           => 'wp_get_environment_type',
 					'wp_max_upload_size'                => 'wp_max_upload_size',
 					'wp_version'                        => array( 'Automattic\\Jetpack\\Sync\\Functions', 'wp_version' ),
+					'jetpack_sync_active_modules'       => array( 'Automattic\\Jetpack\\Sync\\Functions', 'get_jetpack_sync_active_modules' ),
 				),
 				'jetpack_sync_multisite_callable_whitelist' => array(
 					'test_input_10_multisite_callable' => array(


### PR DESCRIPTION
Fixes VULCAN-66

## Proposed changes:

* This PR adds `jetpack_sync_active_modules` to the `jetpack_sync_callable_whitelist` for callables that must be synced.
* This is a continuation of https://github.com/Automattic/jetpack/pull/38831

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

To test:

* Get a test site with any Jetpack plugin that uses Sync (Jetpack, Backup). Using Backup as an example:
* In [class-jetpack-backup.php](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/backup/src/class-jetpack-backup.php) add: `use Automattic\Jetpack\Sync\Data_Settings;`, and within the `__construct` function modify `$config->ensure( 'sync');` to be `$config->ensure( 'sync', Data_Settings::MUST_SYNC_DATA_SETTINGS );`
* In `class-callables.php`, in [maybe_sync_callables](https://github.com/Automattic/jetpack/blob/6ab409f154ec64a3fdb651c77af5957bc587e27d/projects/packages/sync/src/modules/class-callables.php#L480), add `error_log( json_encode( $callables, JSON_PRETTY_PRINT ) );` just after `$callables` has been defined (it will be a big log, you might prefer not to pretty print and then copy / paste and search through it later.
* Make sure Jetpack is deactivated.
* Activate backup. Check your error log, and notice in the output that `jetpack_sync_active_modules` exists.
* Run the same test but without the change from this PR, and notice that it doesn't.

