### PR TITLE
Cornestone pages: avoid fatals on module activation

### DIFF
--- a/projects/plugins/boost/app/lib/cornerstone/class-cornerstone-utils.php
+++ b/projects/plugins/boost/app/lib/cornerstone/class-cornerstone-utils.php
@@ -14,6 +14,11 @@ class Cornerstone_Utils {
 	public static function get_list() {
 		$pages = jetpack_boost_ds_get( 'cornerstone_pages_list' );
 
+		// Bail early if no pages are found.
+		if ( empty( $pages ) ) {
+			return array();
+		}
+
 		$permalink_structure = get_option( 'permalink_structure' );
 
 		// If permalink structure ends with slash, add trailing slashes

--- a/projects/plugins/boost/changelog/fix-cornerstone-no-pages
+++ b/projects/plugins/boost/changelog/fix-cornerstone-no-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Cornestone pages: avoid fatal errors when no pages are set.


### PR DESCRIPTION
Fixes HOG-77

## Proposed changes:

Avoid issues like this one:

```
PHP Fatal error:  Uncaught TypeError: array_map(): Argument #2 ($array) must be of type array, null given in /usr/local/src/jetpack-monorepo/projects/plugins/boost/app/lib/cornerstone/class-cornerstone-utils.php:21
Stack trace:
  thrown in /usr/local/src/jetpack-monorepo/projects/plugins/boost/app/lib/cornerstone/class-cornerstone-utils.php on line 21
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?
* No

## Testing instructions:

* I ran into this when testing #43168. You may want to start by checking out that PR, then deactivating the plugin, then reactivating it.
* Check this branch and ensure you do not experience any fatals.
