### PR TITLE
Forms: Change data structure for integrations endpoint

### DIFF
--- a/projects/packages/forms/changelog/update-integrations-endpoint
+++ b/projects/packages/forms/changelog/update-integrations-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: Integrations endpoint returns array.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/hooks/useIntegrationsStatus.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/hooks/useIntegrationsStatus.js
@@ -9,7 +9,7 @@ import { useState, useEffect, useCallback } from '@wordpress/element';
 export const useIntegrationsStatus = () => {
 	const [ status, setStatus ] = useState( {
 		isLoading: true,
-		integrations: {},
+		integrations: [],
 		error: null,
 	} );
 
@@ -27,7 +27,7 @@ export const useIntegrationsStatus = () => {
 		} catch ( error ) {
 			setStatus( {
 				isLoading: false,
-				integrations: {},
+				integrations: [],
 				error,
 			} );
 		}

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/hooks/useIntegrationsStatus.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/hooks/useIntegrationsStatus.js
@@ -1,5 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useState, useEffect, useCallback } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Custom hook to fetch and manage all integrations status.
@@ -16,7 +17,9 @@ export const useIntegrationsStatus = () => {
 	const fetchIntegrations = useCallback( async () => {
 		try {
 			const response = await apiFetch( {
-				path: '/wp/v2/feedback/integrations',
+				path: addQueryArgs( '/wp/v2/feedback/integrations', {
+					version: 2,
+				} ),
 			} );
 
 			setStatus( {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.js
@@ -31,6 +31,8 @@ const IntegrationsModal = ( {
 		} ) );
 	};
 
+	const findIntegrationById = id => integrationsData?.find( integration => integration.id === id );
+
 	return (
 		<Modal
 			title={ __( 'Manage integrations', 'jetpack-forms' ) }
@@ -41,7 +43,7 @@ const IntegrationsModal = ( {
 				<AkismetCard
 					isExpanded={ expandedCards.akismet }
 					onToggle={ () => toggleCard( 'akismet' ) }
-					data={ integrationsData?.akismet }
+					data={ findIntegrationById( 'akismet' ) }
 					refreshStatus={ refreshIntegrations }
 				/>
 				<JetpackCRMCard
@@ -49,13 +51,13 @@ const IntegrationsModal = ( {
 					onToggle={ () => toggleCard( 'crm' ) }
 					jetpackCRM={ attributes.jetpackCRM }
 					setAttributes={ setAttributes }
-					data={ integrationsData?.[ 'zero-bs-crm' ] }
+					data={ findIntegrationById( 'zero-bs-crm' ) }
 					refreshStatus={ refreshIntegrations }
 				/>
 				<CreativeMailCard
 					isExpanded={ expandedCards.creativemail }
 					onToggle={ () => toggleCard( 'creativemail' ) }
-					data={ integrationsData?.[ 'creative-mail-by-constant-contact' ] }
+					data={ findIntegrationById( 'creative-mail-by-constant-contact' ) }
 					refreshStatus={ refreshIntegrations }
 				/>
 			</VStack>

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -593,7 +593,10 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		foreach ( array_keys( $this->get_supported_integrations() ) as $slug ) {
 			// For now, we only have plugin integrations.
 			// When needed, handle other integration types here.
-			$integrations[ $slug ] = $this->get_plugin_status( $slug );
+			$integrations[] = array_merge(
+				array( 'id' => $slug ),
+				$this->get_plugin_status( $slug )
+			);
 		}
 
 		return rest_ensure_response( $integrations );

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -75,6 +75,17 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_all_integrations_status' ),
 				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				'args'                => array(
+					'version' => array(
+						'type'              => 'integer',
+						'default'           => 1,
+						'sanitize_callback' => 'absint',
+						'validate_callback' => function ( $param ) {
+							$version = absint( $param );
+							return in_array( $version, array( 1, 2 ), true );
+						},
+					),
+				),
 			)
 		);
 
@@ -585,18 +596,24 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	/**
 	 * Get status for all supported integrations.
 	 *
+	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response Response object.
 	 */
-	public function get_all_integrations_status() {
+	public function get_all_integrations_status( $request ) {
+		$version      = absint( $request->get_param( 'version' ) );
 		$integrations = array();
 
 		foreach ( array_keys( $this->get_supported_integrations() ) as $slug ) {
-			// For now, we only have plugin integrations.
-			// When needed, handle other integration types here.
-			$integrations[] = array_merge(
-				array( 'id' => $slug ),
-				$this->get_plugin_status( $slug )
-			);
+			$plugin_status = $this->get_plugin_status( $slug );
+
+			if ( 1 === $version ) {
+				$integrations[ $slug ] = $plugin_status;
+			} else {
+				$integrations[] = array_merge(
+					array( 'id' => $slug ),
+					$plugin_status
+				);
+			}
 		}
 
 		return rest_ensure_response( $integrations );


### PR DESCRIPTION
## Proposed changes:

Updates the forms 'integrations' endpoint to return a normal array, which is received by JS as an array rather than an object. This is more in line with what a rest endpoint should return for a list, and will improve downstream logic and data handling in React and JavaScript. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This is a refactor, and behavior should be the same before and after this PR. 

- Add a form to a page or post
- Click the Manage Integrations button the sidebar
- Confirm that the Integrations modal loads and that the state shown for Akismet, Jetpack CRM, and Creative Mail are correct. 
- Try activating, deactivating, or uninstalling those plugins, refresh the editor if needed, and confirm the state still continues to render correctly. 

