### PR TITLE
Widgets: deprecate Flickr widget

### DIFF
--- a/projects/plugins/jetpack/changelog/update-flickr-widget
+++ b/projects/plugins/jetpack/changelog/update-flickr-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Widgets: deprecate the Flickr widget. Flickr no longer supports fetching recent images from an RSS feed.

--- a/projects/plugins/jetpack/modules/widgets/flickr.php
+++ b/projects/plugins/jetpack/modules/widgets/flickr.php
@@ -1,7 +1,16 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Flickr Widget, pulling recent photos from Flickr using RSS feed.
+ *
+ * This widget is now deprecated.
+ * Flickr does not offer RSS feeds anymore.
+ *
+ * @see https://github.com/Automattic/jetpack/issues/39824
+ *
+ * @package automattic/jetpack
+ */
 
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- TODO: Move classes to appropriately-named class files.
-
 
 /**
  * Disable direct access/execution to/of the widget code.
@@ -228,7 +237,19 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 	 * Register Jetpack_Flickr_Widget widget.
 	 */
 	function jetpack_register_flickr_widget() {
-		register_widget( 'Jetpack_Flickr_Widget' );
+		$transient  = 'jetpack_flickr_widget::is_active';
+		$has_widget = get_transient( $transient );
+
+		if ( false === $has_widget ) {
+			$is_active_widget = is_active_widget( false, false, 'flickr', false );
+			$has_widget       = (int) ! empty( $is_active_widget );
+			set_transient( $transient, $has_widget, 1 * HOUR_IN_SECONDS );
+		}
+
+		// [DEPRECATION]: Only register widget if active widget exists already
+		if ( $has_widget ) {
+			register_widget( 'Jetpack_Flickr_Widget' );
+		}
 	}
 	add_action( 'widgets_init', 'jetpack_register_flickr_widget' );
 }

--- a/projects/plugins/jetpack/modules/widgets/flickr.php
+++ b/projects/plugins/jetpack/modules/widgets/flickr.php
@@ -3,7 +3,9 @@
  * Flickr Widget, pulling recent photos from Flickr using RSS feed.
  *
  * This widget is now deprecated.
- * Flickr does not offer RSS feeds anymore.
+ * Existing widgets will continue to work, but Flickr no longer displays RSS feeds,
+ * making it impossible for site owners to configure this widget.
+ * We consequently only register the widget if it's already in use on the site.
  *
  * @see https://github.com/Automattic/jetpack/issues/39824
  *


### PR DESCRIPTION
Fixes #39824

## Proposed changes:

The flickr interface no longer surfaces RSS feeds that can be used to display recent Flickr photos. The widget continues to work for folks already using it, but new users cannot get their RSS feed anymore.

We can consequently remove this widget when it is not already being used.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start without applying this branch.
* Install a classic theme, like Twenty Twenty.
* Install and activate the Classic Widgets plugin.
* Go to Jetpack > Settings, and ensure the Widgets module is active.
* Go to Appearance > Widgets, and you'll find the Flickr widget being available to use.
* Now switch to this branch
* Go back to Apperance > Widgets
* The widget should not be available.
* Now switch back to `trunk`
* Go to Appearance > Widgets
* Add the Flickr widget to your sidebar.
* You can use `https://api.flickr.com/services/feeds/photos_public.gne?id=15251430@N03&lang=en-us&format=rss_200` as the RSS url.
* Now switch back to this branch.
* The widget should still appear in Appearance > Widgets, and on t
 frontend.
 
