### PR TITLE
Fix wrong coming soon badge

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-wrong-coming-soon-status
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-wrong-coming-soon-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix wrong status showing as coming soon

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -393,7 +393,7 @@ function wpcom_add_site_badges_and_plan( $wp_admin_bar ) {
 	} elseif ( function_exists( 'wpcom_site_has_feature' ) && wpcom_site_has_feature( 'trial' ) ) {
 		// Check for trial site
 		$badge_text = __( 'Trial', 'jetpack-mu-wpcom' );
-	} elseif ( ( get_option( 'launch-status' ) !== 'launched' ) || $status->is_coming_soon() ) {
+	} elseif ( get_option( 'launch-status' ) === 'unlaunched' || $status->is_coming_soon() ) {
 		// Check for Coming Soon site
 		$badge_text = __( 'Coming Soon', 'jetpack-mu-wpcom' );
 	} elseif ( $status->is_private_site() ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/102691

## Proposed changes:

For sites using the classic view or atomic sites, the admin bar was showing the site as "coming soon" (under the site name's dropdown) when the `launch-site` site option was empty, while in reality we consider an empty `launch-site` as a launched site.

This PR fixes that.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

- Update the "launch site" site option of an atomic site to an empty string `wp option set launch-status ''`
- Check that hovering the site name in the admin bar doesn't show the "status" as coming soon. 
