### PR TITLE
Boost dashboard: fix display of upsell in critical CSS modal

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.module.scss
@@ -5,10 +5,17 @@
 
 .tooltip-wrapper {
 	margin: 1em 0;
-}
 
-.tooltip-wrapper p {
-	display: inline;
+	p {
+		display: inline;
+	}
+
+	:global(.icon-tooltip-content) {
+
+		p {
+			display: block;
+		}
+	}
 }
 
 @media (max-width: 768px) {

--- a/projects/plugins/boost/changelog/update-boost-admin-upsell-modal-multiline
+++ b/projects/plugins/boost/changelog/update-boost-admin-upsell-modal-multiline
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: properly display notice to purchase a plan in Critical CSS modal.


### PR DESCRIPTION
Fixes HOG-75 -- Dashboard: display issues in upsell in Critical CSS modal

## Proposed changes:

The text within the upsell is displayed on a single line:

**Before**

<img width="608" alt="Screenshot 2025-04-18 at 19 59 48" src="https://github.com/user-attachments/assets/5921b504-e507-4869-a552-bea28b73b4d1" />


**After**

<img width="547" alt="Screenshot 2025-04-18 at 19 59 57" src="https://github.com/user-attachments/assets/82c3e1f0-0319-4af9-aca7-4041ffcfd5dd" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site running Boost free
* Go to Jetpack > Boost
* Click on the "info" icon after `You should regenerate your Critical CSS whenever you make changes to the HTML or CSS structure of your site.`
* Ensure the upsell at the bottom of the modal is displayed properly (see screenshot above).
