### PR TITLE
fix Server-side request forgery Directly incorporating user input in the URL of an outgoing HTTP request

### DIFF
--- a/.github/actions/tool-setup/packagist-proxy.mjs
+++ b/.github/actions/tool-setup/packagist-proxy.mjs
@@ -77,7 +77,9 @@ server.on( 'request', ( req, res ) => {
 	// about this code using user input to build the request path, it's fine.
 	// This proxy only runs on localhost inside of CI, any attacker could just
 	// make their bad request directly.
-	const upstreamUrl = upstreamHost + req.url.replace( /^\//, '' );
+	const parsedUrl = new URL(req.url, 'http://localhost'); // Parse the incoming URL
+	const sanitizedPath = parsedUrl.pathname.replace(/^\//, '').replace(/\.\./g, ''); // Remove leading slash and prevent path traversal
+	const upstreamUrl = upstreamHost + sanitizedPath;
 	console.log( `!![${ reqid }] Proxying to ${ upstreamUrl }` );
 	const upstreamReq = https.request( upstreamUrl, {
 		method: req.method,


### PR DESCRIPTION
https://github.com/Automattic/jetpack/blob/781ba92939bc9421918aa517150a330a60f48607/.github/actions/tool-setup/packagist-proxy.mjs#L82-L85

fix the SSRF vulnerability need to validate and sanitize the user-controlled `req.url` before using it to construct the `upstreamUrl`. Specifically:
1. Ensure that the `req.url` does not contain malicious path traversal sequences (e.g., `../`) or unexpected query parameters.
2. Use a whitelist approach to allow only specific paths or patterns that are known to be safe.
3. Reject or sanitize any input that does not conform to the expected format.

The fix involves:
- Parsing the `req.url` using the `URL` class to extract and validate the pathname.
- Ensuring the pathname does not contain any path traversal sequences or invalid characters.
- Constructing the `upstreamUrl` using the sanitized pathname.


Directly incorporating user input in the URL of an outgoing HTTP request can enable a request forgery attack, in which the request is altered to target an unintended API endpoint or resource. If the server performing the request is connected to an internal network, this can give an attacker the means to bypass the network boundary and make requests against internal services. A forged request may perform an unintended action on behalf of the attacker, or cause information leak if redirected to an external server or if the request response is fed back to the user. It may also compromise the server making the request, if the request response is handled in an unsafe way.

## POC
The following shows an HTTP request parameter being used directly in the URL of a request without validating the input, which facilitates an SSRF attack. The request `http.get(...)` is vulnerable since attackers can choose the value of `target` to be anything they want. For instance, the attacker can choose `"internal.redacted.com/#"` as the target, causing the URL used in the request to be `"https://internal.redacted.com/#.example.com/data"`. A request to `https://internal.redacted.com` may be problematic if that server is not meant to be directly accessible from the attacker's machine.
```js
import http from 'http';

const server = http.createServer(function(req, res) {
    const target = new URL(req.url, "http://example.com").searchParams.get("target");

    // BAD: `target` is controlled by the attacker
    http.get('https://' + target + ".example.com/data/", res => {
        // process request response ...
    });

});
```
One way to remedy the problem is to use the user input to select a known fixed string before performing the request:
```js
import http from 'http';

const server = http.createServer(function(req, res) {
    const target = new URL(req.url, "http://example.com").searchParams.get("target");

    let subdomain;
    if (target === 'EU') {
        subdomain = "europe"
    } else {
        subdomain = "world"
    }

    // GOOD: `subdomain` is controlled by the server
    http.get('https://' + subdomain + ".example.com/data/", res => {
        // process request response ...
    });

});
```
## References
[SSRF](https://www.owasp.org/index.php/Server_Side_Request_Forgery)
[CWE-918](https://cwe.mitre.org/data/definitions/918.html).



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



