### PR TITLE
Forms: Fix Google Drive connection button style and streamline connection

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-google-sheets-export
+++ b/projects/packages/forms/changelog/fix-forms-google-sheets-export
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix Google Drive connection button style and streamline connection

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-manage-responses-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-manage-responses-settings.js
@@ -1,14 +1,7 @@
-import { getJetpackData } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { get } from 'lodash';
+import { FULL_RESPONSES_PATH } from '../../../util/get-preferred-responses-view';
 import InspectorHint from '../components/inspector-hint';
-
-const preferredView = window?.jpFormsBlocks?.defaults?.preferredView;
-
-const RESPONSES_PATH =
-	get( getJetpackData(), 'adminUrl', false ) +
-	( preferredView === 'classic' ? 'edit.php?post_type=feedback' : 'admin.php?page=jetpack-forms' );
 
 const JetpackManageResponsesSettings = () => {
 	return (
@@ -16,7 +9,7 @@ const JetpackManageResponsesSettings = () => {
 			<InspectorHint>
 				{ __( 'Manage and export your form responses in WPAdmin:', 'jetpack-forms' ) }
 			</InspectorHint>
-			<Button variant="secondary" href={ RESPONSES_PATH } __next40pxDefaultSize={ true }>
+			<Button variant="secondary" href={ FULL_RESPONSES_PATH } __next40pxDefaultSize={ true }>
 				{ __( 'View Form Responses', 'jetpack-forms' ) }
 				<span className="screen-reader-text">
 					{ __( '(opens in a new tab)', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -291,14 +291,6 @@ class Admin {
 				<div class="export-card__body-description">
 					<div>
 						<?php esc_html_e( 'Export your data into a Google Sheets file.', 'jetpack-forms' ); ?>
-						<?php
-						printf(
-							'<a href="%1$s" title="%2$s" target="_blank" rel="noopener noreferer">%3$s</a>',
-							esc_url( Redirect::get_url( 'jetpack-support-contact-form-export' ) ),
-							esc_attr__( 'connect to Google Drive', 'jetpack-forms' ),
-							esc_html__( 'You need to connect to Google Drive.', 'jetpack-forms' )
-						);
-						?>
 					</div>
 				</div>
 				<div class="export-card__body-cta">

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
@@ -4,7 +4,7 @@
 import { useConnection } from '@automattic/jetpack-connection';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
-import { useCallback, useState, useEffect, useRef } from '@wordpress/element';
+import { useCallback, useState, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { tap } from 'lodash';
@@ -15,10 +15,11 @@ import { config } from '../..';
 import { PARTIAL_RESPONSES_PATH, PREFERRED_VIEW } from '../../../util/get-preferred-responses-view';
 
 const GoogleDriveExport = ( { onExport, autoConnect = false } ) => {
-	const [ isConnectedToGoogleDrive, setIsConnectedToGoogleDrive ] = useState( false );
+	const [ isConnectedToGoogleDrive, setIsConnectedToGoogleDrive ] = useState(
+		config( 'gdriveConnection' )
+	);
 	const { tracks } = useAnalytics();
-	const connectButtonRef = useRef( null );
-	const [ hasAutoConnected, setHasAutoConnected ] = useState( false );
+	const autoConnectOpened = useRef( false );
 
 	const { isUserConnected, handleConnectUser, userIsConnecting, isOfflineMode } = useConnection( {
 		redirectUri:
@@ -72,17 +73,6 @@ const GoogleDriveExport = ( { onExport, autoConnect = false } ) => {
 			screen: 'form-responses-inbox',
 		} );
 	}, [ tracks, pollForConnection ] );
-
-	useEffect( () => {
-		if ( autoConnect && ! hasAutoConnected ) {
-			// Wait for the button to be rendered so the ref is available
-			setTimeout( () => {
-				connectButtonRef.current?.click();
-			}, 1000 );
-
-			setHasAutoConnected( true );
-		}
-	}, [ autoConnect, handleConnectClick, hasAutoConnected ] );
 
 	if ( isOfflineMode ) {
 		return null;
@@ -157,7 +147,12 @@ const GoogleDriveExport = ( { onExport, autoConnect = false } ) => {
 							rel="noopener noreferrer"
 							target="_blank"
 							onClick={ handleConnectClick }
-							ref={ connectButtonRef }
+							ref={ el => {
+								if ( autoConnect && ! autoConnectOpened.current ) {
+									el?.click();
+									autoConnectOpened.current = true;
+								}
+							} }
 						>
 							{ __( 'Connect to Google Drive', 'jetpack-forms' ) }
 						</Button>

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
@@ -14,7 +14,9 @@ import { tap } from 'lodash';
 import { config } from '../..';
 
 const GoogleDriveExport = ( { onExport } ) => {
-	const [ isConnected, setIsConnected ] = useState( config( 'gdriveConnection' ) );
+	const [ isConnectedToGoogleDrive, setIsConnectedToGoogleDrive ] = useState(
+		config( 'gdriveConnection' )
+	);
 	const { tracks } = useAnalytics();
 
 	const { isUserConnected, handleConnectUser, userIsConnecting, isOfflineMode } = useConnection( {
@@ -23,7 +25,7 @@ const GoogleDriveExport = ( { onExport } ) => {
 
 	const pollForConnection = useCallback( () => {
 		const interval = setInterval( async () => {
-			if ( isConnected ) {
+			if ( isConnectedToGoogleDrive ) {
 				clearInterval( interval );
 				return;
 			}
@@ -43,12 +45,12 @@ const GoogleDriveExport = ( { onExport } ) => {
 				}
 
 				clearInterval( interval );
-				setIsConnected( true );
+				setIsConnectedToGoogleDrive( true );
 			} catch {
 				clearInterval( interval );
 			}
 		}, 5000 );
-	}, [ isConnected ] );
+	}, [ isConnectedToGoogleDrive ] );
 
 	const exportToGoogleDrive = useCallback( () => {
 		tracks.recordEvent( 'jetpack_forms_export_click', {
@@ -99,25 +101,29 @@ const GoogleDriveExport = ( { onExport } ) => {
 				<div className="jp-forms__export-modal-card-body-description">
 					<div>
 						{ __( 'Export your data into a Google Sheets file.', 'jetpack-forms' ) }
-						&nbsp;
-						<a
-							href={ config( 'gdriveConnectSupportURL' ) }
-							title={ __( 'Connect to Google Drive', 'jetpack-forms' ) }
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							{ __( 'You need to connect to Google Drive.', 'jetpack-forms' ) }
-						</a>
+						{ ! isConnectedToGoogleDrive && (
+							<>
+								&nbsp;
+								<a
+									href={ config( 'gdriveConnectSupportURL' ) }
+									title={ __( 'Connect to Google Drive', 'jetpack-forms' ) }
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									{ __( 'You need to connect to Google Drive.', 'jetpack-forms' ) }
+								</a>
+							</>
+						) }
 					</div>
 				</div>
 				<div className="jp-forms__export-modal-card-body-cta">
-					{ isConnected && (
-						<button className={ buttonClasses } onClick={ exportToGoogleDrive }>
+					{ isConnectedToGoogleDrive && (
+						<Button className={ buttonClasses } variant="primary" onClick={ exportToGoogleDrive }>
 							{ __( 'Export', 'jetpack-forms' ) }
-						</button>
+						</Button>
 					) }
 
-					{ ! isConnected && ! isUserConnected && (
+					{ ! isConnectedToGoogleDrive && ! isUserConnected && (
 						<Button
 							className={ buttonClasses }
 							variant="primary"
@@ -130,7 +136,7 @@ const GoogleDriveExport = ( { onExport } ) => {
 						</Button>
 					) }
 
-					{ ! isConnected && isUserConnected && (
+					{ ! isConnectedToGoogleDrive && isUserConnected && (
 						<Button
 							href={ config( 'gdriveConnectURL' ) }
 							className={ buttonClasses }

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
@@ -12,6 +12,7 @@ import { tap } from 'lodash';
  * Internal dependencies
  */
 import { config } from '../..';
+import { PARTIAL_RESPONSES_PATH } from '../../../util/get-preferred-responses-view';
 
 const GoogleDriveExport = ( { onExport } ) => {
 	const [ isConnectedToGoogleDrive, setIsConnectedToGoogleDrive ] = useState(
@@ -20,7 +21,7 @@ const GoogleDriveExport = ( { onExport } ) => {
 	const { tracks } = useAnalytics();
 
 	const { isUserConnected, handleConnectUser, userIsConnecting, isOfflineMode } = useConnection( {
-		redirectUri: location.href.split( 'wp-admin/' )[ 1 ],
+		redirectUri: PARTIAL_RESPONSES_PATH,
 	} );
 
 	const pollForConnection = useCallback( () => {

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
@@ -4,7 +4,7 @@
 import { useConnection } from '@automattic/jetpack-connection';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useState, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { tap } from 'lodash';
@@ -12,16 +12,17 @@ import { tap } from 'lodash';
  * Internal dependencies
  */
 import { config } from '../..';
-import { PARTIAL_RESPONSES_PATH } from '../../../util/get-preferred-responses-view';
+import { PARTIAL_RESPONSES_PATH, PREFERRED_VIEW } from '../../../util/get-preferred-responses-view';
 
-const GoogleDriveExport = ( { onExport } ) => {
-	const [ isConnectedToGoogleDrive, setIsConnectedToGoogleDrive ] = useState(
-		config( 'gdriveConnection' )
-	);
+const GoogleDriveExport = ( { onExport, autoConnect = false } ) => {
+	const [ isConnectedToGoogleDrive, setIsConnectedToGoogleDrive ] = useState( false );
 	const { tracks } = useAnalytics();
+	const connectButtonRef = useRef( null );
+	const [ hasAutoConnected, setHasAutoConnected ] = useState( false );
 
 	const { isUserConnected, handleConnectUser, userIsConnecting, isOfflineMode } = useConnection( {
-		redirectUri: PARTIAL_RESPONSES_PATH,
+		redirectUri:
+			PARTIAL_RESPONSES_PATH + ( PREFERRED_VIEW === 'classic' ? '' : '&connect-gdrive=true' ),
 	} );
 
 	const pollForConnection = useCallback( () => {
@@ -71,6 +72,17 @@ const GoogleDriveExport = ( { onExport } ) => {
 			screen: 'form-responses-inbox',
 		} );
 	}, [ tracks, pollForConnection ] );
+
+	useEffect( () => {
+		if ( autoConnect && ! hasAutoConnected ) {
+			// Wait for the button to be rendered so the ref is available
+			setTimeout( () => {
+				connectButtonRef.current?.click();
+			}, 1000 );
+
+			setHasAutoConnected( true );
+		}
+	}, [ autoConnect, handleConnectClick, hasAutoConnected ] );
 
 	if ( isOfflineMode ) {
 		return null;
@@ -145,6 +157,7 @@ const GoogleDriveExport = ( { onExport } ) => {
 							rel="noopener noreferrer"
 							target="_blank"
 							onClick={ handleConnectClick }
+							ref={ connectButtonRef }
 						>
 							{ __( 'Connect to Google Drive', 'jetpack-forms' ) }
 						</Button>

--- a/projects/packages/forms/src/util/get-preferred-responses-view.js
+++ b/projects/packages/forms/src/util/get-preferred-responses-view.js
@@ -1,0 +1,6 @@
+import { getJetpackData } from '@automattic/jetpack-shared-extension-utils';
+
+export const PREFERRED_VIEW = window?.jpFormsBlocks?.defaults?.preferredView;
+export const PARTIAL_RESPONSES_PATH =
+	PREFERRED_VIEW === 'classic' ? 'edit.php?post_type=feedback' : 'admin.php?page=jetpack-forms';
+export const FULL_RESPONSES_PATH = getJetpackData()?.adminUrl + PARTIAL_RESPONSES_PATH;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to #43121
Fixes FORMS-30

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the "You need to connect to Google Drive" message when it is already connected
* Fixes the export button on modern view
* Streamlines the connection for users that are not connected to Jetpack either

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With a connected site, but disconnected user, go to the forms Feedback page
* Select the modern (Inbox) view if not selected already
* Use the Google Sheets card to connect to Jetpack (as shown [here](https://github.com/Automattic/jetpack/pull/43121))
* Check that the modal opens and the Google Drive connection is initiated automatically after being redirected back from the Jetpack connection
* Check that the "You need to connect to Google Drive" text is no longer there after the Google Drive connection is established
* Check that the Export button is black, matching the CSV download button
* Change the view to classic
* Check that the "You need to connect to Google Drive" text is no longer there

| Before | After |
| - | - |
| <img src="https://github.com/user-attachments/assets/aedbbe8c-1981-4df8-9f62-7f467d37da33" alt="drawing" width="500"/> | <img src="https://github.com/user-attachments/assets/86e27a9a-b943-4d18-9db0-c5b661e94a1e" alt="drawing" width="500"/> |
