### PR TITLE
Google Analytics: show the setting form inline in Jetpack -> Settings -> Traffic

### DIFF
--- a/projects/plugins/jetpack/_inc/client/traffic/google-analytics.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/google-analytics.jsx
@@ -1,13 +1,18 @@
-import { getRedirectUrl } from '@automattic/jetpack-components';
+import { getRedirectUrl, ToggleControl } from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import React, { Component } from 'react';
-import Card from 'components/card';
+import { FormFieldset, FormLabel } from 'components/forms';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
+import TextInput from 'components/text-input';
 import analytics from 'lib/analytics';
 import { FEATURE_GOOGLE_ANALYTICS_JETPACK } from 'lib/plans/constants';
+
+// The Google Analytics options are JSON-serialized under the following option
+const OPTION_NAME = 'jetpack_wga';
 
 export const GoogleAnalytics = withModuleSettingsFormHelpers(
 	class extends Component {
@@ -15,23 +20,68 @@ export const GoogleAnalytics = withModuleSettingsFormHelpers(
 			analytics.tracks.recordJetpackClick( 'configure-ga' );
 		}
 
+		getOptionValue = key => {
+			const options = this.props.getOptionValue( OPTION_NAME );
+			return options[ key ];
+		};
+
+		updateOption = ( key, value ) => {
+			const options = this.props.getOptionValue( OPTION_NAME );
+			this.props.updateFormStateOptionValue( OPTION_NAME, {
+				...options,
+				[ key ]: value,
+			} );
+		};
+
+		onOptionChange = key => event => {
+			this.updateOption( key, event.target.value );
+		};
+
+		onToggleChange = key => checked => {
+			this.updateOption( key, checked );
+		};
+
+		isSaving = () => {
+			return this.props.isSavingAnyOption( OPTION_NAME );
+		};
+
+		isActive = () => {
+			return this.getOptionValue( 'is_active' );
+		};
+
+		toggleActive = () => {
+			this.updateOption( 'is_active', ! this.isActive() );
+
+			const options = this.props.getOptionValue( OPTION_NAME );
+			this.props.updateOptions( {
+				jetpack_wga: {
+					...options,
+					is_active: ! options.is_active,
+				},
+			} );
+		};
+
+		showForm = () => {
+			const options = this.props.getSettingCurrentValue( OPTION_NAME );
+			return options.is_active;
+		};
+
 		render() {
 			return (
 				<SettingsCard
 					{ ...this.props }
 					header={ _x( 'Google Analytics', 'Settings header', 'jetpack' ) }
 					feature={ FEATURE_GOOGLE_ANALYTICS_JETPACK }
-					hideButton
+					saveDisabled={ this.isSaving() }
 				>
 					<SettingsGroup
 						disableInOfflineMode
-						module={ { module: 'google-analytics' } }
 						support={ {
 							text: __(
 								'Integrates your WordPress site with Google Analytics, a platform that offers insights into your traffic, visitors, and conversions.',
 								'jetpack'
 							),
-							link: getRedirectUrl( 'jetpack-support-google-analytics' ),
+							link: getRedirectUrl( 'wpcom-support-google-analytics' ),
 						} }
 					>
 						{ createInterpolateElement(
@@ -55,23 +105,81 @@ export const GoogleAnalytics = withModuleSettingsFormHelpers(
 						) }
 					</SettingsGroup>
 					{ ! this.props.isUnavailableInOfflineMode( 'google-analytics' ) && (
-						<Card
-							compact
-							className="jp-settings-card__configure-link"
-							onClick={ this.trackConfigureClick }
-							href={ getRedirectUrl(
-								this.props.siteUsesWpAdminInterface
-									? 'calypso-marketing-connections'
-									: 'calypso-marketing-traffic',
-								{
-									site: this.props.site,
-									anchor: 'analytics',
+						<SettingsGroup hasChild>
+							<ToggleControl
+								checked={ this.isActive() }
+								disabled={ this.isSaving() }
+								onChange={ this.toggleActive }
+								label={
+									<span className="jp-form-toggle-explanation">
+										{ __( 'Enable Google Analytics', 'jetpack' ) }
+									</span>
 								}
+							/>
+
+							{ this.showForm() && (
+								<>
+									<FormFieldset>
+										<FormLabel className="jp-form-label-wide" htmlFor="code">
+											{ __( 'Google Analytics Measurement ID', 'jetpack' ) }
+										</FormLabel>
+										<TextInput
+											id="code"
+											pattern="(UA-\d+-\d+)|(G-[A-Z0-9]+)"
+											placeholder="G-XXXXXXX"
+											value={ this.getOptionValue( 'code' ) }
+											onChange={ this.onOptionChange( 'code' ) }
+											disabled={ this.isSaving() }
+										/>
+										<span className="jp-form-setting-explanation">
+											{ createInterpolateElement(
+												__( '<link>Learn more</link> to find your Measurement ID.', 'jetpack' ),
+												{
+													link: (
+														<ExternalLink
+															href={ getRedirectUrl( 'wpcom-support-google-analytics', {
+																anchor: 'step-2-get-your-measurement-id',
+															} ) }
+														/>
+													),
+												}
+											) }
+										</span>
+									</FormFieldset>
+									<FormFieldset>
+										<ToggleControl
+											checked={ this.getOptionValue( 'anonymize_ip' ) }
+											onChange={ this.onToggleChange( 'anonymize_ip' ) }
+											disabled={ this.isSaving() }
+											label={
+												<span className="jp-form-toggle-explanation">
+													{ __( 'Anonymize IP addresses', 'jetpack' ) }
+												</span>
+											}
+											help={
+												<span className="jp-form-setting-explanation jp-form-search-setting-explanation">
+													{ createInterpolateElement(
+														__(
+															'Enabling this option is mandatory in certain countries due to national privacy laws. <link>Learn more</link>',
+															'jetpack'
+														),
+														{
+															link: (
+																<ExternalLink
+																	href={ getRedirectUrl(
+																		'wpcom-support-google-analytics-anonymize-ip'
+																	) }
+																/>
+															),
+														}
+													) }
+												</span>
+											}
+										/>
+									</FormFieldset>
+								</>
 							) }
-							target="_blank"
-						>
-							{ __( 'Configure your Google Analytics settings', 'jetpack' ) }
-						</Card>
+						</SettingsGroup>
 					) }
 				</SettingsCard>
 			);

--- a/projects/plugins/jetpack/_inc/client/traffic/google-analytics/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/traffic/google-analytics/test/component.js
@@ -1,0 +1,127 @@
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { updateSettings } from 'state/settings';
+import { render, screen } from 'test/test-utils';
+import { GoogleAnalytics } from '../../google-analytics';
+
+jest.mock( 'state/settings', () => {
+	const actual = jest.requireActual( 'state/settings' );
+	return {
+		...actual,
+		fetchSettings: jest.fn().mockReturnValue( () => Promise.resolve() ),
+		updateSettings: jest.fn().mockReturnValue( () => Promise.resolve() ),
+	};
+} );
+
+describe( 'Google Analytics', () => {
+	const defaultProps = {
+		active: true,
+		isUnavailableInOfflineMode: () => false,
+	};
+
+	const initialState = {
+		jetpack: {
+			initialState: {
+				userData: {
+					currentUser: {
+						permissions: {
+							manage_modules: true,
+						},
+					},
+				},
+				siteData: {
+					isWoASite: true,
+				},
+			},
+			connection: {
+				status: {
+					siteConnected: {
+						offlineMode: {
+							isActive: false,
+						},
+					},
+				},
+				user: {
+					currentUser: {
+						isConnected: true,
+					},
+				},
+			},
+			modules: {},
+			settings: {
+				items: {
+					jetpack_wga: {
+						is_active: true,
+						code: 'G-123',
+						anonymize_ip: true,
+					},
+				},
+				requests: {
+					fetchingSettingsList: false,
+					settingsSent: {},
+					updatedSettings: {},
+				},
+			},
+			dashboard: {
+				requests: {
+					fetchingVaultPressData: false,
+					checkingAkismetKey: false,
+				},
+			},
+			siteData: {
+				data: {
+					site: {
+						features: {
+							active: [ 'google-analytics' ],
+						},
+					},
+				},
+				requests: {},
+			},
+		},
+	};
+
+	const renderCard = () => {
+		render( <GoogleAnalytics { ...defaultProps } />, {
+			initialState,
+		} );
+		return {
+			enableCheckbox: screen.getByRole( 'checkbox', { name: /Enable Google Analytics/ } ),
+			measurementIdInput: screen.getByRole( 'textbox', { name: /Measurement ID/ } ),
+			anonymizeIpCheckbox: screen.getByRole( 'checkbox', { name: /Anonymize IP addresses/ } ),
+		};
+	};
+
+	it( 'renders existing fields', () => {
+		const { enableCheckbox, measurementIdInput, anonymizeIpCheckbox } = renderCard();
+
+		expect( enableCheckbox ).toBeChecked();
+		expect( measurementIdInput ).toHaveValue( 'G-123' );
+		expect( anonymizeIpCheckbox ).toBeChecked();
+	} );
+
+	describe( 'when the form is updated', () => {
+		it( 'submits the form with the updated values', async () => {
+			const { measurementIdInput, anonymizeIpCheckbox } = renderCard();
+
+			const user = userEvent.setup();
+
+			await user.clear( measurementIdInput );
+			await user.type( measurementIdInput, 'G-456' );
+			await user.click( anonymizeIpCheckbox );
+
+			await user.click( screen.getByRole( 'button', { name: /Save settings/ } ) );
+
+			expect( updateSettings ).toHaveBeenCalledWith(
+				{
+					jetpack_wga: {
+						is_active: true,
+						code: 'G-456',
+						anonymize_ip: false,
+					},
+				},
+				{}
+			);
+		} );
+	} );
+} );

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2935,6 +2935,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_alphanum',
 				'jp_group'          => 'google-analytics',
 			),
+			'jetpack_wga'                               => array(
+				'description' => esc_html__( 'Google Analytics', 'jetpack' ),
+				'type'        => 'object',
+				'jp_group'    => 'settings',
+			),
 
 			// Stats.
 			'admin_bar'                                 => array(

--- a/projects/plugins/jetpack/changelog/ga-form
+++ b/projects/plugins/jetpack/changelog/ga-form
@@ -1,0 +1,5 @@
+Significance: minor
+Type: other
+
+Show the Google Analytics settings form inline under Jetpack -> Settings -> Traffic -> Google Analytics,
+instead of showing a link to WordPress.com Marketing Connections page.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-10631

## Proposed changes:

Currently, the Google Analytics settings in Jetpack -> Settings -> Traffic -> Google Analytics is just a link pointing to /marketing/connections/:site. There is a historical reason -- one being that this feature was once a paid wpcom feature, so we want to decouple it from the Jetpack plugin.

Now, this feature is only available in WoA sites and not self-hosted sites. See the deprecation notice for self-hosted: https://jetpack.com/support/google-analytics/.

Therefore, this PR proposes to show the Google Analytics form inline. This is so that we can remove the form in in wpcom side, prevent screen juggling, and one step towards untangling the Marketing pages.

|Before|After|
|-|-|
|<img width="872" alt="image" src="https://github.com/user-attachments/assets/5692ebef-ebf9-477b-9cc7-6471cae1e2d0" /><br><br>the "Configure" link points to wpcom:<br><img width="757" alt="image" src="https://github.com/user-attachments/assets/2bdf72d2-ba5f-489d-b695-939015fd6678" />|the form is shown inline:<br><img width="877" alt="image" src="https://github.com/user-attachments/assets/00b061c7-33ba-4142-a8cd-9f5fade4d871" />|

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Regression test: self-hosted sites

1. Create a fresh Jurassic Ninja site.
2. Connect to Jetpack.
3. Install Jetpack Beta and activate this feature branch.
4. Go to Jetpack -> Settings -> Traffic.
5. Verify that the Google Analytics section is still NOT present as expected.

### Actual test: WoA sites

1. Prepare an Atomic site with CLASSIC admin interface style.
2. Activate this feature branch via Jetpack Beta.
3. Go to Jetpack -> Settings -> Traffic.
4. Verify that you can see the Google Analytics section and the form.
5. Play around with the form values. Verify that you can save, and they will always match with the ones in `/marketing/connections/:site`.
6. Verify that the "Learn more" links etc are pointing to the correct locations.
7. When GA is enabled, go to your site frontend, view source, and verify that the code is actually injected as expected

<img width="798" alt="image" src="https://github.com/user-attachments/assets/f5406501-d86f-4570-af2c-d71ed590a03a" />


