### PR TITLE
core/media-text: Skip VideoPress replacement for invalid media ID

### DIFF
--- a/projects/packages/videopress/changelog/update-media-and-text
+++ b/projects/packages/videopress/changelog/update-media-and-text
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed warning when core/media-text filter ran on a block without a post_id
+
+

--- a/projects/packages/videopress/src/class-block-replacement.php
+++ b/projects/packages/videopress/src/class-block-replacement.php
@@ -37,7 +37,15 @@ class Block_Replacement {
 	 */
 	public static function replace_media_text_with_videopress( $block_content, $block ) {
 		if ( $block['blockName'] === 'core/media-text' ) {
-			$video_info = video_get_info_by_blogpostid( get_current_blog_id(), $block['attrs']['mediaId'] ?? 0 );
+
+			// Make sure we have a $post_id that could be valid; if we don't, then video_get_info_by_blogpostid()
+			// will fail, so there's no point in calling it.
+			$post_id = isset( $block['attrs']['mediaId'] ) ? (int) $block['attrs']['mediaId'] : 0;
+			if ( $post_id <= 0 ) {
+				return $block_content;
+			}
+
+			$video_info = video_get_info_by_blogpostid( get_current_blog_id(), $post_id );
 			if ( $video_info && $video_info->guid ) {
 				$videopress_shortcode = sprintf( '[videopress %s]', esc_attr( $video_info->guid ) );
 				$block_content        = preg_replace( '/<video.*?<\/video>/is', do_shortcode( $videopress_shortcode ), $block_content );


### PR DESCRIPTION
## Proposed changes:

* Adds a guard check in `replace_media_text_with_videopress()` to ensure we only call `video_get_info_by_blogpostid()` when the block's mediaId is valid. If mediaId is missing or invalid, we skip the VideoPress replacement logic entirely.
   * This is modifying code added in https://github.com/Automattic/jetpack/pull/42522
   * It is generating about a million warnings per day in our logs. `PHP Warning: Attempt to read property "post_content" on null in /.../jetpack-videopress/src/utility-functions.php on line 500` (and similar)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:

Copying instructions from #43233.  I think we want to generally make sure the function works and then eyeball the warning fix:

* Sandbox your test site if you test on WP.com.
* Insert a Text & Media block inside a page or post.
* Upload a video inside the Text & Media block.
  * Make sure it was uploaded to VideoPress and processed. You can check it in Jetpack -> VideoPress, for example.
* Open the post on the frontend and make sure it uses the VideoPress player.
* Open the post on your mobile and make sure it uses the VideoPress player (you should see a preview image).
  * Don't open it in the desktop browser with the responsive/mobile view: it behaves differently for a standard video tag.
* Make sure you can see a thumbnail/preview image for the video.
* Please test it in different environments, for example, on a Simple site.

