### PR TITLE
ci: For PHP tests, update phpunit even if lockfile is ok

### DIFF
--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -85,6 +85,10 @@ for PLUGIN in projects/plugins/*/composer.json; do
 	elif composer check-platform-reqs --lock; then
 		echo 'Platform reqs pass, running `composer install`'
 		composer install
+		if [[ "$TEST_SCRIPT" == 'test-php' ]] && composer info --locked phpunit/phpunit &>/dev/null; then
+			echo 'Updating PHPUnit in case a newer version than locked is usable'
+			composer update -W phpunit/phpunit
+		fi
 	else
 		# Composer can't directly tell us which packages are dev deps, but we can get lists of all deps and just the non-dev deps.
 		# So we use `diff` to find which aren't in the non-dev list, and `sed` to extract just the `> ` lines with the actual package names (and remove the `> ` too).

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -210,6 +210,10 @@ jobs:
                     elif composer --working-dir="$DIR" check-platform-reqs --lock; then
                       echo 'Platform reqs pass, running `composer install`'
                       composer --working-dir="$DIR" install
+                      if [[ "$TEST_SCRIPT" == "test-php" ]] && composer info --locked phpunit/phpunit &>/dev/null; then
+                        echo 'Updating PHPUnit in case a newer version than locked is usable'
+                        composer --working-dir="$DIR" update -W phpunit/phpunit
+                      fi
                     else
                       echo 'Platform reqs failed, running `composer update`'
                       composer --working-dir="$DIR" update


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When we update `yoast/phpunit-polyfills` to v4, the lockfiles will still have PHPUnit 11 because our default PHP version is 8.2. But when we run tests with 8.3+ it'd be better to use PHPUnit 12. So have the action update PHPUnit even when the lock file is ok.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
PT: pf4qpu-Fo-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* Check #43216, see if it used PHPUnit 12 for the Search plugin test with PHPUnit 8.3 and 8.4.