### PR TITLE
Forms: ensure custom CSS in global styles applies correctly to checkbox and radio wrappers

### DIFF
--- a/projects/packages/forms/changelog/update-migrate-form-fields-to-inner-blocks-multiple-wrapper-styles
+++ b/projects/packages/forms/changelog/update-migrate-form-fields-to-inner-blocks-multiple-wrapper-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Some form groups need block classes on their wrapper styles for global styles to apply

--- a/projects/packages/forms/changelog/update-migrate-form-fields-to-inner-blocks-multiple-wrapper-styles
+++ b/projects/packages/forms/changelog/update-migrate-form-fields-to-inner-blocks-multiple-wrapper-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Some form groups need block classes on their wrapper styles for global styles to apply

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -258,66 +258,17 @@ class Contact_Form_Block {
 			)
 		);
 
-		/**
-		 * The block 'jetpack/field-checkbox-multiple' is a wrapper block.
-		 * Styles must be registered
-		 * so that they are available to be overridden by the theme or global styles.
-		 * Form field blocks define the block style via the settings in their index.js files.
-		 * A follow up issue is to update them to use block.json files, which can be reused
-		 * in both JS and PHP block registration.
-		 */
-		register_block_style(
-			'jetpack/field-checkbox-multiple',
-			array(
-				'name'       => 'list',
-				'label'      => __( 'List', 'jetpack-forms' ),
-				'is_default' => true,
-			)
-		);
-
-		register_block_style(
-			'jetpack/field-checkbox-multiple',
-			array(
-				'name'  => 'button',
-				'label' => __( 'Button', 'jetpack-forms' ),
-			)
-		);
-
 		Blocks::jetpack_register_block(
 			'jetpack/field-option-checkbox',
 			array(
 				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_option' ),
 			)
 		);
+
 		Blocks::jetpack_register_block(
 			'jetpack/field-radio',
 			array(
 				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_radio' ),
-			)
-		);
-
-		/**
-		 * The block 'jetpack/field-radio' is a wrapper block.
-		 * Styles must be registered
-		 * so that they are available to be overridden by the theme or global styles.
-		 * Form field blocks define the block style via the settings in their index.js files.
-		 * A follow up issue is to update them to use block.json files, which can be reused
-		 * in both JS and PHP block registration.
-		 */
-		register_block_style(
-			'jetpack/field-radio',
-			array(
-				'name'       => 'list',
-				'label'      => __( 'List', 'jetpack-forms' ),
-				'is_default' => true,
-			)
-		);
-
-		register_block_style(
-			'jetpack/field-radio',
-			array(
-				'name'  => 'button',
-				'label' => __( 'Button', 'jetpack-forms' ),
 			)
 		);
 
@@ -346,6 +297,30 @@ class Contact_Form_Block {
 			array(
 				'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_number' ),
 				'provides_context' => array( 'jetpack/field-required' => 'required' ),
+			)
+		);
+
+		/**
+		 * The blocks 'jetpack/field-checkbox-multiple' and 'jetpack/field-radio' are wrapper blocks.
+		 * Styles must be registered so that they are available to be overridden by the theme or global styles.
+		 * Form field blocks define the block style via the settings in their index.js files.
+		 * A follow up issue is to update them to use block.json files, which can be reused
+		 * in both JS and PHP block registration.
+		 */
+		register_block_style(
+			array( 'jetpack/field-checkbox-multiple', 'jetpack/field-radio' ),
+			array(
+				'name'       => 'list',
+				'label'      => __( 'List', 'jetpack-forms' ),
+				'is_default' => true,
+			)
+		);
+
+		register_block_style(
+			array( 'jetpack/field-checkbox-multiple', 'jetpack/field-radio' ),
+			array(
+				'name'  => 'button',
+				'label' => __( 'Button', 'jetpack-forms' ),
 			)
 		);
 

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -257,6 +257,32 @@ class Contact_Form_Block {
 				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_checkbox_multiple' ),
 			)
 		);
