### PR TITLE
Forms: Upload field: Improve loading for Simple Sites.

### DIFF
--- a/projects/packages/forms/changelog/update-forms-unauth-file-loading
+++ b/projects/packages/forms/changelog/update-forms-unauth-file-loading
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: unreleased feature
+
+

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -436,7 +436,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 						$file_id         = absint( $file['file_id'] );
 						$file['file_id'] = $file_id;
 						$file['size']    = size_format( $file['size'] );
-						$file['url']     = \apply_filters( 'jetpack_unauth_file_download_url', '', $file_id );
+						$file['url']     = apply_filters( 'jetpack_unauth_file_download_url', '', $file_id );
 						$has_file        = true;
 					}
 				}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -293,6 +293,11 @@ class Contact_Form_Plugin {
 
 		add_filter( 'js_do_concat', array( __CLASS__, 'disable_forms_view_script_concat' ), 10, 3 );
 
+		if ( defined( 'JETPACK__PLUGIN_DIR' ) ) {
+			// Register Unauthenticated file download hooks.
+			require_once JETPACK__PLUGIN_DIR . 'unauth-file-upload.php';
+		}
+
 		self::register_contact_form_blocks();
 	}
 

--- a/projects/plugins/jetpack/changelog/update-forms-unauth-file-loading
+++ b/projects/plugins/jetpack/changelog/update-forms-unauth-file-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+unreleased feature

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -105,9 +105,6 @@ class Jetpack_Admin {
 
 		// Register Jetpack partner coupon hooks.
 		Jetpack_Partner_Coupon::register_coupon_admin_hooks( 'jetpack', Jetpack::admin_url() );
-
-		// Register Unauthenticated file download hooks.
-		require_once JETPACK__PLUGIN_DIR . 'unauth-file-upload.php';
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes File Upload functionality for Simple sites

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves filter registration from jetpack-admin.php to the contact-form-plugin.php
* This will register unauth hooks only if there's a functionality that needs it.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply 179247-ghe-Automattic/wpcom and this PR to your sandbox
* Add your blog_id to `Automattic\Jetpack\UnauthFileUpload\ALLOWED_BLOG_IDS`
* Verify that the file upload functionality works as expected on Jetpack and Simple sites.
* Confirm that there are no errors or warnings due to missing files or undefined constants.
* Test forms on sites not in `Automattic\Jetpack\UnauthFileUpload\ALLOWED_BLOG_IDS`