### PR TITLE
VideoPress: do not show transform UI for unsupported blocks

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-videopress-transform-43157
+++ b/projects/plugins/jetpack/changelog/fix-videopress-transform-43157
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: avoid displaying an invitation to transform a block into a VideoPress block for non-supported Video blocks.

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-embed/videopress.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-embed/videopress.js
@@ -31,9 +31,7 @@ export const withVideoPressSettings = createHigherOrderComponent( BlockEdit => {
 				/^https?:\/\/(?:video\.wordpress\.com\/[ve]\/|videopress\.com\/[ve]\/)[a-zA-Z\d]{8}/
 			) ||
 			// Check provider name
-			attributes?.providerNameSlug === 'videopress' ||
-			// Check if it's a VideoPress block
-			attributes?.type === 'video';
+			attributes?.providerNameSlug === 'videopress';
 
 		if ( ! isVideoPress ) {
 			return <BlockEdit { ...props } />;


### PR DESCRIPTION
fixes #43157

## Proposed changes:

Follow-up to #42443

Let's avoid displaying an invitation to transform a block into a VideoPress block when that is not possible.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?
* No

## Testing instructions:

* Open editor, it can be post or page
* Add an Embed block and provide a VideoPress URL. For example: `https://video.wordpress.com/v/VmccXaww`
* Check if there is a transformation notice in the sidebar
* Click the CTA button
* Check if it transforms
* In another post, paste a YouTube URL, for example `https://www.youtube.com/watch?v=IH3RINZ8rWI`
* Ensure no tranformation notice is displayed in the sidebar