+
+		/**
+		 * The block 'jetpack/field-checkbox-multiple' is a wrapper block.
+		 * Styles must be registered
+		 * so that they are available to be overridden by the theme or global styles.
+		 * Form field blocks define the block style via the settings in their index.js files.
+		 * A follow up issue is to update them to use block.json files, which can be reused
+		 * in both JS and PHP block registration.
+		 */
+		register_block_style(
+			'jetpack/field-checkbox-multiple',
+			array(
+				'name'       => 'list',
+				'label'      => __( 'List', 'jetpack-forms' ),
+				'is_default' => true,
+			)
+		);
+
+		register_block_style(
+			'jetpack/field-checkbox-multiple',
+			array(
+				'name'  => 'button',
+				'label' => __( 'Button', 'jetpack-forms' ),
+			)
+		);
+
 		Blocks::jetpack_register_block(
 			'jetpack/field-option-checkbox',
 			array(
@@ -269,6 +295,32 @@ class Contact_Form_Block {
 				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_radio' ),
 			)
 		);
+
+		/**
+		 * The block 'jetpack/field-radio' is a wrapper block.
+		 * Styles must be registered
+		 * so that they are available to be overridden by the theme or global styles.
+		 * Form field blocks define the block style via the settings in their index.js files.
+		 * A follow up issue is to update them to use block.json files, which can be reused
+		 * in both JS and PHP block registration.
+		 */
+		register_block_style(
+			'jetpack/field-radio',
+			array(
+				'name'       => 'list',
+				'label'      => __( 'List', 'jetpack-forms' ),
+				'is_default' => true,
+			)
+		);
+
+		register_block_style(
+			'jetpack/field-radio',
+			array(
+				'name'  => 'button',
+				'label' => __( 'Button', 'jetpack-forms' ),
+			)
+		);
+
 		Blocks::jetpack_register_block(
 			'jetpack/field-option-radio',
 			array(

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1484,18 +1484,17 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		 * but not the input elements. This ensures any updates to block style in the theme
 		 * are applied to the wrapper div, not the input elements.
 		 */
-		$block_style_classes = $this->get_block_style_classes( $class );
-		if ( ! empty( $block_style_classes['block_style_classes'] ) ) {
-			if ( $trimmed_type === 'checkbox-multiple' ) {
-				$block_classes .= ' wp-block-jetpack-field-checkbox-multiple ' . $block_style_classes['block_style_classes'];
-				// Remove block style classes in the $class variable.
-				$class = $block_style_classes['classes'];
-			}
+		if ( $trimmed_type === 'checkbox-multiple' ) {
+			$block_style_classes = $this->get_block_style_classes( $class );
+			$block_classes      .= ' wp-block-jetpack-field-checkbox-multiple ' . $block_style_classes['block_style_classes'];
+			// Remove block style classes in the $class variable.
+			$class = $block_style_classes['classes'];
+		}
 
-			if ( $trimmed_type === 'radio' ) {
-				$block_classes .= ' wp-block-jetpack-field-radio ' . $block_style_classes['block_style_classes'];
-				$class          = $block_style_classes['classes'];
-			}
+		if ( $trimmed_type === 'radio' ) {
+			$block_style_classes = $this->get_block_style_classes( $class );
+			$block_classes      .= ' wp-block-jetpack-field-radio ' . $block_style_classes['block_style_classes'];
+			$class               = $block_style_classes['classes'];
 		}
 
 		$class .= ' grunion-field';

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1486,14 +1486,16 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		 */
 		if ( $trimmed_type === 'checkbox-multiple' ) {
 			$block_style_classes = $this->get_block_style_classes( $class );
-			$block_classes      .= ' wp-block-jetpack-field-checkbox-multiple ' . $block_style_classes['block_style_classes'];
+			$spacer              = ! empty( $block_style_classes['block_style_classes'] ) ? ' ' : '';
+			$block_classes      .= ' wp-block-jetpack-field-checkbox-multiple' . $spacer . $block_style_classes['block_style_classes'];
 			// Remove block style classes in the $class variable.
 			$class = $block_style_classes['classes'];
 		}
 
 		if ( $trimmed_type === 'radio' ) {
 			$block_style_classes = $this->get_block_style_classes( $class );
-			$block_classes      .= ' wp-block-jetpack-field-radio ' . $block_style_classes['block_style_classes'];
+			$spacer              = ! empty( $block_style_classes['block_style_classes'] ) ? ' ' : '';
+			$block_classes      .= ' wp-block-jetpack-field-radio' . $spacer . $block_style_classes['block_style_classes'];
 			$class               = $block_style_classes['classes'];
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1485,8 +1485,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			}
 		}
 
+		$trimmed_type      = trim( esc_attr( $type ) );
 		$field_placeholder = ( '' !== $placeholder ) ? "placeholder='" . esc_attr( $placeholder ) . "'" : '';
-		$field_class       = "class='" . trim( esc_attr( $type ) . ' ' . esc_attr( $class ) ) . "' ";
+		$field_class       = "class='" . $trimmed_type . ' ' . esc_attr( $class ) . "' ";
 		$wrap_classes      = empty( $class ) ? '' : implode( '-wrap ', array_filter( explode( ' ', $class ) ) ) . '-wrap'; // this adds
 		$has_inset_label   = $this->has_inset_label();
 
@@ -1494,7 +1495,21 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$wrap_classes .= ' no-label';
 		}
 
-		$shell_field_class = "class='grunion-field-" . trim( esc_attr( $type ) . '-wrap ' . esc_attr( $wrap_classes ) ) . "' ";
+		$shell_field_class = "class='grunion-field-" . $trimmed_type . '-wrap ' . esc_attr( $wrap_classes );
+
+		// @TODO - this is a hack to get the correct class for the checkbox-multiple and radio fields
+		// @TODO - is there a better way to do this?
+		// @TODO - add tests.
+		if ( $trimmed_type === 'checkbox-multiple' ) {
+			$shell_field_class .= ' wp-block-jetpack-field-checkbox-multiple';
+		}
+
+		if ( $trimmed_type === 'radio' ) {
+			$shell_field_class .= ' wp-block-jetpack-field-radio';
+		}
+
+		// End the classname string.
+		$shell_field_class .= "' ";
 
 		/**
 		 * Filter the Contact Form required field text

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -350,6 +350,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 		if ( $has_block_support_styles ) {
 			// Do any of the block support classes need to be applied at the field wrapper level? Do we need to make the classes etc filterable as per the field classes?
+			// Yes, I think so: checkbox-multiple and field-radio wrapper require this, also to prevent the classes from being applied to the input/option elements in these cases.
 
 			// Classes.
 			if ( ! empty( $label_classes ) ) {
@@ -1474,6 +1475,24 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			return '';
 		}
 
+		$trimmed_type    = trim( esc_attr( $type ) );
+		$block_classes   = '';
+		$wrap_classnames = $class . ' grunion-field'; // Classes for $shell_field_class wrapper.
+
+		/*
+		 * For the checkbox-multiple and radio fields, we need to add the attribute classes to the wrapper div
+		 * but not the input elements.
+		 */
+		if ( $trimmed_type === 'checkbox-multiple' ) {
+			$block_classes .= ' wp-block-jetpack-field-checkbox-multiple ' . $class;
+			$class          = ''; // Remove incoming classes for $field_class input elements.
+		}
+
+		if ( $trimmed_type === 'radio' ) {
+			$block_classes .= ' wp-block-jetpack-field-radio ' . $class;
+			$class          = ''; // Remove incoming classes for $field_class input elements.
+		}
+
 		$class .= ' grunion-field';
 
 		$form_style = $this->get_form_style();
@@ -1481,35 +1500,23 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			if ( ! isset( $placeholder ) || '' === $placeholder ) {
 				$placeholder .= ' ';
 			} else {
-				$class .= ' has-placeholder';
+				$class           .= ' has-placeholder';
+				$wrap_classnames .= ' has-placeholder';
 			}
 		}
 
-		$trimmed_type      = trim( esc_attr( $type ) );
+		// Field classes.
 		$field_placeholder = ( '' !== $placeholder ) ? "placeholder='" . esc_attr( $placeholder ) . "'" : '';
 		$field_class       = "class='" . $trimmed_type . ' ' . esc_attr( $class ) . "' ";
-		$wrap_classes      = empty( $class ) ? '' : implode( '-wrap ', array_filter( explode( ' ', $class ) ) ) . '-wrap'; // this adds
-		$has_inset_label   = $this->has_inset_label();
+
+		// Shell wrapper classes. Add -wrap to each class.
+		$wrap_classes = empty( $wrap_classnames ) ? '' : implode( '-wrap ', array_filter( explode( ' ', $wrap_classnames ) ) ) . '-wrap';
 
 		if ( empty( $label ) ) {
 			$wrap_classes .= ' no-label';
 		}
 
-		$shell_field_class = "class='grunion-field-" . $trimmed_type . '-wrap ' . esc_attr( $wrap_classes );
-
-		// @TODO - this is a hack to get the correct class for the checkbox-multiple and radio fields
-		// @TODO - is there a better way to do this?
-		// @TODO - add tests.
-		if ( $trimmed_type === 'checkbox-multiple' ) {
-			$shell_field_class .= ' wp-block-jetpack-field-checkbox-multiple';
-		}
-
-		if ( $trimmed_type === 'radio' ) {
-			$shell_field_class .= ' wp-block-jetpack-field-radio';
-		}
-
-		// End the classname string.
-		$shell_field_class .= "' ";
+		$shell_field_class = "class='grunion-field-" . $trimmed_type . '-wrap ' . esc_attr( $wrap_classes ) . esc_attr( $block_classes ) . "' ";
 
 		/**
 		 * Filter the Contact Form required field text
@@ -1522,9 +1529,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		 */
 		$required_field_text = wp_kses_post( apply_filters( 'jetpack_required_field_text', $required_field_text ) );
 
-		$block_style = 'style="' . $this->block_styles . '"';
-
-		$field = '';
+		$block_style     = 'style="' . $this->block_styles . '"';
+		$has_inset_label = $this->has_inset_label();
+		$field           = '';
 
 		// Fields with an inset label need an extra wrapper to show the error message below the input.
 		if ( $has_inset_label ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -144,6 +144,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'min'                    => null,
 				'max'                    => null,
 				'maxfiles'               => null,
+				'fieldwrapperclasses'    => null,
 			),
 			$attributes,
 			'contact-field'
@@ -350,7 +351,6 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 		if ( $has_block_support_styles ) {
 			// Do any of the block support classes need to be applied at the field wrapper level? Do we need to make the classes etc filterable as per the field classes?
-			// Yes, I think so: checkbox-multiple and field-radio wrapper require this, also to prevent the classes from being applied to the input/option elements in these cases.
 
 			// Classes.
 			if ( ! empty( $label_classes ) ) {
@@ -675,6 +675,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				$extra_attrs_string .= sprintf( '%s="%s" ', esc_attr( $attr ), esc_attr( $val ) );
 			}
 		}
+
 		return "<input
 					type='" . esc_attr( $type ) . "'
 					name='" . esc_attr( $id ) . "'
@@ -1475,54 +1476,30 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			return '';
 		}
 
