### PR TITLE
phan: Update stubs for PHPUnit 12

### DIFF
--- a/.phan/stubs/phpunit-dirs.txt
+++ b/.phan/stubs/phpunit-dirs.txt
@@ -5,8 +5,6 @@ vendor/phpunit/php-text-template
 vendor/phpunit/php-timer
 vendor/phpunit/phpunit
 vendor/sebastian/cli-parser
-vendor/sebastian/code-unit
-vendor/sebastian/code-unit-reverse-lookup
 vendor/sebastian/comparator
 vendor/sebastian/complexity
 vendor/sebastian/diff

--- a/.phan/stubs/phpunit-stubs.php
+++ b/.phan/stubs/phpunit-stubs.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Stubs automatically generated from PHPUnit 11.5.17
+ * Stubs automatically generated from PHPUnit 12.1.3
  * using the definition file `tools/stubs/phpunit-stub-defs.php` in the Jetpack monorepo.
  *
  * Do not edit this directly! Run tools/stubs/update-stubs.sh to regenerate it.
@@ -144,6 +144,8 @@ final class DispatchingEmitter implements \PHPUnit\Event\Emitter
     {
     }
     /**
+     * @param non-empty-string $filename
+     *
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
@@ -151,6 +153,10 @@ final class DispatchingEmitter implements \PHPUnit\Event\Emitter
     {
     }
     /**
+     * @param non-empty-string $filename
+     * @param non-empty-string $name
+     * @param non-empty-string $version
+     *
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
@@ -292,57 +298,45 @@ final class DispatchingEmitter implements \PHPUnit\Event\Emitter
     {
     }
     /**
-     * @param class-string $testClassName
-     *
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
-    public function beforeTestMethodCalled(string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod): void
+    public function beforeTestMethodCalled(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod): void
     {
     }
     /**
-     * @param class-string $testClassName
-     *
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
-    public function beforeTestMethodErrored(string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable): void
+    public function beforeTestMethodErrored(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable): void
     {
     }
     /**
-     * @param class-string $testClassName
-     *
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
-    public function beforeTestMethodFinished(string $testClassName, \PHPUnit\Event\Code\ClassMethod ...$calledMethods): void
+    public function beforeTestMethodFinished(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod ...$calledMethods): void
     {
     }
     /**
-     * @param class-string $testClassName
-     *
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
-    public function preConditionCalled(string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod): void
+    public function preConditionCalled(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod): void
     {
     }
     /**
-     * @param class-string $testClassName
-     *
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
-    public function preConditionErrored(string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable): void
+    public function preConditionErrored(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable): void
     {
     }
     /**
-     * @param class-string $testClassName
-     *
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
-    public function preConditionFinished(string $testClassName, \PHPUnit\Event\Code\ClassMethod ...$calledMethods): void
+    public function preConditionFinished(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod ...$calledMethods): void
     {
     }
     /**
@@ -380,52 +374,12 @@ final class DispatchingEmitter implements \PHPUnit\Event\Emitter
     {
     }
     /**
-     * @param trait-string $traitName
-     *
-     * @throws InvalidArgumentException
-     * @throws UnknownEventTypeException
-     */
-    public function testCreatedMockObjectForTrait(string $traitName): void
-    {
-    }
-    /**
-     * @param class-string $className
-     *
-     * @throws InvalidArgumentException
-     * @throws UnknownEventTypeException
-     */
-    public function testCreatedMockObjectForAbstractClass(string $className): void
-    {
-    }
-    /**
-     * @param class-string $originalClassName
-     * @param class-string $mockClassName
-     * @param list<string> $methods
-     * @param list<mixed>  $options
-     *
-     * @throws InvalidArgumentException
-     * @throws UnknownEventTypeException
-     */
-    public function testCreatedMockObjectFromWsdl(string $wsdlFile, string $originalClassName, string $mockClassName, array $methods, bool $callOriginalConstructor, array $options): void
-    {
-    }
-    /**
      * @param class-string $className
      *
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
     public function testCreatedPartialMockObject(string $className, string ...$methodNames): void
-    {
-    }
-    /**
-     * @param class-string $className
-     * @param list<mixed>  $constructorArguments
-     *
-     * @throws InvalidArgumentException
-     * @throws UnknownEventTypeException
-     */
-    public function testCreatedTestProxy(string $className, array $constructorArguments): void
     {
     }
     /**
@@ -496,6 +450,16 @@ final class DispatchingEmitter implements \PHPUnit\Event\Emitter
      * @throws UnknownEventTypeException
      */
     public function testTriggeredPhpunitDeprecation(?\PHPUnit\Event\Code\Test $test, string $message): void
+    {
+    }
+    /**
+     * @param non-empty-string $message
+     *
+     * @throws InvalidArgumentException
+     * @throws Code\NoTestCaseObjectOnCallStackException
+     * @throws UnknownEventTypeException
+     */
+    public function testTriggeredPhpunitNotice(?\PHPUnit\Event\Code\Test $test, string $message): void
     {
     }
     /**
@@ -604,6 +568,8 @@ final class DispatchingEmitter implements \PHPUnit\Event\Emitter
     {
     }
     /**
+     * @param non-negative-int $numberOfAssertionsPerformed
+     *
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
@@ -611,57 +577,45 @@ final class DispatchingEmitter implements \PHPUnit\Event\Emitter
     {
     }
     /**
-     * @param class-string $testClassName
-     *
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
-    public function postConditionCalled(string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod): void
+    public function postConditionCalled(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod): void
     {
     }
     /**
-     * @param class-string $testClassName
-     *
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
-    public function postConditionErrored(string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable): void
+    public function postConditionErrored(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable): void
     {
     }
     /**
-     * @param class-string $testClassName
-     *
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
-    public function postConditionFinished(string $testClassName, \PHPUnit\Event\Code\ClassMethod ...$calledMethods): void
+    public function postConditionFinished(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod ...$calledMethods): void
     {
     }
     /**
-     * @param class-string $testClassName
-     *
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
-    public function afterTestMethodCalled(string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod): void
+    public function afterTestMethodCalled(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod): void
     {
     }
     /**
-     * @param class-string $testClassName
-     *
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
-    public function afterTestMethodErrored(string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable): void
+    public function afterTestMethodErrored(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable): void
     {
     }
     /**
-     * @param class-string $testClassName
-     *
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
-    public function afterTestMethodFinished(string $testClassName, \PHPUnit\Event\Code\ClassMethod ...$calledMethods): void
+    public function afterTestMethodFinished(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod ...$calledMethods): void
     {
     }
     /**
@@ -702,10 +656,40 @@ final class DispatchingEmitter implements \PHPUnit\Event\Emitter
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
+    public function testRunnerStartedStaticAnalysisForCodeCoverage(): void
+    {
+    }
+    /**
+     * @param non-negative-int $cacheHits
+     * @param non-negative-int $cacheMisses
+     *
+     * @throws InvalidArgumentException
+     * @throws UnknownEventTypeException
+     */
+    public function testRunnerFinishedStaticAnalysisForCodeCoverage(int $cacheHits, int $cacheMisses): void
+    {
+    }
+    /**
+     * @param non-empty-string $message
+     *
+     * @throws InvalidArgumentException
+     * @throws UnknownEventTypeException
+     */
     public function testRunnerTriggeredPhpunitDeprecation(string $message): void
     {
     }
     /**
+     * @param non-empty-string $message
+     *
+     * @throws InvalidArgumentException
+     * @throws UnknownEventTypeException
+     */
+    public function testRunnerTriggeredPhpunitNotice(string $message): void
+    {
+    }
+    /**
+     * @param non-empty-string $message
+     *
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
@@ -758,7 +742,15 @@ interface Emitter
     public function applicationStarted(): void;
     public function testRunnerStarted(): void;
     public function testRunnerConfigured(\PHPUnit\TextUI\Configuration\Configuration $configuration): void;
+    /**
+     * @param non-empty-string $filename
+     */
     public function testRunnerBootstrapFinished(string $filename): void;
+    /**
+     * @param non-empty-string $filename
+     * @param non-empty-string $name
+     * @param non-empty-string $version
+     */
     public function testRunnerLoadedExtensionFromPhar(string $filename, string $name, string $version): void;
     /**
      * @param class-string          $className
@@ -774,6 +766,9 @@ interface Emitter
     public function testRunnerExecutionStarted(\PHPUnit\Event\TestSuite\TestSuite $testSuite): void;
     public function testRunnerDisabledGarbageCollection(): void;
     public function testRunnerTriggeredGarbageCollection(): void;
+    /**
+     * @param non-empty-string $message
+     */
     public function testSuiteSkipped(\PHPUnit\Event\TestSuite\TestSuite $testSuite, string $message): void;
     public function testSuiteStarted(\PHPUnit\Event\TestSuite\TestSuite $testSuite): void;
     public function testPreparationStarted(\PHPUnit\Event\Code\Test $test): void;
@@ -790,30 +785,12 @@ interface Emitter
      * @param class-string $testClassName
      */
     public function beforeFirstTestMethodFinished(string $testClassName, \PHPUnit\Event\Code\ClassMethod ...$calledMethods): void;
-    /**
-     * @param class-string $testClassName
-     */
-    public function beforeTestMethodCalled(string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod): void;
-    /**
-     * @param class-string $testClassName
-     */
-    public function beforeTestMethodErrored(string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable): void;
-    /**
-     * @param class-string $testClassName
-     */
-    public function beforeTestMethodFinished(string $testClassName, \PHPUnit\Event\Code\ClassMethod ...$calledMethods): void;
-    /**
-     * @param class-string $testClassName
-     */
-    public function preConditionCalled(string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod): void;
-    /**
-     * @param class-string $testClassName
-     */
-    public function preConditionErrored(string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable): void;
-    /**
-     * @param class-string $testClassName
-     */
-    public function preConditionFinished(string $testClassName, \PHPUnit\Event\Code\ClassMethod ...$calledMethods): void;
+    public function beforeTestMethodCalled(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod): void;
+    public function beforeTestMethodErrored(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable): void;
+    public function beforeTestMethodFinished(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod ...$calledMethods): void;
+    public function preConditionCalled(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod): void;
+    public function preConditionErrored(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable): void;
+    public function preConditionFinished(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod ...$calledMethods): void;
     public function testPrepared(\PHPUnit\Event\Code\Test $test): void;
     /**
      * @param class-string $className
@@ -828,29 +805,9 @@ interface Emitter
      */
     public function testCreatedMockObjectForIntersectionOfInterfaces(array $interfaces): void;
     /**
-     * @param trait-string $traitName
-     */
-    public function testCreatedMockObjectForTrait(string $traitName): void;
-    /**
-     * @param class-string $className
-     */
-    public function testCreatedMockObjectForAbstractClass(string $className): void;
-    /**
-     * @param class-string $originalClassName
-     * @param class-string $mockClassName
-     * @param list<string> $methods
-     * @param list<mixed>  $options
-     */
-    public function testCreatedMockObjectFromWsdl(string $wsdlFile, string $originalClassName, string $mockClassName, array $methods, bool $callOriginalConstructor, array $options): void;
-    /**
      * @param class-string $className
      */
     public function testCreatedPartialMockObject(string $className, string ...$methodNames): void;
-    /**
-     * @param class-string $className
-     * @param list<mixed>  $constructorArguments
-     */
-    public function testCreatedTestProxy(string $className, array $constructorArguments): void;
     /**
      * @param class-string $className
      */
@@ -875,6 +832,10 @@ interface Emitter
      * @param non-empty-string $message
      */
     public function testTriggeredPhpunitDeprecation(?\PHPUnit\Event\Code\Test $test, string $message): void;
+    /**
+     * @param non-empty-string $message
+     */
+    public function testTriggeredPhpunitNotice(?\PHPUnit\Event\Code\Test $test, string $message): void;
     /**
      * @param non-empty-string $message
      * @param non-empty-string $file
@@ -930,31 +891,16 @@ interface Emitter
      * @param non-empty-string $output
      */
     public function testPrintedUnexpectedOutput(string $output): void;
+    /**
+     * @param non-negative-int $numberOfAssertionsPerformed
+     */
     public function testFinished(\PHPUnit\Event\Code\Test $test, int $numberOfAssertionsPerformed): void;
-    /**
-     * @param class-string $testClassName
-     */
-    public function postConditionCalled(string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod): void;
-    /**
-     * @param class-string $testClassName
-     */
-    public function postConditionErrored(string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable): void;
-    /**
-     * @param class-string $testClassName
-     */
-    public function postConditionFinished(string $testClassName, \PHPUnit\Event\Code\ClassMethod ...$calledMethods): void;
-    /**
-     * @param class-string $testClassName
-     */
-    public function afterTestMethodCalled(string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod): void;
-    /**
-     * @param class-string $testClassName
-     */
-    public function afterTestMethodErrored(string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable): void;
-    /**
-     * @param class-string $testClassName
-     */
-    public function afterTestMethodFinished(string $testClassName, \PHPUnit\Event\Code\ClassMethod ...$calledMethods): void;
+    public function postConditionCalled(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod): void;
+    public function postConditionErrored(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable): void;
+    public function postConditionFinished(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod ...$calledMethods): void;
+    public function afterTestMethodCalled(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod): void;
+    public function afterTestMethodErrored(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable): void;
+    public function afterTestMethodFinished(\PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod ...$calledMethods): void;
     /**
      * @param class-string $testClassName
      */
@@ -970,7 +916,23 @@ interface Emitter
     public function testSuiteFinished(\PHPUnit\Event\TestSuite\TestSuite $testSuite): void;
     public function testRunnerStartedChildProcess(): void;
     public function testRunnerFinishedChildProcess(string $stdout, string $stderr): void;
+    public function testRunnerStartedStaticAnalysisForCodeCoverage(): void;
+    /**
+     * @param non-negative-int $cacheHits
+     * @param non-negative-int $cacheMisses
+     */
+    public function testRunnerFinishedStaticAnalysisForCodeCoverage(int $cacheHits, int $cacheMisses): void;
+    /**
+     * @param non-empty-string $message
+     */
     public function testRunnerTriggeredPhpunitDeprecation(string $message): void;
+    /**
+     * @param non-empty-string $message
+     */
+    public function testRunnerTriggeredPhpunitNotice(string $message): void;
+    /**
+     * @param non-empty-string $message
+     */
     public function testRunnerTriggeredPhpunitWarning(string $message): void;
     public function testRunnerEnabledGarbageCollection(): void;
     public function testRunnerExecutionAborted(): void;
