### PR TITLE
CRM: Prevent PHP warning on new contact page with custom file field

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-php_warning_on_new_contact_page_with_custom_file_field
+++ b/projects/plugins/crm/changelog/fix-crm-php_warning_on_new_contact_page_with_custom_file_field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contacts: Prevent a PHP warning when adding a new contact when a custom file field exists. 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
@@ -835,23 +835,34 @@ class zeroBS__Metabox_ContactActions extends zeroBS__Metabox{
                         $filePerma = $zbs->DAL->makeSlug($thisFileSlotName);
                     }
 
+				// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+				$zbsFiles = array();
+				if ( $contact ) {
+					// retrieve - shouldn't these vars be "other files"... confusing
+					$zbsFiles = zeroBSCRM_getCustomerFiles( $contact['id'] );
 
-                    #} retrieve - shouldn't these vars be "other files"... confusing
-                    $zbsFiles = zeroBSCRM_getCustomerFiles($contact['id']);
+					// This specifically looks for $args['title'] file
+					$fileSlotSrc = zeroBSCRM_fileslots_fileInSlot( $filePerma, $contact['id'], ZBS_TYPE_CONTACT );
 
-                    // This specifically looks for $args['title'] file :)
-                    //$fileSlotSrc = get_post_meta($contact['id'],'cfile_'.$filePerma,true);
-                    $fileSlotSrc = zeroBSCRM_fileslots_fileInSlot($filePerma,$contact['id'],ZBS_TYPE_CONTACT);
+					// check for file + only show that
+					$zbsFilesArr = array();
+					if ( $fileSlotSrc !== '' && is_array( $zbsFiles ) && count( $zbsFiles ) > 0 ) {
+						foreach ( $zbsFiles as $f ) {
+							if ( $f['file'] === $fileSlotSrc ) {
+								$zbsFilesArr[] = $f;
+							}
+						}
+					}
+					$zbsFiles = $zbsFilesArr;
+				}
 
-
-                    // check for file + only show that
-                    $zbsFilesArr = array(); 
-                    if ($fileSlotSrc !== '' && is_array($zbsFiles) && count($zbsFiles) > 0) foreach ($zbsFiles as $f) if ($f['file'] == $fileSlotSrc) $zbsFilesArr[] = $f;
-                    $zbsFiles = $zbsFilesArr;
-
-                    // while we only have 1 file per slot, we can do this:
-                    // *js uses this to empty if deleted elsewhere (other metabox)
-                    $fileSlotURL = ''; if (is_array($zbsFiles) && count($zbsFiles) == 1) $fileSlotURL = $zbsFiles[0]['url'];
+				// while we only have 1 file per slot, we can do this:
+				// *js uses this to empty if deleted elsewhere (other metabox)
+				$fileSlotURL = '';
+				if ( is_array( $zbsFiles ) && count( $zbsFiles ) === 1 ) {
+					$fileSlotURL = $zbsFiles[0]['url'];
+				}
+				// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
                     ?>
                             <table class="form-table wh-metatab wptbp zbsFileSlotTable" data-sloturl="<?php echo esc_attr( $fileSlotURL ); ?>" id="<?php echo esc_attr( $this->metaboxID ); ?>-tab">

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
@@ -977,16 +977,6 @@ class zeroBS__Metabox_ContactActions extends zeroBS__Metabox{
                               return $contact_id;
                             } // end if
 
-                            /* Switched out for WH Perms model 19/02/16 
-                            if('page' == $_POST['post_type']) { 
-                              if(!current_user_can('edit_page', $contact_id)) {
-                                return $contact_id;
-                              } // end if
-                            } else { 
-                                if(!current_user_can('edit_page', $contact_id)) { 
-                                    return $contact_id;
-                                } // end if
-                            } // end if */
                             if (!zeroBSCRM_permsCustomers()){
                                 return $contact_id;
                             }
@@ -1053,7 +1043,6 @@ class zeroBS__Metabox_ContactActions extends zeroBS__Metabox{
                                             ///update_post_meta($contact_id, 'zbs_customer_files', $zbsCustomerFiles);  
                                             zeroBSCRM_updateCustomerFiles($contact_id,$zbsCustomerFiles);                                            
 
-                                                // actually got wrappers now :) $zbs->updateMeta(ZBS_TYPE_CONTACT,$contact_id,'cfile_'.$cfSubKey,$upload['file']);
                                                 // this'll override any prev in that slot, too
                                                 zeroBSCRM_fileslots_addToSlot($cfSubKey,$upload['file'],$contact_id,ZBS_TYPE_CONTACT,true);        
 
@@ -1088,11 +1077,6 @@ class zeroBS__Metabox_ContactActions extends zeroBS__Metabox{
 /* ======================================================
   Contact Files Metabox
    ====================================================== */
-/*
-function zeroBS__addCustomerMetaBoxes() {   
-    add_meta_box('zerobs-customer-files', __('Contact Files',"zero-bs-crm"), 'zeroBS__MetaboxFilesOther', 'zerobs_customer', 'normal', 'low');  
-}
-add_action('add_meta_boxes', 'zeroBS__addCustomerMetaBoxes');  */
 
     class zeroBS__Metabox_ContactFiles extends zeroBS__Metabox{
 
@@ -1334,17 +1318,7 @@ add_action('add_meta_boxes', 'zeroBS__addCustomerMetaBoxes');  */
             if(defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
               return $id;
             } // end if
-               
-            /* Switched out for WH Perms model 19/02/16 
-            if('page' == $_POST['post_type']) { 
-              if(!current_user_can('edit_page', $id)) {
-                return $id;
-              } // end if
-            } else { 
-                if(!current_user_can('edit_page', $id)) { 
-                    return $id;
-                } // end if
-            } // end if */
+
             if (!zeroBSCRM_permsCustomers()){
                 return $contact_id;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This catches a PHP error I ran into on the "Add contact" page.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
I put most of the code block in a conditional, defined a var needed later, and expanded the code for readability.

I also removed some old comments to balance out the added lines. 🪓 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Add a custom file field: `/wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=customfields`
2. Go here: `/wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=contact`

In `trunk` you'll get two PHP warnings.

In the `fix/crm/php_warning_on_new_contact_page_with_custom_file_field` branch, the warnings are gone.

3. Add a file and save the contact.
4. Remove the file (this can only be done from "View" mode).

Both of the above should continue to function in the new branch.