### PR TITLE
Gravatar comments: fix hovercard style

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/verbum-fix-hovercard-style
+++ b/projects/packages/jetpack-mu-wpcom/changelog/verbum-fix-hovercard-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the style of the Gravatar hovercard

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/EmailForm/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/EmailForm/index.tsx
@@ -12,6 +12,7 @@ import { EmailFormCookieConsent } from './email-form-cookie-consent';
 import { getProfile } from './profile-get';
 import type { ChangeEvent } from 'preact/compat';
 import './style.scss';
+import '@gravatar-com/hovercards/dist/style.css';
 
 interface EmailFormProps {
 	shouldShowEmailForm: boolean;

--- a/projects/packages/jetpack-mu-wpcom/verbum.webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/verbum.webpack.config.js
@@ -38,7 +38,7 @@ module.exports = [
 				cacheGroups: {
 					verbumComments: {
 						name: 'verbum-gravatar',
-						test: /[\\/]node_modules[\\/](@gravatar-com)[\\/]/,
+						test: /[\\/]node_modules[\\/](@gravatar-com)[\\/].*?[\\/]dist[\\/].*?\.(js|mjs)/,
 						chunks: 'all',
 						enforce: true,
 					},


### PR DESCRIPTION
Gravatar was added to Jetpack comments in #42458 but the style for the hovercard somehow got misplaced along the way. This adds it to the main Verbum comments CSS. Ideally it would be lazy loaded by the hovercard code, but I can't quite get Webpack to do this and will take another look once it's fixed. The CSS file size increases by 6KB, so it's not a major problem.

Hovercard changes from:

![image](https://github.com/user-attachments/assets/0576b2df-fe5d-4e43-8b49-2892ac7aabb0)

To:

![image](https://github.com/user-attachments/assets/fa6a0b23-dc5f-454d-b9a1-00fe92ed53cd)

## Proposed changes:
* Includes Gravatar hovercard CSS in Verbum Comments

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

You will need to sandbox `jetpack.wordpress.com`

- Run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin fix/gravatar-comment-hovercard` on a sandbox to set things up without needing to build.
- On a site with Jetpack comments enabled, start typing into a comment form when logged out. The email address should trigger a Gravatar to be loaded
- Hover over the Gravatar and confirm the correct styling of the hovercard
- The Gravatar Quick Editor should open when the image is clicked