### PR TITLE
Forms: add field file as paid with custom setup

### DIFF
--- a/projects/packages/forms/.phan/config.php
+++ b/projects/packages/forms/.phan/config.php
@@ -27,6 +27,7 @@ return make_phan_config(
 			__DIR__ . '/../../../plugins/jetpack/3rd-party/class.jetpack-amp-support.php',    // class Jetpack_AMP_Support
 			__DIR__ . '/../../../plugins/jetpack/functions.global.php',                       // function jetpack_is_frontend
 			__DIR__ . '/../../../plugins/jetpack/_inc/lib/core-api/load-wpcom-endpoints.php', // function wpcom_rest_api_v2_load_plugin
+			__DIR__ . '/../../../plugins/jetpack/class.jetpack-gutenberg.php',                // class Jetpack_Gutenberg
 		),
 	)
 );

--- a/projects/packages/forms/changelog/add-field-file-as-paid-block
+++ b/projects/packages/forms/changelog/add-field-file-as-paid-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+File Upload field: add registration with plan check

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -9,6 +9,7 @@
 		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-logo": "@dev",
+		"automattic/jetpack-plans": "@dev",
 		"automattic/jetpack-status": "@dev",
 		"automattic/jetpack-sync": "@dev"
 	},

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -199,15 +199,14 @@ class Contact_Form_Block {
 			'jetpack/field-file',
 			array(
 				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_file' ),
+				'plan_check'      => apply_filters( 'jetpack_unauth_file_upload_plan_check', true ),
 			)
 		);
 
 		add_action(
 			'jetpack_register_gutenberg_extensions',
 			function () {
-				if ( apply_filters( 'jetpack_unauth_file_upload_plan_check', true ) ) {
-					\Jetpack_Gutenberg::set_availability_for_plan( 'field-file' );
-				} else {
+				if ( ! apply_filters( 'jetpack_unauth_file_upload_plan_check', true ) ) {
 					\Jetpack_Gutenberg::set_extension_available( 'field-file' );
 				}
 			}

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -15,6 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Modules;
 use Jetpack;
+use Jetpack_Gutenberg;
 
 /**
  * Contact Form block render callback.
@@ -199,20 +200,13 @@ class Contact_Form_Block {
 			'jetpack/field-file',
 			array(
 				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_file' ),
-				// See https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/extensions/README.md#paid-blocks
-				'plan_check'      => apply_filters( 'jetpack_unauth_file_upload_plan_check', true ),
 			)
 		);
 
-		// We only need to enable the jetpack_block_editor_enable_upgrade_nudge filter if the plan check is true
-		// This way, packages/blocks/src/class-blocks.php:101 handles the availability method (set_availability_for_plan or set_extension_available)
-		// TODO: once we remove the featire filter, we can just set upgrade nudge filter to return true.
 		add_action(
 			'jetpack_register_gutenberg_extensions',
 			function () {
-				if ( apply_filters( 'jetpack_unauth_file_upload_plan_check', true ) ) {
-					add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );
-				}
+				Jetpack_Gutenberg::set_availability_for_plan( 'field-file' );
 			}
 		);
 	}

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -211,7 +211,7 @@ class Contact_Form_Block {
 			'jetpack_register_gutenberg_extensions',
 			function () {
 				if ( apply_filters( 'jetpack_unauth_file_upload_plan_check', true ) ) {
-						add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );
+					add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );
 				}
 			}
 		);

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -15,7 +15,6 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Modules;
 use Jetpack;
-use Jetpack_Gutenberg;
 
 /**
  * Contact Form block render callback.
@@ -207,9 +206,9 @@ class Contact_Form_Block {
 			'jetpack_register_gutenberg_extensions',
 			function () {
 				if ( apply_filters( 'jetpack_unauth_file_upload_plan_check', true ) ) {
-					Jetpack_Gutenberg::set_availability_for_plan( 'field-file' );
+					\Jetpack_Gutenberg::set_availability_for_plan( 'field-file' );
 				} else {
-					Jetpack_Gutenberg::set_extension_available( 'field-file' );
+					\Jetpack_Gutenberg::set_extension_available( 'field-file' );
 				}
 			}
 		);

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -205,12 +205,17 @@ class Contact_Form_Block {
 
 		add_action(
 			'jetpack_register_gutenberg_extensions',
-			function () {
-				if ( ! apply_filters( 'jetpack_unauth_file_upload_plan_check', true ) ) {
-					\Jetpack_Gutenberg::set_extension_available( 'field-file' );
-				}
-			}
+			array( __CLASS__, 'set_file_field_extension_available' )
 		);
+	}
+
+	/**
+	 * Set field-file extension available hook handler
+	 */
+	public static function set_file_field_extension_available() {
+		if ( ! apply_filters( 'jetpack_unauth_file_upload_plan_check', true ) ) {
+			\Jetpack_Gutenberg::set_extension_available( 'field-file' );
+		}
 	}
 
 	/**

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -199,7 +199,21 @@ class Contact_Form_Block {
 			'jetpack/field-file',
 			array(
 				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_file' ),
+				// See https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/extensions/README.md#paid-blocks
+				'plan_check'      => apply_filters( 'jetpack_unauth_file_upload_plan_check', true ),
 			)
+		);
+
+		// We only need to enable the jetpack_block_editor_enable_upgrade_nudge filter if the plan check is true
+		// This way, packages/blocks/src/class-blocks.php:101 handles the availability method (set_availability_for_plan or set_extension_available)
+		// TODO: once we remove the featire filter, we can just set upgrade nudge filter to return true.
+		add_action(
+			'jetpack_register_gutenberg_extensions',
+			function () {
+				if ( apply_filters( 'jetpack_unauth_file_upload_plan_check', true ) ) {
+						add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );
+				}
+			}
 		);
 	}
 

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -206,7 +206,11 @@ class Contact_Form_Block {
 		add_action(
 			'jetpack_register_gutenberg_extensions',
 			function () {
-				Jetpack_Gutenberg::set_availability_for_plan( 'field-file' );
+				if ( apply_filters( 'jetpack_unauth_file_upload_plan_check', true ) ) {
+					Jetpack_Gutenberg::set_availability_for_plan( 'field-file' );
+				} else {
+					Jetpack_Gutenberg::set_extension_available( 'field-file' );
+				}
 			}
 		);
 	}

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-file/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-file/index.js
@@ -1,13 +1,22 @@
+import getRedirectUrl from '@automattic/jetpack-components/tools/jp-redirect';
+import {
+	isAtomicSite,
+	isSimpleSite,
+	getSiteFragment,
+	useAutosaveAndRedirect,
+	getJetpackExtensionAvailability,
+} from '@automattic/jetpack-shared-extension-utils';
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
-import { __experimentalNumberControl as NumberControl } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { __experimentalNumberControl as NumberControl, Button } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { compose } from '@wordpress/compose';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useFormWrapper } from '../../util/form';
 import { withSharedFieldAttributes } from '../../util/with-shared-field-attributes';
 import JetpackFieldControls from '../jetpack-field-controls';
 import JetpackFieldLabel from '../jetpack-field-label';
 import { useJetpackFieldStyles } from '../use-jetpack-field-styles';
-
 import './editor.css';
 
 const DEFAULT_ICON = `${ window?.jpFormsBlocks?.defaults?.assetsUrl }/images/upload-icon.svg`;
@@ -92,9 +101,52 @@ const BLOCKS_TEMPLATE = [
 	],
 ];
 
+const getWPComRedirectToURL = () => {
+	const searchParams = new URLSearchParams( window.location.search );
+	const site = getSiteFragment();
+
+	if ( isSimpleSite() && searchParams.has( 'post' ) ) {
+		// When there is an explicit post, use it as the destination
+		return `https://wordpress.com/post/${ site }/${ searchParams.get( 'post' ) }`;
+	}
+	// When there is no explicit post, or the site is not Simple, use the home page as the destination
+	return `https://wordpress.com/home/${ site }`;
+};
+
+/**
+ * The hook to get properties for Checkout
+ *
+ * @return {object} - Object containing properties for Checkout.
+ */
+function useFormsCheckout() {
+	const wpcomRedirectToURL = getWPComRedirectToURL();
+
+	const wpcomCheckoutUrl = getRedirectUrl( 'jetpack-ai-yearly-tier-upgrade-nudge', {
+		site: getSiteFragment(),
+		path: 'jetpack_ai_yearly',
+		query: `redirect_to=${ encodeURIComponent( wpcomRedirectToURL ) }`,
+	} );
+
+	const jetpackCheckoutUrl = getRedirectUrl( 'jetpack-ai-upgrade-url-for-jetpack-sites', {
+		site: getSiteFragment(),
+		path: 'jetpack_ai_yearly',
+	} );
+
+	const checkoutUrl = isAtomicSite() || isSimpleSite() ? wpcomCheckoutUrl : jetpackCheckoutUrl;
+
+	const { autosaveAndRedirect, isRedirecting } = useAutosaveAndRedirect( checkoutUrl );
+
+	return {
+		checkoutUrl,
+		autosaveAndRedirect,
+		isRedirecting,
+	};
+}
+
 const JetpackFieldFile = props => {
 	const { attributes, clientId, isSelected, setAttributes } = props;
 	const { id, label, required, requiredText, width } = attributes;
+	const fieldFileAvailability = getJetpackExtensionAvailability( 'field-file' );
 
 	useFormWrapper( { attributes, clientId } );
 	const { blockStyle } = useJetpackFieldStyles( attributes );
@@ -103,6 +155,63 @@ const JetpackFieldFile = props => {
 		className: `jetpack-field${ isSelected ? ' is-selected' : '' }`,
 		style: blockStyle,
 	} );
+
+	const isInnerBlockSelected = useSelect( select => {
+		// select( 'core/block-editor' ).hasSelectedInnerBlock( clientId )
+		const selectedBlockClientId = select( 'core/block-editor' ).getSelectedBlockClientId();
+		const blockParents = select( 'core/block-editor' ).getBlockParents( selectedBlockClientId );
+		return blockParents.includes( clientId );
+	} );
+
+	const { selectBlock } = useDispatch( 'core/block-editor' );
+
+	useEffect( () => {
+		if (
+			isInnerBlockSelected &&
+			( ! fieldFileAvailability || ! fieldFileAvailability.available )
+		) {
+			selectBlock( clientId );
+		}
+	}, [ isInnerBlockSelected, clientId, selectBlock, fieldFileAvailability ] );
+
+	const UnavailableNudge = () => {
+		const { autosaveAndRedirect, isRedirecting } = useFormsCheckout();
+		return (
+			<div
+				className="jetpack-form-file-field__unavailable-nudge"
+				style={ {
+					width: '100%',
+					height: '100%',
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					backgroundColor: 'rgba(0, 0, 0, 0.5)',
+					color: 'white',
+					fontSize: '24px',
+					fontWeight: 'bold',
+					position: 'absolute',
+					top: 0,
+					left: 0,
+					right: 0,
+					bottom: 0,
+					flexDirection: 'column',
+					gap: '16px',
+				} }
+			>
+				<div>{ __( 'This feature is not available on your plan.', 'jetpack-forms' ) }</div>
+				<Button
+					variant="primary"
+					onClick={ event => {
+						autosaveAndRedirect( event );
+					} }
+					disabled={ isRedirecting }
+					isBusy={ isRedirecting }
+				>
+					{ __( 'Upgrade', 'jetpack-forms' ) }
+				</Button>
+			</div>
+		);
+	};
 
 	return (
 		<>
@@ -120,6 +229,8 @@ const JetpackFieldFile = props => {
 						<InnerBlocks template={ BLOCKS_TEMPLATE } templateLock={ false } />
 					</div>
 				</div>
+				{ ( ! fieldFileAvailability || ! fieldFileAvailability.available ) &&
+					( isSelected || isInnerBlockSelected ) && <UnavailableNudge /> }
 			</div>
 
 			<JetpackFieldControls

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-file/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-file/index.js
@@ -1,13 +1,6 @@
-import getRedirectUrl from '@automattic/jetpack-components/tools/jp-redirect';
-import {
-	isAtomicSite,
-	isSimpleSite,
-	getSiteFragment,
-	useAutosaveAndRedirect,
-	getJetpackExtensionAvailability,
-} from '@automattic/jetpack-shared-extension-utils';
+import { getJetpackExtensionAvailability } from '@automattic/jetpack-shared-extension-utils';
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
-import { __experimentalNumberControl as NumberControl, Button } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { __experimentalNumberControl as NumberControl } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { compose } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -16,6 +9,7 @@ import { useFormWrapper } from '../../util/form';
 import { withSharedFieldAttributes } from '../../util/with-shared-field-attributes';
 import JetpackFieldControls from '../jetpack-field-controls';
 import JetpackFieldLabel from '../jetpack-field-label';
+import { UpsellNudge } from '../upsell-nudge';
 import { useJetpackFieldStyles } from '../use-jetpack-field-styles';
 import './editor.css';
 
@@ -101,48 +95,6 @@ const BLOCKS_TEMPLATE = [
 	],
 ];
 
-const getWPComRedirectToURL = () => {
-	const searchParams = new URLSearchParams( window.location.search );
-	const site = getSiteFragment();
-
-	if ( isSimpleSite() && searchParams.has( 'post' ) ) {
-		// When there is an explicit post, use it as the destination
-		return `https://wordpress.com/post/${ site }/${ searchParams.get( 'post' ) }`;
-	}
-	// When there is no explicit post, or the site is not Simple, use the home page as the destination
-	return `https://wordpress.com/home/${ site }`;
-};
-
-/**
- * The hook to get properties for Checkout
- *
- * @return {object} - Object containing properties for Checkout.
- */
-function useFormsCheckout() {
-	const wpcomRedirectToURL = getWPComRedirectToURL();
-
-	const wpcomCheckoutUrl = getRedirectUrl( 'jetpack-ai-yearly-tier-upgrade-nudge', {
-		site: getSiteFragment(),
-		path: 'jetpack_ai_yearly',
-		query: `redirect_to=${ encodeURIComponent( wpcomRedirectToURL ) }`,
-	} );
-
-	const jetpackCheckoutUrl = getRedirectUrl( 'jetpack-ai-upgrade-url-for-jetpack-sites', {
-		site: getSiteFragment(),
-		path: 'jetpack_ai_yearly',
-	} );
-
-	const checkoutUrl = isAtomicSite() || isSimpleSite() ? wpcomCheckoutUrl : jetpackCheckoutUrl;
-
-	const { autosaveAndRedirect, isRedirecting } = useAutosaveAndRedirect( checkoutUrl );
-
-	return {
-		checkoutUrl,
-		autosaveAndRedirect,
-		isRedirecting,
-	};
-}
-
 const JetpackFieldFile = props => {
 	const { attributes, clientId, isSelected, setAttributes } = props;
 	const { id, label, required, requiredText, width } = attributes;
@@ -157,7 +109,6 @@ const JetpackFieldFile = props => {
 	} );
 
 	const isInnerBlockSelected = useSelect( select => {
-		// select( 'core/block-editor' ).hasSelectedInnerBlock( clientId )
 		const selectedBlockClientId = select( 'core/block-editor' ).getSelectedBlockClientId();
 		const blockParents = select( 'core/block-editor' ).getBlockParents( selectedBlockClientId );
 		return blockParents.includes( clientId );
@@ -174,48 +125,13 @@ const JetpackFieldFile = props => {
 		}
 	}, [ isInnerBlockSelected, clientId, selectBlock, fieldFileAvailability ] );
 
-	const UnavailableNudge = () => {
-		const { autosaveAndRedirect, isRedirecting } = useFormsCheckout();
-		return (
-			<div
-				className="jetpack-form-file-field__unavailable-nudge"
-				style={ {
-					width: '100%',
-					height: '100%',
-					display: 'flex',
-					alignItems: 'center',
-					justifyContent: 'center',
-					backgroundColor: 'rgba(0, 0, 0, 0.5)',
-					color: 'white',
-					fontSize: '24px',
-					fontWeight: 'bold',
-					position: 'absolute',
-					top: 0,
-					left: 0,
-					right: 0,
-					bottom: 0,
-					flexDirection: 'column',
-					gap: '16px',
-				} }
-			>
-				<div>{ __( 'This feature is not available on your plan.', 'jetpack-forms' ) }</div>
-				<Button
-					variant="primary"
-					onClick={ event => {
-						autosaveAndRedirect( event );
-					} }
-					disabled={ isRedirecting }
-					isBusy={ isRedirecting }
-				>
-					{ __( 'Upgrade', 'jetpack-forms' ) }
-				</Button>
-			</div>
-		);
-	};
-
 	return (
 		<>
 			<div { ...blockProps }>
+				{ ( ! fieldFileAvailability || ! fieldFileAvailability.available ) &&
+					( isSelected || isInnerBlockSelected ) && (
+						<UpsellNudge requiredPlan={ fieldFileAvailability?.details?.required_plan } />
+					) }
 				<JetpackFieldLabel
 					attributes={ attributes }
 					label={ label }
@@ -229,8 +145,6 @@ const JetpackFieldFile = props => {
 						<InnerBlocks template={ BLOCKS_TEMPLATE } templateLock={ false } />
 					</div>
 				</div>
-				{ ( ! fieldFileAvailability || ! fieldFileAvailability.available ) &&
-					( isSelected || isInnerBlockSelected ) && <UnavailableNudge /> }
 			</div>
 
 			<JetpackFieldControls

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-file/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-file/index.js
@@ -2,8 +2,8 @@ import { getJetpackExtensionAvailability } from '@automattic/jetpack-shared-exte
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { __experimentalNumberControl as NumberControl } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { compose } from '@wordpress/compose';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useFormWrapper } from '../../util/form';
 import { withSharedFieldAttributes } from '../../util/with-shared-field-attributes';
@@ -114,24 +114,19 @@ const JetpackFieldFile = props => {
 		return blockParents.includes( clientId );
 	} );
 
-	const { selectBlock } = useDispatch( 'core/block-editor' );
-
-	useEffect( () => {
-		if (
-			isInnerBlockSelected &&
-			( ! fieldFileAvailability || ! fieldFileAvailability.available )
-		) {
-			selectBlock( clientId );
-		}
-	}, [ isInnerBlockSelected, clientId, selectBlock, fieldFileAvailability ] );
+	const requiresCustomUpgradeNudge = useMemo( () => {
+		return (
+			( ! fieldFileAvailability || ! fieldFileAvailability.available ) &&
+			fieldFileAvailability?.unavailableReason?.includes( 'nudge_disabled' )
+		);
+	}, [ fieldFileAvailability ] );
 
 	return (
 		<>
 			<div { ...blockProps }>
-				{ ( ! fieldFileAvailability || ! fieldFileAvailability.available ) &&
-					( isSelected || isInnerBlockSelected ) && (
-						<UpsellNudge requiredPlan={ fieldFileAvailability?.details?.required_plan } />
-					) }
+				{ requiresCustomUpgradeNudge && ( isSelected || isInnerBlockSelected ) && (
+					<UpsellNudge requiredPlan={ fieldFileAvailability?.details?.required_plan } />
+				) }
 				<JetpackFieldLabel
 					attributes={ attributes }
 					label={ label }

--- a/projects/packages/forms/src/blocks/contact-form/components/upsell-nudge/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/upsell-nudge/index.js
@@ -1,7 +1,7 @@
 import { useUpgradeFlow } from '@automattic/jetpack-shared-extension-utils';
 import { Nudge } from '@automattic/jetpack-shared-extension-utils/components';
 import { __ } from '@wordpress/i18n';
-import './style.scss';
+import './style.scss'; // TODO: decide if we want to look good or we want just use default nudge
 
 export const UpsellNudge = ( { requiredPlan } ) => {
 	const [ checkoutUrl, goToCheckoutPage, isRedirecting ] = useUpgradeFlow( requiredPlan );

--- a/projects/packages/forms/src/blocks/contact-form/components/upsell-nudge/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/upsell-nudge/index.js
@@ -1,7 +1,8 @@
 import { useUpgradeFlow } from '@automattic/jetpack-shared-extension-utils';
 import { Nudge } from '@automattic/jetpack-shared-extension-utils/components';
 import { __ } from '@wordpress/i18n';
-import './style.scss'; // TODO: decide if we want to look good or we want just use default nudge
+// TODO: decide if we want to "dress like calypso" or just default nudge
+// import './style.scss';
 
 export const UpsellNudge = ( { requiredPlan } ) => {
 	const [ checkoutUrl, goToCheckoutPage, isRedirecting ] = useUpgradeFlow( requiredPlan );

--- a/projects/packages/forms/src/blocks/contact-form/components/upsell-nudge/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/upsell-nudge/index.js
@@ -1,0 +1,20 @@
+import { useUpgradeFlow } from '@automattic/jetpack-shared-extension-utils';
+import { Nudge } from '@automattic/jetpack-shared-extension-utils/components';
+import { __ } from '@wordpress/i18n';
+import './style.scss';
+
+export const UpsellNudge = ( { requiredPlan } ) => {
+	const [ checkoutUrl, goToCheckoutPage, isRedirecting ] = useUpgradeFlow( requiredPlan );
+	return (
+		<div className="jetpack-forms-upsell-nudge">
+			<Nudge
+				className=""
+				title={ __( 'Upgrade to a paid plan to use this feature.', 'jetpack-forms' ) }
+				buttonText={ __( 'Upgrade', 'jetpack-forms' ) }
+				checkoutUrl={ checkoutUrl }
+				isRedirecting={ isRedirecting }
+				goToCheckoutPage={ goToCheckoutPage }
+			/>
+		</div>
+	);
+};

--- a/projects/packages/forms/src/blocks/contact-form/components/upsell-nudge/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/upsell-nudge/style.scss
@@ -1,0 +1,47 @@
+.jetpack-forms-upsell-nudge {
+
+    .jetpack-upgrade-plan-banner .jetpack-upgrade-plan-banner__wrapper {
+        background-color: var( --color-surfce, #fff );
+        color: var( --color-neutral-70, #3c434a );
+        align-items: center;
+        padding: 12px 16px;
+        border-left: 3px solid;
+        border-left-color: var( --color-accent, var( --wp-admin-theme-color, #007cba ) );
+        cursor: default;
+        display: flex;
+        line-height: 29px;
+        margin-bottom: 16px;
+        margin-top: 8px;
+        box-shadow: 0 0 0 1px var(--color-border-subtle, var( --color-neutral-5, #dcdcde) );
+        box-sizing: border-box;
+
+        .banner-title,
+        .banner-description {
+            text-rendering: optimizeLegibility;
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: var( --color-neutral-70, #3c434a );
+        }
+
+        .banner-title {
+            font-weight: 600;
+        }
+
+        .components-button.is-primary {
+            background-color: var( --color-accent, var( --wp-admin-theme-color, #007cba ) );
+            border-color: var( --color-accent, var( --wp-admin-theme-color, #007cba ) );
+            color: var( --color-text-inverted, #fff );
+            font-weight: 400;
+
+            &.is-busy {
+                background-size: 100px 100%;
+                background-image: linear-gradient(-45deg, #e34c84 28%, #ab235a 28%, #ab235a 72%, #e34c84 72%);
+            }
+
+            &:hover {
+                background-color: var( --color-accent-60, var( --wp-admin-theme-color-darker-10, #006ba1 ) );
+                border-color: var( --color-accent-60, var( --wp-admin-theme-color-darker-10, #006ba1 ) );
+            }
+        }
+    }
+}

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -50,6 +50,10 @@
 		flex-direction: row;
 		gap: var(--wp--style--block-gap, 1.5rem);
 
+		& > div {
+			flex: 1 1 100%;
+		}
+
 		.wp-block {
 			flex: 0 0 100%;
 			margin-top: 0;

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -9,7 +9,6 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-use Automattic\Jetpack\Current_Plan as Plan;
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Forms\Service\Post_To_Url;
@@ -531,11 +530,6 @@ class Contact_Form_Plugin {
 	 * @return string HTML for the file upload field.
 	 */
 	public static function gutenblock_render_field_file( $atts, $content ) {
-		if ( apply_filters( 'jetpack_unauth_file_upload_plan_check', true ) && ! Plan::supports( 'field-file' ) ) {
-			// if the plan does not support the field-file, return null on the frontend
-			return null;
-		}
-
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'file' );
 
 		// Create wrapper div for the file field

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Forms\Service\Post_To_Url;
@@ -530,6 +531,11 @@ class Contact_Form_Plugin {
 	 * @return string HTML for the file upload field.
 	 */
 	public static function gutenblock_render_field_file( $atts, $content ) {
+		if ( ! Current_Plan::supports( 'field-file' ) ) {
+			// if the plan does not support the field-file, return null on the frontend
+			return null;
+		}
+
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'file' );
 
 		// Create wrapper div for the file field

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -9,7 +9,7 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-use Automattic\Jetpack\Current_Plan;
+use Automattic\Jetpack\Current_Plan as Plan;
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Forms\Service\Post_To_Url;
@@ -531,7 +531,7 @@ class Contact_Form_Plugin {
 	 * @return string HTML for the file upload field.
 	 */
 	public static function gutenblock_render_field_file( $atts, $content ) {
-		if ( apply_filters( 'jetpack_unauth_file_upload_plan_check', true ) && ! Current_Plan::supports( 'field-file' ) ) {
+		if ( apply_filters( 'jetpack_unauth_file_upload_plan_check', true ) && ! Plan::supports( 'field-file' ) ) {
 			// if the plan does not support the field-file, return null on the frontend
 			return null;
 		}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -531,7 +531,7 @@ class Contact_Form_Plugin {
 	 * @return string HTML for the file upload field.
 	 */
 	public static function gutenblock_render_field_file( $atts, $content ) {
-		if ( ! Current_Plan::supports( 'field-file' ) ) {
+		if ( apply_filters( 'jetpack_unauth_file_upload_plan_check', true ) && ! Current_Plan::supports( 'field-file' ) ) {
 			// if the plan does not support the field-file, return null on the frontend
 			return null;
 		}

--- a/projects/packages/plans/changelog/add-field-file-as-paid-block
+++ b/projects/packages/plans/changelog/add-field-file-as-paid-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack Forms: add feature/block field-file support to Personal and Complete plans

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -79,7 +79,6 @@ class Current_Plan {
 				'akismet',
 				'payments',
 				'videopress',
-				'field-file', // Forms
 			),
 		),
 		'premium'  => array(

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -79,6 +79,7 @@ class Current_Plan {
 				'akismet',
 				'payments',
 				'videopress',
+				'field-file', // Forms
 			),
 		),
 		'premium'  => array(
@@ -146,7 +147,9 @@ class Current_Plan {
 				'jetpack_complete_monthly',
 				'vip',
 			),
-			'supports' => array(),
+			'supports' => array(
+				'field-file', // Forms
+			),
 		),
 	);
 

--- a/projects/plugins/jetpack/changelog/add-field-file-as-paid-block
+++ b/projects/plugins/jetpack/changelog/add-field-file-as-paid-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack Forms: add field-file to beta blocks variation

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1367,6 +1367,7 @@
 				"automattic/jetpack-blocks": "@dev",
 				"automattic/jetpack-connection": "@dev",
 				"automattic/jetpack-logo": "@dev",
+				"automattic/jetpack-plans": "@dev",
 				"automattic/jetpack-status": "@dev",
 				"automattic/jetpack-sync": "@dev",
 				"php": ">=7.2"

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1360,7 +1360,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/forms",
-				"reference": "479049196c8106ce0504af8ecc004bd9875066af"
+				"reference": "81106b759baae4f2b16bcb31d2864a3abc3d13d5"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -81,7 +81,8 @@
 		"videopress/video-chapters",
 		"ai-assistant-backend-prompts",
 		"ai-list-to-table-transform",
-		"ai-use-chrome-ai-sometimes"
+		"ai-use-chrome-ai-sometimes",
+		"field-file"
 	],
 	"experimental": [],
 	"no-post-editor": [

--- a/projects/plugins/jetpack/extensions/index.scss
+++ b/projects/plugins/jetpack/extensions/index.scss
@@ -1,13 +1,6 @@
 @import '@automattic/jetpack-base-styles/style';
 
 .is-beta-extension {
-	position: relative;
-	box-shadow: 0 0 0 15px #fff, 0 0 0 16px var( --jp-green-30 );
-	transition: 0.5s box-shadow linear;
-
-	&.inset-shadow {
-		box-shadow: inset 0 0 3px var( --jp-green-30 );
-	}
 
 	&::before {
 		content: 'BETA';
@@ -30,7 +23,6 @@
 
 	&:focus,
 	&:hover {
-		box-shadow: none;
 
 		&::before {
 			opacity: 0;

--- a/projects/plugins/wpcomsh/changelog/add-field-file-custom-paid-block
+++ b/projects/plugins/wpcomsh/changelog/add-field-file-custom-paid-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add field-file feature/block support on WPCOM plans

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -368,6 +368,7 @@ class WPCOM_Features {
 	public const EMAIL_PROFESSIONAL                = 'email-professional';
 	public const EMAIL_SUBSCRIPTION                = 'email-subscription';
 	public const EMAIL_FORWARDS_EXTENDED_LIMIT     = 'email-forwards-extended-limit';
+	public const FIELD_FILE                        = 'field-file';
 	public const FREE_BLOG                         = 'free-blog';
 	public const FULL_ACTIVITY_LOG                 = 'full-activity-log';
 	public const GLOBAL_STYLES                     = 'global-styles';
@@ -703,6 +704,10 @@ class WPCOM_Features {
 			self::BUNDLE_ENTERPRISE,
 			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
 			self::WPCOM_PRO_PLANS,
+		),
+		self::FIELD_FILE                        => array(
+			self::WPCOM_PERSONAL_AND_HIGHER_PLANS,
+			self::JETPACK_COMPLETE_PLANS,
 		),
 		self::FREE_BLOG                         => array(
 			self::WPCOM_ALL_SITES,

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -705,6 +705,8 @@ class WPCOM_Features {
 			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
 			self::WPCOM_PRO_PLANS,
 		),
+		// FIELD_FILE - Premium block/feature (jetpack/field-file) for uploading files with cloud backend.
+		// See: https://github.com/Automattic/jetpack/pull/43177 / https://github.a8c.com/Automattic/wpcom/pull/179247
 		self::FIELD_FILE                        => array(
 			self::WPCOM_PERSONAL_AND_HIGHER_PLANS,
 			self::JETPACK_COMPLETE_PLANS,


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack/issues/41677
Closes JETPACK-335

## Proposed changes:

The changes include a combination of:
- register block as plan supported feature (wpcomsh)
- register block as plan supported by Jetpack
- use default upgrade nudge for dotcom and AT
- use wrapped upgrade nudge for self-hosted
- customize upgrade nudge looks for self-hosted (debatable)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
peKye1-1vf-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

On all cases, test the upgrade flow works and lands on the right plans (for now, personal and above for dotcom, Complete on Jetpack).

**Locally:**

Build packages/plans, packages/forms, plugins/wpcomsh and plugins/jetpack.
Open the editor, add a form and then insert a File Upload field block. Test with and without `add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );` 

Without the filter (custom styled nudge):
<img width="663" alt="image" src="https://github.com/user-attachments/assets/4926e78c-28ea-4d76-b9f5-b985ceef5127" />

With the filter (as will likely look on dotcom):
<img width="661" alt="image" src="https://github.com/user-attachments/assets/a22aac31-e192-49aa-ab81-66251da77071" />

Use the PR links to test on sandbox and simple/business sites, you need to checkout 181551-ghe-Automattic/wpcom

Test on AT sites.