### PR TITLE
SAL_Site: Remove sites[].capabilities.view_hosting field

### DIFF
--- a/projects/packages/stats-admin/changelog/20250424-remove-view-hosting
+++ b/projects/packages/stats-admin/changelog/20250424-remove-view-hosting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+SAL_Site: Remove sites[].capabilities.view_hosting field (no longer used by Calypso)

--- a/projects/packages/stats-admin/src/class-odyssey-config-data.php
+++ b/projects/packages/stats-admin/src/class-odyssey-config-data.php
@@ -223,16 +223,6 @@ class Odyssey_Config_Data {
 			'delete_users'        => current_user_can( 'delete_users' ),
 			'remove_users'        => current_user_can( 'remove_users' ),
 			'own_site'            => current_user_can( 'manage_options' ), // Administrators are considered owners on site.
-			/**
-			 * Filter whether the Hosting section in Calypso should be available for site.
-			 *
-			 * @module json-api
-			 *
-			 * @since 8.2.0
-			 *
-			 * @param bool $view_hosting Can site access Hosting section. Default to false.
-			 */
-			'view_hosting'        => apply_filters( 'jetpack_json_api_site_can_view_hosting', false ),
 			'view_stats'          => current_user_can( 'view_stats' ),
 			'activate_plugins'    => current_user_can( 'activate_plugins' ),
 		);

--- a/projects/plugins/jetpack/changelog/20250424-remove-view-hosting
+++ b/projects/plugins/jetpack/changelog/20250424-remove-view-hosting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+SAL_Site: Remove sites[].capabilities.view_hosting field (no longer used by Calypso)

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -959,16 +959,6 @@ abstract class SAL_Site {
 			'delete_users'        => $this->current_user_can( 'delete_users' ),
 			'remove_users'        => $this->current_user_can( 'remove_users' ),
 			'own_site'            => $is_wpcom_blog_owner,
-			/**
-			 * Filter whether the Hosting section in Calypso should be available for site.
-			 *
-			 * @module json-api
-			 *
-			 * @since 8.2.0
-			 *
-			 * @param bool $view_hosting Can site access Hosting section. Default to false.
-			 */
-			'view_hosting'        => apply_filters( 'jetpack_json_api_site_can_view_hosting', false ),
 			'view_stats'          => stats_is_blog_user( $this->blog_id ),
 			'activate_plugins'    => $this->current_user_can( 'activate_plugins' ),
 			'update_plugins'      => $this->current_user_can( 'update_plugins' ),

--- a/tools/e2e-commons/helpers/plan-helper.js
+++ b/tools/e2e-commons/helpers/plan-helper.js
@@ -81,7 +81,6 @@ function getPlanData(
 			upload_files: false,
 			delete_users: false,
 			remove_users: false,
-			view_hosting: false,
 			view_stats: false,
 		},
 		jetpack: true,


### PR DESCRIPTION
## Proposed changes:

Remove `view_hosting` capability.

The view_hosting capability was originally added here:
* https://github.com/Automattic/wp-calypso/pull/38633
* 37177-ghe-Automattic/wpcom
* https://github.com/Automattic/jetpack/pull/14288

The problem is, it's no longer used by Calypso, and it's expensive to compute because it does SQL queries.

It's no longer used because (1) the old `/hosting-config` page has been replaced by `/hosting-features`, and (2) Calypso slowly migrated away from `view_hosting` checks because they were 1:1 with checks like "Can we migrate this site right now", which didn't always match up with "We want to show that you can get hosting after purchasing a plan." Example here: https://github.com/Automattic/wp-calypso/pull/63936

This field has is no longer being used by Calypso - and has been patched to always return false for a day or two - so, let's remove it entirely.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:

* Apply on simple sandbox
* Sandbox public-api
* Notice that requests to /me/sites no longer contain `view_hosting` in the capabilities list

<img width="562" alt="Screenshot 2025-04-24 at 3 07 02 PM" src="https://github.com/user-attachments/assets/a04ffb90-1eaa-4f00-a501-023653edf60f" />

* In calypso, you should still be able to manage atomic sites, convert sites to atomic, and see atomic upsells