### PR TITLE
Fix Verbum comments enqueuing condition

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-comments
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-comments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-gutenberg-editor.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-gutenberg-editor.php
@@ -71,7 +71,11 @@ class Verbum_Gutenberg_Editor {
 	 * In case the page is singular and has comment closed or front page with comments closed we avoid the enqueueing
 	 */
 	public function enqueue_assets() {
-		if ( ! $this->should_enqueue_assets ) {
+		if (
+			! ( is_singular() && comments_open() )
+			&& ! ( is_front_page() && is_page() && comments_open() )
+			&& ! $this->should_enqueue_assets
+		) {
 			return;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
@@ -127,7 +127,11 @@ class Verbum_Comments {
 	 * Enqueue Assets
 	 */
 	public function enqueue_assets() {
-		if ( ! $this->should_enqueue_assets ) {
+		if (
+			! ( is_singular() && comments_open() )
+			&& ! ( is_front_page() && is_page() && comments_open() )
+			&& ! $this->should_enqueue_assets
+		) {
 			return;
 		}
 


### PR DESCRIPTION
Follow up on https://github.com/Automattic/jetpack/pull/43087

## Proposed changes:
#43087 replaced the condition of rendering the comments form, but sadly apparently some themes don't fire `comment_form_before`, which the new condition relied on. This makes it so that we can use both conditions.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. In `projects/packages/jetpack-mu-wpcom` run ` jetpack rsync mu-wpcom-plugin wpcom-sandbox:~/public_html/wp-content/mu-plugins/jetpack-mu-wpcom-plugin/sun` (or moon). 
2. Sandbox alshakero08.wordpress.com.
3. Go to https://alshakero08.wordpress.com
4. Verbum should be available inside the Query Loop.
5. Comment on either post. Your comment should be submitted to that post.

### Regression testing - in posts
1. Go to https://punsintended418746564.wordpress.com/2025/03/12/test-3/
2. Make sure Verbum works

### Regression testing - moderation
1. Sandbox a simple site. 
1. Go to /wp-admin/comment.php?action=editcomment&c=1 (assuming your site has at least one comment).
2. You should be able to edit the comment with GB.