@@ -984,6 +946,9 @@ interface Emitter
 interface Event
 {
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info;
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string;
 }
 /**
@@ -1233,6 +1198,9 @@ final readonly class Finished implements \PHPUnit\Event\Event
     public function shellExitCode(): int
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -1260,6 +1228,9 @@ final readonly class Started implements \PHPUnit\Event\Event
     public function runtime(): \PHPUnit\Event\Runtime\Runtime
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -1925,7 +1896,7 @@ final readonly class Duration
  */
 final readonly class GarbageCollectorStatus
 {
-    public function __construct(int $runs, int $collected, int $threshold, int $roots, ?float $applicationTime, ?float $collectorTime, ?float $destructorTime, ?float $freeTime, ?bool $running, ?bool $protected, ?bool $full, ?int $bufferSize)
+    public function __construct(int $runs, int $collected, int $threshold, int $roots, float $applicationTime, float $collectorTime, float $destructorTime, float $freeTime, bool $running, bool $protected, bool $full, int $bufferSize)
     {
     }
     public function runs(): int
@@ -1940,64 +1911,27 @@ final readonly class GarbageCollectorStatus
     public function roots(): int
     {
     }
-    /**
-     * @phpstan-assert-if-true !null $this->applicationTime
-     * @phpstan-assert-if-true !null $this->collectorTime
-     * @phpstan-assert-if-true !null $this->destructorTime
-     * @phpstan-assert-if-true !null $this->freeTime
-     * @phpstan-assert-if-true !null $this->running
-     * @phpstan-assert-if-true !null $this->protected
-     * @phpstan-assert-if-true !null $this->full
-     * @phpstan-assert-if-true !null $this->bufferSize
-     */
-    public function hasExtendedInformation(): bool
-    {
-    }
-    /**
-     * @throws \PHPUnit\Event\RuntimeException on PHP < 8.3
-     */
     public function applicationTime(): float
     {
     }
-    /**
-     * @throws \PHPUnit\Event\RuntimeException on PHP < 8.3
-     */
     public function collectorTime(): float
     {
     }
-    /**
-     * @throws \PHPUnit\Event\RuntimeException on PHP < 8.3
-     */
     public function destructorTime(): float
     {
     }
-    /**
-     * @throws \PHPUnit\Event\RuntimeException on PHP < 8.3
-     */
     public function freeTime(): float
     {
     }
-    /**
-     * @throws \PHPUnit\Event\RuntimeException on PHP < 8.3
-     */
     public function isRunning(): bool
     {
     }
-    /**
-     * @throws \PHPUnit\Event\RuntimeException on PHP < 8.3
-     */
     public function isProtected(): bool
     {
     }
-    /**
-     * @throws \PHPUnit\Event\RuntimeException on PHP < 8.3
-     */
     public function isFull(): bool
     {
     }
-    /**
-     * @throws \PHPUnit\Event\RuntimeException on PHP < 8.3
-     */
     public function bufferSize(): int
     {
     }
@@ -2100,30 +2034,6 @@ final readonly class MemoryUsage
     }
 }
 /**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- *
- * @codeCoverageIgnore
- */
-final readonly class Php81GarbageCollectorStatusProvider implements \PHPUnit\Event\Telemetry\GarbageCollectorStatusProvider
-{
-    public function status(): \PHPUnit\Event\Telemetry\GarbageCollectorStatus
-    {
-    }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
-final readonly class Php83GarbageCollectorStatusProvider implements \PHPUnit\Event\Telemetry\GarbageCollectorStatusProvider
-{
-    public function status(): \PHPUnit\Event\Telemetry\GarbageCollectorStatus
-    {
-    }
-}
-/**
  * @immutable
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -2166,6 +2076,17 @@ final readonly class System
     {
     }
     public function snapshot(): \PHPUnit\Event\Telemetry\Snapshot
+    {
+    }
+}
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class SystemGarbageCollectorStatusProvider implements \PHPUnit\Event\Telemetry\GarbageCollectorStatusProvider
+{
+    public function status(): \PHPUnit\Event\Telemetry\GarbageCollectorStatus
     {
     }
 }
@@ -2240,6 +2161,9 @@ final readonly class ComparatorRegistered implements \PHPUnit\Event\Event
     public function className(): string
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -2276,6 +2200,9 @@ final readonly class AfterLastTestMethodCalled implements \PHPUnit\Event\Event
     public function calledMethod(): \PHPUnit\Event\Code\ClassMethod
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -2315,6 +2242,9 @@ final readonly class AfterLastTestMethodErrored implements \PHPUnit\Event\Event
     public function throwable(): \PHPUnit\Event\Code\Throwable
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -2354,6 +2284,9 @@ final readonly class AfterLastTestMethodFinished implements \PHPUnit\Event\Event
     public function calledMethods(): array
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -2372,17 +2305,19 @@ interface AfterLastTestMethodFinishedSubscriber extends \PHPUnit\Event\Subscribe
  */
 final readonly class AfterTestMethodCalled implements \PHPUnit\Event\Event
 {
-    /**
-     * @param class-string $testClassName
-     */
-    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod)
+    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, \PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod)
     {
     }
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    public function test(): \PHPUnit\Event\Code\TestMethod
+    {
+    }
     /**
      * @return class-string
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
      */
     public function testClassName(): string
     {
@@ -2390,6 +2325,9 @@ final readonly class AfterTestMethodCalled implements \PHPUnit\Event\Event
     public function calledMethod(): \PHPUnit\Event\Code\ClassMethod
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -2408,17 +2346,19 @@ interface AfterTestMethodCalledSubscriber extends \PHPUnit\Event\Subscriber
  */
 final readonly class AfterTestMethodErrored implements \PHPUnit\Event\Event
 {
-    /**
-     * @param class-string $testClassName
-     */
-    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable)
+    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, \PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable)
     {
     }
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    public function test(): \PHPUnit\Event\Code\TestMethod
+    {
+    }
     /**
      * @return class-string
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
      */
     public function testClassName(): string
     {
@@ -2429,6 +2369,9 @@ final readonly class AfterTestMethodErrored implements \PHPUnit\Event\Event
     public function throwable(): \PHPUnit\Event\Code\Throwable
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -2447,17 +2390,19 @@ interface AfterTestMethodErroredSubscriber extends \PHPUnit\Event\Subscriber
  */
 final readonly class AfterTestMethodFinished implements \PHPUnit\Event\Event
 {
-    /**
-     * @param class-string $testClassName
-     */
-    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $testClassName, \PHPUnit\Event\Code\ClassMethod ...$calledMethods)
+    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, \PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod ...$calledMethods)
     {
     }
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    public function test(): \PHPUnit\Event\Code\TestMethod
+    {
+    }
     /**
      * @return class-string
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
      */
     public function testClassName(): string
     {
@@ -2468,6 +2413,9 @@ final readonly class AfterTestMethodFinished implements \PHPUnit\Event\Event
     public function calledMethods(): array
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -2504,6 +2452,9 @@ final readonly class BeforeFirstTestMethodCalled implements \PHPUnit\Event\Event
     public function calledMethod(): \PHPUnit\Event\Code\ClassMethod
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -2543,6 +2494,9 @@ final readonly class BeforeFirstTestMethodErrored implements \PHPUnit\Event\Even
     public function throwable(): \PHPUnit\Event\Code\Throwable
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -2582,6 +2536,9 @@ final readonly class BeforeFirstTestMethodFinished implements \PHPUnit\Event\Eve
     public function calledMethods(): array
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -2600,17 +2557,19 @@ interface BeforeFirstTestMethodFinishedSubscriber extends \PHPUnit\Event\Subscri
  */
 final readonly class BeforeTestMethodCalled implements \PHPUnit\Event\Event
 {
-    /**
-     * @param class-string $testClassName
-     */
-    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod)
+    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, \PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod)
     {
     }
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    public function test(): \PHPUnit\Event\Code\TestMethod
+    {
+    }
     /**
      * @return class-string
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
      */
     public function testClassName(): string
     {
@@ -2618,6 +2577,9 @@ final readonly class BeforeTestMethodCalled implements \PHPUnit\Event\Event
     public function calledMethod(): \PHPUnit\Event\Code\ClassMethod
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -2636,17 +2598,19 @@ interface BeforeTestMethodCalledSubscriber extends \PHPUnit\Event\Subscriber
  */
 final readonly class BeforeTestMethodErrored implements \PHPUnit\Event\Event
 {
-    /**
-     * @param class-string $testClassName
-     */
-    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable)
+    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, \PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable)
     {
     }
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    public function test(): \PHPUnit\Event\Code\TestMethod
+    {
+    }
     /**
      * @return class-string
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
      */
     public function testClassName(): string
     {
@@ -2657,6 +2621,9 @@ final readonly class BeforeTestMethodErrored implements \PHPUnit\Event\Event
     public function throwable(): \PHPUnit\Event\Code\Throwable
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -2675,17 +2642,19 @@ interface BeforeTestMethodErroredSubscriber extends \PHPUnit\Event\Subscriber
  */
 final readonly class BeforeTestMethodFinished implements \PHPUnit\Event\Event
 {
-    /**
-     * @param class-string $testClassName
-     */
-    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $testClassName, \PHPUnit\Event\Code\ClassMethod ...$calledMethods)
+    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, \PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod ...$calledMethods)
     {
     }
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    public function test(): \PHPUnit\Event\Code\TestMethod
+    {
+    }
     /**
      * @return class-string
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
      */
     public function testClassName(): string
     {
@@ -2696,6 +2665,9 @@ final readonly class BeforeTestMethodFinished implements \PHPUnit\Event\Event
     public function calledMethods(): array
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -2714,17 +2686,19 @@ interface BeforeTestMethodFinishedSubscriber extends \PHPUnit\Event\Subscriber
  */
 final readonly class PostConditionCalled implements \PHPUnit\Event\Event
 {
-    /**
-     * @param class-string $testClassName
-     */
-    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod)
+    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, \PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod)
     {
     }
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    public function test(): \PHPUnit\Event\Code\TestMethod
+    {
+    }
     /**
      * @return class-string
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
      */
     public function testClassName(): string
     {
@@ -2732,6 +2706,9 @@ final readonly class PostConditionCalled implements \PHPUnit\Event\Event
     public function calledMethod(): \PHPUnit\Event\Code\ClassMethod
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -2750,17 +2727,19 @@ interface PostConditionCalledSubscriber extends \PHPUnit\Event\Subscriber
  */
 final readonly class PostConditionErrored implements \PHPUnit\Event\Event
 {
-    /**
-     * @param class-string $testClassName
-     */
-    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable)
+    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, \PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable)
     {
     }
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    public function test(): \PHPUnit\Event\Code\TestMethod
+    {
+    }
     /**
      * @return class-string
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
      */
     public function testClassName(): string
     {
@@ -2771,6 +2750,9 @@ final readonly class PostConditionErrored implements \PHPUnit\Event\Event
     public function throwable(): \PHPUnit\Event\Code\Throwable
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -2789,17 +2771,19 @@ interface PostConditionErroredSubscriber extends \PHPUnit\Event\Subscriber
  */
 final readonly class PostConditionFinished implements \PHPUnit\Event\Event
 {
-    /**
-     * @param class-string $testClassName
-     */
-    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $testClassName, \PHPUnit\Event\Code\ClassMethod ...$calledMethods)
+    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, \PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod ...$calledMethods)
     {
     }
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    public function test(): \PHPUnit\Event\Code\TestMethod
+    {
+    }
     /**
      * @return class-string
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
      */
     public function testClassName(): string
     {
@@ -2810,6 +2794,9 @@ final readonly class PostConditionFinished implements \PHPUnit\Event\Event
     public function calledMethods(): array
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -2828,17 +2815,19 @@ interface PostConditionFinishedSubscriber extends \PHPUnit\Event\Subscriber
  */
 final readonly class PreConditionCalled implements \PHPUnit\Event\Event
 {
-    /**
-     * @param class-string $testClassName
-     */
-    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod)
+    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, \PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod)
     {
     }
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    public function test(): \PHPUnit\Event\Code\TestMethod
+    {
+    }
     /**
      * @return class-string
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
      */
     public function testClassName(): string
     {
@@ -2846,6 +2835,9 @@ final readonly class PreConditionCalled implements \PHPUnit\Event\Event
     public function calledMethod(): \PHPUnit\Event\Code\ClassMethod
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -2864,17 +2856,19 @@ interface PreConditionCalledSubscriber extends \PHPUnit\Event\Subscriber
  */
 final readonly class PreConditionErrored implements \PHPUnit\Event\Event
 {
-    /**
-     * @param class-string $testClassName
-     */
-    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $testClassName, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable)
+    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, \PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod $calledMethod, \PHPUnit\Event\Code\Throwable $throwable)
     {
     }
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    public function test(): \PHPUnit\Event\Code\TestMethod
+    {
+    }
     /**
      * @return class-string
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
      */
     public function testClassName(): string
     {
@@ -2885,6 +2879,9 @@ final readonly class PreConditionErrored implements \PHPUnit\Event\Event
     public function throwable(): \PHPUnit\Event\Code\Throwable
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -2903,17 +2900,19 @@ interface PreConditionErroredSubscriber extends \PHPUnit\Event\Subscriber
  */
 final readonly class PreConditionFinished implements \PHPUnit\Event\Event
 {
-    /**
-     * @param class-string $testClassName
-     */
-    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $testClassName, \PHPUnit\Event\Code\ClassMethod ...$calledMethods)
+    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, \PHPUnit\Event\Code\TestMethod $test, \PHPUnit\Event\Code\ClassMethod ...$calledMethods)
     {
     }
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    public function test(): \PHPUnit\Event\Code\TestMethod
+    {
+    }
     /**
      * @return class-string
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
      */
     public function testClassName(): string
     {
@@ -2924,6 +2923,9 @@ final readonly class PreConditionFinished implements \PHPUnit\Event\Event
     public function calledMethods(): array
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -2960,6 +2962,9 @@ final readonly class ConsideredRisky implements \PHPUnit\Event\Event
     public function message(): string
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3029,6 +3034,9 @@ final readonly class DeprecationTriggered implements \PHPUnit\Event\Event
     public function stackTrace(): string
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3082,6 +3090,9 @@ final readonly class ErrorTriggered implements \PHPUnit\Event\Event
     public function wasSuppressed(): bool
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3138,6 +3149,9 @@ final readonly class NoticeTriggered implements \PHPUnit\Event\Event
     public function ignoredByBaseline(): bool
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3200,6 +3214,9 @@ final readonly class PhpDeprecationTriggered implements \PHPUnit\Event\Event
     public function trigger(): \PHPUnit\Event\Code\IssueTrigger\IssueTrigger
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3256,6 +3273,9 @@ final readonly class PhpNoticeTriggered implements \PHPUnit\Event\Event
     public function ignoredByBaseline(): bool
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3312,6 +3332,9 @@ final readonly class PhpWarningTriggered implements \PHPUnit\Event\Event
     public function ignoredByBaseline(): bool
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3348,6 +3371,9 @@ final readonly class PhpunitDeprecationTriggered implements \PHPUnit\Event\Event
     public function message(): string
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3384,6 +3410,9 @@ final readonly class PhpunitErrorTriggered implements \PHPUnit\Event\Event
     public function message(): string
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3394,6 +3423,45 @@ final readonly class PhpunitErrorTriggered implements \PHPUnit\Event\Event
 interface PhpunitErrorTriggeredSubscriber extends \PHPUnit\Event\Subscriber
 {
     public function notify(\PHPUnit\Event\Test\PhpunitErrorTriggered $event): void;
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class PhpunitNoticeTriggered implements \PHPUnit\Event\Event
+{
+    /**
+     * @param non-empty-string $message
+     */
+    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, \PHPUnit\Event\Code\Test $test, string $message)
+    {
+    }
+    public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
+    {
+    }
+    public function test(): \PHPUnit\Event\Code\Test
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function message(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function asString(): string
+    {
+    }
+}
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+interface PhpunitNoticeTriggeredSubscriber extends \PHPUnit\Event\Subscriber
+{
+    public function notify(\PHPUnit\Event\Test\PhpunitNoticeTriggered $event): void;
 }
 /**
  * @immutable
@@ -3420,6 +3488,9 @@ final readonly class PhpunitWarningTriggered implements \PHPUnit\Event\Event
     public function message(): string
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3476,6 +3547,9 @@ final readonly class WarningTriggered implements \PHPUnit\Event\Event
     public function ignoredByBaseline(): bool
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3506,6 +3580,9 @@ final readonly class DataProviderMethodCalled implements \PHPUnit\Event\Event
     public function dataProviderMethod(): \PHPUnit\Event\Code\ClassMethod
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3539,6 +3616,9 @@ final readonly class DataProviderMethodFinished implements \PHPUnit\Event\Event
     public function calledMethods(): array
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3557,6 +3637,9 @@ interface DataProviderMethodFinishedSubscriber extends \PHPUnit\Event\Subscriber
  */
 final readonly class Finished implements \PHPUnit\Event\Event
 {
+    /**
+     * @param non-negative-int $numberOfAssertionsPerformed
+     */
     public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, \PHPUnit\Event\Code\Test $test, int $numberOfAssertionsPerformed)
     {
     }
@@ -3566,9 +3649,15 @@ final readonly class Finished implements \PHPUnit\Event\Event
     public function test(): \PHPUnit\Event\Code\Test
     {
     }
+    /**
+     * @return non-negative-int
+     */
     public function numberOfAssertionsPerformed(): int
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3596,6 +3685,9 @@ final readonly class PreparationFailed implements \PHPUnit\Event\Event
     public function test(): \PHPUnit\Event\Code\Test
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3623,6 +3715,9 @@ final readonly class PreparationStarted implements \PHPUnit\Event\Event
     public function test(): \PHPUnit\Event\Code\Test
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3650,6 +3745,9 @@ final readonly class Prepared implements \PHPUnit\Event\Event
     public function test(): \PHPUnit\Event\Code\Test
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3680,6 +3778,9 @@ final readonly class Errored implements \PHPUnit\Event\Event
     public function throwable(): \PHPUnit\Event\Code\Throwable
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3722,6 +3823,9 @@ final readonly class Failed implements \PHPUnit\Event\Event
     public function comparisonFailure(): \PHPUnit\Event\Code\ComparisonFailure
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3752,6 +3856,9 @@ final readonly class MarkedIncomplete implements \PHPUnit\Event\Event
     public function throwable(): \PHPUnit\Event\Code\Throwable
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3779,6 +3886,9 @@ final readonly class Passed implements \PHPUnit\Event\Event
     public function test(): \PHPUnit\Event\Code\Test
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3809,6 +3919,9 @@ final readonly class Skipped implements \PHPUnit\Event\Event
     public function message(): string
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3842,6 +3955,9 @@ final readonly class PrintedUnexpectedOutput implements \PHPUnit\Event\Event
     public function output(): string
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3875,6 +3991,9 @@ final readonly class MockObjectCreated implements \PHPUnit\Event\Event
     public function className(): string
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3885,39 +4004,6 @@ final readonly class MockObjectCreated implements \PHPUnit\Event\Event
 interface MockObjectCreatedSubscriber extends \PHPUnit\Event\Subscriber
 {
     public function notify(\PHPUnit\Event\Test\MockObjectCreated $event): void;
-}
-/**
- * @immutable
- *
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- */
-final readonly class MockObjectForAbstractClassCreated implements \PHPUnit\Event\Event
-{
-    /**
-     * @param class-string $className
-     */
-    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $className)
-    {
-    }
-    public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
-    {
-    }
-    /**
-     * @return class-string
-     */
-    public function className(): string
-    {
-    }
-    public function asString(): string
-    {
-    }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- */
-interface MockObjectForAbstractClassCreatedSubscriber extends \PHPUnit\Event\Subscriber
-{
-    public function notify(\PHPUnit\Event\Test\MockObjectForAbstractClassCreated $event): void;
 }
 /**
  * @immutable
@@ -3941,6 +4027,9 @@ final readonly class MockObjectForIntersectionOfInterfacesCreated implements \PH
     public function interfaces(): array
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -3951,99 +4040,6 @@ final readonly class MockObjectForIntersectionOfInterfacesCreated implements \PH
 interface MockObjectForIntersectionOfInterfacesCreatedSubscriber extends \PHPUnit\Event\Subscriber
 {
     public function notify(\PHPUnit\Event\Test\MockObjectForIntersectionOfInterfacesCreated $event): void;
-}
-/**
- * @immutable
- *
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- */
-final readonly class MockObjectForTraitCreated implements \PHPUnit\Event\Event
-{
-    /**
-     * @param trait-string $traitName
-     */
-    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $traitName)
-    {
-    }
-    public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
-    {
-    }
-    /**
-     * @return trait-string
-     */
-    public function traitName(): string
-    {
-    }
-    public function asString(): string
-    {
-    }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- */
-interface MockObjectForTraitCreatedSubscriber extends \PHPUnit\Event\Subscriber
-{
-    public function notify(\PHPUnit\Event\Test\MockObjectForTraitCreated $event): void;
-}
-/**
- * @immutable
- *
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- */
-final readonly class MockObjectFromWsdlCreated implements \PHPUnit\Event\Event
-{
-    /**
-     * @param class-string $originalClassName
-     * @param class-string $mockClassName
-     * @param list<string> $methods
-     * @param list<mixed>  $options
-     */
-    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $wsdlFile, string $originalClassName, string $mockClassName, array $methods, bool $callOriginalConstructor, array $options)
-    {
-    }
-    public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
-    {
-    }
-    public function wsdlFile(): string
-    {
-    }
-    /**
-     * @return class-string
-     */
-    public function originalClassName(): string
-    {
-    }
-    /**
-     * @return class-string
-     */
-    public function mockClassName(): string
-    {
-    }
-    /**
-     * @return list<string>
-     */
-    public function methods(): array
-    {
-    }
-    public function callOriginalConstructor(): bool
-    {
-    }
-    /**
-     * @return list<mixed>
-     */
-    public function options(): array
-    {
-    }
-    public function asString(): string
-    {
-    }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- */
-interface MockObjectFromWsdlCreatedSubscriber extends \PHPUnit\Event\Subscriber
-{
-    public function notify(\PHPUnit\Event\Test\MockObjectFromWsdlCreated $event): void;
 }
 /**
  * @immutable
@@ -4073,6 +4069,9 @@ final readonly class PartialMockObjectCreated implements \PHPUnit\Event\Event
     public function methodNames(): array
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4083,42 +4082,6 @@ final readonly class PartialMockObjectCreated implements \PHPUnit\Event\Event
 interface PartialMockObjectCreatedSubscriber extends \PHPUnit\Event\Subscriber
 {
     public function notify(\PHPUnit\Event\Test\PartialMockObjectCreated $event): void;
-}
-/**
- * @immutable
- *
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- */
-final readonly class TestProxyCreated implements \PHPUnit\Event\Event
-{
-    /**
-     * @param class-string $className
-     */
-    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $className, string $constructorArguments)
-    {
-    }
-    public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
-    {
-    }
-    /**
-     * @return class-string
-     */
-    public function className(): string
-    {
-    }
-    public function constructorArguments(): string
-    {
-    }
-    public function asString(): string
-    {
-    }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- */
-interface TestProxyCreatedSubscriber extends \PHPUnit\Event\Subscriber
-{
-    public function notify(\PHPUnit\Event\Test\TestProxyCreated $event): void;
 }
 /**
  * @immutable
@@ -4142,6 +4105,9 @@ final readonly class TestStubCreated implements \PHPUnit\Event\Event
     public function className(): string
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4175,6 +4141,9 @@ final readonly class TestStubForIntersectionOfInterfacesCreated implements \PHPU
     public function interfaces(): array
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4336,15 +4305,24 @@ namespace PHPUnit\Event\TestRunner;
  */
 final readonly class BootstrapFinished implements \PHPUnit\Event\Event
 {
+    /**
+     * @param non-empty-string $filename
+     */
     public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $filename)
     {
     }
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function filename(): string
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4375,6 +4353,9 @@ final readonly class ChildProcessFinished implements \PHPUnit\Event\Event
     public function stderr(): string
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4399,6 +4380,9 @@ final readonly class ChildProcessStarted implements \PHPUnit\Event\Event
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4424,6 +4408,9 @@ final readonly class Configured implements \PHPUnit\Event\Event
     public function configuration(): \PHPUnit\TextUI\Configuration\Configuration
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4442,15 +4429,24 @@ interface ConfiguredSubscriber extends \PHPUnit\Event\Subscriber
  */
 final readonly class DeprecationTriggered implements \PHPUnit\Event\Event
 {
+    /**
+     * @param non-empty-string $message
+     */
     public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $message)
     {
     }
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function message(): string
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4475,6 +4471,9 @@ final readonly class EventFacadeSealed implements \PHPUnit\Event\Event
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4499,6 +4498,9 @@ final readonly class ExecutionAborted implements \PHPUnit\Event\Event
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4523,6 +4525,9 @@ final readonly class ExecutionFinished implements \PHPUnit\Event\Event
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4550,6 +4555,9 @@ final readonly class ExecutionStarted implements \PHPUnit\Event\Event
     public function testSuite(): \PHPUnit\Event\TestSuite\TestSuite
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4590,6 +4598,9 @@ final readonly class ExtensionBootstrapped implements \PHPUnit\Event\Event
     public function parameters(): array
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4608,21 +4619,38 @@ interface ExtensionBootstrappedSubscriber extends \PHPUnit\Event\Subscriber
  */
 final readonly class ExtensionLoadedFromPhar implements \PHPUnit\Event\Event
 {
+    /**
+     * @param non-empty-string $filename
+     * @param non-empty-string $name
+     * @param non-empty-string $version
+     */
     public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $filename, string $name, string $version)
     {
     }
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function filename(): string
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function name(): string
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function version(): string
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4647,6 +4675,9 @@ final readonly class Finished implements \PHPUnit\Event\Event
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4671,6 +4702,9 @@ final readonly class GarbageCollectionDisabled implements \PHPUnit\Event\Event
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4695,6 +4729,9 @@ final readonly class GarbageCollectionEnabled implements \PHPUnit\Event\Event
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4719,6 +4756,9 @@ final readonly class GarbageCollectionTriggered implements \PHPUnit\Event\Event
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4735,6 +4775,36 @@ interface GarbageCollectionTriggeredSubscriber extends \PHPUnit\Event\Subscriber
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
+final readonly class NoticeTriggered implements \PHPUnit\Event\Event
+{
+    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $message)
+    {
+    }
+    public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
+    {
+    }
+    public function message(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function asString(): string
+    {
+    }
+}
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+interface NoticeTriggeredSubscriber extends \PHPUnit\Event\Subscriber
+{
+    public function notify(\PHPUnit\Event\TestRunner\NoticeTriggered $event): void;
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
 final readonly class Started implements \PHPUnit\Event\Event
 {
     public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo)
@@ -4743,6 +4813,9 @@ final readonly class Started implements \PHPUnit\Event\Event
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4759,17 +4832,96 @@ interface StartedSubscriber extends \PHPUnit\Event\Subscriber
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
+final readonly class StaticAnalysisForCodeCoverageFinished implements \PHPUnit\Event\Event
+{
+    /**
+     * @param non-negative-int $cacheHits
+     * @param non-negative-int $cacheMisses
+     */
+    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, int $cacheHits, int $cacheMisses)
+    {
+    }
+    public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
+    {
+    }
+    /**
+     * @return non-negative-int
+     */
+    public function cacheHits(): int
+    {
+    }
+    /**
+     * @return non-negative-int
+     */
+    public function cacheMisses(): int
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function asString(): string
+    {
+    }
+}
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+interface StaticAnalysisForCodeCoverageFinishedSubscriber extends \PHPUnit\Event\Subscriber
+{
+    public function notify(\PHPUnit\Event\TestRunner\StaticAnalysisForCodeCoverageFinished $event): void;
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class StaticAnalysisForCodeCoverageStarted implements \PHPUnit\Event\Event
+{
+    public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo)
+    {
+    }
+    public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function asString(): string
+    {
+    }
+}
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+interface StaticAnalysisForCodeCoverageStartedSubscriber extends \PHPUnit\Event\Subscriber
+{
+    public function notify(\PHPUnit\Event\TestRunner\StaticAnalysisForCodeCoverageStarted $event): void;
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
 final readonly class WarningTriggered implements \PHPUnit\Event\Event
 {
+    /**
+     * @param non-empty-string $message
+     */
     public function __construct(\PHPUnit\Event\Telemetry\Info $telemetryInfo, string $message)
     {
     }
     public function telemetryInfo(): \PHPUnit\Event\Telemetry\Info
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function message(): string
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4799,6 +4951,9 @@ final readonly class Filtered implements \PHPUnit\Event\Event
     public function testSuite(): \PHPUnit\Event\TestSuite\TestSuite
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4826,6 +4981,9 @@ final readonly class Finished implements \PHPUnit\Event\Event
     public function testSuite(): \PHPUnit\Event\TestSuite\TestSuite
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4853,6 +5011,9 @@ final readonly class Loaded implements \PHPUnit\Event\Event
     public function testSuite(): \PHPUnit\Event\TestSuite\TestSuite
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4883,6 +5044,9 @@ final readonly class Skipped implements \PHPUnit\Event\Event
     public function message(): string
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4916,6 +5080,9 @@ final readonly class Sorted implements \PHPUnit\Event\Event
     public function resolveDependencies(): bool
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -4943,6 +5110,9 @@ final readonly class Started implements \PHPUnit\Event\Event
     public function testSuite(): \PHPUnit\Event\TestSuite\TestSuite
     {
     }
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
     }
@@ -5234,7 +5404,7 @@ abstract class Assert
      * @throws Exception
      * @throws ExpectationFailedException
      *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6055
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6056
      */
     final public static function assertContainsOnly(string $type, iterable $haystack, ?bool $isNativeType = null, string $message = ''): void
     {
@@ -5390,7 +5560,7 @@ abstract class Assert
      * @throws Exception
      * @throws ExpectationFailedException
      *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6055
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6056
      */
     final public static function assertNotContainsOnly(string $type, iterable $haystack, ?bool $isNativeType = null, string $message = ''): void
     {
@@ -6431,31 +6601,11 @@ abstract class Assert
     {
     }
     /**
-     * Asserts that a string does not match a given format string.
-     *
-     * @throws ExpectationFailedException
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5472
-     */
-    final public static function assertStringNotMatchesFormat(string $format, string $string, string $message = ''): void
-    {
-    }
-    /**
      * Asserts that a string matches a given format file.
      *
      * @throws ExpectationFailedException
      */
     final public static function assertStringMatchesFormatFile(string $formatFile, string $string, string $message = ''): void
-    {
-    }
-    /**
-     * Asserts that a string does not match a given format string.
-     *
-     * @throws ExpectationFailedException
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5472
-     */
-    final public static function assertStringNotMatchesFormatFile(string $formatFile, string $string, string $message = ''): void
     {
     }
     /**
@@ -6705,7 +6855,7 @@ abstract class Assert
      *
      * @throws Exception
      *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6055
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6060
      */
     final public static function containsOnly(string $type): \PHPUnit\Framework\Constraint\TraversableContainsOnly
     {
@@ -6844,9 +6994,9 @@ abstract class Assert
     /**
      * @param 'array'|'bool'|'boolean'|'callable'|'double'|'float'|'int'|'integer'|'iterable'|'null'|'numeric'|'object'|'real'|'resource (closed)'|'resource'|'scalar'|'string' $type
      *
-     * @throws Exception
+     * @throws UnknownNativeTypeException
      *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6052
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6053
      */
     final public static function isType(string $type): \PHPUnit\Framework\Constraint\IsType
     {
@@ -7101,7 +7251,7 @@ function assertNotContainsEquals(mixed $needle, iterable $haystack, string $mess
  * @throws Exception
  * @throws ExpectationFailedException
  *
- * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6055
+ * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6056
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  *
@@ -7317,7 +7467,7 @@ function assertContainsOnlyInstancesOf(string $className, iterable $haystack, st
  * @throws Exception
  * @throws ExpectationFailedException
  *
- * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6055
+ * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6056
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  *
@@ -8794,20 +8944,6 @@ function assertStringMatchesFormat(string $format, string $string, string $messa
 {
 }
 /**
- * Asserts that a string does not match a given format string.
- *
- * @throws ExpectationFailedException
- *
- * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5472
- *
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @see Assert::assertStringNotMatchesFormat
- */
-function assertStringNotMatchesFormat(string $format, string $string, string $message = '', ...$func_get_args): void
-{
-}
-/**
  * Asserts that a string matches a given format file.
  *
  * @throws ExpectationFailedException
@@ -8817,20 +8953,6 @@ function assertStringNotMatchesFormat(string $format, string $string, string $me
  * @see Assert::assertStringMatchesFormatFile
  */
 function assertStringMatchesFormatFile(string $formatFile, string $string, string $message = '', ...$func_get_args): void
-{
-}
-/**
- * Asserts that a string does not match a given format string.
- *
- * @throws ExpectationFailedException
- *
- * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5472
- *
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @see Assert::assertStringNotMatchesFormatFile
- */
-function assertStringNotMatchesFormatFile(string $formatFile, string $string, string $message = '', ...$func_get_args): void
 {
 }
 /**
@@ -9365,33 +9487,7 @@ function exactly(int $count): \PHPUnit\Framework\MockObject\Rule\InvokedCount
 function atMost(int $allowedInvocations): \PHPUnit\Framework\MockObject\Rule\InvokedAtMostCount
 {
 }
-function returnValue(mixed $value): \PHPUnit\Framework\MockObject\Stub\ReturnStub
-{
-}
-/**
- * @param array<mixed> $valueMap
- */
-function returnValueMap(array $valueMap): \PHPUnit\Framework\MockObject\Stub\ReturnValueMap
-{
-}
-function returnArgument(int $argumentIndex): \PHPUnit\Framework\MockObject\Stub\ReturnArgument
-{
-}
-function returnCallback(callable $callback): \PHPUnit\Framework\MockObject\Stub\ReturnCallback
-{
-}
-/**
- * Returns the current object.
- *
- * This method is useful when mocking a fluent interface.
- */
-function returnSelf(): \PHPUnit\Framework\MockObject\Stub\ReturnSelf
-{
-}
 function throwException(\Throwable $exception): \PHPUnit\Framework\MockObject\Stub\Exception
-{
-}
-function onConsecutiveCalls(...$func_get_args): \PHPUnit\Framework\MockObject\Stub\ConsecutiveCalls
 {
 }
 /**
@@ -9439,14 +9535,6 @@ class AssertionFailedError extends \PHPUnit\Framework\Exception implements \PHPU
     public function toString(): string
     {
     }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
-class CodeCoverageException extends \PHPUnit\Framework\Exception
-{
 }
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -9554,14 +9642,6 @@ final class IncompleteTestError extends \PHPUnit\Framework\AssertionFailedError 
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
  */
 abstract class InvalidArgumentException extends \PHPUnit\Framework\Exception
-{
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
-final class InvalidCoversTargetException extends \PHPUnit\Framework\CodeCoverageException
 {
 }
 /**
@@ -9733,9 +9813,9 @@ final class UnknownClassOrInterfaceException extends \PHPUnit\Framework\InvalidA
  *
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
  */
-final class UnknownTypeException extends \PHPUnit\Framework\InvalidArgumentException
+final class UnknownNativeTypeException extends \PHPUnit\Framework\InvalidArgumentException
 {
-    public function __construct(string $name)
+    public function __construct(string $type)
     {
     }
 }
@@ -9869,10 +9949,8 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
      * @param non-empty-string $name
      *
      * @internal This method is not covered by the backward compatibility promise for PHPUnit
-     *
-     * @final
      */
-    public function __construct(string $name)
+    final public function __construct(string $name)
     {
     }
     /**
@@ -9954,7 +10032,6 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
      * @throws \PHPUnit\Util\Exception
      * @throws \SebastianBergmann\CodeCoverage\InvalidArgumentException
      * @throws \SebastianBergmann\Template\InvalidArgumentException
-     * @throws CodeCoverageException
      * @throws Exception
      * @throws \PHPUnit\Event\NoPreviousThrowableException
      * @throws ProcessIsolationException
@@ -10003,6 +10080,8 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
     }
     /**
      * @internal This method is not covered by the backward compatibility promise for PHPUnit
+     *
+     * @phpstan-assert-if-true non-empty-string $this->output()
      */
     final public function hasUnexpectedOutput(): bool
     {
@@ -10271,64 +10350,7 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
     final protected function atMost(int $allowedInvocations): \PHPUnit\Framework\MockObject\Rule\InvokedAtMostCount
     {
     }
-    /**
-     * @deprecated Use <code>$double->willReturn()</code> instead of <code>$double->will($this->returnValue())</code>
-     * @see https://github.com/sebastianbergmann/phpunit/issues/5423
-     *
-     * @codeCoverageIgnore
-     */
-    final protected function returnValue(mixed $value): \PHPUnit\Framework\MockObject\Stub\ReturnStub
-    {
-    }
-    /**
-     * @param array<mixed> $valueMap
-     *
-     * @deprecated Use <code>$double->willReturnMap()</code> instead of <code>$double->will($this->returnValueMap())</code>
-     * @see https://github.com/sebastianbergmann/phpunit/issues/5423
-     *
-     * @codeCoverageIgnore
-     */
-    final protected function returnValueMap(array $valueMap): \PHPUnit\Framework\MockObject\Stub\ReturnValueMap
-    {
-    }
-    /**
-     * @deprecated Use <code>$double->willReturnArgument()</code> instead of <code>$double->will($this->returnArgument())</code>
-     * @see https://github.com/sebastianbergmann/phpunit/issues/5423
-     *
-     * @codeCoverageIgnore
-     */
-    final protected function returnArgument(int $argumentIndex): \PHPUnit\Framework\MockObject\Stub\ReturnArgument
-    {
-    }
-    /**
-     * @deprecated Use <code>$double->willReturnCallback()</code> instead of <code>$double->will($this->returnCallback())</code>
-     * @see https://github.com/sebastianbergmann/phpunit/issues/5423
-     *
-     * @codeCoverageIgnore
-     */
-    final protected function returnCallback(callable $callback): \PHPUnit\Framework\MockObject\Stub\ReturnCallback
-    {
-    }
-    /**
-     * @deprecated Use <code>$double->willReturnSelf()</code> instead of <code>$double->will($this->returnSelf())</code>
-     * @see https://github.com/sebastianbergmann/phpunit/issues/5423
-     *
-     * @codeCoverageIgnore
-     */
-    final protected function returnSelf(): \PHPUnit\Framework\MockObject\Stub\ReturnSelf
-    {
-    }
     final protected function throwException(\Throwable $exception): \PHPUnit\Framework\MockObject\Stub\Exception
-    {
-    }
-    /**
-     * @deprecated Use <code>$double->willReturn()</code> instead of <code>$double->will($this->onConsecutiveCalls())</code>
-     * @see https://github.com/sebastianbergmann/phpunit/issues/5423
-     * @see https://github.com/sebastianbergmann/phpunit/issues/5425
-     *
-     * @codeCoverageIgnore
-     */
-    final protected function onConsecutiveCalls(mixed ...$arguments): \PHPUnit\Framework\MockObject\Stub\ConsecutiveCalls
     {
     }
     final protected function getActualOutputForAssertion(): string
@@ -10338,6 +10360,9 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
     {
     }
     final protected function expectOutputString(string $expectedString): void
+    {
+    }
+    final protected function expectErrorLog(): void
     {
     }
     /**
@@ -10400,38 +10425,11 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
     {
     }
     /**
-     * This method is a wrapper for the ini_set() function that automatically
-     * resets the modified php.ini setting to its original value after the
-     * test is run.
-     *
-     * @throws Exception
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5214
-     *
-     * @codeCoverageIgnore
-     */
-    final protected function iniSet(string $varName, string $newValue): void
-    {
-    }
-    /**
-     * This method is a wrapper for the setlocale() function that automatically
-     * resets the locale to its original value after the test is run.
-     *
-     * @throws Exception
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5216
-     *
-     * @codeCoverageIgnore
-     */
-    final protected function setLocale(mixed ...$arguments): void
-    {
-    }
-    /**
      * Creates a mock object for the specified interface or class.
      *
      * @template RealInstanceType of object
      *
-     * @param class-string<RealInstanceType> $originalClassName
+     * @param class-string<RealInstanceType> $type
      *
      * @throws InvalidArgumentException
      * @throws MockObject\Exception
@@ -10439,7 +10437,7 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
      *
      * @return MockObject\MockObject&RealInstanceType
      */
-    final protected function createMock(string $originalClassName): \PHPUnit\Framework\MockObject\MockObject
+    final protected function createMock(string $type): \PHPUnit\Framework\MockObject\MockObject
     {
     }
     /**
@@ -10455,7 +10453,7 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
      *
      * @template RealInstanceType of object
      *
-     * @param class-string<RealInstanceType> $originalClassName
+     * @param class-string<RealInstanceType> $type
      * @param array<non-empty-string, mixed> $configuration
      *
      * @throws InvalidArgumentException
@@ -10464,13 +10462,13 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
      *
      * @return MockObject\MockObject&RealInstanceType
      */
-    final protected function createConfiguredMock(string $originalClassName, array $configuration): \PHPUnit\Framework\MockObject\MockObject
+    final protected function createConfiguredMock(string $type, array $configuration): \PHPUnit\Framework\MockObject\MockObject
     {
     }
     /**
      * Creates a partial mock object for the specified interface or class.
      *
-     * @param class-string<RealInstanceType> $originalClassName
+     * @param class-string<RealInstanceType> $type
      * @param list<non-empty-string>         $methods
      *
      * @template RealInstanceType of object
@@ -10480,89 +10478,7 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
      *
      * @return MockObject\MockObject&RealInstanceType
      */
-    final protected function createPartialMock(string $originalClassName, array $methods): \PHPUnit\Framework\MockObject\MockObject
-    {
-    }
-    /**
-     * Creates a test proxy for the specified class.
-     *
-     * @template RealInstanceType of object
-     *
-     * @param class-string<RealInstanceType> $originalClassName
-     * @param array<mixed>                   $constructorArguments
-     *
-     * @throws InvalidArgumentException
-     * @throws MockObject\Exception
-     *
-     * @return MockObject\MockObject&RealInstanceType
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5240
-     */
-    final protected function createTestProxy(string $originalClassName, array $constructorArguments = []): \PHPUnit\Framework\MockObject\MockObject
-    {
-    }
-    /**
-     * Creates a mock object for the specified abstract class with all abstract
-     * methods of the class mocked. Concrete methods are not mocked by default.
-     * To mock concrete methods, use the 7th parameter ($mockedMethods).
-     *
-     * @template RealInstanceType of object
-     *
-     * @param class-string<RealInstanceType> $originalClassName
-     * @param array<mixed>                   $arguments
-     * @param list<non-empty-string>         $mockedMethods
-     *
-     * @throws InvalidArgumentException
-     * @throws MockObject\Exception
-     *
-     * @return MockObject\MockObject&RealInstanceType
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5241
-     */
-    final protected function getMockForAbstractClass(string $originalClassName, array $arguments = [], string $mockClassName = '', bool $callOriginalConstructor = true, bool $callOriginalClone = true, bool $callAutoload = true, array $mockedMethods = [], bool $cloneArguments = false): \PHPUnit\Framework\MockObject\MockObject
-    {
-    }
-    /**
-     * Creates a mock object based on the given WSDL file.
-     *
-     * @param list<string> $methods
-     * @param list<mixed>  $options
-     *
-     * @throws MockObject\Exception
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5242
-     */
-    final protected function getMockFromWsdl(string $wsdlFile, string $originalClassName = '', string $mockClassName = '', array $methods = [], bool $callOriginalConstructor = true, array $options = []): \PHPUnit\Framework\MockObject\MockObject
-    {
-    }
-    /**
-     * Creates a mock object for the specified trait with all abstract methods
-     * of the trait mocked. Concrete methods to mock can be specified with the
-     * `$mockedMethods` parameter.
-     *
-     * @param trait-string           $traitName
-     * @param array<mixed>           $arguments
-     * @param list<non-empty-string> $mockedMethods
-     *
-     * @throws InvalidArgumentException
-     * @throws MockObject\Exception
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5243
-     */
-    final protected function getMockForTrait(string $traitName, array $arguments = [], string $mockClassName = '', bool $callOriginalConstructor = true, bool $callOriginalClone = true, bool $callAutoload = true, array $mockedMethods = [], bool $cloneArguments = false): \PHPUnit\Framework\MockObject\MockObject
-    {
-    }
-    /**
-     * Creates an object that uses the specified trait.
-     *
-     * @param trait-string $traitName
-     * @param array<mixed> $arguments
-     *
-     * @throws MockObject\Exception
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5244
-     */
-    final protected function getObjectForTrait(string $traitName, array $arguments = [], string $traitClassName = '', bool $callOriginalConstructor = true, bool $callOriginalClone = true, bool $callAutoload = true): object
+    final protected function createPartialMock(string $type, array $methods): \PHPUnit\Framework\MockObject\MockObject
     {
     }
     protected function transformException(\Throwable $t): \Throwable
@@ -10581,7 +10497,7 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
      *
      * @template RealInstanceType of object
      *
-     * @param class-string<RealInstanceType> $originalClassName
+     * @param class-string<RealInstanceType> $type
      *
      * @throws InvalidArgumentException
      * @throws MockObject\Exception
@@ -10589,7 +10505,7 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
      *
      * @return RealInstanceType&MockObject\Stub
      */
-    final protected static function createStub(string $originalClassName): \PHPUnit\Framework\MockObject\Stub
+    final protected static function createStub(string $type): \PHPUnit\Framework\MockObject\Stub
     {
     }
     /**
@@ -10605,7 +10521,7 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
      *
      * @template RealInstanceType of object
      *
-     * @param class-string<RealInstanceType> $originalClassName
+     * @param class-string<RealInstanceType> $type
      * @param array<non-empty-string, mixed> $configuration
      *
      * @throws InvalidArgumentException
@@ -10614,7 +10530,7 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
      *
      * @return RealInstanceType&MockObject\Stub
      */
-    final protected static function createConfiguredStub(string $originalClassName, array $configuration): \PHPUnit\Framework\MockObject\Stub
+    final protected static function createConfiguredStub(string $type, array $configuration): \PHPUnit\Framework\MockObject\Stub
     {
     }
 }
@@ -10680,7 +10596,6 @@ final class TestRunner
     {
     }
     /**
-     * @throws CodeCoverageException
      * @throws \PHPUnit\Runner\Exception
      * @throws \SebastianBergmann\CodeCoverage\InvalidArgumentException
      * @throws \SebastianBergmann\CodeCoverage\UnintentionallyCoveredCodeException
@@ -10783,7 +10698,6 @@ class TestSuite implements \IteratorAggregate, \PHPUnit\Framework\Reorderable, \
     {
     }
     /**
-     * @throws CodeCoverageException
      * @throws \PHPUnit\Event\RuntimeException
      * @throws Exception
      * @throws \SebastianBergmann\CodeCoverage\InvalidArgumentException
@@ -11013,6 +10927,48 @@ final readonly class CoversClass
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+final readonly class CoversClassesThatExtendClass
+{
+    /**
+     * @param class-string $className
+     */
+    public function __construct(string $className)
+    {
+    }
+    /**
+     * @return class-string
+     */
+    public function className(): string
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+final readonly class CoversClassesThatImplementInterface
+{
+    /**
+     * @param class-string $interfaceName
+     */
+    public function __construct(string $interfaceName)
+    {
+    }
+    /**
+     * @return class-string
+     */
+    public function interfaceName(): string
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final readonly class CoversFunction
 {
     /**
@@ -11053,6 +11009,27 @@ final readonly class CoversMethod
      * @return non-empty-string
      */
     public function methodName(): string
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+final readonly class CoversNamespace
+{
+    /**
+     * @param non-empty-string $namespace
+     */
+    public function __construct(string $namespace)
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function namespace(): string
     {
     }
 }
@@ -11522,6 +11499,24 @@ final readonly class PreserveGlobalState
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final readonly class RequiresEnvironmentVariable
+{
+    public function __construct(string $environmentVariableName, null|string $value = null)
+    {
+    }
+    public function environmentVariableName(): string
+    {
+    }
+    public function value(): null|string
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final readonly class RequiresFunction
 {
     /**
@@ -11896,6 +11891,48 @@ final readonly class UsesClass
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+final readonly class UsesClassesThatExtendClass
+{
+    /**
+     * @param class-string $className
+     */
+    public function __construct(string $className)
+    {
+    }
+    /**
+     * @return class-string
+     */
+    public function className(): string
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+final readonly class UsesClassesThatImplementInterface
+{
+    /**
+     * @param class-string $interfaceName
+     */
+    public function __construct(string $interfaceName)
+    {
+    }
+    /**
+     * @return class-string
+     */
+    public function interfaceName(): string
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final readonly class UsesFunction
 {
     /**
@@ -11945,6 +11982,27 @@ final readonly class UsesMethod
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+final readonly class UsesNamespace
+{
+    /**
+     * @param non-empty-string $namespace
+     */
+    public function __construct(string $namespace)
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function namespace(): string
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final readonly class UsesTrait
 {
     /**
@@ -11957,6 +12015,30 @@ final readonly class UsesTrait
      * @return trait-string
      */
     public function traitName(): string
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final readonly class WithEnvironmentVariable
+{
+    /**
+     * @param non-empty-string $environmentVariableName
+     */
+    public function __construct(string $environmentVariableName, null|string $value = null)
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function environmentVariableName(): string
+    {
+    }
+    public function value(): null|string
     {
     }
 }
@@ -13070,12 +13152,13 @@ final class TraversableContainsIdentical extends \PHPUnit\Framework\Constraint\T
  */
 final class TraversableContainsOnly extends \PHPUnit\Framework\Constraint\Constraint
 {
+    public static function forNativeType(\PHPUnit\Framework\NativeType $type): self
+    {
+    }
     /**
-     * @param 'array'|'bool'|'boolean'|'callable'|'double'|'float'|'int'|'integer'|'iterable'|'null'|'numeric'|'object'|'real'|'resource (closed)'|'resource'|'scalar'|'string'|class-string $type
-     *
-     * @throws \PHPUnit\Framework\Exception
+     * @param class-string $type
      */
-    public function __construct(string $type, bool $isNativeType = true)
+    public static function forClassOrInterface(string $type): self
     {
     }
     /**
@@ -13135,64 +13218,7 @@ final class IsNull extends \PHPUnit\Framework\Constraint\Constraint
  */
 final class IsType extends \PHPUnit\Framework\Constraint\Constraint
 {
-    /**
-     * @var string
-     */
-    public const TYPE_ARRAY = 'array';
-    /**
-     * @var string
-     */
-    public const TYPE_BOOL = 'bool';
-    /**
-     * @var string
-     */
-    public const TYPE_FLOAT = 'float';
-    /**
-     * @var string
-     */
-    public const TYPE_INT = 'int';
-    /**
-     * @var string
-     */
-    public const TYPE_NULL = 'null';
-    /**
-     * @var string
-     */
-    public const TYPE_NUMERIC = 'numeric';
-    /**
-     * @var string
-     */
-    public const TYPE_OBJECT = 'object';
-    /**
-     * @var string
-     */
-    public const TYPE_RESOURCE = 'resource';
-    /**
-     * @var string
-     */
-    public const TYPE_CLOSED_RESOURCE = 'resource (closed)';
-    /**
-     * @var string
-     */
-    public const TYPE_STRING = 'string';
-    /**
-     * @var string
-     */
-    public const TYPE_SCALAR = 'scalar';
-    /**
-     * @var string
-     */
-    public const TYPE_CALLABLE = 'callable';
-    /**
-     * @var string
-     */
-    public const TYPE_ITERABLE = 'iterable';
-    /**
-     * @param 'array'|'bool'|'boolean'|'callable'|'double'|'float'|'int'|'integer'|'iterable'|'null'|'numeric'|'object'|'real'|'resource (closed)'|'resource'|'scalar'|'string' $type
-     *
-     * @throws \PHPUnit\Framework\UnknownTypeException
-     */
-    public function __construct(string $type)
+    public function __construct(\PHPUnit\Framework\NativeType $type)
     {
     }
     /**
@@ -13251,19 +13277,6 @@ final readonly class ConfigurableMethod
  */
 final class BadMethodCallException extends \BadMethodCallException implements \PHPUnit\Framework\MockObject\Exception
 {
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- *
- * @codeCoverageIgnore
- */
-final class CannotCloneTestDoubleForReadonlyClassException extends \PHPUnit\Framework\Exception implements \PHPUnit\Framework\MockObject\Exception
-{
-    public function __construct()
-    {
-    }
 }
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -13426,7 +13439,6 @@ final class MockBuilder
      * @throws \PHPUnit\Framework\InvalidArgumentException
      * @throws Generator\InvalidMethodNameException
      * @throws Generator\NameAlreadyInUseException
-     * @throws Generator\OriginalConstructorInvocationRequiredException
      * @throws Generator\ReflectionException
      * @throws Generator\RuntimeException
      * @throws Generator\UnknownTypeException
@@ -13434,34 +13446,6 @@ final class MockBuilder
      * @return MockedType&MockObject
      */
     public function getMock(): \PHPUnit\Framework\MockObject\MockObject
-    {
-    }
-    /**
-     * Creates a mock object for an abstract class using a fluent interface.
-     *
-     * @throws \PHPUnit\Framework\Exception
-     * @throws Generator\ReflectionException
-     * @throws Generator\RuntimeException
-     *
-     * @return MockedType&MockObject
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5305
-     */
-    public function getMockForAbstractClass(): \PHPUnit\Framework\MockObject\MockObject
-    {
-    }
-    /**
-     * Creates a mock object for a trait using a fluent interface.
-     *
-     * @throws \PHPUnit\Framework\Exception
-     * @throws Generator\ReflectionException
-     * @throws Generator\RuntimeException
-     *
-     * @return MockedType&MockObject
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5306
-     */
-    public function getMockForTrait(): \PHPUnit\Framework\MockObject\MockObject
     {
     }
     /**
@@ -13476,23 +13460,6 @@ final class MockBuilder
      * @phan-return $this<MockedType>
      */
     public function onlyMethods(array $methods): self
-    {
-    }
-    /**
-     * Specifies methods that don't exist in the class which you want to mock.
-     *
-     * @param list<non-empty-string> $methods
-     *
-     * @throws Generator\CannotUseAddMethodsException
-     * @throws Generator\ReflectionException
-     * @throws Generator\RuntimeException
-     *
-     * @return $this
-     * @phan-return $this<MockedType>
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5320
-     */
-    public function addMethods(array $methods): self
     {
     }
     /**
@@ -13554,107 +13521,6 @@ final class MockBuilder
     {
     }
     /**
-     * Disables the use of class autoloading while creating the mock object.
-     *
-     * @return $this
-     * @phan-return $this<MockedType>
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5309
-     *
-     * @codeCoverageIgnore
-     */
-    public function disableAutoload(): self
-    {
-    }
-    /**
-     * Enables the use of class autoloading while creating the mock object.
-     *
-     * @return $this
-     * @phan-return $this<MockedType>
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5309
-     */
-    public function enableAutoload(): self
-    {
-    }
-    /**
-     * Disables the cloning of arguments passed to mocked methods.
-     *
-     * @return $this
-     * @phan-return $this<MockedType>
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5315
-     */
-    public function disableArgumentCloning(): self
-    {
-    }
-    /**
-     * Enables the cloning of arguments passed to mocked methods.
-     *
-     * @return $this
-     * @phan-return $this<MockedType>
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5315
-     */
-    public function enableArgumentCloning(): self
-    {
-    }
-    /**
-     * Enables the invocation of the original methods.
-     *
-     * @return $this
-     * @phan-return $this<MockedType>
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5307
-     *
-     * @codeCoverageIgnore
-     */
-    public function enableProxyingToOriginalMethods(): self
-    {
-    }
-    /**
-     * Disables the invocation of the original methods.
-     *
-     * @return $this
-     * @phan-return $this<MockedType>
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5307
-     */
-    public function disableProxyingToOriginalMethods(): self
-    {
-    }
-    /**
-     * Sets the proxy target.
-     *
-     * @return $this
-     * @phan-return $this<MockedType>
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5307
-     *
-     * @codeCoverageIgnore
-     */
-    public function setProxyTarget(object $object): self
-    {
-    }
-    /**
-     * @return $this
-     * @phan-return $this<MockedType>
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5308
-     */
-    public function allowMockingUnknownTypes(): self
-    {
-    }
-    /**
-     * @return $this
-     * @phan-return $this<MockedType>
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5308
-     */
-    public function disallowMockingUnknownTypes(): self
-    {
-    }
-    /**
      * @return $this
      * @phan-return $this<MockedType>
      */
@@ -13685,46 +13551,11 @@ trait DoubledCloneMethod
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  *
  * @internal This trait is not covered by the backward compatibility promise for PHPUnit
- *
- * @codeCoverageIgnore
- */
-trait ErrorCloneMethod
-{
-    public function __clone(): void
-    {
-    }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This trait is not covered by the backward compatibility promise for PHPUnit
- */
-trait GeneratedAsMockObject
-{
-    public function __phpunit_wasGeneratedAsMockObject(): true
-    {
-    }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This trait is not covered by the backward compatibility promise for PHPUnit
- */
-trait GeneratedAsTestStub
-{
-    public function __phpunit_wasGeneratedAsMockObject(): false
-    {
-    }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This trait is not covered by the backward compatibility promise for PHPUnit
  */
 trait Method
 {
     abstract public function __phpunit_getInvocationHandler(): \PHPUnit\Framework\MockObject\InvocationHandler;
-    public function method(...$func_get_args): \PHPUnit\Framework\MockObject\Builder\InvocationMocker
+    public function method(\PHPUnit\Framework\Constraint\Constraint|\PHPUnit\Framework\MockObject\Runtime\PropertyHook|string $constraint): \PHPUnit\Framework\MockObject\InvocationStubber
     {
     }
 }
@@ -13746,29 +13577,7 @@ trait MockObjectApi
     abstract public function __phpunit_state(): \PHPUnit\Framework\MockObject\TestDoubleState;
     abstract public function __phpunit_getInvocationHandler(): \PHPUnit\Framework\MockObject\InvocationHandler;
     abstract public function __phpunit_unsetInvocationMocker(): void;
-    public function expects(\PHPUnit\Framework\MockObject\Rule\InvocationOrder $matcher): \PHPUnit\Framework\MockObject\Builder\InvocationMocker
-    {
-    }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This trait is not covered by the backward compatibility promise for PHPUnit
- *
- * @codeCoverageIgnore
- */
-trait MutableStubApi
-{
-    private \PHPUnit\Framework\MockObject\TestDoubleState $__phpunit_state;
-    public function __phpunit_state(): \PHPUnit\Framework\MockObject\TestDoubleState
-    {
-    }
-    /** @noinspection MagicMethodsValidityInspection */
-    public function __phpunit_getInvocationHandler(): \PHPUnit\Framework\MockObject\InvocationHandler
-    {
-    }
-    /** @noinspection MagicMethodsValidityInspection */
-    public function __phpunit_unsetInvocationMocker(): void
+    public function expects(\PHPUnit\Framework\MockObject\Rule\InvocationOrder $matcher): \PHPUnit\Framework\MockObject\InvocationStubber
     {
     }
 }
@@ -13826,24 +13635,6 @@ final class TestDoubleState
     public function unsetInvocationHandler(): void
     {
     }
-    public function setProxyTarget(object $proxyTarget): void
-    {
-    }
-    public function proxyTarget(): object
-    {
-    }
-    /**
-     * @param non-empty-string $testId
-     */
-    public function deprecationWasEmittedFor(string $testId): void
-    {
-    }
-    /**
-     * @param non-empty-string $testId
-     */
-    public function wasDeprecationAlreadyEmittedFor(string $testId): bool
-    {
-    }
     /**
      * @return list<ConfigurableMethod>
      */
@@ -13855,13 +13646,81 @@ final class TestDoubleState
     }
 }
 /**
- * @method Builder\InvocationMocker method($constraint)
- *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+interface InvocationStubber
+{
+    /**
+     * @param \PHPUnit\Framework\Constraint\Constraint|non-empty-string|Runtime\PropertyHook $constraint
+     *
+     * @return $this
+     */
+    public function method(\PHPUnit\Framework\Constraint\Constraint|\PHPUnit\Framework\MockObject\Runtime\PropertyHook|string $constraint): self;
+    /**
+     * @param non-empty-string $id
+     *
+     * @return $this
+     */
+    public function id(string $id): self;
+    /**
+     * @param non-empty-string $id
+     *
+     * @return $this
+     */
+    public function after(string $id): self;
+    /**
+     * @return $this
+     */
+    public function with(mixed ...$arguments): self;
+    /**
+     * @return $this
+     */
+    public function withAnyParameters(): self;
+    /**
+     * @return $this
+     */
+    public function will(\PHPUnit\Framework\MockObject\Stub\Stub $stub): self;
+    /**
+     * @return $this
+     */
+    public function willReturn(mixed $value, mixed ...$nextValues): self;
+    /**
+     * @return $this
+     */
+    public function willReturnReference(mixed &$reference): self;
+    /**
+     * @param array<int, array<int, mixed>> $valueMap
+     *
+     * @return $this
+     */
+    public function willReturnMap(array $valueMap): self;
+    /**
+     * @return $this
+     */
+    public function willReturnArgument(int $argumentIndex): self;
+    /**
+     * @return $this
+     */
+    public function willReturnCallback(callable $callback): self;
+    /**
+     * @return $this
+     */
+    public function willReturnSelf(): self;
+    /**
+     * @return $this
+     */
+    public function willReturnOnConsecutiveCalls(mixed ...$values): self;
+    /**
+     * @return $this
+     */
+    public function willThrowException(\Throwable $exception): self;
+}
+/**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
 interface MockObject extends \PHPUnit\Framework\MockObject\Stub
 {
-    public function expects(\PHPUnit\Framework\MockObject\Rule\InvocationOrder $invocationRule): \PHPUnit\Framework\MockObject\Builder\InvocationMocker;
+    public function expects(\PHPUnit\Framework\MockObject\Rule\InvocationOrder $invocationRule): \PHPUnit\Framework\MockObject\InvocationStubber;
 }
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -13874,12 +13733,11 @@ interface MockObjectInternal extends \PHPUnit\Framework\MockObject\MockObject, \
     public function __phpunit_verify(bool $unsetInvocationMocker = true): void;
 }
 /**
- * @method Builder\InvocationStubber method($constraint)
- *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
 interface Stub
 {
+    public function method(\PHPUnit\Framework\Constraint\Constraint|\PHPUnit\Framework\MockObject\Runtime\PropertyHook|string $constraint): \PHPUnit\Framework\MockObject\InvocationStubber;
 }
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -13891,7 +13749,6 @@ interface StubInternal extends \PHPUnit\Framework\MockObject\Stub
     public function __phpunit_state(): \PHPUnit\Framework\MockObject\TestDoubleState;
     public function __phpunit_getInvocationHandler(): \PHPUnit\Framework\MockObject\InvocationHandler;
     public function __phpunit_unsetInvocationMocker(): void;
-    public function __phpunit_wasGeneratedAsMockObject(): bool;
 }
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -13905,7 +13762,7 @@ final readonly class Invocation implements \PHPUnit\Framework\SelfDescribing
      * @param non-empty-string $methodName
      * @param array<mixed>     $parameters
      */
-    public function __construct(string $className, string $methodName, array $parameters, string $returnType, \PHPUnit\Framework\MockObject\MockObjectInternal|\PHPUnit\Framework\MockObject\StubInternal $object, bool $cloneObjects = false, bool $proxiedCall = false)
+    public function __construct(string $className, string $methodName, array $parameters, string $returnType, \PHPUnit\Framework\MockObject\MockObjectInternal|\PHPUnit\Framework\MockObject\StubInternal $object)
     {
     }
     /**
@@ -13957,6 +13814,8 @@ final class InvocationHandler
     }
     /**
      * Looks up the match builder with identification $id and returns it.
+     *
+     * @param non-empty-string $id
      */
     public function lookupMatcher(string $id): ?\PHPUnit\Framework\MockObject\Matcher
     {
@@ -13965,12 +13824,14 @@ final class InvocationHandler
      * Registers a matcher with the identification $id. The matcher can later be
      * looked up using lookupMatcher() to figure out if it has been invoked.
      *
+     * @param non-empty-string $id
+     *
      * @throws MatcherAlreadyRegisteredException
      */
     public function registerMatcher(string $id, \PHPUnit\Framework\MockObject\Matcher $matcher): void
     {
     }
-    public function expects(\PHPUnit\Framework\MockObject\Rule\InvocationOrder $rule): \PHPUnit\Framework\MockObject\Builder\InvocationMocker
+    public function expects(\PHPUnit\Framework\MockObject\Rule\InvocationOrder $rule): \PHPUnit\Framework\MockObject\InvocationStubber
     {
     }
     /**
@@ -13984,6 +13845,99 @@ final class InvocationHandler
      * @throws \Throwable
      */
     public function verify(): void
+    {
+    }
+}
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class InvocationStubberImplementation implements \PHPUnit\Framework\MockObject\InvocationStubber
+{
+    public function __construct(\PHPUnit\Framework\MockObject\InvocationHandler $handler, \PHPUnit\Framework\MockObject\Matcher $matcher, \PHPUnit\Framework\MockObject\ConfigurableMethod ...$configurableMethods)
+    {
+    }
+    /**
+     * @param \PHPUnit\Framework\Constraint\Constraint|non-empty-string|Runtime\PropertyHook $constraint
+     *
+     * @throws \PHPUnit\Framework\InvalidArgumentException
+     * @throws MethodCannotBeConfiguredException
+     * @throws MethodNameAlreadyConfiguredException
+     *
+     * @return $this
+     */
+    public function method(\PHPUnit\Framework\Constraint\Constraint|\PHPUnit\Framework\MockObject\Runtime\PropertyHook|string $constraint): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+    }
+    /**
+     * @param non-empty-string $id
+     *
+     * @throws MatcherAlreadyRegisteredException
+     *
+     * @return $this
+     */
+    public function id(string $id): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+    }
+    /**
+     * @param non-empty-string $id
+     *
+     * @return $this
+     */
+    public function after(string $id): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+    }
+    /**
+     * @throws \PHPUnit\Framework\Exception
+     * @throws MethodNameNotConfiguredException
+     * @throws MethodParametersAlreadyConfiguredException
+     *
+     * @return $this
+     */
+    public function with(mixed ...$arguments): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+    }
+    /**
+     * @throws MethodNameNotConfiguredException
+     * @throws MethodParametersAlreadyConfiguredException
+     *
+     * @return $this
+     */
+    public function withAnyParameters(): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+    }
+    /**
+     * @return $this
+     */
+    public function will(\PHPUnit\Framework\MockObject\Stub\Stub $stub): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+    }
+    /**
+     * @throws IncompatibleReturnValueException
+     */
+    public function willReturn(mixed $value, mixed ...$nextValues): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+    }
+    public function willReturnReference(mixed &$reference): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+    }
+    public function willReturnMap(array $valueMap): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+    }
+    public function willReturnArgument(int $argumentIndex): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+    }
+    public function willReturnCallback(callable $callback): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+    }
+    public function willReturnSelf(): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+    }
+    public function willReturnOnConsecutiveCalls(mixed ...$values): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+    }
+    public function willThrowException(\Throwable $exception): \PHPUnit\Framework\MockObject\InvocationStubber
     {
     }
 }
@@ -14018,6 +13972,9 @@ final class Matcher
     public function setStub(\PHPUnit\Framework\MockObject\Stub\Stub $stub): void
     {
     }
+    /**
+     * @param non-empty-string $id
+     */
     public function setAfterMatchBuilderId(string $id): void
     {
     }
@@ -14079,212 +14036,6 @@ final class ReturnValueGenerator
     {
     }
 }
-namespace PHPUnit\Framework\MockObject\Builder;
-
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
-interface Identity
-{
-    /**
-     * Sets the identification of the expectation to $id.
-     *
-     * @note The identifier is unique per mock object.
-     */
-    public function id(string $id): self;
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- */
-final class InvocationMocker implements \PHPUnit\Framework\MockObject\Builder\InvocationStubber, \PHPUnit\Framework\MockObject\Builder\MethodNameMatch
-{
-    public function __construct(\PHPUnit\Framework\MockObject\InvocationHandler $handler, \PHPUnit\Framework\MockObject\Matcher $matcher, \PHPUnit\Framework\MockObject\ConfigurableMethod ...$configurableMethods)
-    {
-    }
-    /**
-     * @throws \PHPUnit\Framework\MockObject\MatcherAlreadyRegisteredException
-     *
-     * @return $this
-     */
-    public function id(string $id): self
-    {
-    }
-    /**
-     * @return $this
-     */
-    public function will(\PHPUnit\Framework\MockObject\Stub\Stub $stub): \PHPUnit\Framework\MockObject\Builder\Identity
-    {
-    }
-    /**
-     * @throws \PHPUnit\Framework\MockObject\IncompatibleReturnValueException
-     */
-    public function willReturn(mixed $value, mixed ...$nextValues): self
-    {
-    }
-    public function willReturnReference(mixed &$reference): self
-    {
-    }
-    public function willReturnMap(array $valueMap): self
-    {
-    }
-    public function willReturnArgument(int $argumentIndex): self
-    {
-    }
-    public function willReturnCallback(callable $callback): self
-    {
-    }
-    public function willReturnSelf(): self
-    {
-    }
-    public function willReturnOnConsecutiveCalls(mixed ...$values): self
-    {
-    }
-    public function willThrowException(\Throwable $exception): self
-    {
-    }
-    /**
-     * @return $this
-     */
-    public function after(string $id): self
-    {
-    }
-    /**
-     * @throws \PHPUnit\Framework\Exception
-     * @throws \PHPUnit\Framework\MockObject\MethodNameNotConfiguredException
-     * @throws \PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException
-     *
-     * @return $this
-     */
-    public function with(mixed ...$arguments): self
-    {
-    }
-    /**
-     * @throws \PHPUnit\Framework\MockObject\MethodNameNotConfiguredException
-     * @throws \PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException
-     *
-     * @return $this
-     */
-    public function withAnyParameters(): self
-    {
-    }
-    /**
-     * @throws \PHPUnit\Framework\InvalidArgumentException
-     * @throws \PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException
-     * @throws \PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException
-     *
-     * @return $this
-     */
-    public function method(\PHPUnit\Framework\Constraint\Constraint|\PHPUnit\Framework\MockObject\Runtime\PropertyHook|string $constraint): self
-    {
-    }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- */
-interface InvocationStubber
-{
-    public function will(\PHPUnit\Framework\MockObject\Stub\Stub $stub): \PHPUnit\Framework\MockObject\Builder\Identity;
-    /**
-     * @return $this
-     */
-    public function willReturn(mixed $value, mixed ...$nextValues): self;
-    /**
-     * @return $this
-     */
-    public function willReturnReference(mixed &$reference): self;
-    /**
-     * @param array<int, array<int, mixed>> $valueMap
-     *
-     * @return $this
-     */
-    public function willReturnMap(array $valueMap): self;
-    /**
-     * @return $this
-     */
-    public function willReturnArgument(int $argumentIndex): self;
-    /**
-     * @return $this
-     */
-    public function willReturnCallback(callable $callback): self;
-    /**
-     * @return $this
-     */
-    public function willReturnSelf(): self;
-    /**
-     * @return $this
-     */
-    public function willReturnOnConsecutiveCalls(mixed ...$values): self;
-    /**
-     * @return $this
-     */
-    public function willThrowException(\Throwable $exception): self;
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
-interface MethodNameMatch extends \PHPUnit\Framework\MockObject\Builder\ParametersMatch
-{
-    /**
-     * Adds a new method name match and returns the parameter match object for
-     * further matching possibilities.
-     */
-    public function method(\PHPUnit\Framework\Constraint\Constraint|string $constraint): self;
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
-interface ParametersMatch extends \PHPUnit\Framework\MockObject\Builder\Stub
-{
-    /**
-     * Defines the expectation which must occur before the current is valid.
-     */
-    public function after(string $id): \PHPUnit\Framework\MockObject\Builder\Stub;
-    /**
-     * Sets the parameters to match for, each parameter to this function will
-     * be part of match. To perform specific matches or constraints create a
-     * new PHPUnit\Framework\Constraint\Constraint and use it for the parameter.
-     * If the parameter value is not a constraint it will use the
-     * PHPUnit\Framework\Constraint\IsEqual for the value.
-     *
-     * Some examples:
-     * <code>
-     * // match first parameter with value 2
-     * $b->with(2);
-     * // match first parameter with value 'smock' and second identical to 42
-     * $b->with('smock', new PHPUnit\Framework\Constraint\IsEqual(42));
-     * </code>
-     */
-    public function with(mixed ...$arguments): self;
-    /**
-     * Sets a rule which allows any kind of parameters.
-     *
-     * Some examples:
-     * <code>
-     * // match any number of parameters
-     * $b->withAnyParameters();
-     * </code>
-     */
-    public function withAnyParameters(): self;
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
-interface Stub extends \PHPUnit\Framework\MockObject\Builder\Identity
-{
-    /**
-     * Stubs the matching method with the stub object $stub. Any invocations of
-     * the matched method will now be handled by the stub instead.
-     */
-    public function will(\PHPUnit\Framework\MockObject\Stub\Stub $stub): \PHPUnit\Framework\MockObject\Builder\Identity;
-}
 namespace PHPUnit\Framework\MockObject\Generator;
 
 /**
@@ -14292,9 +14043,98 @@ namespace PHPUnit\Framework\MockObject\Generator;
  *
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
  */
-final class CannotUseAddMethodsException extends \PHPUnit\Framework\Exception implements \PHPUnit\Framework\MockObject\Generator\Exception
+final readonly class DoubledClass
 {
-    public function __construct(string $type, string $methodName)
+    /**
+     * @param class-string             $mockName
+     * @param list<\PHPUnit\Framework\MockObject\ConfigurableMethod> $configurableMethods
+     */
+    public function __construct(string $classCode, string $mockName, array $configurableMethods)
+    {
+    }
+    /**
+     * @return class-string
+     */
+    public function generate(): string
+    {
+    }
+    public function classCode(): string
+    {
+    }
+    /**
+     * @return list<\PHPUnit\Framework\MockObject\ConfigurableMethod>
+     */
+    public function configurableMethods(): array
+    {
+    }
+}
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class DoubledMethod
+{
+    use \PHPUnit\Framework\MockObject\Generator\TemplateLoader;
+    /**
+     * @throws ReflectionException
+     * @throws RuntimeException
+     */
+    public static function fromReflection(\ReflectionMethod $method): self
+    {
+    }
+    /**
+     * @param class-string     $className
+     * @param non-empty-string $methodName
+     */
+    public static function fromName(string $className, string $methodName): self
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function methodName(): string
+    {
+    }
+    /**
+     * @throws RuntimeException
+     */
+    public function generateCode(): string
+    {
+    }
+    public function returnType(): \SebastianBergmann\Type\Type
+    {
+    }
+    /**
+     * @return array<int, mixed>
+     */
+    public function defaultParameterValues(): array
+    {
+    }
+    /**
+     * @return non-negative-int
+     */
+    public function numberOfParameters(): int
+    {
+    }
+}
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class DoubledMethodSet
+{
+    public function addMethods(\PHPUnit\Framework\MockObject\Generator\DoubledMethod ...$methods): void
+    {
+    }
+    /**
+     * @return list<DoubledMethod>
+     */
+    public function asArray(): array
+    {
+    }
+    public function hasMethod(string $methodName): bool
     {
     }
 }
@@ -14354,6 +14194,15 @@ final class InvalidMethodNameException extends \PHPUnit\Framework\Exception impl
     }
 }
 /**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class MethodNamedMethodException extends \PHPUnit\Framework\Exception implements \PHPUnit\Framework\MockObject\Generator\Exception
+{
+    public function __construct()
+    {
+    }
+}
+/**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  *
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
@@ -14364,17 +14213,6 @@ final class NameAlreadyInUseException extends \PHPUnit\Framework\Exception imple
      * @param class-string|trait-string $name
      */
     public function __construct(string $name)
-    {
-    }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
-final class OriginalConstructorInvocationRequiredException extends \PHPUnit\Framework\Exception implements \PHPUnit\Framework\MockObject\Generator\Exception
-{
-    public function __construct()
     {
     }
 }
@@ -14399,41 +14237,6 @@ final class RuntimeException extends \PHPUnit\Framework\Exception implements \PH
  *
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
  */
-final class SoapExtensionNotAvailableException extends \PHPUnit\Framework\Exception implements \PHPUnit\Framework\MockObject\Generator\Exception
-{
-    public function __construct()
-    {
-    }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
-final class UnknownClassException extends \PHPUnit\Framework\Exception implements \PHPUnit\Framework\MockObject\Generator\Exception
-{
-    public function __construct(string $className)
-    {
-    }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- *
- * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5243
- */
-final class UnknownTraitException extends \PHPUnit\Framework\Exception implements \PHPUnit\Framework\MockObject\Generator\Exception
-{
-    public function __construct(string $traitName)
-    {
-    }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
 final class UnknownTypeException extends \PHPUnit\Framework\Exception implements \PHPUnit\Framework\MockObject\Generator\Exception
 {
     public function __construct(string $type)
@@ -14451,20 +14254,20 @@ final class Generator
     /**
      * Returns a test double for the specified class.
      *
+     * @param class-string            $type
      * @param ?list<non-empty-string> $methods
-     * @param list<mixed>             $arguments
+     * @param array<mixed>            $arguments
      *
      * @throws ClassIsEnumerationException
      * @throws ClassIsFinalException
      * @throws DuplicateMethodException
      * @throws InvalidMethodNameException
      * @throws NameAlreadyInUseException
-     * @throws OriginalConstructorInvocationRequiredException
      * @throws ReflectionException
      * @throws RuntimeException
      * @throws UnknownTypeException
      */
-    public function testDouble(string $type, bool $mockObject, bool $markAsMockObject, ?array $methods = [], array $arguments = [], string $mockClassName = '', bool $callOriginalConstructor = true, bool $callOriginalClone = true, bool $callAutoload = true, bool $cloneArguments = true, bool $callOriginalMethods = false, ?object $proxyTarget = null, bool $allowMockingUnknownTypes = true, bool $returnValueGeneration = true): \PHPUnit\Framework\MockObject\MockObject|\PHPUnit\Framework\MockObject\Stub
+    public function testDouble(string $type, bool $mockObject, ?array $methods = [], array $arguments = [], string $mockClassName = '', bool $callOriginalConstructor = true, bool $callOriginalClone = true, bool $returnValueGeneration = true): \PHPUnit\Framework\MockObject\MockObject|\PHPUnit\Framework\MockObject\Stub
     {
     }
     /**
@@ -14473,78 +14276,11 @@ final class Generator
      * @throws RuntimeException
      * @throws UnknownTypeException
      */
-    public function testDoubleForInterfaceIntersection(array $interfaces, bool $mockObject, bool $callAutoload = true, bool $returnValueGeneration = true): \PHPUnit\Framework\MockObject\MockObject|\PHPUnit\Framework\MockObject\Stub
+    public function testDoubleForInterfaceIntersection(array $interfaces, bool $mockObject, bool $returnValueGeneration = true): \PHPUnit\Framework\MockObject\MockObject|\PHPUnit\Framework\MockObject\Stub
     {
     }
     /**
-     * Returns a mock object for the specified abstract class with all abstract
-     * methods of the class mocked.
-     *
-     * Concrete methods to mock can be specified with the $mockedMethods parameter.
-     *
-     * @param list<mixed>             $arguments
-     * @param ?list<non-empty-string> $mockedMethods
-     *
-     * @throws ClassIsEnumerationException
-     * @throws ClassIsFinalException
-     * @throws DuplicateMethodException
-     * @throws \PHPUnit\Framework\InvalidArgumentException
-     * @throws InvalidMethodNameException
-     * @throws NameAlreadyInUseException
-     * @throws OriginalConstructorInvocationRequiredException
-     * @throws ReflectionException
-     * @throws RuntimeException
-     * @throws UnknownClassException
-     * @throws UnknownTypeException
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5241
-     */
-    public function mockObjectForAbstractClass(string $originalClassName, array $arguments = [], string $mockClassName = '', bool $callOriginalConstructor = true, bool $callOriginalClone = true, bool $callAutoload = true, ?array $mockedMethods = null, bool $cloneArguments = true): \PHPUnit\Framework\MockObject\MockObject
-    {
-    }
-    /**
-     * Returns a mock object for the specified trait with all abstract methods
-     * of the trait mocked. Concrete methods to mock can be specified with the
-     * `$mockedMethods` parameter.
-     *
-     * @param trait-string            $traitName
-     * @param list<mixed>             $arguments
-     * @param ?list<non-empty-string> $mockedMethods
-     *
-     * @throws ClassIsEnumerationException
-     * @throws ClassIsFinalException
-     * @throws DuplicateMethodException
-     * @throws \PHPUnit\Framework\InvalidArgumentException
-     * @throws InvalidMethodNameException
-     * @throws NameAlreadyInUseException
-     * @throws OriginalConstructorInvocationRequiredException
-     * @throws ReflectionException
-     * @throws RuntimeException
-     * @throws UnknownClassException
-     * @throws UnknownTraitException
-     * @throws UnknownTypeException
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5243
-     */
-    public function mockObjectForTrait(string $traitName, array $arguments = [], string $mockClassName = '', bool $callOriginalConstructor = true, bool $callOriginalClone = true, bool $callAutoload = true, ?array $mockedMethods = null, bool $cloneArguments = true): \PHPUnit\Framework\MockObject\MockObject
-    {
-    }
-    /**
-     * Returns an object for the specified trait.
-     *
-     * @param trait-string $traitName
-     * @param list<mixed>  $arguments
-     *
-     * @throws ReflectionException
-     * @throws RuntimeException
-     * @throws UnknownTraitException
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5244
-     */
-    public function objectForTrait(string $traitName, string $traitClassName = '', bool $callAutoload = true, bool $callOriginalConstructor = false, array $arguments = []): object
-    {
-    }
-    /**
+     * @param class-string            $type
      * @param ?list<non-empty-string> $methods
      *
      * @throws ClassIsEnumerationException
@@ -14556,29 +14292,7 @@ final class Generator
      *
      * @see https://github.com/sebastianbergmann/phpunit/issues/5476
      */
-    public function generate(string $type, bool $mockObject, bool $markAsMockObject, ?array $methods = null, string $mockClassName = '', bool $callOriginalClone = true, bool $callAutoload = true, bool $cloneArguments = true, bool $callOriginalMethods = false): \PHPUnit\Framework\MockObject\Generator\MockClass
-    {
-    }
-    /**
-     * @param non-empty-string       $wsdlFile
-     * @param class-string           $className
-     * @param list<non-empty-string> $methods
-     * @param array<mixed>           $options
-     *
-     * @throws RuntimeException
-     * @throws SoapExtensionNotAvailableException
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5242
-     */
-    public function generateClassFromWsdl(string $wsdlFile, string $className, array $methods = [], array $options = []): string
-    {
-    }
-    /**
-     * @throws ReflectionException
-     *
-     * @return list<MockMethod>
-     */
-    public function mockClassMethods(string $className, bool $callOriginalMethods, bool $cloneArguments): array
+    public function generate(string $type, bool $mockObject, ?array $methods = null, string $mockClassName = '', bool $callOriginalClone = true): \PHPUnit\Framework\MockObject\Generator\DoubledClass
     {
     }
 }
@@ -14618,146 +14332,10 @@ final class HookedPropertyGenerator
     /**
      * @param class-string         $className
      * @param list<HookedProperty> $properties
-     *
-     * @return non-empty-string
      */
     public function generate(string $className, array $properties): string
     {
     }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
-final readonly class MockClass implements \PHPUnit\Framework\MockObject\Generator\MockType
-{
-    /**
-     * @param class-string             $mockName
-     * @param list<\PHPUnit\Framework\MockObject\ConfigurableMethod> $configurableMethods
-     */
-    public function __construct(string $classCode, string $mockName, array $configurableMethods)
-    {
-    }
-    /**
-     * @return class-string
-     */
-    public function generate(): string
-    {
-    }
-    public function classCode(): string
-    {
-    }
-    /**
-     * @return list<\PHPUnit\Framework\MockObject\ConfigurableMethod>
-     */
-    public function configurableMethods(): array
-    {
-    }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
-final class MockMethod
-{
-    use \PHPUnit\Framework\MockObject\Generator\TemplateLoader;
-    /**
-     * @throws ReflectionException
-     * @throws RuntimeException
-     */
-    public static function fromReflection(\ReflectionMethod $method, bool $callOriginalMethod, bool $cloneArguments): self
-    {
-    }
-    /**
-     * @param class-string     $className
-     * @param non-empty-string $methodName
-     */
-    public static function fromName(string $className, string $methodName, bool $cloneArguments): self
-    {
-    }
-    /**
-     * @return non-empty-string
-     */
-    public function methodName(): string
-    {
-    }
-    /**
-     * @throws RuntimeException
-     */
-    public function generateCode(): string
-    {
-    }
-    public function returnType(): \SebastianBergmann\Type\Type
-    {
-    }
-    /**
-     * @return array<int, mixed>
-     */
-    public function defaultParameterValues(): array
-    {
-    }
-    /**
-     * @return non-negative-int
-     */
-    public function numberOfParameters(): int
-    {
-    }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
-final class MockMethodSet
-{
-    public function addMethods(\PHPUnit\Framework\MockObject\Generator\MockMethod ...$methods): void
-    {
-    }
-    /**
-     * @return list<MockMethod>
-     */
-    public function asArray(): array
-    {
-    }
-    public function hasMethod(string $methodName): bool
-    {
-    }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- *
- * @deprecated https://github.com/sebastianbergmann/phpunit/issues/5243
- */
-final readonly class MockTrait implements \PHPUnit\Framework\MockObject\Generator\MockType
-{
-    /**
-     * @param class-string $mockName
-     */
-    public function __construct(string $classCode, string $mockName)
-    {
-    }
-    /**
-     * @return class-string
-     */
-    public function generate(): string
-    {
-    }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
-interface MockType
-{
-    /**
-     * @return class-string
-     */
-    public function generate(): string;
 }
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -16685,23 +16263,6 @@ final readonly class BeforeClass extends \PHPUnit\Metadata\Metadata
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
-final readonly class Covers extends \PHPUnit\Metadata\Metadata
-{
-    public function isCovers(): true
-    {
-    }
-    /**
-     * @return non-empty-string
-     */
-    public function target(): string
-    {
-    }
-}
-/**
- * @immutable
- *
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- */
 final readonly class CoversClass extends \PHPUnit\Metadata\Metadata
 {
     public function isCoversClass(): true
@@ -16713,12 +16274,21 @@ final readonly class CoversClass extends \PHPUnit\Metadata\Metadata
     public function className(): string
     {
     }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class CoversClassesThatExtendClass extends \PHPUnit\Metadata\Metadata
+{
+    public function isCoversClassesThatExtendClass(): true
+    {
+    }
     /**
      * @return class-string
-     *
-     * @internal This method is not covered by the backward compatibility promise for PHPUnit
      */
-    public function asStringForCodeUnitMapper(): string
+    public function className(): string
     {
     }
 }
@@ -16727,15 +16297,15 @@ final readonly class CoversClass extends \PHPUnit\Metadata\Metadata
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
-final readonly class CoversDefaultClass extends \PHPUnit\Metadata\Metadata
+final readonly class CoversClassesThatImplementInterface extends \PHPUnit\Metadata\Metadata
 {
-    public function isCoversDefaultClass(): true
+    public function isCoversClassesThatImplementInterface(): true
     {
     }
     /**
      * @return class-string
      */
-    public function className(): string
+    public function interfaceName(): string
     {
     }
 }
@@ -16753,12 +16323,6 @@ final readonly class CoversFunction extends \PHPUnit\Metadata\Metadata
      * @return non-empty-string
      */
     public function functionName(): string
-    {
-    }
-    /**
-     * @internal This method is not covered by the backward compatibility promise for PHPUnit
-     */
-    public function asStringForCodeUnitMapper(): string
     {
     }
 }
@@ -16784,12 +16348,21 @@ final readonly class CoversMethod extends \PHPUnit\Metadata\Metadata
     public function methodName(): string
     {
     }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class CoversNamespace extends \PHPUnit\Metadata\Metadata
+{
+    public function isCoversNamespace(): true
+    {
+    }
     /**
-     * @return non-empty-string
-     *
-     * @internal This method is not covered by the backward compatibility promise for PHPUnit
+     * @return class-string
      */
-    public function asStringForCodeUnitMapper(): string
+    public function namespace(): string
     {
     }
 }
@@ -16818,14 +16391,6 @@ final readonly class CoversTrait extends \PHPUnit\Metadata\Metadata
      * @return trait-string
      */
     public function traitName(): string
-    {
-    }
-    /**
-     * @return trait-string
-     *
-     * @internal This method is not covered by the backward compatibility promise for PHPUnit
-     */
-    public function asStringForCodeUnitMapper(): string
     {
     }
 }
@@ -16926,20 +16491,6 @@ final readonly class DoesNotPerformAssertions extends \PHPUnit\Metadata\Metadata
     {
     }
 }
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
-final class AnnotationsAreNotSupportedForInternalClassesException extends \RuntimeException implements \PHPUnit\Exception
-{
-    /**
-     * @param class-string $className
-     */
-    public function __construct(string $className)
-    {
-    }
-}
 interface Exception extends \PHPUnit\Exception
 {
 }
@@ -16965,14 +16516,6 @@ final class InvalidVersionRequirementException extends \RuntimeException impleme
 {
 }
 final class NoVersionRequirementException extends \RuntimeException implements \PHPUnit\Metadata\Exception
-{
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
-final class ReflectionException extends \RuntimeException implements \PHPUnit\Exception
 {
 }
 /**
@@ -17088,9 +16631,27 @@ abstract readonly class Metadata
     {
     }
     /**
+     * @param non-empty-string $namespace
+     */
+    public static function coversNamespace(string $namespace): \PHPUnit\Metadata\CoversNamespace
+    {
+    }
+    /**
      * @param class-string $className
      */
     public static function coversClass(string $className): \PHPUnit\Metadata\CoversClass
+    {
+    }
+    /**
+     * @param class-string $className
+     */
+    public static function coversClassesThatExtendClass(string $className): \PHPUnit\Metadata\CoversClassesThatExtendClass
+    {
+    }
+    /**
+     * @param class-string $interfaceName
+     */
+    public static function coversClassesThatImplementInterface(string $interfaceName): \PHPUnit\Metadata\CoversClassesThatImplementInterface
     {
     }
     /**
@@ -17110,24 +16671,6 @@ abstract readonly class Metadata
      * @param non-empty-string $functionName
      */
     public static function coversFunction(string $functionName): \PHPUnit\Metadata\CoversFunction
-    {
-    }
-    /**
-     * @param non-empty-string $target
-     */
-    public static function coversOnClass(string $target): \PHPUnit\Metadata\Covers
-    {
-    }
-    /**
-     * @param non-empty-string $target
-     */
-    public static function coversOnMethod(string $target): \PHPUnit\Metadata\Covers
-    {
-    }
-    /**
-     * @param class-string $className
-     */
-    public static function coversDefaultClass(string $className): \PHPUnit\Metadata\CoversDefaultClass
     {
     }
     public static function coversNothingOnClass(): \PHPUnit\Metadata\CoversNothing
@@ -17319,6 +16862,18 @@ abstract readonly class Metadata
     public static function requiresPhpunitExtensionOnMethod(string $extensionClass): \PHPUnit\Metadata\RequiresPhpunitExtension
     {
     }
+    public static function requiresEnvironmentVariableOnClass(string $environmentVariableName, null|string $value): \PHPUnit\Metadata\RequiresEnvironmentVariable
+    {
+    }
+    public static function requiresEnvironmentVariableOnMethod(string $environmentVariableName, null|string $value): \PHPUnit\Metadata\RequiresEnvironmentVariable
+    {
+    }
+    public static function withEnvironmentVariableOnClass(string $environmentVariableName, null|string $value): \PHPUnit\Metadata\WithEnvironmentVariable
+    {
+    }
+    public static function withEnvironmentVariableOnMethod(string $environmentVariableName, null|string $value): \PHPUnit\Metadata\WithEnvironmentVariable
+    {
+    }
     /**
      * @param non-empty-string $setting
      * @param non-empty-string $value
@@ -17365,9 +16920,27 @@ abstract readonly class Metadata
     {
     }
     /**
+     * @param non-empty-string $namespace
+     */
+    public static function usesNamespace(string $namespace): \PHPUnit\Metadata\UsesNamespace
+    {
+    }
+    /**
      * @param class-string $className
      */
     public static function usesClass(string $className): \PHPUnit\Metadata\UsesClass
+    {
+    }
+    /**
+     * @param class-string $className
+     */
+    public static function usesClassesThatExtendClass(string $className): \PHPUnit\Metadata\UsesClassesThatExtendClass
+    {
+    }
+    /**
+     * @param class-string $interfaceName
+     */
+    public static function usesClassesThatImplementInterface(string $interfaceName): \PHPUnit\Metadata\UsesClassesThatImplementInterface
     {
     }
     /**
@@ -17389,29 +16962,11 @@ abstract readonly class Metadata
     public static function usesMethod(string $className, string $methodName): \PHPUnit\Metadata\UsesMethod
     {
     }
-    /**
-     * @param non-empty-string $target
-     */
-    public static function usesOnClass(string $target): \PHPUnit\Metadata\Uses
-    {
-    }
-    /**
-     * @param non-empty-string $target
-     */
-    public static function usesOnMethod(string $target): \PHPUnit\Metadata\Uses
-    {
-    }
-    /**
-     * @param class-string $className
-     */
-    public static function usesDefaultClass(string $className): \PHPUnit\Metadata\UsesDefaultClass
-    {
-    }
     public static function withoutErrorHandler(): \PHPUnit\Metadata\WithoutErrorHandler
     {
     }
     /**
-     * @param 0|1 $level
+     * @param int<0, 1> $level
      */
     protected function __construct(int $level)
     {
@@ -17459,9 +17014,9 @@ abstract readonly class Metadata
     {
     }
     /**
-     * @phpstan-assert-if-true Covers $this
+     * @phpstan-assert-if-true CoversNamespace $this
      */
-    public function isCovers(): bool
+    public function isCoversNamespace(): bool
     {
     }
     /**
@@ -17471,9 +17026,15 @@ abstract readonly class Metadata
     {
     }
     /**
-     * @phpstan-assert-if-true CoversDefaultClass $this
+     * @phpstan-assert-if-true CoversClassesThatExtendClass $this
      */
-    public function isCoversDefaultClass(): bool
+    public function isCoversClassesThatExtendClass(): bool
+    {
+    }
+    /**
+     * @phpstan-assert-if-true CoversClassesThatImplementInterface $this
+     */
+    public function isCoversClassesThatImplementInterface(): bool
     {
     }
     /**
@@ -17653,6 +17214,18 @@ abstract readonly class Metadata
     {
     }
     /**
+     * @phpstan-assert-if-true RequiresEnvironmentVariable $this
+     */
+    public function isRequiresEnvironmentVariable(): bool
+    {
+    }
+    /**
+     * @phpstan-assert-if-true WithEnvironmentVariable $this
+     */
+    public function isWithEnvironmentVariable(): bool
+    {
+    }
+    /**
      * @phpstan-assert-if-true RequiresSetting $this
      */
     public function isRequiresSetting(): bool
@@ -17671,9 +17244,9 @@ abstract readonly class Metadata
     {
     }
     /**
-     * @phpstan-assert-if-true Uses $this
+     * @phpstan-assert-if-true UsesNamespace $this
      */
-    public function isUses(): bool
+    public function isUsesNamespace(): bool
     {
     }
     /**
@@ -17683,9 +17256,15 @@ abstract readonly class Metadata
     {
     }
     /**
-     * @phpstan-assert-if-true UsesDefaultClass $this
+     * @phpstan-assert-if-true UsesClassesThatExtendClass $this
      */
-    public function isUsesDefaultClass(): bool
+    public function isUsesClassesThatExtendClass(): bool
+    {
+    }
+    /**
+     * @phpstan-assert-if-true UsesClassesThatImplementInterface $this
+     */
+    public function isUsesClassesThatImplementInterface(): bool
     {
     }
     /**
@@ -17773,13 +17352,16 @@ final readonly class MetadataCollection implements \Countable, \IteratorAggregat
     public function isBefore(): self
     {
     }
-    public function isCovers(): self
+    public function isCoversNamespace(): self
     {
     }
     public function isCoversClass(): self
     {
     }
-    public function isCoversDefaultClass(): self
+    public function isCoversClassesThatExtendClass(): self
+    {
+    }
+    public function isCoversClassesThatImplementInterface(): self
     {
     }
     public function isCoversTrait(): self
@@ -17875,6 +17457,12 @@ final readonly class MetadataCollection implements \Countable, \IteratorAggregat
     public function isRequiresPhpunitExtension(): self
     {
     }
+    public function isRequiresEnvironmentVariable(): self
+    {
+    }
+    public function isWithEnvironmentVariable(): self
+    {
+    }
     public function isRequiresSetting(): self
     {
     }
@@ -17884,13 +17472,16 @@ final readonly class MetadataCollection implements \Countable, \IteratorAggregat
     public function isTestWith(): self
     {
     }
-    public function isUses(): self
+    public function isUsesNamespace(): self
     {
     }
     public function isUsesClass(): self
     {
     }
-    public function isUsesDefaultClass(): self
+    public function isUsesClassesThatExtendClass(): self
+    {
+    }
+    public function isUsesClassesThatImplementInterface(): self
     {
     }
     public function isUsesTrait(): self
@@ -17979,6 +17570,26 @@ final readonly class PreserveGlobalState extends \PHPUnit\Metadata\Metadata
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
+final readonly class RequiresEnvironmentVariable extends \PHPUnit\Metadata\Metadata
+{
+    public function __construct(int $level, string $environmentVariableName, null|string $value)
+    {
+    }
+    public function isRequiresEnvironmentVariable(): true
+    {
+    }
+    public function environmentVariableName(): string
+    {
+    }
+    public function value(): null|string
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
 final readonly class RequiresFunction extends \PHPUnit\Metadata\Metadata
 {
     public function isRequiresFunction(): true
@@ -18022,7 +17633,7 @@ final readonly class RequiresMethod extends \PHPUnit\Metadata\Metadata
 final readonly class RequiresOperatingSystem extends \PHPUnit\Metadata\Metadata
 {
     /**
-     * @param 0|1              $level
+     * @param int<0, 1>        $level
      * @param non-empty-string $operatingSystem
      */
     public function __construct(int $level, string $operatingSystem)
@@ -18253,23 +17864,6 @@ final readonly class TestWith extends \PHPUnit\Metadata\Metadata
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
-final readonly class Uses extends \PHPUnit\Metadata\Metadata
-{
-    public function isUses(): true
-    {
-    }
-    /**
-     * @return non-empty-string
-     */
-    public function target(): string
-    {
-    }
-}
-/**
- * @immutable
- *
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- */
 final readonly class UsesClass extends \PHPUnit\Metadata\Metadata
 {
     public function isUsesClass(): true
@@ -18281,23 +17875,15 @@ final readonly class UsesClass extends \PHPUnit\Metadata\Metadata
     public function className(): string
     {
     }
-    /**
-     * @return class-string
-     *
-     * @internal This method is not covered by the backward compatibility promise for PHPUnit
-     */
-    public function asStringForCodeUnitMapper(): string
-    {
-    }
 }
 /**
  * @immutable
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
-final readonly class UsesDefaultClass extends \PHPUnit\Metadata\Metadata
+final readonly class UsesClassesThatExtendClass extends \PHPUnit\Metadata\Metadata
 {
-    public function isUsesDefaultClass(): true
+    public function isUsesClassesThatExtendClass(): true
     {
     }
     /**
@@ -18312,10 +17898,27 @@ final readonly class UsesDefaultClass extends \PHPUnit\Metadata\Metadata
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
+final readonly class UsesClassesThatImplementInterface extends \PHPUnit\Metadata\Metadata
+{
+    public function isUsesClassesThatImplementInterface(): true
+    {
+    }
+    /**
+     * @return class-string
+     */
+    public function interfaceName(): string
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
 final readonly class UsesFunction extends \PHPUnit\Metadata\Metadata
 {
     /**
-     * @param 0|1              $level
+     * @param int<0, 1>        $level
      * @param non-empty-string $functionName
      */
     public function __construct(int $level, string $functionName)
@@ -18328,12 +17931,6 @@ final readonly class UsesFunction extends \PHPUnit\Metadata\Metadata
      * @return non-empty-string
      */
     public function functionName(): string
-    {
-    }
-    /**
-     * @internal This method is not covered by the backward compatibility promise for PHPUnit
-     */
-    public function asStringForCodeUnitMapper(): string
     {
     }
 }
@@ -18359,12 +17956,21 @@ final readonly class UsesMethod extends \PHPUnit\Metadata\Metadata
     public function methodName(): string
     {
     }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class UsesNamespace extends \PHPUnit\Metadata\Metadata
+{
+    public function isUsesNamespace(): true
+    {
+    }
     /**
-     * @return non-empty-string
-     *
-     * @internal This method is not covered by the backward compatibility promise for PHPUnit
+     * @return class-string
      */
-    public function asStringForCodeUnitMapper(): string
+    public function namespace(): string
     {
     }
 }
@@ -18384,12 +17990,30 @@ final readonly class UsesTrait extends \PHPUnit\Metadata\Metadata
     public function traitName(): string
     {
     }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class WithEnvironmentVariable extends \PHPUnit\Metadata\Metadata
+{
     /**
-     * @return trait-string
-     *
-     * @internal This method is not covered by the backward compatibility promise for PHPUnit
+     * @param non-empty-string $environmentVariableName
      */
-    public function asStringForCodeUnitMapper(): string
+    public function __construct(int $level, string $environmentVariableName, null|string $value)
+    {
+    }
+    public function isWithEnvironmentVariable(): true
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function environmentVariableName(): string
+    {
+    }
+    public function value(): null|string
     {
     }
 }
@@ -18401,87 +18025,6 @@ final readonly class UsesTrait extends \PHPUnit\Metadata\Metadata
 final readonly class WithoutErrorHandler extends \PHPUnit\Metadata\Metadata
 {
     public function isWithoutErrorHandler(): true
-    {
-    }
-}
-namespace PHPUnit\Metadata\Annotation\Parser;
-
-/**
- * This is an abstraction around a PHPUnit-specific docBlock,
- * allowing us to ask meaningful questions about a specific
- * reflection symbol.
- *
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
-final class DocBlock
-{
-    /**
-     * @throws \PHPUnit\Metadata\AnnotationsAreNotSupportedForInternalClassesException
-     *
-     * @phpstan-ignore missingType.generics
-     */
-    public static function ofClass(\ReflectionClass $class): self
-    {
-    }
-    /**
-     * @throws \PHPUnit\Metadata\AnnotationsAreNotSupportedForInternalClassesException
-     */
-    public static function ofMethod(\ReflectionMethod $method): self
-    {
-    }
-    /**
-     * @phan-return array{
-     *   __OFFSET: array<string, int>&array{__FILE: string},
-     *   setting?: array<string, string>,
-     *   extension_versions?: array<string, array{version: string, operator: string}>
-     * }&array<
-     *   string,
-     *   string|array{version: string, operator: string}|array{constraint: string}|array<int|string, string>
-     * >
-     *
-     * @phpstan-ignore missingType.iterableValue
-     */
-    public function requirements(): array
-    {
-    }
-    /**
-     * @return array<string, array<int, string>>
-     */
-    public function symbolAnnotations(): array
-    {
-    }
-}
-/**
- * Reflection information, and therefore DocBlock information, is static within
- * a single PHP process. It is therefore okay to use a Singleton registry here.
- *
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
-final class Registry
-{
-    public static function getInstance(): self
-    {
-    }
-    /**
-     * @param class-string $class
-     *
-     * @throws \PHPUnit\Metadata\AnnotationsAreNotSupportedForInternalClassesException
-     * @throws \PHPUnit\Metadata\ReflectionException
-     */
-    public function forClassName(string $class): \PHPUnit\Metadata\Annotation\Parser\DocBlock
-    {
-    }
-    /**
-     * @param class-string $classInHierarchy
-     *
-     * @throws \PHPUnit\Metadata\AnnotationsAreNotSupportedForInternalClassesException
-     * @throws \PHPUnit\Metadata\ReflectionException
-     */
-    public function forMethod(string $classInHierarchy, string $method): \PHPUnit\Metadata\Annotation\Parser\DocBlock
     {
     }
 }
@@ -18497,23 +18040,15 @@ final class CodeCoverage
     /**
      * @param class-string     $className
      * @param non-empty-string $methodName
-     *
-     * @throws \PHPUnit\Framework\CodeCoverageException
-     *
-     * @return array<string,list<int>>|false
      */
-    public function linesToBeCovered(string $className, string $methodName): array|false
+    public function coversTargets(string $className, string $methodName): \SebastianBergmann\CodeCoverage\Test\Target\TargetCollection
     {
     }
     /**
      * @param class-string     $className
      * @param non-empty-string $methodName
-     *
-     * @throws \PHPUnit\Framework\CodeCoverageException
-     *
-     * @return array<string,list<int>>
      */
-    public function linesToBeUsed(string $className, string $methodName): array
+    public function usesTargets(string $className, string $methodName): \SebastianBergmann\CodeCoverage\Test\Target\TargetCollection
     {
     }
     /**
@@ -18624,46 +18159,6 @@ namespace PHPUnit\Metadata\Parser;
  *
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
  */
-final class AnnotationParser implements \PHPUnit\Metadata\Parser\Parser
-{
-    /**
-     * @param class-string $className
-     *
-     * @throws \PHPUnit\Metadata\AnnotationsAreNotSupportedForInternalClassesException
-     * @throws \PHPUnit\Util\InvalidVersionOperatorException
-     * @throws \PHPUnit\Metadata\ReflectionException
-     */
-    public function forClass(string $className): \PHPUnit\Metadata\MetadataCollection
-    {
-    }
-    /**
-     * @param class-string     $className
-     * @param non-empty-string $methodName
-     *
-     * @throws \PHPUnit\Metadata\AnnotationsAreNotSupportedForInternalClassesException
-     * @throws \PHPUnit\Util\InvalidVersionOperatorException
-     * @throws \PHPUnit\Metadata\ReflectionException
-     */
-    public function forMethod(string $className, string $methodName): \PHPUnit\Metadata\MetadataCollection
-    {
-    }
-    /**
-     * @param class-string     $className
-     * @param non-empty-string $methodName
-     *
-     * @throws \PHPUnit\Metadata\AnnotationsAreNotSupportedForInternalClassesException
-     * @throws \PHPUnit\Util\InvalidVersionOperatorException
-     * @throws \PHPUnit\Metadata\ReflectionException
-     */
-    public function forClassAndMethod(string $className, string $methodName): \PHPUnit\Metadata\MetadataCollection
-    {
-    }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
 final readonly class AttributeParser implements \PHPUnit\Metadata\Parser\Parser
 {
     /**
@@ -18741,38 +18236,7 @@ interface Parser
     public function forClassAndMethod(string $className, string $methodName): \PHPUnit\Metadata\MetadataCollection;
 }
 /**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
-final readonly class ParserChain implements \PHPUnit\Metadata\Parser\Parser
-{
-    public function __construct(\PHPUnit\Metadata\Parser\Parser $attributeReader, \PHPUnit\Metadata\Parser\Parser $annotationReader)
-    {
-    }
-    /**
-     * @param class-string $className
-     */
-    public function forClass(string $className): \PHPUnit\Metadata\MetadataCollection
-    {
-    }
-    /**
-     * @param class-string     $className
-     * @param non-empty-string $methodName
-     */
-    public function forMethod(string $className, string $methodName): \PHPUnit\Metadata\MetadataCollection
-    {
-    }
-    /**
-     * @param class-string     $className
-     * @param non-empty-string $methodName
-     */
-    public function forClassAndMethod(string $className, string $methodName): \PHPUnit\Metadata\MetadataCollection
-    {
-    }
-}
-/**
- * Attribute and annotation information is static within a single PHP process.
+ * Attribute information is static within a single PHP process.
  * It is therefore okay to use a Singleton registry here.
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -18844,6 +18308,25 @@ namespace PHPUnit\Runner;
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  *
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class BackedUpEnvironmentVariable
+{
+    /**
+     * @param non-empty-string $name
+     *
+     * @return array{0: self, 1: self}
+     */
+    public static function create(string $name): array
+    {
+    }
+    public function restore(): void
+    {
+    }
+}
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
  *
  * @codeCoverageIgnore
  */
@@ -18870,11 +18353,7 @@ final class CodeCoverage
     public function start(\PHPUnit\Framework\TestCase $test): void
     {
     }
-    /**
-     * @param array<string,list<int>>|false $linesToBeCovered
-     * @param array<string,list<int>>       $linesToBeUsed
-     */
-    public function stop(bool $append, array|false $linesToBeCovered = [], array $linesToBeUsed = []): void
+    public function stop(bool $append, null|false|\SebastianBergmann\CodeCoverage\Test\Target\TargetCollection $covers = null, ?\SebastianBergmann\CodeCoverage\Test\Target\TargetCollection $uses = null): void
     {
     }
     public function deactivate(): void
@@ -19098,6 +18577,8 @@ final class HookMethodCollection
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  *
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ *
+ * @see https://qa.php.net/phpt_details.php
  */
 final class PhptTestCase implements \PHPUnit\Framework\Reorderable, \PHPUnit\Framework\SelfDescribing, \PHPUnit\Framework\Test
 {
@@ -19201,29 +18682,11 @@ final class TestSuiteLoader
  */
 final class TestSuiteSorter
 {
-    /**
-     * @var int
-     */
     public const ORDER_DEFAULT = 0;
-    /**
-     * @var int
-     */
     public const ORDER_RANDOMIZED = 1;
-    /**
-     * @var int
-     */
     public const ORDER_REVERSED = 2;
-    /**
-     * @var int
-     */
     public const ORDER_DEFECTS_FIRST = 3;
-    /**
-     * @var int
-     */
     public const ORDER_DURATION = 4;
-    /**
-     * @var int
-     */
     public const ORDER_SIZE = 5;
     public function __construct(?\PHPUnit\Runner\ResultCache\ResultCache $cache = null)
     {
@@ -19294,7 +18757,7 @@ final class Baseline
     {
     }
     /**
-     * @return array<string, array<positive-int, list<Issue>>>
+     * @return array<non-empty-string, array<positive-int, list<Issue>>>
      */
     public function groupedByFileAndLine(): array
     {
@@ -20333,6 +19796,9 @@ final class Collector
     public function testTriggeredPhpunitDeprecation(\PHPUnit\Event\Test\PhpunitDeprecationTriggered $event): void
     {
     }
+    public function testTriggeredPhpunitNotice(\PHPUnit\Event\Test\PhpunitNoticeTriggered $event): void
+    {
+    }
     public function testTriggeredError(\PHPUnit\Event\Test\ErrorTriggered $event): void
     {
     }
@@ -20355,6 +19821,9 @@ final class Collector
     {
     }
     public function testRunnerTriggeredDeprecation(\PHPUnit\Event\TestRunner\DeprecationTriggered $event): void
+    {
+    }
+    public function testRunnerTriggeredNotice(\PHPUnit\Event\TestRunner\NoticeTriggered $event): void
     {
     }
     public function testRunnerTriggeredWarning(\PHPUnit\Event\TestRunner\WarningTriggered $event): void
@@ -20581,6 +20050,17 @@ final readonly class TestRunnerTriggeredDeprecationSubscriber extends \PHPUnit\T
  *
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
  */
+final readonly class TestRunnerTriggeredNoticeSubscriber extends \PHPUnit\TestRunner\TestResult\Subscriber implements \PHPUnit\Event\TestRunner\NoticeTriggeredSubscriber
+{
+    public function notify(\PHPUnit\Event\TestRunner\NoticeTriggered $event): void
+    {
+    }
+}
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
 final readonly class TestRunnerTriggeredWarningSubscriber extends \PHPUnit\TestRunner\TestResult\Subscriber implements \PHPUnit\Event\TestRunner\WarningTriggeredSubscriber
 {
     public function notify(\PHPUnit\Event\TestRunner\WarningTriggered $event): void
@@ -20724,6 +20204,17 @@ final readonly class TestTriggeredPhpunitErrorSubscriber extends \PHPUnit\TestRu
  *
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
  */
+final readonly class TestTriggeredPhpunitNoticeSubscriber extends \PHPUnit\TestRunner\TestResult\Subscriber implements \PHPUnit\Event\Test\PhpunitNoticeTriggeredSubscriber
+{
+    public function notify(\PHPUnit\Event\Test\PhpunitNoticeTriggered $event): void
+    {
+    }
+}
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
 final readonly class TestTriggeredPhpunitWarningSubscriber extends \PHPUnit\TestRunner\TestResult\Subscriber implements \PHPUnit\Event\Test\PhpunitWarningTriggeredSubscriber
 {
     public function notify(\PHPUnit\Event\Test\PhpunitWarningTriggered $event): void
@@ -20757,8 +20248,10 @@ final readonly class TestResult
      * @param list<\PHPUnit\Event\Test\MarkedIncomplete>                                                $testMarkedIncompleteEvents
      * @param array<string,list<\PHPUnit\Event\Test\PhpunitDeprecationTriggered>>                       $testTriggeredPhpunitDeprecationEvents
      * @param array<string,list<\PHPUnit\Event\Test\PhpunitErrorTriggered>>                             $testTriggeredPhpunitErrorEvents
+     * @param array<string,list<\PHPUnit\Event\Test\PhpunitNoticeTriggered>>                            $testTriggeredPhpunitNoticeEvents
      * @param array<string,list<\PHPUnit\Event\Test\PhpunitWarningTriggered>>                           $testTriggeredPhpunitWarningEvents
      * @param list<\PHPUnit\Event\TestRunner\DeprecationTriggered>                                  $testRunnerTriggeredDeprecationEvents
+     * @param list<\PHPUnit\Event\TestRunner\NoticeTriggered>                                       $testRunnerTriggeredNoticeEvents
      * @param list<\PHPUnit\Event\TestRunner\WarningTriggered>                                      $testRunnerTriggeredWarningEvents
      * @param list<Issues\Issue>                                                           $errors
      * @param list<Issues\Issue>                                                           $deprecations
@@ -20769,7 +20262,7 @@ final readonly class TestResult
      * @param list<Issues\Issue>                                                           $phpWarnings
      * @param non-negative-int                                                      $numberOfIssuesIgnoredByBaseline
      */
-    public function __construct(int $numberOfTests, int $numberOfTestsRun, int $numberOfAssertions, array $testErroredEvents, array $testFailedEvents, array $testConsideredRiskyEvents, array $testSuiteSkippedEvents, array $testSkippedEvents, array $testMarkedIncompleteEvents, array $testTriggeredPhpunitDeprecationEvents, array $testTriggeredPhpunitErrorEvents, array $testTriggeredPhpunitWarningEvents, array $testRunnerTriggeredDeprecationEvents, array $testRunnerTriggeredWarningEvents, array $errors, array $deprecations, array $notices, array $warnings, array $phpDeprecations, array $phpNotices, array $phpWarnings, int $numberOfIssuesIgnoredByBaseline)
+    public function __construct(int $numberOfTests, int $numberOfTestsRun, int $numberOfAssertions, array $testErroredEvents, array $testFailedEvents, array $testConsideredRiskyEvents, array $testSuiteSkippedEvents, array $testSkippedEvents, array $testMarkedIncompleteEvents, array $testTriggeredPhpunitDeprecationEvents, array $testTriggeredPhpunitErrorEvents, array $testTriggeredPhpunitNoticeEvents, array $testTriggeredPhpunitWarningEvents, array $testRunnerTriggeredDeprecationEvents, array $testRunnerTriggeredNoticeEvents, array $testRunnerTriggeredWarningEvents, array $errors, array $deprecations, array $notices, array $warnings, array $phpDeprecations, array $phpNotices, array $phpWarnings, int $numberOfIssuesIgnoredByBaseline)
     {
     }
     public function numberOfTestsRun(): int
@@ -20875,6 +20368,18 @@ final readonly class TestResult
     {
     }
     /**
+     * @return array<string,list<\PHPUnit\Event\Test\PhpunitNoticeTriggered>>
+     */
+    public function testTriggeredPhpunitNoticeEvents(): array
+    {
+    }
+    public function numberOfTestsWithTestTriggeredPhpunitNoticeEvents(): int
+    {
+    }
+    public function hasTestTriggeredPhpunitNoticeEvents(): bool
+    {
+    }
+    /**
      * @return array<string,list<\PHPUnit\Event\Test\PhpunitWarningTriggered>>
      */
     public function testTriggeredPhpunitWarningEvents(): array
@@ -20896,6 +20401,18 @@ final readonly class TestResult
     {
     }
     public function hasTestRunnerTriggeredDeprecationEvents(): bool
+    {
+    }
+    /**
+     * @return list<\PHPUnit\Event\TestRunner\NoticeTriggered>
+     */
+    public function testRunnerTriggeredNoticeEvents(): array
+    {
+    }
+    public function numberOfTestRunnerTriggeredNoticeEvents(): int
+    {
+    }
+    public function hasTestRunnerTriggeredNoticeEvents(): bool
     {
     }
     /**
@@ -21019,6 +20536,12 @@ final readonly class TestResult
      * @return non-negative-int
      */
     public function numberOfIssuesIgnoredByBaseline(): int
+    {
+    }
+    public function hasPhpunitNotices(): bool
+    {
+    }
+    public function numberOfPhpunitNotices(): int
     {
     }
 }
@@ -21251,7 +20774,7 @@ final readonly class Configuration
      * @param ?non-empty-list<non-empty-string>                    $coverageFilter
      * @param ?non-empty-list<non-empty-string>                    $extensions
      */
-    public function __construct(array $arguments, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configurationFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, bool $warmCoverageCache, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?bool $failOnDeprecation, ?bool $failOnPhpunitDeprecation, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnNotice, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?bool $stopOnDefect, ?bool $stopOnDeprecation, ?string $specificDeprecationToStopOn, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnNotice, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $filter, ?string $excludeFilter, ?string $generateBaseline, ?string $useBaseline, bool $ignoreBaseline, bool $generateConfiguration, bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, ?array $testsRequiringPhpExtension, bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, bool $listGroups, bool $listSuites, bool $listTestFiles, bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noOutput, ?bool $noProgress, ?bool $noResults, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?string $teamcityLogfile, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, bool $useDefaultConfiguration, ?bool $displayDetailsOnIncompleteTests, ?bool $displayDetailsOnSkippedTests, ?bool $displayDetailsOnTestsThatTriggerDeprecations, ?bool $displayDetailsOnPhpunitDeprecations, ?bool $displayDetailsOnTestsThatTriggerErrors, ?bool $displayDetailsOnTestsThatTriggerNotices, ?bool $displayDetailsOnTestsThatTriggerWarnings, bool $version, ?array $coverageFilter, ?string $logEventsText, ?string $logEventsVerboseText, ?bool $printerTeamCity, ?bool $testdoxPrinter, ?bool $testdoxPrinterSummary, bool $debug, ?array $extensions)
+    public function __construct(array $arguments, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configurationFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, bool $warmCoverageCache, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?bool $failOnDeprecation, ?bool $failOnPhpunitDeprecation, ?bool $failOnPhpunitNotice, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnNotice, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?bool $stopOnDefect, ?bool $stopOnDeprecation, ?string $specificDeprecationToStopOn, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnNotice, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $filter, ?string $excludeFilter, ?string $generateBaseline, ?string $useBaseline, bool $ignoreBaseline, bool $generateConfiguration, bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, ?array $testsRequiringPhpExtension, bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, bool $listGroups, bool $listSuites, bool $listTestFiles, bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noOutput, ?bool $noProgress, ?bool $noResults, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?string $teamcityLogfile, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, bool $useDefaultConfiguration, ?bool $displayDetailsOnIncompleteTests, ?bool $displayDetailsOnSkippedTests, ?bool $displayDetailsOnTestsThatTriggerDeprecations, ?bool $displayDetailsOnPhpunitDeprecations, ?bool $displayDetailsOnPhpunitNotices, ?bool $displayDetailsOnTestsThatTriggerErrors, ?bool $displayDetailsOnTestsThatTriggerNotices, ?bool $displayDetailsOnTestsThatTriggerWarnings, bool $version, ?array $coverageFilter, ?string $logEventsText, ?string $logEventsVerboseText, ?bool $printerTeamCity, ?bool $testdoxPrinter, ?bool $testdoxPrinterSummary, bool $debug, ?array $extensions)
     {
     }
     /**
@@ -21628,6 +21151,18 @@ final readonly class Configuration
      * @throws Exception
      */
     public function failOnPhpunitDeprecation(): bool
+    {
+    }
+    /**
+     * @phpstan-assert-if-true !null $this->failOnPhpunitNotice
+     */
+    public function hasFailOnPhpunitNotice(): bool
+    {
+    }
+    /**
+     * @throws Exception
+     */
+    public function failOnPhpunitNotice(): bool
     {
     }
     /**
@@ -22318,6 +21853,18 @@ final readonly class Configuration
     {
     }
     /**
+     * @phpstan-assert-if-true !null $this->displayDetailsOnPhpunitNotices
+     */
+    public function hasDisplayDetailsOnPhpunitNotices(): bool
+    {
+    }
+    /**
+     * @throws Exception
+     */
+    public function displayDetailsOnPhpunitNotices(): bool
+    {
+    }
+    /**
      * @phpstan-assert-if-true !null $this->displayDetailsOnTestsThatTriggerErrors
      */
     public function hasDisplayDetailsOnTestsThatTriggerErrors(): bool
@@ -22705,9 +22252,10 @@ final readonly class Configuration
      * @param list<non-empty-string>                                                      $groups
      * @param list<non-empty-string>                                                      $excludeGroups
      * @param non-empty-list<non-empty-string>                                            $testSuffixes
+     * @param null|non-empty-string                                                       $generateBaseline
      * @param non-negative-int                                                            $shortenArraysForExportThreshold
      */
-    public function __construct(array $cliArguments, ?string $configurationFile, ?string $bootstrap, bool $cacheResult, ?string $cacheDirectory, ?string $coverageCacheDirectory, \PHPUnit\TextUI\Configuration\Source $source, string $testResultCacheFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4j, int $coverageCrap4jThreshold, ?string $coverageHtml, int $coverageHtmlLowUpperBound, int $coverageHtmlHighLowerBound, string $coverageHtmlColorSuccessLow, string $coverageHtmlColorSuccessMedium, string $coverageHtmlColorSuccessHigh, string $coverageHtmlColorWarning, string $coverageHtmlColorDanger, ?string $coverageHtmlCustomCssFile, ?string $coveragePhp, ?string $coverageText, bool $coverageTextShowUncoveredFiles, bool $coverageTextShowOnlySummary, ?string $coverageXml, bool $pathCoverage, bool $ignoreDeprecatedCodeUnitsFromCodeCoverage, bool $disableCodeCoverageIgnore, bool $failOnDeprecation, bool $failOnPhpunitDeprecation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, ?string $specificDeprecationToStopOn, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, bool $outputToStandardErrorStream, int|string $columns, bool $noExtensions, ?string $pharExtensionDirectory, array $extensionBootstrappers, bool $backupGlobals, bool $backupStaticProperties, bool $beStrictAboutChangesToGlobalState, bool $colors, bool $processIsolation, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, bool $reportUselessTests, bool $strictCoverage, bool $disallowTestOutput, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnPhpunitDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, bool $noProgress, bool $noResults, bool $noOutput, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies, ?string $logfileTeamcity, ?string $logfileJunit, ?string $logfileTestdoxHtml, ?string $logfileTestdoxText, ?string $logEventsText, ?string $logEventsVerboseText, bool $teamCityOutput, bool $testDoxOutput, bool $testDoxOutputSummary, ?array $testsCovering, ?array $testsUsing, ?array $testsRequiringPhpExtension, ?string $filter, ?string $excludeFilter, array $groups, array $excludeGroups, int $randomOrderSeed, bool $includeUncoveredFiles, \PHPUnit\TextUI\Configuration\TestSuiteCollection $testSuite, string $includeTestSuite, string $excludeTestSuite, ?string $defaultTestSuite, array $testSuffixes, \PHPUnit\TextUI\Configuration\Php $php, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection, ?string $generateBaseline, bool $debug, int $shortenArraysForExportThreshold)
+    public function __construct(array $cliArguments, ?string $configurationFile, ?string $bootstrap, bool $cacheResult, ?string $cacheDirectory, ?string $coverageCacheDirectory, \PHPUnit\TextUI\Configuration\Source $source, string $testResultCacheFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4j, int $coverageCrap4jThreshold, ?string $coverageHtml, int $coverageHtmlLowUpperBound, int $coverageHtmlHighLowerBound, string $coverageHtmlColorSuccessLow, string $coverageHtmlColorSuccessMedium, string $coverageHtmlColorSuccessHigh, string $coverageHtmlColorWarning, string $coverageHtmlColorDanger, ?string $coverageHtmlCustomCssFile, ?string $coveragePhp, ?string $coverageText, bool $coverageTextShowUncoveredFiles, bool $coverageTextShowOnlySummary, ?string $coverageXml, bool $pathCoverage, bool $ignoreDeprecatedCodeUnitsFromCodeCoverage, bool $disableCodeCoverageIgnore, bool $failOnDeprecation, bool $failOnPhpunitDeprecation, bool $failOnPhpunitNotice, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, ?string $specificDeprecationToStopOn, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, bool $outputToStandardErrorStream, int $columns, bool $noExtensions, ?string $pharExtensionDirectory, array $extensionBootstrappers, bool $backupGlobals, bool $backupStaticProperties, bool $beStrictAboutChangesToGlobalState, bool $colors, bool $processIsolation, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, bool $reportUselessTests, bool $strictCoverage, bool $disallowTestOutput, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnPhpunitDeprecations, bool $displayDetailsOnPhpunitNotices, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, bool $noProgress, bool $noResults, bool $noOutput, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies, ?string $logfileTeamcity, ?string $logfileJunit, ?string $logfileTestdoxHtml, ?string $logfileTestdoxText, ?string $logEventsText, ?string $logEventsVerboseText, bool $teamCityOutput, bool $testDoxOutput, bool $testDoxOutputSummary, ?array $testsCovering, ?array $testsUsing, ?array $testsRequiringPhpExtension, ?string $filter, ?string $excludeFilter, array $groups, array $excludeGroups, int $randomOrderSeed, bool $includeUncoveredFiles, \PHPUnit\TextUI\Configuration\TestSuiteCollection $testSuite, string $includeTestSuite, string $excludeTestSuite, ?string $defaultTestSuite, array $testSuffixes, \PHPUnit\TextUI\Configuration\Php $php, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection, ?string $generateBaseline, bool $debug, int $shortenArraysForExportThreshold)
     {
     }
     /**
@@ -22923,6 +22471,9 @@ final readonly class Configuration
     public function failOnPhpunitDeprecation(): bool
     {
     }
+    public function failOnPhpunitNotice(): bool
+    {
+    }
     public function failOnEmptyTestSuite(): bool
     {
     }
@@ -23058,6 +22609,9 @@ final readonly class Configuration
     {
     }
     public function displayDetailsOnPhpunitDeprecations(): bool
+    {
+    }
+    public function displayDetailsOnPhpunitNotices(): bool
     {
     }
     public function displayDetailsOnTestsThatTriggerErrors(): bool
@@ -23318,6 +22872,8 @@ final readonly class Configuration
     }
     /**
      * @throws NoBaselineException
+     *
+     * @return non-empty-string
      */
     public function generateBaseline(): string
     {
@@ -24137,7 +23693,7 @@ final readonly class Source
      * @param non-empty-string                                                          $baseline
      * @param array{functions: list<non-empty-string>, methods: list<non-empty-string>} $deprecationTriggers
      */
-    public function __construct(?string $baseline, bool $ignoreBaseline, \PHPUnit\TextUI\Configuration\FilterDirectoryCollection $includeDirectories, \PHPUnit\TextUI\Configuration\FileCollection $includeFiles, \PHPUnit\TextUI\Configuration\FilterDirectoryCollection $excludeDirectories, \PHPUnit\TextUI\Configuration\FileCollection $excludeFiles, bool $restrictDeprecations, bool $restrictNotices, bool $restrictWarnings, bool $ignoreSuppressionOfDeprecations, bool $ignoreSuppressionOfPhpDeprecations, bool $ignoreSuppressionOfErrors, bool $ignoreSuppressionOfNotices, bool $ignoreSuppressionOfPhpNotices, bool $ignoreSuppressionOfWarnings, bool $ignoreSuppressionOfPhpWarnings, array $deprecationTriggers, bool $ignoreSelfDeprecations, bool $ignoreDirectDeprecations, bool $ignoreIndirectDeprecations)
+    public function __construct(?string $baseline, bool $ignoreBaseline, \PHPUnit\TextUI\Configuration\FilterDirectoryCollection $includeDirectories, \PHPUnit\TextUI\Configuration\FileCollection $includeFiles, \PHPUnit\TextUI\Configuration\FilterDirectoryCollection $excludeDirectories, \PHPUnit\TextUI\Configuration\FileCollection $excludeFiles, bool $restrictNotices, bool $restrictWarnings, bool $ignoreSuppressionOfDeprecations, bool $ignoreSuppressionOfPhpDeprecations, bool $ignoreSuppressionOfErrors, bool $ignoreSuppressionOfNotices, bool $ignoreSuppressionOfPhpNotices, bool $ignoreSuppressionOfWarnings, bool $ignoreSuppressionOfPhpWarnings, array $deprecationTriggers, bool $ignoreSelfDeprecations, bool $ignoreDirectDeprecations, bool $ignoreIndirectDeprecations)
     {
     }
     /**
@@ -24173,9 +23729,6 @@ final readonly class Source
     {
     }
     public function notEmpty(): bool
-    {
-    }
-    public function restrictDeprecations(): bool
     {
     }
     public function restrictNotices(): bool
@@ -24683,7 +24236,7 @@ namespace PHPUnit\TextUI\Output\Default;
  */
 final class ResultPrinter
 {
-    public function __construct(\PHPUnit\TextUI\Output\Printer $printer, bool $displayPhpunitErrors, bool $displayPhpunitWarnings, bool $displayPhpunitDeprecations, bool $displayTestsWithErrors, bool $displayTestsWithFailedAssertions, bool $displayRiskyTests, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $displayDefectsInReverseOrder)
+    public function __construct(\PHPUnit\TextUI\Output\Printer $printer, bool $displayPhpunitDeprecations, bool $displayPhpunitErrors, bool $displayPhpunitNotices, bool $displayPhpunitWarnings, bool $displayTestsWithErrors, bool $displayTestsWithFailedAssertions, bool $displayRiskyTests, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $displayDefectsInReverseOrder)
     {
     }
     public function print(\PHPUnit\TestRunner\TestResult\TestResult $result, bool $stackTraceForDeprecations = false): void
@@ -25675,7 +25228,7 @@ final readonly class PHPUnit
      * @param ?non-empty-string $extensionsDirectory
      * @param non-negative-int  $shortenArraysForExportThreshold
      */
-    public function __construct(?string $cacheDirectory, bool $cacheResult, int|string $columns, string $colors, bool $stderr, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnPhpunitDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, ?string $bootstrap, bool $processIsolation, bool $failOnDeprecation, bool $failOnPhpunitDeprecation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, ?string $extensionsDirectory, bool $beStrictAboutChangesToGlobalState, bool $beStrictAboutOutputDuringTests, bool $beStrictAboutTestsThatDoNotTestAnything, bool $beStrictAboutCoverageMetadata, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, ?string $defaultTestSuite, int $executionOrder, bool $resolveDependencies, bool $defectsFirst, bool $backupGlobals, bool $backupStaticProperties, bool $testdoxPrinter, bool $testdoxPrinterSummary, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection, int $shortenArraysForExportThreshold)
+    public function __construct(?string $cacheDirectory, bool $cacheResult, int|string $columns, string $colors, bool $stderr, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnPhpunitDeprecations, bool $displayDetailsOnPhpunitNotices, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, ?string $bootstrap, bool $processIsolation, bool $failOnDeprecation, bool $failOnPhpunitDeprecation, bool $failOnPhpunitNotice, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, ?string $extensionsDirectory, bool $beStrictAboutChangesToGlobalState, bool $beStrictAboutOutputDuringTests, bool $beStrictAboutTestsThatDoNotTestAnything, bool $beStrictAboutCoverageMetadata, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, ?string $defaultTestSuite, int $executionOrder, bool $resolveDependencies, bool $defectsFirst, bool $backupGlobals, bool $backupStaticProperties, bool $testdoxPrinter, bool $testdoxPrinterSummary, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection, int $shortenArraysForExportThreshold)
     {
     }
     /**
@@ -25714,6 +25267,9 @@ final readonly class PHPUnit
     public function displayDetailsOnPhpunitDeprecations(): bool
     {
     }
+    public function displayDetailsOnPhpunitNotices(): bool
+    {
+    }
     public function displayDetailsOnTestsThatTriggerErrors(): bool
     {
     }
@@ -25748,6 +25304,9 @@ final readonly class PHPUnit
     {
     }
     public function failOnPhpunitDeprecation(): bool
+    {
+    }
+    public function failOnPhpunitNotice(): bool
     {
     }
     public function failOnEmptyTestSuite(): bool
@@ -26415,24 +25974,6 @@ namespace PHPUnit\Util;
  *
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
  */
-final readonly class Cloner
-{
-    /**
-     * @template OriginalType of object
-     *
-     * @param OriginalType $original
-     *
-     * @return OriginalType
-     */
-    public static function clone(object $original): object
-    {
-    }
-}
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
 final class Color
 {
     public static function colorize(string $color, string $buffer): string
@@ -26563,12 +26104,6 @@ final readonly class Filter
      * @throws \PHPUnit\Framework\Exception
      */
     public static function stackTraceFromThrowableAsString(\Throwable $t, bool $unwrap = true): string
-    {
-    }
-    /**
-     * @param list<array{file: string, line: ?int, class?: class-string, function?: string, type: string}> $frames
-     */
-    public static function stackTraceAsString(array $frames): string
     {
     }
 }
@@ -26974,7 +26509,7 @@ final class Parser
      * @throws RequiredOptionArgumentMissingException
      * @throws UnknownOptionException
      *
-     * @return array{0: list<array{0: non-empty-string, 1: ?non-empty-string}>, 1: list<non-empty-string>}
+     * @return array{0: list<array{0: string, 1: ?string}>, 1: list<string>}
      */
     public function parse(array $argv, string $shortOptions, ?array $longOptions = null): array
     {
@@ -27012,10 +26547,8 @@ namespace SebastianBergmann\CodeCoverage;
 /**
  * Provides collection functionality for PHP code coverage information.
  *
- * @phan-type TestType = array{
- *     size: string,
- *     status: string,
- * }
+ * @phan-type TestType array{size: string, status: string}
+ * @phan-type TargetedLines array<non-empty-string, list<positive-int>>
  */
 final class CodeCoverage
 {
@@ -27073,20 +26606,15 @@ final class CodeCoverage
     public function start(string $id, ?\SebastianBergmann\CodeCoverage\Test\TestSize\TestSize $size = null, bool $clear = false): void
     {
     }
-    /**
-     * @param array<string,list<int>> $linesToBeIgnored
-     */
-    public function stop(bool $append = true, ?\SebastianBergmann\CodeCoverage\Test\TestStatus\TestStatus $status = null, array|false $linesToBeCovered = [], array $linesToBeUsed = [], array $linesToBeIgnored = []): \SebastianBergmann\CodeCoverage\Data\RawCodeCoverageData
+    public function stop(bool $append = true, ?\SebastianBergmann\CodeCoverage\Test\TestStatus\TestStatus $status = null, null|false|\SebastianBergmann\CodeCoverage\Test\Target\TargetCollection $covers = null, ?\SebastianBergmann\CodeCoverage\Test\Target\TargetCollection $uses = null): \SebastianBergmann\CodeCoverage\Data\RawCodeCoverageData
     {
     }
     /**
-     * @param array<string,list<int>> $linesToBeIgnored
-     *
      * @throws ReflectionException
      * @throws TestIdMissingException
      * @throws UnintentionallyCoveredCodeException
      */
-    public function append(\SebastianBergmann\CodeCoverage\Data\RawCodeCoverageData $rawData, ?string $id = null, bool $append = true, ?\SebastianBergmann\CodeCoverage\Test\TestStatus\TestStatus $status = null, array|false $linesToBeCovered = [], array $linesToBeUsed = [], array $linesToBeIgnored = []): void
+    public function append(\SebastianBergmann\CodeCoverage\Data\RawCodeCoverageData $rawData, ?string $id = null, bool $append = true, ?\SebastianBergmann\CodeCoverage\Test\TestStatus\TestStatus $status = null, null|false|\SebastianBergmann\CodeCoverage\Test\Target\TargetCollection $covers = null, ?\SebastianBergmann\CodeCoverage\Test\Target\TargetCollection $uses = null): void
     {
     }
     /**
@@ -27152,14 +26680,11 @@ final class CodeCoverage
     public function collectsBranchAndPathCoverage(): bool
     {
     }
-    public function detectsDeadCode(): bool
+    public function validate(\SebastianBergmann\CodeCoverage\Test\Target\TargetCollection $targets): \SebastianBergmann\CodeCoverage\Test\Target\ValidationResult
     {
     }
 }
 final class BranchAndPathCoverageNotSupportedException extends \RuntimeException implements \SebastianBergmann\CodeCoverage\Exception
-{
-}
-final class DeadCodeDetectionNotSupportedException extends \RuntimeException implements \SebastianBergmann\CodeCoverage\Exception
 {
 }
 interface Exception extends \Throwable
@@ -27262,7 +26787,24 @@ namespace SebastianBergmann\CodeCoverage\Data;
  *
  * @phpstan-import-type XdebugFunctionCoverageType from \SebastianBergmann\CodeCoverage\Driver\XdebugDriver
  *
- * @phan-type TestIdType = string
+ * @phan-type TestIdType string
+ * @phan-type FunctionCoverageDataType array{
+ *      branches: array<int, array{
+ *          op_start: int,
+ *          op_end: int,
+ *          line_start: int,
+ *          line_end: int,
+ *          hit: list<TestIdType>,
+ *          out: array<int, int>,
+ *          out_hit: array<int, int>,
+ *      }>,
+ *      paths: array<int, array{
+ *          path: array<int, int>,
+ *          hit: list<TestIdType>,
+ *      }>,
+ *      hit: list<TestIdType>
+ *  }
+ * @phan-type FunctionCoverageType array<string, array<string, FunctionCoverageDataType>>
  */
 final class ProcessedCodeCoverageData
 {
@@ -27413,21 +26955,6 @@ abstract class Driver
     public function disableBranchAndPathCoverage(): void
     {
     }
-    public function canDetectDeadCode(): bool
-    {
-    }
-    public function detectsDeadCode(): bool
-    {
-    }
-    /**
-     * @throws \SebastianBergmann\CodeCoverage\DeadCodeDetectionNotSupportedException
-     */
-    public function enableDeadCodeDetection(): void
-    {
-    }
-    public function disableDeadCodeDetection(): void
-    {
-    }
     abstract public function nameAndVersion(): string;
     abstract public function start(): void;
     abstract public function stop(): \SebastianBergmann\CodeCoverage\Data\RawCodeCoverageData;
@@ -27443,6 +26970,9 @@ final class PcovDriver extends \SebastianBergmann\CodeCoverage\Driver\Driver
     public function __construct(\SebastianBergmann\CodeCoverage\Filter $filter)
     {
     }
+    /**
+     * @codeCoverageIgnore
+     */
     public function start(): void
     {
     }
@@ -27460,6 +26990,7 @@ final class Selector
      * @throws PcovNotAvailableException
      * @throws XdebugNotAvailableException
      * @throws XdebugNotEnabledException
+     * @throws XdebugVersionNotSupportedException
      */
     public function forLineCoverage(\SebastianBergmann\CodeCoverage\Filter $filter): \SebastianBergmann\CodeCoverage\Driver\Driver
     {
@@ -27468,6 +26999,7 @@ final class Selector
      * @throws \SebastianBergmann\CodeCoverage\NoCodeCoverageDriverWithPathCoverageSupportAvailableException
      * @throws XdebugNotAvailableException
      * @throws XdebugNotEnabledException
+     * @throws XdebugVersionNotSupportedException
      */
     public function forLineAndPathCoverage(\SebastianBergmann\CodeCoverage\Filter $filter): \SebastianBergmann\CodeCoverage\Driver\Driver
     {
@@ -27478,8 +27010,8 @@ final class Selector
  *
  * @see https://xdebug.org/docs/code_coverage#xdebug_get_code_coverage
  *
- * @phan-type XdebugLinesCoverageType = array<int, int>
- * @phan-type XdebugBranchCoverageType = array{
+ * @phan-type XdebugLinesCoverageType array<int, int>
+ * @phan-type XdebugBranchCoverageType array{
  *     op_start: int,
  *     op_end: int,
  *     line_start: int,
@@ -27488,35 +27020,33 @@ final class Selector
  *     out: array<int, int>,
  *     out_hit: array<int, int>,
  * }
- * @phan-type XdebugPathCoverageType = array{
+ * @phan-type XdebugPathCoverageType array{
  *     path: array<int, int>,
  *     hit: int,
  * }
- * @phan-type XdebugFunctionCoverageType = array{
+ * @phan-type XdebugFunctionCoverageType array{
  *     branches: array<int, XdebugBranchCoverageType>,
  *     paths: array<int, XdebugPathCoverageType>,
  * }
- * @phan-type XdebugFunctionsCoverageType = array<string, XdebugFunctionCoverageType>
- * @phan-type XdebugPathAndBranchesCoverageType = array{
+ * @phan-type XdebugFunctionsCoverageType array<string, XdebugFunctionCoverageType>
+ * @phan-type XdebugPathAndBranchesCoverageType array{
  *     lines: XdebugLinesCoverageType,
  *     functions: XdebugFunctionsCoverageType,
  * }
- * @phan-type XdebugCodeCoverageWithoutPathCoverageType = array<string, XdebugLinesCoverageType>
- * @phan-type XdebugCodeCoverageWithPathCoverageType = array<string, XdebugPathAndBranchesCoverageType>
+ * @phan-type XdebugCodeCoverageWithoutPathCoverageType array<string, XdebugLinesCoverageType>
+ * @phan-type XdebugCodeCoverageWithPathCoverageType array<string, XdebugPathAndBranchesCoverageType>
  */
 final class XdebugDriver extends \SebastianBergmann\CodeCoverage\Driver\Driver
 {
     /**
      * @throws XdebugNotAvailableException
      * @throws XdebugNotEnabledException
+     * @throws XdebugVersionNotSupportedException
      */
     public function __construct(\SebastianBergmann\CodeCoverage\Filter $filter)
     {
     }
     public function canCollectBranchAndPathCoverage(): bool
-    {
-    }
-    public function canDetectDeadCode(): bool
     {
     }
     public function start(): void
@@ -27559,15 +27089,23 @@ final class XdebugNotEnabledException extends \RuntimeException implements \Seba
     {
     }
 }
+final class XdebugVersionNotSupportedException extends \RuntimeException implements \SebastianBergmann\CodeCoverage\Exception
+{
+    /**
+     * @param non-empty-string $version
+     */
+    public function __construct(string $version)
+    {
+    }
+}
 namespace SebastianBergmann\CodeCoverage\Node;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  *
- * @phpstan-import-type LinesOfCodeType from \SebastianBergmann\CodeCoverage\StaticAnalysis\FileAnalyser
- * @phpstan-import-type ProcessedFunctionType from \SebastianBergmann\CodeCoverage\Node\File
- * @phpstan-import-type ProcessedClassType from \SebastianBergmann\CodeCoverage\Node\File
- * @phpstan-import-type ProcessedTraitType from \SebastianBergmann\CodeCoverage\Node\File
+ * @phpstan-import-type ProcessedFunctionType from File
+ * @phpstan-import-type ProcessedClassType from File
+ * @phpstan-import-type ProcessedTraitType from File
  */
 abstract class AbstractNode implements \Countable
 {
@@ -27583,6 +27121,9 @@ abstract class AbstractNode implements \Countable
     public function pathAsString(): string
     {
     }
+    /**
+     * @return non-empty-list<self>
+     */
     public function pathAsArray(): array
     {
     }
@@ -27646,10 +27187,7 @@ abstract class AbstractNode implements \Countable
      * @return array<string, ProcessedFunctionType>
      */
     abstract public function functions(): array;
-    /**
-     * @return LinesOfCodeType
-     */
-    abstract public function linesOfCode(): array;
+    abstract public function linesOfCode(): \SebastianBergmann\CodeCoverage\StaticAnalysis\LinesOfCode;
     abstract public function numberOfExecutableLines(): int;
     abstract public function numberOfExecutedLines(): int;
     abstract public function numberOfExecutableBranches(): int;
@@ -27670,7 +27208,7 @@ abstract class AbstractNode implements \Countable
  *
  * @phpstan-import-type TestType from \SebastianBergmann\CodeCoverage\CodeCoverage
  */
-final class Builder
+final readonly class Builder
 {
     public function __construct(\SebastianBergmann\CodeCoverage\StaticAnalysis\FileAnalyser $analyser)
     {
@@ -27682,7 +27220,7 @@ final class Builder
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  */
-final class CrapIndex
+final readonly class CrapIndex
 {
     public function __construct(int $cyclomaticComplexity, float $codeCoverage)
     {
@@ -27692,15 +27230,22 @@ final class CrapIndex
     }
 }
 /**
- * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
+ * @template-implements \IteratorAggregate<int, AbstractNode>
  *
- * @phpstan-import-type LinesOfCodeType from \SebastianBergmann\CodeCoverage\StaticAnalysis\FileAnalyser
+ * @phpstan-import-type ProcessedFunctionType from File
+ * @phpstan-import-type ProcessedClassType from File
+ * @phpstan-import-type ProcessedTraitType from File
+ *
+ * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  */
 final class Directory extends \SebastianBergmann\CodeCoverage\Node\AbstractNode implements \IteratorAggregate
 {
     public function count(): int
     {
     }
+    /**
+     * @return \RecursiveIteratorIterator<Iterator<AbstractNode>>
+     */
     public function getIterator(): \RecursiveIteratorIterator
     {
     }
@@ -27710,28 +27255,43 @@ final class Directory extends \SebastianBergmann\CodeCoverage\Node\AbstractNode 
     public function addFile(\SebastianBergmann\CodeCoverage\Node\File $file): void
     {
     }
+    /**
+     * @return list<Directory>
+     */
     public function directories(): array
     {
     }
+    /**
+     * @return list<File>
+     */
     public function files(): array
     {
     }
+    /**
+     * @return list<Directory|File>
+     */
     public function children(): array
     {
     }
+    /**
+     * @return array<string, ProcessedClassType>
+     */
     public function classes(): array
     {
     }
+    /**
+     * @return array<string, ProcessedTraitType>
+     */
     public function traits(): array
     {
     }
+    /**
+     * @return array<string, ProcessedFunctionType>
+     */
     public function functions(): array
     {
     }
-    /**
-     * @return LinesOfCodeType
-     */
-    public function linesOfCode(): array
+    public function linesOfCode(): \SebastianBergmann\CodeCoverage\StaticAnalysis\LinesOfCode
     {
     }
     public function numberOfExecutableLines(): int
@@ -27780,14 +27340,10 @@ final class Directory extends \SebastianBergmann\CodeCoverage\Node\AbstractNode 
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  *
- * @phpstan-import-type CodeUnitFunctionType from \SebastianBergmann\CodeCoverage\StaticAnalysis\CodeUnitFindingVisitor
- * @phpstan-import-type CodeUnitMethodType from \SebastianBergmann\CodeCoverage\StaticAnalysis\CodeUnitFindingVisitor
- * @phpstan-import-type CodeUnitClassType from \SebastianBergmann\CodeCoverage\StaticAnalysis\CodeUnitFindingVisitor
- * @phpstan-import-type CodeUnitTraitType from \SebastianBergmann\CodeCoverage\StaticAnalysis\CodeUnitFindingVisitor
- * @phpstan-import-type LinesOfCodeType from \SebastianBergmann\CodeCoverage\StaticAnalysis\FileAnalyser
+ * @phpstan-import-type TestType from \SebastianBergmann\CodeCoverage\CodeCoverage
  * @phpstan-import-type LinesType from \SebastianBergmann\CodeCoverage\StaticAnalysis\FileAnalyser
  *
- * @phan-type ProcessedFunctionType = array{
+ * @phan-type ProcessedFunctionType array{
  *     functionName: string,
  *     namespace: string,
  *     signature: string,
@@ -27804,7 +27360,7 @@ final class Directory extends \SebastianBergmann\CodeCoverage\Node\AbstractNode 
  *     crap: int|string,
  *     link: string
  * }
- * @phan-type ProcessedMethodType = array{
+ * @phan-type ProcessedMethodType array{
  *     methodName: string,
  *     visibility: string,
  *     signature: string,
@@ -27821,7 +27377,7 @@ final class Directory extends \SebastianBergmann\CodeCoverage\Node\AbstractNode 
  *     crap: int|string,
  *     link: string
  * }
- * @phan-type ProcessedClassType = array{
+ * @phan-type ProcessedClassType array{
  *     className: string,
  *     namespace: string,
  *     methods: array<string, ProcessedMethodType>,
@@ -27837,7 +27393,7 @@ final class Directory extends \SebastianBergmann\CodeCoverage\Node\AbstractNode 
  *     crap: int|string,
  *     link: string
  * }
- * @phan-type ProcessedTraitType = array{
+ * @phan-type ProcessedTraitType array{
  *     traitName: string,
  *     namespace: string,
  *     methods: array<string, ProcessedMethodType>,
@@ -27858,12 +27414,12 @@ final class File extends \SebastianBergmann\CodeCoverage\Node\AbstractNode
 {
     /**
      * @param array<int, ?list<non-empty-string>> $lineCoverageData
-     * @param array<string, CodeUnitClassType>    $classes
-     * @param array<string, CodeUnitTraitType>    $traits
-     * @param array<string, CodeUnitFunctionType> $functions
-     * @param LinesOfCodeType                     $linesOfCode
+     * @param array<string, TestType>             $testData
+     * @param array<string, \SebastianBergmann\CodeCoverage\StaticAnalysis\Class_>               $classes
+     * @param array<string, \SebastianBergmann\CodeCoverage\StaticAnalysis\Trait_>               $traits
+     * @param array<string, \SebastianBergmann\CodeCoverage\StaticAnalysis\Function_>            $functions
      */
-    public function __construct(string $name, \SebastianBergmann\CodeCoverage\Node\AbstractNode $parent, array $lineCoverageData, array $functionCoverageData, array $testData, array $classes, array $traits, array $functions, array $linesOfCode)
+    public function __construct(string $name, \SebastianBergmann\CodeCoverage\Node\AbstractNode $parent, array $lineCoverageData, array $functionCoverageData, array $testData, array $classes, array $traits, array $functions, \SebastianBergmann\CodeCoverage\StaticAnalysis\LinesOfCode $linesOfCode)
     {
     }
     public function count(): int
@@ -27878,6 +27434,9 @@ final class File extends \SebastianBergmann\CodeCoverage\Node\AbstractNode
     public function functionCoverageData(): array
     {
     }
+    /**
+     * @return array<string, TestType>
+     */
     public function testData(): array
     {
     }
@@ -27899,7 +27458,7 @@ final class File extends \SebastianBergmann\CodeCoverage\Node\AbstractNode
     public function functions(): array
     {
     }
-    public function linesOfCode(): array
+    public function linesOfCode(): \SebastianBergmann\CodeCoverage\StaticAnalysis\LinesOfCode
     {
     }
     public function numberOfExecutableLines(): int
@@ -27946,6 +27505,8 @@ final class File extends \SebastianBergmann\CodeCoverage\Node\AbstractNode
     }
 }
 /**
+ * @template-implements \RecursiveIterator<int, AbstractNode>
+ *
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  */
 final class Iterator implements \RecursiveIterator
@@ -27953,45 +27514,24 @@ final class Iterator implements \RecursiveIterator
     public function __construct(\SebastianBergmann\CodeCoverage\Node\Directory $node)
     {
     }
-    /**
-     * Rewinds the Iterator to the first element.
-     */
     public function rewind(): void
     {
     }
-    /**
-     * Checks if there is a current element after calls to rewind() or next().
-     */
     public function valid(): bool
     {
     }
-    /**
-     * Returns the key of the current element.
-     */
     public function key(): int
     {
     }
-    /**
-     * Returns the current element.
-     */
     public function current(): ?\SebastianBergmann\CodeCoverage\Node\AbstractNode
     {
     }
-    /**
-     * Moves forward to next element.
-     */
     public function next(): void
     {
     }
-    /**
-     * Returns the sub iterator for the current element.
-     */
     public function getChildren(): self
     {
     }
-    /**
-     * Checks whether the current element has children.
-     */
     public function hasChildren(): bool
     {
     }
@@ -28016,7 +27556,7 @@ final class Cobertura
     {
     }
 }
-final class Crap4j
+final readonly class Crap4j
 {
     public function __construct(int $threshold = 30)
     {
@@ -28046,7 +27586,7 @@ final class Text
 /**
  * @immutable
  */
-final class Thresholds
+final readonly class Thresholds
 {
     public static function default(): self
     {
@@ -28069,7 +27609,7 @@ namespace SebastianBergmann\CodeCoverage\Report\Html;
 /**
  * @immutable
  */
-final class Colors
+final readonly class Colors
 {
     public static function default(): self
     {
@@ -28096,7 +27636,7 @@ final class Colors
 /**
  * @immutable
  */
-final class CustomCssFile
+final readonly class CustomCssFile
 {
     public static function default(): self
     {
@@ -28111,7 +27651,7 @@ final class CustomCssFile
     {
     }
 }
-final class Facade
+final readonly class Facade
 {
     public function __construct(string $generator = '', ?\SebastianBergmann\CodeCoverage\Report\Html\Colors $colors = null, ?\SebastianBergmann\CodeCoverage\Report\Thresholds $thresholds = null, ?\SebastianBergmann\CodeCoverage\Report\Html\CustomCssFile $customCssFile = null)
     {
@@ -28134,6 +27674,9 @@ abstract class Renderer
     public function __construct(string $templatePath, string $generator, string $date, \SebastianBergmann\CodeCoverage\Report\Thresholds $thresholds, bool $hasBranchCoverage)
     {
     }
+    /**
+     * @param array<non-empty-string, float|int|string> $data
+     */
     protected function renderItemTemplate(\SebastianBergmann\Template\Template $template, array $data): string
     {
     }
@@ -28160,6 +27703,9 @@ abstract class Renderer
     }
 }
 /**
+ * @phpstan-import-type ProcessedClassType from \SebastianBergmann\CodeCoverage\Node\File
+ * @phpstan-import-type ProcessedTraitType from \SebastianBergmann\CodeCoverage\Node\File
+ *
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  */
 final class Dashboard extends \SebastianBergmann\CodeCoverage\Report\Html\Renderer
@@ -28178,6 +27724,11 @@ final class Directory extends \SebastianBergmann\CodeCoverage\Report\Html\Render
     }
 }
 /**
+ * @phpstan-import-type ProcessedClassType from \SebastianBergmann\CodeCoverage\Node\File
+ * @phpstan-import-type ProcessedTraitType from \SebastianBergmann\CodeCoverage\Node\File
+ * @phpstan-import-type ProcessedMethodType from \SebastianBergmann\CodeCoverage\Node\File
+ * @phpstan-import-type ProcessedFunctionType from \SebastianBergmann\CodeCoverage\Node\File
+ *
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  */
 final class File extends \SebastianBergmann\CodeCoverage\Report\Html\Renderer
@@ -28191,7 +27742,7 @@ namespace SebastianBergmann\CodeCoverage\Report\Xml;
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  */
-final class BuildInformation
+final readonly class BuildInformation
 {
     public function __construct(\DOMElement $contextNode)
     {
@@ -28230,6 +27781,12 @@ final class Coverage
 final class Directory extends \SebastianBergmann\CodeCoverage\Report\Xml\Node
 {
 }
+/**
+ * @phpstan-import-type ProcessedClassType from \SebastianBergmann\CodeCoverage\Node\File
+ * @phpstan-import-type ProcessedTraitType from \SebastianBergmann\CodeCoverage\Node\File
+ * @phpstan-import-type ProcessedFunctionType from \SebastianBergmann\CodeCoverage\Node\File
+ * @phpstan-import-type TestType from \SebastianBergmann\CodeCoverage\CodeCoverage
+ */
 final class Facade
 {
     public function __construct(string $version)
@@ -28266,7 +27823,7 @@ class File
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  */
-final class Method
+final readonly class Method
 {
     public function __construct(\DOMElement $context, string $name)
     {
@@ -28316,6 +27873,9 @@ abstract class Node
  */
 final class Project extends \SebastianBergmann\CodeCoverage\Report\Xml\Node
 {
+    /**
+     * @phpstan-ignore constructor.missingParentCall
+     */
     public function __construct(string $directory)
     {
     }
@@ -28343,13 +27903,13 @@ final class Report extends \SebastianBergmann\CodeCoverage\Report\Xml\File
     public function asDom(): \DOMDocument
     {
     }
-    public function functionObject($name): \SebastianBergmann\CodeCoverage\Report\Xml\Method
+    public function functionObject(string $name): \SebastianBergmann\CodeCoverage\Report\Xml\Method
     {
     }
-    public function classObject($name): \SebastianBergmann\CodeCoverage\Report\Xml\Unit
+    public function classObject(string $name): \SebastianBergmann\CodeCoverage\Report\Xml\Unit
     {
     }
-    public function traitObject($name): \SebastianBergmann\CodeCoverage\Report\Xml\Unit
+    public function traitObject(string $name): \SebastianBergmann\CodeCoverage\Report\Xml\Unit
     {
     }
     public function source(): \SebastianBergmann\CodeCoverage\Report\Xml\Source
@@ -28359,7 +27919,7 @@ final class Report extends \SebastianBergmann\CodeCoverage\Report\Xml\File
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  */
-final class Source
+final readonly class Source
 {
     public function __construct(\DOMElement $context)
     {
@@ -28373,7 +27933,7 @@ final class Source
  *
  * @phpstan-import-type TestType from \SebastianBergmann\CodeCoverage\CodeCoverage
  */
-final class Tests
+final readonly class Tests
 {
     public function __construct(\DOMElement $context)
     {
@@ -28388,7 +27948,7 @@ final class Tests
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  */
-final class Totals
+final readonly class Totals
 {
     public function __construct(\DOMElement $container)
     {
@@ -28415,7 +27975,7 @@ final class Totals
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  */
-final class Unit
+final readonly class Unit
 {
     public function __construct(\DOMElement $context, string $name)
     {
@@ -28437,19 +27997,27 @@ namespace SebastianBergmann\CodeCoverage\StaticAnalysis;
 
 final class CacheWarmer
 {
-    public function warmCache(string $cacheDirectory, bool $useAnnotationsForIgnoringCode, bool $ignoreDeprecatedCode, \SebastianBergmann\CodeCoverage\Filter $filter): void
+    /**
+     * @return array{cacheHits: non-negative-int, cacheMisses: non-negative-int}
+     */
+    public function warmCache(string $cacheDirectory, bool $useAnnotationsForIgnoringCode, bool $ignoreDeprecatedCode, \SebastianBergmann\CodeCoverage\Filter $filter): array
     {
     }
 }
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  *
- * @phpstan-import-type CodeUnitFunctionType from \SebastianBergmann\CodeCoverage\StaticAnalysis\CodeUnitFindingVisitor
- * @phpstan-import-type CodeUnitMethodType from \SebastianBergmann\CodeCoverage\StaticAnalysis\CodeUnitFindingVisitor
- * @phpstan-import-type CodeUnitClassType from \SebastianBergmann\CodeCoverage\StaticAnalysis\CodeUnitFindingVisitor
- * @phpstan-import-type CodeUnitTraitType from \SebastianBergmann\CodeCoverage\StaticAnalysis\CodeUnitFindingVisitor
- * @phpstan-import-type LinesOfCodeType from \SebastianBergmann\CodeCoverage\StaticAnalysis\FileAnalyser
- * @phpstan-import-type LinesType from \SebastianBergmann\CodeCoverage\StaticAnalysis\FileAnalyser
+ * @phan-type CachedDataForFile array{
+ *   interfacesIn: array<string, Interface_>,
+ *   classesIn: array<string, Class_>,
+ *   traitsIn: array<string, Trait_>,
+ *   functionsIn: array<string, Function_>,
+ *   linesOfCodeFor: LinesOfCode,
+ *   ignoredLinesFor: LinesType,
+ *   executableLinesIn: LinesType
+ * }
+ *
+ * @phpstan-import-type LinesType from FileAnalyser
  */
 final class CachingFileAnalyser implements \SebastianBergmann\CodeCoverage\StaticAnalysis\FileAnalyser
 {
@@ -28457,27 +28025,30 @@ final class CachingFileAnalyser implements \SebastianBergmann\CodeCoverage\Stati
     {
     }
     /**
-     * @return array<string, CodeUnitClassType>
+     * @return array<string, Interface_>
+     */
+    public function interfacesIn(string $filename): array
+    {
+    }
+    /**
+     * @return array<string, Class_>
      */
     public function classesIn(string $filename): array
     {
     }
     /**
-     * @return array<string, CodeUnitTraitType>
+     * @return array<string, Trait_>
      */
     public function traitsIn(string $filename): array
     {
     }
     /**
-     * @return array<string, CodeUnitFunctionType>
+     * @return array<string, Function_>
      */
     public function functionsIn(string $filename): array
     {
     }
-    /**
-     * @return LinesOfCodeType
-     */
-    public function linesOfCodeFor(string $filename): array
+    public function linesOfCodeFor(string $filename): \SebastianBergmann\CodeCoverage\StaticAnalysis\LinesOfCode
     {
     }
     /**
@@ -28492,66 +28063,50 @@ final class CachingFileAnalyser implements \SebastianBergmann\CodeCoverage\Stati
     public function ignoredLinesFor(string $filename): array
     {
     }
-    public function process(string $filename): void
+    /**
+     * @return array{cacheHits: non-negative-int, cacheMisses: non-negative-int}
+     */
+    public function process(string $filename): array
     {
     }
 }
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
- *
- * @phan-type CodeUnitFunctionType = array{
- *     name: string,
- *     namespacedName: string,
- *     namespace: string,
- *     signature: string,
- *     startLine: int,
- *     endLine: int,
- *     ccn: int
- * }
- * @phan-type CodeUnitMethodType = array{
- *     methodName: string,
- *     signature: string,
- *     visibility: string,
- *     startLine: int,
- *     endLine: int,
- *     ccn: int
- * }
- * @phan-type CodeUnitClassType = array{
- *     name: string,
- *     namespacedName: string,
- *     namespace: string,
- *     startLine: int,
- *     endLine: int,
- *     methods: array<string, CodeUnitMethodType>
- * }
- * @phan-type CodeUnitTraitType = array{
- *     name: string,
- *     namespacedName: string,
- *     namespace: string,
- *     startLine: int,
- *     endLine: int,
- *     methods: array<string, CodeUnitMethodType>
- * }
  */
 final class CodeUnitFindingVisitor extends \PhpParser\NodeVisitorAbstract
 {
-    public function enterNode(\PhpParser\Node $node): void
+    /**
+     * @param non-empty-string $file
+     */
+    public function __construct(string $file)
+    {
+    }
+    public function enterNode(\PhpParser\Node $node): null
+    {
+    }
+    public function leaveNode(\PhpParser\Node $node): null
     {
     }
     /**
-     * @return array<string, CodeUnitClassType>
+     * @return array<string, \SebastianBergmann\CodeCoverage\StaticAnalysis\Interface_>
+     */
+    public function interfaces(): array
+    {
+    }
+    /**
+     * @return array<string, \SebastianBergmann\CodeCoverage\StaticAnalysis\Class_>
      */
     public function classes(): array
     {
     }
     /**
-     * @return array<string, CodeUnitTraitType>
+     * @return array<string, \SebastianBergmann\CodeCoverage\StaticAnalysis\Trait_>
      */
     public function traits(): array
     {
     }
     /**
-     * @return array<string, CodeUnitFunctionType>
+     * @return array<string, \SebastianBergmann\CodeCoverage\StaticAnalysis\Function_>
      */
     public function functions(): array
     {
@@ -28560,17 +28115,17 @@ final class CodeUnitFindingVisitor extends \PhpParser\NodeVisitorAbstract
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  *
- * @phpstan-import-type LinesType from \SebastianBergmann\CodeCoverage\StaticAnalysis\FileAnalyser
+ * @phpstan-import-type LinesType from FileAnalyser
  */
 final class ExecutableLinesFindingVisitor extends \PhpParser\NodeVisitorAbstract
 {
     public function __construct(string $source)
     {
     }
-    public function enterNode(\PhpParser\Node $node): void
+    public function enterNode(\PhpParser\Node $node): null
     {
     }
-    public function afterTraverse(array $nodes): void
+    public function afterTraverse(array $nodes): null
     {
     }
     /**
@@ -28583,36 +28138,27 @@ final class ExecutableLinesFindingVisitor extends \PhpParser\NodeVisitorAbstract
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  *
- * @phpstan-import-type CodeUnitFunctionType from \SebastianBergmann\CodeCoverage\StaticAnalysis\CodeUnitFindingVisitor
- * @phpstan-import-type CodeUnitMethodType from \SebastianBergmann\CodeCoverage\StaticAnalysis\CodeUnitFindingVisitor
- * @phpstan-import-type CodeUnitClassType from \SebastianBergmann\CodeCoverage\StaticAnalysis\CodeUnitFindingVisitor
- * @phpstan-import-type CodeUnitTraitType from \SebastianBergmann\CodeCoverage\StaticAnalysis\CodeUnitFindingVisitor
- *
- * @phan-type LinesOfCodeType = array{
- *     linesOfCode: int,
- *     commentLinesOfCode: int,
- *     nonCommentLinesOfCode: int
- * }
- * @phan-type LinesType = array<int, int>
+ * @phan-type LinesType array<int, int>
  */
 interface FileAnalyser
 {
     /**
-     * @return array<string, CodeUnitClassType>
+     * @return array<string, Interface_>
+     */
+    public function interfacesIn(string $filename): array;
+    /**
+     * @return array<string, Class_>
      */
     public function classesIn(string $filename): array;
     /**
-     * @return array<string, CodeUnitTraitType>
+     * @return array<string, Trait_>
      */
     public function traitsIn(string $filename): array;
     /**
-     * @return array<string, CodeUnitFunctionType>
+     * @return array<string, Function_>
      */
     public function functionsIn(string $filename): array;
-    /**
-     * @return LinesOfCodeType
-     */
-    public function linesOfCodeFor(string $filename): array;
+    public function linesOfCodeFor(string $filename): \SebastianBergmann\CodeCoverage\StaticAnalysis\LinesOfCode;
     /**
      * @return LinesType
      */
@@ -28630,7 +28176,7 @@ final class IgnoredLinesFindingVisitor extends \PhpParser\NodeVisitorAbstract
     public function __construct(bool $useAnnotationsForIgnoringCode, bool $ignoreDeprecated)
     {
     }
-    public function enterNode(\PhpParser\Node $node): void
+    public function enterNode(\PhpParser\Node $node): null
     {
     }
     /**
@@ -28643,12 +28189,7 @@ final class IgnoredLinesFindingVisitor extends \PhpParser\NodeVisitorAbstract
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  *
- * @phpstan-import-type CodeUnitFunctionType from \SebastianBergmann\CodeCoverage\StaticAnalysis\CodeUnitFindingVisitor
- * @phpstan-import-type CodeUnitMethodType from \SebastianBergmann\CodeCoverage\StaticAnalysis\CodeUnitFindingVisitor
- * @phpstan-import-type CodeUnitClassType from \SebastianBergmann\CodeCoverage\StaticAnalysis\CodeUnitFindingVisitor
- * @phpstan-import-type CodeUnitTraitType from \SebastianBergmann\CodeCoverage\StaticAnalysis\CodeUnitFindingVisitor
- * @phpstan-import-type LinesOfCodeType from \SebastianBergmann\CodeCoverage\StaticAnalysis\FileAnalyser
- * @phpstan-import-type LinesType from \SebastianBergmann\CodeCoverage\StaticAnalysis\FileAnalyser
+ * @phpstan-import-type LinesType from FileAnalyser
  */
 final class ParsingFileAnalyser implements \SebastianBergmann\CodeCoverage\StaticAnalysis\FileAnalyser
 {
@@ -28656,27 +28197,30 @@ final class ParsingFileAnalyser implements \SebastianBergmann\CodeCoverage\Stati
     {
     }
     /**
-     * @return array<string, CodeUnitClassType>
+     * @return array<string, Interface_>
+     */
+    public function interfacesIn(string $filename): array
+    {
+    }
+    /**
+     * @return array<string, Class_>
      */
     public function classesIn(string $filename): array
     {
     }
     /**
-     * @return array<string, CodeUnitTraitType>
+     * @return array<string, Trait_>
      */
     public function traitsIn(string $filename): array
     {
     }
     /**
-     * @return array<string, CodeUnitFunctionType>
+     * @return array<string, Function_>
      */
     public function functionsIn(string $filename): array
     {
     }
-    /**
-     * @return LinesOfCodeType
-     */
-    public function linesOfCodeFor(string $filename): array
+    public function linesOfCodeFor(string $filename): \SebastianBergmann\CodeCoverage\StaticAnalysis\LinesOfCode
     {
     }
     /**
@@ -28689,6 +28233,880 @@ final class ParsingFileAnalyser implements \SebastianBergmann\CodeCoverage\Stati
      * @return LinesType
      */
     public function ignoredLinesFor(string $filename): array
+    {
+    }
+}
+/**
+ * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final readonly class Class_
+{
+    /**
+     * @param non-empty-string                $name
+     * @param non-empty-string                $namespacedName
+     * @param non-empty-string                $file
+     * @param non-negative-int                $startLine
+     * @param non-negative-int                $endLine
+     * @param ?non-empty-string               $parentClass
+     * @param list<non-empty-string>          $interfaces
+     * @param list<non-empty-string>          $traits
+     * @param array<non-empty-string, Method> $methods
+     */
+    public function __construct(string $name, string $namespacedName, string $namespace, string $file, int $startLine, int $endLine, ?string $parentClass, array $interfaces, array $traits, array $methods)
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function name(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function namespacedName(): string
+    {
+    }
+    public function isNamespaced(): bool
+    {
+    }
+    public function namespace(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function file(): string
+    {
+    }
+    /**
+     * @return non-negative-int
+     */
+    public function startLine(): int
+    {
+    }
+    /**
+     * @return non-negative-int
+     */
+    public function endLine(): int
+    {
+    }
+    public function hasParent(): bool
+    {
+    }
+    /**
+     * @return ?non-empty-string
+     */
+    public function parentClass(): ?string
+    {
+    }
+    /**
+     * @return list<non-empty-string>
+     */
+    public function interfaces(): array
+    {
+    }
+    /**
+     * @return list<non-empty-string>
+     */
+    public function traits(): array
+    {
+    }
+    /**
+     * @return array<non-empty-string, Method>
+     */
+    public function methods(): array
+    {
+    }
+}
+/**
+ * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final readonly class Function_
+{
+    /**
+     * @param non-empty-string $name
+     * @param non-empty-string $namespacedName
+     * @param non-negative-int $startLine
+     * @param non-negative-int $endLine
+     * @param non-empty-string $signature
+     * @param positive-int     $cyclomaticComplexity
+     */
+    public function __construct(string $name, string $namespacedName, string $namespace, int $startLine, int $endLine, string $signature, int $cyclomaticComplexity)
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function name(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function namespacedName(): string
+    {
+    }
+    public function isNamespaced(): bool
+    {
+    }
+    public function namespace(): string
+    {
+    }
+    /**
+     * @return non-negative-int
+     */
+    public function startLine(): int
+    {
+    }
+    /**
+     * @return non-negative-int
+     */
+    public function endLine(): int
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function signature(): string
+    {
+    }
+    /**
+     * @return positive-int
+     */
+    public function cyclomaticComplexity(): int
+    {
+    }
+}
+/**
+ * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final readonly class Interface_
+{
+    /**
+     * @param non-empty-string       $name
+     * @param non-empty-string       $namespacedName
+     * @param non-negative-int       $startLine
+     * @param non-negative-int       $endLine
+     * @param list<non-empty-string> $parentInterfaces
+     */
+    public function __construct(string $name, string $namespacedName, string $namespace, int $startLine, int $endLine, array $parentInterfaces)
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function name(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function namespacedName(): string
+    {
+    }
+    public function isNamespaced(): bool
+    {
+    }
+    public function namespace(): string
+    {
+    }
+    /**
+     * @return non-negative-int
+     */
+    public function startLine(): int
+    {
+    }
+    /**
+     * @return non-negative-int
+     */
+    public function endLine(): int
+    {
+    }
+    /**
+     * @return list<non-empty-string>
+     */
+    public function parentInterfaces(): array
+    {
+    }
+}
+/**
+ * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final readonly class LinesOfCode
+{
+    /**
+     * @param non-negative-int $linesOfCode
+     * @param non-negative-int $commentLinesOfCode
+     * @param non-negative-int $nonCommentLinesOfCode
+     */
+    public function __construct(int $linesOfCode, int $commentLinesOfCode, int $nonCommentLinesOfCode)
+    {
+    }
+    /**
+     * @return non-negative-int
+     */
+    public function linesOfCode(): int
+    {
+    }
+    /**
+     * @return non-negative-int
+     */
+    public function commentLinesOfCode(): int
+    {
+    }
+    /**
+     * @return non-negative-int
+     */
+    public function nonCommentLinesOfCode(): int
+    {
+    }
+}
+/**
+ * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final readonly class Method
+{
+    /**
+     * @param non-empty-string $name
+     * @param non-negative-int $startLine
+     * @param non-negative-int $endLine
+     * @param non-empty-string $signature
+     * @param positive-int     $cyclomaticComplexity
+     */
+    public function __construct(string $name, int $startLine, int $endLine, string $signature, \SebastianBergmann\CodeCoverage\StaticAnalysis\Visibility $visibility, int $cyclomaticComplexity)
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function name(): string
+    {
+    }
+    /**
+     * @return non-negative-int
+     */
+    public function startLine(): int
+    {
+    }
+    /**
+     * @return non-negative-int
+     */
+    public function endLine(): int
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function signature(): string
+    {
+    }
+    public function visibility(): \SebastianBergmann\CodeCoverage\StaticAnalysis\Visibility
+    {
+    }
+    /**
+     * @return positive-int
+     */
+    public function cyclomaticComplexity(): int
+    {
+    }
+}
+/**
+ * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final readonly class Trait_
+{
+    /**
+     * @param non-empty-string                $name
+     * @param non-empty-string                $namespacedName
+     * @param non-empty-string                $file
+     * @param non-negative-int                $startLine
+     * @param non-negative-int                $endLine
+     * @param list<non-empty-string>          $traits
+     * @param array<non-empty-string, Method> $methods
+     */
+    public function __construct(string $name, string $namespacedName, string $namespace, string $file, int $startLine, int $endLine, array $traits, array $methods)
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function name(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function namespacedName(): string
+    {
+    }
+    public function isNamespaced(): bool
+    {
+    }
+    public function namespace(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function file(): string
+    {
+    }
+    /**
+     * @return non-negative-int
+     */
+    public function startLine(): int
+    {
+    }
+    /**
+     * @return non-negative-int
+     */
+    public function endLine(): int
+    {
+    }
+    /**
+     * @return list<non-empty-string>
+     */
+    public function traits(): array
+    {
+    }
+    /**
+     * @return array<non-empty-string, Method>
+     */
+    public function methods(): array
+    {
+    }
+}
+namespace SebastianBergmann\CodeCoverage\Test\Target;
+
+final class InvalidCodeCoverageTargetException extends \RuntimeException implements \SebastianBergmann\CodeCoverage\Exception
+{
+    public function __construct(\SebastianBergmann\CodeCoverage\Test\Target\Target $target)
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final class Class_ extends \SebastianBergmann\CodeCoverage\Test\Target\Target
+{
+    public function isClass(): true
+    {
+    }
+    /**
+     * @return class-string
+     */
+    public function className(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function key(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function target(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function description(): string
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final class ClassesThatExtendClass extends \SebastianBergmann\CodeCoverage\Test\Target\Target
+{
+    public function isClassesThatExtendClass(): true
+    {
+    }
+    /**
+     * @return class-string
+     */
+    public function className(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function key(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function target(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function description(): string
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final class ClassesThatImplementInterface extends \SebastianBergmann\CodeCoverage\Test\Target\Target
+{
+    public function isClassesThatImplementInterface(): true
+    {
+    }
+    /**
+     * @return class-string
+     */
+    public function interfaceName(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function key(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function target(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function description(): string
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final class Function_ extends \SebastianBergmann\CodeCoverage\Test\Target\Target
+{
+    public function isFunction(): true
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function functionName(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function key(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function target(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function description(): string
+    {
+    }
+}
+/**
+ * @phpstan-import-type TargetMap from Mapper
+ * @phpstan-import-type TargetMapPart from Mapper
+ *
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for phpunit/php-code-coverage
+ *
+ * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final readonly class MapBuilder
+{
+    /**
+     * @return TargetMap
+     */
+    public function build(\SebastianBergmann\CodeCoverage\Filter $filter, \SebastianBergmann\CodeCoverage\StaticAnalysis\FileAnalyser $analyser): array
+    {
+    }
+}
+/**
+ * @phan-type TargetMap array{namespaces: TargetMapPart, traits: TargetMapPart, classes: TargetMapPart, classesThatExtendClass: TargetMapPart, classesThatImplementInterface: TargetMapPart, methods: TargetMapPart, functions: TargetMapPart, reverseLookup: ReverseLookup}
+ * @phan-type TargetMapPart array<non-empty-string, array<non-empty-string, list<positive-int>>>
+ * @phan-type ReverseLookup array<non-empty-string, non-empty-string>
+ *
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for phpunit/php-code-coverage
+ *
+ * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final readonly class Mapper
+{
+    /**
+     * @param TargetMap $map
+     */
+    public function __construct(array $map)
+    {
+    }
+    /**
+     * @return array<non-empty-string, list<positive-int>>
+     */
+    public function mapTargets(\SebastianBergmann\CodeCoverage\Test\Target\TargetCollection $targets): array
+    {
+    }
+    /**
+     * @throws InvalidCodeCoverageTargetException
+     *
+     * @return array<non-empty-string, list<positive-int>>
+     */
+    public function mapTarget(\SebastianBergmann\CodeCoverage\Test\Target\Target $target): array
+    {
+    }
+    /**
+     * @param non-empty-string $file
+     * @param positive-int     $line
+     *
+     * @return non-empty-string
+     */
+    public function lookup(string $file, int $line): string
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final class Method extends \SebastianBergmann\CodeCoverage\Test\Target\Target
+{
+    public function isMethod(): true
+    {
+    }
+    /**
+     * @return class-string
+     */
+    public function className(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function methodName(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function key(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function target(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function description(): string
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final class Namespace_ extends \SebastianBergmann\CodeCoverage\Test\Target\Target
+{
+    public function isNamespace(): true
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function namespace(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function key(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function target(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function description(): string
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+abstract class Target
+{
+    /**
+     * @param non-empty-string $namespace
+     */
+    public static function forNamespace(string $namespace): \SebastianBergmann\CodeCoverage\Test\Target\Namespace_
+    {
+    }
+    /**
+     * @param class-string $className
+     */
+    public static function forClass(string $className): \SebastianBergmann\CodeCoverage\Test\Target\Class_
+    {
+    }
+    /**
+     * @param class-string     $className
+     * @param non-empty-string $methodName
+     */
+    public static function forMethod(string $className, string $methodName): \SebastianBergmann\CodeCoverage\Test\Target\Method
+    {
+    }
+    /**
+     * @param class-string $interfaceName
+     */
+    public static function forClassesThatImplementInterface(string $interfaceName): \SebastianBergmann\CodeCoverage\Test\Target\ClassesThatImplementInterface
+    {
+    }
+    /**
+     * @param class-string $className
+     */
+    public static function forClassesThatExtendClass(string $className): \SebastianBergmann\CodeCoverage\Test\Target\ClassesThatExtendClass
+    {
+    }
+    /**
+     * @param non-empty-string $functionName
+     */
+    public static function forFunction(string $functionName): \SebastianBergmann\CodeCoverage\Test\Target\Function_
+    {
+    }
+    /**
+     * @param trait-string $traitName
+     */
+    public static function forTrait(string $traitName): \SebastianBergmann\CodeCoverage\Test\Target\Trait_
+    {
+    }
+    public function isNamespace(): bool
+    {
+    }
+    public function isClass(): bool
+    {
+    }
+    public function isMethod(): bool
+    {
+    }
+    public function isClassesThatImplementInterface(): bool
+    {
+    }
+    public function isClassesThatExtendClass(): bool
+    {
+    }
+    public function isFunction(): bool
+    {
+    }
+    public function isTrait(): bool
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    abstract public function key(): string;
+    /**
+     * @return non-empty-string
+     */
+    abstract public function target(): string;
+    /**
+     * @return non-empty-string
+     */
+    abstract public function description(): string;
+}
+/**
+ * @template-implements \IteratorAggregate<int, Target>
+ *
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final readonly class TargetCollection implements \Countable, \IteratorAggregate
+{
+    /**
+     * @param list<Target> $targets
+     */
+    public static function fromArray(array $targets): self
+    {
+    }
+    /**
+     * @return list<Target>
+     */
+    public function asArray(): array
+    {
+    }
+    public function count(): int
+    {
+    }
+    public function isEmpty(): bool
+    {
+    }
+    public function isNotEmpty(): bool
+    {
+    }
+    public function getIterator(): \SebastianBergmann\CodeCoverage\Test\Target\TargetCollectionIterator
+    {
+    }
+}
+/**
+ * @template-implements \Iterator<int, Target>
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final class TargetCollectionIterator implements \Iterator
+{
+    public function __construct(\SebastianBergmann\CodeCoverage\Test\Target\TargetCollection $metadata)
+    {
+    }
+    public function rewind(): void
+    {
+    }
+    public function valid(): bool
+    {
+    }
+    public function key(): int
+    {
+    }
+    public function current(): \SebastianBergmann\CodeCoverage\Test\Target\Target
+    {
+    }
+    public function next(): void
+    {
+    }
+}
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for phpunit/php-code-coverage
+ *
+ * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final readonly class TargetCollectionValidator
+{
+    public function validate(\SebastianBergmann\CodeCoverage\Test\Target\Mapper $mapper, \SebastianBergmann\CodeCoverage\Test\Target\TargetCollection $targets): \SebastianBergmann\CodeCoverage\Test\Target\ValidationResult
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final class Trait_ extends \SebastianBergmann\CodeCoverage\Test\Target\Target
+{
+    public function isTrait(): true
+    {
+    }
+    /**
+     * @return trait-string
+     */
+    public function traitName(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function key(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function target(): string
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function description(): string
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final readonly class ValidationFailure extends \SebastianBergmann\CodeCoverage\Test\Target\ValidationResult
+{
+    public function isFailure(): true
+    {
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function message(): string
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+abstract readonly class ValidationResult
+{
+    public static function success(): \SebastianBergmann\CodeCoverage\Test\Target\ValidationSuccess
+    {
+    }
+    /**
+     * @param non-empty-string $message
+     */
+    public static function failure(string $message): \SebastianBergmann\CodeCoverage\Test\Target\ValidationFailure
+    {
+    }
+    /**
+     * @phpstan-assert-if-true ValidationSuccess $this
+     */
+    public function isSuccess(): bool
+    {
+    }
+    /**
+     * @phpstan-assert-if-true ValidationFailure $this
+     */
+    public function isFailure(): bool
+    {
+    }
+}
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final readonly class ValidationSuccess extends \SebastianBergmann\CodeCoverage\Test\Target\ValidationResult
+{
+    public function isSuccess(): true
     {
     }
 }
@@ -28917,7 +29335,7 @@ final class Filesystem
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  */
-final class Percentage
+final readonly class Percentage
 {
     public static function fromFractionAndTotal(float $fraction, float $total): self
     {
@@ -28929,312 +29347,6 @@ final class Percentage
     {
     }
     public function asFixedWidthString(): string
-    {
-    }
-}
-namespace SebastianBergmann\CodeUnit;
-
-/**
- * @immutable
- */
-final readonly class ClassMethodUnit extends \SebastianBergmann\CodeUnit\CodeUnit
-{
-    public function isClassMethod(): bool
-    {
-    }
-}
-/**
- * @immutable
- */
-final readonly class ClassUnit extends \SebastianBergmann\CodeUnit\CodeUnit
-{
-    public function isClass(): bool
-    {
-    }
-}
-/**
- * @immutable
- */
-abstract readonly class CodeUnit
-{
-    /**
-     * @param class-string $className
-     *
-     * @throws InvalidCodeUnitException
-     * @throws ReflectionException
-     */
-    public static function forClass(string $className): \SebastianBergmann\CodeUnit\ClassUnit
-    {
-    }
-    /**
-     * @param class-string $className
-     *
-     * @throws InvalidCodeUnitException
-     * @throws ReflectionException
-     */
-    public static function forClassMethod(string $className, string $methodName): \SebastianBergmann\CodeUnit\ClassMethodUnit
-    {
-    }
-    /**
-     * @param non-empty-string $path
-     *
-     * @throws InvalidCodeUnitException
-     */
-    public static function forFileWithAbsolutePath(string $path): \SebastianBergmann\CodeUnit\FileUnit
-    {
-    }
-    /**
-     * @param class-string $interfaceName
-     *
-     * @throws InvalidCodeUnitException
-     * @throws ReflectionException
-     */
-    public static function forInterface(string $interfaceName): \SebastianBergmann\CodeUnit\InterfaceUnit
-    {
-    }
-    /**
-     * @param class-string $interfaceName
-     *
-     * @throws InvalidCodeUnitException
-     * @throws ReflectionException
-     */
-    public static function forInterfaceMethod(string $interfaceName, string $methodName): \SebastianBergmann\CodeUnit\InterfaceMethodUnit
-    {
-    }
-    /**
-     * @param class-string $traitName
-     *
-     * @throws InvalidCodeUnitException
-     * @throws ReflectionException
-     */
-    public static function forTrait(string $traitName): \SebastianBergmann\CodeUnit\TraitUnit
-    {
-    }
-    /**
-     * @param class-string $traitName
-     *
-     * @throws InvalidCodeUnitException
-     * @throws ReflectionException
-     */
-    public static function forTraitMethod(string $traitName, string $methodName): \SebastianBergmann\CodeUnit\TraitMethodUnit
-    {
-    }
-    /**
-     * @param callable-string $functionName
-     *
-     * @throws InvalidCodeUnitException
-     * @throws ReflectionException
-     */
-    public static function forFunction(string $functionName): \SebastianBergmann\CodeUnit\FunctionUnit
-    {
-    }
-    /**
-     * @return non-empty-string
-     */
-    public function name(): string
-    {
-    }
-    /**
-     * @return non-empty-string
-     */
-    public function sourceFileName(): string
-    {
-    }
-    /**
-     * @return list<int>
-     */
-    public function sourceLines(): array
-    {
-    }
-    /**
-     * @phpstan-assert-if-true ClassUnit $this
-     */
-    public function isClass(): bool
-    {
-    }
-    /**
-     * @phpstan-assert-if-true ClassMethodUnit $this
-     */
-    public function isClassMethod(): bool
-    {
-    }
-    /**
-     * @phpstan-assert-if-true InterfaceUnit $this
-     */
-    public function isInterface(): bool
-    {
-    }
-    /**
-     * @phpstan-assert-if-true InterfaceMethodUnit $this
-     */
-    public function isInterfaceMethod(): bool
-    {
-    }
-    /**
-     * @phpstan-assert-if-true TraitUnit $this
-     */
-    public function isTrait(): bool
-    {
-    }
-    /**
-     * @phpstan-assert-if-true TraitMethodUnit $this
-     */
-    public function isTraitMethod(): bool
-    {
-    }
-    /**
-     * @phpstan-assert-if-true FunctionUnit $this
-     */
-    public function isFunction(): bool
-    {
-    }
-    /**
-     * @phpstan-assert-if-true FileUnit $this
-     */
-    public function isFile(): bool
-    {
-    }
-}
-/**
- * @template-implements \IteratorAggregate<int, CodeUnit>
- *
- * @immutable
- */
-final readonly class CodeUnitCollection implements \Countable, \IteratorAggregate
-{
-    public static function fromList(\SebastianBergmann\CodeUnit\CodeUnit ...$codeUnits): self
-    {
-    }
-    /**
-     * @return list<CodeUnit>
-     */
-    public function asArray(): array
-    {
-    }
-    public function getIterator(): \SebastianBergmann\CodeUnit\CodeUnitCollectionIterator
-    {
-    }
-    public function count(): int
-    {
-    }
-    public function isEmpty(): bool
-    {
-    }
-    public function mergeWith(self $other): self
-    {
-    }
-}
-/**
- * @template-implements \Iterator<int, CodeUnit>
- */
-final class CodeUnitCollectionIterator implements \Iterator
-{
-    public function __construct(\SebastianBergmann\CodeUnit\CodeUnitCollection $collection)
-    {
-    }
-    public function rewind(): void
-    {
-    }
-    public function valid(): bool
-    {
-    }
-    public function key(): int
-    {
-    }
-    public function current(): \SebastianBergmann\CodeUnit\CodeUnit
-    {
-    }
-    public function next(): void
-    {
-    }
-}
-/**
- * @immutable
- */
-final readonly class FileUnit extends \SebastianBergmann\CodeUnit\CodeUnit
-{
-    public function isFile(): bool
-    {
-    }
-}
-/**
- * @immutable
- */
-final readonly class FunctionUnit extends \SebastianBergmann\CodeUnit\CodeUnit
-{
-    public function isFunction(): bool
-    {
-    }
-}
-/**
- * @immutable
- */
-final readonly class InterfaceMethodUnit extends \SebastianBergmann\CodeUnit\CodeUnit
-{
-    public function isInterfaceMethod(): bool
-    {
-    }
-}
-/**
- * @immutable
- */
-final readonly class InterfaceUnit extends \SebastianBergmann\CodeUnit\CodeUnit
-{
-    public function isInterface(): bool
-    {
-    }
-}
-final class Mapper
-{
-    /**
-     * @return array<string,list<int>>
-     */
-    public function codeUnitsToSourceLines(\SebastianBergmann\CodeUnit\CodeUnitCollection $codeUnits): array
-    {
-    }
-    /**
-     * @throws InvalidCodeUnitException
-     * @throws ReflectionException
-     */
-    public function stringToCodeUnits(string $unit): \SebastianBergmann\CodeUnit\CodeUnitCollection
-    {
-    }
-}
-/**
- * @immutable
- */
-final readonly class TraitMethodUnit extends \SebastianBergmann\CodeUnit\CodeUnit
-{
-    public function isTraitMethod(): bool
-    {
-    }
-}
-/**
- * @immutable
- */
-final readonly class TraitUnit extends \SebastianBergmann\CodeUnit\CodeUnit
-{
-    public function isTrait(): bool
-    {
-    }
-}
-interface Exception extends \Throwable
-{
-}
-final class InvalidCodeUnitException extends \RuntimeException implements \SebastianBergmann\CodeUnit\Exception
-{
-}
-final class NoTraitException extends \RuntimeException implements \SebastianBergmann\CodeUnit\Exception
-{
-}
-final class ReflectionException extends \RuntimeException implements \SebastianBergmann\CodeUnit\Exception
-{
-}
-namespace SebastianBergmann\CodeUnitReverseLookup;
-
-final class Wizard
-{
-    public function lookup(string $filename, int $lineNumber): string
     {
     }
 }
@@ -29641,7 +29753,7 @@ final class ComplexityCalculatingVisitor extends \PhpParser\NodeVisitorAbstract
 }
 final class CyclomaticComplexityCalculatingVisitor extends \PhpParser\NodeVisitorAbstract
 {
-    public function enterNode(\PhpParser\Node $node): void
+    public function enterNode(\PhpParser\Node $node): null
     {
     }
     /**
@@ -29838,6 +29950,8 @@ abstract class AbstractChunkOutputBuilder implements \SebastianBergmann\Diff\Out
     /**
      * Takes input of the diff array and returns the common parts.
      * Iterates through diff line by line.
+     *
+     * @return array<int, positive-int>
      */
     protected function getCommonChunks(array $diff, int $lineThreshold = 5): array
     {
@@ -30152,6 +30266,8 @@ final class Factory
      * @param list<non-empty-string>|string           $suffixes
      * @param list<non-empty-string>|string           $prefixes
      * @param list<non-empty-string>                  $exclude
+     *
+     * @phpstan-ignore missingType.generics
      */
     public function getFileIterator(array|string $paths, array|string $suffixes = '', array|string $prefixes = '', array $exclude = []): \AppendIterator
     {
@@ -30394,9 +30510,6 @@ interface Exception extends \Throwable
 final class IllogicalValuesException extends \LogicException implements \SebastianBergmann\LinesOfCode\Exception
 {
 }
-final class NegativeValueException extends \InvalidArgumentException implements \SebastianBergmann\LinesOfCode\Exception
-{
-}
 final class RuntimeException extends \RuntimeException implements \SebastianBergmann\LinesOfCode\Exception
 {
 }
@@ -30408,7 +30521,7 @@ final class LineCountingVisitor extends \PhpParser\NodeVisitorAbstract
     public function __construct(int $linesOfCode)
     {
     }
-    public function enterNode(\PhpParser\Node $node): void
+    public function enterNode(\PhpParser\Node $node): null
     {
     }
     public function result(): \SebastianBergmann\LinesOfCode\LinesOfCode
@@ -30427,7 +30540,6 @@ final readonly class LinesOfCode
      * @param non-negative-int $logicalLinesOfCode
      *
      * @throws IllogicalValuesException
-     * @throws NegativeValueException
      */
     public function __construct(int $linesOfCode, int $commentLinesOfCode, int $nonCommentLinesOfCode, int $logicalLinesOfCode)
     {
@@ -30504,7 +30616,7 @@ final class Context
      *
      * @param-out T $value
      */
-    public function add(array|object &$value): false|int|string
+    public function add(array|object &$value): int
     {
     }
     /**
@@ -30514,7 +30626,7 @@ final class Context
      *
      * @param-out T $value
      */
-    public function contains(array|object &$value): false|int|string
+    public function contains(array|object &$value): false|int
     {
     }
 }

--- a/tools/stubs/munge-phpunit-stubs.php
+++ b/tools/stubs/munge-phpunit-stubs.php
@@ -39,4 +39,11 @@ if ( $stubs === null ) {
 	throw new RuntimeException( preg_last_error_msg() );
 }
 
+// Phan silently fails on PHP 8.3 typed class constants (at least when running with PHP 8.2).
+// https://github.com/phan/phan/issues/4829
+$stubs = preg_replace( '/^(\s*+public const) (?:int|string) /m', '$1 ', $stubs );
+if ( $stubs === null ) {
+	throw new RuntimeException( preg_last_error_msg() );
+}
+
 file_put_contents( $argv[1], $stubs );

--- a/tools/stubs/phpunit-stub-defs.php
+++ b/tools/stubs/phpunit-stub-defs.php
@@ -16,10 +16,10 @@ if ( ! is_dir( $work_dir ) ) {
 }
 
 chdir( "$work_dir/phpunit" );
-if ( ! preg_match( '/^PHPUnit (\d+\.\d+\.\d+) /', (string) shell_exec( 'vendor/bin/phpunit --version' ), $m ) ) {
+$version = trim( (string) shell_exec( 'composer info phpunit/phpunit --format=json | jq -r \'.versions[0]\'' ) );
+if ( ! preg_match( '/^(\d+\.\d+\.\d+)$/', $version ) ) {
 	throw new RuntimeException( 'Failed to determine PHPUnit version' );
 }
-$version = $m[1];
 
 $config = array(
 	'header'  => <<<HEAD

--- a/tools/stubs/update-stubs.sh
+++ b/tools/stubs/update-stubs.sh
@@ -126,7 +126,7 @@ echo
 info 'Downloading PHPUnit'
 mkdir -p "$WORK_DIR/phpunit"
 jq '{ "require-dev": { "yoast/phpunit-polyfills": .["require-dev"]["yoast/phpunit-polyfills"] } }' "$BASE/tools/cli/skeletons/common/composer.json" > "$WORK_DIR/phpunit/composer.json"
-composer --working-dir="$WORK_DIR/phpunit" update
+composer --ignore-platform-reqs --working-dir="$WORK_DIR/phpunit" update
 
 echo
 info 'Extracting PHPUnit stubs'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
First, we need to update the stub generator to actually pull in 12 rather than 11, since it gets run with PHP 8.2 and 12 needs 8.3+.

Then we need an extra munging because Phan apparently doesn't like the typed class constants added in PHP 8.3, it ignores the entire stub file.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
PT: pf4qpu-Fo-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?