-		$trimmed_type    = trim( esc_attr( $type ) );
-		$block_classes   = '';
-		$wrap_classnames = $class . ' grunion-field'; // Classes for $shell_field_class wrapper.
-
-		/*
-		 * For the checkbox-multiple and radio fields, we need to add the `wp-block-jetpack-field-*` and `is-style-*` classes to the wrapper div
-		 * but not the input elements. This ensures any updates to block style in the theme
-		 * are applied to the wrapper div, not the input elements.
-		 */
-		if ( $trimmed_type === 'checkbox-multiple' ) {
-			$block_style_classes = $this->get_block_style_classes( $class );
-			$spacer              = ! empty( $block_style_classes['block_style_classes'] ) ? ' ' : '';
-			$block_classes      .= ' wp-block-jetpack-field-checkbox-multiple' . $spacer . $block_style_classes['block_style_classes'];
-			// Remove block style classes in the $class variable.
-			$class = $block_style_classes['classes'];
-		}
-
-		if ( $trimmed_type === 'radio' ) {
-			$block_style_classes = $this->get_block_style_classes( $class );
-			$spacer              = ! empty( $block_style_classes['block_style_classes'] ) ? ' ' : '';
-			$block_classes      .= ' wp-block-jetpack-field-radio' . $spacer . $block_style_classes['block_style_classes'];
-			$class               = $block_style_classes['classes'];
-		}
-
-		$class .= ' grunion-field';
+		$trimmed_type = trim( esc_attr( $type ) );
+		$class       .= ' grunion-field';
 
 		$form_style = $this->get_form_style();
 		if ( ! empty( $form_style ) && $form_style !== 'default' ) {
 			if ( ! isset( $placeholder ) || '' === $placeholder ) {
 				$placeholder .= ' ';
 			} else {
-				$class           .= ' has-placeholder';
-				$wrap_classnames .= ' has-placeholder';
+				$class .= ' has-placeholder';
 			}
 		}
 
 		// Field classes.
-		$field_placeholder = ( '' !== $placeholder ) ? "placeholder='" . esc_attr( $placeholder ) . "'" : '';
-		$field_class       = "class='" . $trimmed_type . ' ' . esc_attr( $class ) . "' ";
+		$field_class = "class='" . $trimmed_type . ' ' . esc_attr( $class ) . "' ";
 
 		// Shell wrapper classes. Add -wrap to each class.
-		$wrap_classes = empty( $wrap_classnames ) ? '' : implode( '-wrap ', array_filter( explode( ' ', $wrap_classnames ) ) ) . '-wrap';
+		$wrap_classes          = empty( $class ) ? '' : implode( '-wrap ', array_filter( explode( ' ', $class ) ) ) . '-wrap';
+		$field_wrapper_classes = $this->get_attribute( 'fieldwrapperclasses' ) ?? '';
 
 		if ( empty( $label ) ) {
 			$wrap_classes .= ' no-label';
 		}
 
-		$shell_field_class = "class='grunion-field-" . $trimmed_type . '-wrap ' . esc_attr( $wrap_classes ) . esc_attr( $block_classes ) . "' ";
+		$shell_field_class = "class='" . $field_wrapper_classes . ' grunion-field-' . $trimmed_type . '-wrap ' . esc_attr( $wrap_classes ) . "' ";
 
 		/**
 		 * Filter the Contact Form required field text
@@ -1535,9 +1512,10 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		 */
 		$required_field_text = wp_kses_post( apply_filters( 'jetpack_required_field_text', $required_field_text ) );
 
