### PR TITLE
Boost: use transients instead of cache for persistance

### DIFF
--- a/projects/plugins/boost/app/lib/class-storage-post-type.php
+++ b/projects/plugins/boost/app/lib/class-storage-post-type.php
@@ -107,7 +107,7 @@ class Storage_Post_Type {
 	 * @return mixed
 	 */
 	public function get( $key, $default ) {
-		$cached = wp_cache_get( $key, $this->post_type_slug() );
+		$cached = get_transient( $this->post_type_slug() . '_' . $key );
 		if ( $cached ) {
 			return $cached;
 		}
@@ -142,7 +142,7 @@ class Storage_Post_Type {
 			return $default;
 		}
 
-		wp_cache_set( $key, $value['data'], $this->post_type_slug(), HOUR_IN_SECONDS );
+		set_transient( $this->post_type_slug() . '_' . $key, $value['data'], HOUR_IN_SECONDS );
 
 		return $value['data'];
 	}

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/class-css-proxy.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/class-css-proxy.php
@@ -52,7 +52,7 @@ class CSS_Proxy {
 		}
 
 		$cache_key = 'jb_css_proxy_' . md5( $proxy_url );
-		$response  = wp_cache_get( $cache_key );
+		$response  = get_transient( $cache_key );
 
 		if ( is_array( $response ) && isset( $response['error'] ) ) {
 			wp_die( esc_html( $response['error'] ), 400 );
@@ -63,11 +63,11 @@ class CSS_Proxy {
 			$response     = wp_safe_remote_get( $proxy_url );
 			$content_type = wp_remote_retrieve_header( $response, 'content-type' );
 			if ( strpos( $content_type, 'text/css' ) === false ) {
-				wp_cache_set( $cache_key, array( 'error' => 'Invalid content type. Expected CSS.' ), '', HOUR_IN_SECONDS );
+				set_transient( $cache_key, array( 'error' => 'Invalid content type. Expected CSS.' ), HOUR_IN_SECONDS );
 				wp_die( 'Invalid content type. Expected CSS.', 400 );
 			}
 			$css = wp_remote_retrieve_body( $response );
-			wp_cache_set( $cache_key, $css, '', HOUR_IN_SECONDS );
+			set_transient( $cache_key, $css, HOUR_IN_SECONDS );
 		}
 
 		if ( is_wp_error( $response ) ) {

--- a/projects/plugins/boost/changelog/update-boost-cache-to-transient
+++ b/projects/plugins/boost/changelog/update-boost-cache-to-transient
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use transients instead of cache to ensure persistance for sites without object caching


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38272 
Fixes HOG-16

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use transients instead of setting the cache to ensure the data persists beyond the current request.

For sites without object caching, the wp_cache functionality only persists the data until the end of the request, while we want it cached for an hour. Using a transient would save it to the db on those sites and utilize the object caching for sites with that ability.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a site without object caching, ensure transients are set for the critical CSS (start with jb_css_proxy_)

