### PR TITLE
My Jetpack: Add back the tracking for onboarding UIs

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/connection-form.tsx
+++ b/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/connection-form.tsx
@@ -2,6 +2,8 @@ import { JetpackLogo, TermsOfService, Text } from '@automattic/jetpack-component
 import { useConnection } from '@automattic/jetpack-connection';
 import { Button, Spinner, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useCallback, useEffect } from 'react';
+import useAnalytics from '../../../hooks/use-analytics';
 import preventWidows from '../../../utils/prevent-widows';
 import styles from './styles.module.scss';
 
@@ -10,6 +12,21 @@ const ConnectionForm = () => {
 		useConnection( { from: 'jetpack-onboarding' } );
 
 	const isConnecting = userIsConnecting || siteIsRegistering;
+
+	const { recordEvent } = useAnalytics();
+
+	const onClickConnect = useCallback( () => {
+		recordEvent( 'jetpack_my_jetpack_onboarding_click' );
+		handleRegisterSite();
+	}, [ recordEvent, handleRegisterSite ] );
+
+	useEffect( () => {
+		if ( registrationError ) {
+			recordEvent( 'jetpack_my_jetpack_onboarding_error', {
+				error: registrationError,
+			} );
+		}
+	}, [ registrationError, recordEvent ] );
 
 	return (
 		<div className={ styles[ 'connection-form' ] }>
@@ -32,7 +49,7 @@ const ConnectionForm = () => {
 				className={ styles[ 'submit-button' ] }
 				disabled={ isConnecting }
 				aria-busy={ isConnecting }
-				onClick={ handleRegisterSite }
+				onClick={ onClickConnect }
 			>
 				{ isConnecting ? (
 					<Spinner className={ styles.spinner } />

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-onboarding-tracking
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-onboarding-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Onboarding: Add back the tracking for onboarding UIs


### PR DESCRIPTION
In #43203, we simplified the onboarding UI and thus some code is now obsolete and not used. Tracking logic is a part of that unused code.

Completes ONBOARD-98

This PRs restores that tracking.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add back the tracking for onboarding UIs

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Disconnect your site - `jetpack docker wp jetpack disconnect blog`
* Go to My Jetpack 
* Open the browser console and enter this
```js
localStorage.setItem('debug', 'dops:analytics');
```
* Reload the page
* Click on "Supercharge my site"
* Confirm that you see the tracking in the console
* Disconnect the site again
* Try an error state by pointing the site to a non-existent sandbox
* Click on "Supercharge my site" again
* Confirm that you see the tracking event with error

<img width="1036" alt="Screenshot 2025-04-24 at 4 34 29 PM" src="https://github.com/user-attachments/assets/ea76aed9-fcd4-4d5b-8e29-f2c2d89e8d52" />
