### PR TITLE
phpunit: Update to yoast/phpunit-polyfills v4

### DIFF
--- a/.github/files/coverage-munger/composer.json
+++ b/.github/files/coverage-munger/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"phpunit/phpcov": "^10.0.1"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -13,7 +13,7 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/ignorefile",
-                "reference": "475da024318c88a3d1bfdb25e617c32e6d4ed791"
+                "reference": "e0e842588dc62a52434f21e62bcb05d4334835ee"
             },
             "require": {
                 "php": ">=7.2"
@@ -21,7 +21,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "library",
             "extra": {
@@ -64,7 +64,7 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/codesniffer",
-                "reference": "e7023bcebb8b7f229801884d8522ed5d28f0522f"
+                "reference": "4ce408c62dc4e2ee4ab7bb17c186455d81066839"
             },
             "require": {
                 "automattic/vipwpcs": "^3.0",
@@ -79,7 +79,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -140,7 +140,7 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/phan-plugins",
-                "reference": "b9819149ead3b9950338f6d708d1c3e2339bff35"
+                "reference": "2b21bf1032be88edfb43cd72664a2dcc1511e38f"
             },
             "require": {
                 "phan/phan": "^5.4",
@@ -149,7 +149,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "library",
             "extra": {
@@ -198,7 +198,7 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/phpcs-filter",
-                "reference": "dcc3fbf7924df2bea9b4c76db079b120a2bfb329"
+                "reference": "3112a798d2da2b1a08adb7196bef7480bd114e3e"
             },
             "require": {
                 "automattic/ignorefile": "@dev",
@@ -208,7 +208,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "library",
             "extra": {

--- a/projects/packages/a8c-mc-stats/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/a8c-mc-stats/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/a8c-mc-stats/composer.json
+++ b/projects/packages/a8c-mc-stats/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=7.2"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/a8c-mc-stats/phpunit.12.xml.dist
+++ b/projects/packages/a8c-mc-stats/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/account-protection/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/account-protection/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/account-protection/composer.json
+++ b/projects/packages/account-protection/composer.json
@@ -11,7 +11,7 @@
 		"automattic/jetpack-status": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/phpunit-select-config": "@dev"

--- a/projects/packages/account-protection/phpunit.12.xml.dist
+++ b/projects/packages/account-protection/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/admin-ui/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/admin-ui/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/admin-ui/composer.json
+++ b/projects/packages/admin-ui/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=7.2"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-logo": "@dev",
 		"automattic/jetpack-test-environment": "@dev",

--- a/projects/packages/admin-ui/phpunit.12.xml.dist
+++ b/projects/packages/admin-ui/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/assets/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/assets/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/assets/composer.json
+++ b/projects/packages/assets/composer.json
@@ -9,7 +9,7 @@
 	},
 	"require-dev": {
 		"brain/monkey": "^2.6.2",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
 		"automattic/phpunit-select-config": "@dev"

--- a/projects/packages/assets/phpunit.12.xml.dist
+++ b/projects/packages/assets/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/autoloader/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/autoloader/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/autoloader/composer.json
+++ b/projects/packages/autoloader/composer.json
@@ -17,7 +17,7 @@
 	},
 	"require-dev": {
 		"composer/composer": "^2.2",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/autoloader/phpunit.12.xml.dist
+++ b/projects/packages/autoloader/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/backup-helper-script-manager/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/backup-helper-script-manager/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/backup-helper-script-manager/composer.json
+++ b/projects/packages/backup-helper-script-manager/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=7.2"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/phpunit-select-config": "@dev"

--- a/projects/packages/backup-helper-script-manager/phpunit.12.xml.dist
+++ b/projects/packages/backup-helper-script-manager/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/backup/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/backup/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/backup/composer.json
+++ b/projects/packages/backup/composer.json
@@ -18,7 +18,7 @@
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/backup/phpunit.12.xml.dist
+++ b/projects/packages/backup/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/blaze/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/blaze/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/blaze/composer.json
+++ b/projects/packages/blaze/composer.json
@@ -14,7 +14,7 @@
 		"automattic/jetpack-sync": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/phpunit-select-config": "@dev"

--- a/projects/packages/blaze/phpunit.12.xml.dist
+++ b/projects/packages/blaze/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/blocks/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/blocks/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/blocks/composer.json
+++ b/projects/packages/blocks/composer.json
@@ -10,7 +10,7 @@
 	"require-dev": {
 		"automattic/jetpack-test-environment": "@dev",
 		"brain/monkey": "^2.6.2",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/blocks/phpunit.12.xml.dist
+++ b/projects/packages/blocks/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/boost-core/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/boost-core/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/boost-core/composer.json
+++ b/projects/packages/boost-core/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-connection": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/boost-core/phpunit.12.xml.dist
+++ b/projects/packages/boost-core/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/boost-speed-score/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/boost-speed-score/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/boost-speed-score/composer.json
+++ b/projects/packages/boost-speed-score/composer.json
@@ -4,7 +4,7 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"brain/monkey": "^2.6",
 		"automattic/phpunit-select-config": "@dev"

--- a/projects/packages/boost-speed-score/phpunit.12.xml.dist
+++ b/projects/packages/boost-speed-score/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/calypsoify/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/calypsoify/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/calypsoify/composer.json
+++ b/projects/packages/calypsoify/composer.json
@@ -9,7 +9,7 @@
 		"automattic/jetpack-status": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/calypsoify/phpunit.12.xml.dist
+++ b/projects/packages/calypsoify/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/changelogger/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/changelogger/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/changelogger/composer.json
+++ b/projects/packages/changelogger/composer.json
@@ -16,7 +16,7 @@
 		"symfony/process": "^5.4 || ^6.4 || ^7.1"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/changelogger/phpunit.12.xml.dist
+++ b/projects/packages/changelogger/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/chatbot/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/chatbot/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/chatbot/composer.json
+++ b/projects/packages/chatbot/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=7.2"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/chatbot/phpunit.12.xml.dist
+++ b/projects/packages/chatbot/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/classic-theme-helper/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/classic-theme-helper/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/classic-theme-helper/composer.json
+++ b/projects/packages/classic-theme-helper/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-assets": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/classic-theme-helper/phpunit.12.xml.dist
+++ b/projects/packages/classic-theme-helper/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/codesniffer/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/codesniffer/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/codesniffer/composer.json
+++ b/projects/packages/codesniffer/composer.json
@@ -23,7 +23,7 @@
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/phpunit-select-config": "@dev"
 	},
 	"autoload": {

--- a/projects/packages/codesniffer/phpunit.12.xml.dist
+++ b/projects/packages/codesniffer/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/composer-plugin/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/composer-plugin/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/composer-plugin/composer.json
+++ b/projects/packages/composer-plugin/composer.json
@@ -15,7 +15,7 @@
 	},
 	"require-dev": {
 		"composer/composer": "^2.2",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/composer-plugin/phpunit.12.xml.dist
+++ b/projects/packages/composer-plugin/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/connection/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/connection/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -15,7 +15,7 @@
 	},
 	"require-dev": {
 		"automattic/jetpack-test-environment": "@dev",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"brain/monkey": "^2.6.2",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-licensing": "@dev",

--- a/projects/packages/connection/phpunit.12.xml.dist
+++ b/projects/packages/connection/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/constants/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/constants/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/constants/composer.json
+++ b/projects/packages/constants/composer.json
@@ -8,7 +8,7 @@
 	},
 	"require-dev": {
 		"brain/monkey": "^2.6.2",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/constants/phpunit.12.xml.dist
+++ b/projects/packages/constants/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/device-detection/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/device-detection/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/device-detection/composer.json
+++ b/projects/packages/device-detection/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=7.2"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/device-detection/phpunit.12.xml.dist
+++ b/projects/packages/device-detection/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/error/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/error/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/error/composer.json
+++ b/projects/packages/error/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=7.2"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/error/phpunit.12.xml.dist
+++ b/projects/packages/error/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/explat/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/explat/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/explat/composer.json
+++ b/projects/packages/explat/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-connection": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/explat/phpunit.12.xml.dist
+++ b/projects/packages/explat/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/external-media/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/external-media/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/external-media/composer.json
+++ b/projects/packages/external-media/composer.json
@@ -11,7 +11,7 @@
 		"automattic/jetpack-status": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/external-media/phpunit.12.xml.dist
+++ b/projects/packages/external-media/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/forms/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/forms/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -13,7 +13,7 @@
 		"automattic/jetpack-sync": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-test-environment": "@dev",

--- a/projects/packages/forms/phpunit.12.xml.dist
+++ b/projects/packages/forms/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/google-analytics/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/google-analytics/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/google-analytics/composer.json
+++ b/projects/packages/google-analytics/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-status": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/phpunit-select-config": "@dev"

--- a/projects/packages/google-analytics/phpunit.12.xml.dist
+++ b/projects/packages/google-analytics/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/ignorefile/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/ignorefile/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/ignorefile/composer.json
+++ b/projects/packages/ignorefile/composer.json
@@ -8,7 +8,7 @@
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/phpunit-select-config": "@dev"
 	},
 	"autoload": {

--- a/projects/packages/ignorefile/phpunit.12.xml.dist
+++ b/projects/packages/ignorefile/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/image-cdn/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/image-cdn/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/image-cdn/composer.json
+++ b/projects/packages/image-cdn/composer.json
@@ -10,7 +10,7 @@
 	},
 	"require-dev": {
 		"automattic/jetpack-test-environment": "@dev",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/image-cdn/phpunit.12.xml.dist
+++ b/projects/packages/image-cdn/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/import/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/import/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/import/composer.json
+++ b/projects/packages/import/composer.json
@@ -9,7 +9,7 @@
 		"automattic/jetpack-sync": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/import/phpunit.12.xml.dist
+++ b/projects/packages/import/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/ip/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/ip/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/ip/composer.json
+++ b/projects/packages/ip/composer.json
@@ -8,7 +8,7 @@
 	},
 	"require-dev": {
 		"brain/monkey": "^2.6.2",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/ip/phpunit.12.xml.dist
+++ b/projects/packages/ip/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -21,7 +21,7 @@
 		"automattic/jetpack-subscribers-dashboard": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"brain/monkey": "^2.6.2",

--- a/projects/packages/jetpack-mu-wpcom/phpunit.12.xml.dist
+++ b/projects/packages/jetpack-mu-wpcom/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/jitm/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/jitm/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/jitm/composer.json
+++ b/projects/packages/jitm/composer.json
@@ -15,7 +15,7 @@
 	},
 	"require-dev": {
 		"brain/monkey": "^2.6.2",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/jitm/phpunit.12.xml.dist
+++ b/projects/packages/jitm/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/licensing/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/licensing/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/licensing/composer.json
+++ b/projects/packages/licensing/composer.json
@@ -9,7 +9,7 @@
 	},
 	"require-dev": {
 		"automattic/jetpack-test-environment": "@dev",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/licensing/phpunit.12.xml.dist
+++ b/projects/packages/licensing/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/logo/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/logo/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/logo/composer.json
+++ b/projects/packages/logo/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=7.2"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/logo/phpunit.12.xml.dist
+++ b/projects/packages/logo/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/masterbar/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/masterbar/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/masterbar/composer.json
+++ b/projects/packages/masterbar/composer.json
@@ -18,7 +18,7 @@
 	},
 	"require-dev": {
 		"brain/monkey": "^2.6.2",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/patchwork-redefine-exit": "@dev",
 		"automattic/jetpack-test-environment": "@dev",

--- a/projects/packages/masterbar/phpunit.12.xml.dist
+++ b/projects/packages/masterbar/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/my-jetpack/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/my-jetpack/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -21,7 +21,7 @@
 		"automattic/jetpack-protect-status": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/jetpack-search": "@dev",

--- a/projects/packages/my-jetpack/phpunit.12.xml.dist
+++ b/projects/packages/my-jetpack/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/password-checker/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/password-checker/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/password-checker/composer.json
+++ b/projects/packages/password-checker/composer.json
@@ -9,7 +9,7 @@
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/phpunit-select-config": "@dev"
 	},
 	"suggest": {

--- a/projects/packages/password-checker/phpunit.12.xml.dist
+++ b/projects/packages/password-checker/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/patchwork-redefine-exit/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/patchwork-redefine-exit/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/patchwork-redefine-exit/composer.json
+++ b/projects/packages/patchwork-redefine-exit/composer.json
@@ -15,7 +15,7 @@
 		"antecedent/patchwork": "^2.2"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/patchwork-redefine-exit/phpunit.12.xml.dist
+++ b/projects/packages/patchwork-redefine-exit/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/phan-plugins/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/phan-plugins/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/phan-plugins/composer.json
+++ b/projects/packages/phan-plugins/composer.json
@@ -14,7 +14,7 @@
 		"php": ">=8.0"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/phan-plugins/phpunit.12.xml.dist
+++ b/projects/packages/phan-plugins/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/phpcs-filter/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/phpcs-filter/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/phpcs-filter/composer.json
+++ b/projects/packages/phpcs-filter/composer.json
@@ -19,7 +19,7 @@
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/phpunit-select-config": "@dev"
 	},
 	"autoload": {

--- a/projects/packages/phpcs-filter/phpunit.12.xml.dist
+++ b/projects/packages/phpcs-filter/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/phpunit-select-config/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/phpunit-select-config/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/phpunit-select-config/composer.json
+++ b/projects/packages/phpunit-select-config/composer.json
@@ -15,7 +15,7 @@
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"antecedent/patchwork": "^2.2"
 	},
 	"bin": [

--- a/projects/packages/phpunit-select-config/phpunit.12.xml.dist
+++ b/projects/packages/phpunit-select-config/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/plans/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/plans/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/plans/composer.json
+++ b/projects/packages/plans/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-connection": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-status": "@dev",
 		"automattic/jetpack-test-environment": "@dev",

--- a/projects/packages/plans/phpunit.12.xml.dist
+++ b/projects/packages/plans/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/plugin-deactivation/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/plugin-deactivation/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/plugin-deactivation/composer.json
+++ b/projects/packages/plugin-deactivation/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-assets": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/plugin-deactivation/phpunit.12.xml.dist
+++ b/projects/packages/plugin-deactivation/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/plugins-installer/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/plugins-installer/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/plugins-installer/composer.json
+++ b/projects/packages/plugins-installer/composer.json
@@ -9,7 +9,7 @@
 		"automattic/jetpack-status": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/plugins-installer/phpunit.12.xml.dist
+++ b/projects/packages/plugins-installer/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/post-list/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/post-list/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/post-list/composer.json
+++ b/projects/packages/post-list/composer.json
@@ -10,7 +10,7 @@
 	"require-dev": {
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/jetpack-changelogger": "@dev",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/phpunit-select-config": "@dev"
 	},
 	"suggest": {

--- a/projects/packages/post-list/phpunit.12.xml.dist
+++ b/projects/packages/post-list/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/protect-models/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/protect-models/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/protect-models/composer.json
+++ b/projects/packages/protect-models/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-redirect": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/phpunit-select-config": "@dev"

--- a/projects/packages/protect-models/phpunit.12.xml.dist
+++ b/projects/packages/protect-models/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/protect-status/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/protect-status/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/protect-status/composer.json
+++ b/projects/packages/protect-status/composer.json
@@ -12,7 +12,7 @@
 		"automattic/jetpack-plans": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/phpunit-select-config": "@dev"

--- a/projects/packages/protect-status/phpunit.12.xml.dist
+++ b/projects/packages/protect-status/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/publicize/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/publicize/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/publicize/composer.json
+++ b/projects/packages/publicize/composer.json
@@ -15,7 +15,7 @@
 		"automattic/jetpack-status": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/phpunit-select-config": "@dev"

--- a/projects/packages/publicize/phpunit.12.xml.dist
+++ b/projects/packages/publicize/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/redirect/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/redirect/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/redirect/composer.json
+++ b/projects/packages/redirect/composer.json
@@ -9,7 +9,7 @@
 	},
 	"require-dev": {
 		"brain/monkey": "^2.6.2",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/redirect/phpunit.12.xml.dist
+++ b/projects/packages/redirect/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/roles/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/roles/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/roles/composer.json
+++ b/projects/packages/roles/composer.json
@@ -8,7 +8,7 @@
 	},
 	"require-dev": {
 		"brain/monkey": "^2.6.2",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/roles/phpunit.12.xml.dist
+++ b/projects/packages/roles/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/scheduled-updates/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/scheduled-updates/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/scheduled-updates/composer.json
+++ b/projects/packages/scheduled-updates/composer.json
@@ -12,7 +12,7 @@
 		"automattic/jetpack-connection": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"php-mock/php-mock-phpunit": "^2.10",

--- a/projects/packages/scheduled-updates/phpunit.12.xml.dist
+++ b/projects/packages/scheduled-updates/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/schema/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/schema/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/schema/composer.json
+++ b/projects/packages/schema/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=7.2"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/phpunit-select-config": "@dev"

--- a/projects/packages/schema/phpunit.12.xml.dist
+++ b/projects/packages/schema/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/search/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/search/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -15,7 +15,7 @@
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/search/phpunit.12.xml.dist
+++ b/projects/packages/search/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/stats-admin/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/stats-admin/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -14,7 +14,7 @@
 		"automattic/jetpack-jitm": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/phpunit-select-config": "@dev"

--- a/projects/packages/stats-admin/phpunit.12.xml.dist
+++ b/projects/packages/stats-admin/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/stats/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/stats/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/stats/composer.json
+++ b/projects/packages/stats/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-status": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/phpunit-select-config": "@dev"

--- a/projects/packages/stats/phpunit.12.xml.dist
+++ b/projects/packages/stats/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/status/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/status/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/status/composer.json
+++ b/projects/packages/status/composer.json
@@ -9,7 +9,7 @@
 	},
 	"require-dev": {
 		"brain/monkey": "^2.6.2",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-plans": "@dev",

--- a/projects/packages/status/phpunit.12.xml.dist
+++ b/projects/packages/status/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/stub-generator/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/stub-generator/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/stub-generator/composer.json
+++ b/projects/packages/stub-generator/composer.json
@@ -18,7 +18,7 @@
 		"symfony/console": "^5.4 || ^6.4 || ^7.1"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/stub-generator/phpunit.12.xml.dist
+++ b/projects/packages/stub-generator/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/subscribers-dashboard/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/subscribers-dashboard/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/subscribers-dashboard/composer.json
+++ b/projects/packages/subscribers-dashboard/composer.json
@@ -13,7 +13,7 @@
 		"automattic/jetpack-jitm": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/phpunit-select-config": "@dev"

--- a/projects/packages/subscribers-dashboard/phpunit.12.xml.dist
+++ b/projects/packages/subscribers-dashboard/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/sync/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/sync/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -14,7 +14,7 @@
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-search": "@dev",
 		"automattic/jetpack-waf": "@dev",
 		"automattic/jetpack-test-environment": "@dev",

--- a/projects/packages/sync/phpunit.12.xml.dist
+++ b/projects/packages/sync/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/test-environment/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/test-environment/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/test-environment/composer.json
+++ b/projects/packages/test-environment/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=7.2"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/test-environment/phpunit.12.xml.dist
+++ b/projects/packages/test-environment/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/transport-helper/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/transport-helper/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/transport-helper/composer.json
+++ b/projects/packages/transport-helper/composer.json
@@ -9,7 +9,7 @@
 		"automattic/jetpack-connection": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/phpunit-select-config": "@dev"

--- a/projects/packages/transport-helper/phpunit.12.xml.dist
+++ b/projects/packages/transport-helper/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/videopress/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/videopress/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/videopress/composer.json
+++ b/projects/packages/videopress/composer.json
@@ -13,7 +13,7 @@
 		"automattic/jetpack-status": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"brain/monkey": "2.6.2",

--- a/projects/packages/videopress/phpunit.12.xml.dist
+++ b/projects/packages/videopress/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/waf/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/waf/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/waf/composer.json
+++ b/projects/packages/waf/composer.json
@@ -12,7 +12,7 @@
 		"wikimedia/aho-corasick": "^1.0"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/phpunit-select-config": "@dev"

--- a/projects/packages/waf/tests/php/integration/phpunit.12.xml.dist
+++ b/projects/packages/waf/tests/php/integration/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/waf/tests/php/unit/phpunit.12.xml.dist
+++ b/projects/packages/waf/tests/php/unit/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/woocommerce-analytics/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/woocommerce-analytics/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/woocommerce-analytics/composer.json
+++ b/projects/packages/woocommerce-analytics/composer.json
@@ -9,7 +9,7 @@
 		"automattic/jetpack-constants": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/woocommerce-analytics/phpunit.12.xml.dist
+++ b/projects/packages/woocommerce-analytics/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/wordads/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/wordads/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/wordads/composer.json
+++ b/projects/packages/wordads/composer.json
@@ -12,7 +12,7 @@
 		"automattic/jetpack-config": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/wordads/phpunit.12.xml.dist
+++ b/projects/packages/wordads/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/wp-js-data-sync/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/wp-js-data-sync/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/wp-js-data-sync/composer.json
+++ b/projects/packages/wp-js-data-sync/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-schema": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/wp-js-data-sync/phpunit.12.xml.dist
+++ b/projects/packages/wp-js-data-sync/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/yoast-promo/changelog/update-yoast-polyfills-v4
+++ b/projects/packages/yoast-promo/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/packages/yoast-promo/composer.json
+++ b/projects/packages/yoast-promo/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-assets": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/packages/yoast-promo/phpunit.12.xml.dist
+++ b/projects/packages/yoast-promo/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/plugins/automattic-for-agencies-client/changelog/update-yoast-polyfills-v4
+++ b/projects/plugins/automattic-for-agencies-client/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/plugins/automattic-for-agencies-client/composer.json
+++ b/projects/plugins/automattic-for-agencies-client/composer.json
@@ -14,7 +14,7 @@
 		"automattic/jetpack-status": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/phpunit-select-config": "@dev"

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "754bda631b2d8f783a1adf358107eb88",
+    "content-hash": "d9d3dc949263965e9c503e1823c6942c",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "5c10fd1a50834e9d28af3136f79a35617b497dae"
+                "reference": "68b92cc77ac41309dbf2f7a16eecd4e0c9cb03a9"
             },
             "require": {
                 "php": ">=7.2"
@@ -20,7 +20,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "5faef0e6453cac07042d46af33d9a5318c353ca1"
+                "reference": "fee1504bb96380c418e439af5696ba75fbfc0d96"
             },
             "require": {
                 "php": ">=7.2"
@@ -76,7 +76,7 @@
                 "automattic/jetpack-logo": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -126,7 +126,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "110b0ff2aa88f9904c6260c3e399dbfdd7544fa6"
+                "reference": "89a768257b402fb6abeefe5b6c0855f946187fab"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -137,7 +137,7 @@
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -196,7 +196,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "54d6c42f16aec2a60a4dc0133f0444fe1b164a33"
+                "reference": "68901f3b3a256085ebd939a3461ee833be10f86d"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -206,7 +206,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -265,7 +265,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "16772cbb568bc8fc8550671a1bd12aa4705738dc"
+                "reference": "eb028c7425d0591689e2a0b3047c278d8ff2395e"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -275,7 +275,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -400,7 +400,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "8b6fb10f12a15323a4af26c97ed28e3cd98327bd"
+                "reference": "1d0e8466e6188a79ff302ba975d3c2ffc691090b"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -419,7 +419,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -487,7 +487,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "e6cbca1d3b01d10d771d2af899cd6ffb65090549"
+                "reference": "378a5d122aedfc25d3aa42ab913803c85a8c857b"
             },
             "require": {
                 "php": ">=7.2"
@@ -496,7 +496,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -542,7 +542,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/ip",
-                "reference": "ab83ce4e4fa0bcc7fa87600a8b60c7dab8bfe191"
+                "reference": "4c8f48266f1fe2551103c6293e2957e185f87a94"
             },
             "require": {
                 "php": ">=7.2"
@@ -551,7 +551,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -601,7 +601,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/password-checker",
-                "reference": "63e9b52f2c3a5b69c30115e21c02ecf7e4a23e00"
+                "reference": "33cc919e4b75e07ed12975588c42ae2ea723a9a4"
             },
             "require": {
                 "php": ">=7.2"
@@ -610,7 +610,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -657,7 +657,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plugin-deactivation",
-                "reference": "3096c8cde89bb702f5eeb12d0e69200601745f58"
+                "reference": "d94810e1882aa3353325ca5f1154c2082cf13283"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -666,7 +666,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -726,7 +726,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "4738fce156b0b8008bdea47fb52d8c5d3d24e2ae"
+                "reference": "44d6ec93e4d3b3db6287bf82f316a294d7ef868d"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
@@ -736,7 +736,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -782,7 +782,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/roles",
-                "reference": "0606b853fc28d9fbcc013187c626d0a8e2de84b6"
+                "reference": "f7098eb11833c5fddfff032427d8576039aa3521"
             },
             "require": {
                 "php": ">=7.2"
@@ -791,7 +791,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -837,7 +837,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "fc91e61469f31cdab849571507a1aed68a14fafd"
+                "reference": "2af0799e498773ebeafed5e8e5c1a2b4d543a44a"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -850,7 +850,7 @@
                 "automattic/jetpack-plans": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -902,7 +902,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "d69fff7e02a1bfe9045907867d7d59e4c1814de6"
+                "reference": "9846e5fd84a40e97d5b9a0a2b4821968469a87d8"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -919,7 +919,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-waf": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -977,7 +977,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "06b85c8f44fdccebce0bb12823f2d3f1e87e037a"
+                "reference": "30dd97f47c89ca7ec88c3659ef92464965a8e5e8"
             },
             "require": {
                 "composer-runtime-api": "^2.2.0",
@@ -988,7 +988,7 @@
             "require-dev": {
                 "automattic/phpunit-select-config": "@dev",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/changelogger"
@@ -1061,7 +1061,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/test-environment",
-                "reference": "acf2c63d65d9aab5bfff95da40ee011acc66fa04"
+                "reference": "4ebfacd0d0ff37aed8d38faaad374a2b39042154"
             },
             "require": {
                 "php": ">=7.2"
@@ -1069,7 +1069,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1114,7 +1114,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/phpunit-select-config",
-                "reference": "ee8b1e53bfd922accf326802e7c8b8d7b26bf54f"
+                "reference": "3f16352a5a43bdd583b78d895d092a1e1b74c397"
             },
             "require": {
                 "composer-runtime-api": "^2.2.2",
@@ -1124,7 +1124,7 @@
             "require-dev": {
                 "antecedent/patchwork": "^2.2",
                 "automattic/jetpack-changelogger": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/phpunit-select-config"
@@ -3622,21 +3622,21 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "3.1.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618"
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/9cf2ccd990eadfc4a1e390592d4731e590b2c618",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "phpunit/phpunit": "^6.4.4 || ^7.0 || ^8.0 || ^9.0 || ^11.0"
+                "php": ">=7.1",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -3681,7 +3681,7 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2025-02-09T18:36:24+00:00"
+            "time": "2025-02-09T18:58:54+00:00"
         }
     ],
     "aliases": [],

--- a/projects/plugins/automattic-for-agencies-client/phpunit.12.xml.dist
+++ b/projects/plugins/automattic-for-agencies-client/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/plugins/backup/changelog/update-yoast-polyfills-v4
+++ b/projects/plugins/backup/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -11,7 +11,7 @@
 		"automattic/jetpack-status": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dbe66d8d08a49693f759673974b40607",
+    "content-hash": "8e8192d6b7fb40442a4ec0111937b44f",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "5c10fd1a50834e9d28af3136f79a35617b497dae"
+                "reference": "68b92cc77ac41309dbf2f7a16eecd4e0c9cb03a9"
             },
             "require": {
                 "php": ">=7.2"
@@ -20,7 +20,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "5faef0e6453cac07042d46af33d9a5318c353ca1"
+                "reference": "fee1504bb96380c418e439af5696ba75fbfc0d96"
             },
             "require": {
                 "php": ">=7.2"
@@ -76,7 +76,7 @@
                 "automattic/jetpack-logo": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -126,7 +126,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "110b0ff2aa88f9904c6260c3e399dbfdd7544fa6"
+                "reference": "89a768257b402fb6abeefe5b6c0855f946187fab"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -137,7 +137,7 @@
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -196,7 +196,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "54d6c42f16aec2a60a4dc0133f0444fe1b164a33"
+                "reference": "68901f3b3a256085ebd939a3461ee833be10f86d"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -206,7 +206,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -265,7 +265,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "1f4712ec510fe2cf94bb78f2ec3ef5986ebcd22b"
+                "reference": "9fe072d6192b45f389d6cd7d11654198c7876bf4"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -284,7 +284,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -350,7 +350,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup-helper-script-manager",
-                "reference": "ea3bfbf40b845b948ed696bd7053fb52d0397e35"
+                "reference": "a9dad7825f172da6214ca8278d38abed9d7fb33f"
             },
             "require": {
                 "php": ">=7.2"
@@ -359,7 +359,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -405,7 +405,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/boost-core",
-                "reference": "7e2d719bc4842331a0709458595f2c480a7aa6b0"
+                "reference": "e87cba91035b78cb3c3e1aaf414010f82f80787f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -414,7 +414,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -461,7 +461,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/boost-speed-score",
-                "reference": "5d0a1075da9e8da4c90e8c0e92b3c5faf5a0993d"
+                "reference": "30562e15109877d91d5f450d89bfbc3339bfaa4b"
             },
             "require": {
                 "automattic/jetpack-boost-core": "@dev",
@@ -471,7 +471,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -526,7 +526,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "16772cbb568bc8fc8550671a1bd12aa4705738dc"
+                "reference": "eb028c7425d0591689e2a0b3047c278d8ff2395e"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -536,7 +536,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -661,7 +661,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "8b6fb10f12a15323a4af26c97ed28e3cd98327bd"
+                "reference": "1d0e8466e6188a79ff302ba975d3c2ffc691090b"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -680,7 +680,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -748,7 +748,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "e6cbca1d3b01d10d771d2af899cd6ffb65090549"
+                "reference": "378a5d122aedfc25d3aa42ab913803c85a8c857b"
             },
             "require": {
                 "php": ">=7.2"
@@ -757,7 +757,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -803,7 +803,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "dedb91e962e445e3ea344493e298b31125d6c175"
+                "reference": "4f83bde798e393d208074fdb0d06ea43e286367f"
             },
             "require": {
                 "php": ">=7.2"
@@ -811,7 +811,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -857,7 +857,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/explat",
-                "reference": "318352a036de9c75b76b7383509929d98cac8425"
+                "reference": "05a6b81d43a57e333f62154fbef5e1aa9f0dfae5"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -866,7 +866,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -933,7 +933,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/ip",
-                "reference": "ab83ce4e4fa0bcc7fa87600a8b60c7dab8bfe191"
+                "reference": "4c8f48266f1fe2551103c6293e2957e185f87a94"
             },
             "require": {
                 "php": ">=7.2"
@@ -942,7 +942,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -992,7 +992,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "e5ec23b1ab540b0eb208d2568e98a3395ad00e99"
+                "reference": "8f1cfb4b5b6881694f9be7376735501e5f37e19a"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1008,7 +1008,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1068,7 +1068,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/licensing",
-                "reference": "80b7f7af100212cf2f2cc07cd2201c8ed9207842"
+                "reference": "3d3ab5dd82baa76599a9899f4dfef6bddc1dac5d"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1078,7 +1078,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1125,7 +1125,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/logo",
-                "reference": "f08fffc0458c5acac0686368b005e049435d5e35"
+                "reference": "ffa8535e2da982620164c7a251f0b2fbe46d3f16"
             },
             "require": {
                 "php": ">=7.2"
@@ -1133,7 +1133,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1179,7 +1179,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8bc8bd1b22cc42ac9915f23da56d8b6605465b0b"
+                "reference": "e8cd97216467ec43a290c3e8c020ccafa68f5018"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1204,7 +1204,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-videopress": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1278,7 +1278,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/password-checker",
-                "reference": "63e9b52f2c3a5b69c30115e21c02ecf7e4a23e00"
+                "reference": "33cc919e4b75e07ed12975588c42ae2ea723a9a4"
             },
             "require": {
                 "php": ">=7.2"
@@ -1287,7 +1287,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1334,7 +1334,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "6e826adc648851fe3e6d20dd6b9b20fdcc21e3fd"
+                "reference": "de5c26803c2b558b6f64279671e6bec5b81be474"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1345,7 +1345,7 @@
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1397,7 +1397,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plugins-installer",
-                "reference": "a937c79953c77d994a88e7722683a4d1bbe75968"
+                "reference": "c26351d6a169c26719a964ef89c1cc986b5fbbfe"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1407,7 +1407,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1454,7 +1454,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-models",
-                "reference": "9aa24e036a4736f9bff3ced06d144323e3d4ccd3"
+                "reference": "b8e862ee1ac0301a12afa22b03c5503159aab2fa"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -1464,7 +1464,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1520,7 +1520,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-status",
-                "reference": "e229b1ae776d046d10281475b3a89cefa464253a"
+                "reference": "887b85b6fe8085925ca4e80b82c9222e73f17dc3"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1534,7 +1534,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1590,7 +1590,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "4738fce156b0b8008bdea47fb52d8c5d3d24e2ae"
+                "reference": "44d6ec93e4d3b3db6287bf82f316a294d7ef868d"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
@@ -1600,7 +1600,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1646,7 +1646,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/roles",
-                "reference": "0606b853fc28d9fbcc013187c626d0a8e2de84b6"
+                "reference": "f7098eb11833c5fddfff032427d8576039aa3521"
             },
             "require": {
                 "php": ">=7.2"
@@ -1655,7 +1655,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1701,7 +1701,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "fc91e61469f31cdab849571507a1aed68a14fafd"
+                "reference": "2af0799e498773ebeafed5e8e5c1a2b4d543a44a"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1714,7 +1714,7 @@
                 "automattic/jetpack-plans": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1766,7 +1766,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "d69fff7e02a1bfe9045907867d7d59e4c1814de6"
+                "reference": "9846e5fd84a40e97d5b9a0a2b4821968469a87d8"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1783,7 +1783,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-waf": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1841,7 +1841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "06b85c8f44fdccebce0bb12823f2d3f1e87e037a"
+                "reference": "30dd97f47c89ca7ec88c3659ef92464965a8e5e8"
             },
             "require": {
                 "composer-runtime-api": "^2.2.0",
@@ -1852,7 +1852,7 @@
             "require-dev": {
                 "automattic/phpunit-select-config": "@dev",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/changelogger"
@@ -1925,7 +1925,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/phpunit-select-config",
-                "reference": "ee8b1e53bfd922accf326802e7c8b8d7b26bf54f"
+                "reference": "3f16352a5a43bdd583b78d895d092a1e1b74c397"
             },
             "require": {
                 "composer-runtime-api": "^2.2.2",
@@ -1935,7 +1935,7 @@
             "require-dev": {
                 "antecedent/patchwork": "^2.2",
                 "automattic/jetpack-changelogger": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/phpunit-select-config"
@@ -4433,21 +4433,21 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "3.1.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618"
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/9cf2ccd990eadfc4a1e390592d4731e590b2c618",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "phpunit/phpunit": "^6.4.4 || ^7.0 || ^8.0 || ^9.0 || ^11.0"
+                "php": ">=7.1",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -4492,7 +4492,7 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2025-02-09T18:36:24+00:00"
+            "time": "2025-02-09T18:58:54+00:00"
         }
     ],
     "aliases": [],

--- a/projects/plugins/backup/phpunit.12.xml.dist
+++ b/projects/plugins/backup/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/plugins/beta/changelog/update-yoast-polyfills-v4
+++ b/projects/plugins/beta/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/beta/composer.lock
+++ b/projects/plugins/beta/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "5faef0e6453cac07042d46af33d9a5318c353ca1"
+                "reference": "fee1504bb96380c418e439af5696ba75fbfc0d96"
             },
             "require": {
                 "php": ">=7.2"
@@ -22,7 +22,7 @@
                 "automattic/jetpack-logo": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -72,7 +72,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "54d6c42f16aec2a60a4dc0133f0444fe1b164a33"
+                "reference": "68901f3b3a256085ebd939a3461ee833be10f86d"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -82,7 +82,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -274,7 +274,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "06b85c8f44fdccebce0bb12823f2d3f1e87e037a"
+                "reference": "30dd97f47c89ca7ec88c3659ef92464965a8e5e8"
             },
             "require": {
                 "composer-runtime-api": "^2.2.0",
@@ -285,7 +285,7 @@
             "require-dev": {
                 "automattic/phpunit-select-config": "@dev",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/changelogger"

--- a/projects/plugins/boost/changelog/update-yoast-polyfills-v4
+++ b/projects/plugins/boost/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -37,7 +37,7 @@
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/phpunit-select-config": "@dev",
 		"brain/monkey": "^2.6.2",
-		"yoast/phpunit-polyfills": "^3.0.0"
+		"yoast/phpunit-polyfills": "^4.0.0"
 	},
 	"scripts": {
 		"phpunit": [

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0af68a4402d52a828d6b67e167f731d0",
+    "content-hash": "b48a793b6f7811dcde56b395714aea89",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "5c10fd1a50834e9d28af3136f79a35617b497dae"
+                "reference": "68b92cc77ac41309dbf2f7a16eecd4e0c9cb03a9"
             },
             "require": {
                 "php": ">=7.2"
@@ -20,7 +20,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "5faef0e6453cac07042d46af33d9a5318c353ca1"
+                "reference": "fee1504bb96380c418e439af5696ba75fbfc0d96"
             },
             "require": {
                 "php": ">=7.2"
@@ -76,7 +76,7 @@
                 "automattic/jetpack-logo": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -126,7 +126,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "110b0ff2aa88f9904c6260c3e399dbfdd7544fa6"
+                "reference": "89a768257b402fb6abeefe5b6c0855f946187fab"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -137,7 +137,7 @@
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -196,7 +196,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "54d6c42f16aec2a60a4dc0133f0444fe1b164a33"
+                "reference": "68901f3b3a256085ebd939a3461ee833be10f86d"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -206,7 +206,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -265,7 +265,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/boost-core",
-                "reference": "7e2d719bc4842331a0709458595f2c480a7aa6b0"
+                "reference": "e87cba91035b78cb3c3e1aaf414010f82f80787f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -274,7 +274,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -321,7 +321,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/boost-speed-score",
-                "reference": "5d0a1075da9e8da4c90e8c0e92b3c5faf5a0993d"
+                "reference": "30562e15109877d91d5f450d89bfbc3339bfaa4b"
             },
             "require": {
                 "automattic/jetpack-boost-core": "@dev",
@@ -331,7 +331,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -386,7 +386,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "16772cbb568bc8fc8550671a1bd12aa4705738dc"
+                "reference": "eb028c7425d0591689e2a0b3047c278d8ff2395e"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -396,7 +396,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -521,7 +521,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "8b6fb10f12a15323a4af26c97ed28e3cd98327bd"
+                "reference": "1d0e8466e6188a79ff302ba975d3c2ffc691090b"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -540,7 +540,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "e6cbca1d3b01d10d771d2af899cd6ffb65090549"
+                "reference": "378a5d122aedfc25d3aa42ab913803c85a8c857b"
             },
             "require": {
                 "php": ">=7.2"
@@ -617,7 +617,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -663,7 +663,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "dedb91e962e445e3ea344493e298b31125d6c175"
+                "reference": "4f83bde798e393d208074fdb0d06ea43e286367f"
             },
             "require": {
                 "php": ">=7.2"
@@ -671,7 +671,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -717,7 +717,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/explat",
-                "reference": "318352a036de9c75b76b7383509929d98cac8425"
+                "reference": "05a6b81d43a57e333f62154fbef5e1aa9f0dfae5"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -726,7 +726,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -793,7 +793,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/image-cdn",
-                "reference": "81f8eb271b2f37153e4bd2ea4f2c0eb7dc2b5729"
+                "reference": "79b4ce2978edf4a5f586ceab9c2058a6cfcbef94"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -804,7 +804,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -854,7 +854,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/ip",
-                "reference": "ab83ce4e4fa0bcc7fa87600a8b60c7dab8bfe191"
+                "reference": "4c8f48266f1fe2551103c6293e2957e185f87a94"
             },
             "require": {
                 "php": ">=7.2"
@@ -863,7 +863,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -913,7 +913,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "e5ec23b1ab540b0eb208d2568e98a3395ad00e99"
+                "reference": "8f1cfb4b5b6881694f9be7376735501e5f37e19a"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -929,7 +929,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -989,7 +989,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/licensing",
-                "reference": "80b7f7af100212cf2f2cc07cd2201c8ed9207842"
+                "reference": "3d3ab5dd82baa76599a9899f4dfef6bddc1dac5d"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -999,7 +999,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1046,7 +1046,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/logo",
-                "reference": "f08fffc0458c5acac0686368b005e049435d5e35"
+                "reference": "ffa8535e2da982620164c7a251f0b2fbe46d3f16"
             },
             "require": {
                 "php": ">=7.2"
@@ -1054,7 +1054,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1100,7 +1100,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8bc8bd1b22cc42ac9915f23da56d8b6605465b0b"
+                "reference": "e8cd97216467ec43a290c3e8c020ccafa68f5018"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1125,7 +1125,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-videopress": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1199,7 +1199,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/password-checker",
-                "reference": "63e9b52f2c3a5b69c30115e21c02ecf7e4a23e00"
+                "reference": "33cc919e4b75e07ed12975588c42ae2ea723a9a4"
             },
             "require": {
                 "php": ">=7.2"
@@ -1208,7 +1208,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1255,7 +1255,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "6e826adc648851fe3e6d20dd6b9b20fdcc21e3fd"
+                "reference": "de5c26803c2b558b6f64279671e6bec5b81be474"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1266,7 +1266,7 @@
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1318,7 +1318,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plugin-deactivation",
-                "reference": "3096c8cde89bb702f5eeb12d0e69200601745f58"
+                "reference": "d94810e1882aa3353325ca5f1154c2082cf13283"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1327,7 +1327,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1387,7 +1387,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plugins-installer",
-                "reference": "a937c79953c77d994a88e7722683a4d1bbe75968"
+                "reference": "c26351d6a169c26719a964ef89c1cc986b5fbbfe"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1397,7 +1397,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1444,7 +1444,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-models",
-                "reference": "9aa24e036a4736f9bff3ced06d144323e3d4ccd3"
+                "reference": "b8e862ee1ac0301a12afa22b03c5503159aab2fa"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -1454,7 +1454,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1510,7 +1510,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-status",
-                "reference": "e229b1ae776d046d10281475b3a89cefa464253a"
+                "reference": "887b85b6fe8085925ca4e80b82c9222e73f17dc3"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1524,7 +1524,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1580,7 +1580,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "4738fce156b0b8008bdea47fb52d8c5d3d24e2ae"
+                "reference": "44d6ec93e4d3b3db6287bf82f316a294d7ef868d"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
@@ -1590,7 +1590,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1636,7 +1636,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/roles",
-                "reference": "0606b853fc28d9fbcc013187c626d0a8e2de84b6"
+                "reference": "f7098eb11833c5fddfff032427d8576039aa3521"
             },
             "require": {
                 "php": ">=7.2"
@@ -1645,7 +1645,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1691,7 +1691,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/schema",
-                "reference": "c3eb9fa2a6ced9251ead5b1ea77199e0095b7b5e"
+                "reference": "32482fdc9ee295fed8d2cb93087ed9d078ca5672"
             },
             "require": {
                 "php": ">=7.2"
@@ -1700,7 +1700,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1756,7 +1756,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "fc91e61469f31cdab849571507a1aed68a14fafd"
+                "reference": "2af0799e498773ebeafed5e8e5c1a2b4d543a44a"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1769,7 +1769,7 @@
                 "automattic/jetpack-plans": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1821,7 +1821,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "d69fff7e02a1bfe9045907867d7d59e4c1814de6"
+                "reference": "9846e5fd84a40e97d5b9a0a2b4821968469a87d8"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1838,7 +1838,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-waf": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1894,7 +1894,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/wp-js-data-sync",
-                "reference": "bb9cbae7dea802935fb194d10897b2f0a9f6d74c"
+                "reference": "ecd57830845d7bb49884f22c5935d3cbce8666e3"
             },
             "require": {
                 "automattic/jetpack-schema": "@dev",
@@ -1903,7 +1903,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -2127,7 +2127,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "06b85c8f44fdccebce0bb12823f2d3f1e87e037a"
+                "reference": "30dd97f47c89ca7ec88c3659ef92464965a8e5e8"
             },
             "require": {
                 "composer-runtime-api": "^2.2.0",
@@ -2138,7 +2138,7 @@
             "require-dev": {
                 "automattic/phpunit-select-config": "@dev",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/changelogger"
@@ -2211,7 +2211,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/test-environment",
-                "reference": "acf2c63d65d9aab5bfff95da40ee011acc66fa04"
+                "reference": "4ebfacd0d0ff37aed8d38faaad374a2b39042154"
             },
             "require": {
                 "php": ">=7.2"
@@ -2219,7 +2219,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -2264,7 +2264,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/phpunit-select-config",
-                "reference": "ee8b1e53bfd922accf326802e7c8b8d7b26bf54f"
+                "reference": "3f16352a5a43bdd583b78d895d092a1e1b74c397"
             },
             "require": {
                 "composer-runtime-api": "^2.2.2",
@@ -2274,7 +2274,7 @@
             "require-dev": {
                 "antecedent/patchwork": "^2.2",
                 "automattic/jetpack-changelogger": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/phpunit-select-config"
@@ -4976,21 +4976,21 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "3.1.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618"
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/9cf2ccd990eadfc4a1e390592d4731e590b2c618",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "phpunit/phpunit": "^6.4.4 || ^7.0 || ^8.0 || ^9.0 || ^11.0"
+                "php": ">=7.1",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -5035,7 +5035,7 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2025-02-09T18:36:24+00:00"
+            "time": "2025-02-09T18:58:54+00:00"
         }
     ],
     "aliases": [],

--- a/projects/plugins/boost/phpunit.12.xml.dist
+++ b/projects/plugins/boost/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/plugins/classic-theme-helper-plugin/changelog/update-yoast-polyfills-v4
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/classic-theme-helper-plugin/composer.lock
+++ b/projects/plugins/classic-theme-helper-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "5c10fd1a50834e9d28af3136f79a35617b497dae"
+                "reference": "68b92cc77ac41309dbf2f7a16eecd4e0c9cb03a9"
             },
             "require": {
                 "php": ">=7.2"
@@ -20,7 +20,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "110b0ff2aa88f9904c6260c3e399dbfdd7544fa6"
+                "reference": "89a768257b402fb6abeefe5b6c0855f946187fab"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -77,7 +77,7 @@
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -136,7 +136,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "54d6c42f16aec2a60a4dc0133f0444fe1b164a33"
+                "reference": "68901f3b3a256085ebd939a3461ee833be10f86d"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -146,7 +146,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -205,7 +205,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/classic-theme-helper",
-                "reference": "d2a77001355ac061d45c33e7c882ff793f717e07"
+                "reference": "6a1666875f6fb10e5557f7b53963b91999e20863"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -214,7 +214,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -270,7 +270,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "16772cbb568bc8fc8550671a1bd12aa4705738dc"
+                "reference": "eb028c7425d0591689e2a0b3047c278d8ff2395e"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -280,7 +280,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -405,7 +405,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "e6cbca1d3b01d10d771d2af899cd6ffb65090549"
+                "reference": "378a5d122aedfc25d3aa42ab913803c85a8c857b"
             },
             "require": {
                 "php": ">=7.2"
@@ -414,7 +414,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -460,7 +460,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plugins-installer",
-                "reference": "a937c79953c77d994a88e7722683a4d1bbe75968"
+                "reference": "c26351d6a169c26719a964ef89c1cc986b5fbbfe"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -470,7 +470,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -517,7 +517,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "fc91e61469f31cdab849571507a1aed68a14fafd"
+                "reference": "2af0799e498773ebeafed5e8e5c1a2b4d543a44a"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -530,7 +530,7 @@
                 "automattic/jetpack-plans": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -584,7 +584,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "06b85c8f44fdccebce0bb12823f2d3f1e87e037a"
+                "reference": "30dd97f47c89ca7ec88c3659ef92464965a8e5e8"
             },
             "require": {
                 "composer-runtime-api": "^2.2.0",
@@ -595,7 +595,7 @@
             "require-dev": {
                 "automattic/phpunit-select-config": "@dev",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/changelogger"

--- a/projects/plugins/crm/changelog/update-yoast-polyfills-v4
+++ b/projects/plugins/crm/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -10,7 +10,7 @@
 		"codeception/module-db": "^2.0 || 3.1.0 || ^3.1.2",
 		"codeception/module-filesystem": "^2.0 || ^3.0",
 		"codeception/util-universalframework": "^1.0",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/phpunit-select-config": "@dev"
 	},
 	"scripts": {

--- a/projects/plugins/crm/composer.lock
+++ b/projects/plugins/crm/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8ec8c23e68b6dabf7bdf0682ec253449",
+    "content-hash": "10648b2e74e2b57260d08c23a3ad4195",
     "packages": [
         {
             "name": "automattic/jetpack-assets",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "110b0ff2aa88f9904c6260c3e399dbfdd7544fa6"
+                "reference": "89a768257b402fb6abeefe5b6c0855f946187fab"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -23,7 +23,7 @@
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -82,7 +82,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "54d6c42f16aec2a60a4dc0133f0444fe1b164a33"
+                "reference": "68901f3b3a256085ebd939a3461ee833be10f86d"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -92,7 +92,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -151,7 +151,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "16772cbb568bc8fc8550671a1bd12aa4705738dc"
+                "reference": "eb028c7425d0591689e2a0b3047c278d8ff2395e"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -161,7 +161,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -212,7 +212,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "e6cbca1d3b01d10d771d2af899cd6ffb65090549"
+                "reference": "378a5d122aedfc25d3aa42ab913803c85a8c857b"
             },
             "require": {
                 "php": ">=7.2"
@@ -221,7 +221,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -606,7 +606,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "06b85c8f44fdccebce0bb12823f2d3f1e87e037a"
+                "reference": "30dd97f47c89ca7ec88c3659ef92464965a8e5e8"
             },
             "require": {
                 "composer-runtime-api": "^2.2.0",
@@ -617,7 +617,7 @@
             "require-dev": {
                 "automattic/phpunit-select-config": "@dev",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/changelogger"
@@ -690,7 +690,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/phpunit-select-config",
-                "reference": "ee8b1e53bfd922accf326802e7c8b8d7b26bf54f"
+                "reference": "3f16352a5a43bdd583b78d895d092a1e1b74c397"
             },
             "require": {
                 "composer-runtime-api": "^2.2.2",
@@ -700,7 +700,7 @@
             "require-dev": {
                 "antecedent/patchwork": "^2.2",
                 "automattic/jetpack-changelogger": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/phpunit-select-config"
@@ -5225,21 +5225,21 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "3.1.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618"
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/9cf2ccd990eadfc4a1e390592d4731e590b2c618",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "phpunit/phpunit": "^6.4.4 || ^7.0 || ^8.0 || ^9.0 || ^11.0"
+                "php": ">=7.1",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -5284,7 +5284,7 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2025-02-09T18:36:24+00:00"
+            "time": "2025-02-09T18:58:54+00:00"
         }
     ],
     "aliases": [],

--- a/projects/plugins/crm/phpunit.12.xml.dist
+++ b/projects/plugins/crm/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/plugins/debug-helper/changelog/update-yoast-polyfills-v4
+++ b/projects/plugins/debug-helper/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/debug-helper/composer.lock
+++ b/projects/plugins/debug-helper/composer.lock
@@ -13,7 +13,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "06b85c8f44fdccebce0bb12823f2d3f1e87e037a"
+                "reference": "30dd97f47c89ca7ec88c3659ef92464965a8e5e8"
             },
             "require": {
                 "composer-runtime-api": "^2.2.0",
@@ -24,7 +24,7 @@
             "require-dev": {
                 "automattic/phpunit-select-config": "@dev",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/changelogger"

--- a/projects/plugins/inspect/changelog/update-yoast-polyfills-v4
+++ b/projects/plugins/inspect/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/plugins/inspect/composer.json
+++ b/projects/plugins/inspect/composer.json
@@ -24,7 +24,7 @@
 		"automattic/jetpack-config": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/plugins/inspect/composer.lock
+++ b/projects/plugins/inspect/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7f0eeb463cbc4d0fd68acbc02c36dd4d",
+    "content-hash": "c504b18b52f086f859affcf4437c5dd6",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "5c10fd1a50834e9d28af3136f79a35617b497dae"
+                "reference": "68b92cc77ac41309dbf2f7a16eecd4e0c9cb03a9"
             },
             "require": {
                 "php": ">=7.2"
@@ -20,7 +20,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "5faef0e6453cac07042d46af33d9a5318c353ca1"
+                "reference": "fee1504bb96380c418e439af5696ba75fbfc0d96"
             },
             "require": {
                 "php": ">=7.2"
@@ -76,7 +76,7 @@
                 "automattic/jetpack-logo": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -126,7 +126,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "110b0ff2aa88f9904c6260c3e399dbfdd7544fa6"
+                "reference": "89a768257b402fb6abeefe5b6c0855f946187fab"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -137,7 +137,7 @@
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -196,7 +196,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "54d6c42f16aec2a60a4dc0133f0444fe1b164a33"
+                "reference": "68901f3b3a256085ebd939a3461ee833be10f86d"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -206,7 +206,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -265,7 +265,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "16772cbb568bc8fc8550671a1bd12aa4705738dc"
+                "reference": "eb028c7425d0591689e2a0b3047c278d8ff2395e"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -275,7 +275,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -400,7 +400,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "8b6fb10f12a15323a4af26c97ed28e3cd98327bd"
+                "reference": "1d0e8466e6188a79ff302ba975d3c2ffc691090b"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -419,7 +419,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -487,7 +487,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "e6cbca1d3b01d10d771d2af899cd6ffb65090549"
+                "reference": "378a5d122aedfc25d3aa42ab913803c85a8c857b"
             },
             "require": {
                 "php": ">=7.2"
@@ -496,7 +496,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -542,7 +542,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "4738fce156b0b8008bdea47fb52d8c5d3d24e2ae"
+                "reference": "44d6ec93e4d3b3db6287bf82f316a294d7ef868d"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
@@ -552,7 +552,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -598,7 +598,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/roles",
-                "reference": "0606b853fc28d9fbcc013187c626d0a8e2de84b6"
+                "reference": "f7098eb11833c5fddfff032427d8576039aa3521"
             },
             "require": {
                 "php": ">=7.2"
@@ -607,7 +607,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -653,7 +653,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "fc91e61469f31cdab849571507a1aed68a14fafd"
+                "reference": "2af0799e498773ebeafed5e8e5c1a2b4d543a44a"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -666,7 +666,7 @@
                 "automattic/jetpack-plans": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -720,7 +720,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "06b85c8f44fdccebce0bb12823f2d3f1e87e037a"
+                "reference": "30dd97f47c89ca7ec88c3659ef92464965a8e5e8"
             },
             "require": {
                 "composer-runtime-api": "^2.2.0",
@@ -731,7 +731,7 @@
             "require-dev": {
                 "automattic/phpunit-select-config": "@dev",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/changelogger"
@@ -804,7 +804,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/phpunit-select-config",
-                "reference": "ee8b1e53bfd922accf326802e7c8b8d7b26bf54f"
+                "reference": "3f16352a5a43bdd583b78d895d092a1e1b74c397"
             },
             "require": {
                 "composer-runtime-api": "^2.2.2",
@@ -814,7 +814,7 @@
             "require-dev": {
                 "antecedent/patchwork": "^2.2",
                 "automattic/jetpack-changelogger": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/phpunit-select-config"
@@ -3312,21 +3312,21 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "3.1.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618"
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/9cf2ccd990eadfc4a1e390592d4731e590b2c618",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "phpunit/phpunit": "^6.4.4 || ^7.0 || ^8.0 || ^9.0 || ^11.0"
+                "php": ">=7.1",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -3371,7 +3371,7 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2025-02-09T18:36:24+00:00"
+            "time": "2025-02-09T18:58:54+00:00"
         }
     ],
     "aliases": [],

--- a/projects/plugins/inspect/phpunit.12.xml.dist
+++ b/projects/plugins/inspect/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/plugins/jetpack/changelog/update-yoast-polyfills-v4
+++ b/projects/plugins/jetpack/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -60,7 +60,7 @@
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/patchwork-redefine-exit": "@dev",
 		"automattic/phpunit-select-config": "@dev",
-		"yoast/phpunit-polyfills": "^3.0.0"
+		"yoast/phpunit-polyfills": "^4.0.0"
 	},
 	"scripts": {
 		"build-production": [

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
 		"Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
 		"This file is @generated automatically"
 	],
-	"content-hash": "5e69ba2b2a874f5a8c870ac8bfc0687b",
+	"content-hash": "916cfb86dae4ce516e275e174206cc68",
 	"packages": [
 		{
 			"name": "automattic/jetpack-a8c-mc-stats",
@@ -12,7 +12,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/a8c-mc-stats",
-				"reference": "5c10fd1a50834e9d28af3136f79a35617b497dae"
+				"reference": "68b92cc77ac41309dbf2f7a16eecd4e0c9cb03a9"
 			},
 			"require": {
 				"php": ">=7.2"
@@ -20,7 +20,7 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -66,7 +66,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/account-protection",
-				"reference": "b0dc90cd2c96bd61af153cae661e6dbfad5e4b27"
+				"reference": "bd9ac71a7100a78720ce60a7a0812ffac8218bbb"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -79,7 +79,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -135,7 +135,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/admin-ui",
-				"reference": "5faef0e6453cac07042d46af33d9a5318c353ca1"
+				"reference": "fee1504bb96380c418e439af5696ba75fbfc0d96"
 			},
 			"require": {
 				"php": ">=7.2"
@@ -145,7 +145,7 @@
 				"automattic/jetpack-logo": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -195,7 +195,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/assets",
-				"reference": "110b0ff2aa88f9904c6260c3e399dbfdd7544fa6"
+				"reference": "89a768257b402fb6abeefe5b6c0855f946187fab"
 			},
 			"require": {
 				"automattic/jetpack-constants": "@dev",
@@ -206,7 +206,7 @@
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "^2.6.2",
 				"wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -265,7 +265,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/autoloader",
-				"reference": "54d6c42f16aec2a60a4dc0133f0444fe1b164a33"
+				"reference": "68901f3b3a256085ebd939a3461ee833be10f86d"
 			},
 			"require": {
 				"composer-plugin-api": "^2.2",
@@ -275,7 +275,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"composer/composer": "^2.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"type": "composer-plugin",
 			"extra": {
@@ -334,7 +334,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/backup",
-				"reference": "1f4712ec510fe2cf94bb78f2ec3ef5986ebcd22b"
+				"reference": "9fe072d6192b45f389d6cd7d11654198c7876bf4"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -353,7 +353,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -419,7 +419,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/backup-helper-script-manager",
-				"reference": "ea3bfbf40b845b948ed696bd7053fb52d0397e35"
+				"reference": "a9dad7825f172da6214ca8278d38abed9d7fb33f"
 			},
 			"require": {
 				"php": ">=7.2"
@@ -428,7 +428,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -474,7 +474,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/blaze",
-				"reference": "f897f4d450f20d7e0521ca0cdf08754fbef06265"
+				"reference": "119ac65520e11f909fb090015b98dcf686f9d157"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -490,7 +490,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -550,7 +550,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/blocks",
-				"reference": "b5e222941b8a6bf36cd1623ab95e9ddd48440ca0"
+				"reference": "80622ccf1abbbbecd133ec46ef657250ab972968"
 			},
 			"require": {
 				"automattic/jetpack-constants": "@dev",
@@ -561,7 +561,7 @@
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "^2.6.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -607,7 +607,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/boost-core",
-				"reference": "7e2d719bc4842331a0709458595f2c480a7aa6b0"
+				"reference": "e87cba91035b78cb3c3e1aaf414010f82f80787f"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -616,7 +616,7 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -663,7 +663,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/boost-speed-score",
-				"reference": "5d0a1075da9e8da4c90e8c0e92b3c5faf5a0993d"
+				"reference": "30562e15109877d91d5f450d89bfbc3339bfaa4b"
 			},
 			"require": {
 				"automattic/jetpack-boost-core": "@dev",
@@ -673,7 +673,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "^2.6",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -728,7 +728,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/classic-theme-helper",
-				"reference": "d2a77001355ac061d45c33e7c882ff793f717e07"
+				"reference": "6a1666875f6fb10e5557f7b53963b91999e20863"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -737,7 +737,7 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -830,7 +830,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/composer-plugin",
-				"reference": "16772cbb568bc8fc8550671a1bd12aa4705738dc"
+				"reference": "eb028c7425d0591689e2a0b3047c278d8ff2395e"
 			},
 			"require": {
 				"composer-plugin-api": "^2.2",
@@ -840,7 +840,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"composer/composer": "^2.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"type": "composer-plugin",
 			"extra": {
@@ -965,7 +965,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/connection",
-				"reference": "8b6fb10f12a15323a4af26c97ed28e3cd98327bd"
+				"reference": "1d0e8466e6188a79ff302ba975d3c2ffc691090b"
 			},
 			"require": {
 				"automattic/jetpack-a8c-mc-stats": "@dev",
@@ -984,7 +984,7 @@
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "^2.6.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1052,7 +1052,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/constants",
-				"reference": "e6cbca1d3b01d10d771d2af899cd6ffb65090549"
+				"reference": "378a5d122aedfc25d3aa42ab913803c85a8c857b"
 			},
 			"require": {
 				"php": ">=7.2"
@@ -1061,7 +1061,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "^2.6.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1107,7 +1107,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/device-detection",
-				"reference": "dedb91e962e445e3ea344493e298b31125d6c175"
+				"reference": "4f83bde798e393d208074fdb0d06ea43e286367f"
 			},
 			"require": {
 				"php": ">=7.2"
@@ -1115,7 +1115,7 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1161,7 +1161,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/error",
-				"reference": "bd81b64e3e9dd3250239b5a51caa711a30d2359f"
+				"reference": "e4ebe192a192a308d7536af37948469c3c6ae1b5"
 			},
 			"require": {
 				"php": ">=7.2"
@@ -1169,7 +1169,7 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1215,7 +1215,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/explat",
-				"reference": "318352a036de9c75b76b7383509929d98cac8425"
+				"reference": "05a6b81d43a57e333f62154fbef5e1aa9f0dfae5"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -1224,7 +1224,7 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1291,7 +1291,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/external-media",
-				"reference": "a87088f9f12ebeb8493ea02025821d0e9c63c6d4"
+				"reference": "30b785313c8c3b6f1e238d2af4afd6affdb1777d"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -1303,7 +1303,7 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1359,7 +1359,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/forms",
-				"reference": "a73e240bc062eb96f06ea8d2ee5aeba5f1b60125"
+				"reference": "1a14eb5b3a95ceba7486aa4b9faf3b3a54dbc47d"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -1375,7 +1375,7 @@
 				"automattic/jetpack-connection": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1438,7 +1438,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/image-cdn",
-				"reference": "81f8eb271b2f37153e4bd2ea4f2c0eb7dc2b5729"
+				"reference": "79b4ce2978edf4a5f586ceab9c2058a6cfcbef94"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -1449,7 +1449,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1499,7 +1499,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/import",
-				"reference": "fe89ad0695f300cdb2849fb117007b71c6a92a44"
+				"reference": "37bb297c7ace59a9442ea9ca47ac3c9669afefd6"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -1509,7 +1509,7 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1559,7 +1559,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/ip",
-				"reference": "ab83ce4e4fa0bcc7fa87600a8b60c7dab8bfe191"
+				"reference": "4c8f48266f1fe2551103c6293e2957e185f87a94"
 			},
 			"require": {
 				"php": ">=7.2"
@@ -1568,7 +1568,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "^2.6.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1618,7 +1618,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/jitm",
-				"reference": "e5ec23b1ab540b0eb208d2568e98a3395ad00e99"
+				"reference": "8f1cfb4b5b6881694f9be7376735501e5f37e19a"
 			},
 			"require": {
 				"automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1634,7 +1634,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "^2.6.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1694,7 +1694,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/licensing",
-				"reference": "80b7f7af100212cf2f2cc07cd2201c8ed9207842"
+				"reference": "3d3ab5dd82baa76599a9899f4dfef6bddc1dac5d"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -1704,7 +1704,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1751,7 +1751,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/logo",
-				"reference": "f08fffc0458c5acac0686368b005e049435d5e35"
+				"reference": "ffa8535e2da982620164c7a251f0b2fbe46d3f16"
 			},
 			"require": {
 				"php": ">=7.2"
@@ -1759,7 +1759,7 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1805,7 +1805,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/masterbar",
-				"reference": "2f0576b08251752f44d2e82f8b8263ba5bc746e3"
+				"reference": "b6a718f90cbd6e5cad4403d05955347b85a02bf1"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -1826,7 +1826,7 @@
 				"automattic/patchwork-redefine-exit": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "^2.6.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1888,7 +1888,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "8bc8bd1b22cc42ac9915f23da56d8b6605465b0b"
+				"reference": "e8cd97216467ec43a290c3e8c020ccafa68f5018"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1913,7 +1913,7 @@
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/jetpack-videopress": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1987,7 +1987,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/password-checker",
-				"reference": "63e9b52f2c3a5b69c30115e21c02ecf7e4a23e00"
+				"reference": "33cc919e4b75e07ed12975588c42ae2ea723a9a4"
 			},
 			"require": {
 				"php": ">=7.2"
@@ -1996,7 +1996,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -2043,7 +2043,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/plans",
-				"reference": "6e826adc648851fe3e6d20dd6b9b20fdcc21e3fd"
+				"reference": "de5c26803c2b558b6f64279671e6bec5b81be474"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2054,7 +2054,7 @@
 				"automattic/jetpack-status": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -2106,7 +2106,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/plugins-installer",
-				"reference": "a937c79953c77d994a88e7722683a4d1bbe75968"
+				"reference": "c26351d6a169c26719a964ef89c1cc986b5fbbfe"
 			},
 			"require": {
 				"automattic/jetpack-a8c-mc-stats": "@dev",
@@ -2116,7 +2116,7 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -2163,7 +2163,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/post-list",
-				"reference": "3dcd6395d775f858a18c4c61a564bc5c1c35e25d"
+				"reference": "62d4a8fbfe514aff5ce54806df3c7cc1d58f7e9b"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -2173,7 +2173,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -2229,7 +2229,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/protect-models",
-				"reference": "9aa24e036a4736f9bff3ced06d144323e3d4ccd3"
+				"reference": "b8e862ee1ac0301a12afa22b03c5503159aab2fa"
 			},
 			"require": {
 				"automattic/jetpack-redirect": "@dev",
@@ -2239,7 +2239,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -2295,7 +2295,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/protect-status",
-				"reference": "e229b1ae776d046d10281475b3a89cefa464253a"
+				"reference": "887b85b6fe8085925ca4e80b82c9222e73f17dc3"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2309,7 +2309,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -2365,7 +2365,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/publicize",
-				"reference": "9f0861bd29047828afc6c0779078cb26edf524c8"
+				"reference": "5a72982cecf26d1dd6f44ae252f572de4e22012f"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -2382,7 +2382,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -2443,7 +2443,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/redirect",
-				"reference": "4738fce156b0b8008bdea47fb52d8c5d3d24e2ae"
+				"reference": "44d6ec93e4d3b3db6287bf82f316a294d7ef868d"
 			},
 			"require": {
 				"automattic/jetpack-status": "@dev",
@@ -2453,7 +2453,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "^2.6.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -2499,7 +2499,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/roles",
-				"reference": "0606b853fc28d9fbcc013187c626d0a8e2de84b6"
+				"reference": "f7098eb11833c5fddfff032427d8576039aa3521"
 			},
 			"require": {
 				"php": ">=7.2"
@@ -2508,7 +2508,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "^2.6.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -2554,7 +2554,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/search",
-				"reference": "c1adc06d17a159c2945147f56d633453cf34e87a"
+				"reference": "588f60f4e1ee07cb44ecbcc40a29b05c2773a1a0"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -2570,7 +2570,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -2637,7 +2637,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/stats",
-				"reference": "17d370fe6ad03ba4efd6b26ba367dfc8951c1670"
+				"reference": "789c86192e313d719df96ba4fb9bb225a11e6aa1"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2649,7 +2649,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -2704,7 +2704,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/stats-admin",
-				"reference": "d6c733cb5102f8189dcaa1d9b77e5b34403fa32e"
+				"reference": "ed890d948b0713fc8d7c1b2a00d37b8b556244a2"
 			},
 			"require": {
 				"automattic/jetpack-blaze": "@dev",
@@ -2720,7 +2720,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -2773,7 +2773,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/status",
-				"reference": "fc91e61469f31cdab849571507a1aed68a14fafd"
+				"reference": "2af0799e498773ebeafed5e8e5c1a2b4d543a44a"
 			},
 			"require": {
 				"automattic/jetpack-constants": "@dev",
@@ -2786,7 +2786,7 @@
 				"automattic/jetpack-plans": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "^2.6.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -2838,7 +2838,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/subscribers-dashboard",
-				"reference": "bd34a6bb2a4f0e6c0badd9e9a3b3d15bac6922c5"
+				"reference": "68a2f8db8c8f9a683ef8627ffa8cab0c902b39f0"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2853,7 +2853,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -2917,7 +2917,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/sync",
-				"reference": "d69fff7e02a1bfe9045907867d7d59e4c1814de6"
+				"reference": "9846e5fd84a40e97d5b9a0a2b4821968469a87d8"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2934,7 +2934,7 @@
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/jetpack-waf": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -2990,7 +2990,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/videopress",
-				"reference": "c14954ff73879d665f632af7c2074b79186657a1"
+				"reference": "b7c37d3261e3e2ca2b114e309bc0f5e5c9b1826a"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -3006,7 +3006,7 @@
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "2.6.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -3069,7 +3069,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/waf",
-				"reference": "a857ebc1741e7649c6d129fcfd9426fe2d61858b"
+				"reference": "7225dc771c4f99a3c47e5e713a2d760cb5fadfa1"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -3083,7 +3083,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -3138,7 +3138,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/wordads",
-				"reference": "8527450c81e87706b393b8b48cef68cdbbf6c298"
+				"reference": "1ebc89df5215b0bbdd323fc67391b5dbfa4d480f"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -3151,7 +3151,7 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -3218,7 +3218,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/woocommerce-analytics",
-				"reference": "c8652e79b7822b297ade6102a5e96fe6e737d26b"
+				"reference": "59ad6583303a2c51f7d362caf81cf72725e8d062"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -3228,7 +3228,7 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -3465,7 +3465,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/changelogger",
-				"reference": "06b85c8f44fdccebce0bb12823f2d3f1e87e037a"
+				"reference": "30dd97f47c89ca7ec88c3659ef92464965a8e5e8"
 			},
 			"require": {
 				"composer-runtime-api": "^2.2.0",
@@ -3476,7 +3476,7 @@
 			"require-dev": {
 				"automattic/phpunit-select-config": "@dev",
 				"wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"bin": [
 				"bin/changelogger"
@@ -3549,7 +3549,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/patchwork-redefine-exit",
-				"reference": "c320a94ef6d139dfc187e0f9989c6783f1d361e8"
+				"reference": "785106fd16163364224579aa4cb2393baf0af817"
 			},
 			"require": {
 				"antecedent/patchwork": "^2.2",
@@ -3558,7 +3558,7 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"type": "library",
 			"extra": {
@@ -3609,7 +3609,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/phpunit-select-config",
-				"reference": "ee8b1e53bfd922accf326802e7c8b8d7b26bf54f"
+				"reference": "3f16352a5a43bdd583b78d895d092a1e1b74c397"
 			},
 			"require": {
 				"composer-runtime-api": "^2.2.2",
@@ -3619,7 +3619,7 @@
 			"require-dev": {
 				"antecedent/patchwork": "^2.2",
 				"automattic/jetpack-changelogger": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"bin": [
 				"bin/phpunit-select-config"
@@ -6117,21 +6117,21 @@
 		},
 		{
 			"name": "yoast/phpunit-polyfills",
-			"version": "3.1.2",
+			"version": "4.0.0",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-				"reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618"
+				"reference": "134921bfca9b02d8f374c48381451da1d98402f9"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/9cf2ccd990eadfc4a1e390592d4731e590b2c618",
-				"reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618",
+				"url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+				"reference": "134921bfca9b02d8f374c48381451da1d98402f9",
 				"shasum": ""
 			},
 			"require": {
-				"php": ">=7.0",
-				"phpunit/phpunit": "^6.4.4 || ^7.0 || ^8.0 || ^9.0 || ^11.0"
+				"php": ">=7.1",
+				"phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
 			},
 			"require-dev": {
 				"php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -6176,7 +6176,7 @@
 				"security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
 				"source": "https://github.com/Yoast/PHPUnit-Polyfills"
 			},
-			"time": "2025-02-09T18:36:24+00:00"
+			"time": "2025-02-09T18:58:54+00:00"
 		}
 	],
 	"aliases": [],

--- a/projects/plugins/jetpack/phpunit.12.xml.dist
+++ b/projects/plugins/jetpack/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/plugins/jetpack/tests/php.multisite.12.xml
+++ b/projects/plugins/jetpack/tests/php.multisite.12.xml
@@ -1,0 +1,1 @@
+php.multisite.11.xml

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-yoast-polyfills-v4
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -9,7 +9,7 @@
 		"automattic/jetpack-mu-wpcom": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "07d003eca1d34382eba0580f746e1e44",
+    "content-hash": "cb604d11abbeff7a486a2a15be7837c6",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "5c10fd1a50834e9d28af3136f79a35617b497dae"
+                "reference": "68b92cc77ac41309dbf2f7a16eecd4e0c9cb03a9"
             },
             "require": {
                 "php": ">=7.2"
@@ -20,7 +20,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "5faef0e6453cac07042d46af33d9a5318c353ca1"
+                "reference": "fee1504bb96380c418e439af5696ba75fbfc0d96"
             },
             "require": {
                 "php": ">=7.2"
@@ -76,7 +76,7 @@
                 "automattic/jetpack-logo": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -126,7 +126,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "110b0ff2aa88f9904c6260c3e399dbfdd7544fa6"
+                "reference": "89a768257b402fb6abeefe5b6c0855f946187fab"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -137,7 +137,7 @@
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -196,7 +196,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blaze",
-                "reference": "f897f4d450f20d7e0521ca0cdf08754fbef06265"
+                "reference": "119ac65520e11f909fb090015b98dcf686f9d157"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -212,7 +212,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -272,7 +272,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blocks",
-                "reference": "b5e222941b8a6bf36cd1623ab95e9ddd48440ca0"
+                "reference": "80622ccf1abbbbecd133ec46ef657250ab972968"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -283,7 +283,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -329,7 +329,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/calypsoify",
-                "reference": "b81974e2fb7239ad817e030f2de7152cccc34781"
+                "reference": "1e57eb50b5a1d78b81fd8e4241073d1f9ed56142"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -339,7 +339,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -395,7 +395,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/classic-theme-helper",
-                "reference": "d2a77001355ac061d45c33e7c882ff793f717e07"
+                "reference": "6a1666875f6fb10e5557f7b53963b91999e20863"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -404,7 +404,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -497,7 +497,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "16772cbb568bc8fc8550671a1bd12aa4705738dc"
+                "reference": "eb028c7425d0591689e2a0b3047c278d8ff2395e"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -507,7 +507,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -558,7 +558,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "8b6fb10f12a15323a4af26c97ed28e3cd98327bd"
+                "reference": "1d0e8466e6188a79ff302ba975d3c2ffc691090b"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -577,7 +577,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -645,7 +645,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "e6cbca1d3b01d10d771d2af899cd6ffb65090549"
+                "reference": "378a5d122aedfc25d3aa42ab913803c85a8c857b"
             },
             "require": {
                 "php": ">=7.2"
@@ -654,7 +654,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -700,7 +700,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "dedb91e962e445e3ea344493e298b31125d6c175"
+                "reference": "4f83bde798e393d208074fdb0d06ea43e286367f"
             },
             "require": {
                 "php": ">=7.2"
@@ -708,7 +708,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -754,7 +754,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/google-analytics",
-                "reference": "188adf1a5d64278d12a8af42b8ee0641dcb2cccb"
+                "reference": "28cb18c8c47204ca7b0217f7c4b02527a8fd873f"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
@@ -764,7 +764,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -820,7 +820,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/ip",
-                "reference": "ab83ce4e4fa0bcc7fa87600a8b60c7dab8bfe191"
+                "reference": "4c8f48266f1fe2551103c6293e2957e185f87a94"
             },
             "require": {
                 "php": ">=7.2"
@@ -829,7 +829,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -879,7 +879,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "e5ec23b1ab540b0eb208d2568e98a3395ad00e99"
+                "reference": "8f1cfb4b5b6881694f9be7376735501e5f37e19a"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -895,7 +895,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -955,7 +955,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/logo",
-                "reference": "f08fffc0458c5acac0686368b005e049435d5e35"
+                "reference": "ffa8535e2da982620164c7a251f0b2fbe46d3f16"
             },
             "require": {
                 "php": ">=7.2"
@@ -963,7 +963,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1009,7 +1009,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "2f0576b08251752f44d2e82f8b8263ba5bc746e3"
+                "reference": "b6a718f90cbd6e5cad4403d05955347b85a02bf1"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1030,7 +1030,7 @@
                 "automattic/patchwork-redefine-exit": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1092,7 +1092,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "2324a26120cdda4a43d16d40cfa3d61c1aec0486"
+                "reference": "095df0be4fcbc25febd3cc8a73f1d118acb374d3"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1116,7 +1116,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1176,7 +1176,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/password-checker",
-                "reference": "63e9b52f2c3a5b69c30115e21c02ecf7e4a23e00"
+                "reference": "33cc919e4b75e07ed12975588c42ae2ea723a9a4"
             },
             "require": {
                 "php": ">=7.2"
@@ -1185,7 +1185,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1232,7 +1232,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "6e826adc648851fe3e6d20dd6b9b20fdcc21e3fd"
+                "reference": "de5c26803c2b558b6f64279671e6bec5b81be474"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1243,7 +1243,7 @@
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1295,7 +1295,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "4738fce156b0b8008bdea47fb52d8c5d3d24e2ae"
+                "reference": "44d6ec93e4d3b3db6287bf82f316a294d7ef868d"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
@@ -1305,7 +1305,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1351,7 +1351,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/roles",
-                "reference": "0606b853fc28d9fbcc013187c626d0a8e2de84b6"
+                "reference": "f7098eb11833c5fddfff032427d8576039aa3521"
             },
             "require": {
                 "php": ">=7.2"
@@ -1360,7 +1360,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1406,7 +1406,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "17d370fe6ad03ba4efd6b26ba367dfc8951c1670"
+                "reference": "789c86192e313d719df96ba4fb9bb225a11e6aa1"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1418,7 +1418,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1473,7 +1473,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "d6c733cb5102f8189dcaa1d9b77e5b34403fa32e"
+                "reference": "ed890d948b0713fc8d7c1b2a00d37b8b556244a2"
             },
             "require": {
                 "automattic/jetpack-blaze": "@dev",
@@ -1489,7 +1489,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1542,7 +1542,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "fc91e61469f31cdab849571507a1aed68a14fafd"
+                "reference": "2af0799e498773ebeafed5e8e5c1a2b4d543a44a"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1555,7 +1555,7 @@
                 "automattic/jetpack-plans": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1607,7 +1607,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/subscribers-dashboard",
-                "reference": "bd34a6bb2a4f0e6c0badd9e9a3b3d15bac6922c5"
+                "reference": "68a2f8db8c8f9a683ef8627ffa8cab0c902b39f0"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1622,7 +1622,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1686,7 +1686,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "d69fff7e02a1bfe9045907867d7d59e4c1814de6"
+                "reference": "9846e5fd84a40e97d5b9a0a2b4821968469a87d8"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1703,7 +1703,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-waf": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1759,7 +1759,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "d5a89661caaa554d1da1c6450b62a46c61f802d7"
+                "reference": "23e79cec756fee0825405c764a6fa7415f1360a3"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1774,7 +1774,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "php-mock/php-mock-phpunit": "^2.10",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1906,7 +1906,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "06b85c8f44fdccebce0bb12823f2d3f1e87e037a"
+                "reference": "30dd97f47c89ca7ec88c3659ef92464965a8e5e8"
             },
             "require": {
                 "composer-runtime-api": "^2.2.0",
@@ -1917,7 +1917,7 @@
             "require-dev": {
                 "automattic/phpunit-select-config": "@dev",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/changelogger"
@@ -1990,7 +1990,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/phpunit-select-config",
-                "reference": "ee8b1e53bfd922accf326802e7c8b8d7b26bf54f"
+                "reference": "3f16352a5a43bdd583b78d895d092a1e1b74c397"
             },
             "require": {
                 "composer-runtime-api": "^2.2.2",
@@ -2000,7 +2000,7 @@
             "require-dev": {
                 "antecedent/patchwork": "^2.2",
                 "automattic/jetpack-changelogger": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/phpunit-select-config"
@@ -4498,21 +4498,21 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "3.1.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618"
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/9cf2ccd990eadfc4a1e390592d4731e590b2c618",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "phpunit/phpunit": "^6.4.4 || ^7.0 || ^8.0 || ^9.0 || ^11.0"
+                "php": ">=7.1",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -4557,7 +4557,7 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2025-02-09T18:36:24+00:00"
+            "time": "2025-02-09T18:58:54+00:00"
         }
     ],
     "aliases": [],

--- a/projects/plugins/mu-wpcom-plugin/phpunit.12.xml.dist
+++ b/projects/plugins/mu-wpcom-plugin/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/plugins/protect/changelog/update-yoast-polyfills-v4
+++ b/projects/plugins/protect/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/plugins/protect/composer.json
+++ b/projects/plugins/protect/composer.json
@@ -21,7 +21,7 @@
 		"automattic/jetpack-account-protection": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "033b342022c958cbb691844363c0f1b2",
+    "content-hash": "7e799d41df30b213d66f30574a7d80b6",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "5c10fd1a50834e9d28af3136f79a35617b497dae"
+                "reference": "68b92cc77ac41309dbf2f7a16eecd4e0c9cb03a9"
             },
             "require": {
                 "php": ">=7.2"
@@ -20,7 +20,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/account-protection",
-                "reference": "b0dc90cd2c96bd61af153cae661e6dbfad5e4b27"
+                "reference": "bd9ac71a7100a78720ce60a7a0812ffac8218bbb"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -79,7 +79,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -135,7 +135,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "5faef0e6453cac07042d46af33d9a5318c353ca1"
+                "reference": "fee1504bb96380c418e439af5696ba75fbfc0d96"
             },
             "require": {
                 "php": ">=7.2"
@@ -145,7 +145,7 @@
                 "automattic/jetpack-logo": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -195,7 +195,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "110b0ff2aa88f9904c6260c3e399dbfdd7544fa6"
+                "reference": "89a768257b402fb6abeefe5b6c0855f946187fab"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -206,7 +206,7 @@
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -265,7 +265,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "54d6c42f16aec2a60a4dc0133f0444fe1b164a33"
+                "reference": "68901f3b3a256085ebd939a3461ee833be10f86d"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -275,7 +275,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -334,7 +334,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup-helper-script-manager",
-                "reference": "ea3bfbf40b845b948ed696bd7053fb52d0397e35"
+                "reference": "a9dad7825f172da6214ca8278d38abed9d7fb33f"
             },
             "require": {
                 "php": ">=7.2"
@@ -343,7 +343,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -389,7 +389,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/boost-core",
-                "reference": "7e2d719bc4842331a0709458595f2c480a7aa6b0"
+                "reference": "e87cba91035b78cb3c3e1aaf414010f82f80787f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -398,7 +398,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -445,7 +445,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/boost-speed-score",
-                "reference": "5d0a1075da9e8da4c90e8c0e92b3c5faf5a0993d"
+                "reference": "30562e15109877d91d5f450d89bfbc3339bfaa4b"
             },
             "require": {
                 "automattic/jetpack-boost-core": "@dev",
@@ -455,7 +455,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -510,7 +510,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "16772cbb568bc8fc8550671a1bd12aa4705738dc"
+                "reference": "eb028c7425d0591689e2a0b3047c278d8ff2395e"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -520,7 +520,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -645,7 +645,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "8b6fb10f12a15323a4af26c97ed28e3cd98327bd"
+                "reference": "1d0e8466e6188a79ff302ba975d3c2ffc691090b"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -664,7 +664,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -732,7 +732,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "e6cbca1d3b01d10d771d2af899cd6ffb65090549"
+                "reference": "378a5d122aedfc25d3aa42ab913803c85a8c857b"
             },
             "require": {
                 "php": ">=7.2"
@@ -741,7 +741,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -787,7 +787,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "dedb91e962e445e3ea344493e298b31125d6c175"
+                "reference": "4f83bde798e393d208074fdb0d06ea43e286367f"
             },
             "require": {
                 "php": ">=7.2"
@@ -795,7 +795,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -841,7 +841,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/explat",
-                "reference": "318352a036de9c75b76b7383509929d98cac8425"
+                "reference": "05a6b81d43a57e333f62154fbef5e1aa9f0dfae5"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -850,7 +850,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -917,7 +917,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/ip",
-                "reference": "ab83ce4e4fa0bcc7fa87600a8b60c7dab8bfe191"
+                "reference": "4c8f48266f1fe2551103c6293e2957e185f87a94"
             },
             "require": {
                 "php": ">=7.2"
@@ -926,7 +926,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -976,7 +976,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "e5ec23b1ab540b0eb208d2568e98a3395ad00e99"
+                "reference": "8f1cfb4b5b6881694f9be7376735501e5f37e19a"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -992,7 +992,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1052,7 +1052,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/licensing",
-                "reference": "80b7f7af100212cf2f2cc07cd2201c8ed9207842"
+                "reference": "3d3ab5dd82baa76599a9899f4dfef6bddc1dac5d"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1062,7 +1062,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1109,7 +1109,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/logo",
-                "reference": "f08fffc0458c5acac0686368b005e049435d5e35"
+                "reference": "ffa8535e2da982620164c7a251f0b2fbe46d3f16"
             },
             "require": {
                 "php": ">=7.2"
@@ -1117,7 +1117,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1163,7 +1163,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8bc8bd1b22cc42ac9915f23da56d8b6605465b0b"
+                "reference": "e8cd97216467ec43a290c3e8c020ccafa68f5018"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1188,7 +1188,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-videopress": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1262,7 +1262,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/password-checker",
-                "reference": "63e9b52f2c3a5b69c30115e21c02ecf7e4a23e00"
+                "reference": "33cc919e4b75e07ed12975588c42ae2ea723a9a4"
             },
             "require": {
                 "php": ">=7.2"
@@ -1271,7 +1271,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1318,7 +1318,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "6e826adc648851fe3e6d20dd6b9b20fdcc21e3fd"
+                "reference": "de5c26803c2b558b6f64279671e6bec5b81be474"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1329,7 +1329,7 @@
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1381,7 +1381,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plugins-installer",
-                "reference": "a937c79953c77d994a88e7722683a4d1bbe75968"
+                "reference": "c26351d6a169c26719a964ef89c1cc986b5fbbfe"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1391,7 +1391,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1438,7 +1438,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-models",
-                "reference": "9aa24e036a4736f9bff3ced06d144323e3d4ccd3"
+                "reference": "b8e862ee1ac0301a12afa22b03c5503159aab2fa"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -1448,7 +1448,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1504,7 +1504,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-status",
-                "reference": "e229b1ae776d046d10281475b3a89cefa464253a"
+                "reference": "887b85b6fe8085925ca4e80b82c9222e73f17dc3"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1518,7 +1518,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1574,7 +1574,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "4738fce156b0b8008bdea47fb52d8c5d3d24e2ae"
+                "reference": "44d6ec93e4d3b3db6287bf82f316a294d7ef868d"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
@@ -1584,7 +1584,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1630,7 +1630,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/roles",
-                "reference": "0606b853fc28d9fbcc013187c626d0a8e2de84b6"
+                "reference": "f7098eb11833c5fddfff032427d8576039aa3521"
             },
             "require": {
                 "php": ">=7.2"
@@ -1639,7 +1639,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1685,7 +1685,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "fc91e61469f31cdab849571507a1aed68a14fafd"
+                "reference": "2af0799e498773ebeafed5e8e5c1a2b4d543a44a"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1698,7 +1698,7 @@
                 "automattic/jetpack-plans": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1750,7 +1750,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "d69fff7e02a1bfe9045907867d7d59e4c1814de6"
+                "reference": "9846e5fd84a40e97d5b9a0a2b4821968469a87d8"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1767,7 +1767,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-waf": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1823,7 +1823,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/transport-helper",
-                "reference": "baf4f76d3f650fb956830c6938fb944010c7a0cd"
+                "reference": "65f72e29edfcde56b6322d5f966eccd7936b6585"
             },
             "require": {
                 "automattic/jetpack-backup-helper-script-manager": "@dev",
@@ -1834,7 +1834,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1893,7 +1893,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/waf",
-                "reference": "a857ebc1741e7649c6d129fcfd9426fe2d61858b"
+                "reference": "7225dc771c4f99a3c47e5e713a2d760cb5fadfa1"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1907,7 +1907,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -2015,7 +2015,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "06b85c8f44fdccebce0bb12823f2d3f1e87e037a"
+                "reference": "30dd97f47c89ca7ec88c3659ef92464965a8e5e8"
             },
             "require": {
                 "composer-runtime-api": "^2.2.0",
@@ -2026,7 +2026,7 @@
             "require-dev": {
                 "automattic/phpunit-select-config": "@dev",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/changelogger"
@@ -2099,7 +2099,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/phpunit-select-config",
-                "reference": "ee8b1e53bfd922accf326802e7c8b8d7b26bf54f"
+                "reference": "3f16352a5a43bdd583b78d895d092a1e1b74c397"
             },
             "require": {
                 "composer-runtime-api": "^2.2.2",
@@ -2109,7 +2109,7 @@
             "require-dev": {
                 "antecedent/patchwork": "^2.2",
                 "automattic/jetpack-changelogger": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/phpunit-select-config"
@@ -4607,21 +4607,21 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "3.1.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618"
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/9cf2ccd990eadfc4a1e390592d4731e590b2c618",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "phpunit/phpunit": "^6.4.4 || ^7.0 || ^8.0 || ^9.0 || ^11.0"
+                "php": ">=7.1",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -4666,7 +4666,7 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2025-02-09T18:36:24+00:00"
+            "time": "2025-02-09T18:58:54+00:00"
         }
     ],
     "aliases": [],

--- a/projects/plugins/protect/phpunit.12.xml.dist
+++ b/projects/plugins/protect/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/plugins/search/changelog/update-yoast-polyfills-v4
+++ b/projects/plugins/search/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -17,7 +17,7 @@
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev",
-		"yoast/phpunit-polyfills": "^3.0.0"
+		"yoast/phpunit-polyfills": "^4.0.0"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b3fd420bdf2f222a460d6da601febd9",
+    "content-hash": "bfb790e6ddd2d795d6f26bb73100fe38",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "5c10fd1a50834e9d28af3136f79a35617b497dae"
+                "reference": "68b92cc77ac41309dbf2f7a16eecd4e0c9cb03a9"
             },
             "require": {
                 "php": ">=7.2"
@@ -20,7 +20,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "5faef0e6453cac07042d46af33d9a5318c353ca1"
+                "reference": "fee1504bb96380c418e439af5696ba75fbfc0d96"
             },
             "require": {
                 "php": ">=7.2"
@@ -76,7 +76,7 @@
                 "automattic/jetpack-logo": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -126,7 +126,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "110b0ff2aa88f9904c6260c3e399dbfdd7544fa6"
+                "reference": "89a768257b402fb6abeefe5b6c0855f946187fab"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -137,7 +137,7 @@
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -196,7 +196,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "54d6c42f16aec2a60a4dc0133f0444fe1b164a33"
+                "reference": "68901f3b3a256085ebd939a3461ee833be10f86d"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -206,7 +206,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -265,7 +265,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/boost-core",
-                "reference": "7e2d719bc4842331a0709458595f2c480a7aa6b0"
+                "reference": "e87cba91035b78cb3c3e1aaf414010f82f80787f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -274,7 +274,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -321,7 +321,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/boost-speed-score",
-                "reference": "5d0a1075da9e8da4c90e8c0e92b3c5faf5a0993d"
+                "reference": "30562e15109877d91d5f450d89bfbc3339bfaa4b"
             },
             "require": {
                 "automattic/jetpack-boost-core": "@dev",
@@ -331,7 +331,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -386,7 +386,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "16772cbb568bc8fc8550671a1bd12aa4705738dc"
+                "reference": "eb028c7425d0591689e2a0b3047c278d8ff2395e"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -396,7 +396,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -521,7 +521,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "8b6fb10f12a15323a4af26c97ed28e3cd98327bd"
+                "reference": "1d0e8466e6188a79ff302ba975d3c2ffc691090b"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -540,7 +540,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "e6cbca1d3b01d10d771d2af899cd6ffb65090549"
+                "reference": "378a5d122aedfc25d3aa42ab913803c85a8c857b"
             },
             "require": {
                 "php": ">=7.2"
@@ -617,7 +617,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -663,7 +663,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "dedb91e962e445e3ea344493e298b31125d6c175"
+                "reference": "4f83bde798e393d208074fdb0d06ea43e286367f"
             },
             "require": {
                 "php": ">=7.2"
@@ -671,7 +671,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -717,7 +717,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/explat",
-                "reference": "318352a036de9c75b76b7383509929d98cac8425"
+                "reference": "05a6b81d43a57e333f62154fbef5e1aa9f0dfae5"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -726,7 +726,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -793,7 +793,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/ip",
-                "reference": "ab83ce4e4fa0bcc7fa87600a8b60c7dab8bfe191"
+                "reference": "4c8f48266f1fe2551103c6293e2957e185f87a94"
             },
             "require": {
                 "php": ">=7.2"
@@ -802,7 +802,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -852,7 +852,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "e5ec23b1ab540b0eb208d2568e98a3395ad00e99"
+                "reference": "8f1cfb4b5b6881694f9be7376735501e5f37e19a"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -868,7 +868,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -928,7 +928,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/licensing",
-                "reference": "80b7f7af100212cf2f2cc07cd2201c8ed9207842"
+                "reference": "3d3ab5dd82baa76599a9899f4dfef6bddc1dac5d"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -938,7 +938,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -985,7 +985,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/logo",
-                "reference": "f08fffc0458c5acac0686368b005e049435d5e35"
+                "reference": "ffa8535e2da982620164c7a251f0b2fbe46d3f16"
             },
             "require": {
                 "php": ">=7.2"
@@ -993,7 +993,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1039,7 +1039,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8bc8bd1b22cc42ac9915f23da56d8b6605465b0b"
+                "reference": "e8cd97216467ec43a290c3e8c020ccafa68f5018"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1064,7 +1064,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-videopress": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1138,7 +1138,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/password-checker",
-                "reference": "63e9b52f2c3a5b69c30115e21c02ecf7e4a23e00"
+                "reference": "33cc919e4b75e07ed12975588c42ae2ea723a9a4"
             },
             "require": {
                 "php": ">=7.2"
@@ -1147,7 +1147,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1194,7 +1194,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "6e826adc648851fe3e6d20dd6b9b20fdcc21e3fd"
+                "reference": "de5c26803c2b558b6f64279671e6bec5b81be474"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1205,7 +1205,7 @@
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1257,7 +1257,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plugins-installer",
-                "reference": "a937c79953c77d994a88e7722683a4d1bbe75968"
+                "reference": "c26351d6a169c26719a964ef89c1cc986b5fbbfe"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1267,7 +1267,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1314,7 +1314,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-models",
-                "reference": "9aa24e036a4736f9bff3ced06d144323e3d4ccd3"
+                "reference": "b8e862ee1ac0301a12afa22b03c5503159aab2fa"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -1324,7 +1324,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1380,7 +1380,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-status",
-                "reference": "e229b1ae776d046d10281475b3a89cefa464253a"
+                "reference": "887b85b6fe8085925ca4e80b82c9222e73f17dc3"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1394,7 +1394,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1450,7 +1450,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "4738fce156b0b8008bdea47fb52d8c5d3d24e2ae"
+                "reference": "44d6ec93e4d3b3db6287bf82f316a294d7ef868d"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
@@ -1460,7 +1460,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1506,7 +1506,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/roles",
-                "reference": "0606b853fc28d9fbcc013187c626d0a8e2de84b6"
+                "reference": "f7098eb11833c5fddfff032427d8576039aa3521"
             },
             "require": {
                 "php": ">=7.2"
@@ -1515,7 +1515,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1561,7 +1561,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "c1adc06d17a159c2945147f56d633453cf34e87a"
+                "reference": "588f60f4e1ee07cb44ecbcc40a29b05c2773a1a0"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1577,7 +1577,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1644,7 +1644,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "17d370fe6ad03ba4efd6b26ba367dfc8951c1670"
+                "reference": "789c86192e313d719df96ba4fb9bb225a11e6aa1"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1656,7 +1656,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1711,7 +1711,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "fc91e61469f31cdab849571507a1aed68a14fafd"
+                "reference": "2af0799e498773ebeafed5e8e5c1a2b4d543a44a"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1724,7 +1724,7 @@
                 "automattic/jetpack-plans": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1776,7 +1776,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "d69fff7e02a1bfe9045907867d7d59e4c1814de6"
+                "reference": "9846e5fd84a40e97d5b9a0a2b4821968469a87d8"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1793,7 +1793,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-waf": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1851,7 +1851,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "06b85c8f44fdccebce0bb12823f2d3f1e87e037a"
+                "reference": "30dd97f47c89ca7ec88c3659ef92464965a8e5e8"
             },
             "require": {
                 "composer-runtime-api": "^2.2.0",
@@ -1862,7 +1862,7 @@
             "require-dev": {
                 "automattic/phpunit-select-config": "@dev",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/changelogger"
@@ -1935,7 +1935,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/phpunit-select-config",
-                "reference": "ee8b1e53bfd922accf326802e7c8b8d7b26bf54f"
+                "reference": "3f16352a5a43bdd583b78d895d092a1e1b74c397"
             },
             "require": {
                 "composer-runtime-api": "^2.2.2",
@@ -1945,7 +1945,7 @@
             "require-dev": {
                 "antecedent/patchwork": "^2.2",
                 "automattic/jetpack-changelogger": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/phpunit-select-config"
@@ -4443,21 +4443,21 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "3.1.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618"
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/9cf2ccd990eadfc4a1e390592d4731e590b2c618",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "phpunit/phpunit": "^6.4.4 || ^7.0 || ^8.0 || ^9.0 || ^11.0"
+                "php": ">=7.1",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -4502,7 +4502,7 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2025-02-09T18:36:24+00:00"
+            "time": "2025-02-09T18:58:54+00:00"
         }
     ],
     "aliases": [],

--- a/projects/plugins/search/phpunit.12.xml.dist
+++ b/projects/plugins/search/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/plugins/social/changelog/update-yoast-polyfills-v4
+++ b/projects/plugins/social/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -20,7 +20,7 @@
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"brain/monkey": "^2.6.2",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
 		"Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
 		"This file is @generated automatically"
 	],
-	"content-hash": "40726e7daa2db526b39498693daa1e9e",
+	"content-hash": "fa9d1adbc7890705555dc2d7261fef63",
 	"packages": [
 		{
 			"name": "automattic/jetpack-a8c-mc-stats",
@@ -12,7 +12,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/a8c-mc-stats",
-				"reference": "5c10fd1a50834e9d28af3136f79a35617b497dae"
+				"reference": "68b92cc77ac41309dbf2f7a16eecd4e0c9cb03a9"
 			},
 			"require": {
 				"php": ">=7.2"
@@ -20,7 +20,7 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -66,7 +66,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/admin-ui",
-				"reference": "5faef0e6453cac07042d46af33d9a5318c353ca1"
+				"reference": "fee1504bb96380c418e439af5696ba75fbfc0d96"
 			},
 			"require": {
 				"php": ">=7.2"
@@ -76,7 +76,7 @@
 				"automattic/jetpack-logo": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -126,7 +126,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/assets",
-				"reference": "110b0ff2aa88f9904c6260c3e399dbfdd7544fa6"
+				"reference": "89a768257b402fb6abeefe5b6c0855f946187fab"
 			},
 			"require": {
 				"automattic/jetpack-constants": "@dev",
@@ -137,7 +137,7 @@
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "^2.6.2",
 				"wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -196,7 +196,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/autoloader",
-				"reference": "54d6c42f16aec2a60a4dc0133f0444fe1b164a33"
+				"reference": "68901f3b3a256085ebd939a3461ee833be10f86d"
 			},
 			"require": {
 				"composer-plugin-api": "^2.2",
@@ -206,7 +206,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"composer/composer": "^2.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"type": "composer-plugin",
 			"extra": {
@@ -265,7 +265,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/boost-core",
-				"reference": "7e2d719bc4842331a0709458595f2c480a7aa6b0"
+				"reference": "e87cba91035b78cb3c3e1aaf414010f82f80787f"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -274,7 +274,7 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -321,7 +321,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/boost-speed-score",
-				"reference": "5d0a1075da9e8da4c90e8c0e92b3c5faf5a0993d"
+				"reference": "30562e15109877d91d5f450d89bfbc3339bfaa4b"
 			},
 			"require": {
 				"automattic/jetpack-boost-core": "@dev",
@@ -331,7 +331,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "^2.6",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -386,7 +386,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/composer-plugin",
-				"reference": "16772cbb568bc8fc8550671a1bd12aa4705738dc"
+				"reference": "eb028c7425d0591689e2a0b3047c278d8ff2395e"
 			},
 			"require": {
 				"composer-plugin-api": "^2.2",
@@ -396,7 +396,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"composer/composer": "^2.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"type": "composer-plugin",
 			"extra": {
@@ -521,7 +521,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/connection",
-				"reference": "8b6fb10f12a15323a4af26c97ed28e3cd98327bd"
+				"reference": "1d0e8466e6188a79ff302ba975d3c2ffc691090b"
 			},
 			"require": {
 				"automattic/jetpack-a8c-mc-stats": "@dev",
@@ -540,7 +540,7 @@
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "^2.6.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -608,7 +608,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/constants",
-				"reference": "e6cbca1d3b01d10d771d2af899cd6ffb65090549"
+				"reference": "378a5d122aedfc25d3aa42ab913803c85a8c857b"
 			},
 			"require": {
 				"php": ">=7.2"
@@ -617,7 +617,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "^2.6.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -663,7 +663,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/device-detection",
-				"reference": "dedb91e962e445e3ea344493e298b31125d6c175"
+				"reference": "4f83bde798e393d208074fdb0d06ea43e286367f"
 			},
 			"require": {
 				"php": ">=7.2"
@@ -671,7 +671,7 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -717,7 +717,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/explat",
-				"reference": "318352a036de9c75b76b7383509929d98cac8425"
+				"reference": "05a6b81d43a57e333f62154fbef5e1aa9f0dfae5"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -726,7 +726,7 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -793,7 +793,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/ip",
-				"reference": "ab83ce4e4fa0bcc7fa87600a8b60c7dab8bfe191"
+				"reference": "4c8f48266f1fe2551103c6293e2957e185f87a94"
 			},
 			"require": {
 				"php": ">=7.2"
@@ -802,7 +802,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "^2.6.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -852,7 +852,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/jitm",
-				"reference": "e5ec23b1ab540b0eb208d2568e98a3395ad00e99"
+				"reference": "8f1cfb4b5b6881694f9be7376735501e5f37e19a"
 			},
 			"require": {
 				"automattic/jetpack-a8c-mc-stats": "@dev",
@@ -868,7 +868,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "^2.6.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -928,7 +928,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/licensing",
-				"reference": "80b7f7af100212cf2f2cc07cd2201c8ed9207842"
+				"reference": "3d3ab5dd82baa76599a9899f4dfef6bddc1dac5d"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -938,7 +938,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -985,7 +985,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/logo",
-				"reference": "f08fffc0458c5acac0686368b005e049435d5e35"
+				"reference": "ffa8535e2da982620164c7a251f0b2fbe46d3f16"
 			},
 			"require": {
 				"php": ">=7.2"
@@ -993,7 +993,7 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1039,7 +1039,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "8bc8bd1b22cc42ac9915f23da56d8b6605465b0b"
+				"reference": "e8cd97216467ec43a290c3e8c020ccafa68f5018"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1064,7 +1064,7 @@
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/jetpack-videopress": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1138,7 +1138,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/password-checker",
-				"reference": "63e9b52f2c3a5b69c30115e21c02ecf7e4a23e00"
+				"reference": "33cc919e4b75e07ed12975588c42ae2ea723a9a4"
 			},
 			"require": {
 				"php": ">=7.2"
@@ -1147,7 +1147,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1194,7 +1194,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/plans",
-				"reference": "6e826adc648851fe3e6d20dd6b9b20fdcc21e3fd"
+				"reference": "de5c26803c2b558b6f64279671e6bec5b81be474"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -1205,7 +1205,7 @@
 				"automattic/jetpack-status": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1257,7 +1257,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/plugins-installer",
-				"reference": "a937c79953c77d994a88e7722683a4d1bbe75968"
+				"reference": "c26351d6a169c26719a964ef89c1cc986b5fbbfe"
 			},
 			"require": {
 				"automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1267,7 +1267,7 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1314,7 +1314,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/post-list",
-				"reference": "3dcd6395d775f858a18c4c61a564bc5c1c35e25d"
+				"reference": "62d4a8fbfe514aff5ce54806df3c7cc1d58f7e9b"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -1324,7 +1324,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1380,7 +1380,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/protect-models",
-				"reference": "9aa24e036a4736f9bff3ced06d144323e3d4ccd3"
+				"reference": "b8e862ee1ac0301a12afa22b03c5503159aab2fa"
 			},
 			"require": {
 				"automattic/jetpack-redirect": "@dev",
@@ -1390,7 +1390,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1446,7 +1446,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/protect-status",
-				"reference": "e229b1ae776d046d10281475b3a89cefa464253a"
+				"reference": "887b85b6fe8085925ca4e80b82c9222e73f17dc3"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -1460,7 +1460,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1516,7 +1516,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/publicize",
-				"reference": "9f0861bd29047828afc6c0779078cb26edf524c8"
+				"reference": "5a72982cecf26d1dd6f44ae252f572de4e22012f"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1533,7 +1533,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1594,7 +1594,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/redirect",
-				"reference": "4738fce156b0b8008bdea47fb52d8c5d3d24e2ae"
+				"reference": "44d6ec93e4d3b3db6287bf82f316a294d7ef868d"
 			},
 			"require": {
 				"automattic/jetpack-status": "@dev",
@@ -1604,7 +1604,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "^2.6.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1650,7 +1650,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/roles",
-				"reference": "0606b853fc28d9fbcc013187c626d0a8e2de84b6"
+				"reference": "f7098eb11833c5fddfff032427d8576039aa3521"
 			},
 			"require": {
 				"php": ">=7.2"
@@ -1659,7 +1659,7 @@
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "^2.6.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1705,7 +1705,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/status",
-				"reference": "fc91e61469f31cdab849571507a1aed68a14fafd"
+				"reference": "2af0799e498773ebeafed5e8e5c1a2b4d543a44a"
 			},
 			"require": {
 				"automattic/jetpack-constants": "@dev",
@@ -1718,7 +1718,7 @@
 				"automattic/jetpack-plans": "@dev",
 				"automattic/phpunit-select-config": "@dev",
 				"brain/monkey": "^2.6.2",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1770,7 +1770,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/sync",
-				"reference": "d69fff7e02a1bfe9045907867d7d59e4c1814de6"
+				"reference": "9846e5fd84a40e97d5b9a0a2b4821968469a87d8"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -1787,7 +1787,7 @@
 				"automattic/jetpack-test-environment": "@dev",
 				"automattic/jetpack-waf": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1893,7 +1893,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/changelogger",
-				"reference": "06b85c8f44fdccebce0bb12823f2d3f1e87e037a"
+				"reference": "30dd97f47c89ca7ec88c3659ef92464965a8e5e8"
 			},
 			"require": {
 				"composer-runtime-api": "^2.2.0",
@@ -1904,7 +1904,7 @@
 			"require-dev": {
 				"automattic/phpunit-select-config": "@dev",
 				"wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"bin": [
 				"bin/changelogger"
@@ -1977,7 +1977,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/test-environment",
-				"reference": "acf2c63d65d9aab5bfff95da40ee011acc66fa04"
+				"reference": "4ebfacd0d0ff37aed8d38faaad374a2b39042154"
 			},
 			"require": {
 				"php": ">=7.2"
@@ -1985,7 +1985,7 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/phpunit-select-config": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"suggest": {
 				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -2030,7 +2030,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/phpunit-select-config",
-				"reference": "ee8b1e53bfd922accf326802e7c8b8d7b26bf54f"
+				"reference": "3f16352a5a43bdd583b78d895d092a1e1b74c397"
 			},
 			"require": {
 				"composer-runtime-api": "^2.2.2",
@@ -2040,7 +2040,7 @@
 			"require-dev": {
 				"antecedent/patchwork": "^2.2",
 				"automattic/jetpack-changelogger": "@dev",
-				"yoast/phpunit-polyfills": "^3.0.0"
+				"yoast/phpunit-polyfills": "^4.0.0"
 			},
 			"bin": [
 				"bin/phpunit-select-config"
@@ -4742,21 +4742,21 @@
 		},
 		{
 			"name": "yoast/phpunit-polyfills",
-			"version": "3.1.2",
+			"version": "4.0.0",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-				"reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618"
+				"reference": "134921bfca9b02d8f374c48381451da1d98402f9"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/9cf2ccd990eadfc4a1e390592d4731e590b2c618",
-				"reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618",
+				"url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+				"reference": "134921bfca9b02d8f374c48381451da1d98402f9",
 				"shasum": ""
 			},
 			"require": {
-				"php": ">=7.0",
-				"phpunit/phpunit": "^6.4.4 || ^7.0 || ^8.0 || ^9.0 || ^11.0"
+				"php": ">=7.1",
+				"phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
 			},
 			"require-dev": {
 				"php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -4801,7 +4801,7 @@
 				"security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
 				"source": "https://github.com/Yoast/PHPUnit-Polyfills"
 			},
-			"time": "2025-02-09T18:36:24+00:00"
+			"time": "2025-02-09T18:58:54+00:00"
 		}
 	],
 	"aliases": [],

--- a/projects/plugins/social/phpunit.12.xml.dist
+++ b/projects/plugins/social/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/plugins/starter-plugin/changelog/update-yoast-polyfills-v4
+++ b/projects/plugins/starter-plugin/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/plugins/starter-plugin/composer.json
+++ b/projects/plugins/starter-plugin/composer.json
@@ -15,7 +15,7 @@
 		"automattic/jetpack-status": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/phpunit-select-config": "@dev"

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "135c27930d4f73d4b29768de85cd4fee",
+    "content-hash": "682976550e53f0e359e11f5d439d560b",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "5c10fd1a50834e9d28af3136f79a35617b497dae"
+                "reference": "68b92cc77ac41309dbf2f7a16eecd4e0c9cb03a9"
             },
             "require": {
                 "php": ">=7.2"
@@ -20,7 +20,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "5faef0e6453cac07042d46af33d9a5318c353ca1"
+                "reference": "fee1504bb96380c418e439af5696ba75fbfc0d96"
             },
             "require": {
                 "php": ">=7.2"
@@ -76,7 +76,7 @@
                 "automattic/jetpack-logo": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -126,7 +126,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "110b0ff2aa88f9904c6260c3e399dbfdd7544fa6"
+                "reference": "89a768257b402fb6abeefe5b6c0855f946187fab"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -137,7 +137,7 @@
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -196,7 +196,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "54d6c42f16aec2a60a4dc0133f0444fe1b164a33"
+                "reference": "68901f3b3a256085ebd939a3461ee833be10f86d"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -206,7 +206,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -265,7 +265,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/boost-core",
-                "reference": "7e2d719bc4842331a0709458595f2c480a7aa6b0"
+                "reference": "e87cba91035b78cb3c3e1aaf414010f82f80787f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -274,7 +274,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -321,7 +321,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/boost-speed-score",
-                "reference": "5d0a1075da9e8da4c90e8c0e92b3c5faf5a0993d"
+                "reference": "30562e15109877d91d5f450d89bfbc3339bfaa4b"
             },
             "require": {
                 "automattic/jetpack-boost-core": "@dev",
@@ -331,7 +331,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -386,7 +386,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "16772cbb568bc8fc8550671a1bd12aa4705738dc"
+                "reference": "eb028c7425d0591689e2a0b3047c278d8ff2395e"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -396,7 +396,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -521,7 +521,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "8b6fb10f12a15323a4af26c97ed28e3cd98327bd"
+                "reference": "1d0e8466e6188a79ff302ba975d3c2ffc691090b"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -540,7 +540,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "e6cbca1d3b01d10d771d2af899cd6ffb65090549"
+                "reference": "378a5d122aedfc25d3aa42ab913803c85a8c857b"
             },
             "require": {
                 "php": ">=7.2"
@@ -617,7 +617,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -663,7 +663,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "dedb91e962e445e3ea344493e298b31125d6c175"
+                "reference": "4f83bde798e393d208074fdb0d06ea43e286367f"
             },
             "require": {
                 "php": ">=7.2"
@@ -671,7 +671,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -717,7 +717,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/explat",
-                "reference": "318352a036de9c75b76b7383509929d98cac8425"
+                "reference": "05a6b81d43a57e333f62154fbef5e1aa9f0dfae5"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -726,7 +726,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -793,7 +793,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/ip",
-                "reference": "ab83ce4e4fa0bcc7fa87600a8b60c7dab8bfe191"
+                "reference": "4c8f48266f1fe2551103c6293e2957e185f87a94"
             },
             "require": {
                 "php": ">=7.2"
@@ -802,7 +802,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -852,7 +852,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "e5ec23b1ab540b0eb208d2568e98a3395ad00e99"
+                "reference": "8f1cfb4b5b6881694f9be7376735501e5f37e19a"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -868,7 +868,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -928,7 +928,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/licensing",
-                "reference": "80b7f7af100212cf2f2cc07cd2201c8ed9207842"
+                "reference": "3d3ab5dd82baa76599a9899f4dfef6bddc1dac5d"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -938,7 +938,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -985,7 +985,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/logo",
-                "reference": "f08fffc0458c5acac0686368b005e049435d5e35"
+                "reference": "ffa8535e2da982620164c7a251f0b2fbe46d3f16"
             },
             "require": {
                 "php": ">=7.2"
@@ -993,7 +993,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1039,7 +1039,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8bc8bd1b22cc42ac9915f23da56d8b6605465b0b"
+                "reference": "e8cd97216467ec43a290c3e8c020ccafa68f5018"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1064,7 +1064,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-videopress": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1138,7 +1138,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/password-checker",
-                "reference": "63e9b52f2c3a5b69c30115e21c02ecf7e4a23e00"
+                "reference": "33cc919e4b75e07ed12975588c42ae2ea723a9a4"
             },
             "require": {
                 "php": ">=7.2"
@@ -1147,7 +1147,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1194,7 +1194,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "6e826adc648851fe3e6d20dd6b9b20fdcc21e3fd"
+                "reference": "de5c26803c2b558b6f64279671e6bec5b81be474"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1205,7 +1205,7 @@
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1257,7 +1257,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plugins-installer",
-                "reference": "a937c79953c77d994a88e7722683a4d1bbe75968"
+                "reference": "c26351d6a169c26719a964ef89c1cc986b5fbbfe"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1267,7 +1267,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1314,7 +1314,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-models",
-                "reference": "9aa24e036a4736f9bff3ced06d144323e3d4ccd3"
+                "reference": "b8e862ee1ac0301a12afa22b03c5503159aab2fa"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -1324,7 +1324,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1380,7 +1380,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-status",
-                "reference": "e229b1ae776d046d10281475b3a89cefa464253a"
+                "reference": "887b85b6fe8085925ca4e80b82c9222e73f17dc3"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1394,7 +1394,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1450,7 +1450,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "4738fce156b0b8008bdea47fb52d8c5d3d24e2ae"
+                "reference": "44d6ec93e4d3b3db6287bf82f316a294d7ef868d"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
@@ -1460,7 +1460,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1506,7 +1506,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/roles",
-                "reference": "0606b853fc28d9fbcc013187c626d0a8e2de84b6"
+                "reference": "f7098eb11833c5fddfff032427d8576039aa3521"
             },
             "require": {
                 "php": ">=7.2"
@@ -1515,7 +1515,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1561,7 +1561,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "fc91e61469f31cdab849571507a1aed68a14fafd"
+                "reference": "2af0799e498773ebeafed5e8e5c1a2b4d543a44a"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1574,7 +1574,7 @@
                 "automattic/jetpack-plans": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1626,7 +1626,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "d69fff7e02a1bfe9045907867d7d59e4c1814de6"
+                "reference": "9846e5fd84a40e97d5b9a0a2b4821968469a87d8"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1643,7 +1643,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-waf": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1701,7 +1701,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "06b85c8f44fdccebce0bb12823f2d3f1e87e037a"
+                "reference": "30dd97f47c89ca7ec88c3659ef92464965a8e5e8"
             },
             "require": {
                 "composer-runtime-api": "^2.2.0",
@@ -1712,7 +1712,7 @@
             "require-dev": {
                 "automattic/phpunit-select-config": "@dev",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/changelogger"
@@ -1785,7 +1785,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/test-environment",
-                "reference": "acf2c63d65d9aab5bfff95da40ee011acc66fa04"
+                "reference": "4ebfacd0d0ff37aed8d38faaad374a2b39042154"
             },
             "require": {
                 "php": ">=7.2"
@@ -1793,7 +1793,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1838,7 +1838,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/phpunit-select-config",
-                "reference": "ee8b1e53bfd922accf326802e7c8b8d7b26bf54f"
+                "reference": "3f16352a5a43bdd583b78d895d092a1e1b74c397"
             },
             "require": {
                 "composer-runtime-api": "^2.2.2",
@@ -1848,7 +1848,7 @@
             "require-dev": {
                 "antecedent/patchwork": "^2.2",
                 "automattic/jetpack-changelogger": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/phpunit-select-config"
@@ -4346,21 +4346,21 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "3.1.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618"
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/9cf2ccd990eadfc4a1e390592d4731e590b2c618",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "phpunit/phpunit": "^6.4.4 || ^7.0 || ^8.0 || ^9.0 || ^11.0"
+                "php": ">=7.1",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -4405,7 +4405,7 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2025-02-09T18:36:24+00:00"
+            "time": "2025-02-09T18:58:54+00:00"
         }
     ],
     "aliases": [],

--- a/projects/plugins/starter-plugin/phpunit.12.xml.dist
+++ b/projects/plugins/starter-plugin/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/plugins/super-cache/changelog/update-yoast-polyfills-v4
+++ b/projects/plugins/super-cache/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/plugins/super-cache/composer.json
+++ b/projects/plugins/super-cache/composer.json
@@ -7,7 +7,7 @@
 		"automattic/jetpack-device-detection": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/plugins/super-cache/composer.lock
+++ b/projects/plugins/super-cache/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7f9768f9b63c3f38fe5b0932bc3a905d",
+    "content-hash": "19e0f29c4de0f77715e0e92266e7be87",
     "packages": [
         {
             "name": "automattic/jetpack-device-detection",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "dedb91e962e445e3ea344493e298b31125d6c175"
+                "reference": "4f83bde798e393d208074fdb0d06ea43e286367f"
             },
             "require": {
                 "php": ">=7.2"
@@ -20,7 +20,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -68,7 +68,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "06b85c8f44fdccebce0bb12823f2d3f1e87e037a"
+                "reference": "30dd97f47c89ca7ec88c3659ef92464965a8e5e8"
             },
             "require": {
                 "composer-runtime-api": "^2.2.0",
@@ -79,7 +79,7 @@
             "require-dev": {
                 "automattic/phpunit-select-config": "@dev",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/changelogger"
@@ -152,7 +152,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/phpunit-select-config",
-                "reference": "ee8b1e53bfd922accf326802e7c8b8d7b26bf54f"
+                "reference": "3f16352a5a43bdd583b78d895d092a1e1b74c397"
             },
             "require": {
                 "composer-runtime-api": "^2.2.2",
@@ -162,7 +162,7 @@
             "require-dev": {
                 "antecedent/patchwork": "^2.2",
                 "automattic/jetpack-changelogger": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/phpunit-select-config"
@@ -2660,21 +2660,21 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "3.1.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618"
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/9cf2ccd990eadfc4a1e390592d4731e590b2c618",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "phpunit/phpunit": "^6.4.4 || ^7.0 || ^8.0 || ^9.0 || ^11.0"
+                "php": ">=7.1",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -2719,7 +2719,7 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2025-02-09T18:36:24+00:00"
+            "time": "2025-02-09T18:58:54+00:00"
         }
     ],
     "aliases": [],

--- a/projects/plugins/super-cache/phpunit.12.xml.dist
+++ b/projects/plugins/super-cache/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/plugins/vaultpress/changelog/update-yoast-polyfills-v4
+++ b/projects/plugins/vaultpress/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/plugins/vaultpress/composer.json
+++ b/projects/plugins/vaultpress/composer.json
@@ -12,7 +12,7 @@
 		"automattic/jetpack-autoloader": "@dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/plugins/vaultpress/composer.lock
+++ b/projects/plugins/vaultpress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4e1125c9ba75d6a53fb64198cac49bca",
+    "content-hash": "978cef4d06320a5da125d01255a16d09",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "54d6c42f16aec2a60a4dc0133f0444fe1b164a33"
+                "reference": "68901f3b3a256085ebd939a3461ee833be10f86d"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -22,7 +22,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -81,7 +81,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/logo",
-                "reference": "f08fffc0458c5acac0686368b005e049435d5e35"
+                "reference": "ffa8535e2da982620164c7a251f0b2fbe46d3f16"
             },
             "require": {
                 "php": ">=7.2"
@@ -89,7 +89,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -137,7 +137,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "06b85c8f44fdccebce0bb12823f2d3f1e87e037a"
+                "reference": "30dd97f47c89ca7ec88c3659ef92464965a8e5e8"
             },
             "require": {
                 "composer-runtime-api": "^2.2.0",
@@ -148,7 +148,7 @@
             "require-dev": {
                 "automattic/phpunit-select-config": "@dev",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/changelogger"
@@ -221,7 +221,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/phpunit-select-config",
-                "reference": "ee8b1e53bfd922accf326802e7c8b8d7b26bf54f"
+                "reference": "3f16352a5a43bdd583b78d895d092a1e1b74c397"
             },
             "require": {
                 "composer-runtime-api": "^2.2.2",
@@ -231,7 +231,7 @@
             "require-dev": {
                 "antecedent/patchwork": "^2.2",
                 "automattic/jetpack-changelogger": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/phpunit-select-config"
@@ -2729,21 +2729,21 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "3.1.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618"
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/9cf2ccd990eadfc4a1e390592d4731e590b2c618",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "phpunit/phpunit": "^6.4.4 || ^7.0 || ^8.0 || ^9.0 || ^11.0"
+                "php": ">=7.1",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -2788,7 +2788,7 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2025-02-09T18:36:24+00:00"
+            "time": "2025-02-09T18:58:54+00:00"
         }
     ],
     "aliases": [],

--- a/projects/plugins/vaultpress/phpunit.12.xml.dist
+++ b/projects/plugins/vaultpress/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/plugins/videopress/changelog/update-yoast-polyfills-v4
+++ b/projects/plugins/videopress/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "5c10fd1a50834e9d28af3136f79a35617b497dae"
+                "reference": "68b92cc77ac41309dbf2f7a16eecd4e0c9cb03a9"
             },
             "require": {
                 "php": ">=7.2"
@@ -20,7 +20,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "5faef0e6453cac07042d46af33d9a5318c353ca1"
+                "reference": "fee1504bb96380c418e439af5696ba75fbfc0d96"
             },
             "require": {
                 "php": ">=7.2"
@@ -76,7 +76,7 @@
                 "automattic/jetpack-logo": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -126,7 +126,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "110b0ff2aa88f9904c6260c3e399dbfdd7544fa6"
+                "reference": "89a768257b402fb6abeefe5b6c0855f946187fab"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -137,7 +137,7 @@
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -196,7 +196,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "54d6c42f16aec2a60a4dc0133f0444fe1b164a33"
+                "reference": "68901f3b3a256085ebd939a3461ee833be10f86d"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -206,7 +206,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -265,7 +265,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/boost-core",
-                "reference": "7e2d719bc4842331a0709458595f2c480a7aa6b0"
+                "reference": "e87cba91035b78cb3c3e1aaf414010f82f80787f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -274,7 +274,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -321,7 +321,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/boost-speed-score",
-                "reference": "5d0a1075da9e8da4c90e8c0e92b3c5faf5a0993d"
+                "reference": "30562e15109877d91d5f450d89bfbc3339bfaa4b"
             },
             "require": {
                 "automattic/jetpack-boost-core": "@dev",
@@ -331,7 +331,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -386,7 +386,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "16772cbb568bc8fc8550671a1bd12aa4705738dc"
+                "reference": "eb028c7425d0591689e2a0b3047c278d8ff2395e"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -396,7 +396,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -521,7 +521,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "8b6fb10f12a15323a4af26c97ed28e3cd98327bd"
+                "reference": "1d0e8466e6188a79ff302ba975d3c2ffc691090b"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -540,7 +540,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "e6cbca1d3b01d10d771d2af899cd6ffb65090549"
+                "reference": "378a5d122aedfc25d3aa42ab913803c85a8c857b"
             },
             "require": {
                 "php": ">=7.2"
@@ -617,7 +617,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -663,7 +663,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "dedb91e962e445e3ea344493e298b31125d6c175"
+                "reference": "4f83bde798e393d208074fdb0d06ea43e286367f"
             },
             "require": {
                 "php": ">=7.2"
@@ -671,7 +671,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -717,7 +717,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/explat",
-                "reference": "318352a036de9c75b76b7383509929d98cac8425"
+                "reference": "05a6b81d43a57e333f62154fbef5e1aa9f0dfae5"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -726,7 +726,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -793,7 +793,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/ip",
-                "reference": "ab83ce4e4fa0bcc7fa87600a8b60c7dab8bfe191"
+                "reference": "4c8f48266f1fe2551103c6293e2957e185f87a94"
             },
             "require": {
                 "php": ">=7.2"
@@ -802,7 +802,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -852,7 +852,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "e5ec23b1ab540b0eb208d2568e98a3395ad00e99"
+                "reference": "8f1cfb4b5b6881694f9be7376735501e5f37e19a"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -868,7 +868,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -928,7 +928,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/licensing",
-                "reference": "80b7f7af100212cf2f2cc07cd2201c8ed9207842"
+                "reference": "3d3ab5dd82baa76599a9899f4dfef6bddc1dac5d"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -938,7 +938,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -985,7 +985,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/logo",
-                "reference": "f08fffc0458c5acac0686368b005e049435d5e35"
+                "reference": "ffa8535e2da982620164c7a251f0b2fbe46d3f16"
             },
             "require": {
                 "php": ">=7.2"
@@ -993,7 +993,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1039,7 +1039,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8bc8bd1b22cc42ac9915f23da56d8b6605465b0b"
+                "reference": "e8cd97216467ec43a290c3e8c020ccafa68f5018"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1064,7 +1064,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-videopress": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1138,7 +1138,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/password-checker",
-                "reference": "63e9b52f2c3a5b69c30115e21c02ecf7e4a23e00"
+                "reference": "33cc919e4b75e07ed12975588c42ae2ea723a9a4"
             },
             "require": {
                 "php": ">=7.2"
@@ -1147,7 +1147,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1194,7 +1194,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "6e826adc648851fe3e6d20dd6b9b20fdcc21e3fd"
+                "reference": "de5c26803c2b558b6f64279671e6bec5b81be474"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1205,7 +1205,7 @@
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1257,7 +1257,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plugins-installer",
-                "reference": "a937c79953c77d994a88e7722683a4d1bbe75968"
+                "reference": "c26351d6a169c26719a964ef89c1cc986b5fbbfe"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1267,7 +1267,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1314,7 +1314,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-models",
-                "reference": "9aa24e036a4736f9bff3ced06d144323e3d4ccd3"
+                "reference": "b8e862ee1ac0301a12afa22b03c5503159aab2fa"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -1324,7 +1324,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1380,7 +1380,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-status",
-                "reference": "e229b1ae776d046d10281475b3a89cefa464253a"
+                "reference": "887b85b6fe8085925ca4e80b82c9222e73f17dc3"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1394,7 +1394,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1450,7 +1450,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "4738fce156b0b8008bdea47fb52d8c5d3d24e2ae"
+                "reference": "44d6ec93e4d3b3db6287bf82f316a294d7ef868d"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
@@ -1460,7 +1460,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1506,7 +1506,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/roles",
-                "reference": "0606b853fc28d9fbcc013187c626d0a8e2de84b6"
+                "reference": "f7098eb11833c5fddfff032427d8576039aa3521"
             },
             "require": {
                 "php": ">=7.2"
@@ -1515,7 +1515,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1561,7 +1561,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "fc91e61469f31cdab849571507a1aed68a14fafd"
+                "reference": "2af0799e498773ebeafed5e8e5c1a2b4d543a44a"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1574,7 +1574,7 @@
                 "automattic/jetpack-plans": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1626,7 +1626,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "d69fff7e02a1bfe9045907867d7d59e4c1814de6"
+                "reference": "9846e5fd84a40e97d5b9a0a2b4821968469a87d8"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1643,7 +1643,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-waf": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1699,7 +1699,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "c14954ff73879d665f632af7c2074b79186657a1"
+                "reference": "b7c37d3261e3e2ca2b114e309bc0f5e5c9b1826a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1715,7 +1715,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1780,7 +1780,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "06b85c8f44fdccebce0bb12823f2d3f1e87e037a"
+                "reference": "30dd97f47c89ca7ec88c3659ef92464965a8e5e8"
             },
             "require": {
                 "composer-runtime-api": "^2.2.0",
@@ -1791,7 +1791,7 @@
             "require-dev": {
                 "automattic/phpunit-select-config": "@dev",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/changelogger"

--- a/projects/plugins/wpcomsh/changelog/update-yoast-polyfills-v4
+++ b/projects/plugins/wpcomsh/changelog/update-yoast-polyfills-v4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update `yoast/phpunit-polyfills` to v4, and add PHPUnit 12 config (as a symlink to the PHPUnit 11 config, since it's identical).
+
+

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -19,7 +19,7 @@
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/phpunit-select-config": "@dev"
 	},
 	"autoload": {

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7faf21219ffeeb48c7b13b7aa56d3257",
+    "content-hash": "edc4255c124d88513df182105497def5",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
@@ -80,7 +80,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "5c10fd1a50834e9d28af3136f79a35617b497dae"
+                "reference": "68b92cc77ac41309dbf2f7a16eecd4e0c9cb03a9"
             },
             "require": {
                 "php": ">=7.2"
@@ -88,7 +88,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -134,7 +134,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "5faef0e6453cac07042d46af33d9a5318c353ca1"
+                "reference": "fee1504bb96380c418e439af5696ba75fbfc0d96"
             },
             "require": {
                 "php": ">=7.2"
@@ -144,7 +144,7 @@
                 "automattic/jetpack-logo": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -194,7 +194,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "110b0ff2aa88f9904c6260c3e399dbfdd7544fa6"
+                "reference": "89a768257b402fb6abeefe5b6c0855f946187fab"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -205,7 +205,7 @@
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -264,7 +264,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blaze",
-                "reference": "f897f4d450f20d7e0521ca0cdf08754fbef06265"
+                "reference": "119ac65520e11f909fb090015b98dcf686f9d157"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -280,7 +280,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -340,7 +340,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blocks",
-                "reference": "b5e222941b8a6bf36cd1623ab95e9ddd48440ca0"
+                "reference": "80622ccf1abbbbecd133ec46ef657250ab972968"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -351,7 +351,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -397,7 +397,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/calypsoify",
-                "reference": "b81974e2fb7239ad817e030f2de7152cccc34781"
+                "reference": "1e57eb50b5a1d78b81fd8e4241073d1f9ed56142"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -407,7 +407,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -463,7 +463,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/classic-theme-helper",
-                "reference": "d2a77001355ac061d45c33e7c882ff793f717e07"
+                "reference": "6a1666875f6fb10e5557f7b53963b91999e20863"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -472,7 +472,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -565,7 +565,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "16772cbb568bc8fc8550671a1bd12aa4705738dc"
+                "reference": "eb028c7425d0591689e2a0b3047c278d8ff2395e"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
@@ -575,7 +575,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -700,7 +700,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "8b6fb10f12a15323a4af26c97ed28e3cd98327bd"
+                "reference": "1d0e8466e6188a79ff302ba975d3c2ffc691090b"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -719,7 +719,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -787,7 +787,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "e6cbca1d3b01d10d771d2af899cd6ffb65090549"
+                "reference": "378a5d122aedfc25d3aa42ab913803c85a8c857b"
             },
             "require": {
                 "php": ">=7.2"
@@ -796,7 +796,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -842,7 +842,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "dedb91e962e445e3ea344493e298b31125d6c175"
+                "reference": "4f83bde798e393d208074fdb0d06ea43e286367f"
             },
             "require": {
                 "php": ">=7.2"
@@ -850,7 +850,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -896,7 +896,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/google-analytics",
-                "reference": "188adf1a5d64278d12a8af42b8ee0641dcb2cccb"
+                "reference": "28cb18c8c47204ca7b0217f7c4b02527a8fd873f"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
@@ -906,7 +906,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -962,7 +962,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/ip",
-                "reference": "ab83ce4e4fa0bcc7fa87600a8b60c7dab8bfe191"
+                "reference": "4c8f48266f1fe2551103c6293e2957e185f87a94"
             },
             "require": {
                 "php": ">=7.2"
@@ -971,7 +971,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1021,7 +1021,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "e5ec23b1ab540b0eb208d2568e98a3395ad00e99"
+                "reference": "8f1cfb4b5b6881694f9be7376735501e5f37e19a"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1037,7 +1037,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1097,7 +1097,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/logo",
-                "reference": "f08fffc0458c5acac0686368b005e049435d5e35"
+                "reference": "ffa8535e2da982620164c7a251f0b2fbe46d3f16"
             },
             "require": {
                 "php": ">=7.2"
@@ -1105,7 +1105,7 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1151,7 +1151,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "2f0576b08251752f44d2e82f8b8263ba5bc746e3"
+                "reference": "b6a718f90cbd6e5cad4403d05955347b85a02bf1"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1172,7 +1172,7 @@
                 "automattic/patchwork-redefine-exit": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1234,7 +1234,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "2324a26120cdda4a43d16d40cfa3d61c1aec0486"
+                "reference": "095df0be4fcbc25febd3cc8a73f1d118acb374d3"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1258,7 +1258,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1318,7 +1318,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/password-checker",
-                "reference": "63e9b52f2c3a5b69c30115e21c02ecf7e4a23e00"
+                "reference": "33cc919e4b75e07ed12975588c42ae2ea723a9a4"
             },
             "require": {
                 "php": ">=7.2"
@@ -1327,7 +1327,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1374,7 +1374,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "6e826adc648851fe3e6d20dd6b9b20fdcc21e3fd"
+                "reference": "de5c26803c2b558b6f64279671e6bec5b81be474"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1385,7 +1385,7 @@
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1437,7 +1437,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/post-list",
-                "reference": "3dcd6395d775f858a18c4c61a564bc5c1c35e25d"
+                "reference": "62d4a8fbfe514aff5ce54806df3c7cc1d58f7e9b"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1447,7 +1447,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1503,7 +1503,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "4738fce156b0b8008bdea47fb52d8c5d3d24e2ae"
+                "reference": "44d6ec93e4d3b3db6287bf82f316a294d7ef868d"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
@@ -1513,7 +1513,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1559,7 +1559,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/roles",
-                "reference": "0606b853fc28d9fbcc013187c626d0a8e2de84b6"
+                "reference": "f7098eb11833c5fddfff032427d8576039aa3521"
             },
             "require": {
                 "php": ">=7.2"
@@ -1568,7 +1568,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1614,7 +1614,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "17d370fe6ad03ba4efd6b26ba367dfc8951c1670"
+                "reference": "789c86192e313d719df96ba4fb9bb225a11e6aa1"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1626,7 +1626,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1681,7 +1681,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "d6c733cb5102f8189dcaa1d9b77e5b34403fa32e"
+                "reference": "ed890d948b0713fc8d7c1b2a00d37b8b556244a2"
             },
             "require": {
                 "automattic/jetpack-blaze": "@dev",
@@ -1697,7 +1697,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1750,7 +1750,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "fc91e61469f31cdab849571507a1aed68a14fafd"
+                "reference": "2af0799e498773ebeafed5e8e5c1a2b4d543a44a"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1763,7 +1763,7 @@
                 "automattic/jetpack-plans": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1815,7 +1815,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/subscribers-dashboard",
-                "reference": "bd34a6bb2a4f0e6c0badd9e9a3b3d15bac6922c5"
+                "reference": "68a2f8db8c8f9a683ef8627ffa8cab0c902b39f0"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1830,7 +1830,7 @@
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1894,7 +1894,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "d69fff7e02a1bfe9045907867d7d59e4c1814de6"
+                "reference": "9846e5fd84a40e97d5b9a0a2b4821968469a87d8"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1911,7 +1911,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-waf": "@dev",
                 "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -1967,7 +1967,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "d5a89661caaa554d1da1c6450b62a46c61f802d7"
+                "reference": "23e79cec756fee0825405c764a6fa7415f1360a3"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1982,7 +1982,7 @@
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "php-mock/php-mock-phpunit": "^2.10",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -2260,7 +2260,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "06b85c8f44fdccebce0bb12823f2d3f1e87e037a"
+                "reference": "30dd97f47c89ca7ec88c3659ef92464965a8e5e8"
             },
             "require": {
                 "composer-runtime-api": "^2.2.0",
@@ -2271,7 +2271,7 @@
             "require-dev": {
                 "automattic/phpunit-select-config": "@dev",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/changelogger"
@@ -2344,7 +2344,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/phpunit-select-config",
-                "reference": "ee8b1e53bfd922accf326802e7c8b8d7b26bf54f"
+                "reference": "3f16352a5a43bdd583b78d895d092a1e1b74c397"
             },
             "require": {
                 "composer-runtime-api": "^2.2.2",
@@ -2354,7 +2354,7 @@
             "require-dev": {
                 "antecedent/patchwork": "^2.2",
                 "automattic/jetpack-changelogger": "@dev",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
                 "bin/phpunit-select-config"
@@ -4852,21 +4852,21 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "3.1.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618"
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/9cf2ccd990eadfc4a1e390592d4731e590b2c618",
-                "reference": "9cf2ccd990eadfc4a1e390592d4731e590b2c618",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "phpunit/phpunit": "^6.4.4 || ^7.0 || ^8.0 || ^9.0 || ^11.0"
+                "php": ">=7.1",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -4911,7 +4911,7 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2025-02-09T18:36:24+00:00"
+            "time": "2025-02-09T18:58:54+00:00"
         }
     ],
     "aliases": [],

--- a/projects/plugins/wpcomsh/phpunit.12.xml.dist
+++ b/projects/plugins/wpcomsh/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/tools/cli/skeletons/common/composer.json
+++ b/tools/cli/skeletons/common/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "^3.0.0",
+		"yoast/phpunit-polyfills": "^4.0.0",
 		"automattic/jetpack-changelogger": "@dev"
 	},
 	"autoload": {

--- a/tools/cli/skeletons/packages/phpunit.12.xml.dist
+++ b/tools/cli/skeletons/packages/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/tools/cli/skeletons/plugins/phpunit.12.xml.dist
+++ b/tools/cli/skeletons/plugins/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/tools/php-test-env/composer.json
+++ b/tools/php-test-env/composer.json
@@ -6,7 +6,7 @@
 	"require": {
 		"php": ">=7.2",
 		"automattic/wordbless": "^0.6.0",
-		"yoast/phpunit-polyfills": "^3.0.0"
+		"yoast/phpunit-polyfills": "^4.0.0"
 	},
 	"scripts": {
 		"post-install-cmd": "WorDBless\\Composer\\InstallDropin::copy",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This brings in use of PHPUnit 12 for PHP 8.3+. Other than needing `phpunit.12.xml.dist` files (as symlinks to the PHPUnit 11 configs), this seems to work without issue after a few cleanups in #43215 and #43217.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
PT: pf4qpu-Fo-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* Double check PHPUnit 12 is actually used for plugin tests in 8.3 and 8.4.