### PR TITLE
Forms: Fix file field max file pre error

### DIFF
--- a/projects/packages/forms/changelog/fix-file-field-max-file-pre-error
+++ b/projects/packages/forms/changelog/fix-file-field-max-file-pre-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix max file size upload check

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -863,7 +863,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		);
 
 		$global_config = array(
-			'i18n'     => array(
+			'i18n'          => array(
 				'language'           => get_bloginfo( 'language' ),
 				'fileSizeUnits'      => $file_size_units,
 				'zeroBytes'          => __( '0 Bytes', 'jetpack-forms' ),
@@ -875,7 +875,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'maxFiles'           => __( 'You have exeeded the number of files that you can upload.', 'jetpack-forms' ),
 				'uploadFailed'       => __( 'File upload failed, try again.', 'jetpack-forms' ),
 			),
-			'endpoint' => $this->get_unauth_endpoint_url(),
+			'endpoint'      => $this->get_unauth_endpoint_url(),
+			'maxUploadSize' => $max_file_size,
 		);
 
 		wp_interactivity_config( 'jetpack/field-file', $global_config );
@@ -885,7 +886,6 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			'files'            => array(),
 			'hasFiles'         => false,
 			'allowedMimeTypes' => $accepted_file_types,
-			'maxUploadSize'    => $max_file_size,
 			'maxFiles'         => $max_files, // max number of files.
 			'hasMaxFiles'      => false,
 		);


### PR DESCRIPTION
Currenly we don't show any pre file upload errors in the UI before the user uploads the file. 

This PR fix this. 
![Screenshot 2025-04-17 at 1 47 59 PM](https://github.com/user-attachments/assets/0ec3813d-1ef6-42be-ae05-ed643145455e)

## Proposed changes:
* Update the max upload file size to be a global config. 
* We originally set it in the input context. But since we don't allow the user to edit this we prevent limit this. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Here is a large file - https://svs.gsfc.nasa.gov/vis/a030000/a030800/a030877/frames/5760x3240_16x9_01p/BlackMarble_2016_928m_india_labeled.png in case you don't have one ready.

1. Add form with the file upload field. 
2. Try uploading a file with more then 20MB file size. 
3. Notice that you see a message telling you that your file is larger then expected. 
4. Notice that it still works expected with a smaller file. 

