### PR TITLE
Forms: Update form responses link on editor sidebar

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-view-responses-preferred-view
+++ b/projects/packages/forms/changelog/fix-forms-view-responses-preferred-view
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Update form responses link on editor sidebar

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -276,11 +276,13 @@ class Contact_Form_Block {
 		);
 
 		// Create a Contact_Form instance to get the default values
+		$dashboard_view_switch   = new Dashboard_View_Switch();
 		$contact_form            = new Contact_Form( array() );
 		$defaults                = $contact_form->defaults;
-		$admin_url               = ( new Dashboard_View_Switch() )->get_forms_admin_url( 'spam' );
+		$admin_url               = $dashboard_view_switch->get_forms_admin_url( 'spam' );
 		$akismet_active_with_key = Jetpack::is_akismet_active();
 		$akismet_key_url         = admin_url( 'admin.php?page=akismet-key-config' );
+		$preferred_view          = $dashboard_view_switch->get_preferred_view();
 
 		$data = array(
 			'defaults' => array(
@@ -291,6 +293,7 @@ class Contact_Form_Block {
 				'akismetUrl'           => $akismet_key_url,
 				'assetsUrl'            => Jetpack_Forms::assets_url(),
 				'isFormModalEnabled'   => true, // Disable or enable integrations modal and use sidebar panels instead
+				'preferredView'        => $preferred_view,
 			),
 		);
 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-manage-responses-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-manage-responses-settings.js
@@ -4,7 +4,11 @@ import { __ } from '@wordpress/i18n';
 import { get } from 'lodash';
 import InspectorHint from '../components/inspector-hint';
 
-const RESPONSES_PATH = `${ get( getJetpackData(), 'adminUrl', false ) }edit.php?post_type=feedback`;
+const preferredView = window?.jpFormsBlocks?.defaults?.preferredView;
+
+const RESPONSES_PATH =
+	get( getJetpackData(), 'adminUrl', false ) +
+	( preferredView === 'classic' ? 'edit.php?post_type=feedback' : 'admin.php?page=jetpack-forms' );
 
 const JetpackManageResponsesSettings = () => {
 	return (

--- a/projects/plugins/jetpack/changelog/fix-forms-view-responses-preferred-view
+++ b/projects/plugins/jetpack/changelog/fix-forms-view-responses-preferred-view
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Update form responses link on editor sidebar


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-10

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changes the responses link used in the editor sidebar to match the changes introduced [here](https://github.com/Automattic/jetpack/pull/42329)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and add a form
* On the block sidebar, in the "Manage Responses" section, click on "View Form Responses"
* Check that you are redirected to the preferred view or the modern view by default (instead of the previously hardcoded classic view)
