### PR TITLE
Instant Search: Add searched term to results string

### DIFF
--- a/projects/packages/search/changelog/Add searched term to results string.
+++ b/projects/packages/search/changelog/Add searched term to results string.
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Instant Search: add searched term to results string.

--- a/projects/packages/search/src/instant-search/components/search-results.jsx
+++ b/projects/packages/search/src/instant-search/components/search-results.jsx
@@ -114,10 +114,17 @@ class SearchResults extends Component {
 					corrected_query
 				);
 			}
+			// Always include the search query if one exists
 			return sprintf(
-				/* translators: %s: number of results. */
-				_n( 'Found %s result', 'Found %s results', total, 'jetpack-search-pkg' ),
-				num
+				/* translators: %1$s: number of results. %2$s: the search query. */
+				_n(
+					'Found %1$s result for "%2$s"',
+					'Found %1$s results for "%2$s"',
+					total,
+					'jetpack-search-pkg'
+				),
+				num,
+				this.props.searchQuery
 			);
 		}
 

--- a/projects/plugins/jetpack/changelog/add-searched-term-to-results-string
+++ b/projects/plugins/jetpack/changelog/add-searched-term-to-results-string
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Instant Search: add searched term to results string.

--- a/projects/plugins/search/changelog/add-searched-term-to-results-string
+++ b/projects/plugins/search/changelog/add-searched-term-to-results-string
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Instant Search: add searched term to results string.


### PR DESCRIPTION
Addresses: p1745516011684089-slack-jetpack-search

## Proposed changes:

When returning Instant Search results, include the searched term in the results string. This updates the results string from `Found X result(s)` to `Found X result(s) for '$searched-term'`

**Before**

![CleanShot 2025-04-25 at 10 44 00](https://github.com/user-attachments/assets/384b4751-2e71-4620-a86d-b322f0530b00)

**This PR**

![CleanShot 2025-04-25 at 10 40 42](https://github.com/user-attachments/assets/b3657952-344c-4549-8151-240657f98fe4)

**This PR with corrected query**

![CleanShot 2025-04-25 at 10 47 46](https://github.com/user-attachments/assets/70072048-7b8a-4f22-aee0-ae78ca5268be)

**This PR with multiple results**

![CleanShot 2025-04-25 at 11 26 50](https://github.com/user-attachments/assets/d72be3b3-c9d7-48f6-bcbd-f4b5c6a4dfa7)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

This PR does not change what data or activity we track or use.

## Testing instructions:

Ensure you're watching for package changes, e.g. `jp watch packages/search`.

- Enable Instant Search on your local environment
- On `trunk` run a search to confirm the **Before** state shown above.
- Check out branch.
- Run a new search to confirm the **This PR** state shown above, and another to confirm the **This PR with corrected query** state.
