### PR TITLE
Forms: Fix toggle deprecation notice

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-toggle-deprecation-warning
+++ b/projects/packages/forms/changelog/fix-forms-toggle-deprecation-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix toggle deprecation warning.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.js
@@ -97,6 +97,7 @@ const IntegrationCardHeader = ( {
 									checked={ headerToggleValue }
 									onChange={ handleToggleChange }
 									disabled={ ! isHeaderToggleEnabled }
+									__nextHasNoMarginBottom={ true }
 								/>
 							</span>
 						</Tooltip>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -88,10 +88,6 @@
 		display: flex;
 		align-items: center;
 		gap: 12px;
-
-		.components-base-control.components-toggle-control {
-			margin-bottom: 0;
-		}
 	}
 
 	&__links {


### PR DESCRIPTION
## Proposed changes:

We added a core toggle control to the integrations modal to control the integrations active status. That toggle control is generating the notice below in the browser dev console. This PR adds the need prop to remove the notice, and removes some CSS that was manually setting 0px bottom margin on the control. 

```
deprecated.js?ver=741e32edb0e7c2dd30da:115 Bottom margin styles for wp.components.ToggleControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form block to a page or post
* Open the dev console in your browser, clear any warning/notices, and click on the Manage Integrations button in the sidebar. Confirm there are no notices generated by that action. 
* Confirm the integrations modal, and especially the toggles in the card headers, continue to render as before. 

