### PR TITLE
beta: Fix Jetpack on WoA sites

### DIFF
--- a/projects/plugins/beta/changelog/fix-jetpack-beta-for-wpcomsh-force-activation
+++ b/projects/plugins/beta/changelog/fix-jetpack-beta-for-wpcomsh-force-activation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure wpcomsh doesn't reactivate `jetpack/jetpack.php` when we've deactivated it in favor of `jetpack-dev/jetpack.php`.

--- a/projects/plugins/beta/src/class-hooks.php
+++ b/projects/plugins/beta/src/class-hooks.php
@@ -63,6 +63,9 @@ class Hooks {
 
 		add_filter( 'jetpack_options_whitelist', array( $this, 'add_to_options_whitelist' ) );
 
+		// Override the filter from projects/plugins/wpcomsh/feature-plugins/managed-plugins.php that forces jetpack/jetpack.php to be enabled.
+		add_filter( 'pre_update_option_active_plugins', array( $this, 'unbreak_wpcomsh' ), 11 );
+
 		if ( is_admin() ) {
 			self::maybe_schedule_autoupdate();
 			Admin::init();
@@ -623,5 +626,23 @@ class Hooks {
 			// Returning false makes the error go through the standard error handler as well.
 			return false;
 		}
+	}
+
+	/**
+	 * Filter: Ensure wpcomsh doesn't reactivate the non-dev Jetpack.
+	 *
+	 * @param mixed $value The new, unserialized option value.
+	 * @return array The filtered array of active plugins.
+	 */
+	public function unbreak_wpcomsh( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		if ( in_array( 'jetpack/jetpack.php', $value, true ) && in_array( 'jetpack-dev/jetpack.php', $value, true ) ) {
+			$value = array_diff( $value, array( 'jetpack/jetpack.php' ) );
+		}
+
+		return $value;
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PR #42965 added a filter in wpcomsh that tries to ensure that Jetpack-the-plugin (meaning slug `jetpack/jetpack.php`) is always enabled. This conflicts with the Beta Tester which may deactivate it in favor of `jetpack-dev/jetpack.php`.

To avoid this, register a hook with a priority just after theirs which checks if both `jetpack/jetpack.php` and `jetpack-dev/jetpack.php` are active and deactivates the former if so.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1744887204180349-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Verify the bug on a WoA site: try using Jetpack Beta Tester (4.1.2 or trunk) to activate Jetpack bleeding edge. Jetpack Beta should still think the stable version is active, while the plugins page should show the bleeding edge version, and if you check your logs you should see warnings like "Constant JETPACK__VERSION already defined" because both are right.
  * To easily reset your site to a stable state, you should be able to deactivate Jetpack Beta Tester and then re-activate it.
* Use Jetpack Beta Tester to test this branch of Jetpack Beta Tester. 😀 Then switching to Jetpack bleeding edge should work as intended.