### PR TITLE
Boost: Fix Page Cache E2E test

### DIFF
--- a/projects/plugins/boost/changelog/fix-boost-e2e-flaky-cache-e2e
+++ b/projects/plugins/boost/changelog/fix-boost-e2e-flaky-cache-e2e
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix Page Cache Flaky E2E test
+
+

--- a/projects/plugins/boost/tests/e2e/specs/page-cache/page-cache.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/page-cache/page-cache.test.js
@@ -117,15 +117,15 @@ test.describe( 'Cache module', () => {
 			const responseHeaders = response.headers();
 			const cacheHeaderName = 'X-Jetpack-Boost-Cache'.toLowerCase();
 
-			// First visit should always be a miss.
-			const expectValue = totalVisits === 1 ? 'miss' : 'hit';
+			// First visit may be a miss or a hit depending on preloading being finished.
+			const expectValue = totalVisits === 1 ? [ 'miss', 'hit' ] : [ 'hit' ];
 			const expectMessage =
 				totalVisits === 1
-					? 'Page Cache header should be set to miss on first visit.'
+					? 'Page Cache header should be set on first visit.'
 					: 'Page Cache header should be set to hit on second visit.';
 			expect(
 				Object.hasOwn( responseHeaders, cacheHeaderName ) &&
-					responseHeaders[ cacheHeaderName ] === expectValue,
+					expectValue.includes( responseHeaders[ cacheHeaderName ] ),
 				expectMessage
 			).toBeTruthy();
 		} );


### PR DESCRIPTION
## Proposed changes:
* Ensures that the Page Cache E2E test takes Cache Preloading into account.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
* Verify Boost Page Cache E2E tests pass.

