### PR TITLE
Handle undefined reach count in subscriber affirmation

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter_crash
+++ b/projects/plugins/jetpack/changelog/fix-newsletter_crash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletters: Fix editor crash for contributors when using categories for newsletters

--- a/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
@@ -70,7 +70,8 @@ const getCopyForCategorySubscribers = ( {
 	reachCount,
 } ) => {
 	const formattedCategoryNames = getFormattedCategories( postCategories, newsletterCategories );
-	const reachCountString = reachCount.toLocaleString();
+	// This needs a more elegant solution, but for now it stops the crash when the count is undefined.
+	const reachCountString = undefined === reachCount ? '0' : reachCount.toLocaleString();
 
 	if ( futureTense ) {
 		return sprintf(
@@ -78,7 +79,7 @@ const getCopyForCategorySubscribers = ( {
 			_n(
 				'This post will be sent to everyone subscribed to %1$s (%2$s subscriber).',
 				'This post will be sent to everyone subscribed to %1$s (%2$s subscribers).',
-				reachCount,
+				reachCount ?? 0,
 				'jetpack'
 			),
 			formattedCategoryNames,
@@ -91,7 +92,7 @@ const getCopyForCategorySubscribers = ( {
 		_n(
 			'This post was sent to everyone subscribed to %1$s (%2$s subscriber).',
 			'This post was sent to everyone subscribed to %1$s (%2$s subscribers).',
-			reachCount,
+			reachCount ?? 0,
 			'jetpack'
 		),
 		formattedCategoryNames,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Cheap patch to address CML-381 / https://github.com/Automattic/jetpack-roadmap/issues/2458

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Stop crashing the editor when the category subscriber count is undefined. It's undefined when the user doesn't have the `manage_categories` cap, e.g. if they're a contributor.

Instead it will just show 0 subscribers. This isn't correct, just a quick fix to avoid the crash :)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Setup a website on wpcom simple
2. Launch it
3. Add some categories
4. Enable newsletters and select some of the categories to be used for newsletters
5. Add a user as a contributor
6. Login as the contributor
7. Create a new post and press 'Submit for review'.
8. Note that it doesn't crash, you receive a confusing message about editing newsletter categories and the message in the pre-publish panel says "This post will be sent to everyone subscribed to All content (0 subscribers)", even though this isn't true.

Repeat steps 7&8 as the admin user, notice that the subscriber count is now correct.

Before | After
-------|------
 <img width="1439" alt="Screenshot 2025-04-17 at 16 56 20" src="https://github.com/user-attachments/assets/0e568123-a8a2-4ee3-b8ca-e2f7290ad155" /> | <img width="1439" alt="Screenshot 2025-04-17 at 16 51 53" src="https://github.com/user-attachments/assets/0398539c-3b07-47fa-9f80-0b8421b53f86" />


