### PR TITLE
Newsletter: Update learn more link on newsletter widget

### DIFF
--- a/projects/plugins/jetpack/changelog/update-learn-more-link-on-newsletter-widget
+++ b/projects/plugins/jetpack/changelog/update-learn-more-link-on-newsletter-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter: Update learn more link for self hosted websites.

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/components/newsletter-widget.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/components/newsletter-widget.tsx
@@ -115,9 +115,9 @@ export const NewsletterWidget = ( {
 						{
 							link: DashboardLink(
 								isWpcomSite,
-								getRedirectUrl(
-									buildJPRedirectSource( 'learn/courses/newsletters-101/wordpress-com-newsletter' )
-								),
+								isWpcomSite
+									? 'https://wordpress.com/learn/courses/newsletters-101/wordpress-com-newsletter'
+									: 'https://jetpack.com/support/newsletter',
 								'learn_more_click'
 							),
 						}

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/newsletter-widget.test.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/newsletter-widget.test.tsx
@@ -52,22 +52,15 @@ describe( 'NewsletterWidget', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'displays the learn more link with correct href', () => {
-		render( <NewsletterWidget { ...defaultProps } /> );
-		const learnMoreLink = screen.getByText( 'Learn more' );
-		expect( learnMoreLink ).toHaveAttribute(
-			'href',
-			getRedirectUrl(
-				'https://wordpress.com/learn/courses/newsletters-101/wordpress-com-newsletter'
-			)
-		);
-	} );
-
 	it( 'renders correct quick links when hosted on WordPress.com', () => {
 		const redirectDomain = 'wordpress.com';
 		render( <NewsletterWidget { ...defaultProps } /> );
 
 		const expectedLinks = [
+			{
+				text: 'Learn more',
+				href: 'https://wordpress.com/learn/courses/newsletters-101/wordpress-com-newsletter',
+			},
 			{
 				text: 'Publish your next post',
 				href: 'https://example.com/wp-admin/post-new.php',
@@ -112,6 +105,10 @@ describe( 'NewsletterWidget', () => {
 		render( <NewsletterWidget { ...defaultProps } isWpcomSite={ false } /> );
 
 		const expectedLinks = [
+			{
+				text: 'Learn more',
+				href: `https://jetpack.com/support/newsletter`,
+			},
 			{
 				text: 'Publish your next post',
 				href: `https://${ defaultProps.site }/wp-admin/post-new.php`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/loop/issues/647

## Proposed changes:

Change the “Learn More” link in the WP Admin widget [to this Jetpack page](https://jetpack.com/support/newsletter/), for Jetpack sites

The current link leads to the [WordPress.com Newsletter support page](https://wordpress.com/learn/courses/newsletters-101/wordpress-com-newsletter/), which could confuse WordPress.org Jetpack site owners.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### WPCOM or WoA Site:

- Download the branch to your sandbox by following the instructions given in comment.
- Sandbox the site that you are going to test on (example below)
```
[IP ADDRESS] mehmoodak2.wordpress.com
```
* Go to WP Admin.
* Verify that the link is redirecting to the same location as before.

### Self Hosted Site:

- Setup this feature branch using Jetpack Beta plugin.
- Go to WP Admin.
- Verify that the link is redirecting to `https://jetpack.com/support/newsletter/`
