### PR TITLE
Forms: file field error case on an empty form

### DIFF
--- a/projects/packages/forms/changelog/fix-empty-file-field-form
+++ b/projects/packages/forms/changelog/fix-empty-file-field-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix empty file filed error case

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -920,7 +920,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			<div class="jetpack-form-file-field__preview-wrap" name="file-field-<?php echo esc_attr( $id ); ?>" data-wp-class--is-active="state.hasFiles">
 				<template data-wp-each--file="context.files" data-wp-key="context.file.id">
 					<div class="jetpack-form-file-field__preview" data-wp-class--is-error="context.file.hasError" data-wp-class--is-complete="context.file.isUploaded">
-						<input type="hidden" name="<?php echo esc_attr( $id ); ?>[]" class="jetpack-form-file-field__hidden" data-wp-bind--value='context.file.fileJson' value="">
+						<input type="hidden" name="<?php echo esc_attr( $id ); ?>[]" class="jetpack-form-file-field__hidden include-hidden" data-wp-bind--value='context.file.fileJson' value="">
 						<div class="jetpack-form-file-field__image-wrap" data-wp-style----progress="context.file.progress">
 							<div class="jetpack-form-file-field__image" data-wp-style--background-image="context.file.url" ></div>
 							<div class="jetpack-form-file-field__progress-bar" ></div>

--- a/projects/packages/forms/src/contact-form/js/accessible-form.js
+++ b/projects/packages/forms/src/contact-form/js/accessible-form.js
@@ -66,8 +66,8 @@ function isFormEmpty( form ) {
 		select.value = form.querySelector( `select[id="${ select.id }"` )?.value;
 	} );
 	// Remove hidden fields from the cloned form.
-	Array.from( clonedForm.querySelectorAll( 'input[type="hidden"]' ) ).forEach( input =>
-		input.remove()
+	Array.from( clonedForm.querySelectorAll( 'input[type="hidden"]:not(.include-hidden)' ) ).forEach(
+		input => input.remove()
 	);
 	const formData = new FormData( clonedForm );
 	return ! Array.from( formData.values() ).some( value =>

--- a/projects/packages/forms/src/contact-form/js/form-errors.js
+++ b/projects/packages/forms/src/contact-form/js/form-errors.js
@@ -64,7 +64,6 @@ export const clearInputError = ( input, opts ) => {
 	const inputErrors = form.querySelectorAll( '.contact-form__input-error' );
 	const mainErrorDiv = form.querySelector( '.contact-form__error' );
 	if ( mainErrorDiv && inputErrors.length === 0 ) {
-		mainErrorDiv.replaceChildren();
 		mainErrorDiv.remove();
 	}
 };

--- a/projects/packages/forms/src/contact-form/js/form-errors.js
+++ b/projects/packages/forms/src/contact-form/js/form-errors.js
@@ -57,7 +57,15 @@ export const clearInputError = ( input, opts ) => {
 	const error = fieldWrap.querySelector( '.contact-form__input-error' );
 
 	if ( error ) {
-		error.replaceChildren();
+		error.remove();
+	}
+
+	const form = input.closest( 'form' );
+	const inputErrors = form.querySelectorAll( '.contact-form__input-error' );
+	const mainErrorDiv = form.querySelector( '.contact-form__error' );
+	if ( mainErrorDiv && inputErrors.length === 0 ) {
+		mainErrorDiv.replaceChildren();
+		mainErrorDiv.remove();
 	}
 };
 


### PR DESCRIPTION
Fixes case where the file field (even when it was filled out) would show up as an empty form error even if the file form was uploaded. 

## Proposed changes:
* Make sure that the hidden field is not ignored when checking if the form field is empty. 
* Make sure that the errors get cleared up after the file field was uploaded. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Create a form with a field field taht doesn't have any required field. 
* Notice if you try to submit the empty form that you still get the expected error. ( Form is empty) 
* Now add a file to the file field. Notice that the error goes away. 
* Notice that the form submission works as expected. You are able to submit the form even if form only has the file field set.
