### PR TITLE
E2E Tests: Disable modules which may interfere with login

### DIFF
--- a/tools/e2e-commons/bin/e2e-env.sh
+++ b/tools/e2e-commons/bin/e2e-env.sh
@@ -76,6 +76,10 @@ configure_wp_env() {
 	$BASE_CMD wp option set permalink_structure ""
 	$BASE_CMD wp jetpack module deactivate sso
 
+	# Disable modules that may interfere with login flow.
+	$BASE_CMD wp jetpack module deactivate account-protection
+	$BASE_CMD wp jetpack module deactivate protect
+
 	echo
 	$BASE_CMD wp plugin status
 	echo


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disable "Brute force protection" and "Account protection" modules while setting up the test env. It ensures the login flow goes smoothly.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1744996564263139-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
* Run the e2e tests locally
* Ensure they can work as expected