### PR TITLE
A4A: Resolve blank page caused by incorrectly parsing an error object.

### DIFF
--- a/projects/plugins/automattic-for-agencies-client/changelog/fix-a4a-blank-page-bug-due-to-error-parsing
+++ b/projects/plugins/automattic-for-agencies-client/changelog/fix-a4a-blank-page-bug-due-to-error-parsing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Resolved the parsing error that was resulting in a blank page.

--- a/projects/plugins/automattic-for-agencies-client/src/js/components/disconnected-card/index.jsx
+++ b/projects/plugins/automattic-for-agencies-client/src/js/components/disconnected-card/index.jsx
@@ -22,7 +22,7 @@ export default function DisconnectedCard() {
 
 	// Use the highest-level error message.
 	const errorMessage = useMemo( () => {
-		return Object.values( connectionErrors )?.shift()?.shift()?.error_message;
+		return Object.values( Object.values( connectionErrors )?.shift() )?.shift().error_message;
 	}, [ connectionErrors ] );
 
 	return (

--- a/projects/plugins/automattic-for-agencies-client/src/js/components/disconnected-card/index.jsx
+++ b/projects/plugins/automattic-for-agencies-client/src/js/components/disconnected-card/index.jsx
@@ -22,7 +22,8 @@ export default function DisconnectedCard() {
 
 	// Use the highest-level error message.
 	const errorMessage = useMemo( () => {
-		return Object.values( Object.values( connectionErrors )?.shift() )?.shift().error_message;
+		const errorObject = Object.values( connectionErrors );
+		return errorObject ? Object.values( errorObject )?.shift()?.error_message : null;
 	}, [ connectionErrors ] );
 
 	return (

--- a/projects/plugins/automattic-for-agencies-client/src/js/components/test/disconnected-card.test.jsx
+++ b/projects/plugins/automattic-for-agencies-client/src/js/components/test/disconnected-card.test.jsx
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+import React from 'react';
+import DisconnectedCard from '../disconnected-card';
+
+// Mock the WordPress data store
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+} ) );
+
+// Mock WordPress components
+jest.mock( '@wordpress/components', () => ( {
+	Path: 'path',
+	SVG: 'svg',
+	Rect: 'rect',
+} ) );
+
+// Mock Jetpack components
+jest.mock( '@automattic/jetpack-components', () => ( {
+	AutomatticForAgenciesLogo: () => <div>Automattic For Agencies Logo</div>,
+	AutomatticIconLogo: () => <div>Automattic Icon Logo</div>,
+} ) );
+
+// Mock the jetpack-connection package
+jest.mock( '@automattic/jetpack-connection', () => ( {
+	CONNECTION_STORE_ID: 'jetpack-connection-store',
+	ConnectButton: ( { apiRoot, apiNonce, registrationNonce } ) => (
+		<button
+			className="components-button"
+			data-api-root={ apiRoot }
+			data-api-nonce={ apiNonce }
+			data-registration-nonce={ registrationNonce }
+		>
+			Connect Button
+		</button>
+	),
+} ) );
+
+describe( 'DisconnectedCard', () => {
+	beforeEach( () => {
+		// Mock the global window object
+		window.automatticForAgenciesClientInitialState = {
+			apiNonce: 'test-api-nonce',
+			apiRoot: 'test-api-root',
+			registrationNonce: 'test-registration-nonce',
+		};
+
+		// Reset useSelect mock before each test
+		useSelect.mockReset();
+		// Default to empty connection errors
+		useSelect.mockReturnValue( {} );
+	} );
+
+	test( 'renders the disconnected message', () => {
+		render( <DisconnectedCard /> );
+
+		expect(
+			screen.getByText( 'Your site was disconnected from Automattic for Agencies' )
+		).toBeInTheDocument();
+		expect( screen.getByText( 'Site is disconnected' ) ).toBeInTheDocument();
+	} );
+
+	test( 'displays connection error message when present', () => {
+		// Mock connection errors
+		const connectionErrors = {
+			invalid_connection_owner: {
+				invalid: {
+					error_code: 'invalid_connection_owner',
+					user_id: 'invalid',
+					error_message: 'Invalid connection owner',
+				},
+			},
+		};
+
+		useSelect.mockReturnValue( connectionErrors );
+
+		render( <DisconnectedCard /> );
+
+		expect( screen.queryByText( 'Invalid connection owner' ) ).not.toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
This PR resolves an issue with the Disconnection page displaying a blank page, caused by improper parsing of an error object.

Context: p1744737854665639/1743726570.726989-slack-C06RDCDSGBH

Closes https://linear.app/a8c/issue/A4A-772/a4a-plugin-shows-blank-screen-when-there-is-connection-issue

## Proposed changes:
* The issue occurred when using the `shift() `function on an array returned by a prior `shift()` call. To resolve this, we should encapsulate the array in Object.values before invoking `shift() `once more.
* I also added a unit test for this component as it is not easy to test this flow.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Spin up a Pressable site
* SSH on the site and run the following command.
```
wp option add jetpack_connection_xmlrpc_verified_errors '{"invalid_connection_owner":{"invalid":{"error_code":"invalid_connection_owner","user_id":"invalid","error_message":"Invalid connection owner","error_data":{"token":""},"timestamp":1744735409,"nonce":"1rc2JMrv4H","error_type":"connection"}}}'
```
* Build the A4A plugin using this branch and install the plugin.
* Confirm you don't see a blank page when accessing the A4A plugin's setting page.