### PR TITLE
Account Protection: Fix TypeError in login_form_password_detection()

### DIFF
--- a/projects/packages/account-protection/changelog/fix-account-protection-fatal-errors
+++ b/projects/packages/account-protection/changelog/fix-account-protection-fatal-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed an issue where authentication could fail with a fatal error when other authentication plugins are active.

--- a/projects/packages/account-protection/src/class-password-detection.php
+++ b/projects/packages/account-protection/src/class-password-detection.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Account_Protection;
 
 use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
-use WP_User;
 
 /**
  * Class Password_Detection
@@ -48,7 +47,9 @@ class Password_Detection {
 	 * @return \WP_User|\WP_Error|null The user object, error object, or null.
 	 */
 	public function login_form_password_detection( $user, string $password ) {
-		if ( is_wp_error( $user ) || $user === null || ! ( $user instanceof WP_User ) ) {
+		// First check if the user object is valid. Third-party plugins might pass
+		// incompatible types to authentication hooks, so we need this extra check.
+		if ( is_wp_error( $user ) || ! ( $user instanceof \WP_User ) ) {
 			return $user;
 		}
 

--- a/projects/packages/account-protection/src/class-password-detection.php
+++ b/projects/packages/account-protection/src/class-password-detection.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Account_Protection;
 
 use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
+use WP_User;
 
 /**
  * Class Password_Detection
@@ -41,13 +42,17 @@ class Password_Detection {
 	/**
 	 * Check if the password is safe after login.
 	 *
-	 * @param \WP_User|\WP_Error $user The user or error object.
-	 * @param string             $password The password.
+	 * @param \WP_User|\WP_Error|null $user The user or error object, or null.
+	 * @param string                  $password The password.
 	 *
-	 * @return \WP_User|\WP_Error The user object.
+	 * @return \WP_User|\WP_Error|null The user object, error object, or null.
 	 */
 	public function login_form_password_detection( $user, string $password ) {
-		if ( is_wp_error( $user ) || ! $this->user_requires_protection( $user, $password ) ) {
+		if ( is_wp_error( $user ) || $user === null || ! ( $user instanceof WP_User ) ) {
+			return $user;
+		}
+
+		if ( ! $this->user_requires_protection( $user, $password ) ) {
 			return $user;
 		}
 

--- a/projects/packages/account-protection/tests/php/Password_Detection_Test.php
+++ b/projects/packages/account-protection/tests/php/Password_Detection_Test.php
@@ -504,4 +504,15 @@ class Password_Detection_Test extends BaseTestCase {
 		$this->expectOutputRegex( '@' . $error['message'] . '@' );
 		$sut->render_content( $user, 'my_cool_token' );
 	}
+
+	/**
+	 * Tests that login_form_password_detection handles a NULL user gracefully without causing fatal errors.
+	 */
+	public function test_login_form_password_detection_handles_null_user_gracefully(): void {
+		$sut    = new Password_Detection();
+		$return = $sut->login_form_password_detection( null, 'password' );
+
+		// Assert that we reached this point (no fatal error occurred) and that NULL is returned
+		$this->assertNull( $return, 'NULL should be returned when a NULL user is provided.' );
+	}
 }


### PR DESCRIPTION
Fixes p1745260735085449/1744645697.314949-slack-C080AF0NF0R

## Proposed changes:
* Add defensive coding to handle NULL values in `login_form_password_detection()`
* Add a unit test to verify NULL handling works correctly

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them? N/A (Backend only change)
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)? N/A

## Jetpack product discussion
p1745260735085449/1744645697.314949-slack-C080AF0NF0R

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

The best way to verify this fix is through the unit tests, which directly test the NULL handling capability:

* Run unit tests and ensure it passes
```
cd projects/packages/account-protection
composer phpunit
```

This test specifically verifies that:
- When `login_form_password_detection()` receives a NULL user
- It returns NULL without attempting to call `user_requires_protection()`
- No fatal error occurs

In production, this prevents the TypeError when other authentication plugins return NULL during the filter chain.