-		$block_style     = 'style="' . $this->block_styles . '"';
-		$has_inset_label = $this->has_inset_label();
-		$field           = '';
+		$block_style       = 'style="' . $this->block_styles . '"';
+		$has_inset_label   = $this->has_inset_label();
+		$field             = '';
+		$field_placeholder = ( '' !== $placeholder ) ? "placeholder='" . esc_attr( $placeholder ) . "'" : '';
 
 		// Fields with an inset label need an extra wrapper to show the error message below the input.
 		if ( $has_inset_label ) {
@@ -1691,37 +1669,6 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$class_name = $this->form->get_attribute( 'className' );
 		preg_match( '/is-style-([^\s]+)/i', $class_name, $matches );
 		return count( $matches ) >= 2 ? $matches[1] : null;
-	}
-
-	/**
-	 * Returns an array containing the block style classes and the remaining classes from the given class name.
-	 *
-	 * @param string $classname The class name.
-	 *
-	 * @return array {
-	 *     @type string $block_style_classes        The block style classes (is-style-* classes).
-	 *     @type string $classes_without_block_style The remaining classes without block style classes.
-	 * }
-	 */
-	private function get_block_style_classes( $classname = '' ) {
-		if ( ! $classname ) {
-			return array(
-				'block_style_classes' => '',
-				'classes'             => '',
-			);
-		}
-
-		preg_match_all( '/is-style-([^\s]+)/i', $classname, $matches );
-
-		$block_style_classes = empty( $matches[0] ) ? '' : implode( ' ', $matches[0] );
-
-		// Remove block style classes from the original classname
-		$classes_without_block_style = trim( preg_replace( '/is-style-([^\s]+)/i', '', $classname ) );
-
-		return array(
-			'block_style_classes' => $block_style_classes,
-			'classes'             => $classes_without_block_style,
-		);
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1480,17 +1480,22 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$wrap_classnames = $class . ' grunion-field'; // Classes for $shell_field_class wrapper.
 
 		/*
-		 * For the checkbox-multiple and radio fields, we need to add the attribute classes to the wrapper div
-		 * but not the input elements.
+		 * For the checkbox-multiple and radio fields, we need to add the `is-style-*` classes to the wrapper div
+		 * but not the input elements. This ensures any updates to block style in the theme
+		 * are applied to the wrapper div, not the input elements.
 		 */
-		if ( $trimmed_type === 'checkbox-multiple' ) {
-			$block_classes .= ' wp-block-jetpack-field-checkbox-multiple ' . $class;
-			$class          = ''; // Remove incoming classes for $field_class input elements.
-		}
+		$block_style_classes = $this->get_block_style_classes( $class );
+		if ( ! empty( $block_style_classes['block_style_classes'] ) ) {
+			if ( $trimmed_type === 'checkbox-multiple' ) {
+				$block_classes .= ' wp-block-jetpack-field-checkbox-multiple ' . $block_style_classes['block_style_classes'];
+				// Remove block style classes in the $class variable.
+				$class = $block_style_classes['classes'];
+			}
 
-		if ( $trimmed_type === 'radio' ) {
-			$block_classes .= ' wp-block-jetpack-field-radio ' . $class;
-			$class          = ''; // Remove incoming classes for $field_class input elements.
+			if ( $trimmed_type === 'radio' ) {
+				$block_classes .= ' wp-block-jetpack-field-radio ' . $block_style_classes['block_style_classes'];
+				$class          = $block_style_classes['classes'];
+			}
 		}
 
 		$class .= ' grunion-field';
@@ -1685,6 +1690,37 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$class_name = $this->form->get_attribute( 'className' );
 		preg_match( '/is-style-([^\s]+)/i', $class_name, $matches );
 		return count( $matches ) >= 2 ? $matches[1] : null;
+	}
+
+	/**
+	 * Returns an array containing the block style classes and the remaining classes from the given class name.
+	 *
+	 * @param string $classname The class name.
+	 *
+	 * @return array {
+	 *     @type string $block_style_classes        The block style classes (is-style-* classes).
+	 *     @type string $classes_without_block_style The remaining classes without block style classes.
+	 * }
+	 */
+	private function get_block_style_classes( $classname = '' ) {
+		if ( ! $classname ) {
+			return array(
+				'block_style_classes' => '',
+				'classes'             => '',
+			);
+		}
+
+		preg_match_all( '/is-style-([^\s]+)/i', $classname, $matches );
+
+		$block_style_classes = empty( $matches[0] ) ? '' : implode( ' ', $matches[0] );
+
+		// Remove block style classes from the original classname
+		$classes_without_block_style = trim( preg_replace( '/is-style-([^\s]+)/i', '', $classname ) );
+
+		return array(
+			'block_style_classes' => $block_style_classes,
+			'classes'             => $classes_without_block_style,
+		);
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1480,7 +1480,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$wrap_classnames = $class . ' grunion-field'; // Classes for $shell_field_class wrapper.
 
 		/*
-		 * For the checkbox-multiple and radio fields, we need to add the `is-style-*` classes to the wrapper div
+		 * For the checkbox-multiple and radio fields, we need to add the `wp-block-jetpack-field-*` and `is-style-*` classes to the wrapper div
 		 * but not the input elements. This ensures any updates to block style in the theme
 		 * are applied to the wrapper div, not the input elements.
 		 */

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -377,6 +377,42 @@ class Contact_Form_Plugin {
 	}
 
 	/**
+	 * Returns an array containing the block style classes, the remaining classes without block style classes, and the wrap classes.
+	 * The wrap classes are used for the wrapper div around the field.
+	 *
+	 * @param string $classname The class name.
+	 *
+	 * @return array {
+	 *     @type string $block_style_classes         The block style classes (is-style-* classes).
+	 *     @type string $classes_without_block_style The remaining classes without block style classes.
+	 *     @type string $wrap_classes                The wrap classes.
+	 * }
+	 */
+	private static function get_block_style_classes( $classname = '' ) {
+		if ( ! $classname ) {
+			return array(
+				'block_style_classes' => '',
+				'classes'             => '',
+				'wrap_classes'        => '',
+			);
+		}
+
+		preg_match_all( '/is-style-([^\s]+)/i', $classname, $matches );
+
+		$block_style_classes = empty( $matches[0] ) ? '' : implode( ' ', $matches[0] );
+		$wrap_classes        = ! empty( $matches[0] ) ? implode( '-wrap ', $matches[0] ) . '-wrap' : '';
+
+		// Remove block style classes from the original classname
+		$classes_without_block_style = trim( preg_replace( '/is-style-([^\s]+)/i', '', $classname ) );
+
+		return array(
+			'block_style_classes' => $block_style_classes,
+			'classes'             => $classes_without_block_style,
+			'wrap_classes'        => $wrap_classes,
+		);
+	}
+
+	/**
 	 * Turn block attribute to shortcode attributes.
 	 *
 	 * @param array         $atts  - the block attributes.
@@ -399,6 +435,20 @@ class Contact_Form_Plugin {
 
 		// Process inner blocks to shortcode attributes.
 		if ( $block && ! empty( $block->parsed_block['innerBlocks'] ) ) {
+			/*
+			 * Add the `wp-block-jetpack-field-*` and `is-style-*` classes to the field wrapper div
+			 * This ensures any updates to field block styles in theme.json or global styles are
+			 * correctly applied.
+			 */
+			$atts['fieldwrapperclasses'] = 'wp-block-jetpack-field-' . $type;
+			if ( ! empty( $atts['class'] ) ) {
+				$block_style_classes          = self::get_block_style_classes( $atts['class'] );
+				$spacer                       = ! empty( $block_style_classes['block_style_classes'] ) ? ' ' : '';
+				$atts['fieldwrapperclasses'] .= $spacer . $block_style_classes['block_style_classes'] . $spacer . $block_style_classes['wrap_classes'];
+				// Return the rest of the classes without the block style classes.
+				$atts['class'] = ! empty( $block_style_classes['classes'] ) ? $block_style_classes['classes'] : '';
+			}
+
 			foreach ( $block->parsed_block['innerBlocks'] as $inner_block ) {
 				$block_name = $inner_block['blockName'] ?? '';
 

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -708,7 +708,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	line-height: var(--jetpack--contact-form--button-outline--line-height);
 }
 
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button {
+.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio {
 
 	/* visually-hidden */
 	clip: rect(0 0 0 0);
@@ -735,7 +735,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	outline-offset: 2px;
 }
 
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.checkbox-multiple.is-style-button {
+.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.checkbox-multiple {
 	border-radius: var(--jetpack--contact-form--button-outline--border-radius);
 	color: var(--jetpack--contact-form--button-outline--text-color);
 
@@ -746,7 +746,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	outline-width: 0; /* focus style defined on parent */
 }
 
-.contact-form input.grunion-field.is-style-button + .grunion-field-text::before {
+.contact-form .is-style-button input.grunion-field + .grunion-field-text::before {
 	background: var(--jetpack--contact-form--button-outline--background-color);
 	border: var(--jetpack--contact-form--button-outline--border);
 	border-color: currentColor;
@@ -762,7 +762,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	z-index: -1;
 }
 
-.contact-form input.grunion-field.is-style-button {
+.contact-form .is-style-button input.grunion-field {
 	color: var(--jetpack--contact-form--button-outline--color);
 }
 

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -696,15 +696,12 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .grunion-field-wrap.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .contact-form-field,
 .contact-form .grunion-field-wrap.is-style-button-wrap .grunion-radio-label {
 	display: inline-flex;
-  align-items: center;
-
+	align-items: center;
 	padding: var(--jetpack--contact-form--button-outline--padding);
-
 	background: var(--jetpack--contact-form--button-outline--background-color);
 	border: var(--jetpack--contact-form--button-outline--border);
 	border-radius: var(--jetpack--contact-form--button-outline--border-radius);
 	color: var(--jetpack--contact-form--button-outline--text-color);
-
 	line-height: var(--jetpack--contact-form--button-outline--line-height);
 }
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -121,7 +121,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		// Render the shortcode.
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_checkbox_multiple( array(), '', new WP_Block( $block ) );
-		$expected  = '[contact-field type="checkbox-multiple" label="Choose several options" labelclasses="wp-block-jetpack-label has-text-color has-swamp-green-color" options="truth,dare" optionsdata="&#091;{&quot;label&quot;:&quot;truth&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:caramel; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;dare&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:gummy; font-size:24px;&quot;}&#093;"/]';
+		$expected  = '[contact-field type="checkbox-multiple" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple" label="Choose several options" labelclasses="wp-block-jetpack-label has-text-color has-swamp-green-color" options="truth,dare" optionsdata="&#091;{&quot;label&quot;:&quot;truth&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:caramel; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;dare&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:gummy; font-size:24px;&quot;}&#093;"/]';
 
 		$this->assertEquals( $expected, $shortcode, 'Shortcode is not as expected' );
 	}
@@ -155,7 +155,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			),
 		);
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_checkbox( array(), '', new WP_Block( $block ) );
-		$expected  = '[contact-field type="checkbox" label="single" optionclasses=" has-text-color" optionstyles="color:caramel; font-size:24px;"/]';
+		$expected  = '[contact-field type="checkbox" fieldwrapperclasses="wp-block-jetpack-field-checkbox" label="single" optionclasses=" has-text-color" optionstyles="color:caramel; font-size:24px;"/]';
 
 		$this->assertEquals( $expected, $shortcode );
 	}
@@ -205,7 +205,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			),
 		);
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_text( array(), '', new WP_Block( $block ) );
-		$expected  = '[contact-field type="text" label="Label" requiredText="Do it" labelclasses="wp-block-jetpack-label has-text-color" labelstyles="color:caramel; font-size:24px;" placeholder="hi!" min="1" max="10" inputclasses="wp-block-jetpack-input has-text-color has-border-color" inputstyles="color:toot; font-size:33rem; border-color:toot;border-width:1px;"/]';
+		$expected  = '[contact-field type="text" fieldwrapperclasses="wp-block-jetpack-field-text" label="Label" requiredText="Do it" labelclasses="wp-block-jetpack-label has-text-color" labelstyles="color:caramel; font-size:24px;" placeholder="hi!" min="1" max="10" inputclasses="wp-block-jetpack-input has-text-color has-border-color" inputstyles="color:toot; font-size:33rem; border-color:toot;border-width:1px;"/]';
 
 		$this->assertEquals( $expected, $shortcode );
 	}
