### PR TITLE
Featured Content: Add messaging letting users know the tag name is case sensitive

### DIFF
--- a/projects/packages/classic-theme-helper/changelog/add-featured-content-tag-case-message
+++ b/projects/packages/classic-theme-helper/changelog/add-featured-content-tag-case-message
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Featured Content: Add messaging to clarify that the tag name is case sensitive.

--- a/projects/packages/classic-theme-helper/src/class-featured-content.php
+++ b/projects/packages/classic-theme-helper/src/class-featured-content.php
@@ -536,7 +536,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Featured_Content' ) ) {
 							'a' => array(
 								'href' => array(),
 							),
-							'p' => array(), // Allow paragraph tags
+							'p' => array(),
 						)
 					),
 					'priority'       => 130,
@@ -557,7 +557,6 @@ if ( ! class_exists( __NAMESPACE__ . '\Featured_Content' ) ) {
 					'sanitize_js_callback' => array( __CLASS__, 'delete_transient' ),
 				)
 			);
-
 			$wp_customize->add_setting(
 				'featured-content[hide-tag]',
 				array(

--- a/projects/packages/classic-theme-helper/src/class-featured-content.php
+++ b/projects/packages/classic-theme-helper/src/class-featured-content.php
@@ -525,11 +525,19 @@ if ( ! class_exists( __NAMESPACE__ . '\Featured_Content' ) ) {
 				'featured_content',
 				array(
 					'title'          => esc_html__( 'Featured Content', 'jetpack-classic-theme-helper' ),
-					'description'    => sprintf(
+					'description'    => wp_kses(
+						sprintf(
 						/* translators: %1$s: Link to 'featured' admin tag view. %2$s: Max number of posts shown by theme in featured content area. */
-						__( 'Easily feature all posts with the <a href="%1$s">"featured" tag</a> or a tag of your choice. Your theme supports up to %2$s posts in its featured content area.', 'jetpack-classic-theme-helper' ),
-						admin_url( '/edit.php?tag=featured' ),
-						absint( self::$max_posts )
+							__( 'Easily feature all posts with the <a href="%1$s">"featured" tag</a> or a tag of your choice. Your theme supports up to %2$s posts in its featured content area.<p>Please note: The featured tag name is case sensitive.</p>', 'jetpack-classic-theme-helper' ),
+							esc_url( admin_url( '/edit.php?tag=featured' ) ),
+							absint( self::$max_posts )
+						),
+						array(
+							'a' => array(
+								'href' => array(),
+							),
+							'p' => array(), // Allow paragraph tags
+						)
 					),
 					'priority'       => 130,
 					'theme_supports' => 'featured-content',
@@ -549,6 +557,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Featured_Content' ) ) {
 					'sanitize_js_callback' => array( __CLASS__, 'delete_transient' ),
 				)
 			);
+
 			$wp_customize->add_setting(
 				'featured-content[hide-tag]',
 				array(

--- a/projects/packages/classic-theme-helper/src/class-featured-content.php
+++ b/projects/packages/classic-theme-helper/src/class-featured-content.php
@@ -528,15 +528,15 @@ if ( ! class_exists( __NAMESPACE__ . '\Featured_Content' ) ) {
 					'description'    => wp_kses(
 						sprintf(
 						/* translators: %1$s: Link to 'featured' admin tag view. %2$s: Max number of posts shown by theme in featured content area. */
-							__( 'Easily feature all posts with the <a href="%1$s">"featured" tag</a> or a tag of your choice. Your theme supports up to %2$s posts in its featured content area.<p>Please note: The featured tag name is case sensitive.</p>', 'jetpack-classic-theme-helper' ),
+							__( 'Easily feature all posts with the <a href="%1$s">"featured" tag</a> or a tag of your choice. Your theme supports up to %2$s posts in its featured content area.<br><br>Please note: The featured tag name is case sensitive.', 'jetpack-classic-theme-helper' ),
 							esc_url( admin_url( '/edit.php?tag=featured' ) ),
 							absint( self::$max_posts )
 						),
 						array(
-							'a' => array(
+							'a'  => array(
 								'href' => array(),
 							),
-							'p' => array(),
+							'br' => array(),
 						)
 					),
 					'priority'       => 130,

--- a/projects/plugins/classic-theme-helper-plugin/changelog/add-featured-content-tag-case-message
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/add-featured-content-tag-case-message
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Featured Content: Add messaging to clarify that the tag name is case sensitive.

--- a/projects/plugins/jetpack/changelog/add-featured-content-tag-case-message
+++ b/projects/plugins/jetpack/changelog/add-featured-content-tag-case-message
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Featured Content: Add messaging to clarify that the tag name is case sensitive.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-featured-content-tag-case-message
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-featured-content-tag-case-message
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Featured Content: Add messaging to clarify that the tag name is case sensitive.

--- a/projects/plugins/wpcomsh/changelog/add-featured-content-tag-case-message
+++ b/projects/plugins/wpcomsh/changelog/add-featured-content-tag-case-message
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Featured Content: Add messaging to clarify that the tag name is case sensitive.


### PR DESCRIPTION

Fixes https://github.com/Automattic/jetpack/issues/42051

## Proposed changes:

* This PR adds a sentence below the Featured Content section description (in the Customize) to clarify that the tag name must be case sensitive.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?


## Testing instructions:

To test on a self-hosted site, apply this PR locally (or using the Jetpack Beta tester plugin - as with a WoA test site). For Simple - apply the PR by using the command in the generated comment below for a sandboxed Simple site.

* Install and activate a theme that uses Featured Content such as Dara.
* Open up the Customizer, and open up the Featured Content section. 
* You should see a new sentence explaining that the tag name is case sensitive.

