### PR TITLE
phpunit: Clean up tests in preparation for PHPUnit 12

### DIFF
--- a/projects/packages/account-protection/changelog/update-cleanup-tests-for-phpunit-12
+++ b/projects/packages/account-protection/changelog/update-cleanup-tests-for-phpunit-12
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove unneeded `error_log()` in test.
+
+

--- a/projects/packages/account-protection/tests/php/Email_Service_Test.php
+++ b/projects/packages/account-protection/tests/php/Email_Service_Test.php
@@ -70,8 +70,6 @@ class Email_Service_Test extends BaseTestCase {
 
 		$result = $sut->resend_auth_email( $user->ID, $transient_data, $my_token );
 
-		error_log( print_r( $result, true ) );
-
 		// Verify the mail was sent
 		$this->assertTrue( $result, 'Resending auth mail should return true as success indicator.' );
 

--- a/projects/packages/roles/changelog/update-cleanup-tests-for-phpunit-12
+++ b/projects/packages/roles/changelog/update-cleanup-tests-for-phpunit-12
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: `->getMockBuilder()` no longer creates specifically-named classes. And we don't need one here, just an arbitrary object to be passed through.
+
+

--- a/projects/packages/roles/tests/php/Roles_Test.php
+++ b/projects/packages/roles/tests/php/Roles_Test.php
@@ -92,7 +92,9 @@ class Roles_Test extends TestCase {
 	 * Test translating an user to a role by role.
 	 */
 	public function test_user_to_role_with_role() {
-		$user_mock = $this->getMockBuilder( 'WP_User' )->getMock();
+		$user_mock = (object) array();
+		'@phan-var \WP_User $user_mock'; // Not really, but it doesn't matter.
+
 		Functions\when( 'user_can' )->alias(
 			function ( $user, $cap ) use ( $user_mock ) {
 				return $user_mock === $user && 'administrator' === $cap;
@@ -106,7 +108,9 @@ class Roles_Test extends TestCase {
 	 * Test translating an user to a role by capablity.
 	 */
 	public function test_user_to_role_with_capability() {
-		$user_mock = $this->getMockBuilder( 'WP_User' )->getMock();
+		$user_mock = (object) array();
+		'@phan-var \WP_User $user_mock'; // Not really, but it doesn't matter.
+
 		Functions\when( 'user_can' )->alias(
 			function ( $user, $cap ) use ( $user_mock ) {
 				return $user_mock === $user && 'edit_others_posts' === $cap;
@@ -120,7 +124,9 @@ class Roles_Test extends TestCase {
 	 * Test translating an user to a role with no match.
 	 */
 	public function test_user_to_role_with_no_match() {
-		$user_mock = $this->getMockBuilder( 'WP_User' )->getMock();
+		$user_mock = (object) array();
+		'@phan-var \WP_User $user_mock'; // Not really, but it doesn't matter.
+
 		Functions\when( 'user_can' )->justReturn( false );
 
 		$this->assertFalse( $this->roles->translate_user_to_role( $user_mock ) );

--- a/projects/plugins/crm/changelog/update-cleanup-tests-for-phpunit-12
+++ b/projects/plugins/crm/changelog/update-cleanup-tests-for-phpunit-12
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Update `WP_UnitTestCase_Fix` with a simple annotation parser for `@expectedDeprecated` and `@expectedIncorrectUsage`.
+
+

--- a/projects/plugins/crm/tests/php/WP_UnitTestCase_Fix.php
+++ b/projects/plugins/crm/tests/php/WP_UnitTestCase_Fix.php
@@ -6,12 +6,94 @@
  */
 
 // phpcs:disable Generic.Classes.DuplicateClassName.Found, Generic.Files.OneObjectStructurePerFile.MultipleFound
+// phpcs:disable WordPress.NamingConventions.ValidFunctionName, WordPress.NamingConventions.ValidVariableName
 
 namespace Automattic\Jetpack\PHPUnit;
 
 use PHPUnit\Metadata\Annotation\Parser\Registry as AnnotationRegistry;
+use ReflectionClass;
+use ReflectionFunctionAbstract;
+use ReflectionMethod;
 
 if ( explode( '.', \PHPUnit\Runner\Version::id() )[0] >= 10 ) {
+	if ( ! class_exists( AnnotationRegistry::class ) ) {
+
+		/**
+		 * Doc block annotation extraction for getAnnotations in PHPUnit 12.
+		 *
+		 * Adapted from code in PHPUnit 11 `PHPUnit\Metadata\Annotation\Parser\Registry` and `PHPUnit\Metadata\Annotation\Parser\DocBlock`.
+		 */
+		class WP_UnitTestCase_Fix_GetAnnotations {
+			/**
+			 * Cache.
+			 * @var array
+			 */
+			private static $cache;
+
+			/**
+			 * Get annotations for a class method.
+			 *
+			 * @param string $className Class name.
+			 * @param string $methodName Method name.
+			 * @return array Annotation data.
+			 */
+			public static function getAnnotations( $className, $methodName ) {
+				if ( ! isset( self::$cache['class'][ $className ] ) ) {
+					self::$cache['class'][ $className ] = self::getForReflector( new ReflectionClass( $className ) );
+				}
+				if ( ! isset( self::$cache['method'][ $className ][ $methodName ] ) ) {
+					self::$cache['method'][ $className ][ $methodName ] = self::getForReflector( new ReflectionMethod( $className, $methodName ) );
+				}
+				return array(
+					'method' => self::$cache['method'][ $className ][ $methodName ],
+					'class'  => self::$cache['class'][ $className ],
+				);
+			}
+
+			/**
+			 * Extract annotations from a Reflection object.
+			 *
+			 * @param ReflectionClass|ReflectionFunctionAbstract $reflector Reflection object.
+			 * @return array Annotation data.
+			 */
+			private static function getForReflector( $reflector ) {
+				$annotations = array();
+
+				if ( $reflector instanceof ReflectionClass ) {
+					$annotations = array_merge(
+						$annotations,
+						...array_map(
+							static fn ( ReflectionClass $trait ): array => self::parseDocBlock( (string) $trait->getDocComment() ),
+							array_values( $reflector->getTraits() )
+						)
+					);
+				}
+
+				return array_merge(
+					$annotations,
+					self::parseDocBlock( (string) $reflector->getDocComment() )
+				);
+			}
+
+			/**
+			 * Extract annotations from a doc block comment.
+			 *
+			 * @param string $docblock Doc block.
+			 * @return array Annotation data for `@expectedDeprecated` and `@expectedIncorrectUsage`.
+			 */
+			private static function parseDocBlock( $docblock ) {
+				$annotations = array();
+				$docblock    = substr( (string) $docblock, 3, -2 );
+				if ( preg_match_all( '/@(?P<name>expectedDeprecated|expectedIncorrectUsage)(?:[ \t]+(?P<value>.*?))?[ \t]*\r?$/m', $docblock, $matches, PREG_SET_ORDER ) ) {
+					foreach ( $matches as $m ) {
+						$annotations[ $m['name'] ][] = $m['value'];
+					}
+				}
+				return $annotations;
+			}
+		}
+	}
+
 	trait WP_UnitTestCase_Fix {
 
 		/**
@@ -19,18 +101,22 @@ if ( explode( '.', \PHPUnit\Runner\Version::id() )[0] >= 10 ) {
 		 *
 		 * @return array Method and class annotations, at minimum `@expectedDeprecated` and `@expectedIncorrectUsage`.
 		 */
-		public function getAnnotations() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
-			return array(
-				'method' => AnnotationRegistry::getInstance()->forMethod( static::class, $this->name() )->symbolAnnotations(),
-				'class'  => AnnotationRegistry::getInstance()->forClassName( static::class )->symbolAnnotations(),
-			);
+		public function getAnnotations() {
+			if ( class_exists( AnnotationRegistry::class ) ) {
+				return array(
+					'method' => AnnotationRegistry::getInstance()->forMethod( static::class, $this->name() )->symbolAnnotations(),
+					'class'  => AnnotationRegistry::getInstance()->forClassName( static::class )->symbolAnnotations(),
+				);
+			}
+
+			return WP_UnitTestCase_Fix_GetAnnotations::getAnnotations( static::class, $this->name() );
 		}
 
 		/**
 		 * Obsolete method where PHPUnit is mis-processing the doc comment to see a `@group` that doesn't exist.
 		 * This redefinition hides the "bad" doc comment from PHPUnit.
 		 */
-		protected function checkRequirements() { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		protected function checkRequirements() { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
 			parent::checkRequirements();
 		}
 	}

--- a/projects/plugins/crm/tests/php/WP_UnitTestCase_Fix.php
+++ b/projects/plugins/crm/tests/php/WP_UnitTestCase_Fix.php
@@ -63,7 +63,8 @@ if ( explode( '.', \PHPUnit\Runner\Version::id() )[0] >= 10 ) {
 					$annotations = array_merge(
 						$annotations,
 						...array_map(
-							static fn ( ReflectionClass $trait ): array => self::parseDocBlock( (string) $trait->getDocComment() ),
+							static function ( $trait ) {
+								return self::parseDocBlock( (string) $trait->getDocComment() ); },
 							array_values( $reflector->getTraits() )
 						)
 					);

--- a/projects/plugins/jetpack/changelog/update-cleanup-tests-for-phpunit-12
+++ b/projects/plugins/jetpack/changelog/update-cleanup-tests-for-phpunit-12
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update `WP_UnitTestCase_Fix` with a simple annotation parser for `@expectedDeprecated` and `@expectedIncorrectUsage`.
+
+

--- a/projects/plugins/jetpack/changelog/update-cleanup-tests-for-phpunit-12#2
+++ b/projects/plugins/jetpack/changelog/update-cleanup-tests-for-phpunit-12#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: `->getMockBuilder()` no longer creates specifically-named classes. And we don't really need a mock here anyway, just for some class by the name to exist.
+
+

--- a/projects/plugins/jetpack/changelog/update-cleanup-tests-for-phpunit-12#3
+++ b/projects/plugins/jetpack/changelog/update-cleanup-tests-for-phpunit-12#3
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: PHPUnit 12 makes `TestCase::__construct()` final. Use `set_up()` instead.
+
+

--- a/projects/plugins/jetpack/tests/php/WP_UnitTestCase_Fix.php
+++ b/projects/plugins/jetpack/tests/php/WP_UnitTestCase_Fix.php
@@ -64,7 +64,8 @@ if ( explode( '.', \PHPUnit\Runner\Version::id() )[0] >= 10 ) {
 					$annotations = array_merge(
 						$annotations,
 						...array_map(
-							static fn ( ReflectionClass $trait ): array => self::parseDocBlock( (string) $trait->getDocComment() ),
+							static function ( $trait ) {
+								return self::parseDocBlock( (string) $trait->getDocComment() ); },
 							array_values( $reflector->getTraits() )
 						)
 					);

--- a/projects/plugins/jetpack/tests/php/WP_UnitTestCase_Fix.php
+++ b/projects/plugins/jetpack/tests/php/WP_UnitTestCase_Fix.php
@@ -6,12 +6,95 @@
  */
 
 // phpcs:disable Generic.Classes.DuplicateClassName.Found, Generic.Files.OneObjectStructurePerFile.MultipleFound
+// phpcs:disable WordPress.NamingConventions.ValidFunctionName, WordPress.NamingConventions.ValidVariableName
 
 namespace Automattic\Jetpack\PHPUnit;
 
 use PHPUnit\Metadata\Annotation\Parser\Registry as AnnotationRegistry;
+use ReflectionClass;
+use ReflectionFunctionAbstract;
+use ReflectionMethod;
 
 if ( explode( '.', \PHPUnit\Runner\Version::id() )[0] >= 10 ) {
+	if ( ! class_exists( AnnotationRegistry::class ) ) {
+
+		/**
+		 * Doc block annotation extraction for getAnnotations in PHPUnit 12.
+		 *
+		 * Adapted from code in PHPUnit 11 `PHPUnit\Metadata\Annotation\Parser\Registry` and `PHPUnit\Metadata\Annotation\Parser\DocBlock`.
+		 */
+		class WP_UnitTestCase_Fix_GetAnnotations {
+			/**
+			 * Cache.
+			 *
+			 * @var array
+			 */
+			private static $cache;
+
+			/**
+			 * Get annotations for a class method.
+			 *
+			 * @param string $className Class name.
+			 * @param string $methodName Method name.
+			 * @return array Annotation data.
+			 */
+			public static function getAnnotations( $className, $methodName ) {
+				if ( ! isset( self::$cache['class'][ $className ] ) ) {
+					self::$cache['class'][ $className ] = self::getForReflector( new ReflectionClass( $className ) );
+				}
+				if ( ! isset( self::$cache['method'][ $className ][ $methodName ] ) ) {
+					self::$cache['method'][ $className ][ $methodName ] = self::getForReflector( new ReflectionMethod( $className, $methodName ) );
+				}
+				return array(
+					'method' => self::$cache['method'][ $className ][ $methodName ],
+					'class'  => self::$cache['class'][ $className ],
+				);
+			}
+
+			/**
+			 * Extract annotations from a Reflection object.
+			 *
+			 * @param ReflectionClass|ReflectionFunctionAbstract $reflector Reflection object.
+			 * @return array Annotation data.
+			 */
+			private static function getForReflector( $reflector ) {
+				$annotations = array();
+
+				if ( $reflector instanceof ReflectionClass ) {
+					$annotations = array_merge(
+						$annotations,
+						...array_map(
+							static fn ( ReflectionClass $trait ): array => self::parseDocBlock( (string) $trait->getDocComment() ),
+							array_values( $reflector->getTraits() )
+						)
+					);
+				}
+
+				return array_merge(
+					$annotations,
+					self::parseDocBlock( (string) $reflector->getDocComment() )
+				);
+			}
+
+			/**
+			 * Extract annotations from a doc block comment.
+			 *
+			 * @param string $docblock Doc block.
+			 * @return array Annotation data for `@expectedDeprecated` and `@expectedIncorrectUsage`.
+			 */
+			private static function parseDocBlock( $docblock ) {
+				$annotations = array();
+				$docblock    = substr( (string) $docblock, 3, -2 );
+				if ( preg_match_all( '/@(?P<name>expectedDeprecated|expectedIncorrectUsage)(?:[ \t]+(?P<value>.*?))?[ \t]*\r?$/m', $docblock, $matches, PREG_SET_ORDER ) ) {
+					foreach ( $matches as $m ) {
+						$annotations[ $m['name'] ][] = $m['value'];
+					}
+				}
+				return $annotations;
+			}
+		}
+	}
+
 	trait WP_UnitTestCase_Fix {
 
 		/**
@@ -19,18 +102,22 @@ if ( explode( '.', \PHPUnit\Runner\Version::id() )[0] >= 10 ) {
 		 *
 		 * @return array Method and class annotations, at minimum `@expectedDeprecated` and `@expectedIncorrectUsage`.
 		 */
-		public function getAnnotations() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
-			return array(
-				'method' => AnnotationRegistry::getInstance()->forMethod( static::class, $this->name() )->symbolAnnotations(),
-				'class'  => AnnotationRegistry::getInstance()->forClassName( static::class )->symbolAnnotations(),
-			);
+		public function getAnnotations() {
+			if ( class_exists( AnnotationRegistry::class ) ) {
+				return array(
+					'method' => AnnotationRegistry::getInstance()->forMethod( static::class, $this->name() )->symbolAnnotations(),
+					'class'  => AnnotationRegistry::getInstance()->forClassName( static::class )->symbolAnnotations(),
+				);
+			}
+
+			return WP_UnitTestCase_Fix_GetAnnotations::getAnnotations( static::class, $this->name() );
 		}
 
 		/**
 		 * Obsolete method where PHPUnit is mis-processing the doc comment to see a `@group` that doesn't exist.
 		 * This redefinition hides the "bad" doc comment from PHPUnit.
 		 */
-		protected function checkRequirements() { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		protected function checkRequirements() { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
 			parent::checkRequirements();
 		}
 	}

--- a/projects/plugins/jetpack/tests/php/modules/widgets/Jetpack_Display_Posts_Widget_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/widgets/Jetpack_Display_Posts_Widget_Test.php
@@ -15,10 +15,10 @@ class Jetpack_Display_Posts_Widget_Test extends WP_UnitTestCase {
 	private $inst;
 
 	/**
-	 * Jetpack_Display_Posts_Widget_Test constructor.
+	 * Setup function.
 	 */
-	public function __construct( ...$args ) {
-		parent::__construct( ...$args ); // @phan-suppress-current-line PhanParamTooFewUnpack - Should be ok.
+	public function set_up() {
+		parent::set_up();
 		$this->inst = new Jetpack_Display_Posts_Widget();
 	}
 

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
@@ -1300,8 +1300,8 @@ class Jetpack_Sync_Functions_Test extends Jetpack_Sync_TestBase {
 		$this->assertFalse( $functions->get_hosting_provider_by_known_class() );
 
 		// Fake that the class exists for the test.
-		// @phan-suppress-next-line PhanUndeclaredClassReference
-		$this->getMockBuilder( '\\WPaaS\\Plugin' )->getMock();
+		// @phan-suppress-next-line PhanUndeclaredClassReference -- We're defining it here, Phan. 🙄
+		class_alias( static::class, \WPaaS\Plugin::class );
 
 		$this->assertEquals( 'gd-managed-wp', $functions->get_hosting_provider_by_known_class() );
 	}

--- a/projects/plugins/wpcomsh/changelog/update-cleanup-tests-for-phpunit-12
+++ b/projects/plugins/wpcomsh/changelog/update-cleanup-tests-for-phpunit-12
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Update `WP_UnitTestCase_Fix` with a simple annotation parser for `@expectedDeprecated` and `@expectedIncorrectUsage`.
+
+

--- a/projects/plugins/wpcomsh/tests/WP_UnitTestCase_Fix.php
+++ b/projects/plugins/wpcomsh/tests/WP_UnitTestCase_Fix.php
@@ -64,7 +64,8 @@ if ( explode( '.', \PHPUnit\Runner\Version::id() )[0] >= 10 ) {
 					$annotations = array_merge(
 						$annotations,
 						...array_map(
-							static fn ( ReflectionClass $trait ): array => self::parseDocBlock( (string) $trait->getDocComment() ),
+							static function ( $trait ) {
+								return self::parseDocBlock( (string) $trait->getDocComment() ); },
 							array_values( $reflector->getTraits() )
 						)
 					);

--- a/projects/plugins/wpcomsh/tests/WP_UnitTestCase_Fix.php
+++ b/projects/plugins/wpcomsh/tests/WP_UnitTestCase_Fix.php
@@ -6,12 +6,95 @@
  */
 
 // phpcs:disable Generic.Classes.DuplicateClassName.Found, Generic.Files.OneObjectStructurePerFile.MultipleFound
+// phpcs:disable WordPress.NamingConventions.ValidFunctionName, WordPress.NamingConventions.ValidVariableName
 
 namespace Automattic\Jetpack\PHPUnit;
 
 use PHPUnit\Metadata\Annotation\Parser\Registry as AnnotationRegistry;
+use ReflectionClass;
+use ReflectionFunctionAbstract;
+use ReflectionMethod;
 
 if ( explode( '.', \PHPUnit\Runner\Version::id() )[0] >= 10 ) {
+	if ( ! class_exists( AnnotationRegistry::class ) ) {
+
+		/**
+		 * Doc block annotation extraction for getAnnotations in PHPUnit 12.
+		 *
+		 * Adapted from code in PHPUnit 11 `PHPUnit\Metadata\Annotation\Parser\Registry` and `PHPUnit\Metadata\Annotation\Parser\DocBlock`.
+		 */
+		class WP_UnitTestCase_Fix_GetAnnotations {
+			/**
+			 * Cache.
+			 *
+			 * @var array
+			 */
+			private static $cache;
+
+			/**
+			 * Get annotations for a class method.
+			 *
+			 * @param string $className Class name.
+			 * @param string $methodName Method name.
+			 * @return array Annotation data.
+			 */
+			public static function getAnnotations( $className, $methodName ) {
+				if ( ! isset( self::$cache['class'][ $className ] ) ) {
+					self::$cache['class'][ $className ] = self::getForReflector( new ReflectionClass( $className ) );
+				}
+				if ( ! isset( self::$cache['method'][ $className ][ $methodName ] ) ) {
+					self::$cache['method'][ $className ][ $methodName ] = self::getForReflector( new ReflectionMethod( $className, $methodName ) );
+				}
+				return array(
+					'method' => self::$cache['method'][ $className ][ $methodName ],
+					'class'  => self::$cache['class'][ $className ],
+				);
+			}
+
+			/**
+			 * Extract annotations from a Reflection object.
+			 *
+			 * @param ReflectionClass|ReflectionFunctionAbstract $reflector Reflection object.
+			 * @return array Annotation data.
+			 */
+			private static function getForReflector( $reflector ) {
+				$annotations = array();
+
+				if ( $reflector instanceof ReflectionClass ) {
+					$annotations = array_merge(
+						$annotations,
+						...array_map(
+							static fn ( ReflectionClass $trait ): array => self::parseDocBlock( (string) $trait->getDocComment() ),
+							array_values( $reflector->getTraits() )
+						)
+					);
+				}
+
+				return array_merge(
+					$annotations,
+					self::parseDocBlock( (string) $reflector->getDocComment() )
+				);
+			}
+
+			/**
+			 * Extract annotations from a doc block comment.
+			 *
+			 * @param string $docblock Doc block.
+			 * @return array Annotation data for `@expectedDeprecated` and `@expectedIncorrectUsage`.
+			 */
+			private static function parseDocBlock( $docblock ) {
+				$annotations = array();
+				$docblock    = substr( (string) $docblock, 3, -2 );
+				if ( preg_match_all( '/@(?P<name>expectedDeprecated|expectedIncorrectUsage)(?:[ \t]+(?P<value>.*?))?[ \t]*\r?$/m', $docblock, $matches, PREG_SET_ORDER ) ) {
+					foreach ( $matches as $m ) {
+						$annotations[ $m['name'] ][] = $m['value'];
+					}
+				}
+				return $annotations;
+			}
+		}
+	}
+
 	trait WP_UnitTestCase_Fix {
 
 		/**
@@ -19,18 +102,22 @@ if ( explode( '.', \PHPUnit\Runner\Version::id() )[0] >= 10 ) {
 		 *
 		 * @return array Method and class annotations, at minimum `@expectedDeprecated` and `@expectedIncorrectUsage`.
 		 */
-		public function getAnnotations() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
-			return array(
-				'method' => AnnotationRegistry::getInstance()->forMethod( static::class, $this->name() )->symbolAnnotations(),
-				'class'  => AnnotationRegistry::getInstance()->forClassName( static::class )->symbolAnnotations(),
-			);
+		public function getAnnotations() {
+			if ( class_exists( AnnotationRegistry::class ) ) {
+				return array(
+					'method' => AnnotationRegistry::getInstance()->forMethod( static::class, $this->name() )->symbolAnnotations(),
+					'class'  => AnnotationRegistry::getInstance()->forClassName( static::class )->symbolAnnotations(),
+				);
+			}
+
+			return WP_UnitTestCase_Fix_GetAnnotations::getAnnotations( static::class, $this->name() );
 		}
 
 		/**
 		 * Obsolete method where PHPUnit is mis-processing the doc comment to see a `@group` that doesn't exist.
 		 * This redefinition hides the "bad" doc comment from PHPUnit.
 		 */
-		protected function checkRequirements() { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		protected function checkRequirements() { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
 			parent::checkRequirements();
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `TestCase::__construct()` is final, so use `set_up()` instead.
* `->getMockBuilder()` can no longer create specifically-named classes.
* Remove a logging statement.
* Update `WP_UnitTestCase_Fix` with an annotation parser so WP Core's `@expectedDeprecated` and `@expectedIncorrectUsage` can still work.
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pf4qpu-Fo-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?