@@ -217,8 +217,9 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$block = array(
 			'blockName'   => 'jetpack/field-radio',
 			'attrs'       => array(
-				'required' => true,
-				'width'    => '100%',
+				'required'  => true,
+				'width'     => '100%',
+				'className' => 'is-style-button some-custom-class',
 			),
 			'innerBlocks' => array(
 				array(
@@ -277,7 +278,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		// Render the shortcode.
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_radio( array(), '', new WP_Block( $block ) );
-		$expected  = '[contact-field type="radio" label="Radio gaga" labelclasses="wp-block-jetpack-label has-text-color has-turmoil-purple-color" options="freddy,brian" optionsdata="&#091;{&quot;label&quot;:&quot;freddy&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:reddo; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;brian&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:blueo; font-size:100rem;&quot;}&#093;"/]';
+		$expected  = '[contact-field type="radio" fieldwrapperclasses="wp-block-jetpack-field-radio" label="Radio gaga" labelclasses="wp-block-jetpack-label has-text-color has-turmoil-purple-color" options="freddy,brian" optionsdata="&#091;{&quot;label&quot;:&quot;freddy&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:reddo; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;brian&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:blueo; font-size:100rem;&quot;}&#093;"/]';
 
 		$this->assertEquals( $expected, $shortcode, 'Shortcode is not as expected' );
 	}
@@ -323,16 +324,17 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		return array(
 			'label and input'   => array(
 				'expected'     => array(
-					'labelclasses' => 'wp-block-jetpack-label has-text-color has-accent-3-color',
-					'labelstyles'  => 'font-size:32px;',
-					'inputclasses' => 'wp-block-jetpack-input has-text-color has-background has-border-color',
-					'inputstyles'  => 'color:swamp-green;background-color:swamp-red; font-size:24px;font-style:italic;font-weight:bold;line-height:1.5;letter-spacing:0.1em; border-color:swamp-blue;border-style:dashed;border-width:1px;',
-					'label'        => 'Label and Input',
-					'requiredText' => 'Do it',
-					'placeholder'  => 'Yo',
-					'min'          => '1',
-					'max'          => '10',
-					'type'         => 'text',
+					'labelclasses'        => 'wp-block-jetpack-label has-text-color has-accent-3-color',
+					'labelstyles'         => 'font-size:32px;',
+					'inputclasses'        => 'wp-block-jetpack-input has-text-color has-background has-border-color',
+					'inputstyles'         => 'color:swamp-green;background-color:swamp-red; font-size:24px;font-style:italic;font-weight:bold;line-height:1.5;letter-spacing:0.1em; border-color:swamp-blue;border-style:dashed;border-width:1px;',
+					'label'               => 'Label and Input',
+					'requiredText'        => 'Do it',
+					'placeholder'         => 'Yo',
+					'min'                 => '1',
+					'max'                 => '10',
+					'type'                => 'text',
+					'fieldwrapperclasses' => 'wp-block-jetpack-field-text',
 				),
 				'inner_blocks' => array(
 					array(
@@ -382,10 +384,11 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			),
 			'option'            => array(
 				'expected'     => array(
-					'optionclasses' => ' has-text-color has-swamp-cheese-color',
-					'optionstyles'  => 'font-size:24px;font-style:italic;font-weight:bold;line-height:1.5;letter-spacing:0.1em;',
-					'label'         => 'Option',
-					'type'          => 'radio',
+					'optionclasses'       => ' has-text-color has-swamp-cheese-color',
+					'optionstyles'        => 'font-size:24px;font-style:italic;font-weight:bold;line-height:1.5;letter-spacing:0.1em;',
+					'label'               => 'Option',
+					'type'                => 'radio',
+					'fieldwrapperclasses' => 'wp-block-jetpack-field-radio',
 				),
 				'inner_blocks' => array(
 					array(
@@ -417,13 +420,14 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			),
 			'label and options' => array(
 				'expected'     => array(
-					'labelclasses' => 'wp-block-jetpack-label has-text-color has-accent-3-color',
-					'labelstyles'  => 'letter-spacing:0.1em;',
-					'options'      => 'Option 1,Option 2',
-					'optionsdata'  => '[{"label":"Option 1","class":"has-text-color has-sweet-potato-option-1-color","style":"font-size:24px;font-weight:bold;line-height:1.5;letter-spacing:0.1em;"},{"label":"Option 2","class":"has-text-color has-sweet-potato-option-2-color","style":"font-size:22px;font-weight:normal;"}]',
-					'label'        => 'Label multiple options',
-					'type'         => 'checkbox-multiple',
-					'requiredText' => 'Do it again',
+					'labelclasses'        => 'wp-block-jetpack-label has-text-color has-accent-3-color',
+					'labelstyles'         => 'letter-spacing:0.1em;',
+					'options'             => 'Option 1,Option 2',
+					'optionsdata'         => '[{"label":"Option 1","class":"has-text-color has-sweet-potato-option-1-color","style":"font-size:24px;font-weight:bold;line-height:1.5;letter-spacing:0.1em;"},{"label":"Option 2","class":"has-text-color has-sweet-potato-option-2-color","style":"font-size:22px;font-weight:normal;"}]',
+					'label'               => 'Label multiple options',
+					'type'                => 'checkbox-multiple',
+					'requiredText'        => 'Do it again',
+					'fieldwrapperclasses' => 'wp-block-jetpack-field-checkbox-multiple',
 				),
 				'inner_blocks' => array(
 					array(

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
 use WP_Block;
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -879,7 +879,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$attributes          = array(
 			'label'         => 'fun',
 			'type'          => 'checkbox-multiple',
-			'class'         => 'lalala',
+			'class'         => 'is-style-greenish lalala',
 			'default'       => 'option 1',
 			'id'            => 'funID',
 			'options'       => array( 'option 1', 'option 2' ),
@@ -902,7 +902,13 @@ class Contact_Form_Test extends BaseTestCase {
 			),
 		);
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'checkbox' ) );
-		$this->assertValidFieldMultiField( $this->render_field( $attributes ), $expected_attributes );
+
+		/*
+		 * The third argument are the extra classes for the wrapper div.
+		 * For checkbox-multiple fields, we need to add the block style classes to the wrapper div.
+		 * See Contact_Form_Field::render_field() for more details.
+		 */
+		$this->assertValidFieldMultiField( $this->render_field( $attributes ), $expected_attributes, ' wp-block-jetpack-field-checkbox-multiple is-style-greenish' );
 	}
 
 	/**
@@ -912,7 +918,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$attributes = array(
 			'label'   => 'fun',
 			'type'    => 'radio',
-			'class'   => 'lalala',
+			'class'   => 'is-style-blah is-style-blah--2 lalala',
 			'default' => 'option 1',
 			'id'      => 'funID',
 			'options' => array( 'option 1', 'option 2', 'option 3, or 4', 'back\\slash' ),
@@ -920,7 +926,13 @@ class Contact_Form_Test extends BaseTestCase {
 		);
 
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'radio' ) );
-		$this->assertValidFieldMultiField( $this->render_field( $attributes ), $expected_attributes );
+
+		/*
+		 * The third argument are the extra classes for the wrapper div.
+		 * For radio fields, we need to add the block style classes to the wrapper div.
+		 * See Contact_Form_Field::render_field() for more details.
+		 */
+		$this->assertValidFieldMultiField( $this->render_field( $attributes ), $expected_attributes, ' wp-block-jetpack-field-radio is-style-blah is-style-blah--2' );
 	}
 
 	/**
@@ -987,8 +999,9 @@ class Contact_Form_Test extends BaseTestCase {
 	 *
 	 * @param DOMElement $wrapper_div The wrapper div.
 	 * @param array      $attributes An associative array containing the field's attributes.
+	 * @param string     $extra_wrapper_classes Extra classes to add to the wrapper div.
 	 */
-	public function assertFieldClasses( $wrapper_div, $attributes ) {
+	public function assertFieldClasses( $wrapper_div, $attributes, $extra_wrapper_classes = '' ) {
 		if ( 'date' === $attributes['type'] ) {
 			$attributes['class'] = 'jp-contact-form-date';
 		}
@@ -1017,10 +1030,20 @@ class Contact_Form_Test extends BaseTestCase {
 			}
 		}
 
-		$css_class = "grunion-field-{$attributes['type']}-wrap {$attributes['class']}-wrap{$input_classes_wrap}{$options_classes_wrap} grunion-field-wrap";
+		// Multiple classes are also added to the wrapper div with the -wrap suffix.
+		$classes_wrap = '';
+		if ( isset( $attributes['class'] ) ) {
+			$wrapper_classes = explode( ' ', $attributes['class'] );
+			foreach ( $wrapper_classes as $wrapper_class ) {
+				$classes_wrap .= " {$wrapper_class}-wrap";
+			}
+		}
+
+		$css_class         = "grunion-field-{$attributes['type']}-wrap{$classes_wrap}{$input_classes_wrap}{$options_classes_wrap} grunion-field-wrap{$extra_wrapper_classes}";
+		$wrapper_div_class = $wrapper_div->getAttribute( 'class' );
 
 		$this->assertEquals(
-			$wrapper_div->getAttribute( 'class' ),
+			$wrapper_div_class,
 			$css_class,
 			'div class attribute doesn\'t match'
 		);
@@ -1058,9 +1081,21 @@ class Contact_Form_Test extends BaseTestCase {
 			}
 		}
 
+		// Multiple classes are also added to the input element, with the exception of is-style-* classes.
+		$classes_input = '';
+		if ( isset( $attributes['class'] ) ) {
+			$input_classes = explode( ' ', $attributes['class'] );
+			foreach ( $input_classes as $input_class ) {
+				if ( strpos( $input_class, 'is-style-' ) !== false ) {
+					continue;
+				}
+				$classes_input .= " {$input_class}";
+			}
+		}
+
 		$this->assertEquals(
 			$input->getAttribute( 'class' ),
-			$attributes['type'] . ' ' . $attributes['class'] . $input_classes_input . $options_classes_input . ' grunion-field',
+			$attributes['type'] . $classes_input . $input_classes_input . $options_classes_input . ' grunion-field',
 			'input class attribute doesn\'t match'
 		);
 	}
@@ -1221,11 +1256,12 @@ class Contact_Form_Test extends BaseTestCase {
 	 *
 	 * @param string $html The html string.
 	 * @param array  $attributes An associative array containing the field's attributes.
+	 * @param string $extra_wrapper_classes Extra classes to add to the wrapper div.
 	 */
-	public function assertValidFieldMultiField( $html, $attributes ) {
+	public function assertValidFieldMultiField( $html, $attributes, $extra_wrapper_classes = '' ) {
 
 		$wrapper_div = $this->getCommonDiv( $html );
-		$this->assertFieldClasses( $wrapper_div, $attributes );
+		$this->assertFieldClasses( $wrapper_div, $attributes, $extra_wrapper_classes );
 
 		// Inputs.
 		if ( 'select' === $attributes['type'] ) {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -918,6 +918,30 @@ class Contact_Form_Test extends BaseTestCase {
 		$attributes = array(
 			'label'   => 'fun',
 			'type'    => 'radio',
+			'class'   => 'lalala',
+			'default' => 'option 1',
+			'id'      => 'funID',
+			'options' => array( 'option 1', 'option 2', 'option 3, or 4', 'back\\slash' ),
+			'values'  => array( 'option 1', 'option 2', 'option [34]', '\\' ),
+		);
+
+		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'radio' ) );
+
+		/*
+		 * The third argument are the extra classes for the wrapper div.
+		 * For radio fields, we need to add the block style classes to the wrapper div.
+		 * See Contact_Form_Field::render_field() for more details.
+		 */
+		$this->assertValidFieldMultiField( $this->render_field( $attributes ), $expected_attributes, ' wp-block-jetpack-field-radio' );
+	}
+
+	/**
+	 * Test for radio field_renders with block style classes.
+	 */
+	public function test_make_sure_radio_field_renders_as_expected_with_block_style_classes() {
+		$attributes = array(
+			'label'   => 'fun',
+			'type'    => 'radio',
 			'class'   => 'is-style-blah is-style-blah--2 lalala',
 			'default' => 'option 1',
 			'id'      => 'funID',

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -753,12 +753,13 @@ class Contact_Form_Test extends BaseTestCase {
 	 */
 	public function test_make_sure_text_field_renders_as_expected() {
 		$attributes = array(
-			'label'       => 'fun',
-			'type'        => 'text',
-			'class'       => 'lalala',
-			'default'     => 'foo',
-			'placeholder' => 'PLACEHOLDTHIS!',
-			'id'          => 'funID',
+			'label'               => 'fun',
+			'type'                => 'text',
+			'fieldwrapperclasses' => 'wp-block-jetpack-field-text',
+			'class'               => 'lalala',
+			'default'             => 'foo',
+			'placeholder'         => 'PLACEHOLDTHIS!',
+			'id'                  => 'funID',
 		);
 
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'text' ) );
@@ -770,12 +771,13 @@ class Contact_Form_Test extends BaseTestCase {
 	 */
 	public function test_make_sure_email_field_renders_as_expected() {
 		$attributes = array(
-			'label'       => 'fun',
-			'type'        => 'email',
-			'class'       => 'lalala',
-			'default'     => 'foo',
-			'placeholder' => 'PLACEHOLDTHIS!',
-			'id'          => 'funID',
+			'label'               => 'fun',
+			'type'                => 'email',
+			'fieldwrapperclasses' => 'wp-block-jetpack-field-email',
+			'class'               => 'lalala',
+			'default'             => 'foo',
+			'placeholder'         => 'PLACEHOLDTHIS!',
+			'id'                  => 'funID',
 		);
 
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'email' ) );
@@ -787,12 +789,13 @@ class Contact_Form_Test extends BaseTestCase {
 	 */
 	public function test_make_sure_url_field_renders_as_expected() {
 		$attributes = array(
-			'label'       => 'fun',
-			'type'        => 'url',
-			'class'       => 'lalala',
-			'default'     => 'foo',
-			'placeholder' => 'PLACEHOLDTHIS!',
-			'id'          => 'funID',
+			'label'               => 'fun',
+			'type'                => 'url',
+			'fieldwrapperclasses' => 'wp-block-jetpack-field-url',
+			'class'               => 'lalala',
+			'default'             => 'foo',
+			'placeholder'         => 'PLACEHOLDTHIS!',
+			'id'                  => 'funID',
 		);
 
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'text' ) );
@@ -804,12 +807,13 @@ class Contact_Form_Test extends BaseTestCase {
 	 */
 	public function test_make_sure_telephone_field_renders_as_expected() {
 		$attributes = array(
-			'label'       => 'fun',
-			'type'        => 'telephone',
-			'class'       => 'lalala',
-			'default'     => 'foo',
-			'placeholder' => 'PLACEHOLDTHIS!',
-			'id'          => 'funID',
+			'label'               => 'fun',
+			'type'                => 'telephone',
+			'fieldwrapperclasses' => 'wp-block-jetpack-field-telephone',
+			'class'               => 'lalala',
+			'default'             => 'foo',
+			'placeholder'         => 'PLACEHOLDTHIS!',
+			'id'                  => 'funID',
 		);
 
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'tel' ) );
@@ -821,13 +825,14 @@ class Contact_Form_Test extends BaseTestCase {
 	 */
 	public function test_make_sure_date_field_renders_as_expected() {
 		$attributes = array(
-			'label'       => 'fun',
-			'type'        => 'date',
-			'class'       => 'lalala',
-			'default'     => 'foo',
-			'placeholder' => 'PLACEHOLDTHIS!',
-			'id'          => 'funID',
-			'format'      => '(YYYY-MM-DD)',
+			'label'               => 'fun',
+			'type'                => 'date',
+			'fieldwrapperclasses' => 'wp-block-jetpack-field-date',
+			'class'               => 'lalala',
+			'default'             => 'foo',
+			'placeholder'         => 'PLACEHOLDTHIS!',
+			'id'                  => 'funID',
+			'format'              => '(YYYY-MM-DD)',
 		);
 
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'text' ) );
@@ -839,12 +844,13 @@ class Contact_Form_Test extends BaseTestCase {
 	 */
 	public function test_make_sure_textarea_field_renders_as_expected() {
 		$attributes = array(
-			'label'       => 'fun',
-			'type'        => 'textarea',
-			'class'       => 'lalala',
-			'default'     => 'foo',
-			'placeholder' => 'PLACEHOLDTHIS!',
-			'id'          => 'funID',
+			'label'               => 'fun',
+			'type'                => 'textarea',
+			'fieldwrapperclasses' => 'wp-block-jetpack-field-textarea',
+			'class'               => 'lalala',
+			'default'             => 'foo',
+			'placeholder'         => 'PLACEHOLDTHIS!',
+			'id'                  => 'funID',
 		);
 
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'textarea' ) );
@@ -856,16 +862,17 @@ class Contact_Form_Test extends BaseTestCase {
 	 */
 	public function test_make_sure_checkbox_field_renders_as_expected() {
 		$attributes = array(
-			'label'         => 'fun',
-			'type'          => 'checkbox',
-			'class'         => 'lalala',
-			'default'       => 'foo',
-			'placeholder'   => 'PLACEHOLDTHIS!',
-			'id'            => 'funID',
-			'optionclasses' => 'option-tomato option-lettuce',
-			'optionstyles'  => 'color:cheese;font-size:11px;',
-			'labelclasses'  => 'label-tomato label-lettuce',
-			'labelstyles'   => 'color:beef;font-size:22px;',
+			'label'               => 'fun',
+			'type'                => 'checkbox',
+			'fieldwrapperclasses' => 'wp-block-jetpack-field-checkbox',
+			'class'               => 'lalala',
+			'default'             => 'foo',
+			'placeholder'         => 'PLACEHOLDTHIS!',
+			'id'                  => 'funID',
+			'optionclasses'       => 'option-tomato option-lettuce',
+			'optionstyles'        => 'color:cheese;font-size:11px;',
+			'labelclasses'        => 'label-tomato label-lettuce',
+			'labelstyles'         => 'color:beef;font-size:22px;',
 		);
 
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'checkbox' ) );
@@ -877,16 +884,17 @@ class Contact_Form_Test extends BaseTestCase {
 	 */
 	public function test_make_sure_checkbox_multiple_field_renders_as_expected() {
 		$attributes          = array(
-			'label'         => 'fun',
-			'type'          => 'checkbox-multiple',
-			'class'         => 'is-style-greenish lalala',
-			'default'       => 'option 1',
-			'id'            => 'funID',
-			'options'       => array( 'option 1', 'option 2' ),
-			'values'        => array( 'option 1', 'option 2' ),
-			'optionclasses' => 'option-cheese option-ham',
-			'inputclasses'  => 'input-tomato input-lettuce',
-			'optionsdata'   => wp_json_encode(
+			'label'               => 'fun',
+			'type'                => 'checkbox-multiple',
+			'fieldwrapperclasses' => 'wp-block-jetpack-field-checkbox-multiple',
+			'class'               => 'lalala',
+			'default'             => 'option 1',
+			'id'                  => 'funID',
+			'options'             => array( 'option 1', 'option 2' ),
+			'values'              => array( 'option 1', 'option 2' ),
+			'optionclasses'       => 'option-cheese option-ham',
+			'inputclasses'        => 'input-tomato input-lettuce',
+			'optionsdata'         => wp_json_encode(
 				array(
 					array(
 						'label' => 'option 1',
@@ -908,7 +916,7 @@ class Contact_Form_Test extends BaseTestCase {
 		 * For checkbox-multiple fields, we need to add the block style classes to the wrapper div.
 		 * See Contact_Form_Field::render_field() for more details.
 		 */
-		$this->assertValidFieldMultiField( $this->render_field( $attributes ), $expected_attributes, ' wp-block-jetpack-field-checkbox-multiple is-style-greenish' );
+		$this->assertValidFieldMultiField( $this->render_field( $attributes ), $expected_attributes );
 	}
 
 	/**
@@ -916,13 +924,14 @@ class Contact_Form_Test extends BaseTestCase {
 	 */
 	public function test_make_sure_radio_field_renders_as_expected() {
 		$attributes = array(
-			'label'   => 'fun',
-			'type'    => 'radio',
-			'class'   => 'lalala',
-			'default' => 'option 1',
-			'id'      => 'funID',
-			'options' => array( 'option 1', 'option 2', 'option 3, or 4', 'back\\slash' ),
-			'values'  => array( 'option 1', 'option 2', 'option [34]', '\\' ),
+			'label'               => 'fun',
+			'type'                => 'radio',
+			'fieldwrapperclasses' => 'wp-block-jetpack-field-radio',
+			'class'               => 'lalala',
+			'default'             => 'option 1',
+			'id'                  => 'funID',
+			'options'             => array( 'option 1', 'option 2', 'option 3, or 4', 'back\\slash' ),
+			'values'              => array( 'option 1', 'option 2', 'option [34]', '\\' ),
 		);
 
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'radio' ) );
@@ -932,7 +941,7 @@ class Contact_Form_Test extends BaseTestCase {
 		 * For radio fields, we need to add the block style classes to the wrapper div.
 		 * See Contact_Form_Field::render_field() for more details.
 		 */
-		$this->assertValidFieldMultiField( $this->render_field( $attributes ), $expected_attributes, ' wp-block-jetpack-field-radio' );
+		$this->assertValidFieldMultiField( $this->render_field( $attributes ), $expected_attributes );
 	}
 
 	/**
@@ -940,13 +949,14 @@ class Contact_Form_Test extends BaseTestCase {
 	 */
 	public function test_make_sure_radio_field_renders_as_expected_with_block_style_classes() {
 		$attributes = array(
-			'label'   => 'fun',
-			'type'    => 'radio',
-			'class'   => 'is-style-blah is-style-blah--2 lalala',
-			'default' => 'option 1',
-			'id'      => 'funID',
-			'options' => array( 'option 1', 'option 2', 'option 3, or 4', 'back\\slash' ),
-			'values'  => array( 'option 1', 'option 2', 'option [34]', '\\' ),
+			'label'               => 'fun',
+			'type'                => 'radio',
+			'fieldwrapperclasses' => 'wp-block-jetpack-field-radio',
+			'class'               => 'lalala',
+			'default'             => 'option 1',
+			'id'                  => 'funID',
+			'options'             => array( 'option 1', 'option 2', 'option 3, or 4', 'back\\slash' ),
+			'values'              => array( 'option 1', 'option 2', 'option [34]', '\\' ),
 		);
 
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'radio' ) );
@@ -956,7 +966,7 @@ class Contact_Form_Test extends BaseTestCase {
 		 * For radio fields, we need to add the block style classes to the wrapper div.
 		 * See Contact_Form_Field::render_field() for more details.
 		 */
-		$this->assertValidFieldMultiField( $this->render_field( $attributes ), $expected_attributes, ' wp-block-jetpack-field-radio is-style-blah is-style-blah--2' );
+		$this->assertValidFieldMultiField( $this->render_field( $attributes ), $expected_attributes );
 	}
 
 	/**
@@ -964,13 +974,14 @@ class Contact_Form_Test extends BaseTestCase {
 	 */
 	public function test_make_sure_select_field_renders_as_expected() {
 		$attributes = array(
-			'label'   => 'fun',
-			'type'    => 'select',
-			'class'   => 'lalala',
-			'default' => 'option 1',
-			'id'      => 'funID',
-			'options' => array( 'option 1', 'option 2', 'option 3, or 4', 'back\\slash' ),
-			'values'  => array( 'option 1', 'option 2', 'option [34]', '\\' ),
+			'label'               => 'fun',
+			'type'                => 'select',
+			'fieldwrapperclasses' => 'wp-block-jetpack-field-select',
+			'class'               => 'lalala',
+			'default'             => 'option 1',
+			'id'                  => 'funID',
+			'options'             => array( 'option 1', 'option 2', 'option 3, or 4', 'back\\slash' ),
+			'values'              => array( 'option 1', 'option 2', 'option [34]', '\\' ),
 		);
 
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'select' ) );
@@ -1023,9 +1034,8 @@ class Contact_Form_Test extends BaseTestCase {
 	 *
 	 * @param DOMElement $wrapper_div The wrapper div.
 	 * @param array      $attributes An associative array containing the field's attributes.
-	 * @param string     $extra_wrapper_classes Extra classes to add to the wrapper div.
 	 */
-	public function assertFieldClasses( $wrapper_div, $attributes, $extra_wrapper_classes = '' ) {
+	public function assertFieldClasses( $wrapper_div, $attributes ) {
 		if ( 'date' === $attributes['type'] ) {
 			$attributes['class'] = 'jp-contact-form-date';
 		}
@@ -1063,7 +1073,7 @@ class Contact_Form_Test extends BaseTestCase {
 			}
 		}
 
-		$css_class         = "grunion-field-{$attributes['type']}-wrap{$classes_wrap}{$input_classes_wrap}{$options_classes_wrap} grunion-field-wrap{$extra_wrapper_classes}";
+		$css_class         = "wp-block-jetpack-field-{$attributes['type']} grunion-field-{$attributes['type']}-wrap{$classes_wrap}{$input_classes_wrap}{$options_classes_wrap} grunion-field-wrap";
 		$wrapper_div_class = $wrapper_div->getAttribute( 'class' );
 
 		$this->assertEquals(
@@ -1280,12 +1290,11 @@ class Contact_Form_Test extends BaseTestCase {
 	 *
 	 * @param string $html The html string.
 	 * @param array  $attributes An associative array containing the field's attributes.
-	 * @param string $extra_wrapper_classes Extra classes to add to the wrapper div.
 	 */
-	public function assertValidFieldMultiField( $html, $attributes, $extra_wrapper_classes = '' ) {
+	public function assertValidFieldMultiField( $html, $attributes ) {
 
 		$wrapper_div = $this->getCommonDiv( $html );
-		$this->assertFieldClasses( $wrapper_div, $attributes, $extra_wrapper_classes );
+		$this->assertFieldClasses( $wrapper_div, $attributes );
 
 		// Inputs.
 		if ( 'select' === $attributes['type'] ) {


### PR DESCRIPTION
## Proposed changes:

Resolves: https://github.com/Automattic/jetpack-roadmap/issues/2465

Base branch: https://github.com/Automattic/jetpack/pull/42890

This PR:

- Adds `wp-block-*` classes to field wrappers so that theme/user global styles apply.
- Ensures that block style classes (`is-style-*`) are applied at the wrapper level and not to the inner blocks so that any theme/user global style block style variation updates apply.
- Only applies the above changes to fields with inner blocks (presumably blocks that have been migrated according to https://github.com/Automattic/jetpack/pull/42890)

## Testing instructions:

1. In a post insert a form that contains some fields - include an email, multiple checkbox field and a single radio field. The email field is to test the theme.json snippet below.
2. Save. Make sure everything appears as expected on the frontend/editor.
3. Apply the "button" style to both fields.
4. Save. Make sure everything appears as expected on the frontend/editor.
5. Now update your theme's theme.json with some styles targeting these blocks (see JSON snippet below).
6. You guessed it... Make sure everything appears as expected on the frontend/editor.
7. Head over to the site editor and edit the custom CSS for the "button" variation. 
8. Wait for it.... Save. Make sure everything appears as expected on the frontend/editor.


```json
"blocks": {
	"jetpack/field-checkbox-multiple": {
	        "border": {
	                "width": "5px",
	                "radius": "2px",
	              	"color": "yellow"
	        },
	        "color": {
	                "background": "red"
	        },
	        "css": "font-size:12px",
	        "variations": {
	               "button": {
	 					"css": "background:purple;font-size:100px;"
	                 }
	        }
	},
	"jetpack/field-radio": {
	        "border": {
	                "width": "1px",
	                "radius": "12px",
	              	"color": "pink"
	        },
	        "color": {
	                "text": "blue"
	        },
	        "css": "font-size:19px",
	        "variations": {
	               "button": {
	 					"css": "background:red;font-size:11px;"
	                 }
	        }
	},
        "jetpack/field-email": {
                "border": {
                        "width": "1px",
                        "radius": "12px",
                        "color": "orange"
                },
                "color": {
                        "text": "white",
						"background": "grey" 
                },
				"spacing": {"padding":"10px"},
                "css": "font-size:1.3rem"
        },
}
```

| Editor | Frontend | Global style variation |
|--------|--------|--------|
| <img width="400" alt="Screenshot 2025-04-23 at 1 45 51 pm" src="https://github.com/user-attachments/assets/ee1ac7d5-18b2-4fa3-9910-4675f57f8584" /> | <img width="400" alt="Screenshot 2025-04-23 at 1 45 47 pm" src="https://github.com/user-attachments/assets/d7580280-e759-4256-a824-299b47294b7a" /> | <img width="400" alt="Screenshot 2025-04-23 at 1 45 01 pm" src="https://github.com/user-attachments/assets/5c100cb0-a221-4e01-abd4-fcd52ab68a92" /> | 










