### PR TITLE
WordPress Compatibility: Replace deprecated user permission function

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/subscribers.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/subscribers.php
@@ -57,8 +57,8 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 	 * Permission check. Only authors can access this endpoint.
 	 */
 	public function readable_permission_check() {
-		// @phan-suppress-next-line PhanDeprecatedFunction -- @todo Switch to current_user_can_for_site when we drop support for WP 6.6.
-		if ( ! current_user_can_for_blog( get_current_blog_id(), 'edit_posts' ) ) {
+
+		if ( ! current_user_can_for_site( get_current_blog_id(), 'edit_posts' ) ) {
 			return new WP_Error( 'authorization_required', 'Only users with the permission to edit posts can see the subscriber count.', array( 'status' => 401 ) );
 		}
 

--- a/projects/plugins/jetpack/changelog/remove-backwards-compatible-code-lower-than-v-6-7
+++ b/projects/plugins/jetpack/changelog/remove-backwards-compatible-code-lower-than-v-6-7
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Compatibility: Replace a deprecated function to check user capabilities, with the currently expected function.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -4492,8 +4492,7 @@ endif;
 				if ( is_a( $jp_user, 'WP_User' ) ) {
 					wp_set_current_user( $jp_user->ID );
 					$user_can = is_multisite()
-						// @phan-suppress-next-line PhanDeprecatedFunction -- @todo Switch to current_user_can_for_site when we drop support for WP 6.6.
-						? current_user_can_for_blog( get_current_blog_id(), 'manage_options' )
+						? current_user_can_for_site( get_current_blog_id(), 'manage_options' )
 						: current_user_can( 'manage_options' );
 					if ( $user_can ) {
 						$token_type              = 'user';

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-comment-counts-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-comment-counts-endpoint.php
@@ -54,8 +54,7 @@ class WPCOM_JSON_API_GET_Comment_Counts_Endpoint extends WPCOM_JSON_API_Endpoint
 			return new WP_Error( 'authorization_required', 'An active access token must be used to retrieve comment counts.', 403 );
 		}
 
-		// @phan-suppress-next-line PhanDeprecatedFunction -- @todo Switch to current_user_can_for_site when we drop support for WP 6.6.
-		if ( ! current_user_can_for_blog( $blog_id, 'edit_posts' ) ) {
+		if ( ! current_user_can_for_site( $blog_id, 'edit_posts' ) ) {
 			return new WP_Error( 'authorization_required', 'You are not authorized to view comment counts for this blog.', 403 );
 		}
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-comment-history-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-comment-history-endpoint.php
@@ -44,8 +44,7 @@ class WPCOM_JSON_API_GET_Comment_History_Endpoint extends WPCOM_JSON_API_Endpoin
 			return new WP_Error( 'authorization_required', 'An active access token must be used to retrieve comment history.', 403 );
 		}
 
-		// @phan-suppress-next-line PhanDeprecatedFunction -- @todo Switch to current_user_can_for_site when we drop support for WP 6.6.
-		if ( ! current_user_can_for_blog( $blog_id, 'edit_posts' ) ) {
+		if ( ! current_user_can_for_site( $blog_id, 'edit_posts' ) ) {
 			return new WP_Error( 'authorization_required', 'You are not authorized to view comment history on this blog.', 403 );
 		}
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-user-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-user-endpoint.php
@@ -144,8 +144,7 @@ class WPCOM_JSON_API_Site_User_Endpoint extends WPCOM_JSON_API_Endpoint {
 		if ( is_wp_error( $blog_id ) ) {
 			return $blog_id;
 		}
-		// @phan-suppress-next-line PhanDeprecatedFunction -- @todo Switch to current_user_can_for_site when we drop support for WP 6.6.
-		if ( ! current_user_can_for_blog( $blog_id, 'list_users' ) ) {
+		if ( ! current_user_can_for_site( $blog_id, 'list_users' ) ) {
 			return new WP_Error( 'unauthorized', 'User cannot view users for specified site', 403 );
 		}
 
@@ -164,8 +163,7 @@ class WPCOM_JSON_API_Site_User_Endpoint extends WPCOM_JSON_API_Endpoint {
 		if ( 'GET' === $this->api->method ) {
 			return $this->get_user( $user->ID );
 		} elseif ( 'POST' === $this->api->method ) {
-			// @phan-suppress-next-line PhanDeprecatedFunction -- @todo Switch to current_user_can_for_site when we drop support for WP 6.6.
-			if ( ! current_user_can_for_blog( $blog_id, 'promote_users' ) ) {
+			if ( ! current_user_can_for_site( $blog_id, 'promote_users' ) ) {
 				return new WP_Error( 'unauthorized_no_promote_cap', 'User cannot promote users for specified site', 403 );
 			}
 			return $this->update_user( $user_id, $blog_id );


### PR DESCRIPTION
Fixes VULCAN-82

## Proposed changes:

* This PR changes all instances of `current_user_can_for_blog` with `current_user_can_for_site`. The former was deprecated in WordPress 6.7, and the latter also introduced in 6.7. As we no longer support WordPress versions lower than 6.7, these can be replaced.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

As this is a like for like function replacement, this shouldn't need testing. However, you can test the following to confirm functionality remains as expected (no errors being generated), for some of the instances. With the PR applied on a self-hosted test site:

Newsletter:
* Make sure Newsletter is enabled at `/wp-admin/admin.php?page=jetpack#newsletter`
* Open up the post sidebar, and expand the access section. This should work as expected, no errors generated due to the function

Comment Counts:
* Visit the WordPress developer console (see link in Linear issue)
* Test the following endpoint: WP.COM API, v1.1 GET /sites/{YOURBLOGID}/comment-counts
* You should be able to see the comment counts with no error.

User Endpoint:
* Same as above, but a POST request, for /sites/{YOURBLOGID}/users/YOURUSERID
* This POST request will run through both areas of code where the function changes occurred, so if there were issues then you would see warnings in your error logs about the functions.

You should be able to test on Simple and WoA as well.
