### PR TITLE
My Jetpack: Avoid sending invalid email along with social login request

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/connection-form.tsx
+++ b/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/connection-form.tsx
@@ -30,6 +30,7 @@ const ConnectionForm = () => {
 		handleSocialLogin,
 		isLoading: isLoadingOauth,
 		resetState,
+		setUserEmail,
 	} = oauthConnectionData;
 
 	const socialConnectionTitle = __( 'Start with Jetpack for free', 'jetpack-my-jetpack' );
@@ -52,12 +53,14 @@ const ConnectionForm = () => {
 			if ( submitType === 'email' ) {
 				handleSubmitEmail();
 			} else {
+				// Ensure to reset the email when using social login.
+				setUserEmail( '' );
 				handleSocialLogin( submitType );
 			}
 
 			setIsActionInitiated( true );
 		},
-		[ handleSubmitEmail, handleSocialLogin, resetState ]
+		[ handleSubmitEmail, handleSocialLogin, resetState, setUserEmail ]
 	);
 
 	const isLoading = useMemo( () => {

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-invalid-email-sent-on-onboarding
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-invalid-email-sent-on-onboarding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Onboarding: Avoid sending invalid email along with social login request

--- a/projects/plugins/backup/changelog/fix-my-jetpack-invalid-email-sent-on-onboarding
+++ b/projects/plugins/backup/changelog/fix-my-jetpack-invalid-email-sent-on-onboarding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix social login getting stuck when email input not empty

--- a/projects/plugins/boost/changelog/fix-my-jetpack-invalid-email-sent-on-onboarding
+++ b/projects/plugins/boost/changelog/fix-my-jetpack-invalid-email-sent-on-onboarding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix social login getting stuck when email input not empty

--- a/projects/plugins/jetpack/changelog/fix-my-jetpack-invalid-email-sent-on-onboarding
+++ b/projects/plugins/jetpack/changelog/fix-my-jetpack-invalid-email-sent-on-onboarding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+My Jetpack: Fix social login getting stuck when email input not empty

--- a/projects/plugins/protect/changelog/fix-my-jetpack-invalid-email-sent-on-onboarding
+++ b/projects/plugins/protect/changelog/fix-my-jetpack-invalid-email-sent-on-onboarding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix social login getting stuck when email input not empty

--- a/projects/plugins/search/changelog/fix-my-jetpack-invalid-email-sent-on-onboarding
+++ b/projects/plugins/search/changelog/fix-my-jetpack-invalid-email-sent-on-onboarding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix social login getting stuck when email input not empty

--- a/projects/plugins/social/changelog/fix-my-jetpack-invalid-email-sent-on-onboarding
+++ b/projects/plugins/social/changelog/fix-my-jetpack-invalid-email-sent-on-onboarding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix social login getting stuck when email input not empty

--- a/projects/plugins/starter-plugin/changelog/fix-my-jetpack-invalid-email-sent-on-onboarding
+++ b/projects/plugins/starter-plugin/changelog/fix-my-jetpack-invalid-email-sent-on-onboarding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix social login getting stuck when email input not empty

--- a/projects/plugins/videopress/changelog/fix-my-jetpack-invalid-email-sent-on-onboarding
+++ b/projects/plugins/videopress/changelog/fix-my-jetpack-invalid-email-sent-on-onboarding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix social login getting stuck when email input not empty


### PR DESCRIPTION
Fixes JETPACK-323

Currently, in My Jetpack onboarding, if you start typing your email address and then change your mind midway to use social login instead, it gets stuck because we send the email address anyway to the API call

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure to reset the email when using social login.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this PR
* Disconnect the site - `jetpack docker wp jetpack disconnect blog`
* Goto My Jetpack
* Type something like "invalid" in the email input
* Click on Google to use Social login
* Confirm that the request is successful and you are redirected to Jetpack connect screen on wp.com

