### PR TITLE
Forms: append a counter to repeated field names

### DIFF
--- a/projects/packages/forms/changelog/fix-repeated-field-names-response-view
+++ b/projects/packages/forms/changelog/fix-repeated-field-names-response-view
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: avoid overwriting form values when field names are repeated

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -145,7 +145,12 @@ export default function InboxView() {
 				 * 3. Normalize the values to handle the case where the value is an array or if is empty.
 				 */
 				fields: Object.entries( record.fields || {} ).reduce( ( accumulator, [ key, value ] ) => {
-					const _key = formatFieldName( key );
+					let _key = formatFieldName( key );
+					let counter = 1;
+					while ( accumulator[ _key ] ) {
+						_key = `${ formatFieldName( key ) } (${ counter })`;
+						counter++;
+					}
 					accumulator[ _key ] = formatFieldValue( decodeEntities( value ) );
 					return accumulator;
 				}, {} ),

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -146,7 +146,7 @@ export default function InboxView() {
 				 */
 				fields: Object.entries( record.fields || {} ).reduce( ( accumulator, [ key, value ] ) => {
 					let _key = formatFieldName( key );
-					let counter = 1;
+					let counter = 2;
 					while ( accumulator[ _key ] ) {
 						_key = `${ formatFieldName( key ) } (${ counter })`;
 						counter++;


### PR DESCRIPTION
Fixes: FORMS-11

## Proposed changes:
This PR addresses an issue when visualizing response data: repeated field names will step on each other.

Given the form:
<img width="707" alt="image" src="https://github.com/user-attachments/assets/015e7a99-b25a-4891-828e-1b01f83999a6" />

Submit confirmation looks ok:
<img width="379" alt="image" src="https://github.com/user-attachments/assets/9579932c-332d-48dd-a639-46e78be9367f" />

But due to the nature of the dashboard reducer, response looks like this:
<img width="395" alt="image" src="https://github.com/user-attachments/assets/05939ca3-fd06-4ec6-ae7a-28e18eca649f" />

The change will format repeated field names as:
- Fieldname
- Fieldname (1)
- Fieldname (2)
- ...

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Create a form with at least 2 fields with the same label. Visit the form and submit values on both.
Go to responses and check the response, repeated field should show twice, formatted with a counter between parenthesis:
<img width="371" alt="image" src="https://github.com/user-attachments/assets/7514dca0-dc96-4a88-88b3-3dd11205b924" />
 
TODO: this calls for some improvement on how we store and typify data on responses.