### PR TITLE
Forms: Add Tracks for block modal

### DIFF
--- a/projects/packages/forms/changelog/add-forms-modal-tracks-event
+++ b/projects/packages/forms/changelog/add-forms-modal-tracks-event
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add Tracks for block modal.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-controls.js
@@ -20,8 +20,8 @@ export default function IntegrationControls( { attributes, setAttributes } ) {
 	const { integrations, refreshIntegrations } = useIntegrationsStatus();
 	const { tracks } = useAnalytics();
 
-	const handleOpenModal = () => {
-		tracks.recordEvent( 'jetpack_forms_block_modal_view' );
+	const handleOpenModal = entry_point => {
+		tracks.recordEvent( 'jetpack_forms_block_modal_view', { entry_point } );
 		setIsModalOpen( true );
 	};
 
@@ -32,14 +32,22 @@ export default function IntegrationControls( { attributes, setAttributes } ) {
 				className="jetpack-contact-form__integrations-panel"
 				initialOpen={ false }
 			>
-				<Button variant="secondary" onClick={ handleOpenModal } __next40pxDefaultSize={ true }>
+				<Button
+					variant="secondary"
+					onClick={ () => handleOpenModal( 'block-sidebar' ) }
+					__next40pxDefaultSize={ true }
+				>
 					{ __( 'Manage integrations', 'jetpack-forms' ) }
 				</Button>
 			</PanelBody>
 
 			<BlockControls>
 				<ToolbarGroup>
-					<ToolbarButton icon={ plugins } onClick={ handleOpenModal } style={ { paddingLeft: 0 } }>
+					<ToolbarButton
+						icon={ plugins }
+						onClick={ () => handleOpenModal( 'block-toolbar' ) }
+						style={ { paddingLeft: 0 } }
+					>
 						{ __( 'Integrations', 'jetpack-forms' ) }
 					</ToolbarButton>
 				</ToolbarGroup>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-controls.js
@@ -21,7 +21,7 @@ export default function IntegrationControls( { attributes, setAttributes } ) {
 	const { tracks } = useAnalytics();
 
 	const handleOpenModal = () => {
-		tracks.recordEvent( 'jetpack_forms_block_modal_open' );
+		tracks.recordEvent( 'jetpack_forms_block_modal_view' );
 		setIsModalOpen( true );
 	};
 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-controls.js
@@ -1,3 +1,4 @@
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { BlockControls } from '@wordpress/block-editor';
 import { ToolbarGroup, ToolbarButton, Button, PanelBody } from '@wordpress/components';
 import { useState } from '@wordpress/element';
@@ -17,6 +18,12 @@ import { useIntegrationsStatus } from './jetpack-integrations-modal/hooks/useInt
 export default function IntegrationControls( { attributes, setAttributes } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const { integrations, refreshIntegrations } = useIntegrationsStatus();
+	const { tracks } = useAnalytics();
+
+	const handleOpenModal = () => {
+		tracks.recordEvent( 'jetpack_forms_block_modal_open' );
+		setIsModalOpen( true );
+	};
 
 	return (
 		<>
@@ -25,22 +32,14 @@ export default function IntegrationControls( { attributes, setAttributes } ) {
 				className="jetpack-contact-form__integrations-panel"
 				initialOpen={ false }
 			>
-				<Button
-					variant="secondary"
-					onClick={ () => setIsModalOpen( true ) }
-					__next40pxDefaultSize={ true }
-				>
+				<Button variant="secondary" onClick={ handleOpenModal } __next40pxDefaultSize={ true }>
 					{ __( 'Manage integrations', 'jetpack-forms' ) }
 				</Button>
 			</PanelBody>
 
 			<BlockControls>
 				<ToolbarGroup>
-					<ToolbarButton
-						icon={ plugins }
-						onClick={ () => setIsModalOpen( true ) }
-						style={ { paddingLeft: 0 } }
-					>
+					<ToolbarButton icon={ plugins } onClick={ handleOpenModal } style={ { paddingLeft: 0 } }>
 						{ __( 'Integrations', 'jetpack-forms' ) }
 					</ToolbarButton>
 				</ToolbarGroup>


### PR DESCRIPTION
## Proposed changes:

Adds a `jetpack_forms_block_modal_view` Tracks event when users open the form modal. The event includes an `entry_point` property that will be set to either `block-toolbar` or `block-sidebar` depending on where the user clicks to to open the modal. 

(I considered naming this `jetpack_forms_integration_modal_view`, but chose the more generic name because I suspect we'll add other form settings to this modal in the future.)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- You'll need to have [Tracks Vigilante](https://github.com/Automattic/tracks-chrome-extension) installed, or another way to monitor tracks events. You can also watch events by opening the network tab in your browser dev tools, and filtering network requests for `t.gif`.
- Add a form block to a page
- Click on the Manage Integrations button the block sidebar and confirm the event fires and has the correct entry_point property.
- Click the Integrations button in the block toolbar (above the block) and confirm the event fires and has the correct entry_point property.